### PR TITLE
Domains: Overview: Create "Site" featured card

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,15 +1,21 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { siteByIdQuery } from '../../app/queries/site';
 import { Domain } from '../../data/domain';
-import { Site } from '../../data/site';
 import OverviewCard from '../../sites/overview-card';
 import SiteIcon from '../../sites/site-icon';
 
 interface Props {
 	domain: Domain;
-	site: Site;
 }
 
-export default function FeaturedCardSite( { domain, site }: Props ) {
+export default function FeaturedCardSite( { domain }: Props ) {
+	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
+
+	if ( ! site ) {
+		return null;
+	}
+
 	return (
 		<OverviewCard
 			title={ __( 'Site' ) }

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -14,7 +14,7 @@ export default function FeaturedCardSite( { domain, site }: Props ) {
 		<OverviewCard
 			title={ __( 'Site' ) }
 			heading={ <span style={ { wordBreak: 'break-all' } }>{ site.name }</span> }
-			externalLink={ site.URL }
+			link={ `/sites/${ site.slug }` }
 			icon={ <SiteIcon site={ site } /> }
 			description={ domain.domain }
 		/>

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function FeaturedCardSite( { domain, site }: Props ) {
 	return (
 		<OverviewCard
-			title={ __( 'Site' ).toUpperCase() }
+			title={ __( 'Site' ) }
 			heading={ site.name }
 			link={ site.URL }
 			icon={ <SiteIcon site={ site } /> }

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -13,8 +13,8 @@ export default function FeaturedCardSite( { domain, site }: Props ) {
 	return (
 		<OverviewCard
 			title={ __( 'Site' ) }
-			heading={ site.name }
-			link={ site.URL }
+			heading={ <span style={ { wordBreak: 'break-all' } }>{ site.name }</span> }
+			externalLink={ site.URL }
 			icon={ <SiteIcon site={ site } /> }
 			description={ domain.domain }
 		/>

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import { Domain } from '../../data/domain';
+import { Site } from '../../data/site';
+import OverviewCard from '../../sites/overview-card';
+import SiteIcon from '../../sites/site-icon';
+
+interface Props {
+	domain: Domain;
+	site: Site;
+}
+
+export default function FeaturedCardSite( { domain, site }: Props ) {
+	return (
+		<OverviewCard
+			title={ __( 'Site' ).toUpperCase() }
+			heading={ site.name }
+			link={ site.URL }
+			icon={ <SiteIcon site={ site } /> }
+			description={ domain.domain }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -1,7 +1,6 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
-import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
 import FeaturedCardRenew from './featured-card-renew';
 import FeaturedCardSite from './featured-card-site';
@@ -9,12 +8,11 @@ import FeaturedCardSite from './featured-card-site';
 export default function FeaturedCards() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
 
 	return (
 		<Grid columns={ 2 }>
 			<FeaturedCardRenew domain={ domain } />
-			{ site && <FeaturedCardSite domain={ domain } site={ site } /> }
+			<FeaturedCardSite domain={ domain } />
 		</Grid>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -1,16 +1,20 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
+import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
 import FeaturedCardRenew from './featured-card-renew';
+import FeaturedCardSite from './featured-card-site';
 
 export default function FeaturedCards() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 
 	return (
 		<Grid columns={ 2 }>
 			<FeaturedCardRenew domain={ domain } />
+			{ site && <FeaturedCardSite domain={ domain } site={ site } /> }
 		</Grid>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
 import { siteByIdQuery } from '../../app/queries/site';
@@ -9,7 +9,7 @@ import FeaturedCardSite from './featured-card-site';
 export default function FeaturedCards() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
+	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
 
 	return (
 		<Grid columns={ 2 }>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,5 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -19,7 +19,7 @@ export default function DomainOverview() {
 	const locale = useLocale();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: purchase } = useQuery(
+	const { data: purchase } = useSuspenseQuery(
 		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
 	);
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Proposed Changes

* Creates Site featured card

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

[DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Testing Instructions

* Go to /v2/doamins
* Select a domain
* Check the featured card segment

<img width="691" height="354" alt="Screenshot 2025-08-26 at 17 04 08" src="https://github.com/user-attachments/assets/4f01e86c-9df8-4b91-ba28-81cc7646c923" />

<img width="685" height="329" alt="Screenshot 2025-08-26 at 17 06 09" src="https://github.com/user-attachments/assets/38ef699a-5993-4e40-b09b-a582fb2359e2" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
