### PR TITLE
Hosting Dashboard: transfer domain to any user

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -9,6 +9,7 @@ import {
 	mailboxesQuery,
 	siteByIdQuery,
 	queryClient,
+	domainTransferRequestQuery,
 } from '@automattic/api-queries';
 import {
 	createRoute,
@@ -295,6 +296,10 @@ export const domainTransferRoute = createRoute( {
 export const domainTransferToAnyUserRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'transfer/any-user',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
+	},
 } ).lazy( () =>
 	import( '../../domains/domain-transfer/transfer-domain-to-any-user' ).then( ( d ) =>
 		createLazyRoute( 'domain-transfer-to-any-user' )( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -292,6 +292,17 @@ export const domainTransferRoute = createRoute( {
 	)
 );
 
+export const domainTransferToAnyUserRoute = createRoute( {
+	getParentRoute: () => domainRoute,
+	path: 'transfer/any-user',
+} ).lazy( () =>
+	import( '../../domains/domain-transfer/transfer-domain-to-any-user' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-to-any-user' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createDomainsRoutes = () => {
 	return [
 		domainsRoute,
@@ -310,6 +321,7 @@ export const createDomainsRoutes = () => {
 			domainGlueRecordsAddRoute,
 			domainGlueRecordsEditRoute,
 			domainTransferRoute,
+			domainTransferToAnyUserRoute,
 			domainSecurityRoute,
 		] ),
 	];

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Card,
 	CardBody,
@@ -7,17 +7,25 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { DataForm, isItemValid } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useLocale } from '../../app/locale';
 import { domainQuery } from '../../app/queries/domain';
-import { domainTransferRequestQuery } from '../../app/queries/domain-transfer';
+import {
+	domainTransferRequestQuery,
+	domainTransferRequestUpdateMutation,
+	domainTransferRequestDeleteMutation,
+} from '../../app/queries/domain-transfer';
 import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
+import { formatDate } from '../../utils/datetime';
 import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
 import type { Field } from '@wordpress/dataviews';
 
@@ -48,7 +56,14 @@ export default function TransferDomainToAnyUser() {
 	const { data: domainTransferRequest } = useSuspenseQuery(
 		domainTransferRequestQuery( domainName, site.slug )
 	);
+	const { mutate: deleteDomainTransferRequest, isPending: isDeletingDomainTransferRequest } =
+		useMutation( domainTransferRequestDeleteMutation( domainName, site.slug ) );
+	const { mutate: updateDomainTransferRequest, isPending: isUpdatingDomainTransferRequest } =
+		useMutation( domainTransferRequestUpdateMutation( domainName, site.slug ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const locale = useLocale();
 	const transferEmail = domainTransferRequest?.email;
+	const requestedAt = domainTransferRequest?.requested_at;
 
 	const [ formData, setFormData ] = useState( {
 		email: '',
@@ -60,8 +75,27 @@ export default function TransferDomainToAnyUser() {
 
 	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
-		// eslint-disable-next-line no-console
-		console.log( 'Transfer domain to email:', formData.email );
+		updateDomainTransferRequest( formData.email, {
+			onSuccess: () => {
+				createSuccessNotice(
+					__( 'A domain transfer request has been emailed to the recipient’s address.' )
+				);
+			},
+			onError: () => {
+				createErrorNotice( __( 'An error occurred while initiating the domain transfer.' ) );
+			},
+		} );
+	};
+
+	const handleCancelTransfer = () => {
+		deleteDomainTransferRequest( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your domain transfer has been cancelled.' ) );
+			},
+			onError: () => {
+				createErrorNotice( __( 'The domain transfer cannot be cancelled at this time.' ) );
+			},
+		} );
 	};
 
 	const renderTransferNotice = () => {
@@ -74,73 +108,115 @@ export default function TransferDomainToAnyUser() {
 		);
 	};
 
-	const renderEmailForm = () => {
+	const renderTransferForm = () => {
 		return (
-			<form onSubmit={ handleSubmit }>
-				<VStack spacing={ 4 }>
-					<DataForm< TransferFormData >
-						data={ formData }
-						fields={ fields }
-						form={ form }
-						onChange={ ( edits: Partial< TransferFormData > ) => {
-							setFormData( ( data ) => ( { ...data, ...edits } ) );
-						} }
-					/>
-					{ renderTransferNotice() }
-					<HStack justify="flex-start">
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
-							type="submit"
-							disabled={ isSaveDisabled }
-						>
-							{ __( 'Transfer Domain' ) }
-						</Button>
-					</HStack>
+			<VStack spacing={ 8 }>
+				<VStack spacing={ 2 }>
+					<Text as="p">
+						{ sprintf(
+							/* Translators: %s: domainName is the domain name */
+							__(
+								'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
+							),
+							{ domainName }
+						) }
+					</Text>
+					<Text as="p">
+						{ __(
+							'The recipient will need to provide updated contact information and accept the request before the domain transfer can be completed.'
+						) }
+					</Text>
+					{ hasEmailWithUs && (
+						<Text as="p">
+							{ sprintf(
+								/* Translators: %s: domainName is the domain name */
+								__(
+									'The email subscription for %(domainName)s will be transferred along with the domain.'
+								),
+								{ domainName }
+							) }
+						</Text>
+					) }
 				</VStack>
-			</form>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<DataForm< TransferFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< TransferFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						{ renderTransferNotice() }
+						<HStack justify="flex-start">
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isUpdatingDomainTransferRequest }
+								disabled={ isSaveDisabled || isUpdatingDomainTransferRequest }
+							>
+								{ __( 'Transfer Domain' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</VStack>
 		);
 	};
 
-	const renderDeleteForm = () => {
-		return <>Placeholder</>;
+	const renderCancelTransfer = () => {
+		const expiresAt = new Date( requestedAt || '' );
+		expiresAt.setHours( expiresAt.getHours() + 24 );
+
+		return (
+			<VStack spacing={ 8 }>
+				<VStack spacing={ 4 }>
+					<VStack>
+						<Text size={ 14 } weight={ 500 }>
+							{ __( 'Status' ) }
+						</Text>
+						<Text>Pending</Text>
+					</VStack>
+					<VStack>
+						<Text size={ 14 } weight={ 500 }>
+							{ __( 'Transfer recipient' ) }
+						</Text>
+						<Text>{ transferEmail }</Text>
+					</VStack>
+					<VStack>
+						<Text size={ 14 } weight={ 500 }>
+							{ __( 'Valid until' ) }
+						</Text>
+						<Text>{ formatDate( expiresAt, locale ) }</Text>
+					</VStack>
+				</VStack>
+				<HStack justify="flex-start">
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ isDeletingDomainTransferRequest }
+						disabled={ isDeletingDomainTransferRequest }
+						onClick={ handleCancelTransfer }
+					>
+						{ __( 'Cancel Transfer' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		);
 	};
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
 			<Card>
 				<CardBody>
-					<VStack spacing={ 10 }>
-						<VStack spacing={ 3 }>
-							<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
-							<Text as="p">
-								{ sprintf(
-									/* Translators: %s: domainName is the domain name */
-									__(
-										'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
-									),
-									{ domainName }
-								) }
-							</Text>
-							<Text as="p">
-								{ __(
-									'The recipient will need to provide updated contact information and accept the request before the domain transfer can be completed.'
-								) }
-							</Text>
-							{ hasEmailWithUs && (
-								<Text as="p">
-									{ sprintf(
-										/* Translators: %s: domainName is the domain name */
-										__(
-											'The email subscription for %(domainName)s will be transferred along with the domain.'
-										),
-										{ domainName }
-									) }
-								</Text>
-							) }
-						</VStack>
-						{ ! transferEmail && renderEmailForm() }
-						{ transferEmail && renderDeleteForm() }
+					<VStack spacing={ 3 }>
+						<SectionHeader
+							title={ transferEmail ? __( 'Domain transfer pending' ) : __( 'Confirm new owner' ) }
+						/>
+						{ ! transferEmail && renderTransferForm() }
+						{ transferEmail && renderCancelTransfer() }
 					</VStack>
 				</CardBody>
 			</Card>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, isItemValid } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
@@ -36,7 +37,7 @@ export type TransferFormData = {
 const fields: Field< TransferFormData >[] = [
 	{
 		id: 'email',
-		label: __( 'Email' ),
+		label: __( 'Enter domain recipient’s email for transfer' ),
 		type: 'email' as const,
 		isValid: {
 			required: true,
@@ -113,12 +114,12 @@ export default function TransferDomainToAnyUser() {
 			<VStack spacing={ 8 }>
 				<VStack spacing={ 2 }>
 					<Text as="p">
-						{ sprintf(
-							/* Translators: %s: domainName is the domain name */
+						{ createInterpolateElement(
+							/* Translators: %s: domain is the domain name */
 							__(
-								'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
+								'You can transfer <domain/> to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
 							),
-							{ domainName }
+							{ domain: <strong>{ domainName }</strong> }
 						) }
 					</Text>
 					<Text as="p">
@@ -172,13 +173,16 @@ export default function TransferDomainToAnyUser() {
 
 		return (
 			<VStack spacing={ 8 }>
+				<Text as="p">
+					{ createInterpolateElement(
+						/* Translators: <domain/> is the domain name wrapped in a <strong> tag */
+						__(
+							'There’s a pending transfer request for <domain/>. If you wish to cancel the transfer, click the button below.'
+						),
+						{ domain: <strong>{ domainName }</strong> }
+					) }
+				</Text>
 				<VStack spacing={ 4 }>
-					<VStack>
-						<Text size={ 14 } weight={ 500 }>
-							{ __( 'Status' ) }
-						</Text>
-						<Text>Pending</Text>
-					</VStack>
 					<VStack>
 						<Text size={ 14 } weight={ 500 }>
 							{ __( 'Transfer recipient' ) }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -1,3 +1,9 @@
+import {
+	domainQuery,
+	domainTransferRequestQuery,
+	updateDomainTransferRequestMutation,
+	deleteDomainTransferRequestMutation,
+} from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Card,
@@ -14,12 +20,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useLocale } from '../../app/locale';
-import { domainQuery } from '../../app/queries/domain';
-import {
-	domainTransferRequestQuery,
-	updateDomainTransferRequestMutation,
-	deleteDomainTransferRequestMutation,
-} from '../../app/queries/domain-transfer';
 import { domainRoute } from '../../app/router/domains';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -14,6 +14,7 @@ import { domainQuery } from '../../app/queries/domain';
 import { domainTransferRequestQuery } from '../../app/queries/domain-transfer';
 import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -63,6 +64,16 @@ export default function TransferDomainToAnyUser() {
 		console.log( 'Transfer domain to email:', formData.email );
 	};
 
+	const renderTransferNotice = () => {
+		return (
+			<Notice variant="info">
+				{ __(
+					'Transferring a domain to another user will give all the rights of this domain to that user. You will no longer be able to manage the domain.'
+				) }
+			</Notice>
+		);
+	};
+
 	const renderEmailForm = () => {
 		return (
 			<form onSubmit={ handleSubmit }>
@@ -75,8 +86,14 @@ export default function TransferDomainToAnyUser() {
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
+					{ renderTransferNotice() }
 					<HStack justify="flex-start">
-						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+							disabled={ isSaveDisabled }
+						>
 							{ __( 'Transfer Domain' ) }
 						</Button>
 					</HStack>
@@ -93,31 +110,38 @@ export default function TransferDomainToAnyUser() {
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
 			<Card>
 				<CardBody>
-					<VStack spacing={ 2 }>
-						<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
-						<Text as="p">
-							{ sprintf(
-								/* Translators: %s: domainName is the domain name */
-								__(
-									'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
-								),
-								{ domainName }
-							) }
-						</Text>
-						{ hasEmailWithUs && (
+					<VStack spacing={ 10 }>
+						<VStack spacing={ 3 }>
+							<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
 							<Text as="p">
 								{ sprintf(
 									/* Translators: %s: domainName is the domain name */
 									__(
-										'The email subscription for %(domainName)s will be transferred along with the domain.'
+										'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
 									),
 									{ domainName }
 								) }
 							</Text>
-						) }
+							<Text as="p">
+								{ __(
+									'The recipient will need to provide updated contact information and accept the request before the domain transfer can be completed.'
+								) }
+							</Text>
+							{ hasEmailWithUs && (
+								<Text as="p">
+									{ sprintf(
+										/* Translators: %s: domainName is the domain name */
+										__(
+											'The email subscription for %(domainName)s will be transferred along with the domain.'
+										),
+										{ domainName }
+									) }
+								</Text>
+							) }
+						</VStack>
+						{ ! transferEmail && renderEmailForm() }
+						{ transferEmail && renderDeleteForm() }
 					</VStack>
-					{ transferEmail && renderEmailForm() }
-					{ ! transferEmail && renderDeleteForm() }
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -1,0 +1,125 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Card,
+	CardBody,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { DataForm, isItemValid } from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import { domainQuery } from '../../app/queries/domain';
+import { domainTransferRequestQuery } from '../../app/queries/domain-transfer';
+import { siteByIdQuery } from '../../app/queries/site';
+import { domainRoute } from '../../app/router/domains';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
+import type { Field } from '@wordpress/dataviews';
+
+export type TransferFormData = {
+	email: string;
+};
+
+const fields: Field< TransferFormData >[] = [
+	{
+		id: 'email',
+		label: __( 'Email' ),
+		type: 'email' as const,
+		isValid: {
+			required: true,
+		},
+	},
+];
+
+const form = {
+	layout: { type: 'regular' as const },
+	fields: [ 'email' ],
+};
+
+export default function TransferDomainToAnyUser() {
+	const { domainName } = domainRoute.useParams() as { domainName: string };
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
+	const { data: domainTransferRequest } = useSuspenseQuery(
+		domainTransferRequestQuery( domainName, site.slug )
+	);
+	const transferEmail = domainTransferRequest?.email;
+
+	const [ formData, setFormData ] = useState( {
+		email: '',
+	} );
+
+	const hasEmailWithUs = hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain );
+
+	const isSaveDisabled = ! isItemValid( formData, fields, form );
+
+	const handleSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		// eslint-disable-next-line no-console
+		console.log( 'Transfer domain to email:', formData.email );
+	};
+
+	const renderEmailForm = () => {
+		return (
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 }>
+					<DataForm< TransferFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< TransferFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+					<HStack justify="flex-start">
+						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
+							{ __( 'Transfer Domain' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		);
+	};
+
+	const renderDeleteForm = () => {
+		return <>Placeholder</>;
+	};
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 2 }>
+						<SectionHeader title={ __( 'Confirm new owner' ) } level={ 3 } />
+						<Text as="p">
+							{ sprintf(
+								/* Translators: %s: domainName is the domain name */
+								__(
+									'You can transfer %(domainName)s to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
+								),
+								{ domainName }
+							) }
+						</Text>
+						{ hasEmailWithUs && (
+							<Text as="p">
+								{ sprintf(
+									/* Translators: %s: domainName is the domain name */
+									__(
+										'The email subscription for %(domainName)s will be transferred along with the domain.'
+									),
+									{ domainName }
+								) }
+							</Text>
+						) }
+					</VStack>
+					{ transferEmail && renderEmailForm() }
+					{ ! transferEmail && renderDeleteForm() }
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -17,8 +17,8 @@ import { useLocale } from '../../app/locale';
 import { domainQuery } from '../../app/queries/domain';
 import {
 	domainTransferRequestQuery,
-	domainTransferRequestUpdateMutation,
-	domainTransferRequestDeleteMutation,
+	updateDomainTransferRequestMutation,
+	deleteDomainTransferRequestMutation,
 } from '../../app/queries/domain-transfer';
 import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
@@ -58,9 +58,9 @@ export default function TransferDomainToAnyUser() {
 		domainTransferRequestQuery( domainName, site.slug )
 	);
 	const { mutate: deleteDomainTransferRequest, isPending: isDeletingDomainTransferRequest } =
-		useMutation( domainTransferRequestDeleteMutation( domainName, site.slug ) );
+		useMutation( deleteDomainTransferRequestMutation( domainName, site.slug ) );
 	const { mutate: updateDomainTransferRequest, isPending: isUpdatingDomainTransferRequest } =
-		useMutation( domainTransferRequestUpdateMutation( domainName, site.slug ) );
+		useMutation( updateDomainTransferRequestMutation( domainName, site.slug ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const locale = useLocale();
 	const transferEmail = domainTransferRequest?.email;

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -20,7 +20,6 @@ import {
 	updateDomainTransferRequestMutation,
 	deleteDomainTransferRequestMutation,
 } from '../../app/queries/domain-transfer';
-import { siteByIdQuery } from '../../app/queries/site';
 import { domainRoute } from '../../app/router/domains';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -53,14 +52,13 @@ const form = {
 export default function TransferDomainToAnyUser() {
 	const { domainName } = domainRoute.useParams() as { domainName: string };
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
 	const { data: domainTransferRequest } = useSuspenseQuery(
-		domainTransferRequestQuery( domainName, site.slug )
+		domainTransferRequestQuery( domainName, domain.site_slug )
 	);
 	const { mutate: deleteDomainTransferRequest, isPending: isDeletingDomainTransferRequest } =
-		useMutation( deleteDomainTransferRequestMutation( domainName, site.slug ) );
+		useMutation( deleteDomainTransferRequestMutation( domainName, domain.site_slug ) );
 	const { mutate: updateDomainTransferRequest, isPending: isUpdatingDomainTransferRequest } =
-		useMutation( updateDomainTransferRequestMutation( domainName, site.slug ) );
+		useMutation( updateDomainTransferRequestMutation( domainName, domain.site_slug ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const locale = useLocale();
 	const transferEmail = domainTransferRequest?.email;
@@ -84,6 +82,9 @@ export default function TransferDomainToAnyUser() {
 			},
 			onError: () => {
 				createErrorNotice( __( 'An error occurred while initiating the domain transfer.' ) );
+			},
+			onSettled: () => {
+				setFormData( { email: '' } );
 			},
 		} );
 	};

--- a/packages/api-core/src/domain-transfer/mutators.ts
+++ b/packages/api-core/src/domain-transfer/mutators.ts
@@ -2,6 +2,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { wpcom } from '../wpcom-fetcher';
 import type { IpsTag } from './types';
 
+export type DomainTransferRequest = {
+	email: string;
+	requested_at: string;
+};
+
 export async function updateDomainLock( domain: string, enabled: boolean ): Promise< void > {
 	return wpcom.req.post( {
 		path: `/domains/${ domain }/transfer`,
@@ -51,4 +56,33 @@ export async function fetchIpsTagList(): Promise< IpsTag[] > {
 	} catch ( error ) {
 		throw new Error( errorMessage );
 	}
+}
+
+export async function getDomainTransferRequest(
+	domain: string,
+	siteSlug: string
+): Promise< DomainTransferRequest | null > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteSlug }/domains/${ domain }/transfer-to-any-user`,
+	} );
+}
+
+export async function domainTransferRequestUpdate(
+	domain: string,
+	siteSlug: string,
+	email: string
+): Promise< void > {
+	return wpcom.req.post( {
+		path: `/sites/${ siteSlug }/domains/${ domain }/transfer-to-any-user`,
+		body: { email },
+	} );
+}
+
+export async function domainTransferRequestDelete(
+	domain: string,
+	siteSlug: string
+): Promise< void > {
+	return wpcom.req.post( {
+		path: `/sites/${ siteSlug }/domains/${ domain }/transfer-to-any-user/delete`,
+	} );
 }

--- a/packages/api-core/src/domain-transfer/mutators.ts
+++ b/packages/api-core/src/domain-transfer/mutators.ts
@@ -58,7 +58,7 @@ export async function fetchIpsTagList(): Promise< IpsTag[] > {
 	}
 }
 
-export async function getDomainTransferRequest(
+export async function fetchDomainTransferRequest(
 	domain: string,
 	siteSlug: string
 ): Promise< DomainTransferRequest | null > {
@@ -67,7 +67,7 @@ export async function getDomainTransferRequest(
 	} );
 }
 
-export async function domainTransferRequestUpdate(
+export async function updateDomainTransferRequest(
 	domain: string,
 	siteSlug: string,
 	email: string
@@ -78,7 +78,7 @@ export async function domainTransferRequestUpdate(
 	} );
 }
 
-export async function domainTransferRequestDelete(
+export async function deleteDomainTransferRequest(
 	domain: string,
 	siteSlug: string
 ): Promise< void > {

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -1,5 +1,20 @@
 import type { DomainSummary } from '../domains';
 
+export const EmailSubscriptionStatus = {
+	NO_SUBSCRIPTION: 'no_subscription',
+	ACTIVE: 'active',
+	DELETED: 'deleted',
+	SUSPENDED: 'suspended',
+} as const;
+
+export type EmailSubscriptionStatus =
+	( typeof EmailSubscriptionStatus )[ keyof typeof EmailSubscriptionStatus ];
+
+export type EmailSubscription = {
+	status: EmailSubscriptionStatus;
+	is_eligible_for_introductory_offer: boolean;
+};
+
 export interface Domain extends DomainSummary {
 	auth_code_required: boolean;
 	auto_renewal_date: string;
@@ -28,4 +43,6 @@ export interface Domain extends DomainSummary {
 	ssl_status: 'active' | 'inactive' | 'newly_registered' | 'pending';
 	subdomain_part: string;
 	transfer_away_eligible_at: string;
+	google_apps_subscription: EmailSubscription;
+	titan_mail_subscription: EmailSubscription;
 }

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -50,8 +50,12 @@ export const domainTransferRequestQuery = ( domain: string, siteSlug: string ) =
 export const domainTransferRequestUpdateMutation = ( domain: string, siteSlug: string ) =>
 	mutationOptions( {
 		mutationFn: ( email: string ) => domainTransferRequestUpdate( domain, siteSlug, email ),
-		onSuccess: () => {
-			// Manually update the cache before invalidating the query.
+		onSuccess: ( _, email ) => {
+			// Manually update the cache before invalidating the query
+			queryClient.setQueryData( domainTransferRequestQuery( domain, siteSlug ).queryKey, {
+				email,
+				requested_at: new Date().toISOString(),
+			} );
 			queryClient.invalidateQueries( domainTransferRequestQuery( domain, siteSlug ) );
 		},
 	} );
@@ -60,6 +64,8 @@ export const domainTransferRequestDeleteMutation = ( domain: string, siteSlug: s
 	mutationOptions( {
 		mutationFn: () => domainTransferRequestDelete( domain, siteSlug ),
 		onSuccess: () => {
+			// Manually update the cache before invalidating the query
+			queryClient.setQueryData( domainTransferRequestQuery( domain, siteSlug ).queryKey, null );
 			queryClient.removeQueries( domainTransferRequestQuery( domain, siteSlug ) );
 		},
 	} );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -51,6 +51,7 @@ export const domainTransferRequestUpdateMutation = ( domain: string, siteSlug: s
 	mutationOptions( {
 		mutationFn: ( email: string ) => domainTransferRequestUpdate( domain, siteSlug, email ),
 		onSuccess: () => {
+			// Manually update the cache before invalidating the query.
 			queryClient.invalidateQueries( domainTransferRequestQuery( domain, siteSlug ) );
 		},
 	} );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -43,7 +43,7 @@ export const ipsTagMutation = ( domain: string ) =>
 
 export const domainTransferRequestQuery = ( domain: string, siteSlug: string ) =>
 	queryOptions( {
-		queryKey: [ 'domain-transfer-request', domain, siteSlug ],
+		queryKey: [ 'domains', domain, 'domain-transfer-request', siteSlug ],
 		queryFn: () => fetchDomainTransferRequest( domain, siteSlug ),
 	} );
 

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -3,9 +3,9 @@ import {
 	requestTransferCode,
 	saveIpsTag,
 	updateDomainLock,
-	getDomainTransferRequest,
-	domainTransferRequestUpdate,
-	domainTransferRequestDelete,
+	fetchDomainTransferRequest,
+	updateDomainTransferRequest,
+	deleteDomainTransferRequest,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
@@ -44,12 +44,12 @@ export const ipsTagMutation = ( domain: string ) =>
 export const domainTransferRequestQuery = ( domain: string, siteSlug: string ) =>
 	queryOptions( {
 		queryKey: [ 'domain-transfer-request', domain, siteSlug ],
-		queryFn: () => getDomainTransferRequest( domain, siteSlug ),
+		queryFn: () => fetchDomainTransferRequest( domain, siteSlug ),
 	} );
 
-export const domainTransferRequestUpdateMutation = ( domain: string, siteSlug: string ) =>
+export const updateDomainTransferRequestMutation = ( domain: string, siteSlug: string ) =>
 	mutationOptions( {
-		mutationFn: ( email: string ) => domainTransferRequestUpdate( domain, siteSlug, email ),
+		mutationFn: ( email: string ) => updateDomainTransferRequest( domain, siteSlug, email ),
 		onSuccess: ( _, email ) => {
 			// Manually update the cache before invalidating the query
 			queryClient.setQueryData( domainTransferRequestQuery( domain, siteSlug ).queryKey, {
@@ -60,9 +60,9 @@ export const domainTransferRequestUpdateMutation = ( domain: string, siteSlug: s
 		},
 	} );
 
-export const domainTransferRequestDeleteMutation = ( domain: string, siteSlug: string ) =>
+export const deleteDomainTransferRequestMutation = ( domain: string, siteSlug: string ) =>
 	mutationOptions( {
-		mutationFn: () => domainTransferRequestDelete( domain, siteSlug ),
+		mutationFn: () => deleteDomainTransferRequest( domain, siteSlug ),
 		onSuccess: () => {
 			// Manually update the cache before invalidating the query
 			queryClient.setQueryData( domainTransferRequestQuery( domain, siteSlug ).queryKey, null );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -3,6 +3,9 @@ import {
 	requestTransferCode,
 	saveIpsTag,
 	updateDomainLock,
+	getDomainTransferRequest,
+	domainTransferRequestUpdate,
+	domainTransferRequestDelete,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
@@ -36,4 +39,26 @@ export const ipsTagListQuery = () =>
 export const ipsTagMutation = ( domain: string ) =>
 	mutationOptions( {
 		mutationFn: ( ipsTag: string ) => saveIpsTag( domain, ipsTag ),
+	} );
+
+export const domainTransferRequestQuery = ( domain: string, siteSlug: string ) =>
+	queryOptions( {
+		queryKey: [ 'domain-transfer-request', domain, siteSlug ],
+		queryFn: () => getDomainTransferRequest( domain, siteSlug ),
+	} );
+
+export const domainTransferRequestUpdateMutation = ( domain: string, siteSlug: string ) =>
+	mutationOptions( {
+		mutationFn: ( email: string ) => domainTransferRequestUpdate( domain, siteSlug, email ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainTransferRequestQuery( domain, siteSlug ) );
+		},
+	} );
+
+export const domainTransferRequestDeleteMutation = ( domain: string, siteSlug: string ) =>
+	mutationOptions( {
+		mutationFn: () => domainTransferRequestDelete( domain, siteSlug ),
+		onSuccess: () => {
+			queryClient.removeQueries( domainTransferRequestQuery( domain, siteSlug ) );
+		},
 	} );

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -66,6 +66,6 @@ export const domainTransferRequestDeleteMutation = ( domain: string, siteSlug: s
 		onSuccess: () => {
 			// Manually update the cache before invalidating the query
 			queryClient.setQueryData( domainTransferRequestQuery( domain, siteSlug ).queryKey, null );
-			queryClient.removeQueries( domainTransferRequestQuery( domain, siteSlug ) );
+			queryClient.invalidateQueries( domainTransferRequestQuery( domain, siteSlug ) );
 		},
 	} );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOTDASH-337/add-transfer-to-any-user

## Proposed Changes
This PR implements the domain transfer to any user feature in the hosting dashboard, allowing domain-only domains to be transferred to any WordPress.com user without requiring site admin privileges (since domain-only domains have shadow sites).

## Why are these changes being made?
This component is part of the HD Domains projects.

<img width="1404" height="1034" alt="transfer-request" src="https://github.com/user-attachments/assets/3589b1c0-d401-4468-a0a0-f4f5cb4b90a1" />|

<img width="1472" height="890" alt="transfer-cancel" src="https://github.com/user-attachments/assets/9e10ca84-ac60-4225-a94b-4ba995977558" />

## Testing Instructions
### Prerequisites
- Use a domain-only domain for testing
- Have access to multiple WordPress.com accounts or test with unregistered emails
### Transfer Flow Testing
1. Navigate to `/domains/{domain-name}/transfer/any-user`
2. Enter a valid email address (try both existing WordPress.com users and new emails)
3. Click "Transfer Domain" and verify:
   - Success notice appears
   - Email is sent to recipient
   - UI switches to "pending transfer" state showing recipient email and expiration
### Cancellation Flow Testing
4. In the pending transfer state, click "Cancel Transfer"
5. Verify:
   - Cancellation success notice appears
   - UI returns to initial transfer form
   - Transfer request is properly removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
