### PR TITLE
Domain Search Rewrite: Remove unavailable premium domains

### DIFF
--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -1,5 +1,3 @@
-import type { DomainSuggestion } from '@automattic/data';
-
 export type FeaturedSuggestionReason = 'exact-match' | 'recommended' | 'best-alternative';
 
 export interface FeaturedSuggestionWithReason {
@@ -13,7 +11,7 @@ interface PartitionedSuggestions {
 }
 
 interface PartitionSuggestionsParams {
-	suggestions: DomainSuggestion[];
+	suggestions: string[];
 	query: string;
 	deemphasiseTlds: string[];
 }
@@ -23,19 +21,19 @@ export const partitionSuggestions = ( {
 	query,
 	deemphasiseTlds,
 }: PartitionSuggestionsParams ): PartitionedSuggestions => {
-	const exactMatch = suggestions.find( ( suggestion ) => suggestion.domain_name === query );
+	const exactMatch = suggestions.find( ( suggestion ) => suggestion === query );
 
 	if ( exactMatch ) {
 		return {
 			featuredSuggestions: [
 				{
-					suggestion: exactMatch.domain_name,
+					suggestion: exactMatch,
 					reason: 'exact-match',
 				},
 			],
 			regularSuggestions: suggestions
-				.filter( ( suggestion ) => suggestion.domain_name !== query )
-				.map( ( suggestion ) => suggestion.domain_name ),
+				.filter( ( suggestion ) => suggestion !== query )
+				.map( ( suggestion ) => suggestion ),
 		};
 	}
 
@@ -43,14 +41,14 @@ export const partitionSuggestions = ( {
 	const regularSuggestions: string[] = [];
 
 	for ( const suggestion of suggestions ) {
-		if ( deemphasiseTlds.some( ( tld ) => suggestion.domain_name.endsWith( `.${ tld }` ) ) ) {
-			regularSuggestions.push( suggestion.domain_name );
+		if ( deemphasiseTlds.some( ( tld ) => suggestion.endsWith( `.${ tld }` ) ) ) {
+			regularSuggestions.push( suggestion );
 			continue;
 		}
 
 		if ( ! featuredSuggestions.find( ( { reason } ) => reason === 'recommended' ) ) {
 			featuredSuggestions.push( {
-				suggestion: suggestion.domain_name,
+				suggestion: suggestion,
 				reason: 'recommended',
 			} );
 			continue;
@@ -58,13 +56,13 @@ export const partitionSuggestions = ( {
 
 		if ( ! featuredSuggestions.find( ( { reason } ) => reason === 'best-alternative' ) ) {
 			featuredSuggestions.push( {
-				suggestion: suggestion.domain_name,
+				suggestion: suggestion,
 				reason: 'best-alternative',
 			} );
 			continue;
 		}
 
-		regularSuggestions.push( suggestion.domain_name );
+		regularSuggestions.push( suggestion );
 	}
 
 	return {

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -31,9 +31,7 @@ export const partitionSuggestions = ( {
 					reason: 'exact-match',
 				},
 			],
-			regularSuggestions: suggestions
-				.filter( ( suggestion ) => suggestion !== query )
-				.map( ( suggestion ) => suggestion ),
+			regularSuggestions: suggestions.filter( ( suggestion ) => suggestion !== query ),
 		};
 	}
 

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -1,0 +1,80 @@
+import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/data';
+import { useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { partitionSuggestions } from '../helpers/partition-suggestions';
+import { useDomainSearch } from '../page/context';
+
+export const useSuggestionsList = () => {
+	const { query, queries, config } = useDomainSearch();
+
+	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery(
+		queries.domainSuggestions( query )
+	);
+
+	const { isLoading: isLoadingFreeSuggestion } = useQuery( queries.freeSuggestion( query ) );
+
+	const { isLoading: isLoadingQueryAvailability } = useQuery( {
+		...queries.domainAvailability( query ),
+		enabled: true,
+	} );
+
+	const premiumSuggestions = useMemo(
+		() =>
+			suggestions
+				.filter( ( suggestion ) => suggestion.is_premium )
+				.map( ( suggestion ) => suggestion.domain_name ),
+		[ suggestions ]
+	);
+
+	const unavailablePremiumDomainsCombinator = useCallback(
+		( results: UseQueryResult< DomainAvailability, Error >[] ) => {
+			return {
+				isLoadingUnavailablePremiumDomains: results.some( ( result ) => result.isLoading ),
+				unavailablePremiumDomains: premiumSuggestions.filter( ( _, index ) => {
+					const availabilityQuery = results[ index ];
+
+					if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
+						return true;
+					}
+
+					const { status, is_supported_premium_domain } = availabilityQuery.data;
+
+					return (
+						DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain
+					);
+				} ),
+			};
+		},
+		[ premiumSuggestions ]
+	);
+
+	const { isLoadingUnavailablePremiumDomains, unavailablePremiumDomains } = useQueries( {
+		queries: premiumSuggestions.map( ( suggestion ) => ( {
+			...queries.domainAvailability( suggestion ),
+			enabled: true,
+		} ) ),
+		combine: unavailablePremiumDomainsCombinator,
+	} );
+
+	const isLoading =
+		isLoadingSuggestions ||
+		isLoadingFreeSuggestion ||
+		isLoadingQueryAvailability ||
+		isLoadingUnavailablePremiumDomains;
+
+	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
+		return partitionSuggestions( {
+			suggestions: suggestions
+				.map( ( suggestion ) => suggestion.domain_name )
+				.filter( ( suggestion ) => ! unavailablePremiumDomains.includes( suggestion ) ),
+			query,
+			deemphasiseTlds: config.deemphasizedTlds,
+		} );
+	}, [ suggestions, query, config.deemphasizedTlds, unavailablePremiumDomains ] );
+
+	return {
+		isLoading,
+		featuredSuggestions,
+		regularSuggestions,
+	};
+};

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,7 +1,4 @@
-import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/data';
-import { useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useCallback, useMemo } from 'react';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
@@ -9,76 +6,13 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
-import { partitionSuggestions } from '../helpers/partition-suggestions';
+import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
-	const { slots, query, queries, config } = useDomainSearch();
+	const { slots, config } = useDomainSearch();
 
-	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery(
-		queries.domainSuggestions( query )
-	);
-
-	const { isLoading: isLoadingFreeSuggestion } = useQuery( queries.freeSuggestion( query ) );
-
-	const { isLoading: isLoadingQueryAvailability } = useQuery( {
-		...queries.domainAvailability( query ),
-		enabled: true,
-	} );
-
-	const premiumSuggestions = useMemo(
-		() =>
-			suggestions
-				.filter( ( suggestion ) => suggestion.is_premium )
-				.map( ( suggestion ) => suggestion.domain_name ),
-		[ suggestions ]
-	);
-
-	const unavailablePremiumDomainsCombinator = useCallback(
-		( results: UseQueryResult< DomainAvailability, Error >[] ) => {
-			return {
-				isLoadingUnavailablePremiumDomains: results.some( ( result ) => result.isLoading ),
-				unavailablePremiumDomains: premiumSuggestions.filter( ( _, index ) => {
-					const availabilityQuery = results[ index ];
-
-					if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
-						return true;
-					}
-
-					const { status, is_supported_premium_domain } = availabilityQuery.data;
-
-					return (
-						DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain
-					);
-				} ),
-			};
-		},
-		[ premiumSuggestions ]
-	);
-
-	const { isLoadingUnavailablePremiumDomains, unavailablePremiumDomains } = useQueries( {
-		queries: premiumSuggestions.map( ( suggestion ) => ( {
-			...queries.domainAvailability( suggestion ),
-			enabled: true,
-		} ) ),
-		combine: unavailablePremiumDomainsCombinator,
-	} );
-
-	const isLoading =
-		isLoadingSuggestions ||
-		isLoadingFreeSuggestion ||
-		isLoadingQueryAvailability ||
-		isLoadingUnavailablePremiumDomains;
-
-	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
-		return partitionSuggestions( {
-			suggestions: suggestions
-				.map( ( suggestion ) => suggestion.domain_name )
-				.filter( ( suggestion ) => ! unavailablePremiumDomains.includes( suggestion ) ),
-			query,
-			deemphasiseTlds: config.deemphasizedTlds,
-		} );
-	}, [ suggestions, query, config.deemphasizedTlds, unavailablePremiumDomains ] );
+	const { isLoading, featuredSuggestions, regularSuggestions } = useSuggestionsList();
 
 	return (
 		<VStack spacing={ 8 }>

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,3 +1,4 @@
+import { DomainAvailabilityStatus } from '@automattic/data';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useMemo } from 'react';
@@ -25,24 +26,50 @@ export const ResultsPage = () => {
 		enabled: true,
 	} );
 
-	useQueries( {
-		queries: suggestions
-			.filter( ( suggestion ) => suggestion.is_premium )
-			.map( ( suggestion ) => ( {
-				...queries.domainAvailability( suggestion.domain_name ),
-				enabled: true,
-			} ) ),
+	const premiumSuggestions = useMemo(
+		() =>
+			suggestions
+				.filter( ( suggestion ) => suggestion.is_premium )
+				.map( ( suggestion ) => suggestion.domain_name ),
+		[ suggestions ]
+	);
+
+	const premiumDomainAvailabilityQueries = useQueries( {
+		queries: premiumSuggestions.map( ( suggestion ) => ( {
+			...queries.domainAvailability( suggestion ),
+			enabled: true,
+		} ) ),
 	} );
 
-	const isLoading = isLoadingSuggestions || isLoadingFreeSuggestion || isLoadingQueryAvailability;
+	const isLoading =
+		isLoadingSuggestions ||
+		isLoadingFreeSuggestion ||
+		isLoadingQueryAvailability ||
+		premiumDomainAvailabilityQueries.some( ( query ) => query.isLoading );
+
+	const unavailablePremiumDomains = useMemo( () => {
+		return premiumSuggestions.filter( ( _, index ) => {
+			const availabilityQuery = premiumDomainAvailabilityQueries[ index ];
+
+			if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
+				return true;
+			}
+
+			const { status, is_supported_premium_domain } = availabilityQuery.data;
+
+			return DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain;
+		} );
+	}, [ premiumDomainAvailabilityQueries, premiumSuggestions ] );
 
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
 		return partitionSuggestions( {
-			suggestions,
+			suggestions: suggestions
+				.map( ( suggestion ) => suggestion.domain_name )
+				.filter( ( suggestion ) => ! unavailablePremiumDomains.includes( suggestion ) ),
 			query,
 			deemphasiseTlds: config.deemphasizedTlds,
 		} );
-	}, [ suggestions, query, config.deemphasizedTlds ] );
+	}, [ suggestions, query, config.deemphasizedTlds, unavailablePremiumDomains ] );
 
 	return (
 		<VStack spacing={ 8 }>

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,7 +1,7 @@
-import { DomainAvailabilityStatus } from '@automattic/data';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/data';
+import { useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
@@ -34,32 +34,41 @@ export const ResultsPage = () => {
 		[ suggestions ]
 	);
 
-	const premiumDomainAvailabilityQueries = useQueries( {
+	const unavailablePremiumDomainsCombinator = useCallback(
+		( results: UseQueryResult< DomainAvailability, Error >[] ) => {
+			return {
+				isLoadingUnavailablePremiumDomains: results.some( ( result ) => result.isLoading ),
+				unavailablePremiumDomains: premiumSuggestions.filter( ( _, index ) => {
+					const availabilityQuery = results[ index ];
+
+					if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
+						return true;
+					}
+
+					const { status, is_supported_premium_domain } = availabilityQuery.data;
+
+					return (
+						DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain
+					);
+				} ),
+			};
+		},
+		[ premiumSuggestions ]
+	);
+
+	const { isLoadingUnavailablePremiumDomains, unavailablePremiumDomains } = useQueries( {
 		queries: premiumSuggestions.map( ( suggestion ) => ( {
 			...queries.domainAvailability( suggestion ),
 			enabled: true,
 		} ) ),
+		combine: unavailablePremiumDomainsCombinator,
 	} );
 
 	const isLoading =
 		isLoadingSuggestions ||
 		isLoadingFreeSuggestion ||
 		isLoadingQueryAvailability ||
-		premiumDomainAvailabilityQueries.some( ( query ) => query.isLoading );
-
-	const unavailablePremiumDomains = useMemo( () => {
-		return premiumSuggestions.filter( ( _, index ) => {
-			const availabilityQuery = premiumDomainAvailabilityQueries[ index ];
-
-			if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
-				return true;
-			}
-
-			const { status, is_supported_premium_domain } = availabilityQuery.data;
-
-			return DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain;
-		} );
-	}, [ premiumDomainAvailabilityQueries, premiumSuggestions ] );
+		isLoadingUnavailablePremiumDomains;
 
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
 		return partitionSuggestions( {


### PR DESCRIPTION
Closes DOMAINS-1607.

## Proposed Changes

Just like in production, we should remove premium domains that aren't registrable. This PR does exactly that.

## Testing Instructions

Search for `work` within `/v2/domains/purchase` in `trunk` and this PR. Verify that here the domains without a price are removed.
