### PR TITLE
Add orange header to v2 when in support user session

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -27,6 +27,7 @@
 
 	// Header bar
 	--dashboard-header__background-color: #021A23;
+	--dashboard-header__support-background-color: #9F6700;
 	--dashboard-header__color: #FFF;
 	--dashboard-header__border-color: #05374A;
 	--dashboard-header__divider-color: #064057;

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -27,6 +27,7 @@
 
 	// Header bar
 	--dashboard-header__background-color: rgba(252, 252, 252, 0.90);
+	--dashboard-header__support-background-color: rgba(252, 165, 0, 0.5);
 	--dashboard-header__color: #{$gray-900};
 	--dashboard-header__border-color: #{$gray-100};
 	--dashboard-header__divider-color: #{$gray-200};

--- a/client/dashboard/components/header-bar/index.tsx
+++ b/client/dashboard/components/header-bar/index.tsx
@@ -1,11 +1,18 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import clsx from 'clsx';
+import { isSupportUserSession } from '../../app/auth/support-session';
 import './style.scss';
 
 function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: React.ReactNode } ) {
 	return (
 		<HStack
 			as={ as }
-			className="dashboard-header-bar"
+			className={ clsx( 'dashboard-header-bar', {
+				// Only customize header for support "user" sessions because
+				// "next" sessions already have a floating toolbar which acts
+				// as visual indicator.
+				'is-support-user-session': isSupportUserSession(),
+			} ) }
 			alignment="left"
 			spacing={ 2 }
 			justify="flex-start"

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -7,6 +7,10 @@
 	background-color: var( --dashboard-header__background-color );
 	backdrop-filter: blur(4px);
 	color: var( --dashboard-header__color );
+
+	&.is-support-user-session {
+		background-color: var( --dashboard-header__support-background-color );
+	}
 }
 
 .dashboard-header-bar-title > span {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes



Adds an orange background to the primary header. But only for the old-style support session.

See p7DVsv-nSz-p2#comment-54234

It doesn't look that pretty—the header foreground colours could be fixed up to look nicer. But the old style shouldn't really be used much, so I think we should only improve the look if we have to.

<img width="1342" height="452" alt="CleanShot 2025-08-28 at 16 47 14@2x" src="https://github.com/user-attachments/assets/1f46f888-93ea-4886-a7f9-8a89f3fcdf89" />

<img width="1348" height="486" alt="CleanShot 2025-08-28 at 16 46 58@2x" src="https://github.com/user-attachments/assets/f6b88d24-faee-4a25-8e21-54b525b66291" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Without it there would be no indication at all (other than the avatar?) that the HE is looking at a support session.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Look at the instructions in 160142-ghe-Automattic/missioncontrol

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?