### PR TITLE
Staging Sites: Add success / error notifications for sync completion in V2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /client/dashboard/sites/staging-site-sync-modal @Automattic/yolo
 /client/dashboard/sites/staging-site-delete-modal @Automattic/yolo
 /client/dashboard/sites/site/environment-switcher.tsx @Automattic/yolo
+/client/dashboard/app/staging-site-sync-monitor @Automattic/yolo
 
 # Staging sites - interim dashboard
 /client/sites/staging-site @Automattic/yolo

--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -28,7 +28,7 @@ export default function StagingSiteSyncMonitor( { site }: StagingSiteSyncMonitor
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	if ( productionSiteId && stagingSiteSyncState && wasSyncingRef.current && ! isSyncing ) {
+	if ( productionSiteId && wasSyncingRef.current && ! isSyncing ) {
 		if ( stagingSiteSyncState?.status === 'completed' ) {
 			createSuccessNotice( __( 'Synchronization completed successfully.' ), {
 				type: 'snackbar',

--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { getProductionSiteId, isStagingSiteSyncing } from '../../utils/site-staging-site';
+import { stagingSiteSyncStateQuery } from '../queries/site-staging-sites';
+import type { Site } from '../../data/types';
+
+interface StagingSiteSyncMonitorProps {
+	site: Site;
+}
+
+export default function StagingSiteSyncMonitor( { site }: StagingSiteSyncMonitorProps ) {
+	const productionSiteId = getProductionSiteId( site );
+
+	const { data: stagingSiteSyncState } = useQuery( {
+		...stagingSiteSyncStateQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+		refetchInterval: ( query ) => {
+			return isStagingSiteSyncing( query.state.data ) ? 5000 : false;
+		},
+		refetchIntervalInBackground: true,
+	} );
+
+	const isSyncing = isStagingSiteSyncing( stagingSiteSyncState );
+	const wasSyncingRef = useRef( false );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( ! productionSiteId || ! stagingSiteSyncState ) {
+			return;
+		}
+
+		if ( wasSyncingRef.current && ! isSyncing ) {
+			if ( stagingSiteSyncState?.status === 'completed' ) {
+				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			} else if (
+				stagingSiteSyncState?.status === 'failed' ||
+				stagingSiteSyncState?.status === 'allow_retry'
+			) {
+				createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			}
+		}
+
+		wasSyncingRef.current = !! isSyncing;
+	}, [
+		isSyncing,
+		stagingSiteSyncState,
+		createSuccessNotice,
+		createErrorNotice,
+		productionSiteId,
+	] );
+
+	return null;
+}

--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getProductionSiteId, isStagingSiteSyncing } from '../../utils/site-staging-site';
@@ -28,36 +28,24 @@ export default function StagingSiteSyncMonitor( { site }: StagingSiteSyncMonitor
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	useEffect( () => {
-		if ( ! productionSiteId || ! stagingSiteSyncState ) {
-			return;
+	if ( productionSiteId && stagingSiteSyncState && wasSyncingRef.current && ! isSyncing ) {
+		if ( stagingSiteSyncState?.status === 'completed' ) {
+			createSuccessNotice( __( 'Synchronization completed successfully.' ), {
+				type: 'snackbar',
+				explicitDismiss: true,
+			} );
+		} else if (
+			stagingSiteSyncState?.status === 'failed' ||
+			stagingSiteSyncState?.status === 'allow_retry'
+		) {
+			createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
+				type: 'snackbar',
+				explicitDismiss: true,
+			} );
 		}
+	}
 
-		if ( wasSyncingRef.current && ! isSyncing ) {
-			if ( stagingSiteSyncState?.status === 'completed' ) {
-				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
-					type: 'snackbar',
-					explicitDismiss: true,
-				} );
-			} else if (
-				stagingSiteSyncState?.status === 'failed' ||
-				stagingSiteSyncState?.status === 'allow_retry'
-			) {
-				createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
-					type: 'snackbar',
-					explicitDismiss: true,
-				} );
-			}
-		}
-
-		wasSyncingRef.current = !! isSyncing;
-	}, [
-		isSyncing,
-		stagingSiteSyncState,
-		createSuccessNotice,
-		createErrorNotice,
-		productionSiteId,
-	] );
+	wasSyncingRef.current = !! isSyncing;
 
 	return null;
 }

