### PR TITLE
A4A: Dynamically hide migration incentive highlights after the incentive end date

### DIFF
--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -14,6 +14,7 @@ import MigrationIncentiveIcon from 'calypso/assets/images/a8c-for-agencies/migra
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useShowMigrationIncentive } from '../hook/use-show-migration-incentive';
+import { migrationIncentiveEndDateString } from '../lib/constants';
 
 import './style.scss';
 
@@ -80,7 +81,10 @@ export default function PressablePremiumPlanMigrationBanner( {
 
 	const terms = (
 		<span>
-			{ translate( 'Offer ends September 30, 2025. {{a}}Terms{{/a}} ↗', {
+			{ translate( 'Offer ends %(endDate)s. {{a}}Terms{{/a}} ↗', {
+				args: {
+					endDate: migrationIncentiveEndDateString,
+				},
 				components: {
 					a: (
 						<Button

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
@@ -13,6 +13,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { useShowMigrationIncentive } from '../hook/use-show-migration-incentive';
+import { migrationIncentiveEndDateString } from '../lib/constants';
 
 import './style.scss';
 
@@ -110,7 +111,10 @@ export default function PressablePremiumPlanMigrationCard() {
 				</div>
 
 				<div className="pressable-premium-plan-migration-card__description">
-					{ translate( 'Offer ends September 30, 2025. {{a}}Terms{{/a}} ↗', {
+					{ translate( 'Offer ends %(endDate)s. {{a}}Terms{{/a}} ↗', {
+						args: {
+							endDate: migrationIncentiveEndDateString,
+						},
 						components: {
 							a: (
 								<Button

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE } from '../lib/constants';
 
 export function useShowMigrationIncentive() {
 	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
@@ -13,5 +14,8 @@ export function useShowMigrationIncentive() {
 	// This is to handle old signups without the number_sites field.
 	const showMigrationIncentive = numberSites === '51-100' || numberSites === '';
 
-	return isFeatureEnabled && showMigrationIncentive;
+	// We only show the incentive if the current date is before the migration incentive end date.
+	const isIncentiveActive = PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE > new Date();
+
+	return isFeatureEnabled && showMigrationIncentive && isIncentiveActive;
 }

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/lib/constants.ts
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/lib/constants.ts
@@ -1,0 +1,12 @@
+// We want to show the incentive until the end of the day in UTC.
+export const PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE = new Date(
+	'2025-09-30T23:59:59Z'
+);
+
+export const migrationIncentiveEndDateString =
+	PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE.toLocaleDateString( 'en-US', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		timeZone: 'UTC', // we want to show the same date in all timezones
+	} );


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1510/dynamically-hide-migration-incentive-highlights-after-the-incentive

## Proposed Changes

This PR 

- Dynamically hides migration incentive highlights after the incentive end date.
- Uses the constant date to display the incentive's last date.

## Why are these changes being made?

* This is done so that we don't have to manually hide if after the end date or update the incentive date in multiple places.

## Testing Instructions

* Open the A4A live link
* Go to Overview > Verify the migration card shows the correct date: Sept 30

<img width="1567" height="638" alt="Screenshot 2025-08-28 at 12 26 49 PM" src="https://github.com/user-attachments/assets/48ea16e3-cd7e-4f48-9a2e-6af174f54d39" />

* Go to Marketplace > Verify the migration banner shows the correct date: Sept 30

<img width="1567" height="483" alt="Screenshot 2025-08-28 at 12 27 01 PM" src="https://github.com/user-attachments/assets/b051540b-0e1c-4b4f-97c5-c3d90040fc15" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
