### PR TITLE
Notifications: Add notification skeleton for all notifications pages

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -221,6 +221,50 @@ export const notificationsRoute = createRoute( {
 	)
 );
 
+export const notificationsSitesRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'notifications/sites',
+} ).lazy( () =>
+	import( '../../me/notifications-sites' ).then( ( d ) =>
+		createLazyRoute( 'notifications-sites' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const notificationsEmailsRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'notifications/emails',
+} ).lazy( () =>
+	import( '../../me/notifications-emails' ).then( ( d ) =>
+		createLazyRoute( 'notifications-emails' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const notificationsCommentsRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'notifications/comments',
+} ).lazy( () =>
+	import( '../../me/notifications-comments' ).then( ( d ) =>
+		createLazyRoute( 'notifications-comments' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const notificationsExtrasRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'notifications/extras',
+} ).lazy( () =>
+	import( '../../me/notifications-extras' ).then( ( d ) =>
+		createLazyRoute( 'notifications-extras' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const blockedSitesRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'blocked-sites',
@@ -264,6 +308,10 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		securityConnectedAppsRoute,
 		securitySocialLoginsRoute,
 		notificationsRoute,
+		notificationsSitesRoute,
+		notificationsEmailsRoute,
+		notificationsCommentsRoute,
+		notificationsExtrasRoute,
 	];
 
 	if ( config.supports.me.privacy ) {

--- a/client/dashboard/me/notifications-comments/index.tsx
+++ b/client/dashboard/me/notifications-comments/index.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function NotificationsComments() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Comments' ) }
+					description={ __(
+						'Set your notification preferences for activity on comments you’ve made on other sites.'
+					) }
+				/>
+			}
+		></PageLayout>
+	);
+}

--- a/client/dashboard/me/notifications-comments/summary.tsx
+++ b/client/dashboard/me/notifications-comments/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { comment } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export const NotificationsCommentsSummary = () => {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/notifications/comments"
+			title={ __( 'Comments' ) }
+			description={ __(
+				'Set your notification preferences for activity on comments you’ve made on other sites.'
+			) }
+			decoration={ <Icon icon={ comment } /> }
+		/>
+	);
+};

--- a/client/dashboard/me/notifications-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/index.tsx
@@ -1,0 +1,23 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function NotificationsEmails() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Emails' ) }
+					description={ createInterpolateElement(
+						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),
+						{
+							link: <a href="/reader/subscriptions" target="_blank" rel="noopener noreferrer" />,
+						}
+					) }
+				/>
+			}
+		></PageLayout>
+	);
+}

--- a/client/dashboard/me/notifications-emails/summary.tsx
+++ b/client/dashboard/me/notifications-emails/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { layout } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export const NotificationsEmailsSummary = () => {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/notifications/emails"
+			title={ __( 'Emails' ) }
+			description={ __(
+				'Manage how you receive emails. Set the frequency, choose a format, or pause all emails. To manage individual site subscriptions'
+			) }
+			decoration={ <Icon icon={ layout } /> }
+		/>
+	);
+};

--- a/client/dashboard/me/notifications-extras/index.tsx
+++ b/client/dashboard/me/notifications-extras/index.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function NotificationsEmails() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Extras' ) }
+					description={ __(
+						'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'
+					) }
+				/>
+			}
+		></PageLayout>
+	);
+}

--- a/client/dashboard/me/notifications-extras/summary.tsx
+++ b/client/dashboard/me/notifications-extras/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { starEmpty } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export const NotificationsExtrasSummary = () => {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/notifications/extras"
+			title={ __( 'Extras' ) }
+			description={ __(
+				'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'
+			) }
+			decoration={ <Icon icon={ starEmpty } /> }
+		/>
+	);
+};

--- a/client/dashboard/me/notifications-sites/index.tsx
+++ b/client/dashboard/me/notifications-sites/index.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export default function NotificationsSites() {
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Sites' ) }
+					description={ __(
+						'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'
+					) }
+				/>
+			}
+		></PageLayout>
+	);
+}

--- a/client/dashboard/me/notifications-sites/summary.tsx
+++ b/client/dashboard/me/notifications-sites/summary.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { layout } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+
+export const NotificationsSitesSummary = () => {
+	return (
+		<RouterLinkSummaryButton
+			to="/me/notifications/sites"
+			title={ __( 'Sites' ) }
+			description={ __(
+				'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'
+			) }
+			decoration={ <Icon icon={ layout } /> }
+		/>
+	);
+};

--- a/client/dashboard/me/notifications/index.tsx
+++ b/client/dashboard/me/notifications/index.tsx
@@ -2,7 +2,10 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { NotificationsCommentsSummary } from '../notifications-comments/summary';
+import { NotificationsEmailsSummary } from '../notifications-emails/summary';
+import { NotificationsExtrasSummary } from '../notifications-extras/summary';
+import { NotificationsSitesSummary } from '../notifications-sites/summary';
 
 function Notifications() {
 	return (
@@ -11,12 +14,17 @@ function Notifications() {
 			header={
 				<PageHeader
 					title={ __( 'Notifications' ) }
-					description={ __( 'Manage your notification settings.' ) }
+					description={ __(
+						'Control your notification preferences for site activity, comments, updates, and subscriptions.'
+					) }
 				/>
 			}
 		>
 			<VStack spacing={ 4 }>
-				<RouterLinkSummaryButton title={ __( 'Details' ) } to="/me/notifications" />
+				<NotificationsSitesSummary />
+				<NotificationsCommentsSummary />
+				<NotificationsEmailsSummary />
+				<NotificationsExtrasSummary />
 			</VStack>
 		</PageLayout>
 	);

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -43,7 +43,7 @@ export interface SummaryButtonProps {
 	 * For now, this property is only rendered in `low` density variant.
 	 * We might revisit adding this in more variants in the future.
 	 */
-	description?: string;
+	description?: React.ReactNode;
 	/**
 	 * A brief, optional line of text used to highlight important information,
 	 * such as a warning or status.


### PR DESCRIPTION
Closes CML-852 and CML-846

## Proposed Changes
* Configure all notification subpage routes
* Add initial skeleton for all notification pages.


## Why are these changes being made?
* First iteration over the new notifications settings

## Testing Instructions
* Go to http://calypso.localhost:3000/v2/me/notifications
* Click on each card.

> [!IMPORTANT]
>  The back button/breadcrumb will be implemented as part of CML-864

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
