### PR TITLE
A4A: Fix referral form submission

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
@@ -341,7 +341,7 @@ export default function ReferHostingForm( {
 					/>
 				) }
 
-				{ fields.rfp?.enabled && (
+				{ fields.isRfp?.enabled && (
 					<RadioButtonField
 						label={ translate( 'Is this an RFP?' ) }
 						name="isRfp"
@@ -357,7 +357,12 @@ export default function ReferHostingForm( {
 			</FormSection>
 
 			<div className="refer-hosting-form__footer">
-				<Button variant="primary" onClick={ handleSubmit } isBusy={ isPending }>
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					isBusy={ isPending }
+					disabled={ isPending }
+				>
 					{ ctaText }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-referral-config.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-referral-config.ts
@@ -42,7 +42,7 @@ export const getReferralConfig = (
 		leadType: {
 			enabled: type === 'enterprise',
 		},
-		rfp: {
+		isRfp: {
 			enabled: type === 'enterprise',
 		},
 	},


### PR DESCRIPTION
## Proposed Changes

This PR:

- Adds a disabled state to the submit button
- Changes the RFP key from "rfp" to "isRfp" to avoid unnecessary submissions

## Why are these changes being made?

* To avoid multiple requests being made and the `is_rfp` key being sent with the Pressable referral form submission

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Hosting > Premier Agency Hosting > Pressable Plans > Click the refer now button > Fill the form > Open the network tab > Submit and verify the button is disabled > Verify the `is_rfp` is no longer being sent
* Go back to Hosting > Enterprise > Toggle the refer mode on > Click the refer now button > Fill the form > Open the network tab > Submit and verify the button is disabled > Verify the `is_rfp` is being sent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
