### PR TITLE
Notifications v2: Improve note styles

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -14,6 +14,7 @@ import { useAppContext } from '../context';
 import { getFields } from './dataviews';
 import type { Note } from '../types';
 import type { View } from '@wordpress/dataviews';
+import './style.scss';
 
 const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
 	const { goTo } = useNavigator();

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,0 +1,3 @@
+.wpnc__text-summary .wpnc__subject .wpnc__gridicon {
+	vertical-align: top;
+}

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -5,7 +5,6 @@ import {
 	__experimentalHeading as Heading,
 	CardHeader,
 	CardBody,
-	CardFooter,
 	Navigator,
 	useNavigator,
 } from '@wordpress/components';
@@ -20,7 +19,6 @@ import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved'
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
 import { NoteBody, ActionBlock } from '../templates/body';
 import NoteSummary from '../templates/note-summary';
-import '../../panel/boot/stylesheets/style.scss';
 import './style.scss';
 import type { Note as NoteObject, Block } from '../types';
 
@@ -105,17 +103,12 @@ const Note = () => {
 				<VStack justify="flex-start" spacing={ 4 }>
 					<NoteSummary note={ note } />
 					<Divider style={ { color: '#ddd' } } />
-					{ /* Add `wpnc__main` here to keep the same classes structure as v1. We'll iterate styles later. */ }
-					<div className="wpnc__main">
-						<div className={ getClasses( { note, isApproved, isRead } ) }>
-							<NoteBody note={ note } />
-						</div>
+					<div className={ getClasses( { note, isApproved, isRead } ) }>
+						<NoteBody note={ note } />
 					</div>
 				</VStack>
 			</CardBody>
-			<CardFooter size="small">
-				<ActionBlock note={ note } />
-			</CardFooter>
+			<ActionBlock note={ note } />
 		</div>
 	);
 };

--- a/apps/notifications/src/app/note/reset.scss
+++ b/apps/notifications/src/app/note/reset.scss
@@ -1,0 +1,128 @@
+.wpnc__main {
+	div,
+	span,
+	applet,
+	object,
+	iframe,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	p,
+	blockquote,
+	pre,
+	a,
+	abbr,
+	acronym,
+	address,
+	big,
+	cite,
+	code,
+	del,
+	dfn,
+	em,
+	font,
+	ins,
+	kbd,
+	q,
+	s,
+	samp,
+	small,
+	strike,
+	strong,
+	sub,
+	sup,
+	tt,
+	var,
+	dl,
+	dt,
+	dd,
+	ol,
+	ul,
+	li,
+	fieldset,
+	form,
+	label,
+	legend,
+	table,
+	caption,
+	tbody,
+	tfoot,
+	thead,
+	tr,
+	th,
+	td {
+		border: 0;
+		margin: 0;
+		font-family: inherit;
+		font-size: 100%;
+		font-style: inherit;
+		font-weight: inherit;
+		outline: 0;
+		padding: 0;
+		vertical-align: baseline;
+	}
+	article,
+	aside,
+	details,
+	figcaption,
+	figure,
+	footer,
+	header,
+	hgroup,
+	nav,
+	section {
+		display: block;
+	}
+	ol,
+	ul {
+		list-style: none;
+	}
+	table {
+		/* tables still need 'cellspacing="0"' in the markup */
+		border-collapse: separate;
+		border-spacing: 0;
+	}
+	caption,
+	th,
+	td {
+		font-weight: normal;
+		text-align: left;
+	}
+	blockquote::before,
+	blockquote::after,
+	q::before,
+	q::after {
+		content: "";
+	}
+	blockquote,
+	q {
+		quotes: "" "";
+	}
+	a:focus {
+		outline: var(--color-primary-light) solid 2px;
+	}
+	a:hover,
+	a:active {
+		/* Improves readability when focused and also mouse hovered in all browsers people.opera.com/patrickl/experiments/keyboard/test */
+		outline: 0;
+	}
+	a img {
+		border: 0;
+	}
+
+	// Reset the default styling on form inputs in Webkit/iOS
+	input,
+	textarea {
+		border-radius: 0;
+		-webkit-appearance: none; // Autoprefixer does not support appearance
+		appearance: none;
+		overflow: auto;
+	}
+	input[type="radio"],
+	input[type="checkbox"] {
+		-webkit-appearance: none;
+	}
+}

