### PR TITLE
Staging Sync: Use pending statuses to disable Sync button

### DIFF
--- a/client/dashboard/utils/site-staging-site.ts
+++ b/client/dashboard/utils/site-staging-site.ts
@@ -13,6 +13,6 @@ export const hasStagingSite = ( site: Site ) => !! getStagingSiteId( site );
 export const isStagingSiteSyncing = ( stagingSiteSyncState?: StagingSiteSyncState ) => {
 	return (
 		stagingSiteSyncState &&
-		! [ 'completed', 'allow_retry', 'failed' ].includes( stagingSiteSyncState.status )
+		[ 'pending', 'backing_up', 'restoring' ].includes( stagingSiteSyncState.status )
 	);
 };


### PR DESCRIPTION
This PR suggests using the pending statuses to disable the Sync button instead of the negative of the completed statuses. This is to prevent incorrect statuses from disabling the button.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-14297

## Proposed Changes

* Use the pending statuses ` 'pending', 'backing_up', 'restoring' ` instead of the exclusion of completed statuses ` 'completed', 'allow_retry', 'failed' ` so if the status is incorrect, for example `dummy`, the button is not disabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  This has been done because sites have been found with the state field not populated. Please see the issue DOTCOM-14297 that contains more details about the specific sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
I have not found a way to reproduce the incorrect status, so this can be simulated by changing the status manually. To do that:
* Find a site that has a Staging site or add a staging site to an existing site. [More info there](https://developer.wordpress.com/docs/developer-tools/staging-sites/)
* Get the `blog_id` of the production site
* Sandbox your public-api 
* On the sandbox, run `wpsh`
* Run the following command to update the `site_staging_sync_data` meta key:
```sh
update_site_meta(<blog_id>, 'site_staging_sync_data', ['job_id'=>-1, 'updated_at'=>time()])
```
replacing `<blog_id>` with the `blog_id` of the production site
* Navigate to your production site, e.g. `sites/:productionSiteSlug`, and check that the `Sync` button is enabled and it does not change to `Syncing...`, refresh to check.
* Change to the staging site (for example, by using the environment switcher dropdown) and check that the `Sync` button is enabled and it does not change to `Syncing...`, refresh to check.
* Repeat the steps using production code, e.g. `https://wordpress.com/sites/:siteSlug` (you can still point the public.api to your sandbox) and check the `Sync` button is disabled and with the text `Syncing...`
* Using this branch and pointing the public.api to production (so you don't need to sandbox the `staging_site_sync_process` job), check that the Sync dropdown work as expected. Try either a `Pull` or `Push` and check that the button changes to `Syncing...` as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
