### PR TITLE
A4A: Fix display Pressable migration card & banners only for agencies with > 50 sites

### DIFF
--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
@@ -3,16 +3,36 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE } from '../lib/constants';
 
+const MIN_SITES_FOR_INCENTIVE = 50;
+
+const isMoreThanMinSites = ( sites?: string ) => {
+	if ( ! sites || sites === '' ) {
+		return false;
+	}
+
+	// Handle the "500+" case
+	if ( sites.includes( '+' ) ) {
+		const baseNumber = parseInt( sites.replace( '+', '' ) );
+		return baseNumber > MIN_SITES_FOR_INCENTIVE;
+	}
+
+	// Handle range cases like "51-100", "101-500"
+	if ( sites.includes( '-' ) ) {
+		const [ min ] = sites.split( '-' ).map( ( num ) => parseInt( num ) );
+		return min > MIN_SITES_FOR_INCENTIVE;
+	}
+};
+
 export function useShowMigrationIncentive() {
 	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
 
 	const agency = useSelector( getActiveAgency );
 	const numberSites = agency?.signup_meta?.number_sites;
 
-	// Show the migration incentive if the agency has 51-100 sites.
+	// Show the migration incentive if the agency has more than MIN_SITES_FOR_INCENTIVE.
 	// Also, show if the agency has not set the number of sites.
 	// This is to handle old signups without the number_sites field.
-	const showMigrationIncentive = numberSites === '51-100' || numberSites === '';
+	const showMigrationIncentive = isMoreThanMinSites( numberSites ) || numberSites === '';
 
 	// We only show the incentive if the current date is before the migration incentive end date.
 	const isIncentiveActive = PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE > new Date();


### PR DESCRIPTION
## Proposed Changes

This PR fixes the display of Pressable migration card & banners only for agencies with > 50 sites by handling cases like "101-500" and "500+"

## Testing Instructions

* Open the A4A live link or locally
* Verify the [card](https://github.com/Automattic/wp-calypso/pull/105326) and [banners](https://github.com/Automattic/wp-calypso/pull/105323) are shown for agencies with 51-100, 101-500, and 500+ sites. You can manually set the value to test it easily. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
