### PR TITLE
Domain Connect Setup flow for the Hosting Dashboard

### DIFF
--- a/client/dashboard/data/domain-availability.ts
+++ b/client/dashboard/data/domain-availability.ts
@@ -1,0 +1,60 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface DomainAvailability {
+	mappable:
+		| 'available'
+		| 'available_premium'
+		| 'available_reserved'
+		| 'availability_check_error'
+		| 'conflicting_cname_exists'
+		| 'blacklisted_domain'
+		| 'domain_availability_throttle'
+		| 'domain_suggestions_throttled'
+		| 'dotblog_subdomain'
+		| 'empty_query'
+		| 'empty_results'
+		| 'forbidden_domain'
+		| 'forbidden_subdomain'
+		| 'in_redemption'
+		| 'invalid_domain'
+		| 'invalid_length'
+		| 'invalid_query'
+		| 'invalid_tld'
+		| 'tld_in_maintenance'
+		| 'mappable'
+		| 'mapped_domain'
+		| 'mapped_to_other_site_same_user'
+		| 'mapped_to_other_site_same_user_registrable'
+		| 'mapped_to_same_site_not_transferrable'
+		| 'mapped_to_same_site_transferrable'
+		| 'mapped_to_same_site_registrable'
+		| 'not_available'
+		| 'available_but_not_registrable'
+		| 'domain_registration_unavailable'
+		| 'recent_registration_lock_not_transferrable'
+		| 'recently_mapped'
+		| 'recently_expired'
+		| 'registered_domain'
+		| 'registered_on_other_site_same_user'
+		| 'registered_on_same_site'
+		| 'restricted_domain'
+		| 'server_transfer_prohibited_not_transferrable'
+		| 'tld_not_supported'
+		| 'tld_not_supported_and_domain_not_available'
+		| 'tld_not_supported_temporarily'
+		| 'transfer_pending'
+		| 'transfer_pending_same_user'
+		| 'transferrable'
+		| 'transferrable_premium'
+		| 'unknown'
+		| 'unknown_active_domain_with_wpcom'
+		| 'wpcom_staging_domain';
+	root_domain_provider: string;
+}
+
+export function fetchDomainAvailability( domainName: string ): Promise< DomainAvailability > {
+	return wpcom.req.get( `/domains/${ encodeURIComponent( domainName ) }/is-available`, {
+		apiVersion: '1.3',
+		is_cart_pre_check: false,
+	} );
+}