--- a/apps/notifications/src/app/note/reset.scss
+++ b/apps/notifications/src/app/note/reset.scss
@@ -1,4 +1,4 @@
-.wpnc__main {
+.wpnc__body-content {
 	div,
 	span,
 	applet,
@@ -31,7 +31,6 @@
 	samp,
 	small,
 	strike,
-	strong,
 	sub,
 	sup,
 	tt,

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -1,7 +1,8 @@
 @import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/variables";
+@import "./reset.scss";
 
-.wpnc__main {
+.wpnc__note .wpnc__body .wpnc__body-content {
 	.has-text-align-center {
 		text-align: center;
 	}
@@ -105,39 +106,37 @@
 		max-width: 128px;
 	}
 
-	.wpnc__note {
-		blockquote {
-			padding: 0 24px 0 32px;
-			margin: 16px 0 32px;
-			border-left: 3px solid #f6f7f7;
-			color: #646970;
-			font-weight: 400;
-			background: transparent;
-		}
+	blockquote {
+		padding: 0 24px 0 32px;
+		margin: 16px 0 32px;
+		border-left: 3px solid #f6f7f7;
+		color: #646970;
+		font-weight: 400;
+		background: transparent;
+	}
 
-		ul,
-		ol {
-			margin-left: 1.5em;
-			list-style-position: inside;
-		}
+	ul,
+	ol {
+		margin-left: 1.5em;
+		list-style-position: inside;
+	}
 
+	ul {
+		list-style-type: disc;
 		ul {
-			list-style-type: disc;
+			list-style-type: circle;
 			ul {
-				list-style-type: circle;
-				ul {
-					list-style-type: square;
-				}
+				list-style-type: square;
 			}
 		}
+	}
 
-		ol {
-			list-style-type: decimal;
-		}
+	ol {
+		list-style-type: decimal;
+	}
 
-		li {
-			margin: auto;
-		}
+	li {
+		margin: auto;
 	}
 }
 
@@ -201,6 +200,6 @@
 	}
 
 	.wpnc__paragraph {
-		padding: 16px 0 0 !important;
+		padding: 16px 0 0;
 	}
 }

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -1,8 +1,14 @@
 @import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
 @import "./reset.scss";
 
 .wpnc__note .wpnc__body .wpnc__body-content {
+	padding: 0;
+	margin: 0;
+	line-height: 20px;
+	text-wrap: balance;
+
 	.has-text-align-center {
 		text-align: center;
 	}
@@ -20,15 +26,21 @@
 	}
 
 	.wpnc__h1 {
-		font-size: $font-headline-small;
+		font-size: $font-size-2x-large;
+		font-weight: 850; /* stylelint-disable-line scales/font-weights */
+		line-height: 1.4;
 	}
 
 	.wpnc__h2 {
-		font-size: $font-title-large;
+		font-size: 26px;
+		font-weight: 750; /* stylelint-disable-line scales/font-weights */
+		line-height: 1.4;
 	}
 
 	.wpnc__h3 {
-		font-size: $font-title-medium;
+		font-size: 18px;
+		font-weight: 700;
+		line-height: 1.4;
 	}
 
 	.uppercase {
@@ -68,22 +80,30 @@
 
 	.wpnc__image {
 		display: block;
-		margin: auto;
 		max-width: 100%;
 		height: auto;
+		padding: $grid-unit-20;
+		margin: auto;
 	}
 
 	.wpnc__badge {
 		display: block;
 		margin: 0 auto;
-		padding: 36px 16px 16px;
+		padding: $grid-unit-20;
+	}
+
+	.wpnc__paragraph {
+		padding: $grid-unit-20 0;
+
+		&:first-child {
+			padding-top: 0;
+		}
 	}
 
 	// Links
 	a,
 	a:visited {
 		color: var(--wp-admin-theme-color);
-		text-decoration: none;
 	}
 
 	a:hover,
@@ -107,11 +127,12 @@
 	}
 
 	blockquote {
-		padding: 0 24px 0 32px;
-		margin: 16px 0 32px;
-		border-left: 3px solid #f6f7f7;
-		color: #646970;
+		padding: 0 $grid-unit-20;
+		margin: 0 0 $grid-unit-20 0;
+		box-shadow: inset 4px 0 0 #f6f7f7;
 		font-weight: 400;
+		font-style: italic;
+		color: #646970;
 		background: transparent;
 	}
 
@@ -165,6 +186,9 @@
 	}
 }
 
