### PR TITLE
Domains: Overview: Create "Privacy" featured card

### DIFF
--- a/client/dashboard/data/domain.ts
+++ b/client/dashboard/data/domain.ts
@@ -17,6 +17,7 @@ export interface Domain extends DomainSummary {
 	is_subdomain: boolean;
 	move_to_new_site_pending: boolean;
 	private_domain: boolean;
+	privacy_available: boolean;
 	ssl_status: 'active' | 'inactive' | 'newly_registered' | 'pending';
 	subdomain_part: string;
 	auto_renewal_date: string;

--- a/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
@@ -1,3 +1,4 @@
+import { PRIVACY_PROTECTION } from '@automattic/urls';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
@@ -9,12 +10,18 @@ interface Props {
 }
 
 export default function FeaturedCardPrivacy( { domain }: Props ) {
+	const privacyWarning = __(
+		'Privacy protection is not available due to the registry’s policies.'
+	);
+	const privacyProtectionNote = domain.private_domain ? __( 'Enabled' ) : __( 'Disabled' );
+
 	return (
 		<OverviewCard
 			title={ __( 'Privacy' ) }
 			heading={ __( 'WHOIS Privacy' ) }
 			icon={ <Icon icon={ unseen } /> }
-			description={ domain.privacy_available ? __( 'Enabled' ) : __( 'Disabled' ) }
+			externalLink={ ! domain.privacy_available ? PRIVACY_PROTECTION : undefined }
+			description={ ! domain.private_domain ? privacyWarning : privacyProtectionNote }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
@@ -1,0 +1,20 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { unseen } from '@wordpress/icons';
+import { Domain } from '../../data/domain';
+import OverviewCard from '../../sites/overview-card';
+
+interface Props {
+	domain: Domain;
+}
+
+export default function FeaturedCardPrivacy( { domain }: Props ) {
+	return (
+		<OverviewCard
+			title={ __( 'Privacy' ) }
+			heading={ __( 'WHOIS Privacy' ) }
+			icon={ <Icon icon={ unseen } /> }
+			description={ domain.privacy_available ? __( 'Enabled' ) : __( 'Disabled' ) }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -2,8 +2,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
 import { domainRoute } from '../../app/router/domains';
-import FeaturedCardPrivacy from './featured-card-privacy';
 import FeaturedCardEmails from './featured-card-emails';
+import FeaturedCardPrivacy from './featured-card-privacy';
 import FeaturedCardRenew from './featured-card-renew';
 import FeaturedCardSite from './featured-card-site';
 
@@ -16,7 +16,7 @@ export default function FeaturedCards() {
 			<FeaturedCardRenew domain={ domain } />
 			<FeaturedCardSite domain={ domain } />
 			<FeaturedCardEmails domain={ domain } />
-      <FeaturedCardPrivacy domain={ domain } />
+			<FeaturedCardPrivacy domain={ domain } />
 		</Grid>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { domainQuery } from '../../app/queries/domain';
 import { domainRoute } from '../../app/router/domains';
+import FeaturedCardPrivacy from './featured-card-privacy';
 import FeaturedCardRenew from './featured-card-renew';
 
 export default function FeaturedCards() {
@@ -11,6 +12,7 @@ export default function FeaturedCards() {
 	return (
 		<Grid columns={ 2 }>
 			<FeaturedCardRenew domain={ domain } />
+			<FeaturedCardPrivacy domain={ domain } />
 		</Grid>
 	);
 }


### PR DESCRIPTION
Part of [DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Proposed Changes

* Creates the Privacy featured card

## Why are these changes being made?

* [DOTDASH-315](https://linear.app/a8c/issue/DOTDASH-315)

## Testing Instructions

* Go to `/v2/domains`
* Select a domain
* Check the featured card segment

<img width="462" height="224" alt="Screenshot 2025-08-27 at 10 42 11" src="https://github.com/user-attachments/assets/78ee3b4e-e42b-453a-af0d-0e01813de60e" />

<img width="383" height="225" alt="Screenshot 2025-08-28 at 16 28 31" src="https://github.com/user-attachments/assets/4ac75577-6847-4ee6-bf10-de2773f5af21" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