--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -1,11 +1,11 @@
+import { stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getProductionSiteId, isStagingSiteSyncing } from '../../utils/site-staging-site';
-import { stagingSiteSyncStateQuery } from '../queries/site-staging-sites';
-import type { Site } from '../../data/types';
+import type { Site } from '@automattic/api-core';
 
 interface StagingSiteSyncMonitorProps {
 	site: Site;

--- a/client/dashboard/app/staging-site-sync-monitor/index.tsx
+++ b/client/dashboard/app/staging-site-sync-monitor/index.tsx
@@ -1,7 +1,7 @@
 import { stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getProductionSiteId, isStagingSiteSyncing } from '../../utils/site-staging-site';
@@ -28,24 +28,32 @@ export default function StagingSiteSyncMonitor( { site }: StagingSiteSyncMonitor
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	if ( productionSiteId && wasSyncingRef.current && ! isSyncing ) {
-		if ( stagingSiteSyncState?.status === 'completed' ) {
-			createSuccessNotice( __( 'Synchronization completed successfully.' ), {
-				type: 'snackbar',
-				explicitDismiss: true,
-			} );
-		} else if (
-			stagingSiteSyncState?.status === 'failed' ||
-			stagingSiteSyncState?.status === 'allow_retry'
-		) {
-			createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
-				type: 'snackbar',
-				explicitDismiss: true,
-			} );
+	useEffect( () => {
+		if ( productionSiteId && wasSyncingRef.current && ! isSyncing ) {
+			if ( stagingSiteSyncState?.status === 'completed' ) {
+				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			} else if (
+				stagingSiteSyncState?.status === 'failed' ||
+				stagingSiteSyncState?.status === 'allow_retry'
+			) {
+				createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			}
 		}
-	}
 
-	wasSyncingRef.current = !! isSyncing;
+		wasSyncingRef.current = !! isSyncing;
+	}, [
+		isSyncing,
+		stagingSiteSyncState,
+		productionSiteId,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
 
 	return null;
 }

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -13,10 +13,12 @@ import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
+import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
 import Switcher from '../../components/switcher';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { hasStagingSite } from '../../utils/site-staging-site';
 import AddNewSite from '../add-new-site';
 import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteIcon from '../site-icon';
@@ -36,6 +38,7 @@ function Site() {
 
 	return (
 		<>
+			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
 			<HeaderBar>
 				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
 					<HeaderBar.Title>

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,9 +1,11 @@
 import { siteBySlugQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { lazy, Suspense } from 'react';
 import {
 	getProductionSiteId,
@@ -52,6 +54,34 @@ export default function StagingSiteSyncDropdown( {
 	} );
 
 	const isSyncing = isStagingSiteSyncing( stagingSiteSyncState );
+	const wasSyncingRef = useRef( false );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( ! window?.location?.pathname?.startsWith( '/v2' ) ) {
+			return;
+		}
+
+		if ( wasSyncingRef.current && ! isSyncing ) {
+			if ( stagingSiteSyncState?.status === 'completed' ) {
+				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			} else if (
+				stagingSiteSyncState?.status === 'failed' ||
+				stagingSiteSyncState?.status === 'allow_retry'
+			) {
+				createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
+					type: 'snackbar',
+					explicitDismiss: true,
+				} );
+			}
+		}
+
+		wasSyncingRef.current = !! isSyncing;
+	}, [ isSyncing, stagingSiteSyncState, createSuccessNotice, createErrorNotice ] );
 
 	const pullLabel =
 		environment === 'staging' ? __( 'Pull from Production' ) : __( 'Pull from Staging' );

--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,11 +1,9 @@
 import { siteBySlugQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { lazy, Suspense } from 'react';
 import {
 	getProductionSiteId,
@@ -54,34 +52,6 @@ export default function StagingSiteSyncDropdown( {
 	} );
 
 	const isSyncing = isStagingSiteSyncing( stagingSiteSyncState );
-	const wasSyncingRef = useRef( false );
-
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	useEffect( () => {
-		if ( ! window?.location?.pathname?.startsWith( '/v2' ) ) {
-			return;
-		}
-
-		if ( wasSyncingRef.current && ! isSyncing ) {
-			if ( stagingSiteSyncState?.status === 'completed' ) {
-				createSuccessNotice( __( 'Synchronization completed successfully.' ), {
-					type: 'snackbar',
-					explicitDismiss: true,
-				} );
-			} else if (
-				stagingSiteSyncState?.status === 'failed' ||
-				stagingSiteSyncState?.status === 'allow_retry'
-			) {
-				createErrorNotice( __( 'Synchronization failed. Please try again.' ), {
-					type: 'snackbar',
-					explicitDismiss: true,
-				} );
-			}
-		}
-
-		wasSyncingRef.current = !! isSyncing;
-	}, [ isSyncing, stagingSiteSyncState, createSuccessNotice, createErrorNotice ] );
 
 	const pullLabel =
 		environment === 'staging' ? __( 'Pull from Production' ) : __( 'Pull from Staging' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-309

## Proposed Changes

* add sync success and failure notifications

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTDASH-309

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link below).
2. Ensure you have a WoA site with related staging site.
3. Open to the new dashboard and initiate staging site sync.
4. Navigate to a different tab in the new dashboard, e.g. Settings or Backups.
5. Once the process is finished, a persistent success notification should appear in the bottom-left corner.
6. If we repeat the steps on the V1 dashboard, only the original notification (in the top-right corner) should appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
