### PR TITLE
Hosting Dashboard: Daterange picker updates to ensure more user friendly behaviour

### DIFF
--- a/client/dashboard/components/date-range-picker/date-range-content.tsx
+++ b/client/dashboard/components/date-range-picker/date-range-content.tsx
@@ -1,4 +1,4 @@
-import { DateRangeCalendar, TZDate } from '@automattic/ui';
+import { DateRangeCalendar } from '@automattic/ui';
 import {
 	__experimentalText as Text,
 	Button,
@@ -6,10 +6,10 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { formatYmd } from '../../utils/datetime';
+import { format, startOfDay, addHours } from 'date-fns';
 import { DateInputs } from './date-inputs';
 import { PresetsListbox } from './presets-listbox';
-import { computePresetRange, getActivePresetId, PresetId } from './utils';
+import { computePresetRange, getActivePresetId, PresetId, getTimezoneAwareDate } from './utils';
 
 type DateRangeContentProps = {
 	isSmall: boolean;
@@ -22,10 +22,10 @@ type DateRangeContentProps = {
 	setToDraft: ( date?: Date ) => void;
 	setFromStr: ( string: string ) => void;
 	setToStr: ( string: string ) => void;
-	timezoneString?: string;
-	gmtOffset?: number;
 	onChange: ( next: { start: Date; end: Date } ) => void;
 	onClose?: () => void;
+	timezoneString?: string;
+	gmtOffset?: number;
 	compositeActiveId: string | null;
 	setCompositeActiveId: ( id: string | null ) => void;
 	today: Date;
@@ -47,10 +47,10 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 		setToDraft,
 		setFromStr,
 		setToStr,
-		timezoneString,
-		gmtOffset,
 		onChange,
 		onClose,
+		timezoneString,
+		gmtOffset,
 		compositeActiveId,
 		setCompositeActiveId,
 		today,
@@ -59,22 +59,6 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 		desktopLabelId,
 		disableFuture = true,
 	} = props;
-
-	// Avoid passing invalid or empty time zones to Intl consumers
-	const isValidIanaTimeZone = ( timeZone?: string ): timeZone is string => {
-		if ( ! timeZone ) {
-			return false;
-		}
-		try {
-			// Will throw for invalid IANA identifiers (including empty strings)
-			Intl.DateTimeFormat( 'en-US', { timeZone: timeZone } );
-			return true;
-		} catch ( _e ) {
-			return false;
-		}
-	};
-
-	const timeZoneForCalendar = isValidIanaTimeZone( timezoneString ) ? timezoneString : undefined;
 
 	const clear = () => {
 		setFromDraft( undefined );
@@ -94,33 +78,65 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 	};
 
 	const setPreset = ( id: PresetId ) => {
-		const range = computePresetRange( id, today );
+		// For presets, use site timezone, allowing users to access logs from the site's current day
+		let presetToday: Date;
+
+		if ( timezoneString ) {
+			const now = new Date();
+			const siteTime = new Intl.DateTimeFormat( 'en-US', {
+				timeZone: timezoneString,
+				year: 'numeric',
+				month: 'numeric',
+				day: 'numeric',
+			} ).formatToParts( now );
+
+			const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
+			const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1; // Month is 0-indexed
+			const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
+
+			presetToday = startOfDay( new Date( year, month, day ) );
+		} else if ( typeof gmtOffset === 'number' ) {
+			// Use GMT offset if no timezone string
+			const now = new Date();
+			presetToday = startOfDay( addHours( now, gmtOffset ) );
+		} else {
+			// Fallback to UTC (default behavior)
+			const utcNow = new Date();
+			presetToday = startOfDay(
+				new Date( Date.UTC( utcNow.getUTCFullYear(), utcNow.getUTCMonth(), utcNow.getUTCDate() ) )
+			);
+		}
+
+		const range = computePresetRange( id, presetToday );
 		if ( ! range ) {
 			return;
 		}
 		setFromDraft( range.from );
 		setToDraft( range.to );
-		setFromStr( formatYmd( range.from, timezoneString, gmtOffset ) );
-		setToStr( formatYmd( range.to, timezoneString, gmtOffset ) );
+		// Use UTC formatting without timezone conversion for consistency
+		setFromStr( format( range.from, 'yyyy-MM-dd' ) );
+		setToStr( format( range.to, 'yyyy-MM-dd' ) );
 		onChange( { start: range.from, end: range.to } );
 		onClose?.();
 	};
 
-	const activePresetId = getActivePresetId( fromDraft, toDraft, today );
+	// Calculate timezone-aware today for preset detection
+	const timezoneAwareToday = getTimezoneAwareDate( today, timezoneString, gmtOffset );
+
+	const activePresetId = getActivePresetId(
+		fromDraft,
+		toDraft,
+		timezoneAwareToday,
+		timezoneString,
+		gmtOffset
+	);
 
 	const defaultMonth = showTwoMonths
 		? new Date( today.getFullYear(), today.getMonth() - 1, 1 )
 		: today;
 	const endMonth = new Date( today.getFullYear(), today.getMonth(), 1 );
 
-	// Use TZDate for calendar selection when a valid IANA time zone is available
-	const selected =
-		timeZoneForCalendar && ( fromDraft || toDraft )
-			? {
-					from: fromDraft ? new TZDate( +fromDraft, timeZoneForCalendar ) : undefined,
-					to: toDraft ? new TZDate( +toDraft, timeZoneForCalendar ) : undefined,
-			  }
-			: { from: fromDraft ?? undefined, to: toDraft ?? undefined };
+	const selected = { from: fromDraft ?? undefined, to: toDraft ?? undefined };
 
 	return (
 		<VStack as="div" spacing={ 3 } style={ { padding: 12 } }>
@@ -185,7 +201,6 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 
 				<div className="daterange-calendar">
 					<DateRangeCalendar
-						timeZone={ timeZoneForCalendar }
 						numberOfMonths={ isSmall ? 1 : 2 }
 						defaultMonth={ defaultMonth }
 						endMonth={ endMonth }
@@ -198,14 +213,16 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 								const from = toNative( range.from );
 								setFromDraft( from );
 								if ( from ) {
-									setFromStr( formatYmd( from, timezoneString, gmtOffset ) );
+									// Use UTC formatting without timezone conversion for consistency
+									setFromStr( format( from, 'yyyy-MM-dd' ) );
 								}
 							}
 							if ( range?.to ) {
 								const to = toNative( range.to );
 								setToDraft( to );
 								if ( to ) {
-									setToStr( formatYmd( to, timezoneString, gmtOffset ) );
+									// Use UTC formatting without timezone conversion for consistency
+									setToStr( format( to, 'yyyy-MM-dd' ) );
 								}
 							}
 						} }