+/**
+ * User
+ */
 .wpnc__user {
 	.wpnc__note & {
 		padding: 0;
@@ -173,23 +197,30 @@
 	.wpnc__user-title {
 		font-weight: 500;
 	}
+
+	a {
+		text-decoration: none;
+	}
 }
 
 /**
  * Comment
  */
-.wpnc__note.wpnc__comment {
+.wpnc__note.wpnc__comment .wpnc__body .wpnc__body-content {
+	padding: 0 0 0 $grid-unit-20;
+	box-shadow: inset 4px 0 0 #f6f7f7;
+
 	.wpnc__user {
-		padding: 16px;
+		padding: 0 0 $grid-unit-20 0;
 	}
 }
 
 /**
  * Likes, Follows
  */
-.wpnc__note.wpnc__like,
-.wpnc__note.wpnc__comment_like,
-.wpnc__note.wpnc__follow {
+.wpnc__note.wpnc__like .wpnc__body .wpnc__body-content,
+.wpnc__note.wpnc__comment_like .wpnc__body .wpnc__body-content,
+.wpnc__note.wpnc__follow .wpnc__body .wpnc__body-content {
 	.wpnc__user {
 		padding-bottom: 16px;
 		border-bottom: 1px solid $gray-300;
@@ -201,5 +232,21 @@
 
 	.wpnc__paragraph {
 		padding: 16px 0 0;
+	}
+}
+
+/**
+ * Reply
+ */
+.wpnc__reply {
+	color: #646970;
+
+	.wpnc__gridicon {
+		fill: currentColor;
+	}
+
+	a {
+		font-weight: 600;
+		color: inherit;
 	}
 }

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -1,4 +1,4 @@
-import { __experimentalVStack as VStack, ExternalLink } from '@wordpress/components';
+import { __experimentalVStack as VStack, CardFooter, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from 'react';
@@ -79,7 +79,11 @@ export const ActionBlock = ( { note }: { note: Note } ) => {
 		return null;
 	}
 
-	return <NoteActions note={ note } />;
+	return (
+		<CardFooter size="small">
+			<NoteActions note={ note } />
+		</CardFooter>
+	);
 };
 
 export const NoteBody = ( { note }: { note: Note } ) => {

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -126,9 +126,7 @@ export const NoteBody = ( { note }: { note: Note } ) => {
 	return (
 		<VStack className="wpnc__body">
 			{ preface }
-			<div className="wpnc__body-content" style={ { padding: 0, margin: 0 } }>
-				{ body }
-			</div>
+			<div className="wpnc__body-content">{ body }</div>
 			<ReplyBlock note={ note } />
 		</VStack>
 	);

--- a/apps/notifications/src/panel/state/action-middleware/ui/index.js
+++ b/apps/notifications/src/panel/state/action-middleware/ui/index.js
@@ -1,4 +1,4 @@
-import { findNextNoteId } from '../../../templates';
+import findNextNoteId from '../../../utils/find-next-note-id';
 import * as types from '../../action-types';
 import actions from '../../actions';
 import getAllNotes from '../../selectors/get-all-notes';

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -35,31 +35,6 @@ const KEY_U = 85;
  * @property {!number} id notification id
  */
 
-/**
- * Returns the next index into a list of notes following
- * the index for the given sought-after notification id
- * @param {!number} noteId id of note to search for
- * @param {!Array<Notification>} notes list of notes to search through
- * @returns {?number} index into note list of note following that given by noteId
- */
-export const findNextNoteId = ( noteId, notes ) => {
-	if ( notes.length === 0 ) {
-		return null;
-	}
-
-	const index = notes.indexOf( noteId );
-	if ( -1 === index ) {
-		return null;
-	}
-
-	const nextIndex = index + 1;
-	if ( nextIndex >= notes.length ) {
-		return null;
-	}
-
-	return notes[ nextIndex ].id;
-};
-
 class Layout extends Component {
 	state = {
 		lastSelectedIndex: 0,

--- a/apps/notifications/src/panel/utils/find-next-note-id.js
+++ b/apps/notifications/src/panel/utils/find-next-note-id.js
@@ -1,0 +1,26 @@
+/**
+ * Returns the next index into a list of notes following
+ * the index for the given sought-after notification id
+ * @param {!number} noteId id of note to search for
+ * @param {!Array<Notification>} notes list of notes to search through
+ * @returns {?number} index into note list of note following that given by noteId
+ */
+const findNextNoteId = ( noteId, notes ) => {
+	if ( notes.length === 0 ) {
+		return null;
+	}
+
+	const index = notes.indexOf( noteId );
+	if ( -1 === index ) {
+		return null;
+	}
+
+	const nextIndex = index + 1;
+	if ( nextIndex >= notes.length ) {
+		return null;
+	}
+
+	return notes[ nextIndex ].id;
+};
+
+export default findNextNoteId;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-296

## Proposed Changes

* Get rid of the old styles and try to fix any style issues

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notifications
* Select any notification
* Ensure the styles look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
