### PR TITLE
A4A: Implement schedule call for Pressable migrations & minor UI fixes

### DIFF
--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -39,7 +39,7 @@ export default function PressablePremiumPlanMigrationBanner( {
 
 	const handleReferClient = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace', {
+			recordTracksEvent( 'calypso_a4a_pressable_premium_plan_migration_banner_refer_client', {
 				source,
 			} )
 		);
@@ -47,7 +47,7 @@ export default function PressablePremiumPlanMigrationBanner( {
 
 	const handleChatToUs = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace', {
+			recordTracksEvent( 'calypso_a4a_pressable_premium_plan_migration_banner_chat_to_us', {
 				source,
 			} )
 		);

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -1,10 +1,11 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { Icon, chevronDown } from '@wordpress/icons';
+import { Icon, chevronDown, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
 import {
 	PRESSABLE_PREMIUM_PLAN_COMMISSION_PERCENTAGE,
 	PRESSABLE_PREMIUM_PLAN_COMMISSION_AMOUNT,
@@ -32,6 +33,8 @@ export default function PressablePremiumPlanMigrationBanner( {
 
 	const showMigrationIncentive = useShowMigrationIncentive();
 
+	const { scheduleCall, isLoading } = useScheduleCall();
+
 	const handleReferClient = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace' )
@@ -42,8 +45,8 @@ export default function PressablePremiumPlanMigrationBanner( {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace' )
 		);
-		// TODO: Add chat to us logic
-	}, [ dispatch ] );
+		scheduleCall();
+	}, [ dispatch, scheduleCall ] );
 
 	const buttons = (
 		<>
@@ -54,7 +57,16 @@ export default function PressablePremiumPlanMigrationBanner( {
 			>
 				{ translate( 'Refer client now' ) }
 			</Button>
-			<Button variant="secondary" onClick={ handleChatToUs }>
+			<Button
+				className="pressable-premium-plan-migration__chat-to-us-button"
+				variant="secondary"
+				icon={ external }
+				iconPosition="right"
+				iconSize={ 16 }
+				onClick={ handleChatToUs }
+				isBusy={ isLoading }
+				disabled={ isLoading }
+			>
 				{ translate( 'Chat to us about this offer' ) }
 			</Button>
 		</>

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -19,8 +19,10 @@ import './style.scss';
 
 export default function PressablePremiumPlanMigrationBanner( {
 	isCollapsable = true,
+	source,
 }: {
 	isCollapsable?: boolean;
+	source: string;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -37,16 +39,20 @@ export default function PressablePremiumPlanMigrationBanner( {
 
 	const handleReferClient = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace' )
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace', {
+				source,
+			} )
 		);
-	}, [ dispatch ] );
+	}, [ dispatch, source ] );
 
 	const handleChatToUs = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace' )
+			recordTracksEvent( 'calypso_a4a_marketplace_hosting_premium_refer_form_back_to_marketplace', {
+				source,
+			} )
 		);
 		scheduleCall();
-	}, [ dispatch, scheduleCall ] );
+	}, [ dispatch, scheduleCall, source ] );
 
 	const buttons = (
 		<>

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/style.scss
@@ -166,3 +166,7 @@
 		transform: rotate(180deg);
 	}
 }
