### PR TITLE
Show a "Hosting Dashboard" toggle in the v1 account settings

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -2,7 +2,8 @@ import config from '@automattic/calypso-config';
 import { Button, Card, Dialog, FormInputValidation, FormLabel } from '@automattic/components';
 import { canBeTranslated, getLanguage, isLocaleVariant } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
-import { ExternalLink } from '@wordpress/components';
+import { Badge } from '@automattic/ui';
+import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components';
 import debugFactory from 'debug';
 import { fixMe, localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, get, map, size } from 'lodash';
@@ -58,6 +59,7 @@ import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
 import ToggleLandingPageSettings from './toggle-landing-page';
+import ToggleNewHostingDashboard from './toggle-new-hosting-dashboard.tsx';
 import ToggleUseCommunityTranslator from './toggle-use-community-translator';
 
 import './style.scss';
@@ -957,6 +959,23 @@ class Account extends Component {
 				<SectionHeader label={ translate( 'Interface settings' ) } />
 				<Card className="account__settings">
 					<form onSubmit={ this.saveInterfaceSettings }>
+						{ config.isEnabled( 'dashboard/v2' ) && (
+							<FormFieldset className="account__settings-admin-home">
+								<FormLabel id="account__new-hosting-dashboard">
+									<HStack justify="flex-start">
+										<div>{ translate( 'Hosting Dashboard' ) }</div>
+										<Badge intent="info">{ translate( 'New feature' ) }</Badge>
+									</HStack>
+								</FormLabel>
+								<ToggleNewHostingDashboard />
+								<FormSettingExplanation>
+									{ translate(
+										'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						) }
+
 						<FormFieldset>
 							<FormLabel id="account__language" htmlFor="language">
 								{ translate( 'Interface language' ) }

--- a/client/me/account/toggle-new-hosting-dashboard.tsx
+++ b/client/me/account/toggle-new-hosting-dashboard.tsx
@@ -8,16 +8,14 @@ import {
 	isSavingPreference,
 	isFetchingPreferences,
 } from 'calypso/state/preferences/selectors';
-import type { HostingDashboardV2OptInFlags } from '@automattic/api-core';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
 
 export default function ToggleNewHostingDashboard() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const enableNewHostingDashboard = useSelector(
 		( state ) =>
-			getPreference( state, 'enable-hosting-dashboard-v2' ) as
-				| HostingDashboardV2OptInFlags
-				| undefined
+			getPreference( state, 'hosting-dashboard-opt-in' ) as HostingDashboardOptIn | undefined
 	);
 
 	const isSaving = useSelector( isSavingPreference );
@@ -33,9 +31,9 @@ export default function ToggleNewHostingDashboard() {
 		const preference = {
 			value: value ? 'opt-in' : 'opt-out',
 			updated_at: new Date().toISOString(),
-		} satisfies HostingDashboardV2OptInFlags;
+		} satisfies HostingDashboardOptIn;
 
-		dispatch( savePreference( 'enable-hosting-dashboard-v2', preference ) );
+		dispatch( savePreference( 'hosting-dashboard-opt-in', preference ) );
 	};
 
 	return (

--- a/client/me/account/toggle-new-hosting-dashboard.tsx
+++ b/client/me/account/toggle-new-hosting-dashboard.tsx
@@ -8,12 +8,16 @@ import {
 	isSavingPreference,
 	isFetchingPreferences,
 } from 'calypso/state/preferences/selectors';
+import type { HostingDashboardV2OptInFlags } from '@automattic/api-core';
 
 export default function ToggleNewHostingDashboard() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const enableNewHostingDashboard = useSelector( ( state ) =>
-		getPreference( state, 'enable-hosting-dashboard-v2' )
+	const enableNewHostingDashboard = useSelector(
+		( state ) =>
+			getPreference( state, 'enable-hosting-dashboard-v2' ) as
+				| HostingDashboardV2OptInFlags
+				| undefined
 	);
 
 	const isSaving = useSelector( isSavingPreference );
@@ -25,15 +29,19 @@ export default function ToggleNewHostingDashboard() {
 				enabled: value,
 			} )
 		);
-		dispatch(
-			savePreference( 'enable-hosting-dashboard-v2', value ? new Date().toISOString() : '' )
-		);
+
+		const preference = {
+			value: value ? 'opt-in' : 'opt-out',
+			updated_at: new Date().toISOString(),
+		} satisfies HostingDashboardV2OptInFlags;
+
+		dispatch( savePreference( 'enable-hosting-dashboard-v2', preference ) );
 	};
 
 	return (
 		<div>
 			<ToggleControl
-				checked={ !! enableNewHostingDashboard }
+				checked={ enableNewHostingDashboard?.value === 'opt-in' }
 				onChange={ handleChange }
 				disabled={ isSaving || isFetching }
 				label={ translate( 'Try the new Hosting Dashboard' ) }

--- a/client/me/account/toggle-new-hosting-dashboard.tsx
+++ b/client/me/account/toggle-new-hosting-dashboard.tsx
@@ -1,0 +1,43 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import {
+	getPreference,
+	isSavingPreference,
+	isFetchingPreferences,
+} from 'calypso/state/preferences/selectors';
+
+export default function ToggleNewHostingDashboard() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const enableNewHostingDashboard = useSelector( ( state ) =>
+		getPreference( state, 'enable-hosting-dashboard-v2' )
+	);
+
+	const isSaving = useSelector( isSavingPreference );
+	const isFetching = useSelector( isFetchingPreferences );
+
+	const handleChange = ( value: boolean ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_account_new_hosting_dashboard_toggle', {
+				enabled: value,
+			} )
+		);
+		dispatch(
+			savePreference( 'enable-hosting-dashboard-v2', value ? new Date().toISOString() : '' )
+		);
+	};
+
+	return (
+		<div>
+			<ToggleControl
+				checked={ !! enableNewHostingDashboard }
+				onChange={ handleChange }
+				disabled={ isSaving || isFetching }
+				label={ translate( 'Try the new Hosting Dashboard' ) }
+			/>
+		</div>
+	);
+}

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -9,7 +9,13 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
 };
 
