### PR TITLE
Cleanup the streamlined plans grid + checkout experiment: Revert the plan interval dropdown changes

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -2,18 +2,13 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isMultiYearDomainProduct,
-	isWpComPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceDropdownTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { JetpackItemVariantDropDownPrice } from './jetpack-variant-dropdown-price';
-import { CurrentOption, Dropdown, OptionList, Option, WPCheckoutCheckIcon } from './styles';
+import { CurrentOption, Dropdown, OptionList, Option } from './styles';
 import { ItemVariantDropDownPrice } from './variant-dropdown-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -32,32 +27,15 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 } ) => {
 	const translate = useTranslate();
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-	const isStreamlinedPrice =
-		isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) &&
-		isWpComPlan( selectedItem.product_slug );
-
-	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState< string | null >( null );
-
-	useEffect( () => {
-		if ( isStreamlinedPrice ) {
-			setOptimisticSelectedItem( selectedItem.product_slug );
-		}
-	}, [ selectedItem.product_slug, isStreamlinedPrice ] );
 
 	// Multi-year domain products must be compared by volume because they have the same product id.
-	const selectedVariantIndex = useMemo( () => {
-		const rawIndex = variants.findIndex( ( variant ) => {
-			if ( isStreamlinedPrice && optimisticSelectedItem ) {
-				return variant.productSlug === optimisticSelectedItem;
-			}
-			// If not optimistic, or optimisticSelectedItem is not set, use the original logic
-			return isMultiYearDomainProduct( selectedItem )
-				? selectedItem.volume === variant.volume && variant.productId === selectedItem.product_id
-				: selectedItem.product_id === variant.productId;
-		} );
-		return rawIndex > -1 ? rawIndex : null;
-	}, [ variants, isStreamlinedPrice, optimisticSelectedItem, selectedItem ] );
+	const selectedVariantIndexRaw = variants.findIndex( ( variant ) =>
+		isMultiYearDomainProduct( selectedItem )
+			? selectedItem.volume === variant.volume
+			: selectedItem.product_id === variant.productId
+	);
+	// findIndex returns -1 if it fails and we want null.
+	const selectedVariantIndex = selectedVariantIndexRaw > -1 ? selectedVariantIndexRaw : null;
 
 	// reset the dropdown highlight when the selected product changes
 	useEffect( () => {
@@ -67,13 +45,10 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	// wrapper around onChangeItemVariant to close up dropdown on change
 	const handleChange = useCallback(
 		( uuid: string, productSlug: string, productId: number, volume?: number ) => {
-			if ( isStreamlinedPrice ) {
-				setOptimisticSelectedItem( productSlug );
-			}
 			onChangeItemVariant( uuid, productSlug, productId, volume );
 			toggle( null );
 		},
-		[ onChangeItemVariant, toggle, isStreamlinedPrice ]
+		[ onChangeItemVariant, toggle ]
 	);
 
 	const selectNextVariant = useCallback( () => {
@@ -146,22 +121,13 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 		return null;
 	}
 
-	let compareTo = undefined;
-	if ( isStreamlinedPrice ) {
-		compareTo = variants[ 0 ];
-	}
 	const ItemVariantDropDownPriceWrapper: FunctionComponent< { variant: WPCOMProductVariant } > = (
 		props
 	) =>
 		isJetpack( props.variant ) ? (
 			<JetpackItemVariantDropDownPrice { ...props } allVariants={ variants } />
 		) : (
-			<ItemVariantDropDownPrice
-				{ ...props }
-				product={ selectedItem }
-				isStreamlinedPrice={ isStreamlinedPrice }
-				compareTo={ compareTo }
-			/>
+			<ItemVariantDropDownPrice { ...props } product={ selectedItem } />
 		);
 
 	return (
@@ -177,7 +143,6 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				onClick={ () => toggle( id ) }
 				open={ isOpen }
 				role="button"
-				detached={ isStreamlinedPrice }
 			>
 				{ selectedVariantIndex !== null ? (
 					<ItemVariantDropDownPriceWrapper variant={ variants[ selectedVariantIndex ] } />
@@ -192,7 +157,6 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 					highlightedVariantIndex={ highlightedVariantIndex }
 					selectedItem={ selectedItem }
 					handleChange={ handleChange }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
 		</Dropdown>
@@ -204,24 +168,15 @@ function ItemVariantOptionList( {
 	highlightedVariantIndex,
 	selectedItem,
 	handleChange,
-	isStreamlinedPrice,
 }: {
 	variants: WPCOMProductVariant[];
 	highlightedVariantIndex: number | null;
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number, volume?: number ) => void;
-	isStreamlinedPrice: boolean;
 } ) {
-	const compareTo = isStreamlinedPrice
-		? variants[ 0 ]
-		: variants.find( ( variant ) => variant.productId === selectedItem.product_id );
+	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
-		<OptionList
-			id={ `item-variant-listbox-${ selectedItem.uuid }` }
-			role="listbox"
-			tabIndex={ -1 }
-			detached={ isStreamlinedPrice }
-		>
+		<OptionList id={ `item-variant-listbox-${ selectedItem.uuid }` } role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel.noun }
@@ -238,7 +193,6 @@ function ItemVariantOptionList( {
 					variant={ variant }
 					allVariants={ variants }
 					selectedItem={ selectedItem }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) ) }
 		</OptionList>
@@ -252,7 +206,6 @@ function ItemVariantOption( {
 	variant,
 	allVariants,
 	selectedItem,
-	isStreamlinedPrice,
 }: {
 	isSelected: boolean;
 	onSelect: () => void;
@@ -260,7 +213,6 @@ function ItemVariantOption( {
 	variant: WPCOMProductVariant;
 	allVariants: WPCOMProductVariant[];
 	selectedItem: ResponseCartProduct;
-	isStreamlinedPrice: boolean;
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
 	return (
@@ -273,7 +225,6 @@ function ItemVariantOption( {
 			role="option"
 			onClick={ onSelect }
 			selected={ isSelected }
-			detached={ isStreamlinedPrice }
 		>
 			{ isJetpack( variant ) ? (
 				<JetpackItemVariantDropDownPrice variant={ variant } allVariants={ allVariants } />
@@ -282,10 +233,8 @@ function ItemVariantOption( {
 					variant={ variant }
 					compareTo={ compareTo }
 					product={ selectedItem }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
-			{ isStreamlinedPrice && isSelected && <WPCheckoutCheckIcon /> }
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { CheckIcon } from '../check-icon';
 import { CurrentOptionProps, OptionProps } from './types';
 
 export const CurrentOption = styled.button< CurrentOptionProps >`
@@ -22,7 +21,6 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	${ ( props ) =>
 		props.open &&
-		! props.detached &&
 		css`
 			border-radius: 3px 3px 0 0;
 		` }
@@ -41,46 +39,14 @@ export const Option = styled.li< OptionProps >`
 	align-items: center;
 	/* the calc aligns the price with the price in CurrentOption */
 	padding: 10px calc( 14px + 24px + 16px ) 10px 16px;
-	position: relative;
-
-	${ ( props ) =>
-		props.detached &&
-		css`
-			padding-top: 14px;
-			padding-bottom: 14px;
-		` }
 
 	&:hover {
 		background: var( --studio-wordpress-blue-5 );
 	}
 
-	${ ( props ) =>
-		! props.detached
-			? css`
-					&.item-variant-option--selected {
-						background: var( --studio-wordpress-blue-50 );
-						color: #fff;
-					}
-			  `
-			: css`
-					&.item-variant-option--selected * {
-						color: var( --studio-black );
-					}
-			  ` }
-`;
-
-export const WPCheckoutCheckIcon = styled( CheckIcon )`
-	fill: ${ ( props ) => props.theme.colors.success };
-	margin-right: 4px;
-	position: absolute;
-	top: 50%;
-	right: 16px;
-	transform: translateY( -50% );
-	.rtl & {
-		margin-right: 0;
-		margin-left: 4px;
-		right: auto;
-		left: 16px;
+	&.item-variant-option--selected {
+		background: var( --studio-wordpress-blue-50 );
+		color: #fff;
 	}
 `;
 
@@ -94,27 +60,12 @@ export const Dropdown = styled.div`
 	}
 `;
 
-export const OptionList = styled.ul< { detached: boolean } >`
+export const OptionList = styled.ul`
 	position: absolute;
 	width: 100%;
 	z-index: 4;
 	margin: 0;
 	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
-	${ ( props ) =>
-		props.detached &&
-		css`
-			box-shadow:
-				0px 50px 43px 0px rgba( 0, 0, 0, 0.02 ),
-				0px 30px 36px 0px rgba( 0, 0, 0, 0.04 ),
-				0px 15px 27px 0px rgba( 0, 0, 0, 0.07 ),
-				0px 5px 15px 0px rgba( 0, 0, 0, 0.08 );
-			margin-top: 10px;
-
-			${ Option }:first-of-type {
-				border-top-left-radius: 3px;
-				border-top-right-radius: 3px;
-			}
-		` }
 
 	${ Option } {
 		margin-top: -1px;
@@ -146,28 +97,6 @@ export const Discount = styled.span`
 
 	@media ( max-width: 660px ) {
 		width: 100%;
-	}
-`;
-
-export const DiscountAbsolute = styled.span< {
-	color: string;
-	backgroundColor: string;
-} >`
-	text-align: center;
-	color: ${ ( props ) => props.color };
-	display: block;
-	background-color: ${ ( props ) => props.backgroundColor };
-	padding: 0 10px;
-	border-radius: 4px;
-	font-size: 12px;
-	line-height: 20px;
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-	// Keep selected state override for now, adjust if needed
-	.item-variant-option--selected & {
-		color: ${ ( props ) => props.color };
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -42,10 +42,8 @@ export type OnChangeItemVariant = (
 
 export type CurrentOptionProps = {
 	open: boolean;
-	detached?: boolean;
 };
 
 export type OptionProps = {
 	selected: boolean;
-	detached?: boolean;
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,5 +1,4 @@
 import { isMultiYearDomainProduct } from '@automattic/calypso-products';
-import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +6,6 @@ import { FunctionComponent } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import {
 	Discount,
-	DiscountAbsolute,
 	DoNotPayThis,
 	IntroPricing,
 	IntroPricingText,
@@ -33,48 +31,14 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-const DiscountPrice: FunctionComponent< {
-	price: string;
-	termIntervalInMonths: number;
-} > = ( { price, termIntervalInMonths } ) => {
-	const translate = useTranslate();
-
-	// Determine colors for DiscountAbsolute based on term
-	let discountColor = colorStudio.colors[ 'Green 80' ];
-	let discountBackgroundColor = colorStudio.colors[ 'Green 10' ];
-
-	if ( termIntervalInMonths === 12 ) {
-		discountColor = colorStudio.colors[ 'Green 50' ];
-		discountBackgroundColor = colorStudio.colors[ 'Green 0' ]; // As per original request for yearly
-	} else if ( termIntervalInMonths === 24 ) {
-		discountColor = colorStudio.colors[ 'Green 80' ];
-		discountBackgroundColor = colorStudio.colors[ 'Green 5' ]; // As per original request for 2-yearly (using Green 5 as "Green" is ambiguous)
-	}
-
-	return (
-		<DiscountAbsolute color={ discountColor } backgroundColor={ discountBackgroundColor }>
-			{ translate( 'Save %(price)s', { args: { price } } ) }
-		</DiscountAbsolute>
-	);
-};
-
 export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 	product: ResponseCartProduct;
-	isStreamlinedPrice?: boolean;
-} > = ( { variant, compareTo, product, isStreamlinedPrice } ) => {
+} > = ( { variant, compareTo, product } ) => {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscount( variant, compareTo );
-	const discount = formatCurrency(
-		getItemVariantDiscount( variant, compareTo, 'absolute' ),
-		variant.currency,
-		{
-			stripZeros: true,
-			isSmallestUnit: true,
-		}
-	);
 
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
 		stripZeros: true,
@@ -217,61 +181,28 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	// or if it's a Jetpack 2 or 3-year plan
 	const canDisplayDiscountPercentage = ! isIntroductoryOffer;
 
-	const label =
-		variant.termIntervalInMonths === 1 && isStreamlinedPrice
-			? translate( 'Month' )
-			: variant.variantLabel.noun;
-
 	return (
 		<Variant>
 			<Label>
-				{ label }
-				{ hasDiscount &&
-					isMobile &&
-					( isStreamlinedPrice ? (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					) : (
-						<DiscountPercentage percent={ discountPercentage } />
-					) ) }
+				{ variant.variantLabel.noun }
+				{ hasDiscount && isMobile && <DiscountPercentage percent={ discountPercentage } /> }
 			</Label>
 			<PriceTextContainer>
-				{ hasDiscount &&
-					! isMobile &&
-					canDisplayDiscountPercentage &&
-					( isStreamlinedPrice ? (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					) : (
-						<DiscountPercentage percent={ discountPercentage } />
-					) ) }
-				{ hasDiscount && ! isIntroductoryOffer && ! isStreamlinedPrice && (
+				{ hasDiscount && ! isMobile && canDisplayDiscountPercentage && (
+					<DiscountPercentage percent={ discountPercentage } />
+				) }
+				{ hasDiscount && ! isIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
 
-				{ isStreamlinedPrice ? (
-					! canDisplayDiscountPercentage && (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					)
-				) : (
-					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
-				) }
-				{ ! isStreamlinedPrice && (
-					<IntroPricing>
-						{ ! isMultiYearDomain && (
-							<IntroPricingText>
-								{ isIntroductoryOffer && translatedIntroOfferDetails() }
-							</IntroPricingText>
-						) }
-					</IntroPricing>
-				) }
+				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
+				<IntroPricing>
+					{ ! isMultiYearDomain && (
+						<IntroPricingText>
+							{ isIntroductoryOffer && translatedIntroOfferDetails() }
+						</IntroPricingText>
+					) }
+				</IntroPricing>
 			</PriceTextContainer>
 		</Variant>
 	);

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -40,10 +40,3 @@ export function isStreamlinedPriceRadioTreatment( variationName?: string | null 
 	}
 	return variationName.includes( 'checkout_radio' );
 }
-
-export function isStreamlinedPriceDropdownTreatment( variationName?: string | null ) {
-	if ( ! variationName ) {
-		return false;
-	}
-	return variationName.includes( 'checkout_dropdown' );
-}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1029](https://linear.app/a8c/issue/M4R73CH-1029/cleanup-experiment-code)

## Proposed Changes

* removes the changes for the interval dropdown variation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* we need to cleanup the unnecessary code added for the Streamlined Pricing experiment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the `/start/onbarding-pm` flow
* On checkout, there should be no visible changes to the dropdown interval

| Before | After |
|--------|--------|
| <img width="1240" height="1245" alt="Screenshot 2025-08-28 at 12 46 56" src="https://github.com/user-attachments/assets/d8be84c2-6a1a-4121-8f29-f559d500a9d9" /> | <img width="1546" height="1244" alt="Screenshot 2025-08-28 at 12 46 51" src="https://github.com/user-attachments/assets/f5a3c72e-630f-4286-8284-d07cdbdbe7c1" /> | 

* Go through the `/setup/onbarding` flow (or change the `wpcom_signup_complete_flow_name` in the session storage)
* The radio interval variation should be unaffected

| Before | After |
|--------|--------|
| <img width="1343" height="1217" alt="Screenshot 2025-08-28 at 12 49 54" src="https://github.com/user-attachments/assets/148d5016-ef9e-46f4-814e-5ba08fa05b7a" /> | <img width="1660" height="1220" alt="Screenshot 2025-08-28 at 12 50 00" src="https://github.com/user-attachments/assets/d8edbbfd-306e-4e19-9f67-21664928524e" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
