### PR TITLE
[WIP] Staging Sites: Implement Add Staging Site button in the new Dashboard

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -8,7 +8,6 @@ import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import { useSetTabBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-tab-breadcrumb';
 import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-features-icon';
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
-import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import { useSelector } from 'calypso/state';
 import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
@@ -246,7 +245,13 @@ const DotcomPreviewPane = ( {
 					}
 
 					if ( shouldShowProductionBadge ) {
-						return <SitesProductionBadge>{ __( 'Production' ) }</SitesProductionBadge>;
+						return (
+							<SiteEnvironmentSwitcher
+								onChange={ changeSitePreviewPane }
+								site={ siteWithStagingIds }
+								showAddStagingSiteButton
+							/>
+						);
 					}
 
 					if (

--- a/client/sites/components/site-preview-pane/site-environment-switcher.tsx
+++ b/client/sites/components/site-preview-pane/site-environment-switcher.tsx
@@ -1,6 +1,6 @@
 import { SiteExcerptData } from '@automattic/sites';
 import { DropdownMenu, Button } from '@wordpress/components';
-import { chevronDownSmall } from '@wordpress/icons';
+import { chevronDownSmall, plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
@@ -11,11 +11,13 @@ import './site-environment-switcher.scss';
 interface SiteEnvironmentSwitcherProps {
 	onChange: ( siteId: number ) => void;
 	site: SiteExcerptData;
+	showAddStagingSiteButton?: boolean;
 }
 
 export default function SiteEnvironmentSwitcher( {
 	onChange,
 	site,
+	showAddStagingSiteButton,
 }: SiteEnvironmentSwitcherProps ) {
 	const { __ } = useI18n();
 
@@ -35,6 +37,30 @@ export default function SiteEnvironmentSwitcher( {
 		onChange( siteIdToChange as number );
 	};
 
+	const controls = [
+		{
+			title: __( 'Production' ),
+			onClick: () => setEnvironment( productionSiteId ),
+			isActive: ! site.is_wpcom_staging_site,
+		},
+		...( showAddStagingSiteButton
+			? [
+					{
+						icon: plus,
+						title: __( 'Add staging site' ),
+						onClick: () => setEnvironment( stagingSiteId ),
+						isActive: site.is_wpcom_staging_site,
+					},
+			  ]
+			: [
+					{
+						title: __( 'Staging' ),
+						onClick: () => setEnvironment( stagingSiteId ),
+						isActive: site.is_wpcom_staging_site,
+					},
+			  ] ),
+	];
+
 	return (
 		<DropdownMenu
 			icon={ chevronDownSmall }
@@ -48,18 +74,7 @@ export default function SiteEnvironmentSwitcher( {
 				placement: 'bottom-start',
 				className: 'site-preview-pane__site-switcher-dropdown-menu',
 			} }
-			controls={ [
-				{
-					title: __( 'Production' ),
-					onClick: () => setEnvironment( productionSiteId ),
-					isActive: ! site.is_wpcom_staging_site,
-				},
-				{
-					title: __( 'Staging' ),
-					onClick: () => setEnvironment( stagingSiteId ),
-					isActive: site.is_wpcom_staging_site,
-				},
-			] }
+			controls={ controls }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
