### PR TITLE
Hosting Dashboard: Allow support sessions to access hosting dashboard for DIFM sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -4,6 +4,7 @@ import { LogType } from '../../data/site-logs';
 import { canViewHundredYearPlanSettings, canViewWordPressSettings } from '../../sites/features';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
+import { isSupportSession } from '../auth/support-session';
 import { isAutomatticianQuery } from '../queries/me-a8c';
 import { rawUserPreferencesQuery } from '../queries/me-preferences';
 import { siteByIdQuery, siteBySlugQuery } from '../queries/site';
@@ -89,6 +90,7 @@ export const siteRoute = createRoute( {
 		const difmAllowedRoutes = getDifmLiteAllowedRoutes();
 		if (
 			site.options?.is_difm_lite_in_progress &&
+			! isSupportSession() &&
 			! matches.some( ( match ) => difmAllowedRoutes.includes( match.routeId ) )
 		) {
 			throw redirect( { to: difmUrl } );

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { isSupportSession } from '../../app/auth/support-session';
 import { useAppContext } from '../../app/context';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -23,7 +24,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 		);
 	}
 
-	if ( site.options?.is_difm_lite_in_progress ) {
+	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
 		return (
 			<ResponsiveMenu label={ __( 'Site Menu' ) }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-229

## Proposed Changes

HE site builders can use support sessions to build the user's site.

**In a support session before**

<img width="1546" height="280" alt="CleanShot 2025-08-28 at 15 34 31@2x" src="https://github.com/user-attachments/assets/67d906eb-2f2e-46c5-bb95-f16574bcc9d2" />

**In a support session after**

<img width="1458" height="284" alt="CleanShot 2025-08-28 at 15 34 45@2x" src="https://github.com/user-attachments/assets/90a2802a-8c4e-4fae-b3bc-203b90178836" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is how DIFM sites work in v1.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The easiest way to test this is with the old-style support session. You can refer to the instructions from here.
160142-ghe-Automattic/missioncontrol

To make a DIFM site for testing you can create one at `/start/do-it-for-me`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?