### PR TITLE
Zendesk: implement sent messages queue

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -12,7 +12,7 @@ import type {
 	HelpCenterSelect,
 	HelpCenterShowOptions,
 } from './types';
-import type { SupportInteraction } from '@automattic/odie-client/src/types';
+import type { Message, SupportInteraction } from '@automattic/odie-client/src/types';
 import type { Location } from 'history';
 
 /**
@@ -101,6 +101,12 @@ export const setIsMinimized = function* ( minimized: boolean ) {
 		minimized,
 	} as const;
 };
+
+export const setOfflineQueue = ( offlineQueue: Message[] ) =>
+	( {
+		type: 'HELP_CENTER_SET_OFFLINE_QUEUE',
+		offlineQueue,
+	} ) as const;
 
 export const setIsChatLoaded = ( isChatLoaded: boolean ) =>
 	( {
@@ -297,6 +303,7 @@ export type HelpCenterAction =
 			| typeof setAreSoundNotificationsEnabled
 			| typeof setZendeskClientId
 			| typeof setZendeskConnectionStatus
+			| typeof setOfflineQueue
 			| typeof setNavigateToRoute
 			| typeof setOdieInitialPromptText
 			| typeof setOdieBotNameSlug

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -2,14 +2,21 @@ import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
 import type { HelpCenterOptions } from './types';
-import type { SupportInteraction } from '@automattic/odie-client/src/types';
+import type { SupportInteraction, Message } from '@automattic/odie-client/src/types';
 import type { Location } from 'history';
 import type { Reducer } from 'redux';
-
 const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_SHOW':
 			return action.show;
+	}
+	return state;
+};
+
+const offlineQueue: Reducer< Message[], HelpCenterAction > = ( state = [], action ) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_OFFLINE_QUEUE':
+			return action.offlineQueue;
 	}
 	return state;
 };
@@ -202,6 +209,7 @@ const reducer = combineReducers( {
 	showHelpCenter,
 	showMessagingLauncher,
 	showMessagingWidget,
+	offlineQueue,
 	zendeskConnectionStatus,
 	subject,
 	message,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -9,6 +9,7 @@ export const getUserDeclaredSiteUrl = ( state: State ) => state.userDeclaredSite
 export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;
 export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getZendeskConnectionStatus = ( state: State ) => state.zendeskConnectionStatus;
+export const getOfflineQueue = ( state: State ) => state.offlineQueue;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getIsChatLoaded = ( state: State ) => state.isChatLoaded;
 export const getAreSoundNotificationsEnabled = ( state: State ) =>

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -248,11 +248,7 @@ export const OdieSendMessageButton = () => {
 							<div className="odie-send-message-input-and-spinner">
 								<ResizableTextarea
 									shouldDisableInputField={
-										isChatBusy ||
-										isAttachingFile ||
-										cantTransferToZendesk ||
-										isEmailFallback ||
-										( isLiveChat && connectionStatus !== 'connected' )
+										isChatBusy || isAttachingFile || cantTransferToZendesk || isEmailFallback
 									}
 									sendMessageHandler={ sendMessageHandler }
 									className="odie-send-message-input"
@@ -269,9 +265,7 @@ export const OdieSendMessageButton = () => {
 									attachmentButtonRef={ attachmentButtonRef }
 									onFileUpload={ handleFileUpload }
 									isAttachingFile={ isAttachingFile }
-									isDisabled={
-										isEmailFallback || ( isLiveChat && connectionStatus !== 'connected' )
-									}
+									isDisabled={ isEmailFallback }
 								/>
 							) }
 							<button

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getOdieTransferMessage } from '../constants';
 import { emptyChat } from '../context';
@@ -12,6 +12,7 @@ import {
 	getIsRequestingHumanSupport,
 } from '../utils';
 import type { Chat, Message } from '../types';
+import { useSendZendeskMessage } from './use-send-zendesk-message';
 
 /**
  * This combines the ODIE chat with the ZENDESK conversation.
@@ -21,48 +22,62 @@ export const useGetCombinedChat = (
 	canConnectToZendesk: boolean,
 	isLoadingCanConnectToZendesk: boolean
 ) => {
-	const { currentSupportInteraction, conversationId, odieId, isChatLoaded, connectionStatus } =
-		useSelect( ( select ) => {
-			const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-			const currentSupportInteraction = store.getCurrentSupportInteraction();
+	const {
+		currentSupportInteraction,
+		conversationId,
+		odieId,
+		isChatLoaded,
+		connectionStatus,
+		offlineQueue,
+	} = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		const currentSupportInteraction = store.getCurrentSupportInteraction();
+		const offlineQueue = store.getOfflineQueue();
 
-			const odieId = getOdieIdFromInteraction( currentSupportInteraction );
-			const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
+		const odieId = getOdieIdFromInteraction( currentSupportInteraction );
+		const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
 
-			return {
-				currentSupportInteraction,
-				conversationId,
-				odieId,
-				isChatLoaded: store.getIsChatLoaded(),
-				connectionStatus: store.getZendeskConnectionStatus(),
-			};
-		}, [] );
+		return {
+			currentSupportInteraction,
+			conversationId,
+			odieId,
+			offlineQueue,
+			isChatLoaded: store.getIsChatLoaded(),
+			connectionStatus: store.getZendeskConnectionStatus(),
+		};
+	}, [] );
 	const previousUuidRef = useRef< string | undefined >();
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
-	const [ refreshingAfterReconnect, setRefreshingAfterReconnect ] = useState( false );
+	const { setOfflineQueue } = useDispatch( HELP_CENTER_STORE );
 	const chatStatus = mainChatState?.status;
 	const getZendeskConversation = useGetZendeskConversation();
-	const { data: odieChat, isFetching: isOdieChatLoading } = useOdieChat( Number( odieId ) );
+	const sendZendeskMessage = useSendZendeskMessage();
+	const { data: odieChat, status: odieChatStatus } = useOdieChat( Number( odieId ) );
 	const { startNewInteraction } = useManageSupportInteraction();
 
 	useEffect( () => {
 		if ( connectionStatus === 'connected' ) {
+			if ( offlineQueue.length > 0 ) {
+				offlineQueue.forEach( ( message ) => sendZendeskMessage( message, false ) );
+				setOfflineQueue( [] );
+			}
 			setTimeout( () => {
-				setRefreshingAfterReconnect( true );
 				setMainChatState( ( chat ) => ( {
 					...chat,
 					status: 'loading',
 				} ) );
+				// Reset the previous uuid to refetch the messages that were lost while offline.
+				previousUuidRef.current = '';
 				// Give a buffer for ZD to warm up before re-fetching the lost messages.
 			}, 2000 );
 		}
-	}, [ connectionStatus, setRefreshingAfterReconnect ] );
+	}, [ connectionStatus, offlineQueue, setOfflineQueue ] );
 
 	useEffect( () => {
 		const interactionHasChanged = previousUuidRef.current !== currentSupportInteraction?.uuid;
 		if (
 			! currentSupportInteraction?.uuid ||
-			isOdieChatLoading ||
+			odieChatStatus !== 'success' ||
 			isLoadingCanConnectToZendesk ||
 			( chatStatus !== 'loading' && ! interactionHasChanged )
 		) {
@@ -98,7 +113,7 @@ export const useGetCombinedChat = (
 			return;
 		}
 
-		if ( isChatLoaded || refreshingAfterReconnect ) {
+		if ( isChatLoaded ) {
 			try {
 				getZendeskConversation( {
 					chatId: odieChat?.odieId,
@@ -130,14 +145,11 @@ export const useGetCombinedChat = (
 					event_source: 'help-center',
 					event_external_id: crypto.randomUUID(),
 				} );
-			} finally {
-				setRefreshingAfterReconnect( false );
 			}
 		}
 	}, [
-		isOdieChatLoading,
+		odieChatStatus,
 		chatStatus,
-		refreshingAfterReconnect,
 		isChatLoaded,
 		odieChat,
 		conversationId,

--- a/packages/odie-client/src/hooks/use-send-zendesk-message.ts
+++ b/packages/odie-client/src/hooks/use-send-zendesk-message.ts
@@ -1,6 +1,6 @@
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../context';
 import { getConversationIdFromInteraction } from '../utils';
@@ -11,19 +11,30 @@ import type { Message } from '../types';
  * Send a message to the Zendesk conversation.
  */
 export const useSendZendeskMessage = () => {
-	const currentConversationId = useSelect( ( select ) => {
+	const { currentConversationId, connectionStatus, offlineQueue } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		const currentSupportInteraction = store.getCurrentSupportInteraction();
+		const connectionStatus = store.getZendeskConnectionStatus();
+		const offlineQueue = store.getOfflineQueue();
 
-		return getConversationIdFromInteraction( currentSupportInteraction );
+		return {
+			currentConversationId: getConversationIdFromInteraction( currentSupportInteraction ),
+			connectionStatus,
+			offlineQueue,
+		};
 	}, [] );
 
+	const { setOfflineQueue } = useDispatch( HELP_CENTER_STORE );
 	const { setChatStatus, chat } = useOdieAssistantContext();
 	const newConversation = useCreateZendeskConversation();
 
-	const conversationId = currentConversationId || chat.conversationId;
-	return async ( message: Message ) => {
+	return async ( message: Message, queueWhenOffline = true ) => {
+		if ( connectionStatus !== 'connected' && queueWhenOffline ) {
+			return setOfflineQueue( [ ...offlineQueue, message ] );
+		}
+
 		setChatStatus( 'sending' );
+		const conversationId = currentConversationId || chat.conversationId;
 
 		if ( ! conversationId ) {
 			// Start a new conversation if it doesn't exist


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
