### PR TITLE
Site switcher menu closes when "Add new site" button clicked

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,7 +1,10 @@
 import { Dropdown, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import SwitcherContent, { type RenderItemIcon } from './switcher-content';
-import type { PropsWithChildren } from 'react';
+
+interface RenderCallbackProps {
+	onClose: () => void;
+}
 
 export default function Switcher< T >( {
 	items,
@@ -10,13 +13,14 @@ export default function Switcher< T >( {
 	getItemName,
 	getItemUrl,
 	renderItemIcon,
-}: PropsWithChildren< {
+}: {
 	items?: T[];
 	value: T;
+	children?: ( props: RenderCallbackProps ) => React.ReactNode;
 	getItemName: ( item: T ) => string;
 	getItemUrl: ( item: T ) => string;
 	renderItemIcon: RenderItemIcon< T >;
-} > ) {
+} ) {
 	return (
 		<Dropdown
 			renderToggle={ ( { onToggle } ) => (
@@ -40,7 +44,7 @@ export default function Switcher< T >( {
 					renderItemIcon={ renderItemIcon }
 					onClose={ onClose }
 				>
-					{ children }
+					{ children?.( { onClose } ) }
 				</SwitcherContent>
 			) }
 		/>

--- a/client/dashboard/components/switcher/switcher-content.scss
+++ b/client/dashboard/components/switcher/switcher-content.scss
@@ -1,4 +1,0 @@
-// Above the site switcher dropdown.
-.components-modal__screen-overlay:has(.dashboard-site-switcher__modal) {
-    z-index: 1000000;
-}

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -5,8 +5,6 @@ import { type PropsWithChildren, type ReactNode, useMemo, useState } from 'react
 import RouterLinkMenuItem from '../router-link-menu-item';
 import type { View } from '@wordpress/dataviews';
 
-import './switcher-content.scss';
-
 const DEFAULT_VIEW: View = {
 	type: 'list',
 	page: 1,

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -27,7 +27,7 @@ import EnvironmentSwitcher from './environment-switcher';
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const sites = useQuery( sitesQuery() ).data;
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
@@ -47,25 +47,32 @@ function Site() {
 							getItemUrl={ ( site ) => `/sites/${ site.slug }` }
 							renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
 						>
-							<MenuGroup>
-								<MenuItem onClick={ () => setIsModalOpen( true ) }>
-									<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-										<Icon icon={ plus } />
-										{ __( 'Add New Site' ) }
-									</div>
-								</MenuItem>
-							</MenuGroup>
-							{ isModalOpen && (
-								<Modal
-									title={ __( 'Add New Site' ) }
-									onRequestClose={ () => setIsModalOpen( false ) }
-									className="dashboard-site-switcher__modal"
-								>
-									<AddNewSite context="sites-dashboard" />
-								</Modal>
+							{ ( { onClose } ) => (
+								<MenuGroup>
+									<MenuItem
+										onClick={ () => {
+											onClose();
+											setIsAddSiteModalOpen( true );
+										} }
+									>
+										<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+											<Icon icon={ plus } />
+											{ __( 'Add new site' ) }
+										</div>
+									</MenuItem>
+								</MenuGroup>
 							) }
 						</Switcher>
 					</HeaderBar.Title>
+					{ isAddSiteModalOpen && (
+						<Modal
+							title={ __( 'Add new site' ) }
+							onRequestClose={ () => setIsAddSiteModalOpen( false ) }
+							className="dashboard-site-switcher__modal"
+						>
+							<AddNewSite context="sites-dashboard" />
+						</Modal>
+					) }
 					{ canSwitchEnvironment( site ) && (
 						<>
 							<MenuDivider />

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -68,7 +68,6 @@ function Site() {
 						<Modal
 							title={ __( 'Add new site' ) }
 							onRequestClose={ () => setIsAddSiteModalOpen( false ) }
-							className="dashboard-site-switcher__modal"
 						>
 							<AddNewSite context="sites-dashboard" />
 						</Modal>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

* Closes the site switcher menu when the "Add new site" modal is opened
* Fixes capitalisation of button and modal copy

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Whenever any of the other items in the site switcher are clicked, the menu automatically closes. But the "Add new site" button wasn't following this rule. It stayed awkwardly open in the background after one of the menu items was selected.

**Before**


https://github.com/user-attachments/assets/a9709b5e-3850-4f42-9d97-41423bf2a773

**After**


https://github.com/user-attachments/assets/21dbb389-26c7-4e01-a6d0-eb23f70922af



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
