### PR TITLE
Hosting Dashboard: Implement Password screen

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
 							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',
+							'!@automattic/generate-password',
 							'!@automattic/help-center',
 							'!@automattic/number-formatters',
 							'!@automattic/ui',

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -41,8 +41,3 @@ body {
 a {
 	color: var( --wp-admin-theme-color );
 }
-
-// Hide the password reveal button in Edge.
-::-ms-reveal {
-	display: none;
-}

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -41,3 +41,8 @@ body {
 a {
 	color: var( --wp-admin-theme-color );
 }
+
+// Hide the password reveal button in Edge.
+::-ms-reveal {
+	display: none;
+}

--- a/client/dashboard/data/me-profile.ts
+++ b/client/dashboard/data/me-profile.ts
@@ -6,6 +6,7 @@ export interface UserProfile {
 	description: string;
 	display_name: string;
 	is_dev_account: boolean;
+	password: string;
 	tracks_opt_out: boolean;
 	user_email: string;
 	user_login: string;
@@ -24,6 +25,7 @@ export async function updateProfile(
 		'display_name',
 		'description',
 		'is_dev_account',
+		'password',
 		'tracks_opt_out',
 		'user_URL',
 	];

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -83,7 +83,7 @@ export default function SecurityPassword() {
 							suffix={
 								<InputControlSuffixWrapper>
 									<Button
-										icon={ isPasswordVisible ? seen : unseen }
+										icon={ isPasswordVisible ? unseen : seen }
 										onClick={ () => {
 											setIsPasswordVisible( ! isPasswordVisible );
 										} }
@@ -123,11 +123,7 @@ export default function SecurityPassword() {
 								fields={ fields }
 								form={ { layout: { type: 'regular' as const }, fields } }
 								onChange={ ( edits: Partial< SecurityPasswordFormData > ) => {
-									setFormData( ( data ) => ( {
-										...data,
-										...edits,
-										password: edits.password?.trim() ?? data.password,
-									} ) );
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
 							<HStack spacing={ 3 } justify="flex-start">

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -20,6 +20,8 @@ import PageLayout from '../../components/page-layout';
 import SecurityPageHeader from '../security-page-header';
 import type { Field } from '@wordpress/dataviews';
 
+import './style.scss';
+
 type SecurityPasswordFormData = {
 	password: string;
 };
@@ -114,7 +116,7 @@ export default function SecurityPassword() {
 				/>
 			}
 		>
-			<Card>
+			<Card className="security-password-card">
 				<CardBody>
 					<form onSubmit={ handleSubmit }>
 						<VStack spacing={ 4 }>

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -1,9 +1,107 @@
+import { generatePassword } from '@automattic/generate-password';
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { seen, unseen } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from 'react';
+import { profileMutation } from '../../app/queries/me-profile';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
 import SecurityPageHeader from '../security-page-header';
+import type { Field } from '@wordpress/dataviews';
+
+type SecurityPasswordFormData = {
+	password: string;
+};
 
 export default function SecurityPassword() {
+	const mutation = useMutation( profileMutation() );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
+	const [ formData, setFormData ] = useState< SecurityPasswordFormData >( {
+		password: '',
+	} );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ password: formData.password },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Your password was saved successfully.' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message || __( 'Failed to save password.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
+	};
+
+	const handleGeneratePassword = () => {
+		setFormData( ( data ) => ( {
+			...data,
+			password: generatePassword(),
+		} ) );
+	};
+
+	const fields: Field< SecurityPasswordFormData >[] = useMemo(
+		() => [
+			{
+				id: 'password',
+				label: __( 'New password' ),
+				description: __(
+					'If you can’t think of a good password, use the button below to generate one.'
+				),
+				type: 'text' as const,
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					return (
+						<InputControl
+							__next40pxDefaultSize
+							type={ isPasswordVisible ? 'text' : 'password' }
+							label={ field.label }
+							placeholder={ field.placeholder }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => {
+								return onChange( { [ id ]: value ?? '' } );
+							} }
+							suffix={
+								<InputControlSuffixWrapper>
+									<Button
+										icon={ isPasswordVisible ? seen : unseen }
+										onClick={ () => {
+											setIsPasswordVisible( ! isPasswordVisible );
+										} }
+									/>
+								</InputControlSuffixWrapper>
+							}
+							// Hint to LastPass not to attempt autofill
+							data-lpignore="true"
+						/>
+					);
+				},
+				// TODO: Add validation via isValid.custom.
+				// There is currently a bug that prevents it from working.
+			},
+		],
+		[ isPasswordVisible ]
+	);
+
 	return (
 		<PageLayout
 			size="small"
@@ -16,7 +114,39 @@ export default function SecurityPassword() {
 				/>
 			}
 		>
-			<Text>Content goes here</Text>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< SecurityPasswordFormData >
+								data={ formData }
+								fields={ fields }
+								form={ { layout: { type: 'regular' as const }, fields } }
+								onChange={ ( edits: Partial< SecurityPasswordFormData > ) => {
+									setFormData( ( data ) => ( {
+										...data,
+										...edits,
+										password: edits.password?.trim() ?? data.password,
+									} ) );
+								} }
+							/>
+							<HStack spacing={ 3 } justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ mutation.isPending }
+									disabled={ mutation.isPending }
+								>
+									{ __( 'Save' ) }
+								</Button>
+								<Button variant="secondary" onClick={ handleGeneratePassword }>
+									{ __( 'Generate strong password' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security-password/style.scss
+++ b/client/dashboard/me/security-password/style.scss
@@ -1,0 +1,5 @@
+.security-password-card {
+	input[type="password"]::-ms-reveal {
+		display: none;
+	}
+}


### PR DESCRIPTION
Ref DOTDASH-167

## Proposed Changes

Implement the Security → Password screen.
 
<img width="716" height="379" alt="SCR-20250828-mmab" src="https://github.com/user-attachments/assets/dfa7b7cc-80b5-470d-a103-cfb60c334523" />

> [!NOTE]
> Validation via [DataForm isValid](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/README.md#isvalid) seems currently broken. Will implement it separately from this PR when gutenberg#71161 is merged.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/security/password, using a non-a11n account
* Enter a password like 123 and ensure you get a notice saying that the password is weak
* Ensure that Generate a password works as intended
* Ensure that you're able to save a strong password

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
