### PR TITLE
Notifications v2: fix dismissal behavior

### DIFF
--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -20,6 +20,9 @@ export default function NotePanelActions() {
 					dispatch( actions.ui.closeShortcutsPopover() );
 				}
 			} }
+			popoverProps={ {
+				focusOnMount: true,
+			} }
 		>
 			{ ( { onClose } ) =>
 				isShortcutsPopoverOpen ? (

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -9,7 +9,7 @@ import {
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
@@ -23,8 +23,16 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 
 const NotePanel = () => {
 	const [ activeTab, setActiveTab ] = useState< ActiveTab >( 'all' );
+
+	// Ensure the component is focused on mount
+	// to avoid parent's <Popover>'s focus trap from moving.
+	const focusRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		focusRef.current?.focus();
+	}, [] );
+
 	return (
-		<>
+		<div ref={ focusRef } tabIndex={ -1 }>
 			<CardHeader
 				size="small"
 				style={ { flexDirection: 'column', alignItems: 'stretch', paddingBottom: 0 } }
@@ -52,7 +60,7 @@ const NotePanel = () => {
 				</VStack>
 			</CardHeader>
 			<NoteList filterName={ activeTab } />
-		</>
+		</div>
 	);
 };
 

--- a/apps/notifications/src/app/note-shortcuts/index.tsx
+++ b/apps/notifications/src/app/note-shortcuts/index.tsx
@@ -1,5 +1,6 @@
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useRef, useEffect } from 'react';
 
 import './style.scss';
 
@@ -21,8 +22,15 @@ function Shortcut( { letter, title }: { letter: string; title: string } ) {
 }
 
 export default function NoteShortcuts() {
+	// Ensure the component is focused on mount
+	// to avoid parent's <Popover>'s focus trap from moving.
+	const focusRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		focusRef.current?.focus();
+	}, [] );
+
 	return (
-		<div className="wpnc__keyboard-shortcuts-popover">
+		<div tabIndex={ -1 } ref={ focusRef } className="wpnc__keyboard-shortcuts-popover">
 			<Shortcut letter="n" title={ __( 'Toggle panel' ) } />
 			<Shortcut letter="↓" title={ __( 'Next' ) } />
 			<Shortcut letter="↑" title={ __( 'Previous' ) } />

--- a/apps/notifications/src/app/note-shortcuts/index.tsx
+++ b/apps/notifications/src/app/note-shortcuts/index.tsx
@@ -1,6 +1,5 @@
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useRef, useEffect } from 'react';
 
 import './style.scss';
 
@@ -22,15 +21,8 @@ function Shortcut( { letter, title }: { letter: string; title: string } ) {
 }
 
 export default function NoteShortcuts() {
-	// Ensure the component has a focused wrapper container
-	// so that event handlers work when it is rendered inside a <Popover>.
-	const focusRef = useRef< HTMLDivElement >( null );
-	useEffect( () => {
-		focusRef.current?.focus();
-	}, [] );
-
 	return (
-		<div tabIndex={ -1 } ref={ focusRef } className="wpnc__keyboard-shortcuts-popover">
+		<div className="wpnc__keyboard-shortcuts-popover">
 			<Shortcut letter="n" title={ __( 'Toggle panel' ) } />
 			<Shortcut letter="↓" title={ __( 'Next' ) } />
 			<Shortcut letter="↑" title={ __( 'Previous' ) } />

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -12,6 +12,7 @@ import {
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
@@ -75,12 +76,19 @@ const Note = () => {
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
 
+	// Ensure the component is focused on mount
+	// to avoid parent's <Popover>'s focus trap from moving.
+	const focusRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		focusRef.current?.focus();
+	}, [] );
+
 	if ( ! note ) {
 		return null;
 	}
 
 	return (
-		<>
+		<div ref={ focusRef } tabIndex={ -1 }>
 			<CardHeader size="small">
 				<HStack>
 					<Navigator.BackButton
@@ -108,7 +116,7 @@ const Note = () => {
 			<CardFooter size="small">
 				<ActionBlock note={ note } />
 			</CardFooter>
-		</>
+		</div>
 	);
 };
 

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -35,6 +35,7 @@ export default function Notifications( { className }: { className: string } ) {
 			popoverProps={ {
 				placement: 'bottom-end',
 				offset: 8,
+				focusOnMount: true,
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button


### PR DESCRIPTION
## Proposed Changes

This PR fixes the current buggy behavior of notifications v2, where on the first JS load we can't dismiss the notification properly:

https://github.com/user-attachments/assets/7f38030b-bb4a-4425-af0a-cc6f202b9f18

The cause is a bit complicated; the underlying popover had no "tabbable" element so the dropdown has nowhere to focus.

The fix is to pas `focusOnMount: true` to the underlying popover so that it will focus on the container instead (as per the documentation).

### Navigating to a notification's detail

There is a tricky case where we click on a notification. Each notification in the DataViews is a `<button>`, on click, browser will focus on it, then the navigation will unmount it and render the notification detail. Therefore, the focus is lost and the `Popover` will be in a "broken" state without focus.

The fix is to always try to focus to the container when the notification detail component is mounted.

When we click the back button, it will navigate to the notification list with exactly the same problem, so we add this logic in the notification list as well.

## Why are these changes being made?

Fixes annoying bug.

## Testing Instructions

1. Open browser console.
2. Tick DISABLE CACHE.
3. Open /v2
4. Open notification by clicking the bell
5. Verify you cannot reproduce the above video (when you click outside, it should dismiss the popover)
6. This also includes the three-dot icon -> Keyboard shortcuts menu.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?