### PR TITLE
Domains: Renews/Expire: Cover expire case within the renews card

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -12,7 +12,11 @@ interface Props {
 
 export default function FeaturedCardRenew( { domain }: Props ) {
 	const locale = useLocale();
-	const date = domain.auto_renewing ? domain.auto_renewal_date : domain.renewable_until;
+	const date = domain.auto_renewing ? domain.auto_renewal_date : domain.expiry;
+
+	if ( ! date ) {
+		return null;
+	}
 
 	const formattedDate = formatDate( new Date( date ), locale, {
 		day: 'numeric',
@@ -22,7 +26,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 
 	return (
 		<OverviewCard
-			title={ __( 'Renews' ) }
+			title={ domain.auto_renewing ? __( 'Renews' ) : __( 'Expires' ) }
 			heading={ formattedDate }
 			icon={ <Icon icon={ calendar } /> }
 			link={ `/me/billing/purchases/purchase/${ domain.subscription_id }` }


### PR DESCRIPTION
Part of DOTDASH-356

## Proposed Changes

* Cover expires case within the renews card

## Testing Instructions

* Go to `/v2/domains`
* Choose a domain with disabled renewal
* Check the card

Expires
<img width="687" height="323" alt="Screenshot 2025-08-29 at 17 05 13" src="https://github.com/user-attachments/assets/d56a7a3b-925e-4282-9be1-ccf5c201beb2" />

Renews
<img width="688" height="347" alt="Screenshot 2025-08-29 at 17 05 03" src="https://github.com/user-attachments/assets/7c7f3f77-e068-49a2-aab1-9c40d0cadc0d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
