### PR TITLE
Domains: Name Servers: Refactor the name servers component to use the new endpoint

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -20,7 +20,6 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { areAllWpcomNameServers } from '../name-servers/utils';
 import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
 import DnsImportDialog from './dns-import-dialog';
@@ -66,7 +65,9 @@ export default function DomainDns() {
 	const restoreDefaultEmailRecordsMutation = useMutation( domainDnsEmailMutation( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: nameservers } = useSuspenseQuery( domainNameServersQuery( domainName ) );
+	const {
+		data: { nameServers, isUsingDefaultNameServers },
+	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
 	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
 	const [ isRestoreDefaultARecordsDialogOpen, setIsRestoreDefaultARecordsDialogOpen ] =
 		useState( false );
@@ -193,7 +194,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultARecordsNotice = () => {
-		if ( ! areAllWpcomNameServers( nameservers ) || hasDefaultARecordsValue ) {
+		if ( ! isUsingDefaultNameServers || hasDefaultARecordsValue ) {
 			return null;
 		}
 
@@ -226,7 +227,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultCnameRecordNotice = () => {
-		if ( ! areAllWpcomNameServers( nameservers ) || hasDefaultCnameRecordValue ) {
+		if ( ! isUsingDefaultNameServers || hasDefaultCnameRecordValue ) {
 			return null;
 		}
 
@@ -263,7 +264,7 @@ export default function DomainDns() {
 	};
 
 	const renderExternalNameserversNotice = () => {
-		if ( areAllWpcomNameServers( nameservers ) || ! nameservers || ! nameservers.length ) {
+		if ( isUsingDefaultNameServers || ! nameServers || ! nameServers.length ) {
 			return null;
 		}
 

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -19,7 +19,7 @@ import {
 	NameServerKey,
 } from './types';
 import UpsellNudge from './upsell-nudge';
-import { areAllWpcomNameServers, validateHostname } from './utils';
+import { validateHostname } from './utils';
 
 const createNameServerField = ( index: number, formData: FormData, isBusy?: boolean ) => {
 	const baseField = {
@@ -97,6 +97,7 @@ interface Props {
 	domainSiteSlug: string;
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
+	isUsingDefaultNameServers?: boolean;
 	isBusy?: boolean;
 	onSubmit: ( nameServers: string[] ) => void;
 }
@@ -106,14 +107,14 @@ export default function NameServersForm( {
 	domainSiteSlug,
 	showUpsellNudge,
 	nameServers = [],
+	isUsingDefaultNameServers = false,
 	isBusy,
 	onSubmit,
 }: Props ) {
-	const isWpcomNameservers = areAllWpcomNameServers( nameServers );
 	const [ formData, setFormData ] = useState< FormData >( () => {
 		// Start with a partial object
 		const initialData = {
-			useWpcomNameServers: isWpcomNameservers,
+			useWpcomNameServers: isUsingDefaultNameServers,
 		} as Partial< FormData >;
 
 		// Add all nameServer fields

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -40,19 +40,16 @@ export default function NameServers() {
 
 	const onSubmit = useCallback(
 		( ns: string[] ) => {
-			updateNameServers(
-				{ nameServers: ns, isUsingDefaultNameServers },
-				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Name servers updated successfully.' ), {
-							type: 'snackbar',
-						} );
-					},
-					onError: ( e: Error ) => createErrorNotice( e.message, { type: 'snackbar' } ),
-				}
-			);
+			updateNameServers( ns, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Name servers updated successfully.' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( e: Error ) => createErrorNotice( e.message, { type: 'snackbar' } ),
+			} );
 		},
-		[ updateNameServers, createSuccessNotice, createErrorNotice, isUsingDefaultNameServers ]
+		[ updateNameServers, createSuccessNotice, createErrorNotice ]
 	);
 
 	return (

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -24,7 +24,7 @@ export default function NameServers() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const {
-		data: { nameservers: nameServers, is_using_default_nameservers: isUsingDefaultNameServers },
+		data: { nameServers, isUsingDefaultNameServers },
 	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
 
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -40,16 +40,19 @@ export default function NameServers() {
 
 	const onSubmit = useCallback(
 		( ns: string[] ) => {
-			updateNameServers( ns, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Name servers updated successfully.' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: ( e: Error ) => createErrorNotice( e.message, { type: 'snackbar' } ),
-			} );
+			updateNameServers(
+				{ nameServers: ns, isUsingDefaultNameServers },
+				{
+					onSuccess: () => {
+						createSuccessNotice( __( 'Name servers updated successfully.' ), {
+							type: 'snackbar',
+						} );
+					},
+					onError: ( e: Error ) => createErrorNotice( e.message, { type: 'snackbar' } ),
+				}
+			);
 		},
-		[ updateNameServers, createSuccessNotice, createErrorNotice ]
+		[ updateNameServers, createSuccessNotice, createErrorNotice, isUsingDefaultNameServers ]
 	);
 
 	return (

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -23,7 +23,10 @@ export default function NameServers() {
 	const { domainName } = domainRoute.useParams();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const { data: nameServers } = useSuspenseQuery( domainNameServersQuery( domainName ) );
+	const {
+		data: { nameservers: nameServers, is_using_default_nameservers: isUsingDefaultNameServers },
+	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
+
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
 		domainNameServersMutation( domainName )
 	);
@@ -56,10 +59,11 @@ export default function NameServers() {
 					<NameServersForm
 						domainName={ domainName }
 						domainSiteSlug={ getDomainSiteSlug( domain ) }
+						nameServers={ nameServers }
+						isUsingDefaultNameServers={ isUsingDefaultNameServers }
 						isBusy={ isUpdatingNameServers }
-						nameServers={ nameServers ?? [] }
-						onSubmit={ onSubmit }
 						showUpsellNudge={ showUpsellNudge }
+						onSubmit={ onSubmit }
 					/>
 				</CardBody>
 			</Card>

--- a/client/dashboard/domains/name-servers/utils.ts
+++ b/client/dashboard/domains/name-servers/utils.ts
@@ -9,16 +9,6 @@ export const validateHostname = ( hostname: string ) => {
 	return HOSTNAME_REGEX.test( hostname );
 };
 
-export const areAllWpcomNameServers = ( nameservers?: string[] ) => {
-	if ( ! nameservers || nameservers.length === 0 ) {
-		return false;
-	}
-
-	return nameservers.every( ( nameserver: string ) => {
-		return ! nameserver || WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-	} );
-};
-
 export const shouldShowUpsellNudge = ( user: User, domain: Domain, site?: Site ): boolean => {
 	if (
 		! site?.plan?.is_free || // hide nudge for paid plans

--- a/packages/api-core/src/domain-name-servers/fetchers.ts
+++ b/packages/api-core/src/domain-name-servers/fetchers.ts
@@ -1,7 +1,27 @@
 import { wpcom } from '../wpcom-fetcher';
 
-export async function fetchDomainNameServers( domainName: string ): Promise< string[] > {
-	return wpcom.req.get( {
-		path: `/domains/${ domainName }/nameservers`,
-	} );
+interface FetchNameServersResponse {
+	is_using_default_nameservers: boolean;
+	nameservers: string[];
+}
+
+export interface DomainNameServersResponse {
+	nameServers: string[];
+	isUsingDefaultNameServers: boolean;
+}
+
+export async function fetchDomainNameServers(
+	domainName: string
+): Promise< DomainNameServersResponse > {
+	return wpcom.req
+		.get( {
+			path: `/domains/${ domainName }/nameservers`,
+			apiVersion: '1.2',
+		} )
+		.then( ( data: FetchNameServersResponse ) => {
+			return {
+				nameServers: data.nameservers,
+				isUsingDefaultNameServers: data.is_using_default_nameservers,
+			};
+		} );
 }

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -10,9 +10,15 @@ export const domainNameServersQuery = ( domainName: string ) =>
 
 export const domainNameServersMutation = ( domainName: string ) =>
 	mutationOptions( {
-		mutationFn: ( nameservers: string[] ) => updateDomainNameServers( domainName, nameservers ),
-		onSuccess: ( _, variables ) => {
-			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, variables );
+		mutationFn: ( {
+			nameServers,
+		}: {
+			nameServers: string[];
+			isUsingDefaultNameServers: boolean;
+		} ) => updateDomainNameServers( domainName, nameServers ),
+		onSuccess: ( _, data ) => {
+			// optimistically update the query data
+			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, data );
 			queryClient.invalidateQueries( domainNameServersQuery( domainName ) );
 		},
 	} );

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -1,4 +1,8 @@
-import { fetchDomainNameServers, updateDomainNameServers } from '@automattic/api-core';
+import {
+	fetchDomainNameServers,
+	updateDomainNameServers,
+	DomainNameServersResponse,
+} from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -12,10 +16,12 @@ export const domainNameServersMutation = ( domainName: string ) =>
 	mutationOptions( {
 		mutationFn: ( nameServers: string[] ) => updateDomainNameServers( domainName, nameServers ),
 		onSuccess: ( _, data ) => {
-			const oldData = queryClient.getQueryData( domainNameServersQuery( domainName ).queryKey );
+			const oldData = queryClient.getQueryData( domainNameServersQuery( domainName ).queryKey ) as
+				| DomainNameServersResponse
+				| undefined;
 			// optimistically update the query data
 			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, {
-				isUsingDefaultNameServers: !! oldData?.isUsingDefaultNameServers,
+				isUsingDefaultNameServers: oldData?.isUsingDefaultNameServers ?? false,
 				nameServers: data,
 			} );
 			queryClient.invalidateQueries( domainNameServersQuery( domainName ) );

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -10,15 +10,14 @@ export const domainNameServersQuery = ( domainName: string ) =>
 
 export const domainNameServersMutation = ( domainName: string ) =>
 	mutationOptions( {
-		mutationFn: ( {
-			nameServers,
-		}: {
-			nameServers: string[];
-			isUsingDefaultNameServers: boolean;
-		} ) => updateDomainNameServers( domainName, nameServers ),
+		mutationFn: ( nameServers: string[] ) => updateDomainNameServers( domainName, nameServers ),
 		onSuccess: ( _, data ) => {
+			const oldData = queryClient.getQueryData( domainNameServersQuery( domainName ).queryKey );
 			// optimistically update the query data
-			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, data );
+			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, {
+				isUsingDefaultNameServers: !! oldData?.isUsingDefaultNameServers,
+				nameServers: data,
+			} );
 			queryClient.invalidateQueries( domainNameServersQuery( domainName ) );
 		},
 	} );


### PR DESCRIPTION
Part of DOTDASH-322

## Proposed Changes

* Consumes a new API for getting name servers
* Replaces the manual name servers check and relies on data that comes from the API

## Why are these changes being made?

* DOTDASH-322 Use a new API

## Testing Instructions

* Go to `/v2/domains/{DOMAIN_NAME}/name-servers`
* Check if everything works as before
* Go to `/v2/domains/{DOMAIN_NAME}/dns`
* Check if everything works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
