### PR TITLE
Hosting Dashboard: Implement infinite scrolling for Blocked Sites

### DIFF
--- a/client/dashboard/app/queries/me-blocked-sites.ts
+++ b/client/dashboard/app/queries/me-blocked-sites.ts
@@ -1,17 +1,25 @@
-import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchBlockedSites, unblockSite } from '../../data/me-blocked-sites';
 import { queryClient } from '../query-client';
 
-export const blockedSitesQuery = () =>
-	queryOptions( {
-		queryKey: [ 'me', 'blocked-sites' ],
-		queryFn: fetchBlockedSites,
+export const blockedSitesInfiniteQuery = ( perPage: number ) =>
+	infiniteQueryOptions( {
+		queryKey: [ 'me', 'blocked-sites', perPage ],
+		queryFn: ( { pageParam }: { pageParam: number } ) => fetchBlockedSites( pageParam, perPage ),
+		initialPageParam: 1,
+		getNextPageParam: ( lastPage, allPages ) => {
+			if ( lastPage.length < perPage ) {
+				return;
+			}
+
+			return allPages.length + 1;
+		},
 	} );
 
 export const unblockSiteMutation = () =>
 	mutationOptions( {
 		mutationFn: ( siteId: number ) => unblockSite( siteId ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( blockedSitesQuery() );
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'blocked-sites' ] } );
 		},
 	} );

--- a/client/dashboard/components/dataviews-card/index.tsx
+++ b/client/dashboard/components/dataviews-card/index.tsx
@@ -13,4 +13,3 @@ function UnforwardedDataViewsCard(
 }
 
 export const DataViewsCard = forwardRef( UnforwardedDataViewsCard );
-export default DataViewsCard;

--- a/client/dashboard/components/dataviews-card/index.tsx
+++ b/client/dashboard/components/dataviews-card/index.tsx
@@ -1,11 +1,16 @@
 import { Card, CardBody } from '@wordpress/components';
+import { forwardRef } from 'react';
 
