### PR TITLE
A4A > Marketplace: Remove Pressable Premium Plan feature flag logic

### DIFF
--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/hook/use-show-migration-incentive.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE } from '../lib/constants';
@@ -24,8 +23,6 @@ const isMoreThanMinSites = ( sites?: string ) => {
 };
 
 export function useShowMigrationIncentive() {
-	const isFeatureEnabled = isEnabled( 'pressable-premium-plan' );
-
 	const agency = useSelector( getActiveAgency );
 	const numberSites = agency?.signup_meta?.number_sites;
 
@@ -37,5 +34,5 @@ export function useShowMigrationIncentive() {
 	// We only show the incentive if the current date is before the migration incentive end date.
 	const isIncentiveActive = PRESSABLE_PREMIUM_PLAN_MIGRATION_INCENTIVE_END_DATE > new Date();
 
-	return isFeatureEnabled && showMigrationIncentive && isIncentiveActive;
+	return showMigrationIncentive && isIncentiveActive;
 }

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -44,15 +44,13 @@ export default function () {
 		);
 	}
 
-	if ( isEnabled( 'pressable-premium-plan' ) ) {
-		page(
-			A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK,
-			requireAccessContext,
-			marketplaceReferPremiumPlanContext,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK,
+		requireAccessContext,
+		marketplaceReferPremiumPlanContext,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		`${ A4A_MARKETPLACE_HOSTING_LINK }/:section?`,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMobileBreakpoint, useDesktopBreakpoint } from '@automattic/viewport-react';
 import { RadioControl, TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
@@ -182,8 +181,6 @@ export default function PlanSelectionFilter( {
 		}
 	}, [ pressablePlan, lowPlanOptions, areSignaturePlans ] );
 
-	const isPressablePremiumPlanEnabled = isEnabled( 'pressable-premium-plan' );
-
 	const tabs = useMemo(
 		() => [
 			...( areSignaturePlans
@@ -213,16 +210,12 @@ export default function PlanSelectionFilter( {
 							title: isDesktop ? translate( 'Enterprise Plans' ) : translate( 'Enterprise' ),
 						},
 				  ] ),
-			...( isPressablePremiumPlanEnabled
-				? [
-						{
-							name: PLAN_CATEGORY_PREMIUM,
-							title: isDesktop ? translate( 'Premium Plans' ) : translate( 'Premium' ),
-						},
-				  ]
-				: [] ),
+			{
+				name: PLAN_CATEGORY_PREMIUM,
+				title: isDesktop ? translate( 'Premium Plans' ) : translate( 'Premium' ),
+			},
 		],
-		[ areSignaturePlans, disableStandardTab, isPressablePremiumPlanEnabled, translate, isDesktop ]
+		[ areSignaturePlans, disableStandardTab, translate, isDesktop ]
 	);
 
 	if ( isLoading ) {

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -49,8 +49,7 @@
 		"a4a-client-checkout-v2": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true,
-		"pressable-premium-plan": true
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -42,8 +42,7 @@
 		"a4a-client-checkout-v2": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true,
-		"pressable-premium-plan": true
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,8 +42,7 @@
 		"a4a-client-checkout-v2": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true,
-		"pressable-premium-plan": true
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -44,8 +44,7 @@
 		"a4a-client-checkout-v2": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true,
-		"pressable-premium-plan": true
+		"upgrades/redirect-payments": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1512/remove-pressable-woo-migration-incentive-feature-flag-logic

## Proposed Changes

* This PR removes the feature flag and it's logic for Pressable Premium Plan changes

## Why are these changes being made?

* Code cleanup

## Testing Instructions

* Verify the changes make sense
* Open the A4A live link
* Verify the [card](https://github.com/Automattic/wp-calypso/pull/105326) is visible on the Overview page. 
* Verify the [banners](https://github.com/Automattic/wp-calypso/pull/105323) are visible
* Go to Marketplace: Hosting > Premier Agency Hosting > Verify the "Pressable Plans" tab is visible > Click the "Refer now and get rewarded" button  and verify you can see the referral form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
