### PR TITLE
Remove unnecessary typings from log views `useFields` hook

### DIFF
--- a/client/dashboard/sites/logs/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs/dataviews/fields.tsx
@@ -7,7 +7,7 @@ import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useLocale } from '../../../app/locale';
 import { formatDateWithOffset, getUtcOffsetDisplay } from '../../../utils/datetime';
-import type { Field, Operator, DataViewRenderFieldProps } from '@wordpress/dataviews';
+import type { Field } from '@wordpress/dataviews';
 
 import './style.scss';
 
@@ -86,12 +86,12 @@ export function useFields( {
 					label: dateTimeLabel,
 					enableHiding: false,
 					enableSorting: true,
-					getValue: ( { item }: { item: PHPLog } ) => item.timestamp,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => {
+					getValue: ( { item } ) => item.timestamp,
+					render: ( { item } ) => {
 						const value = item.timestamp;
 						return <span>{ formatCell( value ) }</span>;
 					},
-					filterBy: { operators: [] as Operator[] },
+					filterBy: { operators: [] },
 				},
 				{
 					id: 'severity',
@@ -99,63 +99,59 @@ export function useFields( {
 					label: __( 'Severity' ),
 					enableSorting: false,
 					elements: VALUES_SEVERITY.map( ( severity ) => ( { value: severity, label: severity } ) ),
-					getValue: ( { item }: { item: PHPLog } ) => item.severity,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => (
+					getValue: ( { item } ) => item.severity,
+					render: ( { item } ) => (
 						<Badge intent="default" className={ `badge--${ toSeverityClass( item.severity ) }` }>
 							{ item.severity }
 						</Badge>
 					),
-					filterBy: { operators: [ 'isAny' as Operator ] },
+					filterBy: { operators: [ 'isAny' ] },
 				},
 				{
 					id: 'message',
 					type: 'text',
 					label: __( 'Message' ),
 					enableSorting: false,
-					getValue: ( { item }: { item: PHPLog } ) => item.message,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => (
+					getValue: ( { item } ) => item.message,
+					render: ( { item } ) => (
 						<span className="site-logs-ellipsis">{ String( item.message ) }</span>
 					),
-					filterBy: { operators: [] as Operator[] },
+					filterBy: { operators: [] },
 				},
 				{
 					id: 'kind',
 					type: 'text',
 					label: __( 'Group' ),
 					enableSorting: false,
-					getValue: ( { item }: { item: PHPLog } ) => item.kind,
-					filterBy: { operators: [] as Operator[] },
+					getValue: ( { item } ) => item.kind,
+					filterBy: { operators: [] },
 				},
 				{
 					id: 'name',
 					type: 'text',
 					label: __( 'Source' ),
 					enableSorting: false,
-					getValue: ( { item }: { item: PHPLog } ) => item.name,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => (
-						<span className="site-logs-wrap">{ String( item.name ) }</span>
-					),
-					filterBy: { operators: [] as Operator[] },
+					getValue: ( { item } ) => item.name,
+					render: ( { item } ) => <span className="site-logs-wrap">{ String( item.name ) }</span>,
+					filterBy: { operators: [] },
 				},
 				{
 					id: 'file',
 					type: 'text',
 					label: __( 'File' ),
 					enableSorting: false,
-					getValue: ( { item }: { item: PHPLog } ) => item.file,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => (
-						<span className="site-logs-wrap">{ String( item.file ) }</span>
-					),
-					filterBy: { operators: [] as Operator[] },
+					getValue: ( { item } ) => item.file,
+					render: ( { item } ) => <span className="site-logs-wrap">{ String( item.file ) }</span>,
+					filterBy: { operators: [] },
 				},
 				{
 					id: 'line',
 					type: 'integer',
 					label: __( 'Line' ),
 					enableSorting: false,
-					getValue: ( { item }: { item: PHPLog } ) => item.line,
-					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => formatNumber( item.line ),
-					filterBy: { operators: [] as Operator[] },
+					getValue: ( { item } ) => item.line,
+					render: ( { item } ) => formatNumber( item.line ),
+					filterBy: { operators: [] },
 				},
 			] satisfies Field< PHPLog >[];
 		}
@@ -168,12 +164,12 @@ export function useFields( {
 				label: dateTimeLabel,
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: ServerLog } ) => item.date ?? item.timestamp,
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => {
+				getValue: ( { item } ) => item.date ?? item.timestamp,
+				render: ( { item } ) => {
 					const value = item.date ?? item.timestamp;
 					return <span>{ formatCell( value ) }</span>;
 				},
-				filterBy: { operators: [] as Operator[] },
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'request_type',
@@ -181,13 +177,13 @@ export function useFields( {
 				label: __( 'Request type' ),
 				enableSorting: false,
 				elements: VALUES_REQUEST_TYPE.map( ( t ) => ( { value: t, label: t } ) ),
-				getValue: ( { item }: { item: ServerLog } ) => item.request_type,
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
+				getValue: ( { item } ) => item.request_type,
+				render: ( { item } ) => (
 					<Badge intent="default" className={ `badge--${ item.request_type }` }>
 						{ item.request_type }
 					</Badge>
 				),
-				filterBy: { operators: [ 'isAny' as Operator ] },
+				filterBy: { operators: [ 'isAny' ] },
 			},
 			{
 				id: 'status',
@@ -195,156 +191,152 @@ export function useFields( {
 				label: __( 'Status' ),
 				enableSorting: false,
 				elements: VALUES_STATUS.map( ( status ) => ( { value: status, label: status } ) ),
-				getValue: ( { item }: { item: ServerLog } ) => item.status,
-				filterBy: { operators: [ 'isAny' as Operator ] },
+				getValue: ( { item } ) => item.status,
+				filterBy: { operators: [ 'isAny' ] },
 			},
 			{
 				id: 'request_url',
 				type: 'text',
 				label: __( 'Request URL' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.request_url,
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
+				getValue: ( { item } ) => item.request_url,
+				render: ( { item } ) => (
 					<span className="site-logs-wrap">{ String( item.request_url ) }</span>
 				),
-				filterBy: { operators: [] as Operator[] },
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'body_bytes_sent',
 				type: 'integer',
 				label: __( 'Body bytes sent' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.body_bytes_sent,
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
-					<span>{ formatNumber( item.body_bytes_sent ) }</span>
-				),
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.body_bytes_sent,
+				render: ( { item } ) => <span>{ formatNumber( item.body_bytes_sent ) }</span>,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'cached',
 				type: 'text',
 				label: __( 'Cached' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.cached,
+				getValue: ( { item } ) => item.cached,
 				elements: VALUES_CACHED.map( ( cachedValue ) => ( {
 					value: cachedValue,
 					label: getLabelCached( cachedValue ),
 				} ) ),
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
-					<span>{ getLabelCached( item.cached ) }</span>
-				),
-				filterBy: { operators: [ 'isAny' as Operator ] },
+				render: ( { item } ) => <span>{ getLabelCached( item.cached ) }</span>,
+				filterBy: { operators: [ 'isAny' ] },
 			},
 			{
 				id: 'http_host',
 				type: 'text',
 				label: __( 'HTTP Host' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http_host,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.http_host,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'http_referer',
 				type: 'text',
 				label: __( 'HTTP Referrer' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http_referer,
-				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
+				getValue: ( { item } ) => item.http_referer,
+				render: ( { item } ) => (
 					<span className="site-logs-wrap">{ String( item.http_referer ) }</span>
 				),
-				filterBy: { operators: [] as Operator[] },
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'http2',
 				type: 'text',
 				label: __( 'HTTP/2' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http2,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.http2,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'http_user_agent',
 				type: 'text',
 				label: __( 'User Agent' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http_user_agent,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.http_user_agent,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'http_version',
 				type: 'text',
 				label: __( 'HTTP Version' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http_version,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.http_version,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'http_x_forwarded_for',
 				type: 'text',
 				label: __( 'X-Forwarded-For' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.http_x_forwarded_for,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.http_x_forwarded_for,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'renderer',
 				type: 'text',
 				label: __( 'Renderer' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.renderer,
+				getValue: ( { item } ) => item.renderer,
 				elements: VALUES_RENDERER.map( ( renderer ) => ( {
 					value: renderer,
 					label: getLabelRenderer( renderer ),
 				} ) ),
-				filterBy: { operators: [ 'isAny' as Operator ] },
+				filterBy: { operators: [ 'isAny' ] },
 			},
 			{
 				id: 'request_completion',
 				type: 'text',
 				label: __( 'Request Completion' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.request_completion,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.request_completion,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'request_time',
 				type: 'text',
 				label: __( 'Request Time' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.request_time,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.request_time,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'scheme',
 				type: 'text',
 				label: __( 'Scheme' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.scheme,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.scheme,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'timestamp',
 				type: 'integer',
 				label: __( 'Timestamp' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.timestamp,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.timestamp,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'type',
 				type: 'text',
 				label: __( 'Type' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.type,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.type,
+				filterBy: { operators: [] },
 			},
 			{
 				id: 'user_ip',
 				type: 'text',
 				label: __( 'User IP' ),
 				enableSorting: false,
-				getValue: ( { item }: { item: ServerLog } ) => item.user_ip,
-				filterBy: { operators: [] as Operator[] },
+				getValue: ( { item } ) => item.user_ip,
+				filterBy: { operators: [] },
 			},
 		] satisfies Field< ServerLog >[];
 	}, [ dateTimeLabel, gmtOffset, locale, logType, timezoneString ] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

Remove unnecessary types from the `useFields()` hook

Follow up on #105428

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `satisfies Field< ServerLog >[]` does a lot of the heavy lifting for us, so the callback function types are already known to the type checker. The field's `getValue` and `render` methods are easier to read without the long type names.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test the logs view. There should be no behaviour changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