-function DataViewsCard( { children }: { children: React.ReactNode } ) {
+function UnforwardedDataViewsCard(
+	{ children }: { children: React.ReactNode },
+	ref: React.ForwardedRef< HTMLDivElement >
+) {
 	return (
-		<Card>
+		<Card ref={ ref }>
 			<CardBody>{ children }</CardBody>
 		</Card>
 	);
 }
 
+export const DataViewsCard = forwardRef( UnforwardedDataViewsCard );
 export default DataViewsCard;

--- a/client/dashboard/data/me-blocked-sites.ts
+++ b/client/dashboard/data/me-blocked-sites.ts
@@ -6,16 +6,19 @@ export interface BlockedSite {
 	name: string;
 }
 
-export interface BlockedSiteResponse {
-	sites: BlockedSite[];
-	page: number;
-}
+export async function fetchBlockedSites( page: number, perPage: number ): Promise< BlockedSite[] > {
+	const { sites } = await wpcom.req.get(
+		{
+			path: '/me/blocks/sites',
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			page,
+			per_page: perPage,
+		}
+	);
 
-export async function fetchBlockedSites(): Promise< BlockedSiteResponse > {
-	return await wpcom.req.get( {
-		path: '/me/blocks/sites',
-		apiNamespace: 'wpcom/v2',
-	} );
+	return sites;
 }
 
 export async function unblockSite( siteId: number ): Promise< void > {

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../app/queries/domain-dns-records';
 import { domainNameServersQuery } from '../../app/queries/domain-name-servers';
 import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';

--- a/client/dashboard/domains/domain-forwardings/index.tsx
+++ b/client/dashboard/domains/domain-forwardings/index.tsx
@@ -14,7 +14,7 @@ import {
 	domainForwardingAddRoute,
 	domainForwardingEditRoute,
 } from '../../app/router/domains';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';

--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -15,7 +15,7 @@ import {
 	domainGlueRecordsAddRoute,
 	domainGlueRecordsEditRoute,
 } from '../../app/router/domains';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { domainsQuery } from '../app/queries/domains';
 import { domainsPurchaseRoute } from '../app/router/domains';
-import DataViewsCard from '../components/dataviews-card';
+import { DataViewsCard } from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import RouterLinkButton from '../components/router-link-button';

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -5,7 +5,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { emailsQuery } from '../app/queries/emails';
-import DataViewsCard from '../components/dataviews-card';
+import { DataViewsCard } from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import type { Email } from '../data/types';

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -7,7 +7,7 @@ import { userPaymentMethodsQuery } from '../../app/queries/me-payment-methods';
 import { userPurchasesQuery, userTransferredPurchasesQuery } from '../../app/queries/me-purchases';
 import { sitesQuery } from '../../app/queries/sites';
 import { purchasesRoute } from '../../app/router/me';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import {

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -1,18 +1,31 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useInfiniteQuery } from '@tanstack/react-query';
 import { ExternalLink, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataViews } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { blockedSitesQuery, unblockSiteMutation } from '../../app/queries/me-blocked-sites';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { blockedSitesInfiniteQuery, unblockSiteMutation } from '../../app/queries/me-blocked-sites';
 import DataViewsCard from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import type { BlockedSite } from '../../data/me-blocked-sites';
-import type { Field } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 20;
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	descriptionField: 'URL',
+	titleField: 'name',
+	page: DEFAULT_PAGE,
+	perPage: DEFAULT_PER_PAGE,
+	infiniteScrollEnabled: true,
+};
 
 const getHostname = ( url: string ) => {
 	try {
@@ -41,12 +54,53 @@ const fields: Field< BlockedSite >[] = [
 ];
 
 export default function BlockedSites() {
-	// TODO: Implement infinite scroll once DataViews is updated to support it.
-	const { data: { sites, page } = { sites: [], page: 1 }, isLoading } = useQuery(
-		blockedSitesQuery()
-	);
+	const ref = useRef< HTMLDivElement >( null );
 	const unblockSite = useMutation( unblockSiteMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+		blockedSitesInfiniteQuery( DEFAULT_PER_PAGE )
+	);
+
+	const sites = ( data?.pages || [] ).flat();
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
+
+	const infiniteScrollHandler = useCallback( () => {
+		if ( hasNextPage && ! isFetchingNextPage ) {
+			fetchNextPage();
+		}
+	}, [ hasNextPage, isFetchingNextPage, fetchNextPage ] );
+
+	useEffect( () => {
+		setView( ( currentView ) => ( { ...currentView, perPage: sites.length } ) );
+	}, [ sites.length ] );
+
+	useLayoutEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+
+		const dataviewsRef = ref.current.querySelector< HTMLDivElement >( '.dataviews-wrapper' );
+		if ( ! dataviewsRef ) {
+			return;
+		}
+
+		const handleResize = () => {
+			const { top } = dataviewsRef.getBoundingClientRect();
+			const maxHeight = window.innerHeight - top - 32 - 1;
+			dataviewsRef.style.maxHeight = `${ maxHeight }px`;
+		};
+
+		handleResize();
+		window.addEventListener( 'resize', handleResize );
+		window.addEventListener( 'orientationchange', handleResize );
+
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+			window.removeEventListener( 'orientationchange', handleResize );
+		};
+	}, [] );
 
 	return (
 		<PageLayout
@@ -71,15 +125,11 @@ export default function BlockedSites() {
 				/>
 			}
 		>
-			<DataViewsCard>
+			<DataViewsCard ref={ ref }>
 				<DataViews< BlockedSite >
-					data={ sites }
+					data={ filteredData }
 					fields={ fields }
-					view={ {
-						type: 'table',
-						descriptionField: 'URL',
-						titleField: 'name',
-					} }
+					view={ view }
 					actions={ [
 						{
 							id: 'unblock',
@@ -120,10 +170,13 @@ export default function BlockedSites() {
 					] }
 					getItemId={ ( item ) => item.ID.toString() }
 					defaultLayouts={ { table: {} } }
-					paginationInfo={ { totalItems: sites.length, totalPages: page } }
+					paginationInfo={ {
+						...paginationInfo,
+						infiniteScrollHandler,
+					} }
 					empty={ __( 'You haven’t blocked any sites yet.' ) }
 					isLoading={ isLoading }
-					onChangeView={ () => {} }
+					onChangeView={ setView }
 				>
 					<>
 						<DataViews.Layout />

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -54,7 +54,9 @@ const fields: Field< BlockedSite >[] = [
 ];
 
 export default function BlockedSites() {
+	const rafIdRef = useRef< number | null >( null );
 	const ref = useRef< HTMLDivElement >( null );
+	const dataviewsRef = useRef< HTMLDivElement | null >( null );
 	const unblockSite = useMutation( unblockSiteMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
@@ -72,6 +74,26 @@ export default function BlockedSites() {
 		}
 	}, [ hasNextPage, isFetchingNextPage, fetchNextPage ] );
 
+	const handleResize = useCallback( () => {
+		if ( ! dataviewsRef.current ) {
+			return;
+		}
+
+		if ( rafIdRef.current ) {
+			cancelAnimationFrame( rafIdRef.current );
+		}
+
+		rafIdRef.current = requestAnimationFrame( () => {
+			if ( ! dataviewsRef.current ) {
+				return;
+			}
+
+			const { top } = dataviewsRef.current.getBoundingClientRect();
+			const maxHeight = window.innerHeight - top - 32 - 1;
+			dataviewsRef.current.style.maxHeight = `${ maxHeight }px`;
+		} );
+	}, [] );
+
 	useEffect( () => {
 		setView( ( currentView ) => ( { ...currentView, perPage: sites.length } ) );
 	}, [ sites.length ] );
@@ -81,16 +103,10 @@ export default function BlockedSites() {
 			return;
 		}
 
-		const dataviewsRef = ref.current.querySelector< HTMLDivElement >( '.dataviews-wrapper' );
-		if ( ! dataviewsRef ) {
+		dataviewsRef.current = ref.current.querySelector< HTMLDivElement >( '.dataviews-wrapper' );
+		if ( ! dataviewsRef.current ) {
 			return;
 		}
-
-		const handleResize = () => {
-			const { top } = dataviewsRef.getBoundingClientRect();
-			const maxHeight = window.innerHeight - top - 32 - 1;
-			dataviewsRef.style.maxHeight = `${ maxHeight }px`;
-		};
 
 		handleResize();
 		window.addEventListener( 'resize', handleResize );
@@ -99,8 +115,12 @@ export default function BlockedSites() {
 		return () => {
 			window.removeEventListener( 'resize', handleResize );
 			window.removeEventListener( 'orientationchange', handleResize );
+
+			if ( rafIdRef.current ) {
+				cancelAnimationFrame( rafIdRef.current );
+			}
 		};
-	}, [] );
+	}, [ handleResize ] );
 
 	return (
 		<PageLayout

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -8,7 +8,7 @@ import { closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { blockedSitesInfiniteQuery, unblockSiteMutation } from '../../app/queries/me-blocked-sites';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from 'react';
 import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteRewindableActivityLogEntriesQuery } from '../../app/queries/site-activity-log';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { getFields } from './dataviews/fields';
 import type { ActivityLogEntry, Site } from '../../data/types';
 import type { View } from '@wordpress/dataviews';

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -5,7 +5,7 @@ import { siteBySlugQuery } from '../../app/queries/site';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../../app/auth';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteDomainsQuery } from '../../app/queries/site-domains';
 import { siteDomainsPurchaseRoute, siteRoute } from '../../app/router/sites';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -10,7 +10,7 @@ import { isAutomatticianQuery } from '../app/queries/me-a8c';
 import { userPreferenceQuery, userPreferenceMutation } from '../app/queries/me-preferences';
 import { sitesQuery } from '../app/queries/sites';
 import { sitesRoute } from '../app/router/sites';
-import DataViewsCard from '../components/dataviews-card';
+import { DataViewsCard } from '../components/dataviews-card';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -14,7 +14,7 @@ import { siteSettingsQuery } from '../../app/queries/site-settings';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
-import DataViewsCard from '../../components/dataviews-card';
+import { DataViewsCard } from '../../components/dataviews-card';
 import { DateRangePicker } from '../../components/date-range-picker';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';


### PR DESCRIPTION
Ref DOTDASH-317

## Proposed Changes

As title. Infinite scrolling is achieved by setting a max height to the DataViews in order for the scroll event to trigger the infinite scrolling.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a non-a11n account, have more than 20 blocked sites
* Head to /v2/me/blocked-sites
* Ensure that infinite scrolling work as intended
* Also try unblocking a site, and the blocked site list should be the same, sans the unblocked site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
