### PR TITLE
Masterbar: remove comments item when not site context exists

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -343,8 +343,8 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderCommentsMenu() {
-		const { adminMenu } = this.props;
-		if ( ! adminMenu ) {
+		const { adminMenu, domainOnlySite } = this.props;
+		if ( ! adminMenu || domainOnlySite ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-795/remove-comments-from-master-bar-for-domain

When `domainOnlySite` is true, don't show a Comments icon in the menu bar since there is no site to link to (comments don't exist in this context).

Same logic used for hiding other site-only elements.