+export interface HostingDashboardV2OptInFlags {
+	value: 'opt-in' | 'opt-out';
+	updated_at: string; // ISO date string
+}
+
 export interface UserPreferences {
 	'sites-view'?: SitesViewPreferences;
 	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
+	'enable-hosting-dashboard-v2'?: HostingDashboardV2OptInFlags;
 }

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -9,7 +9,7 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 	layout?: Partial< ViewTable[ 'layout' ] & ViewGrid[ 'layout' ] >;
 };
 
-export interface HostingDashboardV2OptInFlags {
+export interface HostingDashboardOptIn {
 	value: 'unset' | 'opt-in' | 'opt-out';
 	updated_at: string; // ISO date string
 }
@@ -17,5 +17,5 @@ export interface HostingDashboardV2OptInFlags {
 export interface UserPreferences {
 	'sites-view'?: SitesViewPreferences;
 	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
-	'enable-hosting-dashboard-v2'?: HostingDashboardV2OptInFlags;
+	'hosting-dashboard-opt-in'?: HostingDashboardOptIn;
 }

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -10,7 +10,7 @@ export type SitesViewPreferences = Partial< Omit< SitesView, 'type' | 'layout' >
 };
 
 export interface HostingDashboardV2OptInFlags {
-	value: 'opt-in' | 'opt-out';
+	value: 'unset' | 'opt-in' | 'opt-out';
 	updated_at: string; // ISO date string
 }
 

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -5,7 +5,7 @@ import type { UserPreferences } from '@automattic/api-core';
 
 const defaultValues: Required< UserPreferences > = {
 	'sites-view': {},
-	'enable-hosting-dashboard-v2': { value: 'unset', updated_at: '' },
+	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
 };
 
 // Returns all user preferences, without applying any defaults.

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -5,6 +5,7 @@ import type { UserPreferences } from '@automattic/api-core';
 
 const defaultValues: Required< UserPreferences > = {
 	'sites-view': {},
+	'enable-hosting-dashboard-v2': { value: 'unset', updated_at: '' },
 };
 
 // Returns all user preferences, without applying any defaults.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-360

## Proposed Changes

* Add hosting dashboard opt-in toggle to account settings in v1
* Save opt-in as Calypso user preference

<img width="1074" height="1044" alt="CleanShot 2025-09-01 at 17 35 13@2x" src="https://github.com/user-attachments/assets/19310160-032f-4b41-bf22-7683d3457bb9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Add ability for early adopters to use the hosting dashboard. The opt-in mechanism is described at p58i-ncy-p2

This preference UI is slightly different from the one proposed in the P2 for the `/v2` user preferences. I thought for v1 it would be better to stay sympathetic with the existing UI. The "New features" badge shows uses an _info_ style instead of the and icon with a star. This is using the `<Badge>` from the `@automattic/ui` package which doesn't which only has intents such as "success" and "info"; no "up sell" or "new feature" intent. But we could follow up with a pull request to add a "promotion"-type intent to the UI package. CC @lucasmendes-design 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

At `/me/account`, toggle the new settings. The setting doesn't do anything at present.

You can confirm the preference is set by using the `dev` menu in the bottom right. Hover over the menu, hover over preferences, and observe the state of the `enable-hosting-dashboard-v2` preference.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?