### PR TITLE
Hosting Dashboard: Fix keyboard navigability of the site and environment switchers

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -19,12 +19,20 @@ export default function Switcher< T >( {
 } > ) {
 	return (
 		<Dropdown
-			renderToggle={ ( { onToggle } ) => (
+			renderToggle={ ( { onToggle, isOpen } ) => (
 				<Button
 					className="dashboard-menu__item active"
 					icon={ chevronDownSmall }
 					iconPosition="right"
 					onClick={ () => onToggle() }
+					onKeyDown={ ( event: React.KeyboardEvent ) => {
+						if ( ! isOpen && event.code === 'ArrowDown' ) {
+							event.preventDefault();
+							onToggle();
+						}
+					} }
+					aria-haspopup="true"
+					aria-expanded={ isOpen }
 				>
 					<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
 						{ renderItemIcon( { item: value, context: 'dropdown', size: 16 } ) }

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -1,4 +1,4 @@
-import { MenuGroup, SearchControl } from '@wordpress/components';
+import { MenuGroup, NavigableMenu, SearchControl } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { type PropsWithChildren, type ReactNode, useMemo, useState } from 'react';
@@ -53,7 +53,7 @@ export default function SwitcherContent< T >( {
 	const { data: filteredData } = filterSortAndPaginate( items, view, fields );
 
 	return (
-		<div style={ { width: '280px' } }>
+		<NavigableMenu style={ { width: '280px' } }>
 			<MenuGroup>
 				<SearchControl
 					label={ __( 'Search' ) }
@@ -81,6 +81,6 @@ export default function SwitcherContent< T >( {
 				} ) }
 			</MenuGroup>
 			{ children }
-		</div>
+		</NavigableMenu>
 	);
 }

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -5,6 +5,7 @@ import {
 	Dropdown,
 	MenuGroup,
 	MenuItem,
+	NavigableMenu,
 	Spinner,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -86,35 +87,39 @@ const EnvironmentSwitcherDropdown = ( {
 	const handleUpsell = () => {};
 
 	return (
-		<MenuGroup>
-			{ productionSite && canManageSite( productionSite ) && (
-				<RouterLinkMenuItem to={ `/sites/${ productionSite.slug }` } onClick={ onClose }>
-					<Environment env="production" />
-				</RouterLinkMenuItem>
-			) }
-			{ stagingSite && canManageSite( stagingSite ) && (
-				<RouterLinkMenuItem to={ `/sites/${ stagingSite.slug }` } onClick={ onClose }>
-					<Environment env="staging" />
-				</RouterLinkMenuItem>
-			) }
-			{ otherEnvironment === 'staging' && productionSite && ! stagingSite && (
-				<MenuItem onClick={ canCreateStagingSite( productionSite ) ? handleCreate : handleUpsell }>
-					<HStack justify="flex-start">
-						{ mutation.isPending ? (
-							<>
-								<Spinner style={ { width: '24px', height: '24px', padding: '4px', margin: 0 } } />
-								<span>{ __( 'Creating staging site…' ) }</span>
-							</>
-						) : (
-							<>
-								<Icon icon={ plus } />
-								<span>{ __( 'Add staging site' ) }</span>
-							</>
-						) }
-					</HStack>
-				</MenuItem>
-			) }
-		</MenuGroup>
+		<NavigableMenu>
+			<MenuGroup>
+				{ productionSite && canManageSite( productionSite ) && (
+					<RouterLinkMenuItem to={ `/sites/${ productionSite.slug }` } onClick={ onClose }>
+						<Environment env="production" />
+					</RouterLinkMenuItem>
+				) }
+				{ stagingSite && canManageSite( stagingSite ) && (
+					<RouterLinkMenuItem to={ `/sites/${ stagingSite.slug }` } onClick={ onClose }>
+						<Environment env="staging" />
+					</RouterLinkMenuItem>
+				) }
+				{ otherEnvironment === 'staging' && productionSite && ! stagingSite && (
+					<MenuItem
+						onClick={ canCreateStagingSite( productionSite ) ? handleCreate : handleUpsell }
+					>
+						<HStack justify="flex-start">
+							{ mutation.isPending ? (
+								<>
+									<Spinner style={ { width: '24px', height: '24px', padding: '4px', margin: 0 } } />
+									<span>{ __( 'Creating staging site…' ) }</span>
+								</>
+							) : (
+								<>
+									<Icon icon={ plus } />
+									<span>{ __( 'Add staging site' ) }</span>
+								</>
+							) }
+						</HStack>
+					</MenuItem>
+				) }
+			</MenuGroup>
+		</NavigableMenu>
 	);
 };
 
@@ -132,7 +137,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	return (
 		<HStack style={ { width: 'auto', flexShrink: 0 } }>
 			<Dropdown
-				renderToggle={ ( { onToggle } ) => {
+				renderToggle={ ( { isOpen, onToggle } ) => {
 					const canToggle =
 						hasStagingSite( site ) ||
 						( otherEnvironmentSite && canManageSite( otherEnvironmentSite ) );
@@ -144,6 +149,14 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 							iconPosition="right"
 							disabled={ ! canToggle }
 							onClick={ onToggle }
+							onKeyDown={ ( event: React.KeyboardEvent ) => {
+								if ( ! isOpen && event.code === 'ArrowDown' ) {
+									event.preventDefault();
+									onToggle();
+								}
+							} }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
 						>
 							<CurrentEnvironment site={ site } />
 						</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Fixes keyboard navigability of the site switcher and environment switcher.
You can now use the up and down keys as you would expect.

https://github.com/user-attachments/assets/56479f8f-0c08-4c5f-a9bd-c39f39837b28



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We have said we will pick up a11y by virtue of using core components. But that assumes we'll use the core components correctly :)

This keyboard behaviour is built in to the `<DropdownMenu>` component, however we're using the more basic `<Dropdown>` for these to menus. That is probably fine for the site switcher which is quite custom.

Perhaps the the environment switcher should have been a `<Dropdown>` all along 🤔 but it has some custom code in it now, so just added the bits that `<DropdownMenu>` would do.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Tab to the secondary menu and then use the arrow keys to navigate the menus. Use escape to close. Etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