--- a/client/dashboard/components/date-range-picker/index.tsx
+++ b/client/dashboard/components/date-range-picker/index.tsx
@@ -3,7 +3,7 @@ import { useMediaQuery, useInstanceId } from '@wordpress/compose';
 import { useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
-import { parseYmdLocal, formatYmd } from '../../utils/datetime';
+import { format } from 'date-fns';
 import { DateRangeContent } from './date-range-content';
 import { formatLabel } from './utils';
 import './style.scss';
@@ -22,8 +22,8 @@ export function DateRangePicker( {
 	start,
 	end,
 	onChange,
-	gmtOffset,
 	timezoneString,
+	gmtOffset,
 	locale,
 	disableFuture = true,
 }: DateRangePickerProps ) {
@@ -34,15 +34,11 @@ export function DateRangePicker( {
 	const mobileLabelId = `presets-label-${ instanceId }-mobile`;
 	const desktopLabelId = `presets-label-${ instanceId }-desktop`;
 
-	const label = formatLabel( start, end, locale, timezoneString, gmtOffset );
+	const label = formatLabel( start, end, locale );
 
 	// Reset internal draft state when key inputs change by remounting the inner component
-	const resetKey = [
-		formatYmd( start, timezoneString, gmtOffset ),
-		formatYmd( end, timezoneString, gmtOffset ),
-		timezoneString ?? '',
-		gmtOffset ?? '',
-	].join( '|' );
+	// Use UTC formatting for consistency with the rest of the component
+	const resetKey = [ format( start, 'yyyy-MM-dd' ), format( end, 'yyyy-MM-dd' ) ].join( '|' );
 
 	return (
 		<div className="daterange-container">
@@ -80,10 +76,10 @@ export function DateRangePicker( {
 						showTwoMonths={ showTwoMonths }
 						start={ start }
 						end={ end }
-						timezoneString={ timezoneString }
-						gmtOffset={ gmtOffset }
 						onChange={ onChange }
 						onClose={ onClose }
+						timezoneString={ timezoneString }
+						gmtOffset={ gmtOffset }
 						mobileLabelId={ mobileLabelId }
 						desktopLabelId={ desktopLabelId }
 						disableFuture={ disableFuture }
@@ -99,10 +95,10 @@ function DateRangePickerInner( {
 	showTwoMonths,
 	start,
 	end,
-	timezoneString,
-	gmtOffset,
 	onChange,
 	onClose,
+	timezoneString,
+	gmtOffset,
 	mobileLabelId,
 	desktopLabelId,
 	disableFuture,
@@ -111,32 +107,33 @@ function DateRangePickerInner( {
 	showTwoMonths: boolean;
 	start: Date;
 	end: Date;
-	timezoneString?: string;
-	gmtOffset?: number;
 	onChange: ( next: { start: Date; end: Date } ) => void;
 	onClose: () => void;
+	timezoneString?: string;
+	gmtOffset?: number;
 	mobileLabelId: string;
 	desktopLabelId: string;
 	disableFuture: boolean;
 } ) {
 	const [ fromDraft, setFromDraft ] = useState< Date | undefined >( () => start );
 	const [ toDraft, setToDraft ] = useState< Date | undefined >( () => end );
-	const [ fromStr, setFromStr ] = useState( () => formatYmd( start, timezoneString, gmtOffset ) );
-	const [ toStr, setToStr ] = useState( () => formatYmd( end, timezoneString, gmtOffset ) );
+	// Use UTC formatting without timezone conversion for consistency
+	const [ fromStr, setFromStr ] = useState( () => format( start, 'yyyy-MM-dd' ) );
+	const [ toStr, setToStr ] = useState( () => format( end, 'yyyy-MM-dd' ) );
 	// Tracks the keyboard-focused preset in the listbox (roving focus), not the selected preset.
 	const [ compositeActiveId, setCompositeActiveId ] = useState< string | null >( null );
 
 	const today = useMemo( () => {
-		const parsed = parseYmdLocal( formatYmd( new Date(), timezoneString, gmtOffset ) );
-		// Fallback to local midnight if parsing ever fails
-		return (
-			parsed ?? new Date( new Date().getFullYear(), new Date().getMonth(), new Date().getDate() )
+		// Use UTC-based today calculation for consistency
+		const utcNow = new Date();
+		return new Date(
+			Date.UTC( utcNow.getUTCFullYear(), utcNow.getUTCMonth(), utcNow.getUTCDate() )
 		);
-	}, [ timezoneString, gmtOffset ] );
+	}, [] );
 
 	const todayStr = useMemo(
-		() => formatYmd( today, timezoneString, gmtOffset ),
-		[ today, timezoneString, gmtOffset ]
+		() => format( today, 'yyyy-MM-dd' ), // No timezone conversion needed
+		[ today ]
 	);
 
 	return (
@@ -150,10 +147,10 @@ function DateRangePickerInner( {
 			setToDraft={ setToDraft }
 			setFromStr={ setFromStr }
 			setToStr={ setToStr }
-			timezoneString={ timezoneString }
-			gmtOffset={ gmtOffset }
 			onChange={ onChange }
 			onClose={ onClose }
+			timezoneString={ timezoneString }
+			gmtOffset={ gmtOffset }
 			compositeActiveId={ compositeActiveId }
 			setCompositeActiveId={ setCompositeActiveId }
 			today={ today }

--- a/client/dashboard/components/date-range-picker/test/index.tsx
+++ b/client/dashboard/components/date-range-picker/test/index.tsx
@@ -18,8 +18,6 @@ function TestDateRangePicker( props: Partial< ComponentProps< typeof DateRangePi
 			start={ range.start }
 			end={ range.end }
 			onChange={ setRange }
-			timezoneString=""
-			gmtOffset={ 0 }
 			locale="en-US"
 			{ ...props }
 		/>
@@ -129,12 +127,13 @@ describe( 'DateRangePicker (new)', () => {
 
 	test( 'preset selection updates label (Yesterday)', async () => {
 		const { getByRole, findByRole } = render( <TestDateRangePicker /> );
+
 		// Open
 		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
 
 		// Click "Yesterday" preset
 		const listbox = await findByRole( 'listbox', { name: /Date range presets/i } );
-		await userEvent.click( within( listbox ).getByRole( 'option', { name: /yesterday/i } ) );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: /Yesterday/i } ) );
 
 		// Label should reflect Aug 24 → Aug 24
 		const updated = await findByRole( 'button', {
@@ -143,64 +142,54 @@ describe( 'DateRangePicker (new)', () => {
 		expect( updated ).toBeVisible();
 	} );
 
-	test( 'blank timezoneString with non-zero gmtOffset normalizes and selects correctly', async () => {
-		const { getByRole, findByRole } = render(
-			<TestDateRangePicker timezoneString="" gmtOffset={ -5 } />
-		);
-		const btn = getByRole( 'button', { name: /Date range:/i } );
-		expect( btn ).toHaveAccessibleName( expect.stringContaining( 'Aug 19, 2025' ) );
-		expect( btn ).toHaveAccessibleName( expect.stringContaining( 'Aug 25, 2025' ) );
+	test( 'preset selection works consistently', async () => {
+		const { getByRole, findByRole } = render( <TestDateRangePicker /> );
 
-		// Open and select a range
-		await userEvent.click( btn );
-		const augGrid = await findByRole( 'grid', { name: /August 2025/i } );
-		await userEvent.click( within( augGrid ).getByRole( 'button', { name: /August 1, 2025/i } ) );
-		await userEvent.click( within( augGrid ).getByRole( 'button', { name: /August 2, 2025/i } ) );
-		await userEvent.click( getByRole( 'button', { name: /Apply/i } ) );
+		// Open
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
 
-		// Label should reflect Aug 1 → Aug 2
-		const updated = getByRole( 'button', { name: /Date range:/i } );
-		expect(
-			within( updated ).getByText(
-				( t ) => t.includes( 'Aug 1, 2025' ) && t.includes( 'Aug 2, 2025' )
-			)
-		).toBeVisible();
+		// Click "Today" preset
+		const listbox = await findByRole( 'listbox', { name: /Date range presets/i } );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: /Today/i } ) );
+
+		// Label should reflect today's date consistently
+		const updated = await findByRole( 'button', {
+			name: /Date range:.*Aug 25, 2025.*Aug 25, 2025/i,
+		} );
+		expect( updated ).toBeVisible();
 	} );
 
-	test( 'invalid IANA timezone falls back gracefully (no crash, label correct)', async () => {
-		// Silence and assert the Moment Timezone warning for invalid zone
-		const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-		try {
-			const { getByRole, findByRole } = render(
-				<TestDateRangePicker timezoneString="Foo/Bar" gmtOffset={ 0 } />
-			);
-			const btn = getByRole( 'button', { name: /Date range:/i } );
-			expect( btn ).toBeVisible();
-			// Label remains the initial normalized dates
-			expect( btn ).toHaveAccessibleName( expect.stringContaining( 'Aug 19, 2025' ) );
-			expect( btn ).toHaveAccessibleName( expect.stringContaining( 'Aug 25, 2025' ) );
+	test( 'preset selection works consistently (Last 7 days)', async () => {
+		const { getByRole, findByRole } = render( <TestDateRangePicker /> );
 
-			// Open and ensure calendar renders and selection works
-			await userEvent.click( btn );
-			const augGrid = await findByRole( 'grid', { name: /August 2025/i } );
-			await userEvent.click( within( augGrid ).getByRole( 'button', { name: /August 3, 2025/i } ) );
-			await userEvent.click( within( augGrid ).getByRole( 'button', { name: /August 4, 2025/i } ) );
-			await userEvent.click( getByRole( 'button', { name: /Apply/i } ) );
+		// Open
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
 
-			const updated = getByRole( 'button', { name: /Date range:/i } );
-			expect(
-				within( updated ).getByText(
-					( t ) => t.includes( 'Aug 3, 2025' ) && t.includes( 'Aug 4, 2025' )
-				)
-			).toBeVisible();
+		// Click "Last 7 days" preset
+		const listbox = await findByRole( 'listbox', { name: /Date range presets/i } );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: /Last 7 days/i } ) );
 
-			// Expect a warning logged about invalid timezone data
-			const warned = errorSpy.mock.calls.some( ( args ) =>
-				args.some( ( a ) => typeof a === 'string' && /has no data for/i.test( a ) )
-			);
-			expect( warned ).toBe( true );
-		} finally {
-			errorSpy.mockRestore();
-		}
+		// Label should reflect 7-day range consistently
+		const updated = await findByRole( 'button', {
+			name: /Date range:.*Aug 19, 2025.*Aug 25, 2025/i,
+		} );
+		expect( updated ).toBeVisible();
+	} );
+
+	test( 'preset calculations work consistently without timezone props', async () => {
+		const { getByRole, findByRole } = render( <TestDateRangePicker /> );
+
+		// Open
+		await userEvent.click( getByRole( 'button', { name: /Date range:/i } ) );
+
+		// Click "Yesterday" preset (should use UTC fallback)
+		const listbox = await findByRole( 'listbox', { name: /Date range presets/i } );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: /Yesterday/i } ) );
+
+		// Label should reflect yesterday's date consistently
+		const updated = await findByRole( 'button', {
+			name: /Date range:.*Aug 24, 2025.*Aug 24, 2025/i,
+		} );
+		expect( updated ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/components/date-range-picker/test/utils.ts
+++ b/client/dashboard/components/date-range-picker/test/utils.ts
@@ -1,50 +1,226 @@
 /**
  * @jest-environment jsdom
  */
-import { formatLabel } from '../utils';
+import { formatLabel, computePresetRange, getTimezoneAwareDate, getActivePresetId } from '../utils';
 
 describe( 'formatLabel', () => {
 	const locale = 'en-US';
 
-	test( 'normalizes with IANA timezone (no off-by-one)', () => {
-		const tz = 'Europe/London';
+	test( 'formats date range consistently (UTC-based)', () => {
 		const start = new Date( 2025, 7, 19 );
 		const end = new Date( 2025, 7, 25 );
-		const label = formatLabel( start, end, locale, tz, undefined );
+		const label = formatLabel( start, end, locale );
 		expect( label ).toBe( 'Aug 19, 2025 to Aug 25, 2025' );
 	} );
 
-	test( 'normalizes with offset-only UTC+0 (empty timezoneString)', () => {
-		const start = new Date( 2025, 7, 19 );
-		const end = new Date( 2025, 7, 25 );
-		const label = formatLabel( start, end, locale, undefined, 0 );
-		expect( label ).toBe( 'Aug 19, 2025 to Aug 25, 2025' );
-	} );
-
-	test( 'normalizes with negative offset (e.g., -5)', () => {
+	test( 'formats different date ranges correctly', () => {
 		const start = new Date( 2025, 0, 1 );
 		const end = new Date( 2025, 0, 2 );
-		const label = formatLabel( start, end, locale, undefined, -5 );
+		const label = formatLabel( start, end, locale );
 		expect( label ).toBe( 'Jan 1, 2025 to Jan 2, 2025' );
 	} );
 
-	describe( 'DST boundaries (America/New_York)', () => {
-		const tz = 'America/New_York';
+	test( 'formats single day range correctly', () => {
+		const start = new Date( 2025, 7, 19 );
+		const end = new Date( 2025, 7, 19 );
+		const label = formatLabel( start, end, locale );
+		expect( label ).toBe( 'Aug 19, 2025 to Aug 19, 2025' );
+	} );
+} );
 
-		test( 'spring-forward does not shift calendar days', () => {
-			// 2025-03-09 is the DST start date in US (clocks jump forward)
-			const start = new Date( 2025, 2, 8, 12 ); // Mar 8 @ 12:00 UTC
-			const end = new Date( 2025, 2, 10, 12 ); // Mar 10 @ 12:00 UTC
-			const label = formatLabel( start, end, locale, tz, undefined );
-			expect( label ).toBe( 'Mar 8, 2025 to Mar 10, 2025' );
-		} );
+describe( 'computePresetRange', () => {
+	// Mock date: August 25, 2025
+	const baseDate = new Date( 2025, 7, 25 );
 
-		test( 'fall-back does not shift calendar days', () => {
-			// 2025-11-02 is the DST end date in US (clocks fall back)
-			const start = new Date( 2025, 10, 1, 12 ); // Nov 1 @ 12:00 UTC
-			const end = new Date( 2025, 10, 3, 12 ); // Nov 3 @ 12:00 UTC
-			const label = formatLabel( start, end, locale, tz, undefined );
-			expect( label ).toBe( 'Nov 1, 2025 to Nov 3, 2025' );
-		} );
+	test( 'today preset returns same date', () => {
+		const result = computePresetRange( 'today', baseDate );
+		expect( result ).toEqual( { from: baseDate, to: baseDate } );
+	} );
+
+	test( 'yesterday preset returns previous day', () => {
+		const result = computePresetRange( 'yesterday', baseDate );
+		// Should be August 24, 2025
+		expect( result?.from.getDate() ).toBe( 24 );
+		expect( result?.to.getDate() ).toBe( 24 );
+		expect( result?.from.getMonth() ).toBe( 7 ); // August
+		expect( result?.from.getFullYear() ).toBe( 2025 );
+	} );
+
+	test( 'last-7-days preset returns 7-day range', () => {
+		const result = computePresetRange( 'last-7-days', baseDate );
+		// Should be August 19-25, 2025 (7 days inclusive)
+		expect( result?.from.getDate() ).toBe( 19 );
+		expect( result?.to.getDate() ).toBe( 25 );
+		expect( result?.from.getMonth() ).toBe( 7 ); // August
+		expect( result?.from.getFullYear() ).toBe( 2025 );
+	} );
+
+	test( 'last-30-days preset returns 30-day range', () => {
+		const result = computePresetRange( 'last-30-days', baseDate );
+		// Should be July 27 - August 25, 2025 (30 days inclusive)
+		expect( result?.from.getMonth() ).toBe( 6 ); // July
+		expect( result?.from.getDate() ).toBe( 27 );
+		expect( result?.to.getDate() ).toBe( 25 );
+		expect( result?.to.getMonth() ).toBe( 7 ); // August
+	} );
+
+	test( 'month-to-date preset returns start of month to base date', () => {
+		const result = computePresetRange( 'month-to-date', baseDate );
+		// Should be August 1 - August 25, 2025
+		expect( result?.from.getDate() ).toBe( 1 );
+		expect( result?.to.getDate() ).toBe( 25 );
+		expect( result?.from.getMonth() ).toBe( 7 ); // August
+	} );
+
+	test( 'year-to-date preset returns start of year to base date', () => {
+		const result = computePresetRange( 'year-to-date', baseDate );
+		// Should be January 1 - August 25, 2025
+		expect( result?.from.getDate() ).toBe( 1 );
+		expect( result?.from.getMonth() ).toBe( 0 ); // January
+		expect( result?.to.getDate() ).toBe( 25 );
+		expect( result?.to.getMonth() ).toBe( 7 ); // August
+	} );
+
+	test( 'last-12-months preset returns 12-month range', () => {
+		const result = computePresetRange( 'last-12-months', baseDate );
+		// Should be August 26, 2024 - August 25, 2025
+		expect( result?.from.getFullYear() ).toBe( 2024 );
+		expect( result?.from.getMonth() ).toBe( 7 ); // August
+		expect( result?.from.getDate() ).toBe( 26 );
+		expect( result?.to.getFullYear() ).toBe( 2025 );
+		expect( result?.to.getMonth() ).toBe( 7 ); // August
+		expect( result?.to.getDate() ).toBe( 25 );
+	} );
+
+	test( 'last-3-years preset returns 3-year range', () => {
+		const result = computePresetRange( 'last-3-years', baseDate );
+		// Should be August 26, 2022 - August 25, 2025
+		expect( result?.from.getFullYear() ).toBe( 2022 );
+		expect( result?.from.getMonth() ).toBe( 7 ); // August
+		expect( result?.from.getDate() ).toBe( 26 );
+		expect( result?.to.getFullYear() ).toBe( 2025 );
+		expect( result?.to.getMonth() ).toBe( 7 ); // August
+		expect( result?.to.getDate() ).toBe( 25 );
+	} );
+
+	test( 'custom preset returns undefined', () => {
+		const result = computePresetRange( 'custom', baseDate );
+		expect( result ).toBeUndefined();
+	} );
+} );
+
+describe( 'getTimezoneAwareDate', () => {
+	const baseDate = new Date( 2025, 7, 25, 12, 30, 45 ); // August 25, 2025 12:30:45
+
+	test( 'returns start of day when no timezone info provided', () => {
+		const result = getTimezoneAwareDate( baseDate );
+		expect( result.getFullYear() ).toBe( 2025 );
+		expect( result.getMonth() ).toBe( 7 ); // August
+		expect( result.getDate() ).toBe( 25 );
+		expect( result.getHours() ).toBe( 0 );
+		expect( result.getMinutes() ).toBe( 0 );
+		expect( result.getSeconds() ).toBe( 0 );
+	} );
+
+	test( 'uses timezone string when available', () => {
+		// Mock a timezone that would give different results
+		const result = getTimezoneAwareDate( baseDate, 'Pacific/Honolulu' );
+		// The exact result depends on the timezone, but it should be normalized to start of day
+		expect( result.getHours() ).toBe( 0 );
+		expect( result.getMinutes() ).toBe( 0 );
+		expect( result.getSeconds() ).toBe( 0 );
+	} );
+
+	test( 'uses GMT offset when available', () => {
+		const result = getTimezoneAwareDate( baseDate, undefined, 5 ); // UTC+5
+		expect( result.getHours() ).toBe( 0 );
+		expect( result.getMinutes() ).toBe( 0 );
+		expect( result.getSeconds() ).toBe( 0 );
+	} );
+
+	test( 'prioritizes timezone string over GMT offset', () => {
+		const result = getTimezoneAwareDate( baseDate, 'Pacific/Honolulu', 5 );
+		// Should use timezone string, not GMT offset
+		expect( result.getHours() ).toBe( 0 );
+		expect( result.getMinutes() ).toBe( 0 );
+		expect( result.getSeconds() ).toBe( 0 );
+	} );
+} );
+
+describe( 'getActivePresetId', () => {
+	const baseDate = new Date( 2025, 7, 25 ); // August 25, 2025
+
+	test( 'returns undefined when required parameters are missing', () => {
+		expect( getActivePresetId( undefined, baseDate, baseDate ) ).toBeUndefined();
+		expect( getActivePresetId( baseDate, undefined, baseDate ) ).toBeUndefined();
+		expect( getActivePresetId( baseDate, baseDate, undefined ) ).toBeUndefined();
+	} );
+
+	test( 'identifies today preset correctly', () => {
+		const today = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( today, today, baseDate );
+		expect( result ).toBe( 'today' );
+	} );
+
+	test( 'identifies yesterday preset correctly', () => {
+		const yesterday = new Date( 2025, 7, 24 );
+		const result = getActivePresetId( yesterday, yesterday, baseDate );
+		expect( result ).toBe( 'yesterday' );
+	} );
+
+	test( 'identifies last-7-days preset correctly', () => {
+		const from = new Date( 2025, 7, 19 );
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'last-7-days' );
+	} );
+
+	test( 'identifies last-30-days preset correctly', () => {
+		const from = new Date( 2025, 6, 27 ); // July 27 (30 days before Aug 25)
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'last-30-days' );
+	} );
+
+	test( 'identifies month-to-date preset correctly', () => {
+		const from = new Date( 2025, 7, 1 );
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'month-to-date' );
+	} );
+
+	test( 'identifies year-to-date preset correctly', () => {
+		const from = new Date( 2025, 0, 1 );
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'year-to-date' );
+	} );
+
+	test( 'identifies last-12-months preset correctly', () => {
+		const from = new Date( 2024, 7, 26 );
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'last-12-months' );
+	} );
+
+	test( 'identifies last-3-years preset correctly', () => {
+		const from = new Date( 2022, 7, 26 );
+		const to = new Date( 2025, 7, 25 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'last-3-years' );
+	} );
+
+	test( 'returns undefined for non-matching ranges', () => {
+		const from = new Date( 2025, 7, 10 );
+		const to = new Date( 2025, 7, 15 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBeUndefined();
+	} );
+
+	test( 'swaps dates when from > to', () => {
+		const from = new Date( 2025, 7, 25 );
+		const to = new Date( 2025, 7, 19 );
+		const result = getActivePresetId( from, to, baseDate );
+		expect( result ).toBe( 'last-7-days' );
 	} );
 } );

--- a/client/dashboard/components/date-range-picker/utils.ts
+++ b/client/dashboard/components/date-range-picker/utils.ts
@@ -1,34 +1,42 @@
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	startOfDay,
-	isSameDay,
+	addHours,
 	addDays,
 	addYears,
 	startOfMonth,
 	startOfYear,
 	differenceInCalendarDays,
+	isSameDay,
+	subDays,
 } from 'date-fns';
-import { formatDate, formatYmd, parseYmdLocal } from '../../utils/datetime';
+import { formatDate } from '../../utils/datetime';
 
 // Range helpers (inclusive)
 const lastNDays = ( date: Date, number: number ) => ( {
-	from: new Date( date.getFullYear(), date.getMonth(), date.getDate() - ( number - 1 ) ),
+	from: new Date(
+		Date.UTC( date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - ( number - 1 ) )
+	),
 	to: date,
 } );
 const monthToDate = ( date: Date ) => ( {
-	from: new Date( date.getFullYear(), date.getMonth(), 1 ),
+	from: new Date( Date.UTC( date.getUTCFullYear(), date.getUTCMonth(), 1 ) ),
 	to: date,
 } );
 const yearToDate = ( date: Date ) => ( {
-	from: new Date( date.getFullYear(), 0, 1 ),
+	from: new Date( Date.UTC( date.getUTCFullYear(), 0, 1 ) ),
 	to: date,
 } );
 const lastTwelveMonths = ( date: Date ) => ( {
-	from: new Date( date.getFullYear() - 1, date.getMonth(), date.getDate() + 1 ),
+	from: new Date(
+		Date.UTC( date.getUTCFullYear() - 1, date.getUTCMonth(), date.getUTCDate() + 1 )
+	),
 	to: date,
 } );
 const lastThreeYears = ( date: Date ) => ( {
-	from: new Date( date.getFullYear() - 3, date.getMonth(), date.getDate() + 1 ),
+	from: new Date(
+		Date.UTC( date.getUTCFullYear() - 3, date.getUTCMonth(), date.getUTCDate() + 1 )
+	),
 	to: date,
 } );
 
@@ -55,13 +63,20 @@ export const presetDefs = [
 ] as const satisfies ReadonlyArray< { id: Exclude< PresetId, 'custom' >; label: string } >;
 
 export function computePresetRange( preset: PresetId, baseDate: Date ) {
+	const addDaysUtc = ( daysOffset: number = 0 ) => {
+		return addDays( baseDate, daysOffset );
+	};
 	switch ( preset ) {
 		case 'today':
+			// Return the same date for both start and end
+			// The actual time boundaries will be set in buildTimeRangeInSeconds
 			return { from: baseDate, to: baseDate };
 		case 'yesterday':
+			// Return the same date for both start and end
+			// The actual time boundaries will be set in buildTimeRangeInSeconds
 			return {
-				from: new Date( baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate() - 1 ),
-				to: new Date( baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate() - 1 ),
+				from: addDaysUtc( -1 ),
+				to: addDaysUtc( -1 ),
 			};
 		case 'last-7-days':
 			return lastNDays( baseDate, 7 );
@@ -80,30 +95,73 @@ export function computePresetRange( preset: PresetId, baseDate: Date ) {
 	}
 }
 
-export function getActivePresetId( from?: Date, to?: Date, baseDate?: Date ): PresetId | undefined {
+export function getActivePresetId(
+	from?: Date,
+	to?: Date,
+	baseDate?: Date,
+	timezoneString?: string,
+	gmtOffset?: number
+): PresetId | undefined {
 	if ( ! from || ! to || ! baseDate ) {
 		return;
 	}
+
+	// Normalize dates to start of day for comparison
 	let newFrom = startOfDay( from );
 	let newTo = startOfDay( to );
-	if ( newFrom!.getTime() > newTo!.getTime() ) {
+
+	if ( newFrom.getTime() > newTo.getTime() ) {
 		const tmp = newFrom;
 		newFrom = newTo;
 		newTo = tmp;
 	}
 
-	const todayStart = startOfDay( baseDate );
-	const yesterdayStart = addDays( todayStart, -1 );
+	// Calculate site timezone dates for comparison
+	let today: Date;
+	let yesterday: Date;
 
-	if ( isSameDay( newFrom, todayStart ) && isSameDay( newTo, todayStart ) ) {
+	if ( timezoneString ) {
+		// Use site timezone if available
+		const now = new Date();
+		const siteTime = new Intl.DateTimeFormat( 'en-US', {
+			timeZone: timezoneString,
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+		} ).formatToParts( now );
+
+		const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
+		const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1;
+		const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
+
+		today = startOfDay( new Date( year, month, day ) );
+		yesterday = subDays( today, 1 );
+	} else if ( typeof gmtOffset === 'number' ) {
+		// Use GMT offset if no timezone string
+		const now = new Date();
+		const utcTime = now.getTime();
+		const siteTime = utcTime + gmtOffset * 60 * 60 * 1000;
+		const siteDate = new Date( siteTime );
+
+		today = startOfDay( siteDate );
+		yesterday = subDays( today, 1 );
+	} else {
+		// Fallback to UTC
+		today = startOfDay( baseDate );
+		yesterday = subDays( baseDate, 1 );
+	}
+
+	if ( isSameDay( newFrom, today ) && isSameDay( newTo, today ) ) {
 		return 'today';
 	}
-	if ( isSameDay( newFrom, yesterdayStart ) && isSameDay( newTo, yesterdayStart ) ) {
+	if ( isSameDay( newFrom, yesterday ) && isSameDay( newTo, yesterday ) ) {
 		return 'yesterday';
 	}
 
-	if ( isSameDay( newTo, todayStart ) ) {
-		const diff = differenceInCalendarDays( todayStart, newFrom ); // inclusive days = diff + 1
+	if ( isSameDay( newTo, today ) ) {
+		const diff = differenceInCalendarDays( today, newFrom );
+		// differenceInCalendarDays returns the number of calendar days between dates
+		// For inclusive ranges, we need to check if the difference matches our expected ranges
 		if ( diff === 6 ) {
 			return 'last-7-days';
 		}
@@ -111,28 +169,29 @@ export function getActivePresetId( from?: Date, to?: Date, baseDate?: Date ): Pr
 			return 'last-30-days';
 		}
 		if (
-			isSameDay( newFrom, addYears( todayStart, -1 ) ) ||
-			isSameDay( newFrom, addDays( addYears( todayStart, -1 ), 1 ) )
+			isSameDay( newFrom, addYears( today, -1 ) ) ||
+			isSameDay( newFrom, addDays( addYears( today, -1 ), 1 ) )
 		) {
 			return 'last-12-months';
 		}
 		if (
-			isSameDay( newFrom, addYears( todayStart, -3 ) ) ||
-			isSameDay( newFrom, addDays( addYears( todayStart, -3 ), 1 ) )
+			isSameDay( newFrom, addYears( today, -3 ) ) ||
+			isSameDay( newFrom, addDays( addYears( today, -3 ), 1 ) )
 		) {
 			return 'last-3-years';
 		}
 	}
 
-	if ( isSameDay( newFrom, startOfMonth( todayStart ) ) && isSameDay( newTo, todayStart ) ) {
+	if ( isSameDay( newFrom, startOfMonth( today ) ) && isSameDay( newTo, today ) ) {
 		return 'month-to-date';
 	}
-	if ( isSameDay( newFrom, startOfYear( todayStart ) ) && isSameDay( newTo, todayStart ) ) {
+	if ( isSameDay( newFrom, startOfYear( today ) ) && isSameDay( newTo, today ) ) {
 		return 'year-to-date';
 	}
 
+	// Test against computed preset ranges
 	for ( const preset of presetDefs ) {
-		const range = computePresetRange( preset.id as PresetId, todayStart );
+		const range = computePresetRange( preset.id as PresetId, today );
 		if (
 			range &&
 			isSameDay( newFrom, startOfDay( range.from ) ) &&
@@ -145,25 +204,39 @@ export function getActivePresetId( from?: Date, to?: Date, baseDate?: Date ): Pr
 }
 
 // UI-specific: Date range label for the picker
-export function formatLabel(
-	start: Date,
-	end: Date,
-	locale: string,
-	timezoneString?: string,
-	gmtOffset?: number
-) {
+export function formatLabel( start: Date, end: Date, locale: string ) {
 	// Normalize to site calendar days first, then format visually for the locale.
 	// This avoids off-by-one issues when the Date carries a different local timezone
 	// than the site's timezone.
-	const startYmd = formatYmd( start, timezoneString, gmtOffset );
-	const endYmd = formatYmd( end, timezoneString, gmtOffset );
-	const startForDisplay = parseYmdLocal( startYmd )!;
-	const endForDisplay = parseYmdLocal( endYmd )!;
-
 	return sprintf(
 		/* translators: %1$s: start date, %2$s: end date */
 		__( '%1$s to %2$s' ),
-		formatDate( startForDisplay, locale, { dateStyle: 'medium' } ),
-		formatDate( endForDisplay, locale, { dateStyle: 'medium' } )
+		formatDate( start, locale, { dateStyle: 'medium' } ),
+		formatDate( end, locale, { dateStyle: 'medium' } )
 	);
+}
+
+// Calculate timezone-aware today for preset detection
+export function getTimezoneAwareDate(
+	baseDate: Date,
+	timezoneString?: string,
+	gmtOffset?: number
+): Date {
+	if ( timezoneString ) {
+		const siteTime = new Intl.DateTimeFormat( 'en-US', {
+			timeZone: timezoneString,
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+		} ).formatToParts( baseDate );
+
+		const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
+		const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1;
+		const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
+
+		return startOfDay( new Date( year, month, day ) );
+	} else if ( typeof gmtOffset === 'number' ) {
+		return startOfDay( addHours( baseDate, gmtOffset ) );
+	}
+	return startOfDay( baseDate );
 }

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -115,7 +115,7 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	const { data } = useSuspenseQuery( {
 		...siteSettingsQuery( siteId ),
 		select: ( s ) => ( {
-			gmtOffset: typeof s?.gmt_offset === 'number' ? s.gmt_offset : 0,
+			gmtOffset: s?.gmt_offset ? Number( s.gmt_offset ) : 0,
 			timezoneString: s?.timezone_string || undefined,
 		} ),
 	} );
@@ -129,7 +129,10 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		initialFilters: getInitialFiltersFromSearch( logType, search ),
 	} );
 
-	const initial = getDefaultDateRange( timezoneString, gmtOffset );
+	const initial = useMemo(
+		() => getDefaultDateRange( timezoneString, gmtOffset ),
+		[ timezoneString, gmtOffset ]
+	);
 
 	const initialFromUrl = getInitialDateRangeFromSearch( search );
 
@@ -144,8 +147,44 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			return;
 		}
 		const tick = () => {
-			const end = new Date();
-			const start = subDays( end, 6 );
+			// Use site timezone for auto-refresh date range (consistent with default range)
+			let end: Date;
+			let start: Date;
+
+			if ( timezoneString ) {
+				// Use site timezone if available
+				const now = new Date();
+				// Get the current time in the site's timezone
+				const siteTime = new Intl.DateTimeFormat( 'en-US', {
+					timeZone: timezoneString,
+					year: 'numeric',
+					month: 'numeric',
+					day: 'numeric',
+				} ).formatToParts( now );
+
+				const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
+				const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1; // Month is 0-indexed
+				const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
+
+				end = new Date( year, month, day );
+				start = subDays( end, 6 );
+			} else if ( typeof gmtOffset === 'number' ) {
+				// Use GMT offset if no timezone string
+				const now = new Date();
+				// Calculate site timezone date using UTC offset
+				const utcTime = now.getTime();
+				const siteTime = utcTime + gmtOffset * 60 * 60 * 1000;
+				const siteDate = new Date( siteTime );
+
+				end = new Date(
+					Date.UTC( siteDate.getUTCFullYear(), siteDate.getUTCMonth(), siteDate.getUTCDate() )
+				);
+				start = subDays( end, 6 );
+			} else {
+				// Fallback to local timezone
+				end = new Date();
+				start = subDays( end, 6 );
+			}
 
 			setDateRange( ( prev ) =>
 				isSameSecond( prev.start, start ) && isSameSecond( prev.end, end ) ? prev : { start, end }
@@ -168,11 +207,11 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		tick();
 		const intervalId = setInterval( tick, 10 * 1000 );
 		return () => clearInterval( intervalId );
-	}, [ autoRefresh ] );
+	}, [ autoRefresh, timezoneString, gmtOffset ] );
 
 	const { startSec, endSec } = useMemo(
 		() => buildTimeRangeInSeconds( dateRange.start, dateRange.end, timezoneString, gmtOffset ),
-		[ dateRange.start, dateRange.end, gmtOffset, timezoneString ]
+		[ dateRange.start, dateRange.end, timezoneString, gmtOffset ]
 	);
 
 	const filter = useMemo( () => toFilterParams( { view, logType } ), [ view, logType ] );
@@ -389,8 +428,8 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 						<DateRangePicker
 							start={ dateRange.start }
 							end={ dateRange.end }
-							gmtOffset={ gmtOffset }
 							timezoneString={ timezoneString }
+							gmtOffset={ gmtOffset }
 							locale={ locale }
 							onChange={ handleDateRangeChange }
 						/>

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -11,7 +11,7 @@ import {
 import { DataViews, View, Filter, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
-import { getUnixTime, subDays, isSameSecond } from 'date-fns';
+import { getUnixTime } from 'date-fns';
 import { useMemo, useState, useRef, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
@@ -22,6 +22,7 @@ import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
 import { DateRangePicker } from '../../components/date-range-picker';
+import { getActivePresetId } from '../../components/date-range-picker/utils';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -140,75 +141,6 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		() => initialFromUrl ?? initial
 	);
 
-	const lastUrlRangeRef = useRef< { from: number; to: number } | null >( null );
-
-	useEffect( () => {
-		if ( ! autoRefresh ) {
-			return;
-		}
-		const tick = () => {
-			// Use site timezone for auto-refresh date range (consistent with default range)
-			let end: Date;
-			let start: Date;
-
-			if ( timezoneString ) {
-				// Use site timezone if available
-				const now = new Date();
-				// Get the current time in the site's timezone
-				const siteTime = new Intl.DateTimeFormat( 'en-US', {
-					timeZone: timezoneString,
-					year: 'numeric',
-					month: 'numeric',
-					day: 'numeric',
-				} ).formatToParts( now );
-
-				const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
-				const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1; // Month is 0-indexed
-				const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
-
-				end = new Date( year, month, day );
-				start = subDays( end, 6 );
-			} else if ( typeof gmtOffset === 'number' ) {
-				// Use GMT offset if no timezone string
-				const now = new Date();
-				// Calculate site timezone date using UTC offset
-				const utcTime = now.getTime();
-				const siteTime = utcTime + gmtOffset * 60 * 60 * 1000;
-				const siteDate = new Date( siteTime );
-
-				end = new Date(
-					Date.UTC( siteDate.getUTCFullYear(), siteDate.getUTCMonth(), siteDate.getUTCDate() )
-				);
-				start = subDays( end, 6 );
-			} else {
-				// Fallback to local timezone
-				end = new Date();
-				start = subDays( end, 6 );
-			}
-
-			setDateRange( ( prev ) =>
-				isSameSecond( prev.start, start ) && isSameSecond( prev.end, end ) ? prev : { start, end }
-			);
-			const from = getUnixTime( start );
-			const to = getUnixTime( end );
-
-			const last = lastUrlRangeRef.current;
-			// Only sync URL when from/to change to avoid unnecessary history updates.
-			if ( ! last || last.from !== from || last.to !== to ) {
-				const url = new URL( window.location.href );
-				url.searchParams.set( 'from', String( from ) );
-				url.searchParams.set( 'to', String( to ) );
-				window.history.replaceState( null, '', url.pathname + url.search );
-				lastUrlRangeRef.current = { from, to };
-			}
-		};
-
-		// Run immediately, then every 10s
-		tick();
-		const intervalId = setInterval( tick, 10 * 1000 );
-		return () => clearInterval( intervalId );
-	}, [ autoRefresh, timezoneString, gmtOffset ] );
-
 	const { startSec, endSec } = useMemo(
 		() => buildTimeRangeInSeconds( dateRange.start, dateRange.end, timezoneString, gmtOffset ),
 		[ dateRange.start, dateRange.end, timezoneString, gmtOffset ]
@@ -231,7 +163,34 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	// For the current page, use its cursor (or null/undefined on page 1).
 	const scrollId = cursorsRef.current.get( view.page ?? 1 ) ?? null;
 
-	const { data: siteLogs, isFetching } = useQuery( siteLogsQuery( siteId, params, scrollId ) );
+	const {
+		data: siteLogs,
+		isFetching,
+		refetch,
+	} = useQuery( siteLogsQuery( siteId, params, scrollId ) );
+
+	useEffect( () => {
+		if ( ! autoRefresh ) {
+			return;
+		}
+
+		// Auto-refresh only works with the default "Last 7 days" preset
+		const activePreset = getActivePresetId(
+			dateRange.start,
+			dateRange.end,
+			new Date(),
+			timezoneString,
+			gmtOffset
+		);
+		if ( activePreset !== 'last-7-days' ) {
+			return;
+		}
+
+		// Simple auto-refresh: just refetch the logs every 10 seconds
+		const intervalId = setInterval( () => refetch(), 10 * 1000 );
+
+		return () => clearInterval( intervalId );
+	}, [ autoRefresh, refetch, dateRange.start, dateRange.end, timezoneString, gmtOffset ] );
 
 	useEffect( () => {
 		if ( ! siteLogs ) {

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -124,6 +124,9 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	const { gmtOffset, timezoneString } = data!;
 
 	const [ autoRefresh, setAutoRefresh ] = useState( false );
+	const [ autoRefreshDisabledReason, setAutoRefreshDisabledReason ] = useState< string | null >(
+		null
+	);
 
 	const [ view, setView ] = useView( {
 		logType,
@@ -183,14 +186,28 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			gmtOffset
 		);
 		if ( activePreset !== 'last-7-days' ) {
+			// Auto-disable auto-refresh when not using the default preset
+			setAutoRefresh( false );
+			setAutoRefreshDisabledReason( __( 'Auto-refresh only works with "Last 7 days" preset' ) );
 			return;
 		}
+
+		// Clear any previous disabled reason when auto-refresh is working
+		setAutoRefreshDisabledReason( null );
 
 		// Simple auto-refresh: just refetch the logs every 10 seconds
 		const intervalId = setInterval( () => refetch(), 10 * 1000 );
 
 		return () => clearInterval( intervalId );
-	}, [ autoRefresh, refetch, dateRange.start, dateRange.end, timezoneString, gmtOffset ] );
+	}, [
+		autoRefresh,
+		refetch,
+		dateRange.start,
+		dateRange.end,
+		timezoneString,
+		gmtOffset,
+		setAutoRefresh,
+	] );
 
 	useEffect( () => {
 		if ( ! siteLogs ) {
@@ -208,6 +225,7 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 
 	const handleDateRangeChange = ( next: { start: Date; end: Date } ) => {
 		setAutoRefresh( false );
+		setAutoRefreshDisabledReason( null );
 		setDateRange( next );
 
 		// Reset pagination + cursors
@@ -340,6 +358,9 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 
 	const handleAutoRefreshClick = ( isChecked: boolean ) => {
 		setAutoRefresh( isChecked );
+		if ( ! isChecked ) {
+			setAutoRefreshDisabledReason( null );
+		}
 		recordTracksEvent( 'calypso_dashboard_site_logs_auto_refresh', { enabled: isChecked } );
 	};
 
@@ -377,6 +398,11 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			{ notice && (
 				<div style={ { marginBottom: 12 } }>
 					<Notice variant={ notice.variant }>{ notice.message }</Notice>
+				</div>
+			) }
+			{ autoRefreshDisabledReason && (
+				<div style={ { marginBottom: 12 } }>
+					<Notice variant="warning">{ autoRefreshDisabledReason }</Notice>
 				</div>
 			) }
 			<CalloutOverlay

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -1,26 +1,63 @@
-import { dateI18n } from '@wordpress/date';
-import { startOfDay, endOfDay, fromUnixTime, isValid as isValidDate } from 'date-fns';
-import { formatDateWithOffset, parseYmdLocal, formatYmd } from '../../utils/datetime';
+import { fromUnixTime, isValid as isValidDate, startOfDay, endOfDay } from 'date-fns';
+import { formatDateWithOffset } from '../../utils/datetime';
 import type { PHPLog } from '../../data/site-logs';
 
 type DateRange = { start: Date; end: Date };
 
-const HOUR_MS = 3_600_000;
-
 /**
  * Get the default date range for the logs.
+ * Uses site timezone for data fetching while keeping UTC display.
  */
 export function getDefaultDateRange( timezoneString?: string, gmtOffset?: number ) {
-	const siteToday = parseYmdLocal( formatYmd( new Date(), timezoneString, gmtOffset ) )!;
+	let today: Date;
+
+	if ( timezoneString ) {
+		// Use site timezone if available
+		const now = new Date();
+		// Get the current time in the site's timezone
+		const siteTime = new Intl.DateTimeFormat( 'en-US', {
+			timeZone: timezoneString,
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+		} ).formatToParts( now );
+
+		const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
+		const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1; // Month is 0-indexed
+		const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
+
+		today = new Date( year, month, day );
+	} else if ( typeof gmtOffset === 'number' ) {
+		// Use GMT offset if no timezone string
+		const now = new Date();
+		// Calculate site timezone date using UTC offset
+		const utcTime = now.getTime();
+		const siteTime = utcTime + gmtOffset * 60 * 60 * 1000;
+		const siteDate = new Date( siteTime );
+
+		today = new Date(
+			Date.UTC( siteDate.getUTCFullYear(), siteDate.getUTCMonth(), siteDate.getUTCDate() )
+		);
+	} else {
+		// Fallback to UTC (default behavior)
+		const utcNow = new Date();
+		today = new Date(
+			Date.UTC( utcNow.getUTCFullYear(), utcNow.getUTCMonth(), utcNow.getUTCDate() )
+		);
+	}
+
+	// Calculate start date (6 days ago from site's today)
+	const start = new Date( today );
+	start.setDate( start.getDate() - 6 );
+
 	return {
-		start: new Date( siteToday.getFullYear(), siteToday.getMonth(), siteToday.getDate() - 6 ),
-		end: siteToday,
+		start,
+		end: today,
 	};
 }
 
 /**
- * Convert a local date range to inclusive epoch-second boundaries (UTC).
- * Covers the full start and end calendar days.
+ * Convert a date range to Unix epoch seconds for API requests.
  */
 export function buildTimeRangeInSeconds(
 	start: Date,
@@ -29,26 +66,37 @@ export function buildTimeRangeInSeconds(
 	gmtOffset?: number
 ): { startSec: number; endSec: number } {
 	if ( timezoneString ) {
-		const startYmd = dateI18n( 'Y-m-d', start, timezoneString );
-		const endYmd = dateI18n( 'Y-m-d', end, timezoneString );
-		const startSec = +dateI18n( 'U', `${ startYmd } 00:00:00`, timezoneString );
-		const endSec = +dateI18n( 'U', `${ endYmd } 23:59:59`, timezoneString );
-		if ( Number.isFinite( startSec ) && Number.isFinite( endSec ) ) {
-			return { startSec, endSec };
-		}
+		// For now, fall back to GMT offset approach for timezone strings
+		const startDate = startOfDay( start );
+		const endDate = startOfDay( end );
+
+		const startSec = Math.floor( startDate.getTime() / 1000 );
+		const endSec = Math.floor( endOfDay( endDate ).getTime() / 1000 );
+
+		return { startSec, endSec };
+	} else if ( typeof gmtOffset === 'number' ) {
+		// Use GMT offset if no timezone string
+		const startDate = startOfDay( start );
+		const endDate = startOfDay( end );
+
+		// Apply GMT offset to get site timezone boundaries
+		const offsetMs = gmtOffset * 60 * 60 * 1000;
+		const startInSiteTz = new Date( startDate.getTime() - offsetMs );
+		const endInSiteTz = new Date( endDate.getTime() - offsetMs );
+
+		const startSec = Math.floor( startInSiteTz.getTime() / 1000 );
+		const endSec = Math.floor( endOfDay( endInSiteTz ).getTime() / 1000 );
+
+		return { startSec, endSec };
 	}
-	if ( typeof gmtOffset === 'number' ) {
-		const startLocal = startOfDay( start ).getTime();
-		const endLocal = endOfDay( end ).getTime();
-		const shiftMs = gmtOffset * HOUR_MS;
-		return {
-			startSec: Math.floor( ( startLocal - shiftMs ) / 1000 ),
-			endSec: Math.floor( ( endLocal - shiftMs ) / 1000 ),
-		};
-	}
-	// last-resort fallback: browser local
-	const startSec = Math.floor( startOfDay( start ).getTime() / 1000 );
-	const endSec = Math.floor( endOfDay( end ).getTime() / 1000 );
+
+	// Fallback to UTC methods for consistency
+	const startUTC = startOfDay( start );
+	const endUTC = endOfDay( end );
+
+	const startSec = Math.floor( startUTC.getTime() / 1000 );
+	const endSec = Math.floor( endUTC.getTime() / 1000 );
+
 	return { startSec, endSec };
 }
 

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -1,4 +1,4 @@
-import { fromUnixTime, isValid as isValidDate, startOfDay, endOfDay } from 'date-fns';
+import { fromUnixTime, isValid as isValidDate, startOfDay, endOfDay, subDays } from 'date-fns';
 import { formatDateWithOffset } from '../../utils/datetime';
 import type { PHPLog } from '../../data/site-logs';
 
@@ -14,7 +14,6 @@ export function getDefaultDateRange( timezoneString?: string, gmtOffset?: number
 	if ( timezoneString ) {
 		// Use site timezone if available
 		const now = new Date();
-		// Get the current time in the site's timezone
 		const siteTime = new Intl.DateTimeFormat( 'en-US', {
 			timeZone: timezoneString,
 			year: 'numeric',
@@ -23,14 +22,13 @@ export function getDefaultDateRange( timezoneString?: string, gmtOffset?: number
 		} ).formatToParts( now );
 
 		const year = parseInt( siteTime.find( ( p ) => p.type === 'year' )?.value || '0' );
-		const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1; // Month is 0-indexed
+		const month = parseInt( siteTime.find( ( p ) => p.type === 'month' )?.value || '0' ) - 1;
 		const day = parseInt( siteTime.find( ( p ) => p.type === 'day' )?.value || '0' );
 
 		today = new Date( year, month, day );
 	} else if ( typeof gmtOffset === 'number' ) {
 		// Use GMT offset if no timezone string
 		const now = new Date();
-		// Calculate site timezone date using UTC offset
 		const utcTime = now.getTime();
 		const siteTime = utcTime + gmtOffset * 60 * 60 * 1000;
 		const siteDate = new Date( siteTime );
@@ -47,8 +45,7 @@ export function getDefaultDateRange( timezoneString?: string, gmtOffset?: number
 	}
 
 	// Calculate start date (6 days ago from site's today)
-	const start = new Date( today );
-	start.setDate( start.getDate() - 6 );
+	const start = subDays( today, 6 );
 
 	return {
 		start,


### PR DESCRIPTION

Part of DOTCOM-14327

## Proposed Changes

* This PR focusses on improving the date range picker (used on the site logs page of the Hosting Dashboard), when used for sites and for users in timezones significantly outside UTC+0. Previous issues included mismatches in what inputs / the calendar / logs would show.
* Tests have also been updated.

## Why are these changes being made?

* This is part of building the Hosting Dashboard site logs page

## Testing Instructions


* Open up the site logs page at `http://calypso.localhost:3000/v2/sites/your-atomic-site/logs`.
* Test the date range picker by changing the site timezone settings for a site, to more extreme locations. Which options to test depend on the time of day testing, but try to select timezones (both with strings, eg Honolulu, and UTC offset, eg UTC+14) that are as far from UTC+0 as possible generally.
* Ensure that the experience is generally what you would expect.
* Ensure auto-refresh works as before.
* This still isn't perfect -- we're not showing dates (eg last 7 days) based on the timezone that you are viewing the logs page from, but factoring in the site timezone. However it is much more likely that a user is in a similar timezone to the site timezones they are managing.
* Compare as well with the old dashboard at `http://calypso.localhost:3000/site-logs/your-atomic-site/web`. There are some situations where the old dashboard won't show results when it really should, but these should display on the new dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