--- a/client/dashboard/data/domain-connection-setup.ts
+++ b/client/dashboard/data/domain-connection-setup.ts
@@ -23,9 +23,12 @@ export interface DomainMappingStatus {
 
 export function fetchDomainSetupInfo(
 	domainName: string,
-	siteId: number
+	siteId: number,
+	redirectURL: string
 ): Promise< DomainSetupInfo > {
-	return wpcom.req.get( `/domains/${ domainName }/mapping-setup-info/${ siteId }` );
+	return wpcom.req.get( `/domains/${ domainName }/mapping-setup-info/${ siteId }`, {
+		redirect_uri: redirectURL,
+	} );
 }
 
 export function updateConnectionModeAndGetMappingStatus(

--- a/client/dashboard/data/domain-connection-setup.ts
+++ b/client/dashboard/data/domain-connection-setup.ts
@@ -1,0 +1,38 @@
+import wpcom from 'calypso/lib/wp';
+import type { DomainSetupInfo } from '../domains/domain-connection-setup/types';
+
+export interface DomainMappingSetupInfo {
+	default_ip_addresses: string[];
+	wpcom_name_servers: string[];
+	is_subdomain: boolean;
+	connection_mode?: string;
+	domain_connect_apply_wpcom_hosting?: boolean;
+	is_supported_tld?: boolean;
+}
+
+export interface DomainMappingStatus {
+	has_mapping_records: boolean;
+	has_wpcom_nameservers: boolean;
+	has_wpcom_ip_addresses: boolean;
+	has_cloudflare_ip_addresses: boolean;
+	resolves_to_wpcom: boolean;
+	host_ip_addresses: string[];
+	name_servers: string[];
+	mode: string;
+}
+
+export function fetchDomainSetupInfo(
+	domainName: string,
+	siteId: number
+): Promise< DomainSetupInfo > {
+	return wpcom.req.get( `/domains/${ domainName }/mapping-setup-info/${ siteId }` );
+}
+
+export function updateConnectionModeAndGetMappingStatus(
+	domainName: string,
+	connectionMode: string
+): Promise< DomainMappingStatus > {
+	return wpcom.req.post( `/domains/${ domainName }/mapping-status`, {
+		mode: connectionMode,
+	} );
+}

--- a/client/dashboard/domains/domain-connection-setup/components/clipboard-button.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/clipboard-button.tsx
@@ -1,0 +1,44 @@
+import {
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	Button,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { copy, check } from '@wordpress/icons';
+import { useState, useCallback } from 'react';
+
+interface ClipboardButtonProps {
+	text: string;
+	className?: string;
+}
+
+export default function ClipboardButton( { text }: ClipboardButtonProps ) {
+	const [ copied, setCopied ] = useState( false );
+
+	const handleCopy = useCallback( async () => {
+		try {
+			await navigator.clipboard.writeText( text );
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		} catch ( error ) {
+			// TODO: handle error somehow?
+		}
+	}, [ text ] );
+
+	return (
+		<HStack justify="flex-start" spacing={ 2 }>
+			<Text>{ text }</Text>
+			<Button
+				variant="tertiary"
+				onClick={ handleCopy }
+				title={ copied ? __( 'Copied!' ) : __( 'Copy to clipboard' ) }
+			>
+				<HStack spacing={ 2 } justify="flex-start">
+					<Icon icon={ copied ? check : copy } size={ 16 } />
+					<span>{ copied ? __( 'Copied' ) : __( 'Copy' ) }</span>
+				</HStack>
+			</Button>
+		</HStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/components/progress.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/progress.tsx
@@ -1,0 +1,74 @@
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import type { ProgressStepList, StepSlug } from '../types';
+
+interface ProgressProps {
+	steps: ProgressStepList;
+	currentStep: StepSlug;
+}
+
+export default function Progress( { steps, currentStep }: ProgressProps ) {
+	const stepEntries = Object.entries( steps );
+	const currentStepIndex = stepEntries.findIndex( ( [ slug ] ) => slug === currentStep );
+
+	if ( stepEntries.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<HStack spacing={ 4 } justify="flex-start" alignment="left" expanded={ false }>
+			{ stepEntries.map( ( [ slug, name ], index ) => {
+				const isCompleted = index < currentStepIndex;
+				const isCurrent = index === currentStepIndex;
+
+				let selectedStyle = {
+					backgroundColor: 'transparent',
+					borderColor: '#ddd',
+					color: '#666',
+				};
+
+				if ( isCompleted ) {
+					selectedStyle = {
+						backgroundColor: '#007CBA',
+						borderColor: '#007CBA',
+						color: '#fff',
+					};
+				} else if ( isCurrent ) {
+					selectedStyle = {
+						backgroundColor: '#007CBA',
+						borderColor: '#007CBA',
+						color: '#fff',
+					};
+				}
+
+				return (
+					<HStack key={ slug } spacing={ 2 } justify="flex-start" expanded={ false }>
+						<div
+							style={ {
+								width: '24px',
+								height: '24px',
+								borderRadius: '50%',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								fontSize: '12px',
+								fontWeight: 500,
+								border: '1px solid',
+								...selectedStyle,
+							} }
+						>
+							{ isCompleted ? <Icon icon={ check } size={ 14 } /> : index + 1 }
+						</div>
+						<span
+							style={ {
+								color: isCurrent ? '#000' : '#666',
+							} }
+						>
+							{ name }
+						</span>
+					</HStack>
+				);
+			} ) }
+		</HStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/components/records-list.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/records-list.tsx
@@ -1,0 +1,59 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ClipboardButton from './clipboard-button';
+import type { DNSRecord } from '../types';
+
+interface RecordsListProps {
+	records: DNSRecord[];
+	justValues?: boolean;
+}
+
+export default function RecordsList( { records, justValues = false }: RecordsListProps ) {
+	if ( records.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Card variant="secondary">
+			<CardBody>
+				<VStack spacing={ 3 }>
+					{ ! justValues && (
+						<HStack>
+							<div style={ { width: '80px' } }>{ __( 'Type' ) }</div>
+							<div style={ { width: '290px' } }>{ __( 'Name' ) }</div>
+							<div style={ { width: '290px' } }>{ __( 'Value' ) }</div>
+						</HStack>
+					) }
+
+					{ ! justValues &&
+						records.map( ( record, index ) => (
+							<HStack key={ index } spacing={ 2 }>
+								<div style={ { width: '80px', fontSize: '14px' } }>{ record.type }</div>
+								<div style={ { width: '290px' } }>
+									<ClipboardButton text={ record.name } />
+								</div>
+								<div style={ { width: '290px' } }>
+									<ClipboardButton text={ record.value } />
+								</div>
+							</HStack>
+						) ) }
+
+					{ justValues && (
+						<VStack spacing={ 2 }>
+							{ records.map( ( record, index ) => (
+								<div style={ { width: '290px' } } key={ index }>
+									<ClipboardButton text={ record.value } />
+								</div>
+							) ) }
+						</VStack>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/components/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/style.scss
@@ -1,0 +1,11 @@
+@import '@wordpress/base-styles/colors';
+
+.dashboard-domain-connect-switch-setup-info-link {
+	color: $gray-700;
+	.dashboard-domain-connect-switch-setup-info-link__icon {
+		fill: $gray-700;
+	}
+	button.is-link {
+		text-decoration: none;
+	}
+}

--- a/client/dashboard/domains/domain-connection-setup/components/switch-setup-info-link.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/switch-setup-info-link.tsx
@@ -1,0 +1,73 @@
+import { __experimentalHStack as HStack, Button, Icon } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { pages } from '@wordpress/icons';
+import { isSubdomain } from '../../../../lib/domains';
+import { modeType, stepType, stepSlug } from '../constants';
+import type { ModeType, StepType, StepSlug } from '../types';
+import './style.scss';
+
+interface SwitchSetupInfoLinkProps {
+	currentStep: StepType;
+	currentMode: ModeType;
+	supportsDomainConnect: boolean;
+	domainName: string;
+	setPage: ( pageSlug: StepSlug ) => void;
+}
+
+export default function SwitchSetupInfoLink( {
+	currentStep,
+	currentMode,
+	supportsDomainConnect,
+	domainName,
+	setPage,
+}: SwitchSetupInfoLinkProps ) {
+	if ( currentStep === stepType.CONNECTED || currentStep === stepType.VERIFYING ) {
+		return null;
+	}
+
+	const isSubdomainDomain = isSubdomain( domainName );
+
+	const switchToAdvancedSetup = () =>
+		setPage( isSubdomainDomain ? stepSlug.SUBDOMAIN_ADVANCED_START : stepSlug.ADVANCED_START );
+	const switchToSuggestedSetup = () =>
+		setPage( isSubdomainDomain ? stepSlug.SUBDOMAIN_SUGGESTED_START : stepSlug.SUGGESTED_START );
+	const switchToDomainConnectSetup = () => setPage( stepSlug.DC_START );
+
+	const getMessage = () => {
+		// Domain Connect does not support subdomains so we don't need to check for that
+		if ( supportsDomainConnect ) {
+			if ( currentMode === modeType.DC ) {
+				return __( 'Switch to our <asug>manual setup</asug> or <aadv>advanced setup</aadv>.' );
+			} else if ( currentMode === modeType.SUGGESTED ) {
+				return __( 'Switch to our <adc>simple setup</adc> or <aadv>advanced setup</aadv>.' );
+			}
+			return __( 'Switch to our <adc>simple setup</adc> or <asug>manual setup</asug>.' );
+		}
+		if ( currentMode === modeType.SUGGESTED && isSubdomainDomain ) {
+			return __(
+				"Can't set NS records for your subdomain? Switch to our <aadv>advanced setup</aadv>."
+			);
+		} else if ( currentMode === modeType.ADVANCED ) {
+			return __( 'Switch to our <asug>suggested setup</asug>.' );
+		}
+		return __( 'Switch to our <aadv>advanced setup</aadv>.' );
+	};
+
+	return (
+		<HStack justify="flex-start" className="dashboard-domain-connect-switch-setup-info-link">
+			<Icon
+				icon={ pages }
+				size={ 16 }
+				className="dashboard-domain-connect-switch-setup-info-link__icon"
+			/>
+			<span>
+				{ createInterpolateElement( getMessage(), {
+					asug: <Button variant="link" onClick={ switchToSuggestedSetup } />,
+					aadv: <Button variant="link" onClick={ switchToAdvancedSetup } />,
+					adc: <Button variant="link" onClick={ switchToDomainConnectSetup } />,
+				} ) }
+			</span>
+		</HStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/connect-domain-steps.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connect-domain-steps.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getPageSlug, getProgressStepList } from './step-definitions';
+import type { ModeType, StepType, StepSlug } from './constants';
+import type { StepsDefinition, StepComponentProps, ProgressStepList } from './types';
+
+interface ConnectDomainStepsProps {
+	domain: string;
+	initialPageSlug: StepSlug;
+	onSetPage?: ( pageSlug: StepSlug ) => void;
+	stepsDefinition: StepsDefinition;
+	queryError?: string;
+	queryErrorDescription?: string;
+	[ key: string ]: unknown;
+}
+
+export default function ConnectDomainSteps( {
+	domain,
+	initialPageSlug,
+	onSetPage,
+	stepsDefinition,
+	queryError,
+	queryErrorDescription,
+	...stepProps
+}: ConnectDomainStepsProps ) {
+	const [ mode, setMode ] = useState< ModeType >( stepsDefinition[ initialPageSlug ].mode );
+	const [ step, setStep ] = useState< StepType >( stepsDefinition[ initialPageSlug ].step );
+	const [ pageSlug, setPageSlug ] = useState< StepSlug >( initialPageSlug );
+	const [ progressStepList, setProgressStepList ] = useState< ProgressStepList >( {} );
+
+	const StepComponent = stepsDefinition?.[ pageSlug ]?.component;
+
+	const setPage = useCallback(
+		( pageStepSlug: StepSlug ) => {
+			setPageSlug( pageStepSlug );
+			onSetPage?.( pageStepSlug );
+			setStep( stepsDefinition[ pageStepSlug ].step );
+			setMode( stepsDefinition[ pageStepSlug ].mode );
+		},
+		[ onSetPage, stepsDefinition ]
+	);
+
+	const setNextStep = useCallback( () => {
+		const next = stepsDefinition[ pageSlug ]?.next;
+		if ( next ) {
+			setPage( next );
+		}
+	}, [ pageSlug, setPage, stepsDefinition ] );
+
+	useEffect( () => {
+		setPage( initialPageSlug );
+	}, [ initialPageSlug, setPage ] );
+
+	useEffect( () => {
+		const resolvedPageSlug = getPageSlug( mode, step, stepsDefinition );
+		if ( resolvedPageSlug ) {
+			setPageSlug( resolvedPageSlug as StepSlug );
+		}
+	}, [ mode, step, stepsDefinition ] );
+
+	useEffect( () => {
+		setProgressStepList( getProgressStepList( mode, stepsDefinition ) );
+	}, [ mode, stepsDefinition ] );
+
+	if ( ! StepComponent ) {
+		// TODO: handle this better
+		return null;
+	}
+
+	const stepComponentProps: StepComponentProps = {
+		domain,
+		step,
+		mode,
+		onNextStep: setNextStep,
+		progressStepList,
+		pageSlug,
+		setPage,
+		queryError,
+		queryErrorDescription,
+		...( stepProps as Omit<
+			StepComponentProps,
+			| 'domain'
+			| 'step'
+			| 'mode'
+			| 'onNextStep'
+			| 'progressStepList'
+			| 'pageSlug'
+			| 'setPage'
+			| 'queryError'
+			| 'queryErrorDescription'
+		> ),
+	};
+
+	return <StepComponent { ...stepComponentProps } />;
+}

--- a/client/dashboard/domains/domain-connection-setup/constants.ts
+++ b/client/dashboard/domains/domain-connection-setup/constants.ts
@@ -1,0 +1,126 @@
+import { __ } from '@wordpress/i18n';
+
+export const modeType = {
+	SUGGESTED: 'suggested',
+	ADVANCED: 'advanced',
+	DC: 'dc',
+	DONE: 'done',
+	OWNERSHIP_VERIFICATION: 'ownership_verification',
+	TRANSFER: 'transfer',
+} as const;
+
+export const stepType = {
+	START: 'start_setup',
+	LOG_IN_TO_PROVIDER: 'log_in_to_provider',
+	UPDATE_NAME_SERVERS: 'update_name_servers',
+	UPDATE_A_RECORDS: 'update_a_records',
+	UPDATE_NS_RECORDS: 'update_ns_records',
+	UPDATE_CNAME_RECORDS: 'update_cname_records',
+	CONNECTED: 'connected',
+	VERIFYING: 'verifying',
+	ENTER_AUTH_CODE: 'enter_auth_code',
+	UNLOCK_DOMAIN: 'unlock_domain',
+	FINALIZE: 'finalize',
+} as const;
+
+export const stepSlug = {
+	SUGGESTED_START: 'suggested_start',
+	SUGGESTED_LOGIN: 'suggested_login',
+	SUGGESTED_UPDATE: 'suggested_update',
+	SUGGESTED_VERIFYING: 'suggested_verifying',
+	SUGGESTED_CONNECTED: 'suggested_connected',
+	ADVANCED_START: 'advanced_start',
+	ADVANCED_LOGIN: 'advanced_login',
+	ADVANCED_UPDATE: 'advanced_update',
+	ADVANCED_VERIFYING: 'advanced_verifying',
+	ADVANCED_CONNECTED: 'advanced_connected',
+	DC_START: 'dc_start',
+	DC_RETURN: 'dc_return',
+	OWNERSHIP_VERIFICATION_LOGIN: 'ownership_verification_login',
+	OWNERSHIP_VERIFICATION_AUTH_CODE: 'ownership_verification_auth_code',
+	TRANSFER_START: 'transfer_start',
+	TRANSFER_LOGIN: 'transfer_login',
+	TRANSFER_UNLOCK: 'transfer_unlock',
+	TRANSFER_AUTH_CODE: 'transfer_auth_code',
+	SUBDOMAIN_SUGGESTED_START: 'subdomain_suggested_start',
+	SUBDOMAIN_SUGGESTED_LOGIN: 'subdomain_suggested_login',
+	SUBDOMAIN_SUGGESTED_UPDATE: 'subdomain_suggested_update',
+	SUBDOMAIN_SUGGESTED_VERIFYING: 'subdomain_suggested_verifying',
+	SUBDOMAIN_SUGGESTED_CONNECTED: 'subdomain_suggested_connected',
+	SUBDOMAIN_ADVANCED_START: 'subdomain_advanced_start',
+	SUBDOMAIN_ADVANCED_LOGIN: 'subdomain_advanced_login',
+	SUBDOMAIN_ADVANCED_UPDATE: 'subdomain_advanced_update',
+	SUBDOMAIN_ADVANCED_VERIFYING: 'subdomain_advanced_verifying',
+	SUBDOMAIN_ADVANCED_CONNECTED: 'subdomain_advanced_connected',
+} as const;
+
+export const defaultDomainSetupInfo = {
+	data: {
+		default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ] as string[],
+		wpcom_name_servers: [
+			'ns1.wordpress.com',
+			'ns2.wordpress.com',
+			'ns3.wordpress.com',
+		] as string[],
+		is_subdomain: false,
+		connection_mode: undefined as string | undefined,
+		domain_connect_apply_wpcom_hosting: undefined as boolean | undefined,
+	},
+};
+
+export const domainLockStatusType = {
+	LOCKED: 'locked',
+	UNLOCKED: 'unlocked',
+	UNKNOWN: 'unknown',
+} as const;
+
+export const domainMappingInstructionsMode = {
+	[ modeType.SUGGESTED ]: stepSlug.SUGGESTED_UPDATE,
+	[ modeType.ADVANCED ]: stepSlug.ADVANCED_UPDATE,
+} as const;
+
+export const subdomainMappingInstructionsMode = {
+	[ modeType.SUGGESTED ]: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE,
+	[ modeType.ADVANCED ]: stepSlug.SUBDOMAIN_ADVANCED_UPDATE,
+} as const;
+
+export const stepsHeading = {
+	get SUGGESTED() {
+		return __( 'Suggested setup' );
+	},
+	get ADVANCED() {
+		return __( 'Advanced setup' );
+	},
+	get OWNERSHIP_VERIFICATION() {
+		return __( 'Verify domain ownership' );
+	},
+	get TRANSFER() {
+		return __( 'Initial setup' );
+	},
+} as const;
+
+export const authCodeStepDefaultDescription = {
+	get label() {
+		return __(
+			'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+		);
+	},
+} as const;
+
+export const transferDomainError = {
+	get AUTH_CODE() {
+		return __( 'Invalid auth code. Please check the specified code and try again.' );
+	},
+	get NO_SELECTED_SITE() {
+		return __( 'Please specify a site.' );
+	},
+	get GENERIC_ERROR() {
+		return __( 'We were unable to start the transfer.' );
+	},
+} as const;
+
+export type ModeType = ( typeof modeType )[ keyof typeof modeType ];
+export type StepType = ( typeof stepType )[ keyof typeof stepType ];
+export type StepSlug = ( typeof stepSlug )[ keyof typeof stepSlug ];
+export type DomainLockStatusType =
+	( typeof domainLockStatusType )[ keyof typeof domainLockStatusType ];

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useParams, useSearch } from '@tanstack/react-router';
+import { useParams, useSearch, useRouter } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -13,6 +13,7 @@ import {
 	updateConnectionModeMutation,
 } from '../../app/queries/domain-connection-setup';
 import { siteBySlugQuery } from '../../app/queries/site';
+import { siteDomainConnectRoute } from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SwitchSetupInfoLink from './components/switch-setup-info-link';
@@ -24,27 +25,22 @@ import {
 } from './step-definitions';
 import { isMappingVerificationSuccess } from './utils';
 import type { StepSlug } from './constants';
-import type {
-	ConnectDomainStepProps,
-	VerificationStatus,
-	DomainSetupInfo,
-	StepsDefinition,
-} from './types';
+import type { VerificationStatus, DomainSetupInfo, StepsDefinition } from './types';
 import type { DomainMappingSetupInfo } from '../../data/domain-connection-setup';
 
-interface ConnectDomainProps extends ConnectDomainStepProps {}
-
-export default function ConnectDomain( {
-	domain,
-	initialStep,
-	showErrors = false,
-	// isFirstVisit = true, // TODO: used to show different breadcrumbs but we don't have breadcrumbs in the HD for now
-	queryError,
-	queryErrorDescription,
-}: ConnectDomainProps ) {
+export default function ConnectDomain() {
 	const params = useParams( { from: '/sites/$siteSlug/domain-connection-setup' } );
 	const search = useSearch( { from: '/sites/$siteSlug/domain-connection-setup' } );
-	const domainName = domain || search.domainName;
+
+	const domainName = search.domainName;
+	const initialStep = search.step;
+	const showErrors = search[ 'show-errors' ] === 'true' || search[ 'show-errors' ] === '1';
+
+	const queryError = search?.error;
+	const queryErrorDescription = search?.error_description;
+
+	// TODO: used to show different breadcrumbs but we don't have breadcrumbs in the HD for now
+	// const isFirstVisit = search?.firstVisit === 'true' || search?.firstVisit === '1';
 	const { data: site } = useQuery( siteBySlugQuery( params.siteSlug ) );
 
 	const stepsDefinition: StepsDefinition = isSubdomain( domainName )
@@ -79,8 +75,23 @@ export default function ConnectDomain( {
 	const prevPageSlug = currentStep.prev;
 	// const isTwoColumnLayout = ! currentStep.singleColumnLayout; // TODO: we do show transfer recommendation in the sidebar in some cases
 
+	const router = useRouter();
+	// TODO: We need to figure out how to build this URL so that it's not hardcoded to v2
+	const redirectURL =
+		'https://wordpress.com/v2' +
+		router.buildLocation( {
+			to: siteDomainConnectRoute.fullPath,
+			params: {
+				siteSlug: site?.slug,
+			},
+			search: {
+				domainName: domainName,
+				step: stepSlug.DC_RETURN,
+			},
+		} ).href;
+
 	const { data: setupInfo, isLoading: loadingDomainSetupInfo } = useQuery(
-		domainSetupInfoQuery( domainName, site?.ID || 0 )
+		domainSetupInfoQuery( domainName, site?.ID || 0, redirectURL )
 	) as { data: DomainMappingSetupInfo | undefined; isLoading: boolean };
 
 	const getConnectedSlug = ( domain: string, mode: string ) => {

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,0 +1,315 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useParams, useSearch } from '@tanstack/react-router';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { isSubdomain } from '../../../lib/domains';
+import {
+	domainSetupInfoQuery,
+	updateConnectionModeMutation,
+} from '../../app/queries/domain-connection-setup';
+import { siteBySlugQuery } from '../../app/queries/site';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import SwitchSetupInfoLink from './components/switch-setup-info-link';
+import ConnectDomainSteps from './connect-domain-steps';
+import { modeType, stepSlug, defaultDomainSetupInfo } from './constants';
+import {
+	connectADomainStepsDefinition,
+	connectASubdomainStepsDefinition,
+} from './step-definitions';
+import { isMappingVerificationSuccess } from './utils';
+import type { StepSlug } from './constants';
+import type {
+	ConnectDomainStepProps,
+	VerificationStatus,
+	DomainSetupInfo,
+	StepsDefinition,
+} from './types';
+import type { DomainMappingSetupInfo } from '../../data/domain-connection-setup';
+
+interface ConnectDomainProps extends ConnectDomainStepProps {}
+
+export default function ConnectDomain( {
+	domain,
+	initialStep,
+	showErrors = false,
+	// isFirstVisit = true, // TODO: used to show different breadcrumbs but we don't have breadcrumbs in the HD for now
+	queryError,
+	queryErrorDescription,
+}: ConnectDomainProps ) {
+	const params = useParams( { from: '/sites/$siteSlug/domain-connection-setup' } );
+	const search = useSearch( { from: '/sites/$siteSlug/domain-connection-setup' } );
+	const domainName = domain || search.domainName;
+	const { data: site } = useQuery( siteBySlugQuery( params.siteSlug ) );
+
+	const stepsDefinition: StepsDefinition = isSubdomain( domainName )
+		? connectASubdomainStepsDefinition
+		: connectADomainStepsDefinition;
+
+	const firstStep = isSubdomain( domainName )
+		? stepSlug.SUBDOMAIN_SUGGESTED_START
+		: stepSlug.SUGGESTED_START;
+
+	const [ pageSlug, setPageSlug ] = useState< StepSlug >( firstStep );
+	const [ verificationStatus, setVerificationStatus ] = useState< VerificationStatus >( {} );
+	const [ verificationInProgress, setVerificationInProgress ] = useState( false );
+	const [ domainSetupInfo, setDomainSetupInfo ] =
+		useState< DomainSetupInfo >( defaultDomainSetupInfo );
+
+	// TODO: we need to handle errors better
+	// const [ domainSetupInfoError, setDomainSetupInfoError ] = useState< Record< string, unknown > >(
+	// 	{}
+	// );
+
+	const statusRef = useRef< Record< string, unknown > >( {} );
+
+	if ( stepsDefinition[ pageSlug ] === undefined ) {
+		// TODO: handle this better
+	}
+
+	const currentStep = stepsDefinition[ pageSlug ] || stepsDefinition[ firstStep ];
+	// const isStepStart = stepType.START === currentStep.step; // TODO: not sure if we need this
+	const mode = currentStep.mode;
+	const step = currentStep.step;
+	const prevPageSlug = currentStep.prev;
+	// const isTwoColumnLayout = ! currentStep.singleColumnLayout; // TODO: we do show transfer recommendation in the sidebar in some cases
+
+	const { data: setupInfo, isLoading: loadingDomainSetupInfo } = useQuery(
+		domainSetupInfoQuery( domainName, site?.ID || 0 )
+	) as { data: DomainMappingSetupInfo | undefined; isLoading: boolean };
+
+	const getConnectedSlug = ( domain: string, mode: string ) => {
+		if ( isSubdomain( domain ) ) {
+			return modeType.SUGGESTED === mode
+				? stepSlug.SUBDOMAIN_SUGGESTED_CONNECTED
+				: stepSlug.SUBDOMAIN_ADVANCED_CONNECTED;
+		}
+		return modeType.SUGGESTED === mode ? stepSlug.SUGGESTED_CONNECTED : stepSlug.ADVANCED_CONNECTED;
+	};
+
+	const getVerifyingSlug = ( domain: string, mode: string ) => {
+		if ( isSubdomain( domain ) ) {
+			return modeType.SUGGESTED === mode
+				? stepSlug.SUBDOMAIN_SUGGESTED_VERIFYING
+				: stepSlug.SUBDOMAIN_ADVANCED_VERIFYING;
+		}
+		return modeType.SUGGESTED === mode ? stepSlug.SUGGESTED_VERIFYING : stepSlug.ADVANCED_VERIFYING;
+	};
+
+	const verifyConnectionMutation = useMutation( {
+		...updateConnectionModeMutation( domainName, site?.ID || 0 ),
+		onSuccess: ( data ) => {
+			setVerificationStatus( {
+				data: {
+					status: data.status,
+					errors: data.errors
+						? Object.entries( data.errors ).map( ( [ code, message ] ) => ( {
+								code,
+								message: String( message ),
+						  } ) )
+						: undefined,
+				},
+			} );
+
+			const connectedSlug = getConnectedSlug( domainName, mode );
+			const verifyingSlug = getVerifyingSlug( domainName, mode );
+
+			if ( isMappingVerificationSuccess( mode, data ) ) {
+				setPageSlug( connectedSlug );
+			} else {
+				setPageSlug( verifyingSlug );
+			}
+		},
+		onError: ( error ) => {
+			setVerificationStatus( { error } );
+			const verifyingSlug = getVerifyingSlug( domainName, mode );
+			setPageSlug( verifyingSlug );
+		},
+		onSettled: () => {
+			setVerificationInProgress( false );
+		},
+	} );
+
+	const verifyConnection = useCallback(
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		( setStepAfterVerify = true ) => {
+			// TODO: I'm not handling the verification properly here - see the original code
+			setVerificationStatus( {} );
+			setVerificationInProgress( true );
+			verifyConnectionMutation.mutate( mode );
+		},
+		[ mode, verifyConnectionMutation ]
+	);
+
+	const resolveMappingSetupStep = useCallback(
+		( connectionMode?: string, supportsDomainConnect?: boolean ) => {
+			if ( initialStep ) {
+				return initialStep;
+			}
+
+			if ( connectionMode ) {
+				if ( isSubdomain( domainName ) ) {
+					return connectionMode === modeType.ADVANCED
+						? stepSlug.SUBDOMAIN_ADVANCED_UPDATE
+						: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE;
+				}
+				if ( connectionMode === modeType.ADVANCED ) {
+					return stepSlug.ADVANCED_UPDATE;
+				} else if ( connectionMode === modeType.DC ) {
+					return stepSlug.DC_START;
+				}
+				return stepSlug.SUGGESTED_UPDATE;
+			}
+
+			if ( supportsDomainConnect ) {
+				return stepSlug.DC_START;
+			}
+			return firstStep;
+		},
+		[ initialStep, firstStep, domainName ]
+	);
+
+	useEffect( () => {
+		if ( setupInfo && ! ( statusRef.current as any )?.hasLoadedStatusInfo?.[ domainName ] ) {
+			// Convert API response to expected format
+			const formattedSetupInfo = {
+				data: {
+					default_ip_addresses: setupInfo.default_ip_addresses || [ '192.0.78.24', '192.0.78.25' ],
+					wpcom_name_servers: setupInfo.wpcom_name_servers || [
+						'ns1.wordpress.com',
+						'ns2.wordpress.com',
+						'ns3.wordpress.com',
+					],
+					is_subdomain: setupInfo.is_subdomain || false,
+					connection_mode: setupInfo.connection_mode,
+					domain_connect_apply_wpcom_hosting: setupInfo.domain_connect_apply_wpcom_hosting,
+				},
+			};
+			setDomainSetupInfo( formattedSetupInfo );
+			const resolvedPageSlug = resolveMappingSetupStep(
+				setupInfo.connection_mode,
+				setupInfo.domain_connect_apply_wpcom_hosting
+			);
+			setPageSlug( resolvedPageSlug );
+			( statusRef.current as any ).hasLoadedStatusInfo = { [ domainName ]: true };
+		}
+	}, [ setupInfo, domainName, resolveMappingSetupStep ] );
+
+	useEffect( () => {
+		if ( showErrors && ! statusRef.current?.hasFetchedVerificationStatus ) {
+			statusRef.current.hasFetchedVerificationStatus = true;
+			verifyConnection( false );
+		}
+	}, [ showErrors, verifyConnection ] );
+
+	const goBack = useCallback( () => {
+		if ( prevPageSlug ) {
+			setPageSlug( prevPageSlug );
+		}
+		// TODO: Implement navigation back to domains list
+	}, [ prevPageSlug ] );
+
+	if ( loadingDomainSetupInfo ) {
+		return (
+			<PageLayout header={ <PageHeader title={ __( 'Connect Domain' ) } /> }>
+				<Card>
+					<VStack spacing={ 4 }>
+						<div>{ __( 'Loading domain setup information…' ) }</div>
+						{ /* Placeholder bars similar to original */ }
+						<div
+							style={ {
+								height: '20px',
+								backgroundColor: '#f0f0f0',
+								borderRadius: '4px',
+								width: '80%',
+							} }
+						></div>
+						<div
+							style={ {
+								height: '20px',
+								backgroundColor: '#f0f0f0',
+								borderRadius: '4px',
+								width: '60%',
+							} }
+						></div>
+						<div
+							style={ {
+								height: '20px',
+								backgroundColor: '#f0f0f0',
+								borderRadius: '4px',
+								width: '70%',
+							} }
+						></div>
+						<div
+							style={ {
+								height: '20px',
+								backgroundColor: '#f0f0f0',
+								borderRadius: '4px',
+								width: '50%',
+							} }
+						></div>
+						<div
+							style={ {
+								height: '20px',
+								backgroundColor: '#f0f0f0',
+								borderRadius: '4px',
+								width: '65%',
+							} }
+						></div>
+					</VStack>
+				</Card>
+			</PageLayout>
+		);
+	}
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ sprintf(
+						// translators: %1s is the domain name
+						__( 'Connect %1s' ),
+						domainName
+					) }
+				/>
+			}
+		>
+			<VStack spacing={ 6 }>
+				{ prevPageSlug && (
+					<HStack>
+						<button onClick={ goBack }>{ __( '← Back' ) }</button>
+					</HStack>
+				) }
+				<ConnectDomainSteps
+					domain={ domainName }
+					initialPageSlug={ pageSlug }
+					stepsDefinition={ stepsDefinition }
+					onSetPage={ setPageSlug }
+					onVerifyConnection={ verifyConnection }
+					verificationInProgress={ verificationInProgress }
+					verificationStatus={ verificationStatus }
+					domainSetupInfo={ domainSetupInfo }
+					// domainSetupInfoError={ domainSetupInfoError } // TODO: need to handle errors better
+					showErrors={ showErrors }
+					queryError={ queryError }
+					queryErrorDescription={ queryErrorDescription }
+				/>
+				{ ! loadingDomainSetupInfo && (
+					<SwitchSetupInfoLink
+						currentMode={ mode }
+						currentStep={ step }
+						supportsDomainConnect={ !! domainSetupInfo?.data?.domain_connect_apply_wpcom_hosting }
+						domainName={ domainName }
+						setPage={ setPageSlug }
+					/>
+				) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -77,8 +77,10 @@ export default function ConnectDomain() {
 
 	const router = useRouter();
 	// TODO: We need to figure out how to build this URL so that it's not hardcoded to v2
+	// TODO: for testing purposes, we're using calypso.localhost:3000
+	// FIX: Make sure this is wpcom before deploying
 	const redirectURL =
-		'https://wordpress.com/v2' +
+		'http://calypso.localhost:3000' +
 		router.buildLocation( {
 			to: siteDomainConnectRoute.fullPath,
 			params: {

--- a/client/dashboard/domains/domain-connection-setup/step-definitions.ts
+++ b/client/dashboard/domains/domain-connection-setup/step-definitions.ts
@@ -1,0 +1,221 @@
+import { __ } from '@wordpress/i18n';
+import { modeType, stepSlug, stepType } from './constants';
+import AdvancedRecords from './steps/advanced-records';
+import AdvancedStart from './steps/advanced-start';
+import DomainConnectStart from './steps/dc-start';
+import Done from './steps/done';
+import Login from './steps/login';
+import SuggestedRecords from './steps/suggested-records';
+import SuggestedStart from './steps/suggested-start';
+import type { StepsDefinition, ProgressStepList } from './types';
+
+export const connectADomainStepsDefinition: StepsDefinition = {
+	// Suggested flow
+	[ stepSlug.SUGGESTED_START ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.START,
+		component: SuggestedStart,
+		next: stepSlug.SUGGESTED_LOGIN,
+	},
+	[ stepSlug.SUGGESTED_LOGIN ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: () => __( 'Log in to provider' ),
+		component: Login,
+		next: stepSlug.SUGGESTED_UPDATE,
+		prev: stepSlug.SUGGESTED_START,
+	},
+	[ stepSlug.SUGGESTED_UPDATE ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.UPDATE_NAME_SERVERS,
+		name: () => __( 'Update name servers' ),
+		component: SuggestedRecords,
+		prev: stepSlug.SUGGESTED_LOGIN,
+	},
+	[ stepSlug.SUGGESTED_CONNECTED ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.CONNECTED,
+		component: Done,
+		prev: stepSlug.SUGGESTED_UPDATE,
+		singleColumnLayout: true,
+	},
+	[ stepSlug.SUGGESTED_VERIFYING ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.VERIFYING,
+		component: Done,
+		prev: stepSlug.SUGGESTED_UPDATE,
+		singleColumnLayout: true,
+	},
+
+	// Advanced flow
+	[ stepSlug.ADVANCED_START ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.START,
+		component: AdvancedStart,
+		next: stepSlug.ADVANCED_LOGIN,
+		prev: stepSlug.SUGGESTED_START,
+	},
+	[ stepSlug.ADVANCED_LOGIN ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: () => __( 'Log in to provider' ),
+		component: Login,
+		next: stepSlug.ADVANCED_UPDATE,
+		prev: stepSlug.ADVANCED_START,
+	},
+	[ stepSlug.ADVANCED_UPDATE ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.UPDATE_A_RECORDS,
+		name: () => __( 'Update root A records & CNAME record' ),
+		component: AdvancedRecords,
+		prev: stepSlug.ADVANCED_LOGIN,
+	},
+	[ stepSlug.ADVANCED_CONNECTED ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.CONNECTED,
+		component: Done,
+		prev: stepSlug.ADVANCED_UPDATE,
+		singleColumnLayout: true,
+	},
+	[ stepSlug.ADVANCED_VERIFYING ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.VERIFYING,
+		component: Done,
+		prev: stepSlug.ADVANCED_UPDATE,
+		singleColumnLayout: true,
+	},
+
+	// Domain Connect flow
+	[ stepSlug.DC_START ]: {
+		mode: modeType.DC,
+		step: stepType.START,
+		component: DomainConnectStart,
+	},
+	[ stepSlug.DC_RETURN ]: {
+		mode: modeType.DC,
+		step: stepType.VERIFYING,
+		component: Done,
+		prev: stepSlug.DC_START,
+		singleColumnLayout: true,
+	},
+};
+
+export const connectASubdomainStepsDefinition: StepsDefinition = {
+	// Suggested flow
+	[ stepSlug.SUBDOMAIN_SUGGESTED_START ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.START,
+		component: SuggestedStart,
+		next: stepSlug.SUBDOMAIN_SUGGESTED_LOGIN,
+	},
+	[ stepSlug.SUBDOMAIN_SUGGESTED_LOGIN ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: () => __( 'Log in to provider' ),
+		component: Login,
+		next: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE,
+		prev: stepSlug.SUBDOMAIN_SUGGESTED_START,
+	},
+	[ stepSlug.SUBDOMAIN_SUGGESTED_UPDATE ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.UPDATE_NS_RECORDS,
+		name: () => __( 'Update NS records' ),
+		component: SuggestedRecords,
+		prev: stepSlug.SUBDOMAIN_SUGGESTED_LOGIN,
+	},
+	[ stepSlug.SUBDOMAIN_SUGGESTED_CONNECTED ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.CONNECTED,
+		component: Done,
+		prev: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE,
+		singleColumnLayout: true,
+	},
+	[ stepSlug.SUBDOMAIN_SUGGESTED_VERIFYING ]: {
+		mode: modeType.SUGGESTED,
+		step: stepType.VERIFYING,
+		component: Done,
+		prev: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE,
+		singleColumnLayout: true,
+	},
+
+	// Advanced flow
+	[ stepSlug.SUBDOMAIN_ADVANCED_START ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.START,
+		component: AdvancedStart,
+		next: stepSlug.SUBDOMAIN_ADVANCED_LOGIN,
+		prev: stepSlug.SUBDOMAIN_SUGGESTED_START,
+	},
+	[ stepSlug.SUBDOMAIN_ADVANCED_LOGIN ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.LOG_IN_TO_PROVIDER,
+		name: () => __( 'Log in to provider' ),
+		component: Login,
+		next: stepSlug.SUBDOMAIN_ADVANCED_UPDATE,
+		prev: stepSlug.SUBDOMAIN_ADVANCED_START,
+	},
+	[ stepSlug.SUBDOMAIN_ADVANCED_UPDATE ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.UPDATE_CNAME_RECORDS,
+		name: () => __( 'Update A & CNAME records' ),
+		component: AdvancedRecords,
+		prev: stepSlug.SUBDOMAIN_ADVANCED_LOGIN,
+	},
+	[ stepSlug.SUBDOMAIN_ADVANCED_CONNECTED ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.CONNECTED,
+		component: Done,
+		prev: stepSlug.SUBDOMAIN_ADVANCED_UPDATE,
+		singleColumnLayout: true,
+	},
+	[ stepSlug.SUBDOMAIN_ADVANCED_VERIFYING ]: {
+		mode: modeType.ADVANCED,
+		step: stepType.VERIFYING,
+		component: Done,
+		prev: stepSlug.SUBDOMAIN_ADVANCED_UPDATE,
+		singleColumnLayout: true,
+	},
+};
+
+export function getPageSlug(
+	mode: string,
+	step: string,
+	stepsDefinition: StepsDefinition
+): string | undefined {
+	const [ pageSlug ] =
+		Object.entries( stepsDefinition ).find( ( [ , pageDefinition ] ) => {
+			return pageDefinition.mode === mode && pageDefinition.step === step;
+		} ) || [];
+
+	return pageSlug;
+}
+
+export function getProgressStepList(
+	mode: string,
+	stepsDefinition: StepsDefinition
+): ProgressStepList {
+	const modeSteps = Object.fromEntries(
+		Object.entries( stepsDefinition ).filter(
+			( [ , pageDefinition ] ) => pageDefinition.mode === mode
+		)
+	);
+
+	let step = Object.values( modeSteps ).find(
+		( pageDefinition ) => pageDefinition.step === stepType.START
+	);
+
+	const stepList: Array< [ string, string ] > = [];
+
+	while ( step?.next ) {
+		const [ nextSlug, nextStep ] =
+			Object.entries( modeSteps ).find( ( [ slug ] ) => slug === step?.next ) || [];
+
+		if ( nextSlug && nextStep?.name ) {
+			stepList.push( [ nextSlug, nextStep.name() ] );
+		}
+
+		step = nextStep;
+	}
+
+	return Object.fromEntries( stepList );
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/advanced-records.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/advanced-records.tsx
@@ -1,0 +1,129 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { isSubdomain } from '../../../../lib/domains';
+import Progress from '../components/progress';
+import RecordsList from '../components/records-list';
+import type { StepComponentProps, DNSRecord } from '../types';
+
+export default function AdvancedRecords( {
+	domain,
+	progressStepList,
+	pageSlug,
+	onVerifyConnection,
+	verificationInProgress,
+	domainSetupInfo,
+}: StepComponentProps ) {
+	const { data } = domainSetupInfo || {};
+	const isSubdomainFlow = isSubdomain( domain );
+
+	// TODO: those need to come from domainSetupInfo data - see the original code in client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
+
+	// Generate the records based on the setup info
+	const records: DNSRecord[] = isSubdomainFlow
+		? [
+				{
+					type: 'A',
+					name: domain,
+					value: data?.default_ip_addresses?.[ 0 ] || '192.0.78.24',
+				},
+				{
+					type: 'A',
+					name: domain,
+					value: data?.default_ip_addresses?.[ 1 ] || '192.0.78.25',
+				},
+				{
+					type: 'CNAME',
+					name: `www.${ domain }`,
+					value: domain,
+				},
+		  ]
+		: [
+				{
+					type: 'A',
+					name: '@',
+					value: data?.default_ip_addresses?.[ 0 ] || '192.0.78.24',
+				},
+				{
+					type: 'A',
+					name: '@',
+					value: data?.default_ip_addresses?.[ 1 ] || '192.0.78.25',
+				},
+				{
+					type: 'CNAME',
+					name: 'www',
+					value: domain,
+				},
+		  ];
+
+	const handleVerify = () => {
+		if ( onVerifyConnection ) {
+			onVerifyConnection();
+		}
+	};
+
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<h2>
+							{ isSubdomainFlow
+								? __( 'Update A & CNAME records' )
+								: __( 'Update root A records & CNAME record' ) }
+						</h2>
+
+						<p>
+							{ isSubdomainFlow
+								? __(
+										'Update the A and CNAME records for your subdomain to point to WordPress.com.'
+								  )
+								: __(
+										"Update your domain's A records and CNAME record to point to WordPress.com."
+								  ) }
+						</p>
+
+						<RecordsList records={ records } />
+
+						<Card variant="secondary">
+							<CardBody>
+								<p>
+									<strong>{ __( 'Important:' ) }</strong>{ ' ' }
+									{ __(
+										'Make sure to delete any existing A records or CNAME records that point to other services before adding these new records.'
+									) }
+								</p>
+							</CardBody>
+						</Card>
+
+						<p>
+							{ __(
+								'After making these changes, it may take up to 72 hours for the changes to take effect.'
+							) }
+						</p>
+
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								onClick={ handleVerify }
+								isBusy={ verificationInProgress }
+								disabled={ verificationInProgress }
+							>
+								{ verificationInProgress ? __( 'Verifying…' ) : __( 'Verify Connection' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/advanced-start.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/advanced-start.tsx
@@ -1,0 +1,82 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { isSubdomain } from '../../../../lib/domains';
+import Notice from '../../../components/notice';
+import Progress from '../components/progress';
+import { stepSlug } from '../constants';
+import type { StepComponentProps } from '../types';
+
+export default function AdvancedStart( {
+	domain,
+	progressStepList,
+	pageSlug,
+	setPage,
+	onNextStep,
+	domainSetupInfo,
+}: StepComponentProps ) {
+	const { data } = domainSetupInfo || {};
+	const isSubdomainFlow = isSubdomain( domain );
+
+	const firstStep = isSubdomainFlow ? stepSlug.SUBDOMAIN_SUGGESTED_START : stepSlug.SUGGESTED_START;
+
+	const switchToSuggestedSetup = () => setPage( firstStep );
+
+	const message = isSubdomainFlow
+		? __(
+				'You can connect your subdomain using A & CNAME records. If your domain provider supports changing NS records, we recommend using our <a>suggested setup</a> instead.'
+		  )
+		: __(
+				'Connect your domain using root A & CNAME records. If your domain provider supports changing name servers, we recommend using our <a>suggested setup</a> instead.'
+		  );
+
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<p>
+							{ createInterpolateElement( message, {
+								a: <Button variant="link" onClick={ switchToSuggestedSetup } />,
+							} ) }
+						</p>
+
+						<Notice variant="info" title={ __( 'How long will it take?' ) }>
+							{ __( 'It takes 5 minutes to set up.' ) }
+							<br />
+							{ __( 'It can take up to 72 hours for the domain to be fully connected.' ) }
+						</Notice>
+
+						{ data?.is_supported_tld && (
+							<Card variant="secondary">
+								<CardBody>
+									<p>
+										{ __(
+											'We recommend transferring your domain instead of connecting it. This will make it easier to manage and will provide better performance.'
+										) }
+									</p>
+								</CardBody>
+							</Card>
+						) }
+
+						<HStack justify="flex-start">
+							<Button variant="primary" onClick={ onNextStep }>
+								{ __( 'Start setup' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/dc-start.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/dc-start.tsx
@@ -1,0 +1,76 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { useCallback } from 'react';
+import Notice from '../../../components/notice';
+import Progress from '../components/progress';
+import type { StepComponentProps } from '../types';
+
+export default function DomainConnectStart( {
+	domain,
+	progressStepList,
+	pageSlug,
+	onVerifyConnection,
+	domainSetupInfo,
+}: StepComponentProps ) {
+	const { data } = domainSetupInfo || {};
+	const domainConnectURL =
+		typeof data?.domain_connect_apply_wpcom_hosting === 'string'
+			? data.domain_connect_apply_wpcom_hosting
+			: undefined;
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+
+	const handleStartSetup = useCallback( () => {
+		if ( onVerifyConnection ) {
+			onVerifyConnection( false );
+		}
+		if ( domainConnectURL ) {
+			window.location.href = domainConnectURL;
+		}
+	}, [ onVerifyConnection, domainConnectURL ] );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<p>
+							{ sprintf(
+								/* translators: %1s is the field to copy */
+								__(
+									'Good news! Your DNS provider for %1s supports a simple click-through way to connect your domain to WordPress.com. Use the button below and follow the on-screen instructions. You might need to log in to your DNS provider account so make sure you have your credentials at hand.'
+								),
+								domain
+							) }
+						</p>
+
+						<Notice variant="info" title={ __( 'How long will it take?' ) }>
+							{ __( 'It takes 2 minutes to set up.' ) }
+							<br />
+							{ __( 'It can take up to 72 hours for the domain to be fully connected.' ) }
+						</Notice>
+
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								onClick={ handleStartSetup }
+								disabled={ ! domainConnectURL }
+								icon={ external }
+							>
+								{ __( 'Start setup' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/done.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/done.tsx
@@ -6,40 +6,51 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 import type { StepComponentProps } from '../types';
 
 // TODO: This file needs full review of the copy and etc.
 // I didn't move to gutenberg components so some things (and styles) can probably be removed and/or replaced
 // Also I didn't review the copy for any of the messages
-export default function Done( { step, verificationStatus }: StepComponentProps ) {
+export default function Done( {
+	step,
+	domain,
+	queryError,
+	queryErrorDescription,
+}: StepComponentProps ) {
 	const isConnected = step === 'connected';
-	const { error } = verificationStatus || {};
 
-	if ( error ) {
+	if ( queryError ) {
+		let heading;
+		let contentMessage;
+
+		if ( queryError === 'access_denied' && queryErrorDescription?.startsWith( 'user_cancel' ) ) {
+			heading = __( 'Connecting your domain to WordPress.com was cancelled' );
+			contentMessage = sprintf(
+				/* translators: %s: the domain name that is being connected (ex.: example.com) */
+				__(
+					'You might want to start over or use one of the alternative methods to connect %s to WordPress.com.'
+				),
+				domain
+			);
+		} else {
+			heading = __( 'There was a problem connecting your domain' );
+			contentMessage = sprintf(
+				/* translators: %s: the domain name that is being connected (ex.: example.com) */
+				__(
+					'We got an error when trying to connect %s to WordPress.com. You might try again or get in contact with your DNS provider to figure out what went wrong.'
+				),
+				domain
+			);
+		}
+
 		return (
 			<Card>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<h2>{ __( 'Connection Error' ) }</h2>
-
-						<p>
-							{ __(
-								'We encountered an error while trying to verify your domain connection. Please check your DNS settings and try again.'
-							) }
-						</p>
-
-						{ error.message && (
-							<Card variant="secondary">
-								<CardBody>
-									<p>
-										<strong>{ __( 'Error details:' ) }</strong> { error.message }
-									</p>
-								</CardBody>
-							</Card>
-						) }
-
+						<h2>{ heading }</h2>
+						<p>{ contentMessage }</p>
 						<HStack justify="flex-start">
 							<Button variant="secondary">{ __( 'Try Again' ) }</Button>
 							<Button variant="tertiary">{ __( 'Get Help' ) }</Button>

--- a/client/dashboard/domains/domain-connection-setup/steps/done.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/done.tsx
@@ -1,0 +1,110 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import type { StepComponentProps } from '../types';
+
+// TODO: This file needs full review of the copy and etc.
+// I didn't move to gutenberg components so some things (and styles) can probably be removed and/or replaced
+// Also I didn't review the copy for any of the messages
+export default function Done( { step, verificationStatus }: StepComponentProps ) {
+	const isConnected = step === 'connected';
+	const { error } = verificationStatus || {};
+
+	if ( error ) {
+		return (
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<h2>{ __( 'Connection Error' ) }</h2>
+
+						<p>
+							{ __(
+								'We encountered an error while trying to verify your domain connection. Please check your DNS settings and try again.'
+							) }
+						</p>
+
+						{ error.message && (
+							<Card variant="secondary">
+								<CardBody>
+									<p>
+										<strong>{ __( 'Error details:' ) }</strong> { error.message }
+									</p>
+								</CardBody>
+							</Card>
+						) }
+
+						<HStack justify="flex-start">
+							<Button variant="secondary">{ __( 'Try Again' ) }</Button>
+							<Button variant="tertiary">{ __( 'Get Help' ) }</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	if ( isConnected ) {
+		return (
+			<VStack spacing={ 6 } style={ { textAlign: 'center', padding: '40px 20px' } }>
+				<div style={ { fontSize: '48px', color: '#00A32A' } }>
+					<Icon icon={ check } size={ 48 } />
+				</div>
+
+				<h2>
+					<Icon icon={ check } size={ 18 } style={ { marginRight: '8px', color: '#00A32A' } } />
+					{ __( 'Successfully connected!' ) }
+				</h2>
+
+				<p>
+					{ __(
+						'Your domain is now connected to WordPress.com. Your site should be accessible at your custom domain within the next few minutes.'
+					) }
+				</p>
+
+				<p>
+					{ __(
+						"If your site isn't loading at your custom domain after a few hours, check that your DNS changes have been saved correctly at your domain provider."
+					) }
+				</p>
+
+				<HStack justify="center">
+					<Button variant="primary">{ __( 'Visit Your Site' ) }</Button>
+					<Button variant="secondary">{ __( 'Manage Domain' ) }</Button>
+				</HStack>
+			</VStack>
+		);
+	}
+
+	// Verifying state
+	return (
+		<VStack spacing={ 6 } style={ { textAlign: 'center', padding: '40px 20px' } }>
+			<div style={ { fontSize: '24px' } }>🔄</div>
+
+			<h2>{ __( 'Verifying connection…' ) }</h2>
+
+			<p>
+				{ __(
+					"We're checking if your domain is properly connected to WordPress.com. This may take a few moments."
+				) }
+			</p>
+
+			<p>
+				{ __(
+					"DNS changes can take up to 72 hours to fully propagate. If the verification doesn't complete immediately, that's normal."
+				) }
+			</p>
+
+			<HStack justify="center">
+				<Button variant="secondary">{ __( 'Check Again' ) }</Button>
+				<Button variant="tertiary">{ __( 'Continue Without Waiting' ) }</Button>
+			</HStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/login.tsx
@@ -1,0 +1,136 @@
+import { useLocalizeUrl } from '@automattic/i18n-utils'; // eslint-disable-line no-restricted-imports
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useRef, useEffect, useState } from 'react';
+import { domainAvailabilityQuery } from '../../../app/queries/domain-availability';
+import Notice from '../../../components/notice';
+import Progress from '../components/progress';
+import type { StepComponentProps } from '../types';
+
+export default function Login( {
+	domain,
+	progressStepList,
+	pageSlug,
+	onNextStep,
+	isOwnershipVerificationFlow,
+}: StepComponentProps ) {
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+	const [ isConnectSupported, setIsConnectSupported ] = useState( true );
+	const [ rootDomainProvider, setRootDomainProvider ] = useState( 'unknown' );
+	const initialValidation = useRef( false );
+
+	const {
+		data: availability,
+		isLoading,
+		error,
+	} = useQuery( {
+		...domainAvailabilityQuery( domain ),
+		enabled: !! isOwnershipVerificationFlow && ! initialValidation.current,
+	} );
+
+	useEffect( () => {
+		if ( ! isOwnershipVerificationFlow || initialValidation.current || ! availability ) {
+			return;
+		}
+
+		if ( 'mappable' !== availability.mappable ) {
+			setIsConnectSupported( false );
+		}
+		setRootDomainProvider( availability.root_domain_provider );
+		initialValidation.current = true;
+	}, [ availability, isOwnershipVerificationFlow ] );
+
+	useEffect( () => {
+		if ( error ) {
+			setIsConnectSupported( false );
+		}
+	}, [ error ] );
+	const localizeUrl = useLocalizeUrl();
+
+	const supportUrl = localizeUrl( 'https://wordpress.com/support/domains/connect-subdomain' );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						{ isOwnershipVerificationFlow && (
+							<p>{ __( 'We need to confirm that you are authorized to connect this domain.' ) }</p>
+						) }
+
+						{ ! isLoading && ! isConnectSupported && (
+							<Notice variant="error">{ __( 'This domain cannot be connected.' ) }</Notice>
+						) }
+
+						{ ! isLoading && (
+							<>
+								{ rootDomainProvider === 'wpcom' && (
+									<p>
+										{ createInterpolateElement(
+											__(
+												"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>).<br/><br/> If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info can be found here</a>."
+											),
+											{
+												br: createElement( 'br' ),
+												em: createElement( 'em' ),
+												a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
+											}
+										) }
+									</p>
+								) }
+								{ rootDomainProvider !== 'wpcom' && (
+									<>
+										<p>
+											{ createInterpolateElement(
+												__(
+													"Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can't remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider."
+												),
+												{
+													em: createElement( 'em' ),
+													a: createElement( 'a', {
+														href: 'https://wordpress.com/site-profiler',
+														target: '_blank',
+													} ),
+												}
+											) }
+										</p>
+										<p>
+											{ sprintf(
+												/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
+												__(
+													"On your domain provider's site go to the domains page. Find %s and go to its settings page."
+												),
+												domain
+											) }
+										</p>
+									</>
+								) }
+							</>
+						) }
+
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								onClick={ onNextStep }
+								isBusy={ isLoading }
+								disabled={ isLoading || ! isConnectSupported }
+							>
+								{ __( "I found the domain's settings page" ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/suggested-records.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/suggested-records.tsx
@@ -1,0 +1,108 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { isSubdomain } from '../../../../lib/domains';
+import Progress from '../components/progress';
+import RecordsList from '../components/records-list';
+import type { StepComponentProps, DNSRecord } from '../types';
+
+export default function SuggestedRecords( {
+	domain,
+	progressStepList,
+	pageSlug,
+	onVerifyConnection,
+	verificationInProgress,
+	domainSetupInfo,
+}: StepComponentProps ) {
+	const { data } = domainSetupInfo || {};
+	const isSubdomainFlow = isSubdomain( domain );
+
+	// Generate the records based on the setup info
+	const records: DNSRecord[] = isSubdomainFlow
+		? [
+				{
+					type: 'NS',
+					name: domain,
+					value: data?.wpcom_name_servers?.[ 0 ] || 'ns1.wordpress.com',
+				},
+				{
+					type: 'NS',
+					name: domain,
+					value: data?.wpcom_name_servers?.[ 1 ] || 'ns2.wordpress.com',
+				},
+				{
+					type: 'NS',
+					name: domain,
+					value: data?.wpcom_name_servers?.[ 2 ] || 'ns3.wordpress.com',
+				},
+		  ]
+		: [
+				{
+					type: 'NS',
+					name: '@',
+					value: data?.wpcom_name_servers?.[ 0 ] || 'ns1.wordpress.com',
+				},
+				{
+					type: 'NS',
+					name: '@',
+					value: data?.wpcom_name_servers?.[ 1 ] || 'ns2.wordpress.com',
+				},
+				{
+					type: 'NS',
+					name: '@',
+					value: data?.wpcom_name_servers?.[ 2 ] || 'ns3.wordpress.com',
+				},
+		  ];
+
+	const handleVerify = () => {
+		if ( onVerifyConnection ) {
+			onVerifyConnection();
+		}
+	};
+
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<p>
+							{ isSubdomainFlow
+								? __(
+										'Update the NS records for your subdomain to point to WordPress.com name servers.'
+								  )
+								: __(
+										'Find the name servers on your domain’s settings page. Replace all the name servers of your domain to use the following values:'
+								  ) }
+						</p>
+
+						<RecordsList records={ records } justValues={ ! isSubdomainFlow } />
+
+						<p>
+							{ __( 'Once you’ve updated the name servers click on "Verify Connection" below.' ) }
+						</p>
+
+						<HStack justify="flex-start">
+							<Button
+								variant="primary"
+								onClick={ handleVerify }
+								isBusy={ verificationInProgress }
+								disabled={ verificationInProgress }
+							>
+								{ verificationInProgress ? __( 'Verifying…' ) : __( 'Verify Connection' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/suggested-start.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/suggested-start.tsx
@@ -1,0 +1,120 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+	Panel,
+	PanelBody,
+	PanelRow,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
+import { isSubdomain } from '../../../../lib/domains';
+import Notice from '../../../components/notice';
+import Progress from '../components/progress';
+import { stepSlug } from '../constants';
+import type { StepComponentProps } from '../types';
+
+export default function SuggestedStart( {
+	domain,
+	progressStepList,
+	pageSlug,
+	setPage,
+	onNextStep,
+	domainSetupInfo,
+}: StepComponentProps ) {
+	const { data } = domainSetupInfo || {};
+	const isSubdomainFlow = isSubdomain( domain );
+
+	const firstStep = isSubdomainFlow ? stepSlug.SUBDOMAIN_ADVANCED_START : stepSlug.ADVANCED_START;
+
+	const switchToAdvancedSetup = () => setPage( firstStep );
+
+	const message = isSubdomainFlow
+		? __(
+				'The easiest way to connect your subdomain is by changing NS records. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
+		  )
+		: __(
+				'This is the easiest way to connect your domain, using name servers. If needed you can also use our <a>advanced setup</a>, using root A & CNAME records.'
+		  );
+
+	const showProgress = Object.keys( progressStepList ).includes( pageSlug );
+
+	return (
+		<VStack spacing={ 6 }>
+			{ showProgress && <Progress steps={ progressStepList } currentStep={ pageSlug } /> }
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<p>
+							{ createInterpolateElement( message, {
+								a: <Button variant="link" onClick={ switchToAdvancedSetup } />,
+							} ) }
+						</p>
+
+						<Notice variant="info" title={ __( 'How long will it take?' ) }>
+							{ __( 'It takes 5–15 minutes to set up.' ) }
+							<br />
+							{ __( 'It can take up to 72 hours for the domain to be fully connected.' ) }
+						</Notice>
+
+						<Panel>
+							<PanelBody
+								title={ __( 'Do you have email or other services connected to this domain?' ) }
+								icon={ caution }
+								initialOpen={ false }
+							>
+								<PanelRow>
+									<VStack spacing={ 2 }>
+										<p>
+											{ createInterpolateElement(
+												__(
+													'If you have any email or services other than web hosting connected to this domain, we recommend you copy over your DNS records before proceeding with this setup to avoid disruptions. You can then start the setup again by going back to <em>Upgrades > Domains</em>.'
+												),
+												{
+													em: <em />,
+												}
+											) }
+										</p>
+										<HStack justify="flex-start">
+											<Button variant="secondary">{ __( 'Go to DNS records' ) }</Button>
+										</HStack>
+										<p>
+											{ __(
+												'Alternatively, you can continue to use your current DNS provider by adding the correct A records and CNAME records using our advanced setup.'
+											) }
+										</p>
+										<HStack justify="flex-start">
+											<Button variant="secondary">{ __( 'Switch to advanced setup' ) }</Button>
+										</HStack>
+									</VStack>
+								</PanelRow>
+							</PanelBody>
+						</Panel>
+
+						{ data?.is_supported_tld && (
+							<Card variant="secondary">
+								<CardBody>
+									<p>
+										{ __(
+											'We recommend transferring your domain instead of connecting it. This will make it easier to manage and will provide better performance.'
+										) }
+									</p>
+								</CardBody>
+							</Card>
+						) }
+
+						<HStack justify="flex-start">
+							<Button variant="primary" onClick={ onNextStep }>
+								{ __( 'Start setup' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/types.ts
+++ b/client/dashboard/domains/domain-connection-setup/types.ts
@@ -81,12 +81,3 @@ export interface DNSRecord {
 	name: string;
 	value: string;
 }
-
-export interface ConnectDomainStepProps {
-	domain: string;
-	initialStep?: StepSlug;
-	showErrors?: boolean;
-	isFirstVisit?: boolean;
-	queryError?: string;
-	queryErrorDescription?: string;
-}

--- a/client/dashboard/domains/domain-connection-setup/types.ts
+++ b/client/dashboard/domains/domain-connection-setup/types.ts
@@ -1,0 +1,92 @@
+import type { ModeType, StepType, StepSlug } from './constants';
+import type { ComponentType } from 'react';
+
+// Re-export types from constants for external use
+export type { ModeType, StepType, StepSlug } from './constants';
+
+export interface StepDefinition {
+	mode: ModeType;
+	step: StepType;
+	component: ComponentType< StepComponentProps >;
+	name?: () => string;
+	next?: StepSlug;
+	prev?: StepSlug;
+	singleColumnLayout?: boolean;
+}
+
+export interface StepsDefinition {
+	[ key: string ]: StepDefinition;
+}
+
+export interface StepComponentProps {
+	className?: string;
+	domain: string;
+	step: StepType;
+	mode: ModeType;
+	onNextStep: () => void;
+	progressStepList: ProgressStepList;
+	pageSlug: StepSlug;
+	setPage: ( pageSlug: StepSlug ) => void;
+	selectedSite?: Site;
+	queryError?: string;
+	queryErrorDescription?: string;
+	verificationInProgress?: boolean;
+	verificationStatus?: VerificationStatus;
+	domainSetupInfo?: DomainSetupInfo;
+	domainSetupInfoError?: Record< string, unknown >;
+	showErrors?: boolean;
+	onVerifyConnection?: ( setStepAfterVerify?: boolean ) => void;
+	isOwnershipVerificationFlow?: boolean;
+}
+
+export interface ProgressStepList {
+	[ key: string ]: string;
+}
+
+export interface Site {
+	ID: number;
+	slug: string;
+	name?: string;
+	URL?: string;
+}
+
+export interface VerificationStatus {
+	data?: {
+		status?: string;
+		errors?: Array< {
+			code: string;
+			message: string;
+		} >;
+	};
+	error?: {
+		message?: string;
+		code?: string;
+	};
+}
+
+export interface DomainSetupInfo {
+	data?: {
+		connection_mode?: string;
+		domain_connect_apply_wpcom_hosting?: boolean;
+		domain_connect_provider_id?: string;
+		default_ip_addresses?: string[];
+		wpcom_name_servers?: string[];
+		is_subdomain?: boolean;
+		is_supported_tld?: boolean;
+	};
+}
+
+export interface DNSRecord {
+	type: string;
+	name: string;
+	value: string;
+}
+
+export interface ConnectDomainStepProps {
+	domain: string;
+	initialStep?: StepSlug;
+	showErrors?: boolean;
+	isFirstVisit?: boolean;
+	queryError?: string;
+	queryErrorDescription?: string;
+}

--- a/client/dashboard/domains/domain-connection-setup/utils.ts
+++ b/client/dashboard/domains/domain-connection-setup/utils.ts
@@ -1,0 +1,14 @@
+import { DomainMappingStatus } from '../../data/domain-connection-setup';
+import { modeType } from './constants';
+
+export function isMappingVerificationSuccess( mode: string, data: DomainMappingStatus ): boolean {
+	if ( modeType.SUGGESTED === mode && data.has_wpcom_nameservers ) {
+		return true;
+	}
+
+	if ( modeType.ADVANCED === mode && data.has_wpcom_ip_addresses ) {
+		return true;
+	}
+
+	return !! ( data.has_cloudflare_ip_addresses && data.resolves_to_wpcom );
+}

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -1,0 +1,22 @@
+import {
+	fetchDomainSetupInfo,
+	updateConnectionModeAndGetMappingStatus,
+} from '@automattic/api-core';
+import { queryClient } from '@automattic/api-queries';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+
+export const domainSetupInfoQuery = ( domainName: string, siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'domain-setup-info', domainName, siteId ],
+		queryFn: () => fetchDomainSetupInfo( domainName, siteId ),
+		enabled: !! siteId && !! domainName,
+	} );
+
+export const updateConnectionModeMutation = ( domainName: string, siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( connectionMode: string ) =>
+			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainSetupInfoQuery( domainName, siteId ) );
+		},
+	} );

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -5,10 +5,10 @@ import {
 import { queryClient } from '@automattic/api-queries';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 
-export const domainSetupInfoQuery = ( domainName: string, siteId: number ) =>
+export const domainSetupInfoQuery = ( domainName: string, siteId: number, redirectURL?: string ) =>
 	queryOptions( {
 		queryKey: [ 'domain-setup-info', domainName, siteId ],
-		queryFn: () => fetchDomainSetupInfo( domainName, siteId ),
+		queryFn: () => fetchDomainSetupInfo( domainName, siteId, redirectURL || '' ),
 		enabled: !! siteId && !! domainName,
 	} );
 


### PR DESCRIPTION
This is the domain connection setup wizard recreated in the Hosting Dashboard

<img width="721" height="510" alt="Screenshot 2025-08-29 at 16 24 43" src="https://github.com/user-attachments/assets/f5eb8cfb-5917-4082-89d6-a92b011d1367" />

The URL to access it is:
`/v2/sites/{site_slug}/domain-connection-setup?domainName={domain_name}`

I've left a bunch of TODOs inside the code but also:
* review the types as those might be a bit mixed up
* error handling is definitely lacking

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
