### PR TITLE
Remove Google Domains offer in /setup/domain-transfer flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -56,9 +56,6 @@ const Intro: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
-						badge: isGoogleDomainsTransferFlow
-							? __( 'We pay the first year' )
-							: __( 'We pay the first year for Google domains' ),
 						description: (
 							<p>
 								{ __(


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/M4R73CH-578/remove-google-domains-offer-in-setuptransfer-signup-flow

### Summary
- Remove Google Domains offer from the `/setup/domain-transfer` introduction step.

### Changes
- client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx

### Diff Stats
- 1 file changed, 3 deletions(-)

### Testing Instructions
- Navigate to `/setup/domain-transfer` flow.
- Ensure the Google Domains offer content is no longer displayed in the intro step.

### Accessibility
- No user-facing interactive changes.

### Screenshots
| Before | After |
|--------|--------|
| <img width="713" height="719" alt="Screenshot 2025-08-28 at 5 34 14 PM" src="https://github.com/user-attachments/assets/5a0489d8-e021-496e-9089-f629d93e0391" /> | <img width="629" height="695" alt="Screenshot 2025-08-28 at 5 58 10 PM" src="https://github.com/user-attachments/assets/b5b21ae9-8924-4663-a7bf-8f653f3c2b08" /> |

