### PR TITLE
POC - Reader full-screen gallery

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -90,6 +90,12 @@
 			border-bottom-right-radius: $radius-large;
 		}
 	}
+
+	// Gallery images should show pointer cursor to indicate they're clickable
+	.wp-block-gallery .wp-block-image img,
+	.tiled-gallery img {
+		cursor: pointer;
+	}
 	.image-wrapper img {
 		border-radius: $radius-large;
 		display: inherit;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -95,6 +95,25 @@
 	.wp-block-gallery .wp-block-image img,
 	.tiled-gallery img {
 		cursor: pointer;
+		transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+		&:hover {
+			transform: scale(1.02);
+			box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		}
+
+		&:active {
+			transform: scale(0.98);
+		}
+	}
+
+	// Add focus styles for keyboard navigation
+	.wp-block-gallery .wp-block-image,
+	.tiled-gallery figure {
+		&:focus-within img {
+			outline: 2px solid var(--color-accent, #0073aa);
+			outline-offset: 2px;
+		}
 	}
 	.image-wrapper img {
 		border-radius: $radius-large;

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -19,6 +19,7 @@ const GalleryOverlay = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ imageError, setImageError ] = useState( false );
+	const [ imageKey, setImageKey ] = useState( 0 );
 	const [ touchStart, setTouchStart ] = useState( null );
 	const [ touchEnd, setTouchEnd ] = useState( null );
 	const [ isTransitioning, setIsTransitioning ] = useState( false );
@@ -138,6 +139,7 @@ const GalleryOverlay = ( {
 	useEffect( () => {
 		if ( isOpen ) {
 			setImageError( false );
+			setImageKey( ( prev ) => prev + 1 );
 		}
 	}, [ currentIndex, isOpen ] );
 
@@ -389,13 +391,8 @@ const GalleryOverlay = ( {
 										className="gallery-overlay__retry-button"
 										onClick={ () => {
 											setImageError( false );
-											// Force image reload by updating src
-											const imgElement = document.querySelector( '.gallery-overlay__image' );
-											if ( imgElement ) {
-												const originalSrc = imgElement.src;
-												imgElement.src = '';
-												imgElement.src = originalSrc;
-											}
+											// Force image reload by incrementing key to trigger re-render
+											setImageKey( ( prev ) => prev + 1 );
 										} }
 									>
 										{ translate( 'Retry' ) }
@@ -404,6 +401,7 @@ const GalleryOverlay = ( {
 							</div>
 						) : (
 							<img
+								key={ `${ currentIndex }-${ imageKey }` }
 								src={ currentImage.src }
 								alt={
 									currentImage.alt ||

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -21,6 +21,8 @@ const GalleryOverlay = ( {
 } ) => {
 	const translate = useTranslate();
 	const [ isImageLoading, setIsImageLoading ] = useState( false );
+	const [ imageError, setImageError ] = useState( false );
+	const [ imageDimensions, setImageDimensions ] = useState( null );
 	const [ touchStart, setTouchStart ] = useState( null );
 	const [ touchEnd, setTouchEnd ] = useState( null );
 
@@ -107,27 +109,85 @@ const GalleryOverlay = ( {
 		};
 	}, [ isOpen ] );
 
-	// Preload adjacent images for smooth navigation
+	// Enhanced preloading for smoother navigation and performance
 	useEffect( () => {
 		if ( ! isOpen || ! hasMultipleImages ) {
 			return;
 		}
 
-		const preloadImage = ( src ) => {
-			const img = new Image();
-			img.src = src;
+		const preloadImage = ( src, priority = 'normal' ) => {
+			return new Promise( ( resolve, reject ) => {
+				const img = new Image();
+
+				// Handle successful load
+				img.onload = () => {
+					resolve( img );
+				};
+
+				// Handle load errors
+				img.onerror = () => {
+					reject( new Error( `Failed to preload image: ${ src }` ) );
+				};
+
+				// Set loading priority if supported
+				if ( 'loading' in img ) {
+					img.loading = priority === 'high' ? 'eager' : 'lazy';
+				}
+
+				// Start loading
+				img.src = src;
+			} );
 		};
 
-		// Preload next image
-		if ( hasNext ) {
-			preloadImage( images[ currentIndex + 1 ].src );
-		}
+		const preloadImages = async () => {
+			const preloadPromises = [];
 
-		// Preload previous image
-		if ( hasPrevious ) {
-			preloadImage( images[ currentIndex - 1 ].src );
-		}
+			// Preload adjacent images with high priority
+			if ( hasNext ) {
+				preloadPromises.push(
+					preloadImage( images[ currentIndex + 1 ].src, 'high' ).catch( () => {} ) // Silently handle preload failures
+				);
+			}
+
+			if ( hasPrevious ) {
+				preloadPromises.push(
+					preloadImage( images[ currentIndex - 1 ].src, 'high' ).catch( () => {} )
+				);
+			}
+
+			// Preload further images with normal priority
+			const furtherIndices = [];
+			if ( currentIndex + 2 < images.length ) {
+				furtherIndices.push( currentIndex + 2 );
+			}
+			if ( currentIndex - 2 >= 0 ) {
+				furtherIndices.push( currentIndex - 2 );
+			}
+
+			furtherIndices.forEach( ( index ) => {
+				preloadPromises.push( preloadImage( images[ index ].src, 'normal' ).catch( () => {} ) );
+			} );
+
+			// Execute all preloads without blocking
+			if ( preloadPromises.length > 0 ) {
+				Promise.allSettled( preloadPromises );
+			}
+		};
+
+		// Debounce preloading to avoid excessive requests during rapid navigation
+		const timeoutId = setTimeout( preloadImages, 100 );
+
+		return () => clearTimeout( timeoutId );
 	}, [ isOpen, hasMultipleImages, hasNext, hasPrevious, currentIndex, images ] );
+
+	// Reset image states when current image changes
+	useEffect( () => {
+		if ( isOpen ) {
+			setImageError( false );
+			setImageDimensions( null );
+			setIsImageLoading( true );
+		}
+	}, [ currentIndex, isOpen ] );
 
 	// Handle orientation changes for better responsive behavior
 	useEffect( () => {
@@ -158,12 +218,60 @@ const GalleryOverlay = ( {
 		return null;
 	}
 
-	const handleImageLoad = () => {
+	const handleImageLoad = ( event ) => {
 		setIsImageLoading( false );
+		setImageError( false );
+
+		// Track image dimensions for better aspect ratio handling
+		const img = event.target;
+		setImageDimensions( {
+			width: img.naturalWidth,
+			height: img.naturalHeight,
+			aspectRatio: img.naturalWidth / img.naturalHeight,
+		} );
 	};
 
 	const handleImageLoadStart = () => {
 		setIsImageLoading( true );
+		setImageError( false );
+		setImageDimensions( null );
+	};
+
+	const getFallbackImageSrc = ( image ) => {
+		// Try different image size variants
+		const originalSrc = image.src;
+
+		// If we're loading a high-res version, try medium or thumbnail
+		if ( originalSrc.includes( '?w=' ) || originalSrc.includes( '&w=' ) ) {
+			// Try medium size first
+			const mediumSrc = originalSrc.replace( /[?&]w=\d+/, '?w=800' );
+			if ( mediumSrc !== originalSrc ) {
+				return mediumSrc;
+			}
+		}
+
+		// Try removing size parameters entirely for original
+		const baseSrc = originalSrc.split( '?' )[ 0 ];
+		if ( baseSrc !== originalSrc ) {
+			return baseSrc;
+		}
+
+		// No fallback available
+		return null;
+	};
+
+	const handleImageError = ( event ) => {
+		setIsImageLoading( false );
+		setImageError( true );
+		setImageDimensions( null );
+
+		// Try to load a fallback if available
+		const img = event.target;
+		const fallbackSrc = getFallbackImageSrc( currentImage );
+
+		if ( fallbackSrc && img.src !== fallbackSrc ) {
+			img.src = fallbackSrc;
+		}
 	};
 
 	const handleBackdropClick = () => {
@@ -277,20 +385,63 @@ const GalleryOverlay = ( {
 						onTouchMove={ handleTouchMove }
 						onTouchEnd={ handleTouchEnd }
 					>
-						{ ( isImageLoading || isLoading ) && (
+						{ ( isImageLoading || isLoading ) && ! imageError && (
 							<div className="gallery-overlay__loading">
 								<Gridicon icon="sync" size={ 48 } />
 							</div>
 						) }
-						<img
-							src={ currentImage.src }
-							alt={ currentImage.alt }
-							className={ clsx( 'gallery-overlay__image', {
-								'is-loading': isImageLoading,
-							} ) }
-							onLoad={ handleImageLoad }
-							onLoadStart={ handleImageLoadStart }
-						/>
+
+						{ imageError ? (
+							<div className="gallery-overlay__image-error">
+								<div className="gallery-overlay__image-error-content">
+									<Gridicon icon="image" size={ 48 } />
+									<p>{ translate( 'Unable to load image' ) }</p>
+									<button
+										className="gallery-overlay__retry-button"
+										onClick={ () => {
+											setImageError( false );
+											setIsImageLoading( true );
+											// Force image reload by updating src
+											const imgElement = document.querySelector( '.gallery-overlay__image' );
+											if ( imgElement ) {
+												const originalSrc = imgElement.src;
+												imgElement.src = '';
+												imgElement.src = originalSrc;
+											}
+										} }
+									>
+										{ translate( 'Retry' ) }
+									</button>
+								</div>
+							</div>
+						) : (
+							<img
+								src={ currentImage.src }
+								alt={ currentImage.alt }
+								width={ currentImage.width }
+								height={ currentImage.height }
+								className={ clsx( 'gallery-overlay__image', {
+									'is-loading': isImageLoading,
+									'has-dimensions': imageDimensions,
+									'is-wide': imageDimensions?.aspectRatio > 1.5,
+									'is-tall': imageDimensions?.aspectRatio < 0.67,
+								} ) }
+								style={
+									imageDimensions
+										? {
+												'--image-aspect-ratio': imageDimensions.aspectRatio,
+												'--image-width': imageDimensions.width,
+												'--image-height': imageDimensions.height,
+										  }
+										: {}
+								}
+								onLoad={ handleImageLoad }
+								onLoadStart={ handleImageLoadStart }
+								onError={ handleImageError }
+								loading="eager"
+								decoding="async"
+							/>
+						) }
 					</div>
 				) }
 

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -75,7 +75,8 @@ const GalleryOverlay = ( {
 						event.preventDefault();
 						onClose();
 					}
-					break;
+					// If focused on a button, let the button handle it naturally
+					return;
 				case 'Home':
 					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst && ! isInteractingWithButton ) {
 						event.preventDefault();
@@ -101,7 +102,6 @@ const GalleryOverlay = ( {
 				default:
 					return;
 			}
-			event.preventDefault();
 		};
 
 		if ( isOpen ) {

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -1,0 +1,194 @@
+import { Gridicon } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+
+import './gallery-overlay.scss';
+
+const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrevious } ) => {
+	const translate = useTranslate();
+	const [ isImageLoading, setIsImageLoading ] = useState( false );
+
+	// Handle keyboard events
+	useEffect( () => {
+		const handleKeydown = ( event ) => {
+			if ( ! isOpen ) {
+				return;
+			}
+
+			switch ( event.key ) {
+				case 'Escape':
+					onClose();
+					break;
+				case 'ArrowLeft':
+					onPrevious();
+					break;
+				case 'ArrowRight':
+					onNext();
+					break;
+				case ' ':
+				case 'Enter':
+					onClose();
+					break;
+				default:
+					return;
+			}
+			event.preventDefault();
+		};
+
+		if ( isOpen ) {
+			document.addEventListener( 'keydown', handleKeydown );
+		}
+
+		return () => {
+			document.removeEventListener( 'keydown', handleKeydown );
+		};
+	}, [ isOpen, onClose, onNext, onPrevious ] );
+
+	// Prevent body scroll when overlay is open
+	useEffect( () => {
+		if ( isOpen ) {
+			document.body.style.overflow = 'hidden';
+		} else {
+			document.body.style.overflow = '';
+		}
+
+		return () => {
+			document.body.style.overflow = '';
+		};
+	}, [ isOpen ] );
+
+	if ( ! isOpen || ! images.length ) {
+		return null;
+	}
+
+	const currentImage = images[ currentIndex ];
+	const hasMultipleImages = images.length > 1;
+	const hasPrevious = currentIndex > 0;
+	const hasNext = currentIndex < images.length - 1;
+
+	const handleImageLoad = () => {
+		setIsImageLoading( false );
+	};
+
+	const handleImageLoadStart = () => {
+		setIsImageLoading( true );
+	};
+
+	const handleBackdropClick = () => {
+		// Close overlay when clicking on the backdrop
+		onClose();
+	};
+
+	const handleBackdropKeyDown = ( event ) => {
+		// Handle keyboard events on the backdrop for accessibility
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			onClose();
+		}
+	};
+
+	return (
+		<div
+			className="gallery-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-label={ translate( 'Gallery image viewer' ) }
+		>
+			<div
+				className="gallery-overlay__backdrop"
+				onClick={ handleBackdropClick }
+				onKeyDown={ handleBackdropKeyDown }
+				role="button"
+				tabIndex={ 0 }
+				aria-label={ translate( 'Close gallery' ) }
+			/>
+
+			{ /* Close button */ }
+			<button
+				className="gallery-overlay__close"
+				onClick={ onClose }
+				aria-label={ translate( 'Close gallery' ) }
+			>
+				<Gridicon icon="cross" size={ 24 } />
+			</button>
+
+			{ /* Previous button */ }
+			{ hasMultipleImages && hasPrevious && (
+				<button
+					className="gallery-overlay__nav gallery-overlay__nav--previous"
+					onClick={ onPrevious }
+					aria-label={ translate( 'Previous image' ) }
+				>
+					<Gridicon icon="chevron-left" size={ 36 } />
+				</button>
+			) }
+
+			{ /* Next button */ }
+			{ hasMultipleImages && hasNext && (
+				<button
+					className="gallery-overlay__nav gallery-overlay__nav--next"
+					onClick={ onNext }
+					aria-label={ translate( 'Next image' ) }
+				>
+					<Gridicon icon="chevron-right" size={ 36 } />
+				</button>
+			) }
+
+			{ /* Image container */ }
+			<div className="gallery-overlay__content">
+				<div className="gallery-overlay__image-container">
+					{ isImageLoading && (
+						<div className="gallery-overlay__loading">
+							<Gridicon icon="sync" size={ 48 } />
+						</div>
+					) }
+					<img
+						src={ currentImage.src }
+						alt={ currentImage.alt }
+						className={ clsx( 'gallery-overlay__image', {
+							'is-loading': isImageLoading,
+						} ) }
+						onLoad={ handleImageLoad }
+						onLoadStart={ handleImageLoadStart }
+					/>
+				</div>
+
+				{ /* Image counter and caption */ }
+				<div className="gallery-overlay__info">
+					{ hasMultipleImages && (
+						<div className="gallery-overlay__counter">
+							{ translate( '%(current)d of %(total)d', {
+								args: {
+									current: currentIndex + 1,
+									total: images.length,
+								},
+							} ) }
+						</div>
+					) }
+					{ currentImage.caption && (
+						<div className="gallery-overlay__caption">{ currentImage.caption }</div>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+GalleryOverlay.propTypes = {
+	isOpen: PropTypes.bool.isRequired,
+	images: PropTypes.arrayOf(
+		PropTypes.shape( {
+			src: PropTypes.string.isRequired,
+			alt: PropTypes.string,
+			caption: PropTypes.string,
+		} )
+	).isRequired,
+	currentIndex: PropTypes.number.isRequired,
+	onClose: PropTypes.func.isRequired,
+	onNext: PropTypes.func.isRequired,
+	onPrevious: PropTypes.func.isRequired,
+};
+
+export default GalleryOverlay;

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -129,6 +129,30 @@ const GalleryOverlay = ( {
 		}
 	}, [ isOpen, hasMultipleImages, hasNext, hasPrevious, currentIndex, images ] );
 
+	// Handle orientation changes for better responsive behavior
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		const handleOrientationChange = () => {
+			// Small delay to allow viewport to adjust
+			setTimeout( () => {
+				// Force a re-render to adjust image sizing
+				setIsImageLoading( true );
+				setTimeout( () => setIsImageLoading( false ), 100 );
+			}, 100 );
+		};
+
+		window.addEventListener( 'orientationchange', handleOrientationChange );
+		window.addEventListener( 'resize', handleOrientationChange );
+
+		return () => {
+			window.removeEventListener( 'orientationchange', handleOrientationChange );
+			window.removeEventListener( 'resize', handleOrientationChange );
+		};
+	}, [ isOpen ] );
+
 	// Early return after all hooks to comply with Rules of Hooks
 	if ( ! isOpen || ! images.length ) {
 		return null;

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -22,10 +22,8 @@ const GalleryOverlay = ( {
 	const translate = useTranslate();
 	const [ isImageLoading, setIsImageLoading ] = useState( false );
 	const [ imageError, setImageError ] = useState( false );
-	const [ imageDimensions, setImageDimensions ] = useState( null );
 	const [ touchStart, setTouchStart ] = useState( null );
 	const [ touchEnd, setTouchEnd ] = useState( null );
-	const [ announcement, setAnnouncement ] = useState( '' );
 
 	// Calculate navigation states (safe defaults if images is empty)
 	const currentImage = images[ currentIndex ] || {};
@@ -54,8 +52,6 @@ const GalleryOverlay = ( {
 					if ( hasPrevious && ! isInteractingWithButton ) {
 						event.preventDefault();
 						onPrevious();
-						// Announce navigation to screen readers
-						setAnnouncement( translate( 'Navigated to previous image' ) );
 					}
 					break;
 				case 'ArrowRight':
@@ -63,8 +59,6 @@ const GalleryOverlay = ( {
 					if ( hasNext && ! isInteractingWithButton ) {
 						event.preventDefault();
 						onNext();
-						// Announce navigation to screen readers
-						setAnnouncement( translate( 'Navigated to next image' ) );
 					}
 					break;
 				case ' ':
@@ -85,7 +79,6 @@ const GalleryOverlay = ( {
 					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst && ! isInteractingWithButton ) {
 						event.preventDefault();
 						onGoToFirst();
-						setAnnouncement( translate( 'Navigated to first image' ) );
 					}
 					break;
 				case 'End':
@@ -97,7 +90,6 @@ const GalleryOverlay = ( {
 					) {
 						event.preventDefault();
 						onGoToLast();
-						setAnnouncement( translate( 'Navigated to last image' ) );
 					}
 					break;
 				case 'ArrowUp':
@@ -145,124 +137,32 @@ const GalleryOverlay = ( {
 		};
 	}, [ isOpen ] );
 
-	// Enhanced preloading for smoother navigation and performance
+	// Basic preloading for smoother navigation
 	useEffect( () => {
 		if ( ! isOpen || ! hasMultipleImages ) {
 			return;
 		}
 
-		const preloadImage = ( src, priority = 'normal' ) => {
-			return new Promise( ( resolve, reject ) => {
-				const img = new Image();
+		// Preload next image
+		if ( hasNext ) {
+			const img = new Image();
+			img.src = images[ currentIndex + 1 ].src;
+		}
 
-				// Handle successful load
-				img.onload = () => {
-					resolve( img );
-				};
-
-				// Handle load errors
-				img.onerror = () => {
-					reject( new Error( `Failed to preload image: ${ src }` ) );
-				};
-
-				// Set loading priority if supported
-				if ( 'loading' in img ) {
-					img.loading = priority === 'high' ? 'eager' : 'lazy';
-				}
-
-				// Start loading
-				img.src = src;
-			} );
-		};
-
-		const preloadImages = async () => {
-			const preloadPromises = [];
-
-			// Preload adjacent images with high priority
-			if ( hasNext ) {
-				preloadPromises.push(
-					preloadImage( images[ currentIndex + 1 ].src, 'high' ).catch( () => {} ) // Silently handle preload failures
-				);
-			}
-
-			if ( hasPrevious ) {
-				preloadPromises.push(
-					preloadImage( images[ currentIndex - 1 ].src, 'high' ).catch( () => {} )
-				);
-			}
-
-			// Preload further images with normal priority
-			const furtherIndices = [];
-			if ( currentIndex + 2 < images.length ) {
-				furtherIndices.push( currentIndex + 2 );
-			}
-			if ( currentIndex - 2 >= 0 ) {
-				furtherIndices.push( currentIndex - 2 );
-			}
-
-			furtherIndices.forEach( ( index ) => {
-				preloadPromises.push( preloadImage( images[ index ].src, 'normal' ).catch( () => {} ) );
-			} );
-
-			// Execute all preloads without blocking
-			if ( preloadPromises.length > 0 ) {
-				Promise.allSettled( preloadPromises );
-			}
-		};
-
-		// Debounce preloading to avoid excessive requests during rapid navigation
-		const timeoutId = setTimeout( preloadImages, 100 );
-
-		return () => clearTimeout( timeoutId );
+		// Preload previous image
+		if ( hasPrevious ) {
+			const img = new Image();
+			img.src = images[ currentIndex - 1 ].src;
+		}
 	}, [ isOpen, hasMultipleImages, hasNext, hasPrevious, currentIndex, images ] );
 
 	// Reset image states when current image changes
 	useEffect( () => {
 		if ( isOpen ) {
 			setImageError( false );
-			setImageDimensions( null );
 			setIsImageLoading( true );
 		}
 	}, [ currentIndex, isOpen ] );
-
-	// Screen reader announcements for navigation
-	useEffect( () => {
-		if ( ! isOpen || ! hasMultipleImages ) {
-			return;
-		}
-
-		const imagePosition = translate( 'Image %(current)d of %(total)d', {
-			args: {
-				current: currentIndex + 1,
-				total: images.length,
-			},
-		} );
-
-		let announcementText = imagePosition;
-
-		if ( currentImage.alt ) {
-			announcementText += `. ${ currentImage.alt }`;
-		}
-
-		if ( currentImage.caption ) {
-			announcementText += `. ${ currentImage.caption }`;
-		}
-
-		// Delay announcement to avoid conflicts with navigation sounds
-		const timeoutId = setTimeout( () => {
-			setAnnouncement( announcementText );
-		}, 300 );
-
-		return () => clearTimeout( timeoutId );
-	}, [
-		currentIndex,
-		isOpen,
-		hasMultipleImages,
-		currentImage.alt,
-		currentImage.caption,
-		images.length,
-		translate,
-	] );
 
 	// Focus trap implementation
 	useEffect( () => {
@@ -373,60 +273,19 @@ const GalleryOverlay = ( {
 		return null;
 	}
 
-	const handleImageLoad = ( event ) => {
+	const handleImageLoad = () => {
 		setIsImageLoading( false );
 		setImageError( false );
-
-		// Track image dimensions for better aspect ratio handling
-		const img = event.target;
-		setImageDimensions( {
-			width: img.naturalWidth,
-			height: img.naturalHeight,
-			aspectRatio: img.naturalWidth / img.naturalHeight,
-		} );
 	};
 
 	const handleImageLoadStart = () => {
 		setIsImageLoading( true );
 		setImageError( false );
-		setImageDimensions( null );
 	};
 
-	const getFallbackImageSrc = ( image ) => {
-		// Try different image size variants
-		const originalSrc = image.src;
-
-		// If we're loading a high-res version, try medium or thumbnail
-		if ( originalSrc.includes( '?w=' ) || originalSrc.includes( '&w=' ) ) {
-			// Try medium size first
-			const mediumSrc = originalSrc.replace( /[?&]w=\d+/, '?w=800' );
-			if ( mediumSrc !== originalSrc ) {
-				return mediumSrc;
-			}
-		}
-
-		// Try removing size parameters entirely for original
-		const baseSrc = originalSrc.split( '?' )[ 0 ];
-		if ( baseSrc !== originalSrc ) {
-			return baseSrc;
-		}
-
-		// No fallback available
-		return null;
-	};
-
-	const handleImageError = ( event ) => {
+	const handleImageError = () => {
 		setIsImageLoading( false );
 		setImageError( true );
-		setImageDimensions( null );
-
-		// Try to load a fallback if available
-		const img = event.target;
-		const fallbackSrc = getFallbackImageSrc( currentImage );
-
-		if ( fallbackSrc && img.src !== fallbackSrc ) {
-			img.src = fallbackSrc;
-		}
 	};
 
 	const handleBackdropClick = () => {
@@ -479,17 +338,7 @@ const GalleryOverlay = ( {
 			role="dialog"
 			aria-modal="true"
 			aria-label={ translate( 'Gallery image viewer' ) }
-			aria-describedby={ hasMultipleImages ? 'gallery-description' : undefined }
 		>
-			{ /* Screen reader announcements */ }
-			<div
-				id="gallery-announcements"
-				aria-live="polite"
-				aria-atomic="true"
-				className="gallery-overlay__sr-only"
-			>
-				{ announcement }
-			</div>
 			<div
 				className="gallery-overlay__backdrop"
 				onClick={ handleBackdropClick }
@@ -514,15 +363,9 @@ const GalleryOverlay = ( {
 				<button
 					className="gallery-overlay__nav gallery-overlay__nav--previous"
 					onClick={ onPrevious }
-					aria-label={ translate( 'Previous image (%(current)d of %(total)d)', {
-						args: {
-							current: currentIndex,
-							total: images.length,
-						},
-					} ) }
-					title={ translate( 'Previous image' ) }
+					aria-label={ translate( 'Previous image' ) }
 				>
-					<Gridicon icon="chevron-left" size={ 36 } aria-hidden="true" />
+					<Gridicon icon="chevron-left" size={ 36 } />
 				</button>
 			) }
 
@@ -531,15 +374,9 @@ const GalleryOverlay = ( {
 				<button
 					className="gallery-overlay__nav gallery-overlay__nav--next"
 					onClick={ onNext }
-					aria-label={ translate( 'Next image (%(current)d of %(total)d)', {
-						args: {
-							current: currentIndex + 2,
-							total: images.length,
-						},
-					} ) }
-					title={ translate( 'Next image' ) }
+					aria-label={ translate( 'Next image' ) }
 				>
-					<Gridicon icon="chevron-right" size={ 36 } aria-hidden="true" />
+					<Gridicon icon="chevron-right" size={ 36 } />
 				</button>
 			) }
 
@@ -604,29 +441,12 @@ const GalleryOverlay = ( {
 										},
 									} )
 								}
-								width={ currentImage.width }
-								height={ currentImage.height }
 								className={ clsx( 'gallery-overlay__image', {
 									'is-loading': isImageLoading,
-									'has-dimensions': imageDimensions,
-									'is-wide': imageDimensions?.aspectRatio > 1.5,
-									'is-tall': imageDimensions?.aspectRatio < 0.67,
 								} ) }
-								style={
-									imageDimensions
-										? {
-												'--image-aspect-ratio': imageDimensions.aspectRatio,
-												'--image-width': imageDimensions.width,
-												'--image-height': imageDimensions.height,
-										  }
-										: {}
-								}
 								onLoad={ handleImageLoad }
 								onLoadStart={ handleImageLoadStart }
 								onError={ handleImageError }
-								loading="eager"
-								decoding="async"
-								aria-describedby={ currentImage.caption ? 'gallery-caption' : undefined }
 							/>
 						) }
 					</div>
@@ -636,11 +456,7 @@ const GalleryOverlay = ( {
 				{ ! error && (
 					<div className="gallery-overlay__info">
 						{ hasMultipleImages && (
-							<div
-								id="gallery-description"
-								className="gallery-overlay__counter"
-								aria-label={ translate( 'Gallery navigation information' ) }
-							>
+							<div className="gallery-overlay__counter">
 								{ translate( '%(current)d of %(total)d', {
 									args: {
 										current: currentIndex + 1,
@@ -650,14 +466,7 @@ const GalleryOverlay = ( {
 							</div>
 						) }
 						{ currentImage.caption && (
-							<div
-								id="gallery-caption"
-								className="gallery-overlay__caption"
-								role="img"
-								aria-label={ translate( 'Image caption' ) }
-							>
-								{ currentImage.caption }
-							</div>
+							<div className="gallery-overlay__caption">{ currentImage.caption }</div>
 						) }
 					</div>
 				) }

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -154,10 +154,12 @@ const GalleryOverlay = ( {
 		const previouslyFocusedElement = document.activeElement;
 
 		// Focus the close button when modal opens
-		const closeButton = document.querySelector( '.gallery-overlay__close' );
-		if ( closeButton ) {
-			closeButton.focus();
-		}
+		requestAnimationFrame( () => {
+			const closeButton = document.querySelector( '.gallery-overlay__close' );
+			if ( closeButton ) {
+				closeButton.focus();
+			}
+		} );
 
 		// Get all focusable elements within the modal
 		const getFocusableElements = () => {
@@ -167,21 +169,22 @@ const GalleryOverlay = ( {
 			}
 
 			const focusableSelectors = [
-				'button',
-				'[href]',
-				'input',
-				'select',
-				'textarea',
-				'[tabindex]:not([tabindex="-1"])',
+				'button:not([disabled]):not([aria-hidden="true"])',
+				'[href]:not([disabled]):not([aria-hidden="true"])',
+				'input:not([disabled]):not([aria-hidden="true"])',
+				'select:not([disabled]):not([aria-hidden="true"])',
+				'textarea:not([disabled]):not([aria-hidden="true"])',
+				'[tabindex]:not([tabindex="-1"]):not([disabled]):not([aria-hidden="true"])',
 			];
 
 			return Array.from( modal.querySelectorAll( focusableSelectors.join( ',' ) ) ).filter(
 				( element ) => {
+					const style = getComputedStyle( element );
 					return (
-						! element.disabled &&
 						element.offsetWidth > 0 &&
 						element.offsetHeight > 0 &&
-						getComputedStyle( element ).visibility !== 'hidden'
+						style.visibility !== 'hidden' &&
+						style.display !== 'none'
 					);
 				}
 			);
@@ -194,20 +197,29 @@ const GalleryOverlay = ( {
 
 			const focusableElements = getFocusableElements();
 			if ( focusableElements.length === 0 ) {
+				event.preventDefault();
 				return;
 			}
 
 			const firstElement = focusableElements[ 0 ];
 			const lastElement = focusableElements[ focusableElements.length - 1 ];
+			const currentElement = document.activeElement;
+
+			// Find current element index in our focusable list
+			const currentElementIndex = focusableElements.indexOf( currentElement );
 
 			if ( event.shiftKey ) {
-				// Shift + Tab: if focused on first element, go to last
-				if ( document.activeElement === firstElement ) {
+				// Shift + Tab (backwards)
+				if ( currentElementIndex <= 0 ) {
+					// If on first element or outside modal, go to last element
 					event.preventDefault();
 					lastElement.focus();
 				}
-			} else if ( document.activeElement === lastElement ) {
-				// Tab: if focused on last element, go to first
+			} else if (
+				currentElementIndex >= focusableElements.length - 1 ||
+				currentElementIndex === -1
+			) {
+				// Tab (forwards) - if on last element or outside modal, go to first element
 				event.preventDefault();
 				firstElement.focus();
 			}
@@ -219,7 +231,9 @@ const GalleryOverlay = ( {
 		return () => {
 			document.removeEventListener( 'keydown', handleTabKey );
 			if ( previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function' ) {
-				previouslyFocusedElement.focus();
+				requestAnimationFrame( () => {
+					previouslyFocusedElement.focus();
+				} );
 			}
 		};
 	}, [ isOpen ] );

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import './gallery-overlay.scss';
@@ -24,6 +24,7 @@ const GalleryOverlay = ( {
 	const [ touchEnd, setTouchEnd ] = useState( null );
 	const [ isTransitioning, setIsTransitioning ] = useState( false );
 	const [ slideDirection, setSlideDirection ] = useState( null );
+	const imageRef = useRef( null );
 
 	// Calculate navigation states (safe defaults if images is empty)
 	const currentImage = images[ currentIndex ] || {};
@@ -255,6 +256,32 @@ const GalleryOverlay = ( {
 		setImageError( true );
 	};
 
+	// Handle transition end for slide animations
+	const handleTransitionEnd = ( event ) => {
+		// Only handle our slide animations, not other transitions
+		if (
+			event.target === imageRef.current &&
+			( event.animationName === 'gallery-slide-out-left' ||
+				event.animationName === 'gallery-slide-out-right' )
+		) {
+			// Determine navigation direction from animation
+			const direction = event.animationName === 'gallery-slide-out-left' ? 'next' : 'previous';
+
+			// Perform navigation
+			if ( direction === 'next' && hasNext ) {
+				onNext();
+			} else if ( direction === 'previous' && hasPrevious ) {
+				onPrevious();
+			}
+
+			// Reset transition state after a brief delay for new image to appear
+			requestAnimationFrame( () => {
+				setIsTransitioning( false );
+				setSlideDirection( null );
+			} );
+		}
+	};
+
 	const handleBackdropClick = () => {
 		// Close overlay when clicking on the backdrop
 		onClose();
@@ -290,24 +317,10 @@ const GalleryOverlay = ( {
 		if ( isLeftSwipe && hasNext ) {
 			setSlideDirection( 'left' );
 			setIsTransitioning( true );
-			setTimeout( () => {
-				onNext();
-				setTimeout( () => {
-					setIsTransitioning( false );
-					setSlideDirection( null );
-				}, 50 );
-			}, 150 );
 		}
 		if ( isRightSwipe && hasPrevious ) {
 			setSlideDirection( 'right' );
 			setIsTransitioning( true );
-			setTimeout( () => {
-				onPrevious();
-				setTimeout( () => {
-					setIsTransitioning( false );
-					setSlideDirection( null );
-				}, 50 );
-			}, 150 );
 		}
 
 		setTouchStart( null );
@@ -401,6 +414,7 @@ const GalleryOverlay = ( {
 							</div>
 						) : (
 							<img
+								ref={ imageRef }
 								key={ `${ currentIndex }-${ imageKey }` }
 								src={ currentImage.src }
 								alt={
@@ -419,6 +433,7 @@ const GalleryOverlay = ( {
 								} ) }
 								onLoad={ handleImageLoad }
 								onError={ handleImageError }
+								onAnimationEnd={ handleTransitionEnd }
 							/>
 						) }
 					</div>

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 import './gallery-overlay.scss';
 
@@ -332,7 +333,7 @@ const GalleryOverlay = ( {
 		setTouchEnd( null );
 	};
 
-	return (
+	const overlayContent = (
 		<div
 			className="gallery-overlay"
 			role="dialog"
@@ -473,6 +474,9 @@ const GalleryOverlay = ( {
 			</div>
 		</div>
 	);
+
+	// Render the overlay at the document body level to ensure it's above all other elements
+	return isOpen ? createPortal( overlayContent, document.body ) : null;
 };
 
 GalleryOverlay.propTypes = {

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -6,7 +6,19 @@ import { useState, useEffect } from 'react';
 
 import './gallery-overlay.scss';
 
-const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrevious } ) => {
+const GalleryOverlay = ( {
+	isOpen,
+	images,
+	currentIndex,
+	isLoading,
+	error,
+	onClose,
+	onNext,
+	onPrevious,
+	onGoToFirst,
+	onGoToLast,
+	onClearError,
+} ) => {
 	const translate = useTranslate();
 	const [ isImageLoading, setIsImageLoading ] = useState( false );
 	const [ touchStart, setTouchStart ] = useState( null );
@@ -46,20 +58,13 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 					onClose();
 					break;
 				case 'Home':
-					if ( hasMultipleImages && currentIndex > 0 ) {
-						// Go to first image - we need to implement this
-						for ( let i = 0; i < currentIndex; i++ ) {
-							onPrevious();
-						}
+					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst ) {
+						onGoToFirst();
 					}
 					break;
 				case 'End':
-					if ( hasMultipleImages && currentIndex < images.length - 1 ) {
-						// Go to last image - we need to implement this
-						const stepsToEnd = images.length - 1 - currentIndex;
-						for ( let i = 0; i < stepsToEnd; i++ ) {
-							onNext();
-						}
+					if ( hasMultipleImages && currentIndex < images.length - 1 && onGoToLast ) {
+						onGoToLast();
 					}
 					break;
 				default:
@@ -80,6 +85,8 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 		onClose,
 		onNext,
 		onPrevious,
+		onGoToFirst,
+		onGoToLast,
 		hasPrevious,
 		hasNext,
 		hasMultipleImages,
@@ -228,44 +235,59 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 
 			{ /* Image container */ }
 			<div className="gallery-overlay__content">
-				<div
-					className="gallery-overlay__image-container"
-					onTouchStart={ handleTouchStart }
-					onTouchMove={ handleTouchMove }
-					onTouchEnd={ handleTouchEnd }
-				>
-					{ isImageLoading && (
-						<div className="gallery-overlay__loading">
-							<Gridicon icon="sync" size={ 48 } />
+				{ error ? (
+					<div className="gallery-overlay__error">
+						<div className="gallery-overlay__error-content">
+							<Gridicon icon="notice" size={ 48 } />
+							<h3>{ translate( 'Gallery Error' ) }</h3>
+							<p>{ error }</p>
+							<button onClick={ onClearError } className="gallery-overlay__error-button">
+								{ translate( 'Try Again' ) }
+							</button>
 						</div>
-					) }
-					<img
-						src={ currentImage.src }
-						alt={ currentImage.alt }
-						className={ clsx( 'gallery-overlay__image', {
-							'is-loading': isImageLoading,
-						} ) }
-						onLoad={ handleImageLoad }
-						onLoadStart={ handleImageLoadStart }
-					/>
-				</div>
+					</div>
+				) : (
+					<div
+						className="gallery-overlay__image-container"
+						onTouchStart={ handleTouchStart }
+						onTouchMove={ handleTouchMove }
+						onTouchEnd={ handleTouchEnd }
+					>
+						{ ( isImageLoading || isLoading ) && (
+							<div className="gallery-overlay__loading">
+								<Gridicon icon="sync" size={ 48 } />
+							</div>
+						) }
+						<img
+							src={ currentImage.src }
+							alt={ currentImage.alt }
+							className={ clsx( 'gallery-overlay__image', {
+								'is-loading': isImageLoading,
+							} ) }
+							onLoad={ handleImageLoad }
+							onLoadStart={ handleImageLoadStart }
+						/>
+					</div>
+				) }
 
 				{ /* Image counter and caption */ }
-				<div className="gallery-overlay__info">
-					{ hasMultipleImages && (
-						<div className="gallery-overlay__counter">
-							{ translate( '%(current)d of %(total)d', {
-								args: {
-									current: currentIndex + 1,
-									total: images.length,
-								},
-							} ) }
-						</div>
-					) }
-					{ currentImage.caption && (
-						<div className="gallery-overlay__caption">{ currentImage.caption }</div>
-					) }
-				</div>
+				{ ! error && (
+					<div className="gallery-overlay__info">
+						{ hasMultipleImages && (
+							<div className="gallery-overlay__counter">
+								{ translate( '%(current)d of %(total)d', {
+									args: {
+										current: currentIndex + 1,
+										total: images.length,
+									},
+								} ) }
+							</div>
+						) }
+						{ currentImage.caption && (
+							<div className="gallery-overlay__caption">{ currentImage.caption }</div>
+						) }
+					</div>
+				) }
 			</div>
 		</div>
 	);
@@ -278,12 +300,19 @@ GalleryOverlay.propTypes = {
 			src: PropTypes.string.isRequired,
 			alt: PropTypes.string,
 			caption: PropTypes.string,
+			width: PropTypes.number,
+			height: PropTypes.number,
 		} )
 	).isRequired,
 	currentIndex: PropTypes.number.isRequired,
+	isLoading: PropTypes.bool,
+	error: PropTypes.string,
 	onClose: PropTypes.func.isRequired,
 	onNext: PropTypes.func.isRequired,
 	onPrevious: PropTypes.func.isRequired,
+	onGoToFirst: PropTypes.func,
+	onGoToLast: PropTypes.func,
+	onClearError: PropTypes.func,
 };
 
 export default GalleryOverlay;

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -9,6 +9,14 @@ import './gallery-overlay.scss';
 const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrevious } ) => {
 	const translate = useTranslate();
 	const [ isImageLoading, setIsImageLoading ] = useState( false );
+	const [ touchStart, setTouchStart ] = useState( null );
+	const [ touchEnd, setTouchEnd ] = useState( null );
+
+	// Calculate navigation states (safe defaults if images is empty)
+	const currentImage = images[ currentIndex ] || {};
+	const hasMultipleImages = images.length > 1;
+	const hasPrevious = currentIndex > 0;
+	const hasNext = currentIndex < images.length - 1;
 
 	// Handle keyboard events
 	useEffect( () => {
@@ -22,14 +30,37 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 					onClose();
 					break;
 				case 'ArrowLeft':
-					onPrevious();
+				case 'h': // Vim-style navigation
+					if ( hasPrevious ) {
+						onPrevious();
+					}
 					break;
 				case 'ArrowRight':
-					onNext();
+				case 'l': // Vim-style navigation
+					if ( hasNext ) {
+						onNext();
+					}
 					break;
 				case ' ':
 				case 'Enter':
 					onClose();
+					break;
+				case 'Home':
+					if ( hasMultipleImages && currentIndex > 0 ) {
+						// Go to first image - we need to implement this
+						for ( let i = 0; i < currentIndex; i++ ) {
+							onPrevious();
+						}
+					}
+					break;
+				case 'End':
+					if ( hasMultipleImages && currentIndex < images.length - 1 ) {
+						// Go to last image - we need to implement this
+						const stepsToEnd = images.length - 1 - currentIndex;
+						for ( let i = 0; i < stepsToEnd; i++ ) {
+							onNext();
+						}
+					}
 					break;
 				default:
 					return;
@@ -44,7 +75,17 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 		return () => {
 			document.removeEventListener( 'keydown', handleKeydown );
 		};
-	}, [ isOpen, onClose, onNext, onPrevious ] );
+	}, [
+		isOpen,
+		onClose,
+		onNext,
+		onPrevious,
+		hasPrevious,
+		hasNext,
+		hasMultipleImages,
+		currentIndex,
+		images.length,
+	] );
 
 	// Prevent body scroll when overlay is open
 	useEffect( () => {
@@ -59,14 +100,32 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 		};
 	}, [ isOpen ] );
 
+	// Preload adjacent images for smooth navigation
+	useEffect( () => {
+		if ( ! isOpen || ! hasMultipleImages ) {
+			return;
+		}
+
+		const preloadImage = ( src ) => {
+			const img = new Image();
+			img.src = src;
+		};
+
+		// Preload next image
+		if ( hasNext ) {
+			preloadImage( images[ currentIndex + 1 ].src );
+		}
+
+		// Preload previous image
+		if ( hasPrevious ) {
+			preloadImage( images[ currentIndex - 1 ].src );
+		}
+	}, [ isOpen, hasMultipleImages, hasNext, hasPrevious, currentIndex, images ] );
+
+	// Early return after all hooks to comply with Rules of Hooks
 	if ( ! isOpen || ! images.length ) {
 		return null;
 	}
-
-	const currentImage = images[ currentIndex ];
-	const hasMultipleImages = images.length > 1;
-	const hasPrevious = currentIndex > 0;
-	const hasNext = currentIndex < images.length - 1;
 
 	const handleImageLoad = () => {
 		setIsImageLoading( false );
@@ -87,6 +146,37 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 			event.preventDefault();
 			onClose();
 		}
+	};
+
+	// Touch event handlers for swipe navigation
+	const handleTouchStart = ( event ) => {
+		setTouchEnd( null ); // Clear previous touch end
+		setTouchStart( event.targetTouches[ 0 ].clientX );
+	};
+
+	const handleTouchMove = ( event ) => {
+		setTouchEnd( event.targetTouches[ 0 ].clientX );
+	};
+
+	const handleTouchEnd = () => {
+		if ( ! touchStart || ! touchEnd ) {
+			return;
+		}
+
+		const distance = touchStart - touchEnd;
+		const isLeftSwipe = distance > 50;
+		const isRightSwipe = distance < -50;
+
+		if ( isLeftSwipe && hasNext ) {
+			onNext();
+		}
+		if ( isRightSwipe && hasPrevious ) {
+			onPrevious();
+		}
+
+		// Reset touch state
+		setTouchStart( null );
+		setTouchEnd( null );
 	};
 
 	return (
@@ -138,7 +228,12 @@ const GalleryOverlay = ( { isOpen, images, currentIndex, onClose, onNext, onPrev
 
 			{ /* Image container */ }
 			<div className="gallery-overlay__content">
-				<div className="gallery-overlay__image-container">
+				<div
+					className="gallery-overlay__image-container"
+					onTouchStart={ handleTouchStart }
+					onTouchMove={ handleTouchMove }
+					onTouchEnd={ handleTouchEnd }
+				>
 					{ isImageLoading && (
 						<div className="gallery-overlay__loading">
 							<Gridicon icon="sync" size={ 48 } />

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -224,25 +224,6 @@ const GalleryOverlay = ( {
 		};
 	}, [ isOpen ] );
 
-	// Handle orientation changes for better responsive behavior
-	useEffect( () => {
-		if ( ! isOpen ) {
-			return;
-		}
-
-		const handleOrientationChange = () => {
-			// Small delay to allow viewport to adjust
-		};
-
-		window.addEventListener( 'orientationchange', handleOrientationChange );
-		window.addEventListener( 'resize', handleOrientationChange );
-
-		return () => {
-			window.removeEventListener( 'orientationchange', handleOrientationChange );
-			window.removeEventListener( 'resize', handleOrientationChange );
-		};
-	}, [ isOpen ] );
-
 	// Early return after all hooks to comply with Rules of Hooks
 	if ( ! isOpen || ! images.length ) {
 		return null;

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -25,6 +25,7 @@ const GalleryOverlay = ( {
 	const [ imageDimensions, setImageDimensions ] = useState( null );
 	const [ touchStart, setTouchStart ] = useState( null );
 	const [ touchEnd, setTouchEnd ] = useState( null );
+	const [ announcement, setAnnouncement ] = useState( '' );
 
 	// Calculate navigation states (safe defaults if images is empty)
 	const currentImage = images[ currentIndex ] || {};
@@ -39,35 +40,70 @@ const GalleryOverlay = ( {
 				return;
 			}
 
+			// Don't handle key events if user is interacting with focusable elements
+			const activeElement = document.activeElement;
+			const isInteractingWithButton = activeElement && activeElement.tagName === 'BUTTON';
+
 			switch ( event.key ) {
 				case 'Escape':
+					event.preventDefault();
 					onClose();
 					break;
 				case 'ArrowLeft':
 				case 'h': // Vim-style navigation
-					if ( hasPrevious ) {
+					if ( hasPrevious && ! isInteractingWithButton ) {
+						event.preventDefault();
 						onPrevious();
+						// Announce navigation to screen readers
+						setAnnouncement( translate( 'Navigated to previous image' ) );
 					}
 					break;
 				case 'ArrowRight':
 				case 'l': // Vim-style navigation
-					if ( hasNext ) {
+					if ( hasNext && ! isInteractingWithButton ) {
+						event.preventDefault();
 						onNext();
+						// Announce navigation to screen readers
+						setAnnouncement( translate( 'Navigated to next image' ) );
 					}
 					break;
 				case ' ':
+					// Space should only close if not focused on a button
+					if ( ! isInteractingWithButton ) {
+						event.preventDefault();
+						onClose();
+					}
+					break;
 				case 'Enter':
-					onClose();
+					// Enter should close from anywhere except buttons (which have their own handlers)
+					if ( ! isInteractingWithButton ) {
+						event.preventDefault();
+						onClose();
+					}
 					break;
 				case 'Home':
-					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst ) {
+					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst && ! isInteractingWithButton ) {
+						event.preventDefault();
 						onGoToFirst();
+						setAnnouncement( translate( 'Navigated to first image' ) );
 					}
 					break;
 				case 'End':
-					if ( hasMultipleImages && currentIndex < images.length - 1 && onGoToLast ) {
+					if (
+						hasMultipleImages &&
+						currentIndex < images.length - 1 &&
+						onGoToLast &&
+						! isInteractingWithButton
+					) {
+						event.preventDefault();
 						onGoToLast();
+						setAnnouncement( translate( 'Navigated to last image' ) );
 					}
+					break;
+				case 'ArrowUp':
+				case 'ArrowDown':
+					// Prevent default scrolling behavior
+					event.preventDefault();
 					break;
 				default:
 					return;
@@ -188,6 +224,125 @@ const GalleryOverlay = ( {
 			setIsImageLoading( true );
 		}
 	}, [ currentIndex, isOpen ] );
+
+	// Screen reader announcements for navigation
+	useEffect( () => {
+		if ( ! isOpen || ! hasMultipleImages ) {
+			return;
+		}
+
+		const imagePosition = translate( 'Image %(current)d of %(total)d', {
+			args: {
+				current: currentIndex + 1,
+				total: images.length,
+			},
+		} );
+
+		let announcementText = imagePosition;
+
+		if ( currentImage.alt ) {
+			announcementText += `. ${ currentImage.alt }`;
+		}
+
+		if ( currentImage.caption ) {
+			announcementText += `. ${ currentImage.caption }`;
+		}
+
+		// Delay announcement to avoid conflicts with navigation sounds
+		const timeoutId = setTimeout( () => {
+			setAnnouncement( announcementText );
+		}, 300 );
+
+		return () => clearTimeout( timeoutId );
+	}, [
+		currentIndex,
+		isOpen,
+		hasMultipleImages,
+		currentImage.alt,
+		currentImage.caption,
+		images.length,
+		translate,
+	] );
+
+	// Focus trap implementation
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		// Store the previously focused element
+		const previouslyFocusedElement = document.activeElement;
+
+		// Focus the close button when modal opens
+		const closeButton = document.querySelector( '.gallery-overlay__close' );
+		if ( closeButton ) {
+			closeButton.focus();
+		}
+
+		// Get all focusable elements within the modal
+		const getFocusableElements = () => {
+			const modal = document.querySelector( '.gallery-overlay' );
+			if ( ! modal ) {
+				return [];
+			}
+
+			const focusableSelectors = [
+				'button',
+				'[href]',
+				'input',
+				'select',
+				'textarea',
+				'[tabindex]:not([tabindex="-1"])',
+			];
+
+			return Array.from( modal.querySelectorAll( focusableSelectors.join( ',' ) ) ).filter(
+				( element ) => {
+					return (
+						! element.disabled &&
+						element.offsetWidth > 0 &&
+						element.offsetHeight > 0 &&
+						getComputedStyle( element ).visibility !== 'hidden'
+					);
+				}
+			);
+		};
+
+		const handleTabKey = ( event ) => {
+			if ( event.key !== 'Tab' ) {
+				return;
+			}
+
+			const focusableElements = getFocusableElements();
+			if ( focusableElements.length === 0 ) {
+				return;
+			}
+
+			const firstElement = focusableElements[ 0 ];
+			const lastElement = focusableElements[ focusableElements.length - 1 ];
+
+			if ( event.shiftKey ) {
+				// Shift + Tab: if focused on first element, go to last
+				if ( document.activeElement === firstElement ) {
+					event.preventDefault();
+					lastElement.focus();
+				}
+			} else if ( document.activeElement === lastElement ) {
+				// Tab: if focused on last element, go to first
+				event.preventDefault();
+				firstElement.focus();
+			}
+		};
+
+		document.addEventListener( 'keydown', handleTabKey );
+
+		// Return focus to previously focused element when modal closes
+		return () => {
+			document.removeEventListener( 'keydown', handleTabKey );
+			if ( previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function' ) {
+				previouslyFocusedElement.focus();
+			}
+		};
+	}, [ isOpen ] );
 
 	// Handle orientation changes for better responsive behavior
 	useEffect( () => {
@@ -324,7 +479,17 @@ const GalleryOverlay = ( {
 			role="dialog"
 			aria-modal="true"
 			aria-label={ translate( 'Gallery image viewer' ) }
+			aria-describedby={ hasMultipleImages ? 'gallery-description' : undefined }
 		>
+			{ /* Screen reader announcements */ }
+			<div
+				id="gallery-announcements"
+				aria-live="polite"
+				aria-atomic="true"
+				className="gallery-overlay__sr-only"
+			>
+				{ announcement }
+			</div>
 			<div
 				className="gallery-overlay__backdrop"
 				onClick={ handleBackdropClick }
@@ -339,8 +504,9 @@ const GalleryOverlay = ( {
 				className="gallery-overlay__close"
 				onClick={ onClose }
 				aria-label={ translate( 'Close gallery' ) }
+				title={ translate( 'Close gallery (Escape)' ) }
 			>
-				<Gridicon icon="cross" size={ 24 } />
+				<Gridicon icon="cross" size={ 24 } aria-hidden="true" />
 			</button>
 
 			{ /* Previous button */ }
@@ -348,9 +514,15 @@ const GalleryOverlay = ( {
 				<button
 					className="gallery-overlay__nav gallery-overlay__nav--previous"
 					onClick={ onPrevious }
-					aria-label={ translate( 'Previous image' ) }
+					aria-label={ translate( 'Previous image (%(current)d of %(total)d)', {
+						args: {
+							current: currentIndex,
+							total: images.length,
+						},
+					} ) }
+					title={ translate( 'Previous image' ) }
 				>
-					<Gridicon icon="chevron-left" size={ 36 } />
+					<Gridicon icon="chevron-left" size={ 36 } aria-hidden="true" />
 				</button>
 			) }
 
@@ -359,9 +531,15 @@ const GalleryOverlay = ( {
 				<button
 					className="gallery-overlay__nav gallery-overlay__nav--next"
 					onClick={ onNext }
-					aria-label={ translate( 'Next image' ) }
+					aria-label={ translate( 'Next image (%(current)d of %(total)d)', {
+						args: {
+							current: currentIndex + 2,
+							total: images.length,
+						},
+					} ) }
+					title={ translate( 'Next image' ) }
 				>
-					<Gridicon icon="chevron-right" size={ 36 } />
+					<Gridicon icon="chevron-right" size={ 36 } aria-hidden="true" />
 				</button>
 			) }
 
@@ -417,7 +595,15 @@ const GalleryOverlay = ( {
 						) : (
 							<img
 								src={ currentImage.src }
-								alt={ currentImage.alt }
+								alt={
+									currentImage.alt ||
+									translate( 'Gallery image %(current)d of %(total)d', {
+										args: {
+											current: currentIndex + 1,
+											total: images.length,
+										},
+									} )
+								}
 								width={ currentImage.width }
 								height={ currentImage.height }
 								className={ clsx( 'gallery-overlay__image', {
@@ -440,6 +626,7 @@ const GalleryOverlay = ( {
 								onError={ handleImageError }
 								loading="eager"
 								decoding="async"
+								aria-describedby={ currentImage.caption ? 'gallery-caption' : undefined }
 							/>
 						) }
 					</div>
@@ -449,7 +636,11 @@ const GalleryOverlay = ( {
 				{ ! error && (
 					<div className="gallery-overlay__info">
 						{ hasMultipleImages && (
-							<div className="gallery-overlay__counter">
+							<div
+								id="gallery-description"
+								className="gallery-overlay__counter"
+								aria-label={ translate( 'Gallery navigation information' ) }
+							>
 								{ translate( '%(current)d of %(total)d', {
 									args: {
 										current: currentIndex + 1,
@@ -459,7 +650,14 @@ const GalleryOverlay = ( {
 							</div>
 						) }
 						{ currentImage.caption && (
-							<div className="gallery-overlay__caption">{ currentImage.caption }</div>
+							<div
+								id="gallery-caption"
+								className="gallery-overlay__caption"
+								role="img"
+								aria-label={ translate( 'Image caption' ) }
+							>
+								{ currentImage.caption }
+							</div>
 						) }
 					</div>
 				) }

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -16,15 +16,11 @@ const GalleryOverlay = ( {
 	onClose,
 	onNext,
 	onPrevious,
-	onGoToFirst,
-	onGoToLast,
 	onClearError,
 } ) => {
 	const translate = useTranslate();
 	const [ isImageLoading, setIsImageLoading ] = useState( false );
 	const [ imageError, setImageError ] = useState( false );
-	const [ touchStart, setTouchStart ] = useState( null );
-	const [ touchEnd, setTouchEnd ] = useState( null );
 
 	// Calculate navigation states (safe defaults if images is empty)
 	const currentImage = images[ currentIndex ] || {};
@@ -49,14 +45,12 @@ const GalleryOverlay = ( {
 					onClose();
 					break;
 				case 'ArrowLeft':
-				case 'h': // Vim-style navigation
 					if ( hasPrevious && ! isInteractingWithButton ) {
 						event.preventDefault();
 						onPrevious();
 					}
 					break;
 				case 'ArrowRight':
-				case 'l': // Vim-style navigation
 					if ( hasNext && ! isInteractingWithButton ) {
 						event.preventDefault();
 						onNext();
@@ -77,23 +71,6 @@ const GalleryOverlay = ( {
 					}
 					// If focused on a button, let the button handle it naturally
 					return;
-				case 'Home':
-					if ( hasMultipleImages && currentIndex > 0 && onGoToFirst && ! isInteractingWithButton ) {
-						event.preventDefault();
-						onGoToFirst();
-					}
-					break;
-				case 'End':
-					if (
-						hasMultipleImages &&
-						currentIndex < images.length - 1 &&
-						onGoToLast &&
-						! isInteractingWithButton
-					) {
-						event.preventDefault();
-						onGoToLast();
-					}
-					break;
 				case 'ArrowUp':
 				case 'ArrowDown':
 					// Prevent default scrolling behavior
@@ -116,8 +93,6 @@ const GalleryOverlay = ( {
 		onClose,
 		onNext,
 		onPrevious,
-		onGoToFirst,
-		onGoToLast,
 		hasPrevious,
 		hasNext,
 		hasMultipleImages,
@@ -302,37 +277,6 @@ const GalleryOverlay = ( {
 		}
 	};
 
-	// Touch event handlers for swipe navigation
-	const handleTouchStart = ( event ) => {
-		setTouchEnd( null ); // Clear previous touch end
-		setTouchStart( event.targetTouches[ 0 ].clientX );
-	};
-
-	const handleTouchMove = ( event ) => {
-		setTouchEnd( event.targetTouches[ 0 ].clientX );
-	};
-
-	const handleTouchEnd = () => {
-		if ( ! touchStart || ! touchEnd ) {
-			return;
-		}
-
-		const distance = touchStart - touchEnd;
-		const isLeftSwipe = distance > 50;
-		const isRightSwipe = distance < -50;
-
-		if ( isLeftSwipe && hasNext ) {
-			onNext();
-		}
-		if ( isRightSwipe && hasPrevious ) {
-			onPrevious();
-		}
-
-		// Reset touch state
-		setTouchStart( null );
-		setTouchEnd( null );
-	};
-
 	const overlayContent = (
 		<div
 			className="gallery-overlay"
@@ -395,12 +339,7 @@ const GalleryOverlay = ( {
 						</div>
 					</div>
 				) : (
-					<div
-						className="gallery-overlay__image-container"
-						onTouchStart={ handleTouchStart }
-						onTouchMove={ handleTouchMove }
-						onTouchEnd={ handleTouchEnd }
-					>
+					<div className="gallery-overlay__image-container">
 						{ ( isImageLoading || isLoading ) && ! imageError && (
 							<div className="gallery-overlay__loading">
 								<Gridicon icon="sync" size={ 48 } />
@@ -496,8 +435,6 @@ GalleryOverlay.propTypes = {
 	onClose: PropTypes.func.isRequired,
 	onNext: PropTypes.func.isRequired,
 	onPrevious: PropTypes.func.isRequired,
-	onGoToFirst: PropTypes.func,
-	onGoToLast: PropTypes.func,
 	onClearError: PropTypes.func,
 };
 

--- a/client/blocks/reader-full-post/gallery-overlay.jsx
+++ b/client/blocks/reader-full-post/gallery-overlay.jsx
@@ -11,7 +11,6 @@ const GalleryOverlay = ( {
 	isOpen,
 	images,
 	currentIndex,
-	isLoading,
 	error,
 	onClose,
 	onNext,
@@ -19,8 +18,11 @@ const GalleryOverlay = ( {
 	onClearError,
 } ) => {
 	const translate = useTranslate();
-	const [ isImageLoading, setIsImageLoading ] = useState( false );
 	const [ imageError, setImageError ] = useState( false );
+	const [ touchStart, setTouchStart ] = useState( null );
+	const [ touchEnd, setTouchEnd ] = useState( null );
+	const [ isTransitioning, setIsTransitioning ] = useState( false );
+	const [ slideDirection, setSlideDirection ] = useState( null );
 
 	// Calculate navigation states (safe defaults if images is empty)
 	const currentImage = images[ currentIndex ] || {};
@@ -136,7 +138,6 @@ const GalleryOverlay = ( {
 	useEffect( () => {
 		if ( isOpen ) {
 			setImageError( false );
-			setIsImageLoading( true );
 		}
 	}, [ currentIndex, isOpen ] );
 
@@ -228,11 +229,6 @@ const GalleryOverlay = ( {
 
 		const handleOrientationChange = () => {
 			// Small delay to allow viewport to adjust
-			setTimeout( () => {
-				// Force a re-render to adjust image sizing
-				setIsImageLoading( true );
-				setTimeout( () => setIsImageLoading( false ), 100 );
-			}, 100 );
 		};
 
 		window.addEventListener( 'orientationchange', handleOrientationChange );
@@ -250,17 +246,10 @@ const GalleryOverlay = ( {
 	}
 
 	const handleImageLoad = () => {
-		setIsImageLoading( false );
-		setImageError( false );
-	};
-
-	const handleImageLoadStart = () => {
-		setIsImageLoading( true );
 		setImageError( false );
 	};
 
 	const handleImageError = () => {
-		setIsImageLoading( false );
 		setImageError( true );
 	};
 
@@ -275,6 +264,52 @@ const GalleryOverlay = ( {
 			event.preventDefault();
 			onClose();
 		}
+	};
+
+	// Simple touch handlers for mobile swiping
+	const handleTouchStart = ( event ) => {
+		setTouchEnd( null );
+		setTouchStart( event.targetTouches[ 0 ].clientX );
+	};
+
+	const handleTouchMove = ( event ) => {
+		setTouchEnd( event.targetTouches[ 0 ].clientX );
+	};
+
+	const handleTouchEnd = () => {
+		if ( ! touchStart || ! touchEnd ) {
+			return;
+		}
+
+		const distance = touchStart - touchEnd;
+		const isLeftSwipe = distance > 50;
+		const isRightSwipe = distance < -50;
+
+		if ( isLeftSwipe && hasNext ) {
+			setSlideDirection( 'left' );
+			setIsTransitioning( true );
+			setTimeout( () => {
+				onNext();
+				setTimeout( () => {
+					setIsTransitioning( false );
+					setSlideDirection( null );
+				}, 50 );
+			}, 150 );
+		}
+		if ( isRightSwipe && hasPrevious ) {
+			setSlideDirection( 'right' );
+			setIsTransitioning( true );
+			setTimeout( () => {
+				onPrevious();
+				setTimeout( () => {
+					setIsTransitioning( false );
+					setSlideDirection( null );
+				}, 50 );
+			}, 150 );
+		}
+
+		setTouchStart( null );
+		setTouchEnd( null );
 	};
 
 	const overlayContent = (
@@ -339,13 +374,12 @@ const GalleryOverlay = ( {
 						</div>
 					</div>
 				) : (
-					<div className="gallery-overlay__image-container">
-						{ ( isImageLoading || isLoading ) && ! imageError && (
-							<div className="gallery-overlay__loading">
-								<Gridicon icon="sync" size={ 48 } />
-							</div>
-						) }
-
+					<div
+						className="gallery-overlay__image-container"
+						onTouchStart={ handleTouchStart }
+						onTouchMove={ handleTouchMove }
+						onTouchEnd={ handleTouchEnd }
+					>
 						{ imageError ? (
 							<div className="gallery-overlay__image-error">
 								<div className="gallery-overlay__image-error-content">
@@ -355,7 +389,6 @@ const GalleryOverlay = ( {
 										className="gallery-overlay__retry-button"
 										onClick={ () => {
 											setImageError( false );
-											setIsImageLoading( true );
 											// Force image reload by updating src
 											const imgElement = document.querySelector( '.gallery-overlay__image' );
 											if ( imgElement ) {
@@ -382,10 +415,11 @@ const GalleryOverlay = ( {
 									} )
 								}
 								className={ clsx( 'gallery-overlay__image', {
-									'is-loading': isImageLoading,
+									'is-transitioning': isTransitioning,
+									'slide-left': slideDirection === 'left',
+									'slide-right': slideDirection === 'right',
 								} ) }
 								onLoad={ handleImageLoad }
-								onLoadStart={ handleImageLoadStart }
 								onError={ handleImageError }
 							/>
 						) }
@@ -430,7 +464,7 @@ GalleryOverlay.propTypes = {
 		} )
 	).isRequired,
 	currentIndex: PropTypes.number.isRequired,
-	isLoading: PropTypes.bool,
+
 	error: PropTypes.string,
 	onClose: PropTypes.func.isRequired,
 	onNext: PropTypes.func.isRequired,

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -1,5 +1,5 @@
 // Z-index management for gallery overlay
-$gallery-overlay-z-index: 100000; // Higher than most UI elements
+$gallery-overlay-z-index: 10000000; // Higher than all Calypso UI elements (above webpack monitor)
 $gallery-backdrop-z-index: 1;
 $gallery-controls-z-index: 10;
 $gallery-content-z-index: 5;
@@ -12,7 +12,7 @@ $gallery-content-z-index: 5;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: $gallery-overlay-z-index;
+	z-index: $gallery-overlay-z-index !important;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -1,0 +1,243 @@
+@import '@automattic/calypso-config';
+@import '@automattic/color-studio/dist/color-variables';
+
+.gallery-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 10000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: gallery-overlay-fade-in 0.2s ease-out;
+}
+
+.gallery-overlay__backdrop {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.9);
+}
+
+.gallery-overlay__close {
+	position: absolute;
+	top: 20px;
+	right: 20px;
+	z-index: 10;
+	width: 48px;
+	height: 48px;
+	border: none;
+	border-radius: 50%;
+	background-color: rgba(255, 255, 255, 0.1);
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background-color 0.2s ease;
+
+	&:hover {
+		background-color: rgba(255, 255, 255, 0.2);
+	}
+
+	&:focus {
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		top: 16px;
+		right: 16px;
+		width: 44px;
+		height: 44px;
+	}
+}
+
+.gallery-overlay__nav {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	z-index: 10;
+	width: 64px;
+	height: 64px;
+	border: none;
+	border-radius: 50%;
+	background-color: rgba(255, 255, 255, 0.1);
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background-color 0.2s ease, transform 0.2s ease;
+
+	&:hover {
+		background-color: rgba(255, 255, 255, 0.2);
+		transform: translateY(-50%) scale(1.05);
+	}
+
+	&:focus {
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+
+	&--previous {
+		left: 32px;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			left: 16px;
+		}
+	}
+
+	&--next {
+		right: 32px;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			right: 16px;
+		}
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		width: 56px;
+		height: 56px;
+	}
+}
+
+.gallery-overlay__content {
+	position: relative;
+	max-width: 90vw;
+	max-height: 90vh;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.gallery-overlay__image-container {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 200px;
+	min-height: 200px;
+}
+
+.gallery-overlay__image {
+	max-width: 90vw;
+	max-height: 80vh;
+	width: auto;
+	height: auto;
+	border-radius: 8px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+	transition: opacity 0.2s ease;
+
+	&.is-loading {
+		opacity: 0.5;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		max-width: 95vw;
+		max-height: 75vh;
+		border-radius: 4px;
+	}
+}
+
+.gallery-overlay__loading {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	color: #fff;
+	animation: gallery-overlay-spin 1s linear infinite;
+}
+
+.gallery-overlay__info {
+	margin-top: 16px;
+	text-align: center;
+	max-width: 90vw;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		margin-top: 12px;
+		max-width: 95vw;
+	}
+}
+
+.gallery-overlay__counter {
+	color: #fff;
+	font-size: 14px;
+	font-weight: 500;
+	margin-bottom: 8px;
+	opacity: 0.8;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		font-size: 13px;
+	}
+}
+
+.gallery-overlay__caption {
+	color: #fff;
+	font-size: 16px;
+	line-height: 1.4;
+	max-width: 600px;
+	margin: 0 auto;
+	opacity: 0.9;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		max-width: 500px;
+		font-size: 15px;
+	}
+
+	@include breakpoint-deprecated( '<660px' ) {
+		max-width: 400px;
+		font-size: 14px;
+	}
+}
+
+// Animations
+@keyframes gallery-overlay-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes gallery-overlay-spin {
+	from {
+		transform: translate(-50%, -50%) rotate(0deg);
+	}
+	to {
+		transform: translate(-50%, -50%) rotate(360deg);
+	}
+}
+
+// Accessibility improvements
+@media (prefers-reduced-motion: reduce) {
+	.gallery-overlay {
+		animation: none;
+	}
+
+	.gallery-overlay__nav {
+		transition-duration: 0s;
+	}
+
+	.gallery-overlay__loading {
+		animation: none;
+	}
+
+	.gallery-overlay__image {
+		transition: none;
+	}
+}
+
+// Focus management
+.gallery-overlay:focus-within {
+	.gallery-overlay__close,
+	.gallery-overlay__nav {
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+}

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -7,6 +7,19 @@ $gallery-backdrop-z-index: 1;
 $gallery-controls-z-index: 10;
 $gallery-content-z-index: 5;
 
+// Screen reader only utility class
+.gallery-overlay__sr-only {
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	padding: 0 !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	clip: rect(0, 0, 0, 0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
+}
+
 .gallery-overlay {
 	position: fixed;
 	top: 0;

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -25,7 +25,7 @@ $gallery-content-z-index: 5;
 		.gallery-overlay__nav,
 		.gallery-overlay__error-button {
 			&:focus {
-				outline: 1px dotted rgba(255, 255, 255, 0.4);
+				background: #999;
 			}
 		}
 	}
@@ -86,7 +86,8 @@ $gallery-content-z-index: 5;
 	justify-content: center;
 	transition: all 0.2s ease;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		background-color: #999;
 		color: #fff;
 	}
@@ -569,6 +570,18 @@ $gallery-content-z-index: 5;
 
 	.gallery-overlay__image {
 		transition: none;
+	}
+}
+
+// Gallery image focus styles in the main content
+.reader-full-post__content {
+	.wp-block-gallery img,
+	.wp-block-gallery .wp-block-image .image-wrapper img,
+	.tiled-gallery img {
+		&:focus {
+			outline: 1px dashed var(--color-accent);
+			outline-offset: 2px;
+		}
 	}
 }
 

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -1,17 +1,62 @@
 @import '@automattic/calypso-config';
 @import '@automattic/color-studio/dist/color-variables';
 
+// Z-index management for gallery overlay
+$gallery-overlay-z-index: 100000; // Higher than most UI elements
+$gallery-backdrop-z-index: 1;
+$gallery-controls-z-index: 10;
+$gallery-content-z-index: 5;
+
 .gallery-overlay {
 	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: 10000;
+	z-index: $gallery-overlay-z-index;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	animation: gallery-overlay-fade-in 0.2s ease-out;
+	animation: gallery-overlay-fade-in 0.3s ease-out;
+	backdrop-filter: blur(2px); // Modern browser backdrop blur
+
+	// Focus trap indicator
+	&:focus-within {
+		.gallery-overlay__close,
+		.gallery-overlay__nav,
+		.gallery-overlay__error-button {
+			&:focus {
+				outline: 3px solid #fff;
+				outline-offset: 3px;
+				box-shadow: 
+					0 0 0 1px rgba(0, 0, 0, 0.8),
+					0 0 0 4px #fff;
+			}
+		}
+	}
+
+	// High contrast mode support
+	@media (prefers-contrast: high) {
+		.gallery-overlay__close,
+		.gallery-overlay__nav,
+		.gallery-overlay__error-button {
+			border: 2px solid #fff;
+			background-color: rgba(0, 0, 0, 0.8);
+		}
+
+		.gallery-overlay__backdrop {
+			background: #000;
+		}
+	}
+
+	// Keyboard navigation indicator
+	&.is-keyboard-navigation {
+		.gallery-overlay__nav,
+		.gallery-overlay__close {
+			opacity: 1;
+			background-color: rgba(255, 255, 255, 0.2);
+		}
+	}
 }
 
 .gallery-overlay__backdrop {
@@ -20,17 +65,24 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: rgba(0, 0, 0, 0.9);
+	z-index: $gallery-backdrop-z-index;
+	background: linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0.95) 0%,
+		rgba(0, 0, 0, 0.9) 50%,
+		rgba(0, 0, 0, 0.95) 100%
+	);
+	transition: opacity 0.3s ease;
 }
 
 .gallery-overlay__close {
 	position: absolute;
-	top: 20px;
-	right: 20px;
-	z-index: 10;
+	top: 24px;
+	right: 24px;
+	z-index: $gallery-controls-z-index;
 	width: 48px;
 	height: 48px;
-	border: none;
+	border: 1px solid rgba(255, 255, 255, 0.1);
 	border-radius: 50%;
 	background-color: rgba(255, 255, 255, 0.1);
 	color: #fff;
@@ -38,15 +90,24 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition: background-color 0.2s ease;
+	transition: all 0.2s ease;
+	backdrop-filter: blur(8px);
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.2);
+		background-color: rgba(255, 255, 255, 0.25);
+		transform: scale(1.05);
+		border-color: rgba(255, 255, 255, 0.2);
 	}
 
 	&:focus {
 		outline: 2px solid #fff;
 		outline-offset: 2px;
+		background-color: rgba(255, 255, 255, 0.2);
+	}
+
+	&:active {
+		transform: scale(0.95);
+		background-color: rgba(255, 255, 255, 0.3);
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -61,10 +122,10 @@
 	position: absolute;
 	top: 50%;
 	transform: translateY(-50%);
-	z-index: 10;
+	z-index: $gallery-controls-z-index;
 	width: 64px;
 	height: 64px;
-	border: none;
+	border: 1px solid rgba(255, 255, 255, 0.1);
 	border-radius: 50%;
 	background-color: rgba(255, 255, 255, 0.1);
 	color: #fff;
@@ -72,26 +133,32 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition: background-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+	transition: all 0.2s ease;
 	opacity: 0.8;
+	backdrop-filter: blur(8px);
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.3);
-		transform: translateY(-50%) scale(1.1);
+		background-color: rgba(255, 255, 255, 0.25);
+		transform: translateY(-50%) scale(1.08);
 		opacity: 1;
+		border-color: rgba(255, 255, 255, 0.2);
+		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
 	}
 
 	&:focus {
 		outline: 2px solid #fff;
 		outline-offset: 2px;
-		background-color: rgba(255, 255, 255, 0.25);
+		background-color: rgba(255, 255, 255, 0.2);
 		opacity: 1;
 	}
 
 	&:active {
-		transform: translateY(-50%) scale(0.95);
-		background-color: rgba(255, 255, 255, 0.4);
+		transform: translateY(-50%) scale(0.98);
+		background-color: rgba(255, 255, 255, 0.35);
 	}
+
+	// Add subtle shadow for depth
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 
 	&--previous {
 		left: 32px;
@@ -130,11 +197,18 @@
 
 .gallery-overlay__content {
 	position: relative;
-	max-width: 90vw;
+	z-index: $gallery-content-z-index;
+	max-width: 95vw;
 	max-height: 90vh;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	animation: gallery-content-slide-in 0.4s ease-out;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		max-width: 98vw;
+		max-height: 85vh;
+	}
 }
 
 .gallery-overlay__image-container {
@@ -157,21 +231,39 @@
 
 .gallery-overlay__image {
 	max-width: 90vw;
-	max-height: 80vh;
+	max-height: 75vh;
 	width: auto;
 	height: auto;
 	border-radius: 8px;
-	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-	transition: opacity 0.2s ease;
+	box-shadow: 
+		0 20px 40px rgba(0, 0, 0, 0.5),
+		0 8px 16px rgba(0, 0, 0, 0.3);
+	transition: all 0.3s ease;
+	transform: scale(1);
 
 	&.is-loading {
-		opacity: 0.5;
+		opacity: 0.7;
+		transform: scale(0.98);
+	}
+
+	// Add subtle glow effect
+	&:not(.is-loading) {
+		filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.1));
+	}
+
+	@include breakpoint-deprecated( '<960px' ) {
+		max-width: 92vw;
+		max-height: 70vh;
+		border-radius: 8px;
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 95vw;
-		max-height: 75vh;
+		max-height: 65vh;
 		border-radius: 4px;
+		box-shadow: 
+			0 12px 24px rgba(0, 0, 0, 0.4),
+			0 4px 8px rgba(0, 0, 0, 0.2);
 	}
 }
 
@@ -276,9 +368,22 @@
 @keyframes gallery-overlay-fade-in {
 	from {
 		opacity: 0;
+		backdrop-filter: blur(0);
 	}
 	to {
 		opacity: 1;
+		backdrop-filter: blur(2px);
+	}
+}
+
+@keyframes gallery-content-slide-in {
+	from {
+		opacity: 0;
+		transform: translateY(20px) scale(0.95);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
 	}
 }
 
@@ -288,6 +393,18 @@
 	}
 	to {
 		transform: translate(-50%, -50%) rotate(360deg);
+	}
+}
+
+// Image transition animation
+@keyframes gallery-image-transition {
+	0% {
+		opacity: 0;
+		transform: scale(0.9);
+	}
+	100% {
+		opacity: 1;
+		transform: scale(1);
 	}
 }
 
@@ -310,11 +427,4 @@
 	}
 }
 
-// Focus management
-.gallery-overlay:focus-within {
-	.gallery-overlay__close,
-	.gallery-overlay__nav {
-		outline: 2px solid #fff;
-		outline-offset: 2px;
-	}
-}
+

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -25,11 +25,7 @@ $gallery-content-z-index: 5;
 		.gallery-overlay__nav,
 		.gallery-overlay__error-button {
 			&:focus {
-				outline: 3px solid #fff;
-				outline-offset: 3px;
-				box-shadow: 
-					0 0 0 1px rgba(0, 0, 0, 0.8),
-					0 0 0 4px #fff;
+				outline: 1px dotted rgba(255, 255, 255, 0.4);
 			}
 		}
 	}
@@ -39,7 +35,6 @@ $gallery-content-z-index: 5;
 		.gallery-overlay__close,
 		.gallery-overlay__nav,
 		.gallery-overlay__error-button {
-			border: 2px solid #fff;
 			background-color: rgba(0, 0, 0, 0.8);
 		}
 
@@ -79,41 +74,28 @@ $gallery-content-z-index: 5;
 	top: 24px;
 	right: 24px;
 	z-index: $gallery-controls-z-index;
-	width: 48px;
-	height: 48px;
-	border: 1px solid rgba(255, 255, 255, 0.1);
-	border-radius: 50%;
-	background-color: rgba(255, 255, 255, 0.1);
-	color: #fff;
+	width: 32px;
+	height: 32px;
+	border: none;
+	border-radius: 3px;
+	background-color: rgba(255, 255, 255, 0.05);
+	color: rgba(255, 255, 255, 0.7);
 	cursor: pointer;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	transition: all 0.2s ease;
-	backdrop-filter: blur(8px);
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.25);
-		transform: scale(1.05);
-		border-color: rgba(255, 255, 255, 0.2);
-	}
-
-	&:focus {
-		outline: 2px solid #fff;
-		outline-offset: 2px;
-		background-color: rgba(255, 255, 255, 0.2);
-	}
-
-	&:active {
-		transform: scale(0.95);
-		background-color: rgba(255, 255, 255, 0.3);
+		background-color: #999;
+		color: #fff;
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
-		top: 16px;
-		right: 16px;
-		width: 44px;
-		height: 44px;
+		top: 20px;
+		right: 20px;
+		width: 28px;
+		height: 28px;
 	}
 }
 
@@ -122,126 +104,57 @@ $gallery-content-z-index: 5;
 	top: 50%;
 	transform: translateY(-50%);
 	z-index: $gallery-controls-z-index;
-	width: 64px;
-	height: 64px;
-	border: 1px solid rgba(255, 255, 255, 0.1);
-	border-radius: 50%;
-	background-color: rgba(255, 255, 255, 0.1);
-	color: #fff;
+	width: 36px;
+	height: 36px;
+	border: none;
+	border-radius: 3px;
+	background-color: rgba(255, 255, 255, 0.05);
+	color: rgba(255, 255, 255, 0.7);
 	cursor: pointer;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	transition: all 0.2s ease;
 	opacity: 0.8;
-	backdrop-filter: blur(8px);
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.25);
-		transform: translateY(-50%) scale(1.08);
+		background-color: #999;
+		color: rgba(255, 255, 255, 0.9);
 		opacity: 1;
-		border-color: rgba(255, 255, 255, 0.2);
-		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
 	}
 
 	&:focus {
-		outline: 2px solid #fff;
-		outline-offset: 2px;
-		background-color: rgba(255, 255, 255, 0.2);
+		background-color: #999;
 		opacity: 1;
 	}
 
-	&:active {
-		transform: translateY(-50%) scale(0.98);
-		background-color: rgba(255, 255, 255, 0.35);
-	}
-
-	// Add subtle shadow for depth
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-
 	&--previous {
-		left: 40px;
+		left: 24px;
 
-		// Desktop: larger click area
 		@include breakpoint-deprecated( '>1200px' ) {
-			left: 60px;
-			width: 72px;
-			height: 72px;
+			left: 32px;
 		}
 
 		@include breakpoint-deprecated( '<960px' ) {
-			left: 24px;
-		}
-
-		@include breakpoint-deprecated( '<660px' ) {
-			left: 16px;
+			left: 20px;
 		}
 	}
 
 	&--next {
-		right: 40px;
+		right: 24px;
 
-		// Desktop: larger click area
 		@include breakpoint-deprecated( '>1200px' ) {
-			right: 60px;
-			width: 72px;
-			height: 72px;
+			right: 32px;
 		}
 
 		@include breakpoint-deprecated( '<960px' ) {
-			right: 24px;
-		}
-
-		@include breakpoint-deprecated( '<660px' ) {
-			right: 16px;
+			right: 20px;
 		}
 	}
 
-	// Tablet optimizations
-	@include breakpoint-deprecated( '<960px' ) {
-		width: 60px;
-		height: 60px;
-		opacity: 0.9;
-
-		&:hover {
-			transform: translateY(-50%) scale(1.06);
-		}
-	}
-
-	// Mobile optimizations
+	// Mobile optimizations - hide navigation buttons on mobile
 	@include breakpoint-deprecated( '<660px' ) {
-		width: 56px;
-		height: 56px;
-		opacity: 0.9;
-
-		&:hover {
-			// On mobile, reduce hover effects since they're not as useful
-			transform: translateY(-50%) scale(1.05);
-		}
-	}
-
-	// Better touch targets for touch devices
-	@media (pointer: coarse) {
-		width: 64px;
-		height: 64px;
-		opacity: 0.95;
-
-		// Larger touch area for easier interaction
-		&::before {
-			content: '';
-			position: absolute;
-			top: -8px;
-			left: -8px;
-			right: -8px;
-			bottom: -8px;
-		}
-	}
-
-	// High-resolution displays
-	@media (-webkit-min-device-pixel-ratio: 2) {
-		&:hover {
-			transform: translateY(-50%) scale(1.05);
-		}
+		display: none;
 	}
 }
 
@@ -453,11 +366,6 @@ $gallery-content-z-index: 5;
 	&:active {
 		transform: translateY(0);
 	}
-
-	&:focus {
-		outline: 2px solid rgba(255, 255, 255, 0.6);
-		outline-offset: 2px;
-	}
 }
 
 .gallery-overlay__loading {
@@ -507,11 +415,6 @@ $gallery-content-z-index: 5;
 
 	&:hover {
 		background-color: rgba(255, 255, 255, 0.3);
-	}
-
-	&:focus {
-		outline: 2px solid #fff;
-		outline-offset: 2px;
 	}
 }
 
@@ -668,5 +571,6 @@ $gallery-content-z-index: 5;
 		transition: none;
 	}
 }
+
 
 

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -7,18 +7,7 @@ $gallery-backdrop-z-index: 1;
 $gallery-controls-z-index: 10;
 $gallery-content-z-index: 5;
 
-// Screen reader only utility class
-.gallery-overlay__sr-only {
-	position: absolute !important;
-	width: 1px !important;
-	height: 1px !important;
-	padding: 0 !important;
-	margin: -1px !important;
-	overflow: hidden !important;
-	clip: rect(0, 0, 0, 0) !important;
-	white-space: nowrap !important;
-	border: 0 !important;
-}
+
 
 .gallery-overlay {
 	position: fixed;
@@ -314,12 +303,6 @@ $gallery-content-z-index: 5;
 		min-height: 300px;
 	}
 	
-	// Tablet: medium size
-	@include breakpoint-deprecated( '<960px' ) {
-		min-width: 250px;
-		min-height: 250px;
-	}
-	
 	// Mobile: smaller minimum size
 	@include breakpoint-deprecated( '<660px' ) {
 		min-width: 150px;
@@ -417,24 +400,7 @@ $gallery-content-z-index: 5;
 		max-height: 85vh;
 	}
 
-	// Enhanced image aspect ratio handling
-	&.has-dimensions {
-		object-fit: contain;
-	}
 
-	&.is-wide {
-		max-height: 70vh;
-	}
-
-	&.is-tall {
-		max-width: 60vw;
-	}
-
-	// High DPI display optimizations
-	@media (-webkit-min-device-pixel-ratio: 2) {
-		image-rendering: -webkit-optimize-contrast;
-		image-rendering: crisp-edges;
-	}
 }
 
 // Image error state

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -403,6 +403,85 @@ $gallery-content-z-index: 5;
 		max-width: 80vw;
 		max-height: 85vh;
 	}
+
+	// Enhanced image aspect ratio handling
+	&.has-dimensions {
+		object-fit: contain;
+	}
+
+	&.is-wide {
+		max-height: 70vh;
+	}
+
+	&.is-tall {
+		max-width: 60vw;
+	}
+
+	// High DPI display optimizations
+	@media (-webkit-min-device-pixel-ratio: 2) {
+		image-rendering: -webkit-optimize-contrast;
+		image-rendering: crisp-edges;
+	}
+}
+
+// Image error state
+.gallery-overlay__image-error {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	min-height: 200px;
+	padding: 2rem;
+	text-align: center;
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.gallery-overlay__image-error-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1rem;
+	max-width: 300px;
+
+	.gridicon {
+		opacity: 0.6;
+		color: rgba(255, 255, 255, 0.8);
+	}
+
+	p {
+		margin: 0;
+		font-size: 1rem;
+		line-height: 1.4;
+		color: rgba(255, 255, 255, 0.9);
+	}
+}
+
+.gallery-overlay__retry-button {
+	background: rgba(255, 255, 255, 0.1);
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	border-radius: 4px;
+	padding: 0.5rem 1rem;
+	color: #fff;
+	font-size: 0.875rem;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	backdrop-filter: blur(4px);
+
+	&:hover {
+		background: rgba(255, 255, 255, 0.2);
+		border-color: rgba(255, 255, 255, 0.5);
+		transform: translateY(-1px);
+	}
+
+	&:active {
+		transform: translateY(0);
+	}
+
+	&:focus {
+		outline: 2px solid rgba(255, 255, 255, 0.6);
+		outline-offset: 2px;
+	}
 }
 
 .gallery-overlay__loading {

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -185,15 +185,18 @@ $gallery-content-z-index: 5;
 	transition: all 0.3s ease;
 	transform: scale(1);
 
-	&.is-loading {
-		opacity: 0.7;
-		transform: scale(0.98);
+	&.is-transitioning {
+		&.slide-left {
+			animation: gallery-slide-out-left 0.2s ease-out;
+		}
+		
+		&.slide-right {
+			animation: gallery-slide-out-right 0.2s ease-out;
+		}
 	}
 
 	// Add subtle glow effect
-	&:not(.is-loading) {
-		filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.1));
-	}
+	filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.1));
 
 	@include breakpoint-deprecated( '>1200px' ) {
 		max-width: 85vw;
@@ -269,15 +272,6 @@ $gallery-content-z-index: 5;
 	&:active {
 		transform: translateY(0);
 	}
-}
-
-.gallery-overlay__loading {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	color: #fff;
-	animation: gallery-overlay-spin 1s linear infinite;
 }
 
 .gallery-overlay__error {
@@ -384,12 +378,26 @@ $gallery-content-z-index: 5;
 	}
 }
 
-@keyframes gallery-overlay-spin {
-	from {
-		transform: translate(-50%, -50%) rotate(0deg);
+// Slide animations for swipe transitions
+@keyframes gallery-slide-out-left {
+	0% {
+		opacity: 1;
+		transform: translateX(0);
 	}
-	to {
-		transform: translate(-50%, -50%) rotate(360deg);
+	100% {
+		opacity: 0;
+		transform: translateX(-30px);
+	}
+}
+
+@keyframes gallery-slide-out-right {
+	0% {
+		opacity: 1;
+		transform: translateX(0);
+	}
+	100% {
+		opacity: 0;
+		transform: translateX(30px);
 	}
 }
 
@@ -405,12 +413,12 @@ $gallery-content-z-index: 5;
 		transition-duration: 0s;
 	}
 
-	.gallery-overlay__loading {
-		animation: none;
-	}
-
 	.gallery-overlay__image {
 		transition: none;
+		
+		&.is-transitioning {
+			animation: none;
+		}
 	}
 }
 

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -1,10 +1,8 @@
 // Z-index management for gallery overlay
-$gallery-overlay-z-index: 10000000; // Higher than all Calypso UI elements (above webpack monitor)
+$gallery-overlay-z-index: 10000000;
 $gallery-backdrop-z-index: 1;
 $gallery-controls-z-index: 10;
 $gallery-content-z-index: 5;
-
-
 
 .gallery-overlay {
 	position: fixed;
@@ -17,38 +15,12 @@ $gallery-content-z-index: 5;
 	align-items: center;
 	justify-content: center;
 	animation: gallery-overlay-fade-in 0.3s ease-out;
-	backdrop-filter: blur(2px); // Modern browser backdrop blur
-
-	// Focus trap indicator
-	&:focus-within {
-		.gallery-overlay__close,
-		.gallery-overlay__nav,
-		.gallery-overlay__error-button {
-			&:focus {
-				background: #999;
-			}
-		}
-	}
+	backdrop-filter: blur(2px);
 
 	// High contrast mode support
 	@media (prefers-contrast: high) {
-		.gallery-overlay__close,
-		.gallery-overlay__nav,
-		.gallery-overlay__error-button {
-			background-color: rgba(0, 0, 0, 0.8);
-		}
-
 		.gallery-overlay__backdrop {
 			background: #000;
-		}
-	}
-
-	// Keyboard navigation indicator
-	&.is-keyboard-navigation {
-		.gallery-overlay__nav,
-		.gallery-overlay__close {
-			opacity: 1;
-			background-color: rgba(255, 255, 255, 0.2);
 		}
 	}
 }
@@ -169,34 +141,17 @@ $gallery-content-z-index: 5;
 	align-items: center;
 	animation: gallery-content-slide-in 0.4s ease-out;
 
-	// Tablet portrait/landscape handling
 	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 98vw;
 		max-height: 85vh;
 	}
 
-	// Mobile optimizations
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 100vw;
 		max-height: 80vh;
 	}
 
-	// Orientation-specific adjustments
-	@media (orientation: landscape) and (max-height: 600px) {
-		max-height: 75vh;
-		
-		.gallery-overlay__info {
-			margin-top: 8px;
-		}
-	}
 
-	@media (orientation: portrait) and (max-width: 480px) {
-		max-height: 85vh;
-		
-		.gallery-overlay__info {
-			margin-top: 12px;
-		}
-	}
 }
 
 .gallery-overlay__image-container {
@@ -206,47 +161,16 @@ $gallery-content-z-index: 5;
 	justify-content: center;
 	min-width: 200px;
 	min-height: 200px;
-	touch-action: pan-x; // Allow horizontal panning for swipe gestures
-	
-	// Desktop: larger minimum size
 	@include breakpoint-deprecated( '>1200px' ) {
 		min-width: 300px;
 		min-height: 300px;
 	}
 	
-	// Mobile: smaller minimum size
 	@include breakpoint-deprecated( '<660px' ) {
 		min-width: 150px;
 		min-height: 150px;
 	}
-	
-	// Add subtle touch feedback on touch devices
-	@media (pointer: coarse) {
-		&:active {
-			transform: scale(0.98);
-			transition: transform 0.1s ease;
-		}
-		
-		// Enhanced swipe area for better gesture detection
-		&::after {
-			content: '';
-			position: absolute;
-			top: -20px;
-			left: -20px;
-			right: -20px;
-			bottom: -20px;
-			pointer-events: none;
-		}
-	}
-	
-	// Orientation handling for image container
-	@media (orientation: landscape) and (max-height: 600px) {
-		min-height: 120px;
-	}
-	
-	@media (orientation: portrait) and (max-width: 480px) {
-		min-width: 120px;
-	}
+
 }
 
 .gallery-overlay__image {
@@ -271,20 +195,17 @@ $gallery-content-z-index: 5;
 		filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.1));
 	}
 
-	// Desktop: optimal viewing size
 	@include breakpoint-deprecated( '>1200px' ) {
 		max-width: 85vw;
 		max-height: 80vh;
 	}
 
-	// Tablet: adjust for smaller screens
 	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 92vw;
 		max-height: 70vh;
 		border-radius: 8px;
 	}
 
-	// Mobile: maximize screen usage
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 95vw;
 		max-height: 65vh;
@@ -293,25 +214,6 @@ $gallery-content-z-index: 5;
 			0 12px 24px rgba(0, 0, 0, 0.4),
 			0 4px 8px rgba(0, 0, 0, 0.2);
 	}
-
-	// Orientation-specific image sizing
-	@media (orientation: landscape) and (max-height: 600px) {
-		max-height: 60vh;
-		max-width: 90vw;
-	}
-
-	@media (orientation: portrait) and (max-width: 480px) {
-		max-height: 70vh;
-		max-width: 98vw;
-	}
-
-	// Ultra-wide screens
-	@media (min-width: 1600px) {
-		max-width: 80vw;
-		max-height: 85vh;
-	}
-
-
 }
 
 // Image error state
@@ -425,31 +327,9 @@ $gallery-content-z-index: 5;
 	max-width: 90vw;
 	padding: 0 16px;
 
-	// Desktop: more spacing
-	@include breakpoint-deprecated( '>1200px' ) {
-		margin-top: 24px;
-		max-width: 80vw;
-		padding: 0 24px;
-	}
-
-	// Tablet: moderate spacing
-	@include breakpoint-deprecated( '<960px' ) {
-		margin-top: 14px;
-		max-width: 92vw;
-		padding: 0 20px;
-	}
-
-	// Mobile: compact spacing
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 12px;
 		max-width: 95vw;
-		padding: 0 16px;
-	}
-
-	// Orientation adjustments
-	@media (orientation: landscape) and (max-height: 600px) {
-		margin-top: 8px;
-		padding: 0 12px;
 	}
 }
 
@@ -460,13 +340,6 @@ $gallery-content-z-index: 5;
 	margin-bottom: 8px;
 	opacity: 0.8;
 
-	// Desktop: slightly larger
-	@include breakpoint-deprecated( '>1200px' ) {
-		font-size: 15px;
-		margin-bottom: 10px;
-	}
-
-	// Mobile: smaller but readable
 	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 13px;
 		margin-bottom: 6px;
@@ -481,32 +354,10 @@ $gallery-content-z-index: 5;
 	margin: 0 auto;
 	opacity: 0.9;
 
-	// Desktop: optimal reading size
-	@include breakpoint-deprecated( '>1200px' ) {
-		max-width: 700px;
-		font-size: 17px;
-		line-height: 1.5;
-	}
-
-	// Tablet: moderate sizing
-	@include breakpoint-deprecated( '<960px' ) {
-		max-width: 500px;
-		font-size: 15px;
-		line-height: 1.4;
-	}
-
-	// Mobile: compact but readable
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 400px;
 		font-size: 14px;
 		line-height: 1.3;
-	}
-
-	// Landscape mobile: even more compact
-	@media (orientation: landscape) and (max-height: 600px) {
-		font-size: 13px;
-		line-height: 1.3;
-		max-width: 350px;
 	}
 }
 
@@ -542,17 +393,7 @@ $gallery-content-z-index: 5;
 	}
 }
 
-// Image transition animation
-@keyframes gallery-image-transition {
-	0% {
-		opacity: 0;
-		transform: scale(0.9);
-	}
-	100% {
-		opacity: 1;
-		transform: scale(1);
-	}
-}
+
 
 // Accessibility improvements
 @media (prefers-reduced-motion: reduce) {
@@ -584,6 +425,3 @@ $gallery-content-z-index: 5;
 		}
 	}
 }
-
-
-

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -72,16 +72,25 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition: background-color 0.2s ease, transform 0.2s ease;
+	transition: background-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+	opacity: 0.8;
 
 	&:hover {
-		background-color: rgba(255, 255, 255, 0.2);
-		transform: translateY(-50%) scale(1.05);
+		background-color: rgba(255, 255, 255, 0.3);
+		transform: translateY(-50%) scale(1.1);
+		opacity: 1;
 	}
 
 	&:focus {
 		outline: 2px solid #fff;
 		outline-offset: 2px;
+		background-color: rgba(255, 255, 255, 0.25);
+		opacity: 1;
+	}
+
+	&:active {
+		transform: translateY(-50%) scale(0.95);
+		background-color: rgba(255, 255, 255, 0.4);
 	}
 
 	&--previous {
@@ -103,6 +112,19 @@
 	@include breakpoint-deprecated( '<660px' ) {
 		width: 56px;
 		height: 56px;
+		opacity: 0.9;
+
+		&:hover {
+			// On mobile, reduce hover effects since they're not as useful
+			transform: translateY(-50%) scale(1.05);
+		}
+	}
+
+	// Better touch targets on mobile
+	@media (pointer: coarse) {
+		width: 60px;
+		height: 60px;
+		opacity: 0.9;
 	}
 }
 
@@ -122,6 +144,15 @@
 	justify-content: center;
 	min-width: 200px;
 	min-height: 200px;
+	touch-action: pan-x; // Allow horizontal panning for swipe gestures
+	
+	// Add subtle touch feedback on mobile
+	@media (pointer: coarse) {
+		&:active {
+			transform: scale(0.98);
+			transition: transform 0.1s ease;
+		}
+	}
 }
 
 .gallery-overlay__image {

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -184,6 +184,52 @@
 	animation: gallery-overlay-spin 1s linear infinite;
 }
 
+.gallery-overlay__error {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 200px;
+	color: #fff;
+}
+
+.gallery-overlay__error-content {
+	text-align: center;
+	max-width: 400px;
+	padding: 24px;
+
+	h3 {
+		margin: 16px 0 12px;
+		font-size: 20px;
+		font-weight: 600;
+	}
+
+	p {
+		margin: 0 0 20px;
+		opacity: 0.8;
+		line-height: 1.5;
+	}
+}
+
+.gallery-overlay__error-button {
+	background-color: rgba(255, 255, 255, 0.2);
+	border: 1px solid rgba(255, 255, 255, 0.3);
+	border-radius: 4px;
+	color: #fff;
+	padding: 8px 16px;
+	cursor: pointer;
+	font-size: 14px;
+	transition: background-color 0.2s ease;
+
+	&:hover {
+		background-color: rgba(255, 255, 255, 0.3);
+	}
+
+	&:focus {
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+}
+
 .gallery-overlay__info {
 	margin-top: 16px;
 	text-align: center;

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -1,6 +1,3 @@
-@import '@automattic/calypso-config';
-@import '@automattic/color-studio/dist/color-variables';
-
 // Z-index management for gallery overlay
 $gallery-overlay-z-index: 100000; // Higher than most UI elements
 $gallery-backdrop-z-index: 1;

--- a/client/blocks/reader-full-post/gallery-overlay.scss
+++ b/client/blocks/reader-full-post/gallery-overlay.scss
@@ -161,7 +161,18 @@ $gallery-content-z-index: 5;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 
 	&--previous {
-		left: 32px;
+		left: 40px;
+
+		// Desktop: larger click area
+		@include breakpoint-deprecated( '>1200px' ) {
+			left: 60px;
+			width: 72px;
+			height: 72px;
+		}
+
+		@include breakpoint-deprecated( '<960px' ) {
+			left: 24px;
+		}
 
 		@include breakpoint-deprecated( '<660px' ) {
 			left: 16px;
@@ -169,13 +180,36 @@ $gallery-content-z-index: 5;
 	}
 
 	&--next {
-		right: 32px;
+		right: 40px;
+
+		// Desktop: larger click area
+		@include breakpoint-deprecated( '>1200px' ) {
+			right: 60px;
+			width: 72px;
+			height: 72px;
+		}
+
+		@include breakpoint-deprecated( '<960px' ) {
+			right: 24px;
+		}
 
 		@include breakpoint-deprecated( '<660px' ) {
 			right: 16px;
 		}
 	}
 
+	// Tablet optimizations
+	@include breakpoint-deprecated( '<960px' ) {
+		width: 60px;
+		height: 60px;
+		opacity: 0.9;
+
+		&:hover {
+			transform: translateY(-50%) scale(1.06);
+		}
+	}
+
+	// Mobile optimizations
 	@include breakpoint-deprecated( '<660px' ) {
 		width: 56px;
 		height: 56px;
@@ -187,11 +221,28 @@ $gallery-content-z-index: 5;
 		}
 	}
 
-	// Better touch targets on mobile
+	// Better touch targets for touch devices
 	@media (pointer: coarse) {
-		width: 60px;
-		height: 60px;
-		opacity: 0.9;
+		width: 64px;
+		height: 64px;
+		opacity: 0.95;
+
+		// Larger touch area for easier interaction
+		&::before {
+			content: '';
+			position: absolute;
+			top: -8px;
+			left: -8px;
+			right: -8px;
+			bottom: -8px;
+		}
+	}
+
+	// High-resolution displays
+	@media (-webkit-min-device-pixel-ratio: 2) {
+		&:hover {
+			transform: translateY(-50%) scale(1.05);
+		}
 	}
 }
 
@@ -205,9 +256,33 @@ $gallery-content-z-index: 5;
 	align-items: center;
 	animation: gallery-content-slide-in 0.4s ease-out;
 
+	// Tablet portrait/landscape handling
 	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 98vw;
 		max-height: 85vh;
+	}
+
+	// Mobile optimizations
+	@include breakpoint-deprecated( '<660px' ) {
+		max-width: 100vw;
+		max-height: 80vh;
+	}
+
+	// Orientation-specific adjustments
+	@media (orientation: landscape) and (max-height: 600px) {
+		max-height: 75vh;
+		
+		.gallery-overlay__info {
+			margin-top: 8px;
+		}
+	}
+
+	@media (orientation: portrait) and (max-width: 480px) {
+		max-height: 85vh;
+		
+		.gallery-overlay__info {
+			margin-top: 12px;
+		}
 	}
 }
 
@@ -220,12 +295,50 @@ $gallery-content-z-index: 5;
 	min-height: 200px;
 	touch-action: pan-x; // Allow horizontal panning for swipe gestures
 	
-	// Add subtle touch feedback on mobile
+	// Desktop: larger minimum size
+	@include breakpoint-deprecated( '>1200px' ) {
+		min-width: 300px;
+		min-height: 300px;
+	}
+	
+	// Tablet: medium size
+	@include breakpoint-deprecated( '<960px' ) {
+		min-width: 250px;
+		min-height: 250px;
+	}
+	
+	// Mobile: smaller minimum size
+	@include breakpoint-deprecated( '<660px' ) {
+		min-width: 150px;
+		min-height: 150px;
+	}
+	
+	// Add subtle touch feedback on touch devices
 	@media (pointer: coarse) {
 		&:active {
 			transform: scale(0.98);
 			transition: transform 0.1s ease;
 		}
+		
+		// Enhanced swipe area for better gesture detection
+		&::after {
+			content: '';
+			position: absolute;
+			top: -20px;
+			left: -20px;
+			right: -20px;
+			bottom: -20px;
+			pointer-events: none;
+		}
+	}
+	
+	// Orientation handling for image container
+	@media (orientation: landscape) and (max-height: 600px) {
+		min-height: 120px;
+	}
+	
+	@media (orientation: portrait) and (max-width: 480px) {
+		min-width: 120px;
 	}
 }
 
@@ -251,12 +364,20 @@ $gallery-content-z-index: 5;
 		filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.1));
 	}
 
+	// Desktop: optimal viewing size
+	@include breakpoint-deprecated( '>1200px' ) {
+		max-width: 85vw;
+		max-height: 80vh;
+	}
+
+	// Tablet: adjust for smaller screens
 	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 92vw;
 		max-height: 70vh;
 		border-radius: 8px;
 	}
 
+	// Mobile: maximize screen usage
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 95vw;
 		max-height: 65vh;
@@ -264,6 +385,23 @@ $gallery-content-z-index: 5;
 		box-shadow: 
 			0 12px 24px rgba(0, 0, 0, 0.4),
 			0 4px 8px rgba(0, 0, 0, 0.2);
+	}
+
+	// Orientation-specific image sizing
+	@media (orientation: landscape) and (max-height: 600px) {
+		max-height: 60vh;
+		max-width: 90vw;
+	}
+
+	@media (orientation: portrait) and (max-width: 480px) {
+		max-height: 70vh;
+		max-width: 98vw;
+	}
+
+	// Ultra-wide screens
+	@media (min-width: 1600px) {
+		max-width: 80vw;
+		max-height: 85vh;
 	}
 }
 
@@ -326,10 +464,33 @@ $gallery-content-z-index: 5;
 	margin-top: 16px;
 	text-align: center;
 	max-width: 90vw;
+	padding: 0 16px;
 
+	// Desktop: more spacing
+	@include breakpoint-deprecated( '>1200px' ) {
+		margin-top: 24px;
+		max-width: 80vw;
+		padding: 0 24px;
+	}
+
+	// Tablet: moderate spacing
+	@include breakpoint-deprecated( '<960px' ) {
+		margin-top: 14px;
+		max-width: 92vw;
+		padding: 0 20px;
+	}
+
+	// Mobile: compact spacing
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 12px;
 		max-width: 95vw;
+		padding: 0 16px;
+	}
+
+	// Orientation adjustments
+	@media (orientation: landscape) and (max-height: 600px) {
+		margin-top: 8px;
+		padding: 0 12px;
 	}
 }
 
@@ -340,8 +501,16 @@ $gallery-content-z-index: 5;
 	margin-bottom: 8px;
 	opacity: 0.8;
 
+	// Desktop: slightly larger
+	@include breakpoint-deprecated( '>1200px' ) {
+		font-size: 15px;
+		margin-bottom: 10px;
+	}
+
+	// Mobile: smaller but readable
 	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 13px;
+		margin-bottom: 6px;
 	}
 }
 
@@ -353,14 +522,32 @@ $gallery-content-z-index: 5;
 	margin: 0 auto;
 	opacity: 0.9;
 
+	// Desktop: optimal reading size
+	@include breakpoint-deprecated( '>1200px' ) {
+		max-width: 700px;
+		font-size: 17px;
+		line-height: 1.5;
+	}
+
+	// Tablet: moderate sizing
 	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 500px;
 		font-size: 15px;
+		line-height: 1.4;
 	}
 
+	// Mobile: compact but readable
 	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 400px;
 		font-size: 14px;
+		line-height: 1.3;
+	}
+
+	// Landscape mobile: even more compact
+	@media (orientation: landscape) and (max-height: 600px) {
+		font-size: 13px;
+		line-height: 1.3;
+		max-width: 350px;
 	}
 }
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -276,7 +276,7 @@ export class FullPostView extends Component {
 		this.setState( { galleryError: null } );
 	};
 
-	// Extract image data from a gallery element with performance optimization
+	// Extract image data from a gallery element
 	extractGalleryImages = ( galleryElement ) => {
 		try {
 			const images = [];
@@ -285,22 +285,17 @@ export class FullPostView extends Component {
 			);
 
 			galleryImages.forEach( ( img, index ) => {
-				// Get the best available image source
-				const src = this.getOptimizedImageSrc( img );
-
 				// Validate image source
-				if ( ! src || src === '' ) {
+				if ( ! img.src || img.src === '' ) {
 					return; // Skip images without valid source
 				}
 
 				images.push( {
-					src,
+					src: img.src,
 					alt: img.alt || `Gallery image ${ index + 1 }`,
 					caption: this.getImageCaption( img ),
 					width: img.naturalWidth || img.width || null,
 					height: img.naturalHeight || img.height || null,
-					originalSrc: img.src, // Keep original for fallback
-					index,
 				} );
 			} );
 
@@ -309,49 +304,6 @@ export class FullPostView extends Component {
 			this.handleGalleryError( error );
 			return [];
 		}
-	};
-
-	// Get optimized image source based on screen size and device capabilities
-	getOptimizedImageSrc = ( img ) => {
-		const originalSrc = img.src || img.dataset.src || img.dataset.originalSrc;
-
-		if ( ! originalSrc ) {
-			return null;
-		}
-
-		// Check if we're on a high-DPI display
-		const devicePixelRatio = window.devicePixelRatio || 1;
-		const isHighDPI = devicePixelRatio > 1.5;
-
-		// Get viewport dimensions
-		const viewportWidth = window.innerWidth;
-		const viewportHeight = window.innerHeight;
-
-		// Calculate optimal image size (accounting for overlay max-width/height)
-		const maxDisplayWidth = Math.min( viewportWidth * 0.9, 1200 );
-		const maxDisplayHeight = Math.min( viewportHeight * 0.8, 900 );
-
-		// Adjust for high-DPI displays
-		const targetWidth = Math.round( maxDisplayWidth * ( isHighDPI ? 1.5 : 1 ) );
-		const targetHeight = Math.round( maxDisplayHeight * ( isHighDPI ? 1.5 : 1 ) );
-
-		// Try to optimize WordPress.com image URLs
-		if ( originalSrc.includes( 'wp.com' ) || originalSrc.includes( 'wordpress.com' ) ) {
-			// Remove existing size parameters
-			const baseSrc = originalSrc.split( '?' )[ 0 ];
-
-			// Add optimized parameters
-			const params = new URLSearchParams();
-			params.set( 'w', targetWidth );
-			params.set( 'h', targetHeight );
-			params.set( 'fit', 'fit' );
-			params.set( 'quality', isHighDPI ? '85' : '90' );
-
-			return `${ baseSrc }?${ params.toString() }`;
-		}
-
-		// For other CDNs or direct images, return original
-		return originalSrc;
 	};
 
 	// Get caption text for an image
@@ -424,133 +376,29 @@ export class FullPostView extends Component {
 			return;
 		}
 
-		// Performance optimization: only add handler if galleries exist
-		const hasGalleries = this.postContentWrapper.current.querySelector(
-			'.wp-block-gallery, .tiled-gallery'
-		);
-		if ( ! hasGalleries ) {
-			// Track that no galleries were found
-			this.trackGalleryEvent( 'gallery_no_galleries_found', {
-				post_id: this.props.post?.ID,
-			} );
-			return;
-		}
-
-		// Add event listener with passive option for better performance
-		this.postContentWrapper.current.addEventListener( 'click', this.handleGalleryImageClick, {
-			capture: true,
-			passive: false, // We need to call preventDefault
-		} );
-
-		// Track successful setup
-		this.trackGalleryEvent( 'gallery_handlers_setup', {
-			post_id: this.props.post?.ID,
-			gallery_count: this.postContentWrapper.current.querySelectorAll(
-				'.wp-block-gallery, .tiled-gallery'
-			).length,
-		} );
+		// Add event listener for gallery clicks
+		this.postContentWrapper.current.addEventListener( 'click', this.handleGalleryImageClick, true );
 	};
 
-	// Initialize gallery integration with error handling
+	// Initialize gallery integration
 	initializeGalleryIntegration = () => {
 		try {
 			// Set up gallery click handling
 			this.setupGalleryClickHandlers();
-
-			// Set up mutation observer for dynamic content
-			this.setupDynamicContentObserver();
-
-			// Track gallery integration success
-			this.trackGalleryEvent( 'gallery_integration_initialized', {
-				post_id: this.props.post?.ID,
-				has_content_wrapper: !! this.postContentWrapper.current,
-			} );
 		} catch ( error ) {
 			// If gallery integration fails, don't break the entire component
 			this.handleGalleryError( new Error( 'Gallery integration failed: ' + error.message ) );
 		}
 	};
 
-	// Set up observer for dynamically loaded content
-	setupDynamicContentObserver = () => {
-		if ( ! this.postContentWrapper.current || ! window.MutationObserver ) {
-			return;
-		}
-
-		// Create observer to watch for new gallery content
-		this.contentObserver = new MutationObserver( ( mutations ) => {
-			let hasNewGalleries = false;
-
-			mutations.forEach( ( mutation ) => {
-				if ( mutation.type === 'childList' ) {
-					mutation.addedNodes.forEach( ( node ) => {
-						if ( node.nodeType === Node.ELEMENT_NODE ) {
-							// Check if new node contains galleries
-							const galleries = node.querySelectorAll?.( '.wp-block-gallery, .tiled-gallery' );
-							if ( galleries && galleries.length > 0 ) {
-								hasNewGalleries = true;
-							}
-						}
-					} );
-				}
-			} );
-
-			// If new galleries are detected, refresh click handlers
-			if ( hasNewGalleries ) {
-				this.refreshGalleryHandlers();
-			}
-		} );
-
-		// Start observing
-		this.contentObserver.observe( this.postContentWrapper.current, {
-			childList: true,
-			subtree: true,
-		} );
-	};
-
-	// Refresh gallery handlers for dynamic content
-	refreshGalleryHandlers = () => {
-		try {
-			// Remove existing handlers
-			this.cleanupGalleryClickHandlers();
-
-			// Re-setup handlers with new content
-			this.setupGalleryClickHandlers();
-
-			// Track dynamic content detection
-			this.trackGalleryEvent( 'gallery_dynamic_content_detected', {
-				post_id: this.props.post?.ID,
-			} );
-		} catch ( error ) {
-			this.handleGalleryError(
-				new Error( 'Failed to refresh gallery handlers: ' + error.message )
-			);
-		}
-	};
-
 	// Clean up gallery click handlers
 	cleanupGalleryClickHandlers = () => {
 		if ( this.postContentWrapper.current ) {
-			// Remove event listener (matching the options used when adding)
-			this.postContentWrapper.current.removeEventListener( 'click', this.handleGalleryImageClick, {
-				capture: true,
-				passive: false,
-			} );
-
-			// Fallback: also try to remove with old format for compatibility
 			this.postContentWrapper.current.removeEventListener(
 				'click',
 				this.handleGalleryImageClick,
 				true
 			);
-		}
-	};
-
-	// Clean up dynamic content observer
-	cleanupDynamicContentObserver = () => {
-		if ( this.contentObserver ) {
-			this.contentObserver.disconnect();
-			this.contentObserver = null;
 		}
 	};
 
@@ -646,7 +494,6 @@ export class FullPostView extends Component {
 
 		// Clean up gallery integration
 		this.cleanupGalleryClickHandlers();
-		this.cleanupDynamicContentObserver();
 
 		// Track scroll depth and remove related instruments
 		this.trackScrollDepth( this.props.post );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -77,6 +77,7 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { disableAppBanner, enableAppBanner } from 'calypso/state/ui/actions';
+import GalleryOverlay from './gallery-overlay';
 import ReaderFullPostHeader from './header';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
 import ScrollTracker from './scroll-tracker';
@@ -1003,6 +1004,15 @@ export class FullPostView extends Component {
 							author={ feed?.blog_owner }
 						/>
 					) }
+
+					<GalleryOverlay
+						isOpen={ this.state.isGalleryOpen }
+						images={ this.state.galleryImages }
+						currentIndex={ this.state.currentImageIndex }
+						onClose={ this.closeGallery }
+						onNext={ this.nextImage }
+						onPrevious={ this.previousImage }
+					/>
 				</ReaderMain>
 			</div>
 		);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -155,10 +155,15 @@ export class FullPostView extends Component {
 
 		// Restore focus to the originally clicked image
 		if ( this.clickedImageElement && this.clickedImageElement.isConnected ) {
-			// Use setTimeout to ensure the modal is fully closed
-			setTimeout( () => {
-				this.clickedImageElement.focus();
-			}, 100 );
+			// Use requestAnimationFrame to ensure the modal is fully closed
+			requestAnimationFrame( () => {
+				// Double RAF to ensure DOM updates are complete
+				requestAnimationFrame( () => {
+					if ( this.clickedImageElement && this.clickedImageElement.isConnected ) {
+						this.clickedImageElement.focus();
+					}
+				} );
+			} );
 		}
 	};
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -142,22 +142,9 @@ export class FullPostView extends Component {
 			galleryError: null,
 			isGalleryLoading: false,
 		} );
-
-		// Track gallery opened event
-		this.trackGalleryEvent( 'gallery_opened', {
-			image_count: images.length,
-			starting_index: imageIndex,
-		} );
 	};
 
 	closeGallery = () => {
-		// Track gallery closed event
-		const { currentImageIndex, galleryImages } = this.state;
-		this.trackGalleryEvent( 'gallery_closed', {
-			final_index: currentImageIndex,
-			total_images: galleryImages.length,
-		} );
-
 		this.setState( {
 			isGalleryOpen: false,
 			currentImageIndex: 0,
@@ -165,6 +152,14 @@ export class FullPostView extends Component {
 			galleryError: null,
 			isGalleryLoading: false,
 		} );
+
+		// Restore focus to the originally clicked image
+		if ( this.clickedImageElement && this.clickedImageElement.isConnected ) {
+			// Use setTimeout to ensure the modal is fully closed
+			setTimeout( () => {
+				this.clickedImageElement.focus();
+			}, 100 );
+		}
 	};
 
 	nextImage = () => {
@@ -176,13 +171,6 @@ export class FullPostView extends Component {
 		if ( currentImageIndex < galleryImages.length - 1 ) {
 			const newIndex = currentImageIndex + 1;
 			this.setState( { currentImageIndex: newIndex } );
-
-			// Track navigation event
-			this.trackGalleryEvent( 'gallery_navigate', {
-				direction: 'next',
-				from_index: currentImageIndex,
-				to_index: newIndex,
-			} );
 		}
 	};
 
@@ -195,13 +183,6 @@ export class FullPostView extends Component {
 		if ( currentImageIndex > 0 ) {
 			const newIndex = currentImageIndex - 1;
 			this.setState( { currentImageIndex: newIndex } );
-
-			// Track navigation event
-			this.trackGalleryEvent( 'gallery_navigate', {
-				direction: 'previous',
-				from_index: currentImageIndex,
-				to_index: newIndex,
-			} );
 		}
 	};
 
@@ -218,13 +199,6 @@ export class FullPostView extends Component {
 			imageIndex !== currentImageIndex
 		) {
 			this.setState( { currentImageIndex: imageIndex } );
-
-			// Track navigation event
-			this.trackGalleryEvent( 'gallery_navigate', {
-				direction: 'jump',
-				from_index: currentImageIndex,
-				to_index: imageIndex,
-			} );
 		}
 	};
 
@@ -241,16 +215,6 @@ export class FullPostView extends Component {
 		}
 	};
 
-	// Track gallery events for analytics
-	trackGalleryEvent = ( eventName, properties = {} ) => {
-		if ( this.props.post ) {
-			recordTrackForPost( `calypso_reader_gallery_${ eventName }`, this.props.post, {
-				...properties,
-				context: 'full-post',
-			} );
-		}
-	};
-
 	// Handle gallery errors
 	handleGalleryError = ( error ) => {
 		// Log error for debugging (avoiding console.error in production)
@@ -262,12 +226,6 @@ export class FullPostView extends Component {
 		this.setState( {
 			galleryError: error.message || 'An error occurred while loading the gallery',
 			isGalleryLoading: false,
-		} );
-
-		// Track error for analytics
-		this.trackGalleryEvent( 'gallery_error', {
-			error_message: error.message || 'Unknown error',
-			error_type: error.name || 'Error',
 		} );
 	};
 
@@ -344,6 +302,9 @@ export class FullPostView extends Component {
 			event.preventDefault();
 			event.stopPropagation();
 
+			// Store reference to the clicked image for focus restoration
+			this.clickedImageElement = img;
+
 			// Set loading state
 			this.setState( { isGalleryLoading: true, galleryError: null } );
 
@@ -378,6 +339,63 @@ export class FullPostView extends Component {
 
 		// Add event listener for gallery clicks
 		this.postContentWrapper.current.addEventListener( 'click', this.handleGalleryImageClick, true );
+
+		// Add keyboard navigation for gallery images
+		this.postContentWrapper.current.addEventListener( 'keydown', this.handleGalleryKeydown, true );
+
+		// Make gallery images focusable
+		this.makeGalleryImagesFocusable();
+	};
+
+	// Handle keyboard events on gallery images
+	handleGalleryKeydown = ( event ) => {
+		const img = event.target;
+
+		// Only handle keydown on img elements in galleries
+		if ( img.tagName !== 'IMG' ) {
+			return;
+		}
+
+		const galleryElement = img.closest( '.wp-block-gallery, .tiled-gallery' );
+		if ( ! galleryElement ) {
+			return;
+		}
+
+		// Handle Enter and Space to open gallery
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			// Simulate a click event
+			this.handleGalleryImageClick( {
+				target: img,
+				preventDefault: () => {},
+				stopPropagation: () => {},
+			} );
+		}
+	};
+
+	// Make gallery images focusable and accessible
+	makeGalleryImagesFocusable = () => {
+		if ( ! this.postContentWrapper.current ) {
+			return;
+		}
+
+		const galleryImages = this.postContentWrapper.current.querySelectorAll(
+			'.wp-block-gallery img, .tiled-gallery img'
+		);
+
+		galleryImages.forEach( ( img ) => {
+			// Make image focusable
+			img.setAttribute( 'tabindex', '0' );
+
+			// Add role and label for screen readers
+			img.setAttribute( 'role', 'button' );
+			img.setAttribute( 'aria-label', `Open gallery image: ${ img.alt || 'Image' }` );
+
+			// Add visual focus indicator
+			img.style.cursor = 'pointer';
+		} );
 	};
 
 	// Initialize gallery integration
@@ -397,6 +415,11 @@ export class FullPostView extends Component {
 			this.postContentWrapper.current.removeEventListener(
 				'click',
 				this.handleGalleryImageClick,
+				true
+			);
+			this.postContentWrapper.current.removeEventListener(
+				'keydown',
+				this.handleGalleryKeydown,
 				true
 			);
 		}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -202,19 +202,6 @@ export class FullPostView extends Component {
 		}
 	};
 
-	// Go to first image
-	goToFirstImage = () => {
-		this.goToImage( 0 );
-	};
-
-	// Go to last image
-	goToLastImage = () => {
-		const { galleryImages } = this.state;
-		if ( galleryImages.length > 0 ) {
-			this.goToImage( galleryImages.length - 1 );
-		}
-	};
-
 	// Handle gallery errors
 	handleGalleryError = ( error ) => {
 		// Log error for debugging (avoiding console.error in production)
@@ -959,8 +946,6 @@ export class FullPostView extends Component {
 					onClose={ this.closeGallery }
 					onNext={ this.nextImage }
 					onPrevious={ this.previousImage }
-					onGoToFirst={ this.goToFirstImage }
-					onGoToLast={ this.goToLastImage }
 					onClearError={ this.clearGalleryError }
 				/>
 			);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -106,6 +106,9 @@ export class FullPostView extends Component {
 
 	state = {
 		isSuggestedFollowsModalOpen: false,
+		isGalleryOpen: false,
+		currentImageIndex: 0,
+		galleryImages: [],
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -113,6 +116,127 @@ export class FullPostView extends Component {
 	};
 	onCloseSuggestedFollowModal = () => {
 		this.setState( { isSuggestedFollowsModalOpen: false } );
+	};
+
+	// Gallery overlay methods
+	openGallery = ( imageIndex, images ) => {
+		this.setState( {
+			isGalleryOpen: true,
+			currentImageIndex: imageIndex,
+			galleryImages: images,
+		} );
+	};
+
+	closeGallery = () => {
+		this.setState( {
+			isGalleryOpen: false,
+			currentImageIndex: 0,
+			galleryImages: [],
+		} );
+	};
+
+	nextImage = () => {
+		const { currentImageIndex, galleryImages } = this.state;
+		if ( currentImageIndex < galleryImages.length - 1 ) {
+			this.setState( { currentImageIndex: currentImageIndex + 1 } );
+		}
+	};
+
+	previousImage = () => {
+		const { currentImageIndex } = this.state;
+		if ( currentImageIndex > 0 ) {
+			this.setState( { currentImageIndex: currentImageIndex - 1 } );
+		}
+	};
+
+	// Extract image data from a gallery element
+	extractGalleryImages = ( galleryElement ) => {
+		const images = [];
+		const galleryImages = galleryElement.querySelectorAll(
+			'.wp-block-image img, .blocks-gallery-item img'
+		);
+
+		galleryImages.forEach( ( img ) => {
+			images.push( {
+				src: img.src,
+				alt: img.alt || '',
+				caption: this.getImageCaption( img ),
+			} );
+		} );
+
+		return images;
+	};
+
+	// Get caption text for an image
+	getImageCaption = ( img ) => {
+		// Look for caption in various possible structures
+		const figcaption = img.closest( 'figure' )?.querySelector( 'figcaption' );
+		if ( figcaption ) {
+			return figcaption.textContent.trim();
+		}
+
+		const caption = img
+			.closest( '.wp-block-image' )
+			?.querySelector( '.blocks-gallery-item__caption, .wp-block-image__caption' );
+		if ( caption ) {
+			return caption.textContent.trim();
+		}
+
+		return '';
+	};
+
+	// Handle clicks on gallery images
+	handleGalleryImageClick = ( event ) => {
+		const img = event.target;
+
+		// Only handle clicks on img elements
+		if ( img.tagName !== 'IMG' ) {
+			return;
+		}
+
+		// Check if this is a gallery image
+		const galleryElement = img.closest( '.wp-block-gallery, .tiled-gallery' );
+		if ( ! galleryElement ) {
+			return;
+		}
+
+		// Prevent default link behavior
+		event.preventDefault();
+		event.stopPropagation();
+
+		// Extract all images from this gallery
+		const galleryImages = this.extractGalleryImages( galleryElement );
+
+		// Find the index of the clicked image
+		const clickedImageIndex = galleryImages.findIndex(
+			( galleryImg ) => galleryImg.src === img.src
+		);
+
+		if ( clickedImageIndex !== -1 ) {
+			this.openGallery( clickedImageIndex, galleryImages );
+		}
+	};
+
+	// Set up gallery click handlers using event delegation
+	setupGalleryClickHandlers = () => {
+		if ( this.postContentWrapper.current ) {
+			this.postContentWrapper.current.addEventListener(
+				'click',
+				this.handleGalleryImageClick,
+				true
+			);
+		}
+	};
+
+	// Clean up gallery click handlers
+	cleanupGalleryClickHandlers = () => {
+		if ( this.postContentWrapper.current ) {
+			this.postContentWrapper.current.removeEventListener(
+				'click',
+				this.handleGalleryImageClick,
+				true
+			);
+		}
 	};
 
 	componentDidMount() {
@@ -141,6 +265,9 @@ export class FullPostView extends Component {
 		document.addEventListener( 'keydown', this.handleKeydown, true );
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
+
+		// Set up gallery click handling
+		this.setupGalleryClickHandlers();
 
 		const scrollableContainer =
 			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
@@ -201,6 +328,9 @@ export class FullPostView extends Component {
 		this.trackReadingTime();
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
+
+		// Clean up gallery click handlers
+		this.cleanupGalleryClickHandlers();
 
 		// Track scroll depth and remove related instruments
 		this.trackScrollDepth( this.props.post );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -343,8 +343,15 @@ export class FullPostView extends Component {
 		// Add keyboard navigation for gallery images
 		this.postContentWrapper.current.addEventListener( 'keydown', this.handleGalleryKeydown, true );
 
-		// Make gallery images focusable
-		this.makeGalleryImagesFocusable();
+		// Make gallery images focusable (with a small delay to ensure DOM is ready)
+		setTimeout( () => {
+			this.makeGalleryImagesFocusable();
+		}, 100 );
+
+		// Also try again after a longer delay in case content loads asynchronously
+		setTimeout( () => {
+			this.makeGalleryImagesFocusable();
+		}, 1000 );
 	};
 
 	// Handle keyboard events on gallery images
@@ -381,20 +388,33 @@ export class FullPostView extends Component {
 			return;
 		}
 
-		const galleryImages = this.postContentWrapper.current.querySelectorAll(
-			'.wp-block-gallery img, .tiled-gallery img'
-		);
+		// Try multiple selector patterns to catch all gallery structures
+		const selectors = [
+			'.wp-block-gallery img',
+			'.wp-block-gallery .wp-block-image img',
+			'.wp-block-gallery .wp-block-image .image-wrapper img',
+			'.tiled-gallery img',
+		];
 
-		galleryImages.forEach( ( img ) => {
-			// Make image focusable
-			img.setAttribute( 'tabindex', '0' );
+		selectors.forEach( ( selector ) => {
+			const galleryImages = this.postContentWrapper.current.querySelectorAll( selector );
 
-			// Add role and label for screen readers
-			img.setAttribute( 'role', 'button' );
-			img.setAttribute( 'aria-label', `Open gallery image: ${ img.alt || 'Image' }` );
+			galleryImages.forEach( ( img ) => {
+				// Skip if already processed
+				if ( img.getAttribute( 'tabindex' ) === '0' ) {
+					return;
+				}
 
-			// Add visual focus indicator
-			img.style.cursor = 'pointer';
+				// Make image focusable
+				img.setAttribute( 'tabindex', '0' );
+
+				// Add role and label for screen readers
+				img.setAttribute( 'role', 'button' );
+				img.setAttribute( 'aria-label', `Open gallery image: ${ img.alt || 'Image' }` );
+
+				// Add visual focus indicator
+				img.style.cursor = 'pointer';
+			} );
 		} );
 	};
 
@@ -483,6 +503,11 @@ export class FullPostView extends Component {
 				this.trackExitBeforeCompletion( prevProps.post );
 				this.setReadingStartTime();
 				this.resetScroll();
+
+				// Re-initialize gallery integration for new post
+				setTimeout( () => {
+					this.makeGalleryImagesFocusable();
+				}, 500 );
 			}
 		}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -372,11 +372,110 @@ export class FullPostView extends Component {
 
 	// Set up gallery click handlers using event delegation
 	setupGalleryClickHandlers = () => {
-		if ( this.postContentWrapper.current ) {
-			this.postContentWrapper.current.addEventListener(
-				'click',
-				this.handleGalleryImageClick,
-				true
+		if ( ! this.postContentWrapper.current ) {
+			return;
+		}
+
+		// Performance optimization: only add handler if galleries exist
+		const hasGalleries = this.postContentWrapper.current.querySelector(
+			'.wp-block-gallery, .tiled-gallery'
+		);
+		if ( ! hasGalleries ) {
+			// Track that no galleries were found
+			this.trackGalleryEvent( 'gallery_no_galleries_found', {
+				post_id: this.props.post?.ID,
+			} );
+			return;
+		}
+
+		// Add event listener with passive option for better performance
+		this.postContentWrapper.current.addEventListener( 'click', this.handleGalleryImageClick, {
+			capture: true,
+			passive: false, // We need to call preventDefault
+		} );
+
+		// Track successful setup
+		this.trackGalleryEvent( 'gallery_handlers_setup', {
+			post_id: this.props.post?.ID,
+			gallery_count: this.postContentWrapper.current.querySelectorAll(
+				'.wp-block-gallery, .tiled-gallery'
+			).length,
+		} );
+	};
+
+	// Initialize gallery integration with error handling
+	initializeGalleryIntegration = () => {
+		try {
+			// Set up gallery click handling
+			this.setupGalleryClickHandlers();
+
+			// Set up mutation observer for dynamic content
+			this.setupDynamicContentObserver();
+
+			// Track gallery integration success
+			this.trackGalleryEvent( 'gallery_integration_initialized', {
+				post_id: this.props.post?.ID,
+				has_content_wrapper: !! this.postContentWrapper.current,
+			} );
+		} catch ( error ) {
+			// If gallery integration fails, don't break the entire component
+			this.handleGalleryError( new Error( 'Gallery integration failed: ' + error.message ) );
+		}
+	};
+
+	// Set up observer for dynamically loaded content
+	setupDynamicContentObserver = () => {
+		if ( ! this.postContentWrapper.current || ! window.MutationObserver ) {
+			return;
+		}
+
+		// Create observer to watch for new gallery content
+		this.contentObserver = new MutationObserver( ( mutations ) => {
+			let hasNewGalleries = false;
+
+			mutations.forEach( ( mutation ) => {
+				if ( mutation.type === 'childList' ) {
+					mutation.addedNodes.forEach( ( node ) => {
+						if ( node.nodeType === Node.ELEMENT_NODE ) {
+							// Check if new node contains galleries
+							const galleries = node.querySelectorAll?.( '.wp-block-gallery, .tiled-gallery' );
+							if ( galleries && galleries.length > 0 ) {
+								hasNewGalleries = true;
+							}
+						}
+					} );
+				}
+			} );
+
+			// If new galleries are detected, refresh click handlers
+			if ( hasNewGalleries ) {
+				this.refreshGalleryHandlers();
+			}
+		} );
+
+		// Start observing
+		this.contentObserver.observe( this.postContentWrapper.current, {
+			childList: true,
+			subtree: true,
+		} );
+	};
+
+	// Refresh gallery handlers for dynamic content
+	refreshGalleryHandlers = () => {
+		try {
+			// Remove existing handlers
+			this.cleanupGalleryClickHandlers();
+
+			// Re-setup handlers with new content
+			this.setupGalleryClickHandlers();
+
+			// Track dynamic content detection
+			this.trackGalleryEvent( 'gallery_dynamic_content_detected', {
+				post_id: this.props.post?.ID,
+			} );
+		} catch ( error ) {
+			this.handleGalleryError(
+				new Error( 'Failed to refresh gallery handlers: ' + error.message )
 			);
 		}
 	};
@@ -384,11 +483,26 @@ export class FullPostView extends Component {
 	// Clean up gallery click handlers
 	cleanupGalleryClickHandlers = () => {
 		if ( this.postContentWrapper.current ) {
+			// Remove event listener (matching the options used when adding)
+			this.postContentWrapper.current.removeEventListener( 'click', this.handleGalleryImageClick, {
+				capture: true,
+				passive: false,
+			} );
+
+			// Fallback: also try to remove with old format for compatibility
 			this.postContentWrapper.current.removeEventListener(
 				'click',
 				this.handleGalleryImageClick,
 				true
 			);
+		}
+	};
+
+	// Clean up dynamic content observer
+	cleanupDynamicContentObserver = () => {
+		if ( this.contentObserver ) {
+			this.contentObserver.disconnect();
+			this.contentObserver = null;
 		}
 	};
 
@@ -419,8 +533,8 @@ export class FullPostView extends Component {
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		// Set up gallery click handling
-		this.setupGalleryClickHandlers();
+		// Set up gallery click handling with error boundary
+		this.initializeGalleryIntegration();
 
 		const scrollableContainer =
 			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
@@ -482,8 +596,9 @@ export class FullPostView extends Component {
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		// Clean up gallery click handlers
+		// Clean up gallery integration
 		this.cleanupGalleryClickHandlers();
+		this.cleanupDynamicContentObserver();
 
 		// Track scroll depth and remove related instruments
 		this.trackScrollDepth( this.props.post );
@@ -883,6 +998,36 @@ export class FullPostView extends Component {
 		);
 	};
 
+	// Render gallery overlay with error boundary
+	renderGalleryOverlay = () => {
+		try {
+			// Only render if we have the necessary data
+			if ( ! this.state.galleryImages && ! this.state.galleryError && ! this.state.isGalleryOpen ) {
+				return null;
+			}
+
+			return (
+				<GalleryOverlay
+					isOpen={ this.state.isGalleryOpen }
+					images={ this.state.galleryImages }
+					currentIndex={ this.state.currentImageIndex }
+					isLoading={ this.state.isGalleryLoading }
+					error={ this.state.galleryError }
+					onClose={ this.closeGallery }
+					onNext={ this.nextImage }
+					onPrevious={ this.previousImage }
+					onGoToFirst={ this.goToFirstImage }
+					onGoToLast={ this.goToLastImage }
+					onClearError={ this.clearGalleryError }
+				/>
+			);
+		} catch ( error ) {
+			// If gallery overlay fails to render, track error and return null
+			this.handleGalleryError( new Error( 'Gallery overlay render failed: ' + error.message ) );
+			return null;
+		}
+	};
+
 	render() {
 		const {
 			post,
@@ -1157,19 +1302,8 @@ export class FullPostView extends Component {
 						/>
 					) }
 
-					<GalleryOverlay
-						isOpen={ this.state.isGalleryOpen }
-						images={ this.state.galleryImages }
-						currentIndex={ this.state.currentImageIndex }
-						isLoading={ this.state.isGalleryLoading }
-						error={ this.state.galleryError }
-						onClose={ this.closeGallery }
-						onNext={ this.nextImage }
-						onPrevious={ this.previousImage }
-						onGoToFirst={ this.goToFirstImage }
-						onGoToLast={ this.goToLastImage }
-						onClearError={ this.clearGalleryError }
-					/>
+					{ /* Gallery Overlay with error boundary */ }
+					{ this.renderGalleryOverlay() }
 				</ReaderMain>
 			</div>
 		);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -330,15 +330,9 @@ export class FullPostView extends Component {
 		// Add keyboard navigation for gallery images
 		this.postContentWrapper.current.addEventListener( 'keydown', this.handleGalleryKeydown, true );
 
-		// Make gallery images focusable (with a small delay to ensure DOM is ready)
-		setTimeout( () => {
-			this.makeGalleryImagesFocusable();
-		}, 100 );
-
-		// Also try again after a longer delay in case content loads asynchronously
-		setTimeout( () => {
-			this.makeGalleryImagesFocusable();
-		}, 1000 );
+		// Make gallery images focusable immediately and watch for DOM changes
+		this.makeGalleryImagesFocusable();
+		this.setupGalleryObserver();
 	};
 
 	// Handle keyboard events on gallery images
@@ -405,6 +399,60 @@ export class FullPostView extends Component {
 		} );
 	};
 
+	// Set up MutationObserver to watch for gallery DOM changes
+	setupGalleryObserver = () => {
+		if ( ! this.postContentWrapper.current || ! window.MutationObserver ) {
+			return;
+		}
+
+		// Clean up any existing observer
+		this.cleanupGalleryObserver();
+
+		this.galleryObserver = new MutationObserver( ( mutations ) => {
+			let shouldUpdateGalleries = false;
+
+			mutations.forEach( ( mutation ) => {
+				// Check if new nodes were added that might contain galleries
+				if ( mutation.type === 'childList' && mutation.addedNodes.length > 0 ) {
+					for ( const node of mutation.addedNodes ) {
+						if ( node.nodeType === Node.ELEMENT_NODE ) {
+							// Check if the added node contains gallery elements
+							if (
+								node.matches &&
+								( node.matches( '.wp-block-gallery, .tiled-gallery' ) ||
+									node.querySelector( '.wp-block-gallery, .tiled-gallery' ) )
+							) {
+								shouldUpdateGalleries = true;
+								break;
+							}
+						}
+					}
+				}
+			} );
+
+			if ( shouldUpdateGalleries ) {
+				// Use requestAnimationFrame to ensure DOM is settled
+				requestAnimationFrame( () => {
+					this.makeGalleryImagesFocusable();
+				} );
+			}
+		} );
+
+		// Observe changes to child elements and their subtrees
+		this.galleryObserver.observe( this.postContentWrapper.current, {
+			childList: true,
+			subtree: true,
+		} );
+	};
+
+	// Clean up MutationObserver
+	cleanupGalleryObserver = () => {
+		if ( this.galleryObserver ) {
+			this.galleryObserver.disconnect();
+			this.galleryObserver = null;
+		}
+	};
+
 	// Initialize gallery integration
 	initializeGalleryIntegration = () => {
 		try {
@@ -430,6 +478,9 @@ export class FullPostView extends Component {
 				true
 			);
 		}
+
+		// Clean up MutationObserver
+		this.cleanupGalleryObserver();
 	};
 
 	componentDidMount() {
@@ -492,9 +543,9 @@ export class FullPostView extends Component {
 				this.resetScroll();
 
 				// Re-initialize gallery integration for new post
-				setTimeout( () => {
+				requestAnimationFrame( () => {
 					this.makeGalleryImagesFocusable();
-				}, 500 );
+				} );
 			}
 		}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -276,7 +276,7 @@ export class FullPostView extends Component {
 		this.setState( { galleryError: null } );
 	};
 
-	// Extract image data from a gallery element
+	// Extract image data from a gallery element with performance optimization
 	extractGalleryImages = ( galleryElement ) => {
 		try {
 			const images = [];
@@ -284,18 +284,23 @@ export class FullPostView extends Component {
 				'.wp-block-image img, .blocks-gallery-item img'
 			);
 
-			galleryImages.forEach( ( img ) => {
+			galleryImages.forEach( ( img, index ) => {
+				// Get the best available image source
+				const src = this.getOptimizedImageSrc( img );
+
 				// Validate image source
-				if ( ! img.src || img.src === '' ) {
+				if ( ! src || src === '' ) {
 					return; // Skip images without valid source
 				}
 
 				images.push( {
-					src: img.src,
-					alt: img.alt || '',
+					src,
+					alt: img.alt || `Gallery image ${ index + 1 }`,
 					caption: this.getImageCaption( img ),
 					width: img.naturalWidth || img.width || null,
 					height: img.naturalHeight || img.height || null,
+					originalSrc: img.src, // Keep original for fallback
+					index,
 				} );
 			} );
 
@@ -304,6 +309,49 @@ export class FullPostView extends Component {
 			this.handleGalleryError( error );
 			return [];
 		}
+	};
+
+	// Get optimized image source based on screen size and device capabilities
+	getOptimizedImageSrc = ( img ) => {
+		const originalSrc = img.src || img.dataset.src || img.dataset.originalSrc;
+
+		if ( ! originalSrc ) {
+			return null;
+		}
+
+		// Check if we're on a high-DPI display
+		const devicePixelRatio = window.devicePixelRatio || 1;
+		const isHighDPI = devicePixelRatio > 1.5;
+
+		// Get viewport dimensions
+		const viewportWidth = window.innerWidth;
+		const viewportHeight = window.innerHeight;
+
+		// Calculate optimal image size (accounting for overlay max-width/height)
+		const maxDisplayWidth = Math.min( viewportWidth * 0.9, 1200 );
+		const maxDisplayHeight = Math.min( viewportHeight * 0.8, 900 );
+
+		// Adjust for high-DPI displays
+		const targetWidth = Math.round( maxDisplayWidth * ( isHighDPI ? 1.5 : 1 ) );
+		const targetHeight = Math.round( maxDisplayHeight * ( isHighDPI ? 1.5 : 1 ) );
+
+		// Try to optimize WordPress.com image URLs
+		if ( originalSrc.includes( 'wp.com' ) || originalSrc.includes( 'wordpress.com' ) ) {
+			// Remove existing size parameters
+			const baseSrc = originalSrc.split( '?' )[ 0 ];
+
+			// Add optimized parameters
+			const params = new URLSearchParams();
+			params.set( 'w', targetWidth );
+			params.set( 'h', targetHeight );
+			params.set( 'fit', 'fit' );
+			params.set( 'quality', isHighDPI ? '85' : '90' );
+
+			return `${ baseSrc }?${ params.toString() }`;
+		}
+
+		// For other CDNs or direct images, return original
+		return originalSrc;
 	};
 
 	// Get caption text for an image

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -110,6 +110,8 @@ export class FullPostView extends Component {
 		isGalleryOpen: false,
 		currentImageIndex: 0,
 		galleryImages: [],
+		galleryError: null,
+		isGalleryLoading: false,
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -121,51 +123,187 @@ export class FullPostView extends Component {
 
 	// Gallery overlay methods
 	openGallery = ( imageIndex, images ) => {
+		// Validate inputs
+		if ( ! Array.isArray( images ) || images.length === 0 ) {
+			this.setState( { galleryError: 'No images available to display' } );
+			return;
+		}
+
+		if ( imageIndex < 0 || imageIndex >= images.length ) {
+			this.setState( { galleryError: 'Invalid image index' } );
+			return;
+		}
+
+		// Clear any previous errors and open gallery
 		this.setState( {
 			isGalleryOpen: true,
 			currentImageIndex: imageIndex,
 			galleryImages: images,
+			galleryError: null,
+			isGalleryLoading: false,
+		} );
+
+		// Track gallery opened event
+		this.trackGalleryEvent( 'gallery_opened', {
+			image_count: images.length,
+			starting_index: imageIndex,
 		} );
 	};
 
 	closeGallery = () => {
+		// Track gallery closed event
+		const { currentImageIndex, galleryImages } = this.state;
+		this.trackGalleryEvent( 'gallery_closed', {
+			final_index: currentImageIndex,
+			total_images: galleryImages.length,
+		} );
+
 		this.setState( {
 			isGalleryOpen: false,
 			currentImageIndex: 0,
 			galleryImages: [],
+			galleryError: null,
+			isGalleryLoading: false,
 		} );
 	};
 
 	nextImage = () => {
 		const { currentImageIndex, galleryImages } = this.state;
+		if ( ! galleryImages.length ) {
+			return;
+		}
+
 		if ( currentImageIndex < galleryImages.length - 1 ) {
-			this.setState( { currentImageIndex: currentImageIndex + 1 } );
+			const newIndex = currentImageIndex + 1;
+			this.setState( { currentImageIndex: newIndex } );
+
+			// Track navigation event
+			this.trackGalleryEvent( 'gallery_navigate', {
+				direction: 'next',
+				from_index: currentImageIndex,
+				to_index: newIndex,
+			} );
 		}
 	};
 
 	previousImage = () => {
-		const { currentImageIndex } = this.state;
-		if ( currentImageIndex > 0 ) {
-			this.setState( { currentImageIndex: currentImageIndex - 1 } );
+		const { currentImageIndex, galleryImages } = this.state;
+		if ( ! galleryImages.length ) {
+			return;
 		}
+
+		if ( currentImageIndex > 0 ) {
+			const newIndex = currentImageIndex - 1;
+			this.setState( { currentImageIndex: newIndex } );
+
+			// Track navigation event
+			this.trackGalleryEvent( 'gallery_navigate', {
+				direction: 'previous',
+				from_index: currentImageIndex,
+				to_index: newIndex,
+			} );
+		}
+	};
+
+	// Jump to specific image index
+	goToImage = ( imageIndex ) => {
+		const { galleryImages, currentImageIndex } = this.state;
+		if ( ! galleryImages.length ) {
+			return;
+		}
+
+		if (
+			imageIndex >= 0 &&
+			imageIndex < galleryImages.length &&
+			imageIndex !== currentImageIndex
+		) {
+			this.setState( { currentImageIndex: imageIndex } );
+
+			// Track navigation event
+			this.trackGalleryEvent( 'gallery_navigate', {
+				direction: 'jump',
+				from_index: currentImageIndex,
+				to_index: imageIndex,
+			} );
+		}
+	};
+
+	// Go to first image
+	goToFirstImage = () => {
+		this.goToImage( 0 );
+	};
+
+	// Go to last image
+	goToLastImage = () => {
+		const { galleryImages } = this.state;
+		if ( galleryImages.length > 0 ) {
+			this.goToImage( galleryImages.length - 1 );
+		}
+	};
+
+	// Track gallery events for analytics
+	trackGalleryEvent = ( eventName, properties = {} ) => {
+		if ( this.props.post ) {
+			recordTrackForPost( `calypso_reader_gallery_${ eventName }`, this.props.post, {
+				...properties,
+				context: 'full-post',
+			} );
+		}
+	};
+
+	// Handle gallery errors
+	handleGalleryError = ( error ) => {
+		// Log error for debugging (avoiding console.error in production)
+		if ( 'development' === process.env.NODE_ENV ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Gallery error:', error );
+		}
+
+		this.setState( {
+			galleryError: error.message || 'An error occurred while loading the gallery',
+			isGalleryLoading: false,
+		} );
+
+		// Track error for analytics
+		this.trackGalleryEvent( 'gallery_error', {
+			error_message: error.message || 'Unknown error',
+			error_type: error.name || 'Error',
+		} );
+	};
+
+	// Clear gallery error
+	clearGalleryError = () => {
+		this.setState( { galleryError: null } );
 	};
 
 	// Extract image data from a gallery element
 	extractGalleryImages = ( galleryElement ) => {
-		const images = [];
-		const galleryImages = galleryElement.querySelectorAll(
-			'.wp-block-image img, .blocks-gallery-item img'
-		);
+		try {
+			const images = [];
+			const galleryImages = galleryElement.querySelectorAll(
+				'.wp-block-image img, .blocks-gallery-item img'
+			);
 
-		galleryImages.forEach( ( img ) => {
-			images.push( {
-				src: img.src,
-				alt: img.alt || '',
-				caption: this.getImageCaption( img ),
+			galleryImages.forEach( ( img ) => {
+				// Validate image source
+				if ( ! img.src || img.src === '' ) {
+					return; // Skip images without valid source
+				}
+
+				images.push( {
+					src: img.src,
+					alt: img.alt || '',
+					caption: this.getImageCaption( img ),
+					width: img.naturalWidth || img.width || null,
+					height: img.naturalHeight || img.height || null,
+				} );
 			} );
-		} );
 
-		return images;
+			return images;
+		} catch ( error ) {
+			this.handleGalleryError( error );
+			return [];
+		}
 	};
 
 	// Get caption text for an image
@@ -188,33 +326,47 @@ export class FullPostView extends Component {
 
 	// Handle clicks on gallery images
 	handleGalleryImageClick = ( event ) => {
-		const img = event.target;
+		try {
+			const img = event.target;
 
-		// Only handle clicks on img elements
-		if ( img.tagName !== 'IMG' ) {
-			return;
-		}
+			// Only handle clicks on img elements
+			if ( img.tagName !== 'IMG' ) {
+				return;
+			}
 
-		// Check if this is a gallery image
-		const galleryElement = img.closest( '.wp-block-gallery, .tiled-gallery' );
-		if ( ! galleryElement ) {
-			return;
-		}
+			// Check if this is a gallery image
+			const galleryElement = img.closest( '.wp-block-gallery, .tiled-gallery' );
+			if ( ! galleryElement ) {
+				return;
+			}
 
-		// Prevent default link behavior
-		event.preventDefault();
-		event.stopPropagation();
+			// Prevent default link behavior
+			event.preventDefault();
+			event.stopPropagation();
 
-		// Extract all images from this gallery
-		const galleryImages = this.extractGalleryImages( galleryElement );
+			// Set loading state
+			this.setState( { isGalleryLoading: true, galleryError: null } );
 
-		// Find the index of the clicked image
-		const clickedImageIndex = galleryImages.findIndex(
-			( galleryImg ) => galleryImg.src === img.src
-		);
+			// Extract all images from this gallery
+			const galleryImages = this.extractGalleryImages( galleryElement );
 
-		if ( clickedImageIndex !== -1 ) {
-			this.openGallery( clickedImageIndex, galleryImages );
+			if ( galleryImages.length === 0 ) {
+				this.handleGalleryError( new Error( 'No valid images found in gallery' ) );
+				return;
+			}
+
+			// Find the index of the clicked image
+			const clickedImageIndex = galleryImages.findIndex(
+				( galleryImg ) => galleryImg.src === img.src
+			);
+
+			if ( clickedImageIndex !== -1 ) {
+				this.openGallery( clickedImageIndex, galleryImages );
+			} else {
+				this.handleGalleryError( new Error( 'Could not find clicked image in gallery' ) );
+			}
+		} catch ( error ) {
+			this.handleGalleryError( error );
 		}
 	};
 
@@ -1009,9 +1161,14 @@ export class FullPostView extends Component {
 						isOpen={ this.state.isGalleryOpen }
 						images={ this.state.galleryImages }
 						currentIndex={ this.state.currentImageIndex }
+						isLoading={ this.state.isGalleryLoading }
+						error={ this.state.galleryError }
 						onClose={ this.closeGallery }
 						onNext={ this.nextImage }
 						onPrevious={ this.previousImage }
+						onGoToFirst={ this.goToFirstImage }
+						onGoToLast={ this.goToLastImage }
+						onClearError={ this.clearGalleryError }
 					/>
 				</ReaderMain>
 			</div>


### PR DESCRIPTION
## Description

Note: This is meant to be a proof of concept, not something we'd merge directly.

Matt asked that we add a lightbox to gallery images in the reader. On our team call this morning we decided to look into porting the existing Jetpack carousel functionality over.

As a back up option, I decided to see what it would take to create a solution from scratch. I leaned heavily on Cursor for the code. If we need a back up plan, some of this code may serve useful.

## Preview

https://github.com/user-attachments/assets/a53dfa34-772d-41b9-98be-469cf2159bac

## Testing:

- Apply this PR
- Visit `http://calypso.localhost:3000/reader/blogs/4/posts/9442` or `http://calypso.localhost:3000/reader/blogs/10296851/posts/2015` 
- Click into a gallery image directly