### PR TITLE
Hosting Dashboard: Force reload after password save

### DIFF
--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -14,7 +14,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { seen, unseen } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { profileMutation } from '../../app/queries/me-profile';
 import PageLayout from '../../components/page-layout';
 import SecurityPageHeader from '../security-page-header';
@@ -35,6 +35,17 @@ export default function SecurityPassword() {
 		password: '',
 	} );
 
+	useEffect( () => {
+		const params = new URLSearchParams( window.location.search );
+		if ( params.get( 'updated' ) === 'password' ) {
+			createSuccessNotice( __( 'Your password was saved successfully.' ), {
+				type: 'snackbar',
+			} );
+
+			window.history.replaceState( {}, '', window.location.pathname );
+		}
+	}, [ createSuccessNotice ] );
+
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
 		mutation.mutate(
@@ -44,6 +55,9 @@ export default function SecurityPassword() {
 					createSuccessNotice( __( 'Your password was saved successfully.' ), {
 						type: 'snackbar',
 					} );
+
+					// Since changing a user's password invalidates the session, we reload.
+					window.location.replace( '?updated=password' );
 				},
 				onError: ( error: Error ) => {
 					createErrorNotice( error.message || __( 'Failed to save password.' ), {


### PR DESCRIPTION
## Proposed Changes

Follow up of https://github.com/Automattic/wp-calypso/pull/105413. We need to reload the page after the password has been saved since the session is invalidated. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes issue with invalid session.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/security/password, preferably with a non-a11n account
* Change your password and ensure the page reloads
* Ensure you see the snackbar after the reload

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
