### PR TITLE
Notifications v2: Keep selected tab when navigating back

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -111,9 +111,9 @@ const NotificationApp = ( {
 	return (
 		<Provider store={ store }>
 			<AppProvider client={ client } locale={ locale }>
-				<Navigator initialPath="/" style={ { maxHeight: 'inherit', height: '100%' } }>
+				<Navigator initialPath="/all" style={ { maxHeight: 'inherit', height: '100%' } }>
 					<Navigator.Screen
-						path="/"
+						path="/:filterName"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
 						<Suspense fallback={ null }>
@@ -121,7 +121,7 @@ const NotificationApp = ( {
 						</Suspense>
 					</Navigator.Screen>
 					<Navigator.Screen
-						path="/notes/:noteId"
+						path="/:filterName/notes/:noteId"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
 						<Suspense fallback={ null }>

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -1,5 +1,5 @@
 import { Navigator } from '@wordpress/components';
-import { useEffect, useState, Suspense, lazy } from 'react';
+import { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import repliesCache from '../panel/comment-replies-cache';
 import RestClient from '../panel/rest-client';
@@ -9,6 +9,8 @@ import { SET_IS_SHOWING } from '../panel/state/action-types';
 import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
 import { AppProvider } from './context';
+import Note from './note';
+import NotePanel from './note-panel';
 
 let client: any;
 
@@ -42,10 +44,6 @@ const defaultHandlers = {
 		},
 	],
 };
-
-const NotePanel = lazy( () => import( './note-panel' ) );
-
-const Note = lazy( () => import( './note' ) );
 
 const NotificationApp = ( {
 	locale = 'en',
@@ -116,17 +114,13 @@ const NotificationApp = ( {
 						path="/:filterName"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<Suspense fallback={ null }>
-							<NotePanel />
-						</Suspense>
+						<NotePanel />
 					</Navigator.Screen>
 					<Navigator.Screen
 						path="/:filterName/notes/:noteId"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<Suspense fallback={ null }>
-							<Note />
-						</Suspense>
+						<Note />
 					</Navigator.Screen>
 				</Navigator>
 			</AppProvider>

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -41,7 +41,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
 
 	const onChangeSelection = ( selection: string[] ) => {
-		goTo( `/notes/${ selection[ 0 ] }`, { skipFocus: true } );
+		goTo( `/${ filterName }/notes/${ selection[ 0 ] }` );
 	};
 
 	const infiniteScrollHandler = useCallback( () => {

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -5,16 +5,16 @@ import {
 	CardHeader,
 	Icon,
 	TabPanel,
+	useNavigator,
 } from '@wordpress/components';
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
-import { useEffect, useRef, useState } from 'react';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
 import NotePanelActions from './actions';
 
-type ActiveTab = keyof ReturnType< typeof getFilters >;
+type FilterName = keyof ReturnType< typeof getFilters >;
 
 const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
 	name,
@@ -22,17 +22,11 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 } ) );
 
 const NotePanel = () => {
-	const [ activeTab, setActiveTab ] = useState< ActiveTab >( 'all' );
-
-	// Ensure the component is focused on mount
-	// to avoid parent's <Popover>'s focus trap from moving.
-	const focusRef = useRef< HTMLDivElement >( null );
-	useEffect( () => {
-		focusRef.current?.focus();
-	}, [] );
+	const { params, goTo } = useNavigator();
+	const { filterName = 'all' } = params;
 
 	return (
-		<div ref={ focusRef } tabIndex={ -1 }>
+		<>
 			<CardHeader
 				size="small"
 				style={ { flexDirection: 'column', alignItems: 'stretch', paddingBottom: 0 } }
@@ -50,17 +44,17 @@ const NotePanel = () => {
 					<TabPanel
 						activeClass="is-active"
 						tabs={ NOTIFICATION_TABS }
-						initialTabName={ activeTab }
+						initialTabName={ filterName as string }
 						onSelect={ ( tabName ) => {
-							setActiveTab( tabName as ActiveTab );
+							goTo( `/${ tabName }`, { replace: true } );
 						} }
 					>
 						{ () => null /* Placeholder div since content is rendered elsewhere */ }
 					</TabPanel>
 				</VStack>
 			</CardHeader>
-			<NoteList filterName={ activeTab } />
-		</div>
+			<NoteList filterName={ filterName as FilterName } />
+		</>
 	);
 };
 

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -11,7 +11,6 @@ import {
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
@@ -74,19 +73,12 @@ const Note = () => {
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
 
-	// Ensure the component is focused on mount
-	// to avoid parent's <Popover>'s focus trap from moving.
-	const focusRef = useRef< HTMLDivElement >( null );
-	useEffect( () => {
-		focusRef.current?.focus();
-	}, [] );
-
 	if ( ! note ) {
 		return null;
 	}
 
 	return (
-		<div ref={ focusRef } tabIndex={ -1 }>
+		<>
 			<CardHeader size="small">
 				<HStack>
 					<Navigator.BackButton
@@ -109,7 +101,7 @@ const Note = () => {
 				</VStack>
 			</CardBody>
 			<ActionBlock note={ note } />
-		</div>
+		</>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Keep selected tab when navigating back to the list
* Also, this seems to resolve the focus issue that causing the popover cannot be closed correctly

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notifications
* Switch to different tab
* Select any notification
* Click `Back`
* Ensure you can go back to the list with the previous selected tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
