### PR TITLE
Notifications v2: implement keyboard shortcuts (pt 1)

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -2,10 +2,12 @@ import { Navigator } from '@wordpress/components';
 import { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import repliesCache from '../panel/comment-replies-cache';
+import { modifierKeyIsActive } from '../panel/helpers/input';
 import RestClient from '../panel/rest-client';
 import { init as initAPI } from '../panel/rest-client/wpcom';
 import { init as initStore } from '../panel/state';
 import { SET_IS_SHOWING } from '../panel/state/action-types';
+import actions from '../panel/state/actions';
 import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import { AppProvider } from './context';
@@ -101,6 +103,34 @@ const NotificationApp = ( {
 			store.dispatch( removeListeners( defaultHandlers ) );
 		};
 	}, [ actionHandlers ] );
+
+	useEffect( () => {
+		const stopEvent = ( event: KeyboardEvent ) => {
+			event.stopPropagation();
+			event.preventDefault();
+		};
+
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( modifierKeyIsActive( event ) ) {
+				return;
+			}
+			switch ( event.key ) {
+				case 'n':
+					stopEvent( event );
+					store.dispatch( actions.ui.closePanel() );
+					break;
+				case 'i':
+					stopEvent( event );
+					store.dispatch( actions.ui.toggleShortcutsPopover() );
+					break;
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, false );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown, false );
+		};
+	}, [] );
 
 	if ( ! isReady ) {
 		return null;

--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -1,6 +1,7 @@
 import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import actions from '../../panel/state/actions';
 import getIsShortcutsPopoverOpen from '../../panel/state/selectors/get-is-shortcuts-popover-open';
@@ -9,17 +10,21 @@ import NoteShortcuts from '../note-shortcuts';
 export default function NotePanelActions() {
 	const dispatch = useDispatch();
 
+	const [ isOpen, setIsOpen ] = useState( false );
 	const isShortcutsPopoverOpen = useSelector( getIsShortcutsPopoverOpen );
+
+	useEffect( () => {
+		if ( ! isOpen && isShortcutsPopoverOpen ) {
+			dispatch( actions.ui.closeShortcutsPopover() );
+		}
+	}, [ isOpen, dispatch ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
 			label={ __( 'Actions' ) }
-			onToggle={ ( willOpen ) => {
-				if ( ! willOpen ) {
-					dispatch( actions.ui.closeShortcutsPopover() );
-				}
-			} }
+			onToggle={ setIsOpen }
+			open={ isOpen || isShortcutsPopoverOpen }
 			popoverProps={ {
 				focusOnMount: true,
 			} }

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -10,6 +10,8 @@ import {
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
+import { useEffect } from 'react';
+import { modifierKeyIsActive } from '../../panel/helpers/input';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
@@ -24,6 +26,46 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 const NotePanel = () => {
 	const { params, goTo } = useNavigator();
 	const { filterName = 'all' } = params;
+
+	useEffect( () => {
+		const stopEvent = ( event: KeyboardEvent ) => {
+			event.stopPropagation();
+			event.preventDefault();
+		};
+
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( modifierKeyIsActive( event ) ) {
+				return;
+			}
+			switch ( event.key ) {
+				case 'a':
+					stopEvent( event );
+					goTo( '/all', { replace: true } );
+					break;
+				case 'u':
+					stopEvent( event );
+					goTo( '/unread', { replace: true } );
+					break;
+				case 'c':
+					stopEvent( event );
+					goTo( '/comments', { replace: true } );
+					break;
+				case 'f':
+					stopEvent( event );
+					goTo( '/follows', { replace: true } );
+					break;
+				case 'l':
+					stopEvent( event );
+					goTo( '/likes', { replace: true } );
+					break;
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, false );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown, false );
+		};
+	}, [] );
 
 	return (
 		<>
@@ -45,6 +87,7 @@ const NotePanel = () => {
 						activeClass="is-active"
 						tabs={ NOTIFICATION_TABS }
 						initialTabName={ filterName as string }
+						key={ filterName as string }
 						onSelect={ ( tabName ) => {
 							goTo( `/${ tabName }`, { replace: true } );
 						} }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -3,7 +3,7 @@ import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, lazy, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
 import { useLocale } from '../locale';
@@ -15,9 +15,18 @@ export default function Notifications( { className }: { className: string } ) {
 	const navigate = useNavigate();
 	const { user } = useAuth();
 	const locale = useLocale();
+	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 
-	const actionHandlers = ( onClosePanel: () => void ) => ( {
+	const handleToggle = ( willOpen: boolean ) => {
+		setIsOpen( willOpen );
+	};
+
+	const handleClose = () => {
+		handleToggle( false );
+	};
+
+	const actionHandlers = {
 		APP_RENDER_NOTES: [
 			( store: any, { newNoteCount }: { newNoteCount: number } ) => {
 				setHasUnseenNotifications( newNoteCount > 0 );
@@ -25,12 +34,33 @@ export default function Notifications( { className }: { className: string } ) {
 		],
 		VIEW_SETTINGS: [
 			() => {
-				onClosePanel();
+				handleClose();
 				navigate( { to: '/me/notifications' } );
 			},
 		],
-		CLOSE_PANEL: [ onClosePanel ],
-	} );
+		CLOSE_PANEL: [ handleClose ],
+	};
+
+	useEffect( () => {
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( event.target !== document.body && ( event.target as HTMLElement )?.tagName !== 'A' ) {
+				return;
+			}
+			if ( event.altKey || event.ctrlKey || event.metaKey ) {
+				return;
+			}
+			if ( event.key === 'n' ) {
+				event.stopPropagation();
+				event.preventDefault();
+				handleToggle( true );
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, false );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown, false );
+		};
+	}, [] );
 
 	return (
 		<Dropdown
@@ -39,6 +69,8 @@ export default function Notifications( { className }: { className: string } ) {
 				offset: 8,
 				focusOnMount: true,
 			} }
+			open={ isOpen }
+			onToggle={ handleToggle }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					className={ clsx( className, 'dashboard-notifications__icon' ) }
@@ -49,12 +81,12 @@ export default function Notifications( { className }: { className: string } ) {
 					icon={ hasUnseenNotifications ? bellUnread : bell }
 				/>
 			) }
-			renderContent={ ( { onClose } ) => (
+			renderContent={ () => (
 				<div style={ { width: '480px', height: '100vh', maxHeight: 'inherit', margin: '-8px' } }>
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp
 							locale={ locale }
-							actionHandlers={ actionHandlers( onClose ) }
+							actionHandlers={ actionHandlers }
 							wpcom={ wpcom }
 						/>
 					</Suspense>

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -43,7 +43,7 @@ export default function Notifications( { className }: { className: string } ) {
 
 	useEffect( () => {
 		const handleKeyDown = ( event: KeyboardEvent ) => {
-			if ( event.target !== document.body && ( event.target as HTMLElement )?.tagName !== 'A' ) {
+			if ( event.target !== document.body ) {
 				return;
 			}
 			if ( event.altKey || event.ctrlKey || event.metaKey ) {


### PR DESCRIPTION
Part of DOTCOM-14291

## Proposed Changes

This PR implements the following shortcuts for notifications v2: `n`, `a`, `c`, `u`, `f`, `l`, `i`:

<img width="217" height="430" alt="image" src="https://github.com/user-attachments/assets/402e2488-cca8-4bb2-bf60-e48b4375591c" />


## Testing Instructions

1. Go to `/v2`
2. Type `n`
   - Verify the notification panel is open
3. Verify the shortcuts as mentioned in the PR description above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
