### PR TITLE
Hosting Dashboard: Fix WordPress.com log in settings updated too optimistically

### DIFF
--- a/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
@@ -131,21 +131,23 @@ export default function SsoForm( { site }: { site: Site } ) {
 			);
 		}
 
-		// Avoid showing a double notification if both module and settings have been changed.
-		if ( areSettingsDirty && ! isModuleDirty ) {
+		if ( areSettingsDirty ) {
 			jetpackSettingsMutation.mutate(
 				{
 					jetpack_sso_match_by_email: formData.jetpack_sso_match_by_email,
 					jetpack_sso_require_two_step: formData.jetpack_sso_require_two_step,
 				},
-				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
-					},
-					onError: () => {
-						createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
-					},
-				}
+				// Avoid showing a double notification if both module and settings have been changed.
+				! isModuleDirty
+					? {
+							onSuccess: () => {
+								createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+							},
+							onError: () => {
+								createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+							},
+					  }
+					: {}
 			);
 		}
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14357

## Proposed Changes

* Fix a regression introduced when preventing a double notification when saving a form updating two different queries.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In https://github.com/Automattic/wp-calypso/pull/105182/commits/0938343006713ef7cc5b75bd9307ee3fe5c86121 I added an `! isModuleDirty` check to avoid showing a double notification if both module and settings have been changed.

The check was carelessly added to the main conditional block instead of just the notices.

The result was that the settings checkboxes would only be saved if the module checkboxes was unchanged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: these instructions are only relevant for Atomic/Jetpack sites.

* Open `/v2/sites/:SITE/settings/wpcom-login`
* In separate tab, open `/settings/security/:SITE` to check if the changes are actually saved on the server.
* Play around with the three checkboxes.
* Ensure that, by changing both the module checkbox (the first one) and the settings checkboxes together in the same save, all changes are saved on the server.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
