### PR TITLE
Staging sites: Rewrite sync mutations for the V2 dashboard

### DIFF
--- a/client/dashboard/app/queries/site-staging-sync.ts
+++ b/client/dashboard/app/queries/site-staging-sync.ts
@@ -1,0 +1,35 @@
+import { mutationOptions } from '@tanstack/react-query';
+import {
+	pullFromStaging,
+	pushToStaging,
+	type StagingSyncOptions,
+} from '../../data/site-staging-sync';
+import { queryClient } from '../query-client';
+import { stagingSiteSyncStateQuery } from './site-staging-sites';
+
+export const PUSH_TO_STAGING = 'push-to-staging-site-mutation-key';
+export const PULL_FROM_STAGING = 'pull-from-staging-site-mutation-key';
+
+export const pushToStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
+	mutationOptions( {
+		mutationKey: [ PUSH_TO_STAGING, stagingSiteId ],
+		mutationFn: ( options: StagingSyncOptions ) =>
+			pushToStaging( productionSiteId, stagingSiteId, options ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: stagingSiteSyncStateQuery( productionSiteId ).queryKey,
+			} );
+		},
+	} );
+
+export const pullFromStagingMutation = ( productionSiteId: number, stagingSiteId: number ) =>
+	mutationOptions( {
+		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],
+		mutationFn: ( options: StagingSyncOptions ) =>
+			pullFromStaging( productionSiteId, stagingSiteId, options ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: stagingSiteSyncStateQuery( productionSiteId ).queryKey,
+			} );
+		},
+	} );

--- a/client/dashboard/data/site-staging-sync.ts
+++ b/client/dashboard/data/site-staging-sync.ts
@@ -1,0 +1,38 @@
+import wpcom from 'calypso/lib/wp';
+
+export type StagingSyncOptions =
+	| string[]
+	| { types: string; include_paths: string; exclude_paths: string }
+	| undefined;
+
+export interface StagingSyncResponse {
+	message: string;
+}
+
+export async function pushToStaging(
+	productionSiteId: number,
+	stagingSiteId: number,
+	options: StagingSyncOptions
+): Promise< StagingSyncResponse > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ productionSiteId }/staging-site/push-to-staging/${ stagingSiteId }`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ options }
+	);
+}
+
+export async function pullFromStaging(
+	productionSiteId: number,
+	stagingSiteId: number,
+	options: StagingSyncOptions
+): Promise< StagingSyncResponse > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ options, allow_woo_sync: 1 }
+	);
+}

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
 	ExternalLink,
@@ -13,6 +13,10 @@ import { createInterpolateElement, useState, useCallback } from '@wordpress/elem
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { siteByIdQuery } from '../../app/queries/site';
+import {
+	pushToStagingMutation,
+	pullFromStagingMutation,
+} from '../../app/queries/site-staging-sync';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
@@ -140,6 +144,7 @@ export default function StagingSiteSyncModal( {
 	environment,
 	productionSiteId,
 	stagingSiteId,
+	onSyncStart,
 }: StagingSiteSyncModalProps ) {
 	const syncConfig = getSyncConfig( syncType );
 	const [ domainConfirmation, setDomainConfirmation ] = useState( '' );
@@ -167,28 +172,37 @@ export default function StagingSiteSyncModal( {
 	const targetSiteTitle =
 		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
 
-	// TODO: Uncomment once we need it.
+	// TODO: Uncomment once we need it for granular sync.
 	// const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
+
+	const pullMutation = useMutation( pullFromStagingMutation( productionSiteId, stagingSiteId ) );
+	const pushMutation = useMutation( pushToStagingMutation( productionSiteId, stagingSiteId ) );
 
 	const handleClose = useCallback( () => {
 		onClose();
 	}, [ onClose ] );
 
 	const handleConfirm = () => {
-		// Sync everything
-		// TODO: Uncomment once pullFromStaging and pushToStaging are available
-		// const include_paths = '';
-		// const exclude_paths = '';
+		// TODO: Sync everything for now. Later we will add granular sync.
+		const options = { types: 'paths', include_paths: '', exclude_paths: '' };
 
 		if (
 			( syncType === 'pull' && environment === 'production' ) ||
 			( syncType === 'push' && environment === 'staging' )
 		) {
-			// TODO: Replace with the correct pullFromStaging (once it is moved to V2)
-			// pullFromStaging( { types: 'paths', include_paths, exclude_paths } );
+			pullMutation.mutate( options, {
+				onSuccess: () => {
+					onSyncStart();
+					handleClose();
+				},
+			} );
 		} else {
-			// TODO: Replace with the correct pushToStaging (once it is moved to V2)
-			// pushToStaging( { types: 'paths', include_paths, exclude_paths } );
+			pushMutation.mutate( options, {
+				onSuccess: () => {
+					onSyncStart();
+					handleClose();
+				},
+			} );
 		}
 	};
 
@@ -263,7 +277,12 @@ export default function StagingSiteSyncModal( {
 							<Button variant="tertiary" onClick={ handleClose }>
 								{ __( 'Cancel' ) }
 							</Button>
-							<Button variant="primary" onClick={ handleConfirm } disabled={ isSubmitDisabled }>
+							<Button
+								variant="primary"
+								onClick={ handleConfirm }
+								disabled={ isSubmitDisabled || pullMutation.isPending || pushMutation.isPending }
+								isBusy={ pullMutation.isPending || pushMutation.isPending }
+							>
 								{ syncConfig.submit }
 							</Button>
 						</HStack>

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -192,15 +193,41 @@ export default function StagingSiteSyncModal( {
 		) {
 			pullMutation.mutate( options, {
 				onSuccess: () => {
+					recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success', {
+						types: options.types,
+						include_paths: options.include_paths,
+						exclude_paths: options.exclude_paths,
+					} );
 					onSyncStart();
 					handleClose();
+				},
+				onError: ( error: Error ) => {
+					recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_failure', {
+						message: error.message,
+						types: options.types,
+						include_paths: options.include_paths,
+						exclude_paths: options.exclude_paths,
+					} );
 				},
 			} );
 		} else {
 			pushMutation.mutate( options, {
 				onSuccess: () => {
+					recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success', {
+						types: options.types,
+						include_paths: options.include_paths,
+						exclude_paths: options.exclude_paths,
+					} );
 					onSyncStart();
 					handleClose();
+				},
+				onError: ( error: Error ) => {
+					recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_failure', {
+						message: error.message,
+						types: options.types,
+						include_paths: options.include_paths,
+						exclude_paths: options.exclude_paths,
+					} );
 				},
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-198

## Proposed Changes

* create new `pushToStagingMutation` and `pullFromStagingMutation` mutations in the V2 dashboard
* use these new mutations in the current Sync modal used in production and new Sync modal introduced in https://github.com/Automattic/wp-calypso/pull/105352

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTDEV-198

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use Calypso Live link below).
2. Ensure you have WoA site and related staging site created.
3. Head over to the new (V2) dashboard (`http://calypso.localhost:3000/v2/sites/{site-slug}`) and try to initiate full sync between the sites. It should work correctly.
4. Navigate to the current (V1) dashboard (`http://calypso.localhost:3000/sites/{site-slug}`) and try to initiate partial and full syncs between the sites. Everything should work as before. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
