### PR TITLE
Hosting Dashboard: Implement hosting activation modal

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
@@ -1,0 +1,84 @@
+import { Button, Card, CardBody, SelectControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import InlineSupportLink from '../../components/inline-support-link';
+import { Text } from '../../components/text';
+
+const DataCenterOptions = [
+	{
+		value: '',
+		label: __( 'Optimal data center' ),
+	},
+	{
+		value: 'bur',
+		label: __( 'US West' ),
+	},
+	{
+		value: 'dfw',
+		label: __( 'US Central' ),
+	},
+	{
+		value: 'dca',
+		label: __( 'US East' ),
+	},
+	{
+		value: 'ams',
+		label: __( 'EU West' ),
+	},
+];
+
+interface DataCenterFormProps {
+	value: string;
+	onChange: ( value: string ) => void;
+}
+
+export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
+	const [ shouldShowForm, setShouldShowForm ] = useState( false );
+
+	if ( ! shouldShowForm ) {
+		return (
+			<Text>
+				{ createInterpolateElement(
+					__(
+						'Your site will be placed in the optimal data center, but you can <button>change it</button>.'
+					),
+					{
+						button: <Button variant="link" onClick={ () => setShouldShowForm( true ) } />,
+					}
+				) }
+			</Text>
+		);
+	}
+
+	return (
+		<Card size="small">
+			<CardBody>
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={ __( 'Pick your primary data center' ) }
+					help={ createInterpolateElement(
+						__(
+							'For redundancy, your site will be replicated in real-time to another region. <link>Learn more</link>'
+						),
+						{
+							link: (
+								<InlineSupportLink
+									supportPostId={ 227309 }
+									// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+									supportLink="https://wordpress.com/support/choose-your-sites-primary-data-center/"
+								/>
+							),
+						}
+					) }
+					options={ DataCenterOptions.map( ( option ) => ( {
+						label: option.label,
+						value: option.value,
+					} ) ) }
+					onChange={ ( value ) => onChange( value ) }
+					value={ value }
+				/>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
@@ -1,0 +1,208 @@
+import {
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	CardDivider,
+	CardHeader,
+	ExternalLink,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
+import { Notice } from '../../components/notice';
+import { Text } from '../../components/text';
+import type { NoticeVariant } from '../../components/notice/types';
+import type { AutomatedTransferEligibilityError } from '@automattic/api-core';
+
+const EligibilityErrors = {
+	BLOCKED_ATOMIC_TRANSFER: 'blocked_atomic_transfer',
+	TRANSFER_ALREADY_EXISTS: 'transfer_already_exists',
+	NO_BUSINESS_PLAN: 'no_business_plan',
+	NO_JETPACK_SITES: 'no_jetpack_sites',
+	NO_VIP_SITES: 'no_vip_sites',
+	SITE_GRAYLISTED: 'site_graylisted',
+	NON_ADMIN_USER: 'non_admin_user',
+	NOT_RESOLVING_TO_WPCOM: 'not_resolving_to_wpcom',
+	NO_SSL_CERTIFICATE: 'no_ssl_certificate',
+	EMAIL_UNVERIFIED: 'email_unverified',
+	EXCESSIVE_DISK_SPACE: 'excessive_disk_space',
+	IS_STAGING_SITE: 'is_staging_site',
+} as const;
+
+type EligibilityErrors = ( typeof EligibilityErrors )[ keyof typeof EligibilityErrors ];
+
+type BlockingMessage = {
+	message: string;
+	variant: NoticeVariant;
+	supportUrl?: string;
+};
+
+const BlockingMessages: Partial< Record< EligibilityErrors, BlockingMessage > > = {
+	[ EligibilityErrors.BLOCKED_ATOMIC_TRANSFER ]: {
+		message: __(
+			'This site is not currently eligible to install themes and plugins, or activate hosting access. Please contact our support team for help.'
+		),
+		variant: 'error',
+	},
+	[ EligibilityErrors.TRANSFER_ALREADY_EXISTS ]: {
+		message: __(
+			'Installation in progress. Just a minute! Please wait until the installation is finished, then try again.'
+		),
+		variant: 'info',
+	},
+	[ EligibilityErrors.NO_JETPACK_SITES ]: {
+		message: __( 'Try using a different site.' ),
+		variant: 'error',
+	},
+	[ EligibilityErrors.NO_VIP_SITES ]: {
+		message: __( 'Try using a different site.' ),
+		variant: 'error',
+	},
+	[ EligibilityErrors.SITE_GRAYLISTED ]: {
+		message: __(
+			'There’s an ongoing site dispute. Contact us to review your site’s standing and resolve the dispute.'
+		),
+		variant: 'error',
+		// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+		supportUrl: 'https://wordpress.com/support/suspended-blogs/',
+	},
+	[ EligibilityErrors.NO_SSL_CERTIFICATE ]: {
+		message: __(
+			'Certificate installation in progress. Hold tight! We are setting up a digital certificate to allow secure browsing on your site using "HTTPS".'
+		),
+		variant: 'info',
+	},
+};
+
+type HoldingMessage = {
+	title: string;
+	description: string;
+	supportUrl?: string;
+};
+
+const HoldingMessages: Partial< Record< EligibilityErrors, HoldingMessage > > = {
+	[ EligibilityErrors.NO_BUSINESS_PLAN ]: {
+		// TODO: Resolve plan name instead of hardcoding it.
+		title: __( 'Business plan required' ),
+		description: __( 'You’ll also get to install custom themes, plugins, and have more storage.' ),
+	},
+	[ EligibilityErrors.NON_ADMIN_USER ]: {
+		title: __( 'Site administrator only' ),
+		description: __( 'Only the site administrators can use this feature.' ),
+		// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+		supportUrl: 'https://wordpress.com/support/user-roles/',
+	},
+	[ EligibilityErrors.NOT_RESOLVING_TO_WPCOM ]: {
+		title: __( 'Domain pointing to a different site' ),
+		description: __(
+			'Your domain is not properly set up to point to your site. Reset your domain’s A records in the Domains section to fix this.'
+		),
+		// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+		supportUrl: 'https://wordpress.com/support/move-domain/setting-custom-a-records/',
+	},
+	[ EligibilityErrors.EMAIL_UNVERIFIED ]: {
+		title: __( 'Confirm your email address' ),
+		description: __(
+			'Check your email for a message we sent you when you signed up. Click the link inside to confirm your email address. You may have to check your email client’s spam folder.'
+		),
+	},
+	[ EligibilityErrors.EXCESSIVE_DISK_SPACE ]: {
+		// TODO: Implement upsells
+		title: __( 'Increase storage space' ),
+		description: __(
+			'Your site does not have enough available storage space. Please purchase a plan with additional storage or contact our support team for help.'
+		),
+	},
+	[ EligibilityErrors.IS_STAGING_SITE ]: {
+		title: __( 'Create a new staging site' ),
+		description: __(
+			'Hosting features cannot be activated for a staging site. Create a new staging site to continue.'
+		),
+	},
+};
+
+/*
+	For Atomic sites on plans below Business it will return the holds TRANSFER_ALREADY_EXISTS and NO_BUSINESS_PLAN.
+	Because TRANSFER_ALREADY_EXISTS is present and 'blocking' it will show an "Upload in progress" notice even when there isn't one.
+	In this scenario we need to check if it's an Atomic ste (TRANSFER_ALREADY_EXISTS) on a plan below Business (NO_BUSINESS_PLAN)
+	so we can stop the render of "Upload in progress" and prompt them to upgrade instead.
+*/
+function isAtomicSiteWithoutBusinessPlan( errors: AutomatedTransferEligibilityError[] ) {
+	return [ EligibilityErrors.TRANSFER_ALREADY_EXISTS, EligibilityErrors.NO_BUSINESS_PLAN ].every(
+		( code ) => errors.some( ( error ) => error.code === code )
+	);
+}
+
+function findFirstBlockingError( errors: AutomatedTransferEligibilityError[] ) {
+	const error = errors.find( ( err ) => err.code in BlockingMessages );
+	if ( ! error ) {
+		return null;
+	}
+
+	return BlockingMessages[ error.code as EligibilityErrors ];
+}
+
+function findHoldingErrors( errors: AutomatedTransferEligibilityError[] ) {
+	return errors.reduce( ( acc, err ) => {
+		const holdingMessage = HoldingMessages[ err.code as EligibilityErrors ];
+		if ( holdingMessage ) {
+			acc.push( holdingMessage );
+		}
+
+		return acc;
+	}, [] as HoldingMessage[] );
+}
+
+export function hasBlockingError( errors: AutomatedTransferEligibilityError[] ) {
+	return findFirstBlockingError( errors ) !== null;
+}
+
+export function ErrorContentInfo( { errors }: { errors: AutomatedTransferEligibilityError[] } ) {
+	const blocking = ! isAtomicSiteWithoutBusinessPlan( errors ) && findFirstBlockingError( errors );
+	const holds = findHoldingErrors( errors );
+
+	return (
+		<VStack>
+			{ blocking && (
+				<Notice variant={ blocking.variant }>
+					{ blocking.message }
+					{ blocking.supportUrl && (
+						<>
+							{ ' ' }
+							<ExternalLink href={ blocking.supportUrl }>{ __( 'Learn more' ) }</ExternalLink>
+						</>
+					) }
+				</Notice>
+			) }
+			{ holds.length > 0 && (
+				<Card size="small">
+					<CardHeader>
+						<Text as="h2" weight={ 500 }>
+							{ __( 'To activate hosting access you’ll need to:' ) }
+						</Text>
+					</CardHeader>
+					{ holds.map( ( hold, index ) => (
+						<Fragment key={ index }>
+							<CardBody>
+								<VStack>
+									<Text as="h3" weight={ 500 }>
+										{ hold.title }
+									</Text>
+									<Text as="p">
+										{ hold.description }
+										{ hold.supportUrl && (
+											<>
+												{ ' ' }
+												<ExternalLink href={ hold.supportUrl }>{ __( 'Learn more' ) }</ExternalLink>
+											</>
+										) }
+									</Text>
+								</VStack>
+							</CardBody>
+							{ index < holds.length - 1 && <CardDivider /> }
+						</Fragment>
+					) ) }
+				</Card>
+			) }
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
@@ -1,0 +1,63 @@
+import { siteAutomatedTransfersEligibilityQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useHelpCenter } from '../../app/help-center';
+import { Notice } from '../../components/notice';
+import { DataCenterForm } from './data-center-form';
+import { hasBlockingError as getHasBlockingError, ErrorContentInfo } from './error-content-info';
+import { WarningContentInfo } from './warning-content-info';
+
+export default function HostingFeatureActivationModal( { siteId }: { siteId: number } ) {
+	const { data } = useSuspenseQuery( siteAutomatedTransfersEligibilityQuery( siteId ) );
+	const { setShowHelpCenter } = useHelpCenter();
+	const [ selectedGeoAffinity, setSelectedGeoAffinity ] = useState( '' );
+
+	if ( ! data ) {
+		return null;
+	}
+
+	const errors = data.errors;
+	const warnings = data.warnings;
+	const flattenedWarnings = Object.values( data.warnings ).flat();
+	const hasBlockingError = getHasBlockingError( errors );
+	const isEligibleAndNoIssues =
+		data.is_eligible && errors.length === 0 && flattenedWarnings.length === 0;
+
+	function getContent() {
+		if ( isEligibleAndNoIssues ) {
+			return <Notice variant="success">{ __( 'This site is eligible to continue.' ) }</Notice>;
+		}
+
+		return (
+			<>
+				{ errors.length > 0 && <ErrorContentInfo errors={ errors } /> }
+				{ flattenedWarnings.length > 0 && ! hasBlockingError && (
+					<WarningContentInfo warnings={ warnings } />
+				) }
+			</>
+		);
+	}
+
+	return (
+		<VStack spacing={ 6 }>
+			{ getContent() }
+			{ data.is_eligible && ! hasBlockingError && (
+				<DataCenterForm
+					value={ selectedGeoAffinity }
+					onChange={ ( value ) => setSelectedGeoAffinity( value ) }
+				/>
+			) }
+			<HStack>
+				<Button variant="link" onClick={ () => setShowHelpCenter( true ) }>
+					{ __( 'Need help?' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/hosting-feature-activation-modal/warning-content-info.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/warning-content-info.tsx
@@ -1,0 +1,112 @@
+import { Badge } from '@automattic/ui';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	CardDivider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
+import InlineSupportLink from '../../components/inline-support-link';
+import { Text } from '../../components/text';
+import type {
+	AutomatedTransferEligibilityWarning,
+	AutomatedTransferEligibilityWarningDomainNames,
+} from '@automattic/api-core';
+
+function splitDomainName( domainName: string ) {
+	const parts = domainName.split( '.' );
+	const first = parts.shift();
+	const rest = '.' + parts.join( '.' );
+	return { first, rest };
+}
+
+function DomainNames( { names }: { names: AutomatedTransferEligibilityWarningDomainNames } ) {
+	const items = [
+		{
+			label: splitDomainName( names.current ),
+			badgeLabel: __( 'current' ),
+			badgeIntent: 'default' as const,
+		},
+		{
+			label: splitDomainName( names.new ),
+			badgeLabel: __( 'new' ),
+			badgeIntent: 'success' as const,
+		},
+	];
+
+	return (
+		<VStack>
+			<Card size="small">
+				{ items.map( ( item, index ) => (
+					<Fragment key={ index }>
+						<CardBody>
+							<HStack>
+								<HStack justify="flex-start" spacing={ 0 } expanded={ false }>
+									<Text
+										as="span"
+										style={ {
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											whiteSpace: 'nowrap',
+										} }
+									>
+										{ item.label.first }
+									</Text>
+									<Text as="span" style={ { flexShrink: 0 } }>
+										{ item.label.rest }
+									</Text>
+								</HStack>
+								<Badge intent={ item.badgeIntent } style={ { flexShrink: 0 } }>
+									{ item.badgeLabel }
+								</Badge>
+							</HStack>
+						</CardBody>
+						{ index < items.length - 1 && <CardDivider /> }
+					</Fragment>
+				) ) }
+			</Card>
+		</VStack>
+	);
+}
+
+export function WarningContentInfo( {
+	warnings,
+}: {
+	warnings: AutomatedTransferEligibilityWarning;
+} ) {
+	return (
+		<VStack>
+			{ Object.keys( warnings ).map( ( type ) => {
+				const warningsByType = warnings[ type as keyof AutomatedTransferEligibilityWarning ];
+				if ( ! warningsByType.length ) {
+					return null;
+				}
+
+				return warningsByType.map( ( warning ) => (
+					<VStack key={ warning.id } spacing={ 6 }>
+						<Text>
+							<span
+								// eslint-disable-next-line react/no-danger
+								dangerouslySetInnerHTML={ { __html: warning.description } }
+							/>
+							{ warning.support_url && (
+								<>
+									{ ' ' }
+									<InlineSupportLink
+										supportLink={ warning.support_url }
+										supportPostId={ warning.support_post_id }
+									>
+										{ __( 'Learn more' ) }
+									</InlineSupportLink>
+								</>
+							) }
+						</Text>
+						{ warning.domain_names && <DomainNames names={ warning.domain_names } /> }
+					</VStack>
+				) );
+			} ) }
+		</VStack>
+	);
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -35,6 +35,7 @@ export * from './site';
 export * from './site-activity-log';
 export * from './site-address-change';
 export * from './site-atomic-transfers';
+export * from './site-automated-transfers-eligibility';
 export * from './site-backup';
 export * from './site-backup-download';
 export * from './site-backup-restore';

--- a/packages/api-core/src/site-automated-transfers-eligibility/fetchers.ts
+++ b/packages/api-core/src/site-automated-transfers-eligibility/fetchers.ts
@@ -1,0 +1,11 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AutomatedTransferEligibility } from './types';
+
+export async function fetchSiteAutomatedTransfersEligibility(
+	siteId: number
+): Promise< AutomatedTransferEligibility > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/automated-transfers/eligibility`,
+		apiVersion: '1',
+	} );
+}

--- a/packages/api-core/src/site-automated-transfers-eligibility/index.ts
+++ b/packages/api-core/src/site-automated-transfers-eligibility/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/site-automated-transfers-eligibility/types.ts
+++ b/packages/api-core/src/site-automated-transfers-eligibility/types.ts
@@ -1,0 +1,27 @@
+export type AutomatedTransferEligibilityError = {
+	code: string;
+	message: string;
+};
+
+export type AutomatedTransferEligibilityWarning = {
+	subdomains: AutomatedTransferEligibilityWarningDomain[];
+};
+
+export type AutomatedTransferEligibilityWarningDomainNames = {
+	current: string;
+	new: string;
+};
+
+export type AutomatedTransferEligibilityWarningDomain = {
+	id: string;
+	description: string;
+	domain_names: AutomatedTransferEligibilityWarningDomainNames;
+	support_url?: string;
+	support_post_id?: number;
+};
+
+export type AutomatedTransferEligibility = {
+	errors: Array< AutomatedTransferEligibilityError >;
+	is_eligible: boolean;
+	warnings: AutomatedTransferEligibilityWarning;
+};

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -27,6 +27,7 @@ export * from './site-activity-log';
 export * from './site-address-change';
 export * from './site-agency';
 export * from './site-atomic-transfers';
+export * from './site-automated-transfers-eligibility';
 export * from './site-backup-download';
 export * from './site-backup-restore';
 export * from './site-backups';

--- a/packages/api-queries/src/site-automated-transfers-eligibility.ts
+++ b/packages/api-queries/src/site-automated-transfers-eligibility.ts
@@ -1,0 +1,8 @@
+import { fetchSiteAutomatedTransfersEligibility } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const siteAutomatedTransfersEligibilityQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'automated-transfers', 'eligibility' ],
+		queryFn: () => fetchSiteAutomatedTransfersEligibility( siteId ),
+	} );


### PR DESCRIPTION
Ref DOTDASH-72

## Proposed Changes

This PR implements the eligibility status for the hosting activations modal. It has three states: blocking, warning, and success.

This PR also implements data center selection.

| Collapsed | Expanded |
| --- | --- |
| <img width="684" height="599" alt="SCR-20250902-jvlh" src="https://github.com/user-attachments/assets/6a92c4d1-d6c2-4b19-b35d-ed11d873639b" /> | <img width="621" height="575" alt="SCR-20250902-jvmw" src="https://github.com/user-attachments/assets/cd02dde7-4133-43e2-852a-57f745a6005b" /> |

>[!NOTE]
>Save button behavior and event tracking will be addressed in separate PRs.

### Blocking Error

| v1 | v2 |
| --- | --- |
|  <img width="526" height="368" alt="SCR-20250831-ikfw" src="https://github.com/user-attachments/assets/3ab57f82-f81b-4c60-bb74-b97febced87a" /> | <img width="522" height="220" alt="SCR-20250831-ukog" src="https://github.com/user-attachments/assets/933e93f3-d05d-48db-bfd7-1b6ec798e133" /> |

>[!NOTE]
>Blocking status SITE_PRIVATE and SITE_UNLAUNCHED are legacy and thus not brought over. See fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sngbzvp%2Sryvtvovyvgl.cuc%3Se%3Q0opq54o4%23143-og  and notice `can_transfer_private_blog()` now always return true.

### Holding Error

| v1 | v2 | 
| --- | --- | 
| <img width="538" height="854" alt="SCR-20250901-obpn" src="https://github.com/user-attachments/assets/9fa63294-c310-47d8-acf9-28a605335373" /> |  <img width="522" height="481" alt="SCR-20250901-obkw" src="https://github.com/user-attachments/assets/e893a3dc-587f-4b67-a192-7461d6ace48c" /> |

>[!NOTE]
>Blocking and holding errors are different in the sense that the latter are solvable by the user. Hence holding errors provide guidance for users to follow so that they can transfer their site to Atomic.

>[!NOTE]
>Holding errors NO_BUSINESS and EXCESSIVE_DISK_SPACE are more complicated in that they require additional data. They'll be addressed separately once the modal is completed. 

### Warning

| v1 | v2 |
| --- | --- |
| <img width="535" height="453" alt="SCR-20250901-socf" src="https://github.com/user-attachments/assets/bafd91d5-cbf5-48ce-a827-9d3967080eb4" /> | <img width="534" height="380" alt="SCR-20250902-jmxs" src="https://github.com/user-attachments/assets/31a96303-cc16-4463-8ea3-916112ac37b4" /> |

### Success

| v1 | v2 |
| --- | --- | 
| <img width="537" height="151" alt="SCR-20250901-oigo" src="https://github.com/user-attachments/assets/839191d3-1242-4ed7-a577-368b8a8cec0f" /> |  <img width="528" height="181" alt="SCR-20250901-oirl" src="https://github.com/user-attachments/assets/4cc9b753-69f0-4093-b450-fe24a063c996" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The hosting activation modal is only enabled in the HD. As such, ensure that the v1 backport still loads the existing activation modal.

To test success, ensure you have a Simple Business site with a custom domain. 
To test warnings, ensure you have a Simple Business site without a custom domain.
To test other warnings, holdings, and blockings, just modify fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sngbzvp%2Sryvtvovyvgl.cuc%3Se%3Q0opq54o4%23143-og in your sandbox and update the logic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?