### PR TITLE
Notifications v2: Filter the notes by the active tab

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -1,17 +1,27 @@
-import { useNavigator } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	ExternalLink,
+	useNavigator,
+} from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useContext, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import Filters from '../../panel/templates/filters';
 import { RestClientContext } from '../context';
 import { getFields } from './dataviews';
 import type { Note } from '../types';
 import type { View } from '@wordpress/dataviews';
 
-const NoteList = () => {
+const NoteList = ( { filterName }: { filterName: keyof typeof Filters } ) => {
 	const { goTo } = useNavigator();
-	const notes = useSelector( ( state ) => getAllNotes( state ) );
+	const filter = Filters[ filterName ];
+	const notes = useSelector( ( state ) =>
+		( ( getAllNotes( state ) || [] ) as Note[] ).filter( ( note ) => filter.filter( note ) )
+	);
+
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const restClient = useContext( RestClientContext );
 
@@ -43,6 +53,12 @@ const NoteList = () => {
 		setView( ( currentView ) => ( { ...currentView, perPage: notes.length } ) );
 	}, [ notes.length ] );
 
+	useEffect( () => {
+		if ( filterName !== 'all' && notes.length < 10 && ! isLoading ) {
+			infiniteScrollHandler();
+		}
+	}, [ filterName, notes.length, isLoading, infiniteScrollHandler ] );
+
 	return (
 		<DataViews< Note >
 			data={ filteredData }
@@ -54,6 +70,14 @@ const NoteList = () => {
 				...paginationInfo,
 				infiniteScrollHandler,
 			} }
+			empty={
+				<VStack alignment="center">
+					<Text size={ 15 } weight={ 500 }>
+						{ filter.emptyMessage }
+					</Text>
+					<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
+				</VStack>
+			}
 			getItemId={ ( item ) => item.id.toString() }
 			onChangeView={ setView }
 			onChangeSelection={ onChangeSelection }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -9,15 +9,15 @@ import { useState, useContext, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
-import Filters from '../../panel/templates/filters';
+import { getFilters } from '../../panel/templates/filters';
 import { RestClientContext } from '../context';
 import { getFields } from './dataviews';
 import type { Note } from '../types';
 import type { View } from '@wordpress/dataviews';
 
-const NoteList = ( { filterName }: { filterName: keyof typeof Filters } ) => {
+const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
 	const { goTo } = useNavigator();
-	const filter = Filters[ filterName ];
+	const filter = getFilters()[ filterName ];
 	const notes = useSelector( ( state ) =>
 		( ( getAllNotes( state ) || [] ) as Note[] ).filter( ( note ) => filter.filter( note ) )
 	);

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -14,13 +14,15 @@ import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
 
+type ActiveTab = keyof ReturnType< typeof getFilters >;
+
 const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
 	name,
 	title: label,
 } ) );
 
 const NotePanel = () => {
-	const [ activeTab, setActiveTab ] = useState< keyof ReturnType< typeof getFilters > >( 'all' );
+	const [ activeTab, setActiveTab ] = useState< ActiveTab >( 'all' );
 	return (
 		<>
 			<CardHeader
@@ -42,7 +44,7 @@ const NotePanel = () => {
 						tabs={ NOTIFICATION_TABS }
 						initialTabName={ activeTab }
 						onSelect={ ( tabName ) => {
-							setActiveTab( tabName as keyof typeof Filters );
+							setActiveTab( tabName as ActiveTab );
 						} }
 					>
 						{ () => null /* Placeholder div since content is rendered elsewhere */ }

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -10,17 +10,17 @@ import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
 import { useState } from 'react';
-import Filters from '../../panel/templates/filters';
+import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
 
-const NOTIFICATION_TABS = Object.values( Filters ).map( ( { name, label } ) => ( {
+const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
 	name,
 	title: label,
 } ) );
 
 const NotePanel = () => {
-	const [ activeTab, setActiveTab ] = useState< keyof typeof Filters >( 'all' );
+	const [ activeTab, setActiveTab ] = useState< keyof ReturnType< typeof getFilters > >( 'all' );
 	return (
 		<>
 			<CardHeader

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -9,16 +9,18 @@ import {
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
+import { useState } from 'react';
+import Filters from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
 
-const NOTIFICATION_TABS = [
-	{ name: 'all', title: __( 'All' ) },
-	{ name: 'unread', title: __( 'Unread' ) },
-	{ name: 'alerts', title: __( 'Alerts' ) },
-];
+const NOTIFICATION_TABS = Object.values( Filters ).map( ( { name, label } ) => ( {
+	name,
+	title: label,
+} ) );
 
 const NotePanel = () => {
+	const [ activeTab, setActiveTab ] = useState< keyof typeof Filters >( 'all' );
 	return (
 		<>
 			<CardHeader
@@ -35,12 +37,19 @@ const NotePanel = () => {
 							<NotePanelActions />
 						</div>
 					</HStack>
-					<TabPanel activeClass="is-active" tabs={ NOTIFICATION_TABS } initialTabName="all">
+					<TabPanel
+						activeClass="is-active"
+						tabs={ NOTIFICATION_TABS }
+						initialTabName={ activeTab }
+						onSelect={ ( tabName ) => {
+							setActiveTab( tabName as keyof typeof Filters );
+						} }
+					>
 						{ () => null /* Placeholder div since content is rendered elsewhere */ }
 					</TabPanel>
 				</VStack>
 			</CardHeader>
-			<NoteList />
+			<NoteList filterName={ activeTab } />
 		</>
 	);
 };

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -153,7 +153,7 @@ export class Notifications extends PureComponent {
 						data={ globalData }
 						global={ globalData }
 						isShowing={ this.props.isShowing }
-						locale={ this.props.local }
+						locale={ this.props.locale }
 					/>
 				</RestClientContext.Provider>
 			</Provider>

--- a/apps/notifications/src/panel/templates/filter-bar-controller.js
+++ b/apps/notifications/src/panel/templates/filter-bar-controller.js
@@ -3,7 +3,7 @@ import { store } from '../state';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
 import noteHasFilteredRead from '../state/selectors/note-has-filtered-read';
-import Filters from './filters';
+import { getFilters } from './filters';
 
 function FilterBarController( refreshFunction ) {
 	if ( ! ( this instanceof FilterBarController ) ) {
@@ -14,7 +14,7 @@ function FilterBarController( refreshFunction ) {
 }
 
 FilterBarController.prototype.selectFilter = function ( filterName ) {
-	if ( Object.keys( Filters ).indexOf( filterName ) === -1 ) {
+	if ( Object.keys( getFilters() ).indexOf( filterName ) === -1 ) {
 		return;
 	}
 
@@ -30,7 +30,7 @@ FilterBarController.prototype.selectFilter = function ( filterName ) {
 FilterBarController.prototype.getFilteredNotes = function ( notes ) {
 	const state = store.getState();
 	const filterName = getFilterName( state );
-	const activeTab = Filters[ filterName ];
+	const activeTab = getFilters()[ filterName ];
 	if ( ! notes || ! activeTab ) {
 		return [];
 	}

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import getFilterName from '../state/selectors/get-filter-name';
-import Filters from './filters';
+import { getFilters } from './filters';
 
 export class FilterBar extends Component {
 	filterListRef = createRef();
@@ -37,7 +37,7 @@ export class FilterBar extends Component {
 	}
 
 	setFilterItems = () => {
-		this.filterItems = Object.values( Filters ).sort( ( a, b ) => a.index - b.index );
+		this.filterItems = Object.values( getFilters() ).sort( ( a, b ) => a.index - b.index );
 	};
 
 	getFilterItems = () => {

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -97,9 +97,7 @@ export class FilterBar extends Component {
 					__next40pxDefaultSize
 				>
 					{ filterItems.map( ( { label, name } ) => {
-						return (
-							<ToggleGroupControlOption key={ name } label={ label( translate ) } value={ name } />
-						);
+						return <ToggleGroupControlOption key={ name } label={ label } value={ name } />;
 					} ) }
 				</ToggleGroupControl>
 			</div>

--- a/apps/notifications/src/panel/templates/filters.js
+++ b/apps/notifications/src/panel/templates/filters.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { store } from '../state';
 import getNoteIsRead from '../state/selectors/get-is-note-read';
 
-const Filters = {
+export const getFilters = () => ( {
 	all: {
 		name: 'all',
 		index: 0,
@@ -52,6 +52,4 @@ const Filters = {
 		emptyLink: 'https://wordpress.com/activities/likes/',
 		filter: ( { type } ) => 'comment_like' === type || 'like' === type,
 	},
-};
-
-export default Filters;
+} );

--- a/apps/notifications/src/panel/templates/filters.js
+++ b/apps/notifications/src/panel/templates/filters.js
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { store } from '../state';
 import getNoteIsRead from '../state/selectors/get-is-note-read';
 
@@ -5,90 +6,49 @@ const Filters = {
 	all: {
 		name: 'all',
 		index: 0,
-		label: ( translate ) =>
-			translate( 'All', {
-				comment: "Notifications filter: all of a users' notifications",
-			} ),
-		emptyMessage: ( translate ) =>
-			translate( 'No notifications yet.', {
-				comment: 'Notifications all filter: no notifications',
-			} ),
-		emptyLinkMessage: ( translate ) =>
-			translate( 'Get active! Comment on posts from blogs you follow.', {
-				comment: 'Notifications all filter: no notifications',
-			} ),
+		label: __( 'All' ),
+		emptyMessage: __( 'No notifications yet.' ),
+		emptyLinkMessage: __( 'Get active! Comment on posts from blogs you follow.' ),
 		emptyLink: 'https://wordpress.com/reader/',
 		filter: () => true,
 	},
 	unread: {
 		name: 'unread',
 		index: 1,
-		label: ( translate ) =>
-			translate( 'Unread', {
-				comment: 'Notifications filter: unread notifications',
-			} ),
-		emptyMessage: ( translate ) =>
-			translate( "You're all caught up!", {
-				comment: 'Notifications unread filter: no notifications',
-			} ),
-		emptyLinkMessage: ( translate ) =>
-			translate( 'Reignite the conversation: write a new post.', {
-				comment: 'Notifications unread filter: no notifications',
-			} ),
+		label: __( 'Unread' ),
+		emptyMessage: __( "You're all caught up!" ),
+		emptyLinkMessage: __( 'Reignite the conversation: write a new post.' ),
 		emptyLink: 'https://wordpress.com/post/',
 		filter: ( note ) => ! getNoteIsRead( store.getState(), note ),
 	},
 	comments: {
 		name: 'comments',
 		index: 2,
-		label: ( translate ) =>
-			translate( 'Comments', {
-				comment: 'Notifications filter: comment notifications',
-			} ),
-		emptyMessage: ( translate ) =>
-			translate( 'No new comments yet!', {
-				comment: 'Notifications comments filter: no notifications',
-			} ),
-		emptyLinkMessage: ( translate ) =>
-			translate( 'Join a conversation: search for blogs that share your interests in the Reader.', {
-				comment: 'Notifications comments filter: no notifications',
-			} ),
+		label: __( 'Comments' ),
+		emptyMessage: __( 'No new comments yet!' ),
+		emptyLinkMessage: __(
+			'Join a conversation: search for blogs that share your interests in the Reader.'
+		),
 		emptyLink: 'https://wordpress.com/reader/search/',
 		filter: ( { type } ) => 'comment' === type,
 	},
 	follows: {
 		name: 'follows',
 		index: 3,
-		label: ( translate ) =>
-			translate( 'Subscribers', {
-				comment: 'Notifications filter: notifications about users subscribing to your blogs',
-			} ),
-		emptyMessage: ( translate ) =>
-			translate( 'No new subscribers to report yet.', {
-				comment: 'Notifications subscribers filter: no notifications',
-			} ),
-		emptyLinkMessage: ( translate ) =>
-			translate( "Get noticed: comment on posts you've read.", {
-				comment: 'Notifications subscribers filter: no notifications',
-			} ),
+		label: __( 'Subscribers' ),
+		emptyMessage: __( 'No new subscribers to report yet.' ),
+		emptyLinkMessage: __( 'Get noticed: comment on posts you’ve read.' ),
 		emptyLink: 'https://wordpress.com/activities/likes/',
 		filter: ( { type } ) => 'follow' === type,
 	},
 	likes: {
 		name: 'likes',
 		index: 4,
-		label: ( translate ) =>
-			translate( 'Likes', {
-				comment: 'Notifications filter: notifications about users liking your posts or comments',
-			} ),
-		emptyMessage: ( translate ) =>
-			translate( 'No new likes to show yet.', {
-				comment: 'Notifications likes filter: no Notifications',
-			} ),
-		emptyLinkMessage: ( translate ) =>
-			translate( "Get noticed: comment on posts you've read.", {
-				comment: 'Notifications likes filter: no Notifications',
-			} ),
+		label: __( 'Likes', {
+			comment: 'Notifications filter: notifications about users liking your posts or comments',
+		} ),
+		emptyMessage: __( 'No new likes to show yet.' ),
+		emptyLinkMessage: __( 'Get noticed: comment on posts you‘ve read.' ),
 		emptyLink: 'https://wordpress.com/activities/likes/',
 		filter: ( { type } ) => 'comment_like' === type || 'like' === type,
 	},

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -364,9 +364,9 @@ export class NoteList extends Component {
 		} else if ( ! this.props.initialLoad && emptyNoteList && filter.emptyMessage ) {
 			notes = (
 				<EmptyMessage
-					emptyMessage={ filter.emptyMessage( translate ) }
+					emptyMessage={ filter.emptyMessage }
 					height={ this.props.height }
-					linkMessage={ filter.emptyLinkMessage( translate ) }
+					linkMessage={ filter.emptyLinkMessage }
 					link={ filter.emptyLink }
 					name={ filter.name }
 					showing={ this.props.isPanelOpen }

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -10,7 +10,7 @@ import getIsPanelOpen from '../state/selectors/get-is-panel-open';
 import getSelectedNoteId from '../state/selectors/get-selected-note-id';
 import EmptyMessage from './empty-message';
 import FilterBar from './filter-bar';
-import Filters from './filters';
+import { getFilters } from './filters';
 import ListHeader from './list-header';
 import Note from './note';
 import Spinner from './spinner';
@@ -354,7 +354,7 @@ export class NoteList extends Component {
 
 		const emptyNoteList = 0 === notes.length;
 
-		const filter = Filters[ this.props.filterName ];
+		const filter = getFilters()[ this.props.filterName ];
 		const loadingIndicatorVisibility = { opacity: 0 };
 		if ( this.props.isLoading ) {
 			loadingIndicatorVisibility.opacity = 1;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Filter the notes by the active tab

<img width="495" height="767" alt="image" src="https://github.com/user-attachments/assets/4cc7fb61-5180-41a1-bf88-0b5451d3dafa" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notifications
* Select any tab
* Ensure the notes are filtered by the selected tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
