### PR TITLE
Add Backups track events

### DIFF
--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -13,6 +13,7 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../app/analytics';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -34,15 +35,18 @@ function SiteBackupDownload() {
 	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );
 	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 
 	const router = useRouter();
 
 	const handleDownloadInitiate = ( newDownloadId: number ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_started' );
 		setCurrentStep( 'progress' );
 		setDownloadId( newDownloadId );
 	};
 
 	const handleDownloadComplete = ( newDownloadUrl: string, newFileSizeBytes?: string ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_completed' );
 		setCurrentStep( 'success' );
 		setDownloadUrl( newDownloadUrl );
 		setFileSizeBytes( newFileSizeBytes );
@@ -52,10 +56,12 @@ function SiteBackupDownload() {
 	};
 
 	const handleDownloadError = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_failed' );
 		setCurrentStep( 'error' );
 	};
 
 	const handleRetry = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_retry' );
 		setCurrentStep( 'form' );
 		setDownloadId( null );
 		setDownloadUrl( null );

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, download, check } from '@wordpress/icons';
+import { useAnalytics } from '../../app/analytics';
 import { siteBackupsRoute } from '../../app/router/sites';
 import Notice from '../../components/notice';
 import type { Site } from '@automattic/api-core';
@@ -22,13 +23,16 @@ function SiteBackupDownloadSuccess( {
 	downloadUrl: string;
 	fileSizeBytes?: string;
 } ) {
+	const { recordTracksEvent } = useAnalytics();
 	const router = useRouter();
 
 	const handleAllBackupsClick = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_all_backups' );
 		router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } );
 	};
 
 	const handleDownloadClick = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_download_download_file' );
 		window.open( downloadUrl, '_blank' );
 	};
 

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -13,6 +13,7 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../app/analytics';
 import { siteBySlugQuery } from '../../app/queries/site';
 import { siteBackupRestoreRoute, siteBackupsRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -32,15 +33,18 @@ function SiteBackupRestore() {
 	const [ currentStep, setCurrentStep ] = useState< RestoreStep >( 'form' );
 	const [ restoreId, setRestoreId ] = useState< number | null >( null );
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 
 	const router = useRouter();
 
 	const handleRestoreInitiate = ( newRestoreId: number ) => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_started' );
 		setCurrentStep( 'progress' );
 		setRestoreId( newRestoreId );
 	};
 
 	const handleRestoreComplete = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_completed' );
 		setCurrentStep( 'success' );
 		createSuccessNotice( __( 'Site restore completed.' ), {
 			type: 'snackbar',
@@ -48,10 +52,12 @@ function SiteBackupRestore() {
 	};
 
 	const handleRestoreError = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_failed' );
 		setCurrentStep( 'error' );
 	};
 
 	const handleRetry = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_retry' );
 		setCurrentStep( 'form' );
 		setRestoreId( null );
 	};

--- a/client/dashboard/sites/backup-restore/success.tsx
+++ b/client/dashboard/sites/backup-restore/success.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
+import { useAnalytics } from '../../app/analytics';
 import { siteBackupsRoute } from '../../app/router/sites';
 import type { Site } from '@automattic/api-core';
 
@@ -17,7 +18,19 @@ const SiteBackupRestoreSuccess = ( {
 	restorePointDate: string;
 	site: Site;
 } ) => {
+	const { recordTracksEvent } = useAnalytics();
 	const router = useRouter();
+
+	const handleAllBackupsClick = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_all_backups' );
+		router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } );
+	};
+
+	const handleViewWebsiteClick = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_restore_view_website' );
+		window.open( site.URL, '_blank' );
+	};
+
 	return (
 		<HStack spacing={ 4 }>
 			<HStack justify="flex-start">
@@ -30,18 +43,11 @@ const SiteBackupRestoreSuccess = ( {
 				</VStack>
 			</HStack>
 			<HStack justify="flex-end">
-				<Button
-					variant="tertiary"
-					text={ __( 'All backups' ) }
-					onClick={ () =>
-						router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } )
-					}
-				/>
+				<Button variant="tertiary" text={ __( 'All backups' ) } onClick={ handleAllBackupsClick } />
 				<Button
 					variant="primary"
-					href={ site.URL }
-					target="_blank"
 					text={ __( 'View website ↗' ) }
+					onClick={ handleViewWebsiteClick }
 				/>
 			</HStack>
 		</HStack>

--- a/client/dashboard/sites/backups/backup-now-button.tsx
+++ b/client/dashboard/sites/backups/backup-now-button.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { useBackupState } from '../../app/hooks/site-backup-state';
 import { siteBackupEnqueueMutation } from '../../app/queries/site-backups';
 import type { Site } from '@automattic/api-core';
@@ -11,6 +12,8 @@ interface BackupNowButtonProps {
 }
 
 export function BackupNowButton( { site }: BackupNowButtonProps ) {
+	const { recordTracksEvent } = useAnalytics();
+
 	const [ isEnqueued, setIsEnqueued ] = useState( false );
 
 	const { backupState, isBackupActive } = useBackupState( site.ID, isEnqueued );
@@ -28,6 +31,11 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 			setIsEnqueued( false );
 		}
 	}, [ backupState, isEnqueued ] );
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_backups_backup_now' );
+		triggerBackup();
+	};
 
 	const buttonContent = {
 		enqueued: {
@@ -49,7 +57,7 @@ export function BackupNowButton( { site }: BackupNowButtonProps ) {
 	return (
 		<Button
 			variant="secondary"
-			onClick={ () => triggerBackup() }
+			onClick={ handleClick }
 			disabled={ isBusy }
 			isBusy={ isBusy }
 			accessibleWhenDisabled


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-327][1].

## Proposed Changes

This PR adds tracking events to Backups-related actions in the Hosting Dashboard:

- Triggering a backup via the `Backup up now` button.
- Downloading a backup (request, success and failure).
- Restoring a site (request, success and failure).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We need to gather usage stats about different parts of the dashboard, similar to what we do in Jetpack Cloud.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live link below.
- Go to `/v2/sites/{site}/backups`
- Open the browser network tab.
- Navigate through the actions, like starting a backup, downloading or restoring.
- There should be different `t.gif` requests for the track events added.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-327/