### PR TITLE
Dotcom 14339/redesign the closed chat footer

### DIFF
--- a/packages/odie-client/src/components/closed-conversation-footer/index.tsx
+++ b/packages/odie-client/src/components/closed-conversation-footer/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useOdieAssistantContext } from '../../context';
 import { useManageSupportInteraction } from '../../data';
@@ -20,11 +19,13 @@ export const ClosedConversationFooter = () => {
 	};
 
 	return (
-		<div className="odie-closed-conversation-footer">
-			<Button onClick={ handleOnClick } className="odie-closed-conversation-footer__button">
-				<Icon icon={ comment } />
-				{ __( 'New conversation', __i18n_text_domain__ ) }
-			</Button>
-		</div>
+		<Button
+			onClick={ handleOnClick }
+			className="button odie-closed-conversation-footer__button"
+			variant="secondary"
+			__next40pxDefaultSize
+		>
+			{ __( 'Still need help? Start a new chat', __i18n_text_domain__ ) }
+		</Button>
 	);
 };

--- a/packages/odie-client/src/components/closed-conversation-footer/style.scss
+++ b/packages/odie-client/src/components/closed-conversation-footer/style.scss
@@ -1,56 +1,7 @@
 @import "@automattic/typography/styles/variables";
 
-.odie-closed-conversation-footer {
-	border-top: 1px solid var(--studio-gray-5, #DCDCDE);
+.odie-closed-conversation-footer__button {
 	background: var(--studio-white, #FFF);
-	box-sizing: border-box;
-
+	border-radius: 8px;
 	width: 100%;
-	display: flex;
-	padding: 16px;
-	flex-direction: column;
-	align-items: center;
-	gap: 10px;
-
-	span {
-		color: var(--studio-gray-40, #787C82);
-		font-size: $font-body-small;
-		line-height: 20px;
-	}
-
-	.odie-closed-conversation-footer__button {
-		display: flex;
-		height: 40px;
-		padding: 10px 24px;
-		justify-content: center;
-		align-items: center;
-		gap: 10px;
-		align-self: stretch;
-
-		border-radius: 4px;
-		border: 1px solid var(--studio-gray-10, #C3C4C7);
-		background: var(--studio-white, #FFF);
-		color: var(--studio-gray-100, #101517);
-
-		svg {
-			color: var(--studio-gray-40);
-		}
-
-		&:hover {
-			border-color: var(--color-neutral-20)  !important;
-		}
-
-		&:focus {
-			outline: var(--studio-blue-50, #0675c4) solid 2px !important;
-		}
-
-		&:focus,
-		&:hover {
-			color: var(--studio-gray-100, #101517) !important;
-
-			svg {
-				color: var(--studio-gray-40);
-			}
-		}
-	}
 }

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -33,7 +33,9 @@ export const OdieAssistant: React.FC = () => {
 			<div className="chat-box-message-container" id="odie-messages-container">
 				<MessagesContainer currentUser={ currentUser } />
 			</div>
-			{ showClosedConversationFooter ? <ClosedConversationFooter /> : <OdieSendMessageButton /> }
+			<div className="odie-chat-message-input-container">
+				{ showClosedConversationFooter ? <ClosedConversationFooter /> : <OdieSendMessageButton /> }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14339/redesign-the-closed-chat-footer

## Proposed Changes

Before

<img width="429" height="291" alt="image" src="https://github.com/user-attachments/assets/2f5683f7-2d68-4d4a-8c6e-d58e45a8863d" />


After

<img width="437" height="269" alt="image" src="https://github.com/user-attachments/assets/fdfc36c0-1379-4dc5-83e2-5ce72c1ad7ae" />


The part changed in the PR is just the button, not the feedback or the messages.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a solved chat or open a new chat with Zendesk and solve it.