### PR TITLE
Restore Summer Special until Aug 31st

### DIFF
--- a/client/blocks/summer-special-banner/index.jsx
+++ b/client/blocks/summer-special-banner/index.jsx
@@ -63,7 +63,7 @@ export default function SummerSpecialBanner( { visiblePlans = [], isFixed = fals
 											date: new Intl.DateTimeFormat( translate.localeSlug || 'en-US', {
 												month: 'long',
 												day: 'numeric',
-											} ).format( new Date( '2025-08-25' ) ),
+											} ).format( new Date( '2025-08-31' ) ),
 										},
 									}
 								),
@@ -75,7 +75,7 @@ export default function SummerSpecialBanner( { visiblePlans = [], isFixed = fals
 											date: new Intl.DateTimeFormat( translate.localeSlug || 'en-US', {
 												month: 'long',
 												day: 'numeric',
-											} ).format( new Date( '2025-08-25' ) ),
+											} ).format( new Date( '2025-08-31' ) ),
 										},
 									}
 								),

--- a/config/development.json
+++ b/config/development.json
@@ -33,7 +33,7 @@
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
 		"a4a-dev-sites": true,
-		"summer-special-2025": false,
+		"summer-special-2025": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,7 +39,7 @@
 		"home/layout-dev": true,
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
-		"summer-special-2025": false,
+		"summer-special-2025": true,
 		"hosting/staging-sites-redesign": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -49,7 +49,7 @@
 		"help/gpt-response": true,
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
-		"summer-special-2025": false,
+		"summer-special-2025": true,
 		"hosting/staging-sites-redesign": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,7 +49,7 @@
 		"help/gpt-response": true,
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
-		"summer-special-2025": false,
+		"summer-special-2025": true,
 		"hosting/staging-sites-redesign": true,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -58,7 +58,7 @@
 		"hosting/hosting-features-callout": true,
 		"hosting/staging-sites-redesign": true,
 		"hosting-server-settings-enhancements": true,
-		"summer-special-2025": false,
+		"summer-special-2025": true,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -825,7 +825,7 @@ const FEATURES_LIST: FeatureList = {
 								month: 'long',
 								day: 'numeric',
 								year: 'numeric',
-							} ).format( new Date( '2025-08-25' ) ),
+							} ).format( new Date( '2025-08-31' ) ),
 						},
 					}
 				),
@@ -838,7 +838,7 @@ const FEATURES_LIST: FeatureList = {
 								month: 'long',
 								day: 'numeric',
 								year: 'numeric',
-							} ).format( new Date( '2025-08-25' ) ),
+							} ).format( new Date( '2025-08-31' ) ),
 						},
 					}
 				),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-316

## Proposed Changes

* Bring back Summer Special until the end of the month

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Checkout the branch and restart Calypso
* Create a new site. Summer special should be there both during signup and when you visit the /plans page

<img width="1333" height="817" alt="Screenshot 2025-08-28 at 8 06 03" src="https://github.com/user-attachments/assets/14dfa9a4-9488-4c66-b37e-befeb8dd9734" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
