### PR TITLE
Hosting Dashboard: Use single purchase endpoint for fetching a purchase

### DIFF
--- a/client/dashboard/app/queries/me-purchases.ts
+++ b/client/dashboard/app/queries/me-purchases.ts
@@ -1,6 +1,6 @@
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchUserPurchases, fetchUserTransferredPurchases } from '../../data/me-purchases';
-import { setPurchaseAutoRenew, fetchUserPurchase } from '../../data/upgrades';
+import { setPurchaseAutoRenew, fetchPurchase } from '../../data/upgrades';
 import { queryClient } from '../query-client';
 
 export const userPurchasesQuery = () =>
@@ -19,7 +19,7 @@ export function userTransferredPurchasesQuery() {
 export const purchaseQuery = ( purchaseId: number ) =>
 	queryOptions( {
 		queryKey: [ 'me', 'purchases', purchaseId ],
-		queryFn: () => fetchUserPurchase( purchaseId ),
+		queryFn: () => fetchPurchase( purchaseId ),
 	} );
 
 export const userPurchaseSetAutoRenewQuery = ( purchaseId: number ) =>

--- a/client/dashboard/app/queries/me-purchases.ts
+++ b/client/dashboard/app/queries/me-purchases.ts
@@ -1,6 +1,6 @@
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { fetchUserPurchases, fetchUserTransferredPurchases } from '../../data/me-purchases';
-import { setPurchaseAutoRenew } from '../../data/upgrades';
+import { setPurchaseAutoRenew, fetchUserPurchase } from '../../data/upgrades';
 import { queryClient } from '../query-client';
 
 export const userPurchasesQuery = () =>
@@ -19,14 +19,13 @@ export function userTransferredPurchasesQuery() {
 export const purchaseQuery = ( purchaseId: number ) =>
 	queryOptions( {
 		queryKey: [ 'me', 'purchases', purchaseId ],
-		queryFn: () => fetchUserPurchases(),
-		select: ( purchases ) => purchases.find( ( p ) => p.ID === purchaseId ),
+		queryFn: () => fetchUserPurchase( purchaseId ),
 	} );
 
 export const userPurchaseSetAutoRenewQuery = ( purchaseId: number ) =>
 	mutationOptions( {
 		mutationFn: ( autoRenew: boolean ) => setPurchaseAutoRenew( purchaseId, autoRenew ),
 		onSuccess: ( data ) => {
-			queryClient.setQueryData( purchaseQuery( purchaseId ).queryKey, [ data.upgrade ] );
+			queryClient.setQueryData( purchaseQuery( purchaseId ).queryKey, data.upgrade );
 		},
 	} );

--- a/client/dashboard/data/upgrades.ts
+++ b/client/dashboard/data/upgrades.ts
@@ -16,3 +16,11 @@ export async function setPurchaseAutoRenew(
 		upgrade: normalizePurchase( data.upgrade ),
 	};
 }
+
+export async function fetchPurchase( purchaseId: number ): Promise< Purchase > {
+	const data = await wpcom.req.get( {
+		path: `/upgrades/${ purchaseId }`,
+		apiVersion: '1.1',
+	} );
+	return normalizePurchase( data );
+}


### PR DESCRIPTION
Fixes SHILL-1073

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR uses the new single-purchase endpoint when fetching single purchases, rather than fetching all the user's purchases or all the site's purchases, and filtering. This should be much more efficient for users with a lot of purchases.

> [!NOTE]
> This can be used to replace `sitePurchaseQuery` (and `fetchSitePurchases`) as well, but that's a much bigger change so I felt it wise to only modify the purchase settings page for now.

Depends on 191543-ghe-Automattic/wpcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `v2/me/billing/purchases` and click through to a purchase. Verify that it loads correctly.
