### PR TITLE
Domain Search Rewrite: Introduce a basic configuration object

### DIFF
--- a/client/dashboard/components/domain-search/index.tsx
+++ b/client/dashboard/components/domain-search/index.tsx
@@ -16,6 +16,7 @@ import './style.scss';
 interface DashboardDomainSearchProps {
 	currentSiteId?: number;
 	currentSiteUrl?: string;
+	config?: ComponentProps< typeof DomainSearch >[ 'config' ];
 }
 
 function DomainSearchWithCart( {

--- a/client/dashboard/domains/purchase.tsx
+++ b/client/dashboard/domains/purchase.tsx
@@ -9,7 +9,7 @@ export default function DomainsPurchase() {
 			backLabel={ __( 'Back to domains' ) }
 			fallbackCloseRoute={ domainsRoute.fullPath }
 		>
-			<DomainSearch />
+			<DomainSearch config={ { vendor: 'variation8_front' } } />
 		</FullScreenOverlay>
 	);
 }

--- a/client/dashboard/domains/purchase.tsx
+++ b/client/dashboard/domains/purchase.tsx
@@ -2,6 +2,12 @@ import { __ } from '@wordpress/i18n';
 import { domainsRoute } from '../app/router/domains';
 import DomainSearch from '../components/domain-search';
 import FullScreenOverlay from '../components/full-screen-overlay';
+import type { ComponentProps } from 'react';
+
+const config: ComponentProps< typeof DomainSearch >[ 'config' ] = {
+	vendor: 'variation8_front',
+	skippable: false,
+};
 
 export default function DomainsPurchase() {
 	return (
@@ -9,7 +15,7 @@ export default function DomainsPurchase() {
 			backLabel={ __( 'Back to domains' ) }
 			fallbackCloseRoute={ domainsRoute.fullPath }
 		>
-			<DomainSearch config={ { vendor: 'variation8_front' } } />
+			<DomainSearch config={ config } />
 		</FullScreenOverlay>
 	);
 }

--- a/client/lib/domains/suggestions/index.ts
+++ b/client/lib/domains/suggestions/index.ts
@@ -4,6 +4,7 @@ import {
 	isHundredYearDomainFlow,
 	isNewsletterFlow,
 } from '@automattic/onboarding';
+import type { DomainSuggestionQueryVendor } from '@automattic/data';
 
 interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
@@ -11,15 +12,6 @@ interface DomainSuggestionsVendorOptions {
 	isPremium?: boolean;
 	flowName?: string;
 }
-
-type DomainSuggestionsVendor =
-	| 'variation2_front'
-	| 'variation4_front'
-	| 'variation8_front'
-	| 'newsletter'
-	| 'ecommerce'
-	| 'gravatar'
-	| '100-year-domains';
 
 /**
  * Get the suggestions vendor
@@ -35,7 +27,7 @@ export const getSuggestionsVendor = ( {
 	flowName,
 	isSignup,
 	isDomainOnly,
-}: DomainSuggestionsVendorOptions = {} ): DomainSuggestionsVendor => {
+}: DomainSuggestionsVendorOptions = {} ): DomainSuggestionQueryVendor => {
 	if ( isDomainForGravatarFlow( flowName ) ) {
 		return 'gravatar';
 	}

--- a/packages/data/src/domain-suggestions/types.ts
+++ b/packages/data/src/domain-suggestions/types.ts
@@ -1,3 +1,13 @@
+export type DomainSuggestionQueryVendor =
+	| 'variation2_front'
+	| 'variation4_front'
+	| 'variation8_front'
+	| 'newsletter'
+	| 'ecommerce'
+	| 'gravatar'
+	| '100-year-domains'
+	| 'domain-upsell';
+
 export interface DomainSuggestionQuery {
 	/**
 	 * True to include .blog subdomain suggestions
@@ -45,7 +55,7 @@ export interface DomainSuggestionQuery {
 	/**
 	 * Vendor
 	 */
-	vendor: string;
+	vendor: DomainSuggestionQueryVendor;
 
 	/**
 	 * The vertical id or slug

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -1,7 +1,7 @@
-import { createContext, useContext } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { domainAvailabilityQuery } from '../queries/availability';
 import { domainSuggestionsQuery, freeSuggestionQuery } from '../queries/suggestions';
-import { type DomainSearchContextType } from './types';
+import type { DomainSearchProps, DomainSearchContextType } from './types';
 
 const noop = () => {};
 
@@ -44,4 +44,73 @@ export const useDomainSearch = () => {
 	}
 
 	return context;
+};
+
+export const useDomainSearchContextValue = (
+	props: DomainSearchProps
+): typeof DEFAULT_CONTEXT_VALUE => {
+	const { currentSiteUrl, initialQuery, cart, events, slots, config } = props;
+
+	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
+	const [ query, setQuery ] = useState( initialQuery ?? '' );
+
+	const closeFullCart = useCallback( () => {
+		setIsFullCartOpen( false );
+	}, [] );
+
+	const openFullCart = useCallback( () => {
+		setIsFullCartOpen( true );
+	}, [] );
+
+	const normalizedEvents = useMemo( () => {
+		return {
+			...DEFAULT_CONTEXT_VALUE.events,
+			...events,
+		};
+	}, [ events ] );
+
+	const normalizedConfig = useMemo( () => {
+		return {
+			...DEFAULT_CONTEXT_VALUE.config,
+			...config,
+		};
+	}, [ config ] );
+
+	return useMemo( () => {
+		return {
+			events: normalizedEvents,
+			config: normalizedConfig,
+			queries: {
+				domainSuggestions: ( query ) =>
+					domainSuggestionsQuery( query, {
+						quantity: 30,
+						vendor: normalizedConfig.vendor,
+					} ),
+				freeSuggestion: ( query ) => ( {
+					...freeSuggestionQuery( query ),
+					enabled: normalizedConfig.skippable,
+				} ),
+				domainAvailability: domainAvailabilityQuery,
+			},
+			cart,
+			isFullCartOpen,
+			closeFullCart,
+			openFullCart,
+			query,
+			setQuery,
+			slots,
+			currentSiteUrl,
+		};
+	}, [
+		isFullCartOpen,
+		closeFullCart,
+		openFullCart,
+		query,
+		setQuery,
+		cart,
+		normalizedEvents,
+		slots,
+		currentSiteUrl,
+		normalizedConfig,
+	] );
 };

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -27,6 +27,10 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	openFullCart: () => {},
 	query: '',
 	setQuery: () => {},
+	config: {
+		vendor: 'variation2_front',
+		skippable: false,
+	},
 };
 
 export const DomainSearchContext =

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -32,21 +32,28 @@ export const DomainSearch = ( {
 		setIsFullCartOpen( true );
 	}, [] );
 
-	const vendor = config?.vendor ?? 'variation2_front';
+	const contextValue: typeof DEFAULT_CONTEXT_VALUE = useMemo( () => {
+		const normalizedConfig = {
+			...DEFAULT_CONTEXT_VALUE.config,
+			...config,
+		};
 
-	const contextValue: typeof DEFAULT_CONTEXT_VALUE = useMemo(
-		() => ( {
+		return {
 			events: {
 				...DEFAULT_CONTEXT_VALUE.events,
 				...events,
 			},
+			config: normalizedConfig,
 			queries: {
 				domainSuggestions: ( query ) =>
 					domainSuggestionsQuery( query, {
 						quantity: 30,
-						vendor,
+						vendor: normalizedConfig.vendor,
 					} ),
-				freeSuggestion: freeSuggestionQuery,
+				freeSuggestion: ( query ) => ( {
+					...freeSuggestionQuery( query ),
+					enabled: normalizedConfig.skippable,
+				} ),
 				domainAvailability: domainAvailabilityQuery,
 			},
 			cart,
@@ -57,20 +64,19 @@ export const DomainSearch = ( {
 			setQuery,
 			slots,
 			currentSiteUrl,
-		} ),
-		[
-			isFullCartOpen,
-			closeFullCart,
-			openFullCart,
-			query,
-			setQuery,
-			cart,
-			events,
-			slots,
-			currentSiteUrl,
-			vendor,
-		]
-	);
+		};
+	}, [
+		isFullCartOpen,
+		closeFullCart,
+		openFullCart,
+		query,
+		setQuery,
+		cart,
+		events,
+		slots,
+		currentSiteUrl,
+		config,
+	] );
 
 	const cartItemsLength = cart.items.length;
 

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -1,9 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import clsx from 'clsx';
-import { useCallback, useState, useMemo, useLayoutEffect } from 'react';
-import { domainAvailabilityQuery } from '../queries/availability';
-import { domainSuggestionsQuery, freeSuggestionQuery } from '../queries/suggestions';
-import { DEFAULT_CONTEXT_VALUE, DomainSearchContext } from './context';
+import { useLayoutEffect } from 'react';
+import { DomainSearchContext, useDomainSearchContextValue } from './context';
 import { EmptyPage } from './empty';
 import { fallbackQueryClient } from './fallback-query-client';
 import { ResultsPage } from './results';
@@ -11,74 +9,12 @@ import type { DomainSearchProps } from './types';
 
 import './style.scss';
 
-export const DomainSearch = ( {
-	className,
-	currentSiteUrl,
-	initialQuery,
-	cart,
-	events,
-	slots,
-	queryClient = fallbackQueryClient,
-	config,
-}: DomainSearchProps ) => {
-	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
-	const [ query, setQuery ] = useState( initialQuery ?? '' );
+export const DomainSearch = ( props: DomainSearchProps ) => {
+	const contextValue = useDomainSearchContextValue( props );
 
-	const closeFullCart = useCallback( () => {
-		setIsFullCartOpen( false );
-	}, [] );
-
-	const openFullCart = useCallback( () => {
-		setIsFullCartOpen( true );
-	}, [] );
-
-	const contextValue: typeof DEFAULT_CONTEXT_VALUE = useMemo( () => {
-		const normalizedConfig = {
-			...DEFAULT_CONTEXT_VALUE.config,
-			...config,
-		};
-
-		return {
-			events: {
-				...DEFAULT_CONTEXT_VALUE.events,
-				...events,
-			},
-			config: normalizedConfig,
-			queries: {
-				domainSuggestions: ( query ) =>
-					domainSuggestionsQuery( query, {
-						quantity: 30,
-						vendor: normalizedConfig.vendor,
-					} ),
-				freeSuggestion: ( query ) => ( {
-					...freeSuggestionQuery( query ),
-					enabled: normalizedConfig.skippable,
-				} ),
-				domainAvailability: domainAvailabilityQuery,
-			},
-			cart,
-			isFullCartOpen,
-			closeFullCart,
-			openFullCart,
-			query,
-			setQuery,
-			slots,
-			currentSiteUrl,
-		};
-	}, [
-		isFullCartOpen,
-		closeFullCart,
-		openFullCart,
-		query,
-		setQuery,
-		cart,
-		events,
-		slots,
-		currentSiteUrl,
-		config,
-	] );
-
-	const cartItemsLength = cart.items.length;
+	const cartItemsLength = contextValue.cart.items.length;
+	const isFullCartOpen = contextValue.isFullCartOpen;
+	const closeFullCart = contextValue.closeFullCart;
 
 	useLayoutEffect( () => {
 		if ( cartItemsLength === 0 && isFullCartOpen ) {
@@ -87,7 +23,7 @@ export const DomainSearch = ( {
 	}, [ cartItemsLength, isFullCartOpen, closeFullCart ] );
 
 	const getContent = () => {
-		if ( ! query ) {
+		if ( ! contextValue.query ) {
 			return <EmptyPage />;
 		}
 
@@ -95,9 +31,9 @@ export const DomainSearch = ( {
 	};
 
 	return (
-		<QueryClientProvider client={ queryClient }>
+		<QueryClientProvider client={ fallbackQueryClient }>
 			<DomainSearchContext.Provider value={ contextValue }>
-				<div className={ clsx( 'domain-search', className ) }>{ getContent() }</div>
+				<div className={ clsx( 'domain-search', props.className ) }>{ getContent() }</div>
 			</DomainSearchContext.Provider>
 		</QueryClientProvider>
 	);

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -19,6 +19,7 @@ export const DomainSearch = ( {
 	events,
 	slots,
 	queryClient = fallbackQueryClient,
+	config,
 }: DomainSearchProps ) => {
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
 	const [ query, setQuery ] = useState( initialQuery ?? '' );
@@ -31,6 +32,8 @@ export const DomainSearch = ( {
 		setIsFullCartOpen( true );
 	}, [] );
 
+	const vendor = config?.vendor ?? 'variation2_front';
+
 	const contextValue: typeof DEFAULT_CONTEXT_VALUE = useMemo(
 		() => ( {
 			events: {
@@ -38,7 +41,11 @@ export const DomainSearch = ( {
 				...events,
 			},
 			queries: {
-				domainSuggestions: domainSuggestionsQuery,
+				domainSuggestions: ( query ) =>
+					domainSuggestionsQuery( query, {
+						quantity: 30,
+						vendor,
+					} ),
 				freeSuggestion: freeSuggestionQuery,
 				domainAvailability: domainAvailabilityQuery,
 			},
@@ -61,6 +68,7 @@ export const DomainSearch = ( {
 			events,
 			slots,
 			currentSiteUrl,
+			vendor,
 		]
 	);
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -12,7 +12,7 @@ import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
-	const { slots, query, queries } = useDomainSearch();
+	const { slots, query, queries, config } = useDomainSearch();
 
 	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery(
 		queries.domainSuggestions( query )
@@ -54,7 +54,9 @@ export const ResultsPage = () => {
 				) : (
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
 				) }
-				{ isLoading ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> }
+				{ config.skippable && (
+					<> { isLoading ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> } </>
+				) }
 				{ isLoading ? (
 					<SearchResults.Placeholder />
 				) : (

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -5,7 +5,6 @@ import type {
 	DomainSuggestionQueryVendor,
 	FreeDomainSuggestion,
 } from '@automattic/data';
-import type { QueryClient } from '@tanstack/react-query';
 import type { ComponentType } from 'react';
 
 export interface SelectedDomain {
@@ -44,7 +43,6 @@ export interface DomainSearchProps {
 	initialQuery?: string;
 	events?: Partial< DomainSearchEvents >;
 	currentSiteUrl?: string;
-	queryClient?: QueryClient;
 	config?: Partial< DomainSearchConfig >;
 }
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -1,6 +1,10 @@
 import { domainAvailabilityQuery } from '../queries/availability';
 import { domainSuggestionsQuery, freeSuggestionQuery } from '../queries/suggestions';
-import type { DomainSuggestion, FreeDomainSuggestion } from '@automattic/data';
+import type {
+	DomainSuggestion,
+	DomainSuggestionQueryVendor,
+	FreeDomainSuggestion,
+} from '@automattic/data';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ComponentType } from 'react';
 
@@ -25,6 +29,10 @@ export interface DomainSearchEvents {
 	onSkip: ( suggestion?: FreeDomainSuggestion ) => void;
 }
 
+export interface DomainSearchConfig {
+	vendor?: DomainSuggestionQueryVendor;
+}
+
 export interface DomainSearchProps {
 	slots?: {
 		BeforeResults?: ComponentType;
@@ -36,6 +44,7 @@ export interface DomainSearchProps {
 	events?: Partial< DomainSearchEvents >;
 	currentSiteUrl?: string;
 	queryClient?: QueryClient;
+	config?: DomainSearchConfig;
 }
 
 export interface DomainSearchContextType

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -30,7 +30,8 @@ export interface DomainSearchEvents {
 }
 
 export interface DomainSearchConfig {
-	vendor?: DomainSuggestionQueryVendor;
+	vendor: DomainSuggestionQueryVendor;
+	skippable: boolean;
 }
 
 export interface DomainSearchProps {
@@ -44,11 +45,14 @@ export interface DomainSearchProps {
 	events?: Partial< DomainSearchEvents >;
 	currentSiteUrl?: string;
 	queryClient?: QueryClient;
-	config?: DomainSearchConfig;
+	config?: Partial< DomainSearchConfig >;
 }
 
 export interface DomainSearchContextType
-	extends Omit< DomainSearchProps, 'className' | 'initialQuery' | 'events' | 'queryClient' > {
+	extends Omit<
+		DomainSearchProps,
+		'className' | 'initialQuery' | 'events' | 'queryClient' | 'config'
+	> {
 	events: DomainSearchEvents;
 	isFullCartOpen: boolean;
 	closeFullCart: () => void;
@@ -60,4 +64,5 @@ export interface DomainSearchContextType
 		domainAvailability: ( domainName: string ) => ReturnType< typeof domainAvailabilityQuery >;
 		freeSuggestion: ( query: string ) => ReturnType< typeof freeSuggestionQuery >;
 	};
+	config: DomainSearchConfig;
 }

--- a/packages/domain-search/src/queries/suggestions.ts
+++ b/packages/domain-search/src/queries/suggestions.ts
@@ -1,13 +1,17 @@
-import { fetchDomainSuggestions, fetchFreeDomainSuggestion } from '@automattic/data';
+import {
+	type DomainSuggestionQuery,
+	fetchDomainSuggestions,
+	fetchFreeDomainSuggestion,
+} from '@automattic/data';
 import { queryOptions } from '@tanstack/react-query';
 
-export const domainSuggestionsQuery = ( query: string ) =>
+export const domainSuggestionsQuery = (
+	query: string,
+	params: Partial< DomainSuggestionQuery > = {}
+) =>
 	queryOptions( {
-		queryKey: [ 'domain-suggestions', query ],
-		queryFn: () =>
-			fetchDomainSuggestions( query, {
-				quantity: 30,
-			} ),
+		queryKey: [ 'domain-suggestions', query, params ],
+		queryFn: () => fetchDomainSuggestions( query, params ),
 		refetchOnWindowFocus: false,
 		refetchOnMount: false,
 	} );


### PR DESCRIPTION
Closes DOMAINS-1610.

## Proposed Changes

Adds a basic configuration object (vendor, skippable) that serves as the base for further configuration settings.

## Testing Instructions

Search for "work online" in `/v2/domains/purchase` and verify you see premium domains. Enter `/v2/sites/%s/domains/purchase` and try the same query. You shouldn't see premium domains there. The same goes for the ability to skip the purchase.