+
+.pressable-premium-plan-migration__chat-to-us-button.components-button.has-icon.has-text {
+	justify-content: center;
+}

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
@@ -1,9 +1,10 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Card, Button } from '@wordpress/components';
-import { close } from '@wordpress/icons';
+import { close, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
 import { PRESSABLE_PREMIUM_PLAN_COMMISSION_AMOUNT } from 'calypso/a8c-for-agencies/sections/marketplace/lib/constants';
 import PressableWooMigrationIcon from 'calypso/assets/images/a8c-for-agencies/pressable-woo-migration-icon.svg';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -25,6 +26,8 @@ export default function PressablePremiumPlanMigrationCard() {
 
 	const showMigrationIncentive = useShowMigrationIncentive();
 
+	const { scheduleCall, isLoading } = useScheduleCall();
+
 	const onDismiss = useCallback( () => {
 		dispatch(
 			recordTracksEvent(
@@ -44,8 +47,8 @@ export default function PressablePremiumPlanMigrationCard() {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_overview_pressable_premium_plan_migration_card_chat_click' )
 		);
-		// TODO: Add chat to us logic
-	}, [ dispatch ] );
+		scheduleCall();
+	}, [ dispatch, scheduleCall ] );
 
 	if ( isDismissed || ! showMigrationIncentive ) {
 		return null;
@@ -86,13 +89,22 @@ export default function PressablePremiumPlanMigrationCard() {
 
 				<div className="pressable-premium-plan-migration-card__buttons">
 					<Button
-						className="is-light"
+						className="is-light pressable-premium-plan-migration-card__primary-button"
 						href={ A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK }
 						onClick={ handleReferClient }
 					>
 						{ translate( 'Refer client now' ) }
 					</Button>
-					<Button className="is-light" variant="secondary" onClick={ handleChatToUs }>
+					<Button
+						className="is-light pressable-premium-plan-migration-card__chat-to-us-button"
+						variant="secondary"
+						icon={ external }
+						iconPosition="right"
+						iconSize={ 16 }
+						onClick={ handleChatToUs }
+						isBusy={ isLoading }
+						disabled={ isLoading }
+					>
 						{ translate( 'Chat to us about this offer' ) }
 					</Button>
 				</div>

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
@@ -85,15 +85,13 @@ export default function PressablePremiumPlanMigrationCard() {
 				</div>
 
 				<div className="pressable-premium-plan-migration-card__buttons">
-					<div className="pressable-premium-plan-migration-card__primary-button">
-						<Button
-							className="is-light"
-							href={ A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK }
-							onClick={ handleReferClient }
-						>
-							{ translate( 'Refer client now' ) }
-						</Button>
-					</div>
+					<Button
+						className="is-light"
+						href={ A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK }
+						onClick={ handleReferClient }
+					>
+						{ translate( 'Refer client now' ) }
+					</Button>
 					<Button className="is-light" variant="secondary" onClick={ handleChatToUs }>
 						{ translate( 'Chat to us about this offer' ) }
 					</Button>

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
@@ -14,6 +14,8 @@ $pressable-card-background: #050C29;
 
 .pressable-premium-plan-migration-card__primary-button {
 	color: $pressable-card-background;
+	flex: 1;
+	min-width: 200px;
 }
 
 .pressable-premium-plan-migration-card__content {
@@ -25,10 +27,11 @@ $pressable-card-background: #050C29;
 .pressable-premium-plan-migration-card__buttons {
 	display: flex;
 	gap: 12px;
-	flex-direction: column;
+	flex-direction: row;
+	flex-wrap: wrap;
 
-	@include break-medium {
-		flex-direction: row;
+	svg {
+		min-width: 16px;
 	}
 }
 
@@ -48,6 +51,8 @@ $pressable-card-background: #050C29;
 	text-wrap: balance;
 }
 
-.is-light svg {
-	fill: var(--color-text-white);
+.pressable-premium-plan-migration-card__chat-to-us-button.components-button.has-icon.has-text {
+	justify-content: center;
+	flex: 1;
+	min-width: 200px;
 }

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
@@ -51,3 +51,7 @@ $pressable-card-background: #050C29;
 .is-light svg {
 	fill: var(--color-text-white);
 }
+
+.is-light svg {
+	fill: var(--color-text-white);
+}

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/style.scss
@@ -51,7 +51,3 @@ $pressable-card-background: #050C29;
 .is-light svg {
 	fill: var(--color-text-white);
 }
-
-.is-light svg {
-	fill: var(--color-text-white);
-}

--- a/client/a8c-for-agencies/hooks/use-schedule-call.ts
+++ b/client/a8c-for-agencies/hooks/use-schedule-call.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+import useFetchScheduleCallLink from 'calypso/a8c-for-agencies/data/agencies/use-fetch-schedule-call-link';
+
+const DEFAULT_FALLBACK_URL =
+	'https://meetings.hubspot.com/automattic-for-agencies/discovery-meeting';
+
+type UseScheduleCallOptions = {
+	onSuccess?: () => void;
+	onError?: ( error: Error ) => void;
+};
+
+type UseScheduleCallReturn = {
+	scheduleCall: () => Promise< void >;
+	isLoading: boolean;
+};
+
+/**
+ * A reusable hook for scheduling calls that handles fetching the schedule call link
+ * and opening it in a new window with proper fallback handling.
+ */
+export default function useScheduleCall(
+	options: UseScheduleCallOptions = {}
+): UseScheduleCallReturn {
+	const { onSuccess, onError } = options;
+
+	const { refetch: fetchScheduleCallLink, isFetching } = useFetchScheduleCallLink();
+
+	const scheduleCall = useCallback( async () => {
+		try {
+			const result = await fetchScheduleCallLink();
+			const url = result.data || DEFAULT_FALLBACK_URL;
+
+			window.open( url, '_blank' );
+			onSuccess?.();
+		} catch ( error ) {
+			// If the API call fails, still open the fallback URL
+			window.open( DEFAULT_FALLBACK_URL, '_blank' );
+			onError?.( error instanceof Error ? error : new Error( 'Unknown error occurred' ) );
+		}
+	}, [ fetchScheduleCallLink, onSuccess, onError ] );
+
+	return {
+		scheduleCall,
+		isLoading: isFetching,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
@@ -86,7 +86,7 @@ export function HeroSection(
 						)
 					) }
 				</div>
-				<PressablePremiumPlanMigrationBanner />
+				<PressablePremiumPlanMigrationBanner source="hosting-overview" />
 			</div>
 
 			<ul className="hosting-hero-section__tabs">{ navItems }</ul>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -1,8 +1,11 @@
 import { formatCurrency } from '@automattic/number-formatters';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
 import { PRESSABLE_PREMIUM_PLAN_COMMISSION_PERCENTAGE } from 'calypso/a8c-for-agencies/sections/marketplace/lib/constants';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import { useDispatch } from 'calypso/state';
@@ -19,6 +22,10 @@ export default function PremiumPlanSection( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const isDesktop = useBreakpoint( '>1280px' );
+
+	const { scheduleCall, isLoading } = useScheduleCall();
+
 	const onReferNowClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_premium_refer_now_click' )
@@ -29,7 +36,7 @@ export default function PremiumPlanSection( {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_premium_talk_to_us_click' )
 		);
-		// TODO: Add chat to us logic
+		scheduleCall();
 	};
 
 	return (
@@ -63,15 +70,18 @@ export default function PremiumPlanSection( {
 
 						<Button
 							className="premium-plan-section__cta-button"
-							href="https://wpvip.com/get-a-demo/?utm_source=partner&utm_medium=referral&utm_campaign=a4a"
 							onClick={ onTalkToUsClick }
-							target="_blank"
 							variant="secondary"
+							icon={ external }
 							iconPosition="right"
 							iconSize={ 16 }
 							__next40pxDefaultSize
+							isBusy={ isLoading }
+							disabled={ isLoading }
 						>
-							{ translate( 'Buying for your agency? Talk to us' ) }
+							{ isDesktop
+								? translate( 'Buying for your agency? Talk to us' )
+								: translate( 'For your agency? Talk to us' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -81,6 +81,10 @@
 	}
 }
 
+.premium-plan-section__cta-button.components-button.has-icon.has-text {
+	justify-content: center;
+}
+
 .premium-plan-section__two-columns-list {
 	display: grid;
 

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
@@ -20,7 +20,7 @@ export default function MigrationsBanner() {
 			) }
 			background={ BackgroundType5 }
 		>
-			<PressablePremiumPlanMigrationBanner isCollapsable={ false } />
+			<PressablePremiumPlanMigrationBanner isCollapsable={ false } source="migrations-overview" />
 			<div />
 		</PageSection>
 	);

--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta.tsx
@@ -3,7 +3,7 @@ import { external, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import useFetchScheduleCallLink from 'calypso/a8c-for-agencies/data/agencies/use-fetch-schedule-call-link';
+import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -21,23 +21,15 @@ export default function OverviewSidebarGrowthAcceleratorCta( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { refetch: fetchScheduleCallLink, isFetching: isFetchingScheduleCallLink } =
-		useFetchScheduleCallLink();
+	const { scheduleCall, isLoading: isFetchingScheduleCallLink } = useScheduleCall( {
+		onSuccess: onRequestSuccess,
+	} );
 
 	const onRequestCallClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_overview_growth_accelerator_schedule_call_click' ) );
 		dispatch( savePreference( GROWTH_ACCELERATOR_REQUESTED_PREFERENCE, true ) );
-
-		fetchScheduleCallLink().then( ( result ) => {
-			onRequestSuccess?.();
-			window.open(
-				result.data
-					? result.data
-					: 'https://meetings.hubspot.com/automattic-for-agencies/discovery-meeting',
-				'_blank'
-			);
-		} );
-	}, [ dispatch, fetchScheduleCallLink, onRequestSuccess ] );
+		scheduleCall();
+	}, [ dispatch, scheduleCall ] );
 
 	return (
 		<Button

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -220,7 +220,7 @@
 
 	.components-button.is-light {
 		background-color: var(--color-text-white);
-		color: inherit;
+		color: initial;
 
 		&:focus {
 			box-shadow: 0 0 0 2px var(--color-primary-light);
@@ -229,6 +229,18 @@
 		&.is-secondary, &.is-link {
 			color: var(--color-text-white);
 			background-color: transparent;
+		}
+
+		svg {
+			fill: var(--color-text-white);
+		}
+
+		&.is-busy {
+			color: var(--color-text);
+
+			svg {
+				fill: var(--color-text);
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1506/implement-action-for-chat-to-us-about-this-offer

## Proposed Changes

This PR:
 
* Implements scheduling a call for Pressable migrations
* Does minor UI fixes

## Testing Instructions

* Open the A4A live link
* Go to Overview > Click the "Chat to us about this offer" button on the card > Verify you are redirected to the meeting scheduler in a new tab.

<img width="506" height="329" alt="Screenshot 2025-08-26 at 8 06 53 PM" src="https://github.com/user-attachments/assets/dc5e75d5-9024-4cf0-9fc1-227cfe1a6bc3" />

* Click the "Schedule a call" button on the "Accelerate your agency’s growth" option on the Overview page > Verify you are redirected to the meeting scheduler in a new tab.

<img width="506" height="215" alt="Screenshot 2025-08-26 at 8 08 47 PM" src="https://github.com/user-attachments/assets/22bf709f-717b-4e6b-b135-dd5023ea0da2" />

* Go to Marketplace > Click the "Chat to us about this offer" button on the banner on the hosting page > Verify you are redirected to the meeting scheduler in a new tab.

<img width="1526" height="469" alt="Screenshot 2025-08-26 at 8 09 10 PM" src="https://github.com/user-attachments/assets/4068fad2-78ee-4d3f-aa29-047b7df32534" />

* Go to Premier Agency Hosting > Click the "Premium Plans" > Click the "Buying for your agency? Talk to us" button > Verify you are redirected to the meeting scheduler in a new tab.
* Switch to a small screen > Verify the button text is updated from "Buying for your agency? Talk to us" to "For your agency? Talk to us"

<img width="238" height="265" alt="Screenshot 2025-08-26 at 8 10 23 PM" src="https://github.com/user-attachments/assets/b582fd44-f25d-4053-948b-53c6479eb06b" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
