### PR TITLE
Domain Search Rewrite: Organize featured suggestions

### DIFF
--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
+		deemphasizedTlds: [],
 	},
 };
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -37,8 +37,12 @@ export const ResultsPage = () => {
 	const isLoading = isLoadingSuggestions || isLoadingFreeSuggestion || isLoadingQueryAvailability;
 
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
-		return partitionSuggestions( suggestions, query );
-	}, [ suggestions, query ] );
+		return partitionSuggestions( {
+			suggestions,
+			query,
+			deemphasiseTlds: config.deemphasizedTlds,
+		} );
+	}, [ suggestions, query, config.deemphasizedTlds ] );
 
 	return (
 		<VStack spacing={ 8 }>

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -31,6 +31,7 @@ export interface DomainSearchEvents {
 export interface DomainSearchConfig {
 	vendor: DomainSuggestionQueryVendor;
 	skippable: boolean;
+	deemphasizedTlds: string[];
 }
 
 export interface DomainSearchProps {


### PR DESCRIPTION
Closes DOMAINS-1611.

## Proposed Changes

Partitions suggestions according to the criteria from production.

## Testing Instructions

Enter `/v2/domains/purchase` and `/start/domain`, and input the same query. You should observe the same featured and regular results.

