### PR TITLE
Login: add link to account-recovery page in lost-password page

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { Button, Spinner } from '@wordpress/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button, Spinner, ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -194,6 +195,15 @@ const LostPasswordForm = ( {
 					ref={ inputRef }
 				/>
 				{ showError && <FormInputValidation isError text={ error } /> }
+				<ExternalLink
+					href={ localizeUrl(
+						'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
+						locale
+					) }
+					className="login__lostpassword-form-external-link"
+				>
+					{ translate( 'Need More Help?' ) }
+				</ExternalLink>
 			</div>
 			<div className="login__form-action">
 				<Button

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -312,3 +312,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 }
+
+.login__lostpassword-form-external-link {
+	font-size: 0.875em;
+}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOTOBRD-309/no-link-to-the-account-recovery-form-from-the-lost-password-page

### Summary
- Add “Need More Help?” link below the lost-password input validation message pointing to account recovery help. Uses ExternalLink and localizeUrl(locale).
- Adds class `login__lostpassword-form-external-link` with spacing in styles.

### Changes
- client/blocks/login/lost-password-form.jsx
- client/blocks/login/style.scss

### Diff Stats
- 2 files changed, 15 insertions(+), 1 deletion(-)

### Testing Instructions
- Go to `/log-in/lostpassword`.
- Confirm the “Need More Help?” link appears below the field and below any validation message.
- Clicking opens `https://wordpress.com/support/account-recovery/#verify-your-account-ownership` in a new tab.
- URL is localized based on locale.
- RTL spacing looks correct.

### Accessibility
- Link text is descriptive; placed after input validation for logical reading order.

### Screenshots

<img width="500" alt="Screenshot 2025-08-28 at 4 37 08 PM" src="https://github.com/user-attachments/assets/ef42c3d3-5799-443b-8f02-75383bb3f548" />
