### PR TITLE
Fix backups layout on mobile viewport

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -9,6 +9,7 @@ import {
 	CardHeader,
 	Icon,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { rotateLeft, download } from '@wordpress/icons';
 import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
@@ -24,6 +25,9 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 		dateStyle: 'medium',
 		timeStyle: 'short',
 	} );
+
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const direction = isSmallViewport ? 'column' : 'row';
 
 	const handleRestoreClick = () => {
 		router.navigate( {
@@ -47,7 +51,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 					actions={
 						backup.rewind_id && (
-							<ButtonStack>
+							<ButtonStack alignment="stretch" direction={ direction }>
 								<Button
 									variant="secondary"
 									size="compact"

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -79,7 +79,7 @@ export function BackupsListPage() {
 			notices={ <BackupNotices site={ site } /> }
 		>
 			{ hasBackups && (
-				<Grid columns={ columns }>
+				<Grid className="dashboard-backups__list-grid" columns={ columns }>
 					<BackupsList
 						site={ site }
 						selectedBackup={ selectedBackup }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -3,6 +3,7 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalGrid as Grid, __experimentalText as Text } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { useState } from 'react';
@@ -62,6 +63,8 @@ export function BackupsListPage() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const [ selectedBackup, setSelectedBackup ] = useState< ActivityLogEntry | null >( null );
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const columns = isSmallViewport ? 1 : 2;
 
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
 
@@ -76,7 +79,7 @@ export function BackupsListPage() {
 			notices={ <BackupNotices site={ site } /> }
 		>
 			{ hasBackups && (
-				<Grid columns={ 2 }>
+				<Grid columns={ columns }>
 					<BackupsList
 						site={ site }
 						selectedBackup={ selectedBackup }

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,3 +1,11 @@
+.dashboard-backups__list-grid {
+	@media ( max-width: 782px ) {
+		> *:last-child {
+			order: -1;
+		}
+	}
+}
+
 .dashboard-backups__list-icon {
 	position: relative;
 	top: 50%;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-355][1].

## Proposed Changes

This PR fixes the backups listing layout on mobile viewport.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There were issues showing the backups listing, resulting in a situation where only backup details were displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`
- In a mobile browser (or using a desktop browser device mode), the layout should be similar to:

| Before | After |
| :-: | :-: |
| <img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/0f461a69-77e3-4f14-9390-f029e15d6280" /> | <img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/3e2290e6-d726-4c9d-9dbd-e28fcca280c6" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-355/