### PR TITLE
Remove back button from importer flow linked from overview page

### DIFF
--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -186,7 +186,7 @@ export default function OverviewCard( {
 					href={ externalLink }
 					className="dashboard-overview-card__link"
 					target="_blank"
-					rel="noreferrer"
+					rel="external noreferrer noopener"
 					onClick={ handleClick }
 				>
 					{ topContent }

--- a/client/dashboard/sites/overview-site-action-menu/index.tsx
+++ b/client/dashboard/sites/overview-site-action-menu/index.tsx
@@ -21,12 +21,12 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 
 	const handleEditSite = () => {
 		trackActionClick( 'edit-site' );
-		window.open( getSiteEditUrl( site, isSiteUsingBlockTheme ), '_blank' );
+		window.open( getSiteEditUrl( site, isSiteUsingBlockTheme ), '_blank', 'noreferrer,noopener' );
 	};
 
 	const handleWritePost = () => {
 		trackActionClick( 'write-post' );
-		window.open( `${ site.options?.admin_url }post-new.php`, '_blank' );
+		window.open( `${ site.options?.admin_url }post-new.php`, '_blank', 'noreferrer,noopener' );
 	};
 
 	const handleImportSite = () => {
@@ -35,7 +35,7 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 			: addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } );
 
 		trackActionClick( 'import-site' );
-		window.open( url, '_blank' );
+		window.open( url, '_blank', 'noreferrer,noopener' );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Adds `noreferrer,noopener` to site over action menu links

Adds `rel="external noreferrer noopener" to overview link cards so they behave more like `<ExternalLink>` components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Discovered while testing overview page

When you click the migrate card

<img width="842" height="526" alt="CleanShot 2025-08-29 at 17 49 54@2x" src="https://github.com/user-attachments/assets/c5673593-8f20-4a4a-a3b6-f3d38b607e8b" />

It correctly opens an import flow that doesn't have a back button

<img width="1758" height="686" alt="CleanShot 2025-08-29 at 17 50 07@2x" src="https://github.com/user-attachments/assets/b6b4c1b8-ef97-43a6-ad59-b0951b71247c" />

It is correct because the page opens in a new tab. Nowhere to go back to.

But when you open the import flow from the kebab menu

<img width="1112" height="566" alt="CleanShot 2025-08-29 at 17 50 35@2x" src="https://github.com/user-attachments/assets/64826274-2366-4654-bfca-18eb7882722e" />

The resulting import flow has a back button (which doesn't do anything)

<img width="1740" height="670" alt="CleanShot 2025-08-29 at 17 50 24@2x" src="https://github.com/user-attachments/assets/78658eb1-9a2d-4c39-a978-54612a992f5a" />

The bug is fixed just by adjusting the "Import site" link, but I figured I'd tidy up the other external links while there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
