### PR TITLE
Hosting Dashboard: Enable security settings in production

### DIFF
--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -4,9 +4,7 @@ import {
 	siteJetpackConnectionQuery,
 	siteJetpackModulesQuery,
 } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import { __experimentalText as Text, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -32,10 +30,6 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 		...siteJetpackConnectionQuery( site.ID ),
 		enabled: ! isSimple( site ),
 	} );
-
-	if ( ! isEnabled( 'dashboard/v2/security-settings' ) ) {
-		throw notFound();
-	}
 
 	const modulesAvailable =
 		isJetpackModuleAvailable( jetpackModules, jetpackConnection, JetpackModules.WAF ) &&

--- a/client/dashboard/sites/settings-web-application-firewall/summary.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/summary.tsx
@@ -1,6 +1,5 @@
 import { JetpackModules } from '@automattic/api-core';
 import { siteJetpackConnectionQuery, siteJetpackModulesQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -26,10 +25,6 @@ export default function WebApplicationFirewallSettingsSummary( {
 		...siteJetpackConnectionQuery( site.ID ),
 		enabled: ! isSimple( site ),
 	} );
-
-	if ( ! isEnabled( 'dashboard/v2/security-settings' ) ) {
-		return null;
-	}
 
 	const modulesAvailable =
 		isJetpackModuleAvailable( jetpackModules, jetpackConnection, JetpackModules.WAF ) &&

--- a/client/dashboard/sites/settings-wpcom-login/index.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/index.tsx
@@ -4,9 +4,7 @@ import {
 	siteJetpackConnectionQuery,
 	siteJetpackModulesQuery,
 } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import { __experimentalText as Text, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -29,10 +27,6 @@ export default function WpcomLoginSettings( { siteSlug }: { siteSlug: string } )
 		...siteJetpackConnectionQuery( site.ID ),
 		enabled: ! isSimple( site ),
 	} );
-
-	if ( ! isEnabled( 'dashboard/v2/security-settings' ) ) {
-		throw notFound();
-	}
 
 	const ssoAvailable = isJetpackModuleAvailable(
 		jetpackModules,

--- a/client/dashboard/sites/settings-wpcom-login/summary.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/summary.tsx
@@ -1,6 +1,5 @@
 import { HostingFeatures, JetpackModules } from '@automattic/api-core';
 import { siteJetpackConnectionQuery, siteJetpackModulesQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -30,10 +29,6 @@ export default function WpcomLoginSettingsSummary( {
 		...siteJetpackConnectionQuery( site.ID ),
 		enabled: ! isSimple( site ),
 	} );
-
-	if ( ! isEnabled( 'dashboard/v2/security-settings' ) ) {
-		return null;
-	}
 
 	const ssoAvailable = isJetpackModuleAvailable(
 		jetpackModules,

--- a/config/development.json
+++ b/config/development.json
@@ -54,7 +54,6 @@
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/backport/sites-list": true,
-		"dashboard/v2/security-settings": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,6 @@
 		"dashboard/v2": false,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/backport/sites-list": true,
-		"dashboard/v2/security-settings": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domains/ui-redesign": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,6 @@
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/backport/sites-list": true,
-		"dashboard/v2/security-settings": false,
 		"domains/ui-redesign": true,
 		"domain-search-rewrite": false,
 		"global-styles/on-personal-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,6 @@
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/backport/sites-list": true,
-		"dashboard/v2/security-settings": false,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domains/ui-redesign": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,7 +37,6 @@
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/backport/sites-list": true,
-		"dashboard/v2/security-settings": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14359
Fixes DOTCOM-13963

## Proposed Changes

* Removes the `dashboard/v2/security-settings` feature flag, releasing the security settings of the Hosting Dashboard in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the security settings in `/v2/sites/:SITE/settings`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
