### PR TITLE
Domains: Overview: Create "Emails" featured card

### DIFF
--- a/client/dashboard/app/queries/emails.ts
+++ b/client/dashboard/app/queries/emails.ts
@@ -11,5 +11,4 @@ export const mailboxesQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'mailboxes', siteId ],
 		queryFn: () => fetchMailboxes( siteId ),
-		select: ( data ) => data.mailboxes,
 	} );

--- a/client/dashboard/app/queries/emails.ts
+++ b/client/dashboard/app/queries/emails.ts
@@ -1,8 +1,15 @@
 import { queryOptions } from '@tanstack/react-query';
-import { fetchEmails } from '../../data/emails';
+import { fetchEmails, fetchMailboxes } from '../../data/emails';
 
 export const emailsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'emails' ],
 		queryFn: fetchEmails,
+	} );
+
+export const mailboxesQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'mailboxes', siteId ],
+		queryFn: () => fetchMailboxes( siteId ),
+		select: ( data ) => data.mailboxes,
 	} );

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -13,6 +13,7 @@ import { domainGlueRecordsQuery } from '../queries/domain-glue-records';
 import { domainNameServersQuery } from '../queries/domain-name-servers';
 import { sslDetailsQuery } from '../queries/domain-ssl';
 import { domainsQuery } from '../queries/domains';
+import { mailboxesQuery } from '../queries/emails';
 import { queryClient } from '../query-client';
 import { rootRoute } from './root';
 
@@ -71,6 +72,12 @@ export const domainRoute = createRoute( {
 export const domainOverviewRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: '/',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const mailboxes = await queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) );
+
+		return { domain, mailboxes };
+	},
 } ).lazy( () =>
 	import( '../../domains/domain-overview' ).then( ( d ) =>
 		createLazyRoute( 'domain-overview' )( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -75,8 +75,10 @@ export const domainOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
-		const site = await queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
-		const mailboxes = await queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) );
+		const [ site, mailboxes ] = await Promise.all( [
+			queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) ),
+			queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) ),
+		] );
 
 		return { domain, site, mailboxes };
 	},

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -14,6 +14,7 @@ import { domainNameServersQuery } from '../queries/domain-name-servers';
 import { sslDetailsQuery } from '../queries/domain-ssl';
 import { domainsQuery } from '../queries/domains';
 import { mailboxesQuery } from '../queries/emails';
+import { siteByIdQuery } from '../queries/site';
 import { queryClient } from '../query-client';
 import { rootRoute } from './root';
 
@@ -74,9 +75,10 @@ export const domainOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const site = await queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
 		const mailboxes = await queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) );
 
-		return { domain, mailboxes };
+		return { domain, site, mailboxes };
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-overview' ).then( ( d ) =>

--- a/client/dashboard/data/emails.ts
+++ b/client/dashboard/data/emails.ts
@@ -148,9 +148,11 @@ export async function fetchEmail( id: string ): Promise< Email | undefined > {
 	return Promise.resolve( findEmailById( id ) );
 }
 
