### PR TITLE
Improve restore form semantics

### DIFF
--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -1,5 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -99,6 +103,11 @@ function SiteBackupRestoreForm( {
 		);
 	};
 
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		handleRestore();
+	};
+
 	const restoreWarning = formData.sqls
 		? __(
 				'This action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
@@ -110,31 +119,33 @@ function SiteBackupRestoreForm( {
 	const isFormValid = Object.values( formData ).some( ( value ) => value );
 
 	return (
-		<>
-			<p>{ __( 'Choose the items you wish to restore:' ) }</p>
-			<DataForm< RestoreConfig >
-				data={ formData }
-				fields={ fields }
-				form={ form }
-				onChange={ handleFormChange }
-			/>
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
+				<p>{ __( 'Choose the items you wish to restore:' ) }</p>
+				<DataForm< RestoreConfig >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ handleFormChange }
+				/>
 
-			<Notice variant="info" title={ __( 'Important' ) }>
-				{ restoreWarning }
-			</Notice>
+				<Notice variant="info" title={ __( 'Important' ) }>
+					{ restoreWarning }
+				</Notice>
 
-			<HStack justify="flex-start">
-				<Button
-					variant="primary"
-					icon={ rotateLeft }
-					onClick={ handleRestore }
-					isBusy={ isRestoreMutationPending }
-					disabled={ ! isFormValid || isRestoreMutationPending }
-				>
-					{ __( 'Restore now' ) }
-				</Button>
-			</HStack>
-		</>
+				<HStack justify="flex-start">
+					<Button
+						variant="primary"
+						icon={ rotateLeft }
+						type="submit"
+						isBusy={ isRestoreMutationPending }
+						disabled={ ! isFormValid || isRestoreMutationPending }
+					>
+						{ __( 'Restore now' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-278][1].

## Proposed Changes

Improve the restore form semantics, making it an actual `<form>` with a proper `submit` button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This was [suggested in a related PR][2], where we have a similar form for the download backup flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`
- Test the form from the `Restore to this point` button.
- It should render and work properly.

<img width="707" height="794" alt="image" src="https://github.com/user-attachments/assets/ed34a552-e845-4bd0-a108-7bde4c7f3c31" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-278/
[2]: https://github.com/Automattic/wp-calypso/pull/105367#pullrequestreview-3163032859