### PR TITLE
Notifications v2: Add external link to the note summary

### DIFF
--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -147,3 +147,13 @@
 		margin-bottom: 0;
 	}
 }
+
+.wpnc__text-summary {
+	.components-external-link {
+		color: inherit;
+	}
+
+	.components-external-link__contents {
+		text-decoration: none;
+	}
+}

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -156,10 +156,4 @@
 	.components-external-link__contents {
 		text-decoration: none;
 	}
-
-	// Hide external link icons in Notifications for consistency, since most
-	// links are external, while post content links won’t display the icon.
-	.components-external-link__icon {
-		display: none;
-	}
 }

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -156,4 +156,10 @@
 	.components-external-link__contents {
 		text-decoration: none;
 	}
+
+	// Hide external link icons in Notifications for consistency, since most
+	// links are external, while post content links won’t display the icon.
+	.components-external-link__icon {
+		display: none;
+	}
 }

--- a/apps/notifications/src/app/templates/comment-reply-input.tsx
+++ b/apps/notifications/src/app/templates/comment-reply-input.tsx
@@ -219,6 +219,7 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 						rows={ getRowCount( replyInputRef.current ) }
 						value={ value }
 						placeholder={ defaultValue }
+						__nextHasNoMarginBottom
 						onFocus={ handleFocus }
 						onBlur={ handleBlur }
 						onChange={ handleChange }

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -47,7 +47,6 @@ const NoteSummary = ( { note }: { note: Note } ) => {
 				<ExternalLink href={ note.url }>
 					<span
 						className="wpnc__subject"
-						style={ { whiteSpace: 'pre-wrap' } }
 						/* eslint-disable-next-line react/no-danger */
 						dangerouslySetInnerHTML={ {
 							__html: html( note.subject[ 0 ], {

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -1,47 +1,61 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	ExternalLink,
 } from '@wordpress/components';
 import { html } from '../../panel/indices-to-html';
-import noticon2gridicon from '../../panel/utils/noticon2gridicon';
-import Gridicon from './gridicons';
 import NoteIcon from './note-icon';
 import type { Note } from '../types';
+
+const getNoteIconLink = ( note: Note ) => {
+	if ( note.header?.[ 0 ].ranges?.[ 0 ].type === 'user' ) {
+		const { id: userId, site_id: siteId, url } = note.header[ 0 ].ranges[ 0 ];
+		// Some site notifications populate id with the siteId, so consider the userId falsy in this
+		// case.
+		return userId && userId !== siteId ? `https://wordpress.com/reader/users/id/${ userId }` : url;
+	}
+
+	return '';
+};
+
+const NoteSummaryIcon = ( { note }: { note: Note } ) => {
+	const link = getNoteIconLink( note );
+	const content = (
+		<div style={ { position: 'relative', flexShrink: 0 } }>
+			<div style={ { width: '32px', height: '32px', borderRadius: '50%', overflow: 'hidden' } }>
+				<NoteIcon icon={ note.icon } size={ 32 } />
+			</div>
+		</div>
+	);
+
+	if ( ! link ) {
+		return content;
+	}
+
+	return (
+		<a href={ link } target="_blank" rel="noopener noreferrer">
+			{ content }
+		</a>
+	);
+};
 
 const NoteSummary = ( { note }: { note: Note } ) => {
 	return (
 		<HStack justify="flex-start" spacing={ 4 }>
-			<div style={ { position: 'relative', flexShrink: 0 } }>
-				<div style={ { width: '32px', height: '32px', borderRadius: '50%', overflow: 'hidden' } }>
-					<NoteIcon icon={ note.icon } size={ 32 } />
-				</div>
-				<span
-					className="wpnc__gridicon"
-					style={ {
-						position: 'absolute',
-						bottom: '-5px',
-						right: '-8px',
-						width: '16px',
-						height: '16px',
-						border: '1px solid #fff',
-						borderRadius: '50%',
-						background: '#ddd',
-					} }
-				>
-					<Gridicon icon={ noticon2gridicon( note.noticon ) } size={ 16 } />
-				</span>
-			</div>
+			<NoteSummaryIcon note={ note } />
 			<VStack className="wpnc__text-summary">
-				<div
-					className="wpnc__subject"
-					style={ { whiteSpace: 'pre-wrap' } }
-					/* eslint-disable-next-line react/no-danger */
-					dangerouslySetInnerHTML={ {
-						__html: html( note.subject[ 0 ], {
-							links: false,
-						} ),
-					} }
-				/>
+				<ExternalLink href={ note.url }>
+					<span
+						className="wpnc__subject"
+						style={ { whiteSpace: 'pre-wrap' } }
+						/* eslint-disable-next-line react/no-danger */
+						dangerouslySetInnerHTML={ {
+							__html: html( note.subject[ 0 ], {
+								links: false,
+							} ),
+						} }
+					/>
+				</ExternalLink>
 			</VStack>
 		</HStack>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-296

## Proposed Changes

* Add external link to the note summary
  * The user avatar should point to the user page on the reader, e.g.: `https://wordpress.com/reader/users/id/:user`
  * The title should point to the post, the comment or the site
* Remove the gridicon to follow the design on Figma
* There is a writing prompt note but I couldn't see the notification even if I followed instructions on https://github.com/Automattic/wp-calypso/pull/69352 🫠

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notification
* Select any notification
* Ensure the link on the summary opens the correct page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