-export function fetchMailboxes( siteId: number ): Promise< { mailboxes: Mailbox[] } > {
-	return wpcom.req.get( {
-		path: `/sites/${ siteId }/emails/mailboxes`,
-		apiNamespace: 'wpcom/v2',
-	} );
+export function fetchMailboxes( siteId: number ): Promise< Mailbox[] > {
+	return wpcom.req
+		.get( {
+			path: `/sites/${ siteId }/emails/mailboxes`,
+			apiNamespace: 'wpcom/v2',
+		} )
+		.then( ( data: { mailboxes: Mailbox[] } ) => data.mailboxes );
 }

--- a/client/dashboard/data/emails.ts
+++ b/client/dashboard/data/emails.ts
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
-export type EmailProvider = 'titan' | 'google_workspace' | 'forwarding';
+export type EmailProvider = 'titan' | 'google_workspace' | 'email_forwarding';
 
 export interface Mailbox {
 	account_type: EmailProvider;
@@ -71,7 +71,7 @@ export const EMAIL_DATA: Email[] = [
 		id: '4',
 		emailAddress: 'contact@creative-portfolio.design',
 		type: 'forwarding',
-		provider: 'forwarding',
+		provider: 'email_forwarding',
 		providerDisplayName: 'Email Forwarding',
 		domainName: 'creative-portfolio.design',
 		siteId: '3',
@@ -84,7 +84,7 @@ export const EMAIL_DATA: Email[] = [
 		id: '5',
 		emailAddress: 'jobs@mybusiness.store',
 		type: 'forwarding',
-		provider: 'forwarding',
+		provider: 'email_forwarding',
 		providerDisplayName: 'Email Forwarding',
 		domainName: 'mybusiness.store',
 		siteId: '2',
@@ -97,7 +97,7 @@ export const EMAIL_DATA: Email[] = [
 		id: '6',
 		emailAddress: 'newsletter@myblog.com',
 		type: 'forwarding',
-		provider: 'forwarding',
+		provider: 'email_forwarding',
 		providerDisplayName: 'Email Forwarding',
 		domainName: 'myblog.com',
 		siteId: '1',

--- a/client/dashboard/data/emails.ts
+++ b/client/dashboard/data/emails.ts
@@ -1,4 +1,12 @@
-export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';
+import wpcom from 'calypso/lib/wp';
+export type EmailProvider = 'titan' | 'google_workspace' | 'forwarding';
+
+export interface Mailbox {
+	account_type: EmailProvider;
+	domain: string;
+	last_access_time: string | null;
+	mailbox: string;
+}
 
 export interface Email {
 	id: string;
@@ -49,7 +57,7 @@ export const EMAIL_DATA: Email[] = [
 		id: '3',
 		emailAddress: 'billing@mybusiness.store',
 		type: 'mailbox',
-		provider: 'google-workspace',
+		provider: 'google_workspace',
 		providerDisplayName: 'Google Workspace',
 		domainName: 'mybusiness.store',
 		siteId: '2',
@@ -102,7 +110,7 @@ export const EMAIL_DATA: Email[] = [
 		id: '7',
 		emailAddress: 'admin@mybusiness.store',
 		type: 'mailbox',
-		provider: 'google-workspace',
+		provider: 'google_workspace',
 		providerDisplayName: 'Google Workspace',
 		domainName: 'mybusiness.store',
 		siteId: '2',
@@ -138,4 +146,11 @@ export function findEmailById( id: string ): Email | undefined {
 
 export async function fetchEmail( id: string ): Promise< Email | undefined > {
 	return Promise.resolve( findEmailById( id ) );
+}
+
+export function fetchMailboxes( siteId: number ): Promise< { mailboxes: Mailbox[] } > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/emails/mailboxes`,
+		apiNamespace: 'wpcom/v2',
+	} );
 }

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,0 +1,44 @@
+import { Icon } from '@wordpress/components';
+import { __, _n } from '@wordpress/i18n';
+import { envelope } from '@wordpress/icons';
+import { Domain } from '../../data/domain';
+import OverviewCard from '../../sites/overview-card';
+import type { Mailbox, EmailProvider } from '../../data/emails';
+
+const getAccountTypeLabel = ( accountType: EmailProvider ) => {
+	switch ( accountType ) {
+		case 'google_workspace':
+			return __( 'Google Workspace' );
+		case 'forwarding':
+			return __( 'Forwarding' );
+		case 'titan':
+		default:
+			return __( 'Professional Email' );
+	}
+};
+
+interface Props {
+	domain: Domain;
+	mailboxes: Mailbox[];
+}
+
+export default function FeaturedCardEmails( { domain, mailboxes }: Props ) {
+	const description =
+		mailboxes.length > 1
+			? // translators: %d is the number of additional mailboxes.
+			  _n( '+ one more mailbox', '+ %d more mailboxes', mailboxes.length - 1 )
+			: getAccountTypeLabel( mailboxes[ 0 ].account_type );
+
+	return (
+		<OverviewCard
+			title={ __( 'Emails' ) }
+			heading={
+				<span style={ { wordBreak: 'break-all' } }>
+					{ `${ mailboxes[ 0 ].mailbox }@${ domain.domain }` }
+				</span>
+			}
+			icon={ <Icon icon={ envelope } /> }
+			description={ description }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -9,8 +9,8 @@ const getAccountTypeLabel = ( accountType: EmailProvider ) => {
 	switch ( accountType ) {
 		case 'google_workspace':
 			return __( 'Google Workspace' );
-		case 'forwarding':
-			return __( 'Forwarding' );
+		case 'email_forwarding':
+			return __( 'Email Forwarding' );
 		case 'titan':
 		default:
 			return __( 'Professional Email' );

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/components';
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 import { Domain } from '../../data/domain';
 import OverviewCard from '../../sites/overview-card';
@@ -23,10 +23,16 @@ interface Props {
 }
 
 export default function FeaturedCardEmails( { domain, mailboxes }: Props ) {
+	const additionalMailboxes = mailboxes.length - 1;
+
 	const description =
-		mailboxes.length > 1
-			? // translators: %d is the number of additional mailboxes.
-			  _n( '+ one more mailbox', '+ %d more mailboxes', mailboxes.length - 1 )
+		additionalMailboxes > 0
+			? // eslint-disable-next-line @wordpress/valid-sprintf
+			  sprintf(
+					// translators: %d is the number of additional mailboxes.
+					_n( '+ one more mailbox', '+ %d more mailboxes', additionalMailboxes ),
+					additionalMailboxes
+			  )
 			: getAccountTypeLabel( mailboxes[ 0 ].account_type );
 
 	return (

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,10 +1,12 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
+import { mailboxesQuery } from '../../app/queries/emails';
 import { emailsRoute } from '../../app/router/emails';
 import { Domain } from '../../data/domain';
 import OverviewCard from '../../sites/overview-card';
-import type { Mailbox, EmailProvider } from '../../data/emails';
+import type { EmailProvider, Mailbox } from '../../data/emails';
 
 const getAccountTypeLabel = ( accountType: EmailProvider ) => {
 	switch ( accountType ) {
@@ -28,30 +30,37 @@ const getAdditionlMailboxesLabel = ( count: number ) => {
 		  );
 };
 
-interface Props {
-	domain: Domain;
-	mailboxes: Mailbox[];
-}
-
-export default function FeaturedCardEmails( { domain, mailboxes }: Props ) {
+const getDescription = ( mailboxes: Mailbox[] ) => {
 	const additionalMailboxes = mailboxes.length - 1;
 
-	const description =
-		additionalMailboxes > 0
-			? getAdditionlMailboxesLabel( additionalMailboxes )
-			: getAccountTypeLabel( mailboxes[ 0 ].account_type );
+	if ( mailboxes.length === 0 ) {
+		return __( 'Add proffesional email' );
+	}
+
+	return additionalMailboxes > 0
+		? getAdditionlMailboxesLabel( additionalMailboxes )
+		: getAccountTypeLabel( mailboxes[ 0 ].account_type );
+};
+
+interface Props {
+	domain: Domain;
+}
+
+export default function FeaturedCardEmails( { domain }: Props ) {
+	const { data: mailboxes } = useSuspenseQuery( mailboxesQuery( domain.blog_id ) );
+
+	const email = mailboxes.length
+		? `${ mailboxes[ 0 ].mailbox }@${ domain.domain }`
+		: // translators: %s is the mailbox name: youremail@example.com
+		  sprintf( __( 'youremail@%s' ), domain.domain );
 
 	return (
 		<OverviewCard
 			title={ __( 'Emails' ) }
-			heading={
-				<span style={ { wordBreak: 'break-all' } }>
-					{ `${ mailboxes[ 0 ].mailbox }@${ domain.domain }` }
-				</span>
-			}
+			heading={ <span style={ { wordBreak: 'break-all' } }>{ email }</span> }
 			link={ emailsRoute.fullPath }
 			icon={ <Icon icon={ envelope } /> }
-			description={ description }
+			description={ getDescription( mailboxes ) }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -34,7 +34,7 @@ const getDescription = ( mailboxes: Mailbox[] ) => {
 	const additionalMailboxes = mailboxes.length - 1;
 
 	if ( mailboxes.length === 0 ) {
-		return __( 'Add proffesional email' );
+		return __( 'Add professional email' );
 	}
 
 	return additionalMailboxes > 0

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 import { Domain } from '../../data/domain';
 import OverviewCard from '../../sites/overview-card';
@@ -17,6 +17,16 @@ const getAccountTypeLabel = ( accountType: EmailProvider ) => {
 	}
 };
 
+const getAdditionlMailboxesLabel = ( count: number ) => {
+	return count === 1
+		? __( '+ one more mailbox' )
+		: sprintf(
+				// translators: %d is the number of additional mailboxes.
+				__( '+ %d more mailboxes' ),
+				count
+		  );
+};
+
 interface Props {
 	domain: Domain;
 	mailboxes: Mailbox[];
@@ -27,12 +37,7 @@ export default function FeaturedCardEmails( { domain, mailboxes }: Props ) {
 
 	const description =
 		additionalMailboxes > 0
-			? // eslint-disable-next-line @wordpress/valid-sprintf
-			  sprintf(
-					// translators: %d is the number of additional mailboxes.
-					_n( '+ one more mailbox', '+ %d more mailboxes', additionalMailboxes ),
-					additionalMailboxes
-			  )
+			? getAdditionlMailboxesLabel( additionalMailboxes )
 			: getAccountTypeLabel( mailboxes[ 0 ].account_type );
 
 	return (

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
+import { emailsRoute } from '../../app/router/emails';
 import { Domain } from '../../data/domain';
 import OverviewCard from '../../sites/overview-card';
 import type { Mailbox, EmailProvider } from '../../data/emails';
@@ -48,6 +49,7 @@ export default function FeaturedCardEmails( { domain, mailboxes }: Props ) {
 					{ `${ mailboxes[ 0 ].mailbox }@${ domain.domain }` }
 				</span>
 			}
+			link={ emailsRoute.fullPath }
 			icon={ <Icon icon={ envelope } /> }
 			description={ description }
 		/>

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
 import { domainRoute } from '../../app/router/domains';
+import FeaturedCardEmails from './featured-card-emails';
 import FeaturedCardRenew from './featured-card-renew';
 import FeaturedCardSite from './featured-card-site';
 
@@ -13,6 +14,7 @@ export default function FeaturedCards() {
 		<Grid columns={ 2 }>
 			<FeaturedCardRenew domain={ domain } />
 			<FeaturedCardSite domain={ domain } />
+			<FeaturedCardEmails domain={ domain } />
 		</Grid>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Proposed Changes

* Creates the Emails featured card

## Why are these changes being made?

[DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Testing Instructions

* Go to `/v2/doamins`
* Select a domain with a configured mailbox
* Check the featured card segment
* For domains without a configured mailbox, the card will be hidden.

<img width="698" height="363" alt="Screenshot 2025-08-26 at 19 06 04" src="https://github.com/user-attachments/assets/8117962c-9fd7-4359-b230-681e2f8a873d" />

<img width="343" height="198" alt="Screenshot 2025-08-26 at 19 14 59" src="https://github.com/user-attachments/assets/fbc234d7-3add-44b6-a9a4-5d6d032e66dc" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
