### PR TITLE
Backup Dashboard: move restore status polling logic to SiteBackupRestoreProgress

### DIFF
--- a/client/dashboard/app/queries/site-backup-restore.ts
+++ b/client/dashboard/app/queries/site-backup-restore.ts
@@ -2,7 +2,6 @@ import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import {
 	fetchSiteBackupRestoreProgress,
 	initiateSiteBackupRestore,
-	type RestoreProgress,
 	type RestoreConfig,
 } from '../../data/site-backup-restore';
 import { queryClient } from '../query-client';
@@ -17,17 +16,6 @@ export const siteBackupRestoreProgressQuery = ( siteId: number, restoreId: numbe
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', 'restore', restoreId, 'progress' ],
 		queryFn: () => fetchSiteBackupRestoreProgress( siteId, restoreId ),
-		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
-			const { data } = query.state;
-
-			// Poll every 1.5 seconds if restore is in progress
-			if ( data?.status === 'queued' || data?.status === 'running' ) {
-				return 1500;
-			}
-
-			// Stop polling if finished or failed
-			return false;
-		},
 	} );
 
 /**

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -10,6 +10,7 @@ import { useEffect } from 'react';
 import { siteBackupRestoreProgressQuery } from '../../app/queries/site-backup-restore';
 import Notice from '../../components/notice';
 import noSitesIllustration from '../no-sites-illustration.svg';
+import type { RestoreProgress } from '../../data/site-backup-restore';
 import type { Site } from '../../data/types';
 
 function SiteBackupRestoreProgress( {
@@ -26,6 +27,17 @@ function SiteBackupRestoreProgress( {
 	const { data: restoreProgress } = useQuery( {
 		...siteBackupRestoreProgressQuery( site.ID, restoreId ),
 		enabled: !! restoreId,
+		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
+			const { data } = query.state;
+
+			// Poll every 1.5 seconds if restore is in progress
+			if ( data?.status === 'queued' || data?.status === 'running' ) {
+				return 1500;
+			}
+
+			// Stop polling if finished or failed
+			return false;
+		},
 	} );
 
 	useEffect( () => {

--- a/client/dashboard/sites/backup-restore/progress.tsx
+++ b/client/dashboard/sites/backup-restore/progress.tsx
@@ -10,7 +10,6 @@ import { useEffect } from 'react';
 import { siteBackupRestoreProgressQuery } from '../../app/queries/site-backup-restore';
 import Notice from '../../components/notice';
 import noSitesIllustration from '../no-sites-illustration.svg';
-import type { RestoreProgress } from '../../data/site-backup-restore';
 import type { Site } from '../../data/types';
 
 function SiteBackupRestoreProgress( {
@@ -27,7 +26,7 @@ function SiteBackupRestoreProgress( {
 	const { data: restoreProgress } = useQuery( {
 		...siteBackupRestoreProgressQuery( site.ID, restoreId ),
 		enabled: !! restoreId,
-		refetchInterval: ( query: { state: { data?: RestoreProgress } } ) => {
+		refetchInterval: ( query ) => {
 			const { data } = query.state;
 
 			// Poll every 1.5 seconds if restore is in progress


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-278

## Proposed Changes

* Move restore status polling logic to SiteBackupRestoreProgress

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addressing [this PR review comment](https://github.com/Automattic/wp-calypso/pull/105367#discussion_r2306079126) from the download flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/v2/sites/SITE_SLUG/backups` using a site with the backup feature
* Click on any of the backups on the list, then click on -> Restore to this point
* Run a new restore and verify it shows the progress and succeeds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
