### PR TITLE
Hosting Dashboard: Add PurchaseNotice to purchase settings page

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1127,11 +1127,11 @@ export default function PurchaseSettings() {
 					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 					{ ! purchase.partner_name && <PluginList purchase={ purchase } /> }
-					<PurchaseNotice purchase={ purchase } />
 				</VStack>
 			}
 		>
 			<VStack spacing={ 6 }>
+				<PurchaseNotice purchase={ purchase } />
 				<HStack spacing={ 6 } justify="flex-start" alignment="center">
 					<PurchaseSettingsCard
 						icon={ calendar }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -81,6 +81,7 @@ import {
 } from '../../../utils/purchase';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import { getPurchaseUrlForId, getAddPaymentMethodUrlFor } from '../urls';
+import { PurchaseNotice } from './purchase-notice';
 import type { User, Purchase } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 import type { ReactNode, ReactElement } from 'react';
@@ -1126,6 +1127,7 @@ export default function PurchaseSettings() {
 					<ProductLink purchase={ purchase } />
 					<DomainRegistrationAgreement purchase={ purchase } />
 					{ ! purchase.partner_name && <PluginList purchase={ purchase } /> }
+					<PurchaseNotice purchase={ purchase } />
 				</VStack>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -38,6 +38,7 @@ import {
 	Notice,
 	ExternalLink,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, isRTL, sprintf } from '@wordpress/i18n';
@@ -50,6 +51,7 @@ import {
 	siteLogo,
 	commentAuthorAvatar,
 } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
@@ -443,11 +445,10 @@ function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
 }
 
 function ReinstallButton( { purchase }: { purchase: Purchase } ) {
-	const {
-		mutate: reinstallPlugins,
-		error,
-		isPending: isMutationPending,
-	} = useMutation( reinstallMarketplacePluginsQuery( purchase.blog_id ) );
+	const { mutate: reinstallPlugins, isPending: isMutationPending } = useMutation(
+		reinstallMarketplacePluginsQuery( purchase.blog_id )
+	);
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	if ( ! isMarketplacePlugin( purchase ) ) {
 		return null;
 	}
@@ -465,19 +466,20 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 						size="compact"
 						disabled={ isMutationPending }
 						onClick={ () => {
-							reinstallPlugins();
+							reinstallPlugins( undefined, {
+								onSuccess: () => {
+									createSuccessNotice( __( 'Plugins reinstalled.' ), { type: 'snackbar' } );
+								},
+								onError: ( error ) => {
+									createErrorNotice( error?.message || __( 'Failed to reinstall plugins.' ), {
+										type: 'snackbar',
+									} );
+								},
+							} );
 						} }
 					>
 						{ __( 'Reinstall plugins' ) }
 					</Button>
-					{
-						// FIXME: there's probably a better place for this error message
-						error && (
-							<Notice status="error" isDismissible={ false }>
-								{ error.message }
-							</Notice>
-						)
-					}
 				</>
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -38,7 +38,6 @@ import {
 	Notice,
 	ExternalLink,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, isRTL, sprintf } from '@wordpress/i18n';
@@ -51,7 +50,6 @@ import {
 	siteLogo,
 	commentAuthorAvatar,
 } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { useLocale } from '../../../app/locale';
@@ -445,10 +443,15 @@ function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
 }
 
 function ReinstallButton( { purchase }: { purchase: Purchase } ) {
-	const { mutate: reinstallPlugins, isPending: isMutationPending } = useMutation(
-		reinstallMarketplacePluginsQuery( purchase.blog_id )
-	);
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { mutate: reinstallPlugins, isPending: isMutationPending } = useMutation( {
+		...reinstallMarketplacePluginsQuery( purchase.blog_id ),
+		meta: {
+			snackbar: {
+				success: __( 'Plugins reinstalled.' ),
+				error: __( 'Failed to reinstall plugins.' ),
+			},
+		},
+	} );
 	if ( ! isMarketplacePlugin( purchase ) ) {
 		return null;
 	}
@@ -466,16 +469,7 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 						size="compact"
 						disabled={ isMutationPending }
 						onClick={ () => {
-							reinstallPlugins( undefined, {
-								onSuccess: () => {
-									createSuccessNotice( __( 'Plugins reinstalled.' ), { type: 'snackbar' } );
-								},
-								onError: ( error ) => {
-									createErrorNotice( error?.message || __( 'Failed to reinstall plugins.' ), {
-										type: 'snackbar',
-									} );
-								},
-							} );
+							reinstallPlugins();
 						} }
 					>
 						{ __( 'Reinstall plugins' ) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -2,6 +2,7 @@ import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
 import Notice from '../../../components/notice';
 import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
 import {
@@ -12,10 +13,12 @@ import {
 	needsToRenewSoon,
 	isRecentMonthlyPurchase,
 	creditCardExpiresBeforeSubscription,
+	getRenewUrlForPurchases,
 } from '../../../utils/purchase';
 import { getPurchaseUrl, getAddPaymentMethodUrlFor } from '../urls';
 import { ExpiringLaterText } from './purchase-expiring-notice';
 import { shouldShowCardExpiringWarning } from './purchase-notice';
+import { UpcomingRenewalsDialog } from './upcoming-renewals-dialog';
 import type { NoticeVariant } from '../../../components/notice/types';
 import type { Purchase } from '@automattic/api-core';
 
@@ -86,6 +89,9 @@ export function OtherRenewablePurchasesNotice( {
 	purchaseAttachedTo: Purchase | undefined;
 	renewableSitePurchases: Purchase[];
 } ) {
+	const [ isUpcomingRenewalsDialogVisible, setUpcomingRenewalsDialogVisible ] =
+		useState< boolean >( false );
+
 	if ( ! purchase.site_slug ) {
 		return null;
 	}
@@ -147,9 +153,8 @@ export function OtherRenewablePurchasesNotice( {
 	const earliestOtherExpiry = earliestOtherExpiringPurchase
 		? getRelativeTimeString( new Date( earliestOtherExpiringPurchase.expiry_date ) )
 		: '';
-	// FIXME: open upcoming renewals dialog
-	const openUpcomingRenewalsDialog = () => undefined;
-	const link = <Button onClick={ () => openUpcomingRenewalsDialog() } />;
+	const openUpcomingRenewalsDialog = () => setUpcomingRenewalsDialogVisible( true );
+	const link = <Button variant="link" onClick={ () => openUpcomingRenewalsDialog() } />;
 	const managePurchase = <a href={ getPurchaseUrl( currentPurchase ) } />;
 
 	let noticeStatus: NoticeVariant = 'info';
@@ -164,8 +169,8 @@ export function OtherRenewablePurchasesNotice( {
 			suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
 				? 'info'
 				: 'error';
-		// FIXME: handle "renew all" action
-		noticeActionOnClick = () => null;
+		noticeActionOnClick = () =>
+			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
 		noticeActionText = __( 'Renew all' );
 
 		if ( isExpired( currentPurchase ) ) {
@@ -425,8 +430,8 @@ export function OtherRenewablePurchasesNotice( {
 		anotherPurchaseIsExpiring
 	) {
 		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		// FIXME: handle "renew all" action
-		noticeActionOnClick = () => null;
+		noticeActionOnClick = () =>
+			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
 		noticeActionText = __( 'Renew all' );
 
 		if ( anotherPurchaseIsExpired ) {
@@ -568,8 +573,8 @@ export function OtherRenewablePurchasesNotice( {
 		anotherPurchaseIsExpiring
 	) {
 		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		// FIXME: handle "renew all" action
-		noticeActionOnClick = () => null;
+		noticeActionOnClick = () =>
+			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
 		noticeActionText = __( 'Renew Now' );
 
 		if ( anotherPurchaseIsExpired ) {
@@ -627,8 +632,8 @@ export function OtherRenewablePurchasesNotice( {
 		anotherPurchaseIsExpiring
 	) {
 		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		// FIXME: handle "renew all" action
-		noticeActionOnClick = () => null;
+		noticeActionOnClick = () =>
+			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
 		noticeActionText = __( 'Renew Now' );
 
 		if ( anotherPurchaseIsExpired ) {
@@ -694,24 +699,37 @@ export function OtherRenewablePurchasesNotice( {
 		}
 	}
 
-	if ( ! noticeText ) {
-		return null;
+	if ( noticeText ) {
+		return (
+			<>
+				{ isUpcomingRenewalsDialogVisible && (
+					<UpcomingRenewalsDialog
+						onClose={ () => setUpcomingRenewalsDialogVisible( false ) }
+						onConfirm={ ( purchases ) => {
+							if ( purchases.length < 1 ) {
+								setUpcomingRenewalsDialogVisible( false );
+								return;
+							}
+							window.location.href = getRenewUrlForPurchases( purchases );
+						} }
+						siteDomain={ purchase.meta ?? purchase.domain }
+						purchases={ renewableSitePurchases }
+					/>
+				) }
+				<Notice variant={ noticeStatus }>
+					{ noticeText }
+					{ ( noticeActionHref || noticeActionOnClick ) && (
+						<Button
+							href={ noticeActionHref ?? undefined }
+							onClick={ noticeActionOnClick ?? undefined }
+						>
+							{ noticeActionText }
+						</Button>
+					) }
+				</Notice>
+			</>
+		);
 	}
 
-	// FIXME: render UpcomingRenewalsDialog for renewableSitePurchases
-	return (
-		<>
-			<Notice variant={ noticeStatus }>
-				{ noticeText }
-				{ ( noticeActionHref || noticeActionOnClick ) && (
-					<Button
-						href={ noticeActionHref ?? undefined }
-						onClick={ noticeActionOnClick ?? undefined }
-					>
-						{ noticeActionText }
-					</Button>
-				) }
-			</Notice>
-		</>
-	);
+	return null;
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -546,8 +546,6 @@ export function OtherRenewablePurchasesNotice( {
 		} else if ( currentPurchase.payment_card_id ) {
 			noticeStatus = shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info';
 			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
-			// FIXME: handle "update all" action
-			noticeActionOnClick = () => null;
 			noticeActionText = __( 'Update all' );
 			noticeText = createInterpolateElement(
 				sprintf(
@@ -677,8 +675,6 @@ export function OtherRenewablePurchasesNotice( {
 		} else if ( currentPurchase.payment_card_id ) {
 			noticeStatus = 'info';
 			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
-			// FIXME: handle "update all" action
-			noticeActionOnClick = () => null;
 			noticeActionText = __( 'Update all' );
 			noticeText = createInterpolateElement(
 				sprintf(
@@ -720,6 +716,7 @@ export function OtherRenewablePurchasesNotice( {
 					{ noticeText }
 					{ ( noticeActionHref || noticeActionOnClick ) && (
 						<Button
+							variant="primary"
 							href={ noticeActionHref ?? undefined }
 							onClick={ noticeActionOnClick ?? undefined }
 						>

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -712,17 +712,21 @@ export function OtherRenewablePurchasesNotice( {
 						purchases={ renewableSitePurchases }
 					/>
 				) }
-				<Notice variant={ noticeStatus }>
+				<Notice
+					variant={ noticeStatus }
+					actions={
+						( noticeActionHref || noticeActionOnClick ) && (
+							<Button
+								variant="primary"
+								href={ noticeActionHref ?? undefined }
+								onClick={ noticeActionOnClick ?? undefined }
+							>
+								{ noticeActionText }
+							</Button>
+						)
+					}
+				>
 					{ noticeText }
-					{ ( noticeActionHref || noticeActionOnClick ) && (
-						<Button
-							variant="primary"
-							href={ noticeActionHref ?? undefined }
-							onClick={ noticeActionOnClick ?? undefined }
-						>
-							{ noticeActionText }
-						</Button>
-					) }
 				</Notice>
 			</>
 		);

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -80,6 +80,63 @@ export function shouldShowOtherRenewablePurchasesNotice(
 	return true;
 }
 
+function NoticeContent( {
+	purchase,
+	renewableSitePurchases,
+	isUpcomingRenewalsDialogVisible,
+	setUpcomingRenewalsDialogVisible,
+	noticeStatus,
+	noticeText,
+	noticeActionHref,
+	noticeActionOnClick,
+	noticeActionText,
+}: {
+	purchase: Purchase;
+	renewableSitePurchases: Purchase[];
+	isUpcomingRenewalsDialogVisible: boolean;
+	setUpcomingRenewalsDialogVisible: ( visible: boolean ) => void;
+	noticeStatus: NoticeVariant;
+	noticeText: React.ReactNode;
+	noticeActionHref?: string;
+	noticeActionOnClick?: () => void;
+	noticeActionText?: string;
+} ) {
+	return (
+		<>
+			{ isUpcomingRenewalsDialogVisible && (
+				<UpcomingRenewalsDialog
+					onClose={ () => setUpcomingRenewalsDialogVisible( false ) }
+					onConfirm={ ( purchases ) => {
+						if ( purchases.length < 1 ) {
+							setUpcomingRenewalsDialogVisible( false );
+							return;
+						}
+						window.location.href = getRenewUrlForPurchases( purchases );
+					} }
+					siteDomain={ purchase.meta ?? purchase.domain }
+					purchases={ renewableSitePurchases }
+				/>
+			) }
+			<Notice
+				variant={ noticeStatus }
+				actions={
+					( noticeActionHref || noticeActionOnClick ) && (
+						<Button
+							variant="primary"
+							href={ noticeActionHref ?? undefined }
+							onClick={ noticeActionOnClick ?? undefined }
+						>
+							{ noticeActionText }
+						</Button>
+					)
+				}
+			>
+				{ noticeText }
+			</Notice>
+		</>
+	);
+}
+
 export function OtherRenewablePurchasesNotice( {
 	purchase,
 	purchaseAttachedTo,
@@ -157,21 +214,16 @@ export function OtherRenewablePurchasesNotice( {
 	const link = <Button variant="link" onClick={ () => openUpcomingRenewalsDialog() } />;
 	const managePurchase = <a href={ getPurchaseUrl( currentPurchase ) } />;
 
-	let noticeStatus: NoticeVariant = 'info';
-	let noticeActionHref: undefined | string;
-	let noticeActionOnClick: undefined | ( () => void );
-	let noticeActionText = '';
-	let noticeText: React.ReactNode | undefined;
-
 	// Scenario 1: current-expires-soon-others-expire-soon
 	if ( currentPurchaseNeedsToRenewSoon && currentPurchaseIsExpiring && anotherPurchaseIsExpiring ) {
-		noticeStatus =
+		let noticeText: React.ReactNode;
+		const noticeStatus =
 			suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
 				? 'info'
 				: 'error';
-		noticeActionOnClick = () =>
+		const noticeActionOnClick = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		noticeActionText = __( 'Renew all' );
+		const noticeActionText = __( 'Renew all' );
 
 		if ( isExpired( currentPurchase ) ) {
 			if ( currentPurchase.is_domain_registration ) {
@@ -316,6 +368,19 @@ export function OtherRenewablePurchasesNotice( {
 				{ link }
 			);
 		}
+
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus={ noticeStatus }
+				noticeText={ noticeText }
+				noticeActionOnClick={ noticeActionOnClick }
+				noticeActionText={ noticeActionText }
+			/>
+		);
 	}
 
 	// Scenario 2: current-expires-soon-others-renew-soon
@@ -324,7 +389,8 @@ export function OtherRenewablePurchasesNotice( {
 		currentPurchaseIsExpiring &&
 		! anotherPurchaseIsExpiring
 	) {
-		noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
+		let noticeText: React.ReactNode;
+		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
 
 		if ( isExpired( currentPurchase ) ) {
 			if ( currentPurchase.is_domain_registration ) {
@@ -421,6 +487,17 @@ export function OtherRenewablePurchasesNotice( {
 				{ link }
 			);
 		}
+
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus={ noticeStatus }
+				noticeText={ noticeText }
+			/>
+		);
 	}
 
 	// Scenario 3: current-renews-soon-others-expire-soon
@@ -429,10 +506,11 @@ export function OtherRenewablePurchasesNotice( {
 		! currentPurchaseIsExpiring &&
 		anotherPurchaseIsExpiring
 	) {
-		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		noticeActionOnClick = () =>
+		let noticeText: React.ReactNode;
+		const noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		const noticeActionOnClick = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		noticeActionText = __( 'Renew all' );
+		const noticeActionText = __( 'Renew all' );
 
 		if ( anotherPurchaseIsExpired ) {
 			if ( currentPurchase.is_domain_registration ) {
@@ -529,6 +607,19 @@ export function OtherRenewablePurchasesNotice( {
 				{ link }
 			);
 		}
+
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus={ noticeStatus }
+				noticeText={ noticeText }
+				noticeActionOnClick={ noticeActionOnClick }
+				noticeActionText={ noticeActionText }
+			/>
+		);
 	}
 
 	// Scenario 4: current-renews-soon-others-renew-soon and current-renews-soon-others-renew-soon-cc-expiring
@@ -538,28 +629,48 @@ export function OtherRenewablePurchasesNotice( {
 		! anotherPurchaseIsExpiring
 	) {
 		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-			noticeStatus = 'success';
-			noticeText = createInterpolateElement(
-				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
-				{ link }
+			return (
+				<NoticeContent
+					purchase={ purchase }
+					renewableSitePurchases={ renewableSitePurchases }
+					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+					noticeStatus="success"
+					noticeText={ createInterpolateElement(
+						__(
+							'You have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ link }
+					) }
+				/>
 			);
-		} else if ( currentPurchase.payment_card_id ) {
-			noticeStatus = shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info';
-			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
-			noticeActionText = __( 'Update all' );
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
-					__(
-						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
-					),
-					{
-						cardType: purchase.payment_card_type,
-						cardNumber: purchase.payment_card_id,
-						cardExpiry: purchase.payment_expiry,
-					}
-				),
-				{ link }
+		}
+
+		if ( currentPurchase.payment_card_id ) {
+			return (
+				<NoticeContent
+					purchase={ purchase }
+					renewableSitePurchases={ renewableSitePurchases }
+					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+					noticeStatus={ shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info' }
+					noticeText={ createInterpolateElement(
+						sprintf(
+							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+							__(
+								'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+							),
+							{
+								cardType: purchase.payment_card_type,
+								cardNumber: purchase.payment_card_id,
+								cardExpiry: purchase.payment_expiry,
+							}
+						),
+						{ link }
+					) }
+					noticeActionHref={ getAddPaymentMethodUrlFor( purchase ) }
+					noticeActionText={ __( 'Update all' ) }
+				/>
 			);
 		}
 	}
@@ -570,34 +681,44 @@ export function OtherRenewablePurchasesNotice( {
 		currentPurchaseIsExpiring &&
 		anotherPurchaseIsExpiring
 	) {
-		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		noticeActionOnClick = () =>
+		const noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		const noticeActionOnClick = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		noticeActionText = __( 'Renew Now' );
+		const noticeActionText = __( 'Renew Now' );
+		const noticeText = anotherPurchaseIsExpired
+			? createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+						),
+						{ earliestOtherExpiry }
+					),
+					{ link }
+			  )
+			: createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+						),
+						{ earliestOtherExpiry }
+					),
+					{ link }
+			  );
 
-		if ( anotherPurchaseIsExpired ) {
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
-					__(
-						'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
-					),
-					{ earliestOtherExpiry }
-				),
-				{ link }
-			);
-		} else {
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
-					__(
-						'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
-					),
-					{ earliestOtherExpiry }
-				),
-				{ link }
-			);
-		}
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus={ noticeStatus }
+				noticeText={ noticeText }
+				noticeActionOnClick={ noticeActionOnClick }
+				noticeActionText={ noticeActionText }
+			/>
+		);
 	}
 
 	// Scenario 6: current-expires-later-others-renew-soon
@@ -606,21 +727,31 @@ export function OtherRenewablePurchasesNotice( {
 		currentPurchaseIsExpiring &&
 		! anotherPurchaseIsExpiring
 	) {
-		noticeStatus = 'info';
-
-		if ( currentPurchase.is_plan && purchaseIsIncludedInPlan ) {
-			noticeText = createInterpolateElement(
-				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
-				{ link }
-			);
-		} else {
-			noticeText = (
+		const noticeText =
+			currentPurchase.is_plan && purchaseIsIncludedInPlan ? (
+				createInterpolateElement(
+					__(
+						'You have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+					),
+					{ link }
+				)
+			) : (
 				<ExpiringLaterText
 					purchase={ purchase }
 					autoRenewingUpgradesAction={ openUpcomingRenewalsDialog }
 				/>
 			);
-		}
+
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus="info"
+				noticeText={ noticeText }
+			/>
+		);
 	}
 
 	// Scenario 7: current-renews-later-others-expire-soon
@@ -629,34 +760,44 @@ export function OtherRenewablePurchasesNotice( {
 		! currentPurchaseIsExpiring &&
 		anotherPurchaseIsExpiring
 	) {
-		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
-		noticeActionOnClick = () =>
+		const noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		const noticeActionOnClick = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		noticeActionText = __( 'Renew Now' );
+		const noticeActionText = __( 'Renew Now' );
+		const noticeText = anotherPurchaseIsExpired
+			? createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+						),
+						{ earliestOtherExpiry }
+					),
+					{ link }
+			  )
+			: createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+						),
+						{ earliestOtherExpiry }
+					),
+					{ link }
+			  );
 
-		if ( anotherPurchaseIsExpired ) {
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
-					__(
-						'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
-					),
-					{ earliestOtherExpiry }
-				),
-				{ link }
-			);
-		} else {
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
-					__(
-						'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
-					),
-					{ earliestOtherExpiry }
-				),
-				{ link }
-			);
-		}
+		return (
+			<NoticeContent
+				purchase={ purchase }
+				renewableSitePurchases={ renewableSitePurchases }
+				isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+				noticeStatus={ noticeStatus }
+				noticeText={ noticeText }
+				noticeActionOnClick={ noticeActionOnClick }
+				noticeActionText={ noticeActionText }
+			/>
+		);
 	}
 
 	// Scenario 8: current-renews-later-others-renew-soon and current-renews-later-others-renew-soon-cc-expiring
@@ -667,69 +808,50 @@ export function OtherRenewablePurchasesNotice( {
 		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
 	) {
 		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-			noticeStatus = 'success';
-			noticeText = createInterpolateElement(
-				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
-				{ link }
-			);
-		} else if ( currentPurchase.payment_card_id ) {
-			noticeStatus = 'info';
-			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
-			noticeActionText = __( 'Update all' );
-			noticeText = createInterpolateElement(
-				sprintf(
-					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
-					__(
-						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
-					),
-					{
-						cardType: purchase.payment_card_type,
-						cardNumber: purchase.payment_card_id,
-						cardExpiry: purchase.payment_expiry,
-					}
-				),
-				{
-					link,
-				}
+			return (
+				<NoticeContent
+					purchase={ purchase }
+					renewableSitePurchases={ renewableSitePurchases }
+					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+					noticeStatus="success"
+					noticeText={ createInterpolateElement(
+						__(
+							'You have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ link }
+					) }
+				/>
 			);
 		}
-	}
 
-	if ( noticeText ) {
-		return (
-			<>
-				{ isUpcomingRenewalsDialogVisible && (
-					<UpcomingRenewalsDialog
-						onClose={ () => setUpcomingRenewalsDialogVisible( false ) }
-						onConfirm={ ( purchases ) => {
-							if ( purchases.length < 1 ) {
-								setUpcomingRenewalsDialogVisible( false );
-								return;
+		if ( currentPurchase.payment_card_id ) {
+			return (
+				<NoticeContent
+					purchase={ purchase }
+					renewableSitePurchases={ renewableSitePurchases }
+					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+					noticeStatus="info"
+					noticeText={ createInterpolateElement(
+						sprintf(
+							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+							__(
+								'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+							),
+							{
+								cardType: purchase.payment_card_type,
+								cardNumber: purchase.payment_card_id,
+								cardExpiry: purchase.payment_expiry,
 							}
-							window.location.href = getRenewUrlForPurchases( purchases );
-						} }
-						siteDomain={ purchase.meta ?? purchase.domain }
-						purchases={ renewableSitePurchases }
-					/>
-				) }
-				<Notice
-					variant={ noticeStatus }
-					actions={
-						( noticeActionHref || noticeActionOnClick ) && (
-							<Button
-								variant="primary"
-								href={ noticeActionHref ?? undefined }
-								onClick={ noticeActionOnClick ?? undefined }
-							>
-								{ noticeActionText }
-							</Button>
-						)
-					}
-				>
-					{ noticeText }
-				</Notice>
-			</>
-		);
+						),
+						{ link }
+					) }
+					noticeActionHref={ getAddPaymentMethodUrlFor( purchase ) }
+					noticeActionText={ __( 'Update all' ) }
+				/>
+			);
+		}
 	}
 
 	return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -9,8 +9,7 @@ import {
 	isExpiring,
 	isRenewing,
 	isIncludedWithPlan,
-	isOneTimePurchase,
-	isCloseToExpiration,
+	needsToRenewSoon,
 	isRecentMonthlyPurchase,
 	creditCardExpiresBeforeSubscription,
 } from '../../../utils/purchase';
@@ -22,7 +21,8 @@ import type { Purchase } from '@automattic/api-core';
 
 export function shouldShowOtherRenewablePurchasesNotice(
 	purchase: Purchase,
-	purchaseAttachedTo: Purchase | undefined
+	purchaseAttachedTo: Purchase | undefined,
+	renewableSitePurchases: Purchase[]
 ): boolean {
 	if ( ! purchase.site_slug ) {
 		return false;
@@ -36,7 +36,6 @@ export function shouldShowOtherRenewablePurchasesNotice(
 		purchaseIsIncludedInPlan && purchaseAttachedTo ? purchaseAttachedTo : purchase;
 
 	// Get other renewable purchases for this site
-	const renewableSitePurchases: Purchase[] = []; // FIXME: get this; see getRenewableSitePurchases
 	const otherRenewableSitePurchases = renewableSitePurchases.filter(
 		( otherPurchase ) => otherPurchase.ID !== currentPurchase.ID
 	);
@@ -81,9 +80,11 @@ export function shouldShowOtherRenewablePurchasesNotice(
 export function OtherRenewablePurchasesNotice( {
 	purchase,
 	purchaseAttachedTo,
+	renewableSitePurchases,
 }: {
 	purchase: Purchase;
 	purchaseAttachedTo: Purchase | undefined;
+	renewableSitePurchases: Purchase[];
 } ) {
 	if ( ! purchase.site_slug ) {
 		return null;
@@ -100,7 +101,6 @@ export function OtherRenewablePurchasesNotice( {
 	const includedPurchase = purchase;
 
 	// Show only if there is at least one other purchase to notify about.
-	const renewableSitePurchases: Purchase[] = []; // FIXME: get this; see getRenewableSitePurchases
 	const otherRenewableSitePurchases = renewableSitePurchases.filter(
 		( otherPurchase ) => otherPurchase.ID !== currentPurchase.ID
 	);
@@ -109,12 +109,7 @@ export function OtherRenewablePurchasesNotice( {
 	}
 
 	// Main logic branches for determining which message to display.
-	const currentPurchaseNeedsToRenewSoon =
-		( isOneTimePurchase( currentPurchase ) ||
-			currentPurchase.partner_name ||
-			! currentPurchase.is_renewable ||
-			! currentPurchase.can_explicit_renew ) &&
-		isCloseToExpiration( currentPurchase );
+	const currentPurchaseNeedsToRenewSoon = needsToRenewSoon( currentPurchase );
 	const currentPurchaseCreditCardExpiresBeforeSubscription =
 		isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
 	const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -28,116 +28,54 @@ export function shouldShowOtherRenewablePurchasesNotice(
 		return false;
 	}
 
-	// For purchases included with a plan (for example, a domain mapping
-	// bundled with the plan), the plan purchase should be used here, since
-	// that is the one that can be directly renewed.
+	// For purchases included with a plan, use the plan purchase instead
 	const purchaseIsIncludedInPlan = Boolean(
 		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
 	);
 	const currentPurchase =
 		purchaseIsIncludedInPlan && purchaseAttachedTo ? purchaseAttachedTo : purchase;
 
-	// Show only if there is at least one other purchase to notify about.
+	// Get other renewable purchases for this site
 	const renewableSitePurchases: Purchase[] = []; // FIXME: get this; see getRenewableSitePurchases
 	const otherRenewableSitePurchases = renewableSitePurchases.filter(
 		( otherPurchase ) => otherPurchase.ID !== currentPurchase.ID
 	);
+
 	if ( otherRenewableSitePurchases.length === 0 ) {
 		return false;
 	}
 
-	// Main logic branches for determining which message to display.
-	const currentPurchaseNeedsToRenewSoon =
-		( isOneTimePurchase( currentPurchase ) ||
-			currentPurchase.partner_name ||
-			! currentPurchase.is_renewable ||
-			! currentPurchase.can_explicit_renew ) &&
-		isCloseToExpiration( currentPurchase );
-	const currentPurchaseCreditCardExpiresBeforeSubscription =
-		isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
+	// Calculate purchase states once
 	const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );
 	const anotherPurchaseIsExpiring = otherRenewableSitePurchases.some(
 		( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
 	);
 
-	// Scenario 1: current-expires-soon-others-expire-soon
-	if ( currentPurchaseNeedsToRenewSoon && currentPurchaseIsExpiring && anotherPurchaseIsExpiring ) {
-		return true;
-	}
-
-	// Scenario 2: current-expires-soon-others-renew-soon
-	if (
-		currentPurchaseNeedsToRenewSoon &&
-		currentPurchaseIsExpiring &&
-		! anotherPurchaseIsExpiring
-	) {
-		return true;
-	}
-
-	// Scenario 3: current-renews-soon-others-expire-soon
-	if (
-		currentPurchaseNeedsToRenewSoon &&
+	// Special case: centennial plans with no expiring purchases don't show notices
+	const isCentennialWithNoExpiring =
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
 		! currentPurchaseIsExpiring &&
-		anotherPurchaseIsExpiring
-	) {
-		return true;
+		! anotherPurchaseIsExpiring;
+
+	if ( isCentennialWithNoExpiring ) {
+		return false;
 	}
 
-	// Scenario 4: current-renews-soon-others-renew-soon and current-renews-soon-others-renew-soon-cc-expiring
-	if (
-		currentPurchaseNeedsToRenewSoon &&
-		! currentPurchaseIsExpiring &&
-		! anotherPurchaseIsExpiring
-	) {
-		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-			return true;
-		} else if ( currentPurchase.payment_card_id ) {
-			return true;
+	// Special case: credit card expiring scenarios need additional checks
+	const needsCreditCardCheck = ! currentPurchaseIsExpiring && ! anotherPurchaseIsExpiring;
+
+	if ( needsCreditCardCheck ) {
+		const currentPurchaseCreditCardExpiresBeforeSubscription =
+			isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
+
+		// Don't show if credit card expires but no payment card ID
+		if ( currentPurchaseCreditCardExpiresBeforeSubscription && ! currentPurchase.payment_card_id ) {
+			return false;
 		}
 	}
 
-	// Scenario 5: current-expires-later-others-expire-soon
-	if (
-		! currentPurchaseNeedsToRenewSoon &&
-		currentPurchaseIsExpiring &&
-		anotherPurchaseIsExpiring
-	) {
-		return true;
-	}
-
-	// Scenario 6: current-expires-later-others-renew-soon
-	if (
-		! currentPurchaseNeedsToRenewSoon &&
-		currentPurchaseIsExpiring &&
-		! anotherPurchaseIsExpiring
-	) {
-		return true;
-	}
-
-	// Scenario 7: current-renews-later-others-expire-soon
-	if (
-		! currentPurchaseNeedsToRenewSoon &&
-		! currentPurchaseIsExpiring &&
-		anotherPurchaseIsExpiring
-	) {
-		return true;
-	}
-
-	// Scenario 8: current-renews-later-others-renew-soon and current-renews-later-others-renew-soon-cc-expiring
-	if (
-		! currentPurchaseNeedsToRenewSoon &&
-		! currentPurchaseIsExpiring &&
-		! anotherPurchaseIsExpiring &&
-		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
-	) {
-		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-			return true;
-		} else if ( currentPurchase.payment_card_id ) {
-			return true;
-		}
-	}
-
-	return false;
+	// Show notice in all other cases
+	return true;
 }
 
 export function OtherRenewablePurchasesNotice( {

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -1,0 +1,784 @@
+import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import Notice from '../../../components/notice';
+import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
+import {
+	isExpired,
+	isExpiring,
+	isRenewing,
+	isIncludedWithPlan,
+	isOneTimePurchase,
+	isCloseToExpiration,
+	isRecentMonthlyPurchase,
+	creditCardExpiresBeforeSubscription,
+} from '../../../utils/purchase';
+import { getPurchaseUrl, getAddPaymentMethodUrlFor } from '../urls';
+import { ExpiringLaterText } from './purchase-expiring-notice';
+import { shouldShowCardExpiringWarning } from './purchase-notice';
+import type { NoticeVariant } from '../../../components/notice/types';
+import type { Purchase } from '@automattic/api-core';
+
+export function shouldShowOtherRenewablePurchasesNotice(
+	purchase: Purchase,
+	purchaseAttachedTo: Purchase | undefined
+): boolean {
+	if ( ! purchase.site_slug ) {
+		return false;
+	}
+
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase should be used here, since
+	// that is the one that can be directly renewed.
+	const purchaseIsIncludedInPlan = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase =
+		purchaseIsIncludedInPlan && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	// Show only if there is at least one other purchase to notify about.
+	const renewableSitePurchases: Purchase[] = []; // FIXME: get this; see getRenewableSitePurchases
+	const otherRenewableSitePurchases = renewableSitePurchases.filter(
+		( otherPurchase ) => otherPurchase.ID !== currentPurchase.ID
+	);
+	if ( otherRenewableSitePurchases.length === 0 ) {
+		return false;
+	}
+
+	// Main logic branches for determining which message to display.
+	const currentPurchaseNeedsToRenewSoon =
+		( isOneTimePurchase( currentPurchase ) ||
+			currentPurchase.partner_name ||
+			! currentPurchase.is_renewable ||
+			! currentPurchase.can_explicit_renew ) &&
+		isCloseToExpiration( currentPurchase );
+	const currentPurchaseCreditCardExpiresBeforeSubscription =
+		isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
+	const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );
+	const anotherPurchaseIsExpiring = otherRenewableSitePurchases.some(
+		( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+	);
+
+	// Scenario 1: current-expires-soon-others-expire-soon
+	if ( currentPurchaseNeedsToRenewSoon && currentPurchaseIsExpiring && anotherPurchaseIsExpiring ) {
+		return true;
+	}
+
+	// Scenario 2: current-expires-soon-others-renew-soon
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		return true;
+	}
+
+	// Scenario 3: current-renews-soon-others-expire-soon
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		return true;
+	}
+
+	// Scenario 4: current-renews-soon-others-renew-soon and current-renews-soon-others-renew-soon-cc-expiring
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+			return true;
+		} else if ( currentPurchase.payment_card_id ) {
+			return true;
+		}
+	}
+
+	// Scenario 5: current-expires-later-others-expire-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		return true;
+	}
+
+	// Scenario 6: current-expires-later-others-renew-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		return true;
+	}
+
+	// Scenario 7: current-renews-later-others-expire-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		return true;
+	}
+
+	// Scenario 8: current-renews-later-others-renew-soon and current-renews-later-others-renew-soon-cc-expiring
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring &&
+		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
+	) {
+		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+			return true;
+		} else if ( currentPurchase.payment_card_id ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function OtherRenewablePurchasesNotice( {
+	purchase,
+	purchaseAttachedTo,
+}: {
+	purchase: Purchase;
+	purchaseAttachedTo: Purchase | undefined;
+} ) {
+	if ( ! purchase.site_slug ) {
+		return null;
+	}
+
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase should be used here, since
+	// that is the one that can be directly renewed.
+	const purchaseIsIncludedInPlan = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase =
+		purchaseIsIncludedInPlan && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+	const includedPurchase = purchase;
+
+	// Show only if there is at least one other purchase to notify about.
+	const renewableSitePurchases: Purchase[] = []; // FIXME: get this; see getRenewableSitePurchases
+	const otherRenewableSitePurchases = renewableSitePurchases.filter(
+		( otherPurchase ) => otherPurchase.ID !== currentPurchase.ID
+	);
+	if ( otherRenewableSitePurchases.length === 0 ) {
+		return null;
+	}
+
+	// Main logic branches for determining which message to display.
+	const currentPurchaseNeedsToRenewSoon =
+		( isOneTimePurchase( currentPurchase ) ||
+			currentPurchase.partner_name ||
+			! currentPurchase.is_renewable ||
+			! currentPurchase.can_explicit_renew ) &&
+		isCloseToExpiration( currentPurchase );
+	const currentPurchaseCreditCardExpiresBeforeSubscription =
+		isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
+	const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );
+	const anotherPurchaseIsExpiring = otherRenewableSitePurchases.some(
+		( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+	);
+
+	// Other information needed by some of the messages.
+	const suppressErrorStylingForCurrentPurchase =
+		isRecentMonthlyPurchase( currentPurchase ) && ! isExpired( currentPurchase );
+	const suppressErrorStylingForOtherPurchases = otherRenewableSitePurchases.every(
+		( otherPurchase ) => isRecentMonthlyPurchase( otherPurchase ) && ! isExpired( otherPurchase )
+	);
+	const anotherPurchaseIsCloseToExpiration = otherRenewableSitePurchases.some( ( otherPurchase ) =>
+		isWithinNext(
+			new Date( otherPurchase.expiry_date ),
+			SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD,
+			'days'
+		)
+	);
+	const anotherPurchaseIsExpired = otherRenewableSitePurchases.some( isExpired );
+	const expiringPurchases = otherRenewableSitePurchases
+		.filter( ( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase ) )
+		.sort( ( a, b ) => new Date( a.expiry_date ).getTime() - new Date( b.expiry_date ).getTime() );
+	const earliestOtherExpiringPurchase: Purchase | undefined =
+		expiringPurchases.length > 0 ? expiringPurchases[ 0 ] : undefined;
+
+	const purchaseName = currentPurchase.is_domain
+		? currentPurchase.meta ?? ''
+		: currentPurchase.product_name;
+	const expiry = getRelativeTimeString( new Date( currentPurchase.expiry_date ) );
+	const includedPurchaseName = includedPurchase.is_domain
+		? includedPurchase.meta ?? ''
+		: includedPurchase.product_name;
+	const earliestOtherExpiry = earliestOtherExpiringPurchase
+		? getRelativeTimeString( new Date( earliestOtherExpiringPurchase.expiry_date ) )
+		: '';
+	// FIXME: open upcoming renewals dialog
+	const openUpcomingRenewalsDialog = () => undefined;
+	const link = <Button onClick={ () => openUpcomingRenewalsDialog() } />;
+	const managePurchase = <a href={ getPurchaseUrl( currentPurchase ) } />;
+
+	let noticeStatus: NoticeVariant = 'info';
+	let noticeActionHref: undefined | string;
+	let noticeActionOnClick: undefined | ( () => void );
+	let noticeActionText = '';
+	let noticeText: React.ReactNode | undefined;
+
+	// Scenario 1: current-expires-soon-others-expire-soon
+	if ( currentPurchaseNeedsToRenewSoon && currentPurchaseIsExpiring && anotherPurchaseIsExpiring ) {
+		noticeStatus =
+			suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
+				? 'info'
+				: 'error';
+		// FIXME: handle "renew all" action
+		noticeActionOnClick = () => null;
+		noticeActionText = __( 'Renew all' );
+
+		if ( isExpired( currentPurchase ) ) {
+			if ( currentPurchase.is_domain_registration ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago"
+						__(
+							'Your %(purchaseName)s domain expired %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_plan ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+							),
+							{ purchaseName, expiry, includedPurchaseName }
+						),
+						{ link, managePurchase }
+					);
+				} else {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your %(purchaseName)s plan expired %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+							),
+							{ purchaseName, expiry }
+						),
+						{ link }
+					);
+				}
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s subscription expired %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			}
+		} else if ( anotherPurchaseIsCloseToExpiration ) {
+			if ( currentPurchase.is_domain_registration ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s domain will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_plan ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+							),
+							{ purchaseName, expiry, includedPurchaseName }
+						),
+						{ link, managePurchase }
+					);
+				} else {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your %(purchaseName)s plan will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+							),
+							{ purchaseName, expiry }
+						),
+						{ link }
+					);
+				}
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s subscription will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed soon unless you take action.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			}
+		} else if ( currentPurchase.is_domain_registration ) {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s domain will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed unless you take action.'
+					),
+					{ purchaseName, expiry }
+				),
+				{ link }
+			);
+		} else if ( currentPurchase.is_plan ) {
+			if ( purchaseIsIncludedInPlan ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed unless you take action.'
+						),
+						{ purchaseName, expiry, includedPurchaseName }
+					),
+					{ link, managePurchase }
+				);
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s plan will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed unless you take action.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			}
+		} else {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s subscription will expire %(expiry)s, and you have <link>other upgrades</link> on this site that will also be removed unless you take action.'
+					),
+					{ purchaseName, expiry }
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 2: current-expires-soon-others-renew-soon
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
+
+		if ( isExpired( currentPurchase ) ) {
+			if ( currentPurchase.is_domain_registration ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_plan ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s and will be removed soon unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+							),
+							{ purchaseName, expiry, includedPurchaseName }
+						),
+						{ link, managePurchase }
+					);
+				} else {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your %(purchaseName)s plan expired %(expiry)s and will be removed soon unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+							),
+							{ purchaseName, expiry }
+						),
+						{ link }
+					);
+				}
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			}
+		} else if ( currentPurchase.is_domain_registration ) {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s domain will expire %(expiry)s unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+					),
+					{ purchaseName, expiry }
+				),
+				{ link }
+			);
+		} else if ( currentPurchase.is_plan ) {
+			if ( purchaseIsIncludedInPlan ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ purchaseName, expiry, includedPurchaseName }
+					),
+					{ link, managePurchase }
+				);
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s plan will expire %(expiry)s unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+						),
+						{ purchaseName, expiry }
+					),
+					{ link }
+				);
+			}
+		} else {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s subscription will expire %(expiry)s unless you take action. You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
+					),
+					{ purchaseName, expiry }
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 3: current-renews-soon-others-expire-soon
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		// FIXME: handle "renew all" action
+		noticeActionOnClick = () => null;
+		noticeActionText = __( 'Renew all' );
+
+		if ( anotherPurchaseIsExpired ) {
+			if ( currentPurchase.is_domain_registration ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s domain is scheduled to renew, but you have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+						),
+						{ purchaseName, earliestOtherExpiry }
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_plan ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) is scheduled to renew, but you have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+							),
+							{ purchaseName, includedPurchaseName, earliestOtherExpiry }
+						),
+						{ link, managePurchase }
+					);
+				} else {
+					noticeText = createInterpolateElement(
+						sprintf(
+							// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+							__(
+								'Your %(purchaseName)s plan is scheduled to renew, but you have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+							),
+							{ purchaseName, earliestOtherExpiry }
+						),
+						{ link }
+					);
+				}
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s subscription is scheduled to renew, but you have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+						),
+						{ purchaseName, earliestOtherExpiry }
+					),
+					{ link }
+				);
+			}
+		} else if ( currentPurchase.is_domain_registration ) {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s domain is scheduled to renew, but you have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+					),
+					{ purchaseName, earliestOtherExpiry }
+				),
+				{ link }
+			);
+		} else if ( currentPurchase.is_plan ) {
+			if ( purchaseIsIncludedInPlan ) {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) is scheduled to renew, but you have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+						),
+						{ purchaseName, earliestOtherExpiry }
+					),
+					{ link, managePurchase }
+				);
+			} else {
+				noticeText = createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+						__(
+							'Your %(purchaseName)s plan is scheduled to renew, but you have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+						),
+						{ purchaseName, earliestOtherExpiry }
+					),
+					{ link }
+				);
+			}
+		} else {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'Your %(purchaseName)s subscription is scheduled to renew, but you have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+					),
+					{ purchaseName, earliestOtherExpiry }
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 4: current-renews-soon-others-renew-soon and current-renews-soon-others-renew-soon-cc-expiring
+	if (
+		currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+			noticeStatus = 'success';
+			noticeText = createInterpolateElement(
+				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
+				{ link }
+			);
+		} else if ( currentPurchase.payment_card_id ) {
+			noticeStatus = shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info';
+			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
+			// FIXME: handle "update all" action
+			noticeActionOnClick = () => null;
+			noticeActionText = __( 'Update all' );
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+					__(
+						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+					),
+					{
+						cardType: purchase.payment_card_type,
+						cardNumber: purchase.payment_card_id,
+						cardExpiry: purchase.payment_expiry,
+					}
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 5: current-expires-later-others-expire-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		// FIXME: handle "renew all" action
+		noticeActionOnClick = () => null;
+		noticeActionText = __( 'Renew Now' );
+
+		if ( anotherPurchaseIsExpired ) {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+					),
+					{ earliestOtherExpiry }
+				),
+				{ link }
+			);
+		} else {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+					),
+					{ earliestOtherExpiry }
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 6: current-expires-later-others-renew-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring
+	) {
+		noticeStatus = 'info';
+
+		if ( currentPurchase.is_plan && purchaseIsIncludedInPlan ) {
+			noticeText = createInterpolateElement(
+				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
+				{ link }
+			);
+		} else {
+			noticeText = (
+				<ExpiringLaterText
+					purchase={ purchase }
+					autoRenewingUpgradesAction={ openUpcomingRenewalsDialog }
+				/>
+			);
+		}
+	}
+
+	// Scenario 7: current-renews-later-others-expire-soon
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		anotherPurchaseIsExpiring
+	) {
+		noticeStatus = suppressErrorStylingForOtherPurchases ? 'info' : 'error';
+		// FIXME: handle "renew all" action
+		noticeActionOnClick = () => null;
+		noticeActionText = __( 'Renew Now' );
+
+		if ( anotherPurchaseIsExpired ) {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'You have <link>other upgrades</link> on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.'
+					),
+					{ earliestOtherExpiry }
+				),
+				{ link }
+			);
+		} else {
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the product, earliestOtherExpiry is a string like "3 months ago", and includedPurchaseName is the name of another product
+					__(
+						'You have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
+					),
+					{ earliestOtherExpiry }
+				),
+				{ link }
+			);
+		}
+	}
+
+	// Scenario 8: current-renews-later-others-renew-soon and current-renews-later-others-renew-soon-cc-expiring
+	if (
+		! currentPurchaseNeedsToRenewSoon &&
+		! currentPurchaseIsExpiring &&
+		! anotherPurchaseIsExpiring &&
+		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
+	) {
+		if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+			noticeStatus = 'success';
+			noticeText = createInterpolateElement(
+				__( 'You have <link>other upgrades</link> on this site that are scheduled to renew soon.' ),
+				{ link }
+			);
+		} else if ( currentPurchase.payment_card_id ) {
+			noticeStatus = 'info';
+			noticeActionHref = getAddPaymentMethodUrlFor( purchase );
+			// FIXME: handle "update all" action
+			noticeActionOnClick = () => null;
+			noticeActionText = __( 'Update all' );
+			noticeText = createInterpolateElement(
+				sprintf(
+					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+					__(
+						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+					),
+					{
+						cardType: purchase.payment_card_type,
+						cardNumber: purchase.payment_card_id,
+						cardExpiry: purchase.payment_expiry,
+					}
+				),
+				{
+					link,
+				}
+			);
+		}
+	}
+
+	if ( ! noticeText ) {
+		return null;
+	}
+
+	// FIXME: render UpcomingRenewalsDialog for renewableSitePurchases
+	return (
+		<>
+			<Notice variant={ noticeStatus }>
+				{ noticeText }
+				{ ( noticeActionHref || noticeActionOnClick ) && (
+					<Button
+						href={ noticeActionHref ?? undefined }
+						onClick={ noticeActionOnClick ?? undefined }
+					>
+						{ noticeActionText }
+					</Button>
+				) }
+			</Notice>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -219,7 +219,7 @@ export function ExpiringLaterText( {
 					{ purchaseName, expiry }
 				),
 				{
-					link: <Button onClick={ autoRenewingUpgradesAction } />,
+					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
 				}
 			);
 		}
@@ -245,7 +245,7 @@ export function ExpiringLaterText( {
 						{ purchaseName, expiry }
 					),
 					{
-						link: <Button onClick={ autoRenewingUpgradesAction } />,
+						link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
 					}
 				);
 			}
@@ -269,7 +269,7 @@ export function ExpiringLaterText( {
 					{ purchaseName, expiry }
 				),
 				{
-					link: <Button onClick={ autoRenewingUpgradesAction } />,
+					link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
 				}
 			);
 		}
@@ -293,7 +293,7 @@ export function ExpiringLaterText( {
 				{ purchaseName, expiry }
 			),
 			{
-				link: <Button onClick={ autoRenewingUpgradesAction } />,
+				link: <Button variant="link" onClick={ autoRenewingUpgradesAction } />,
 			}
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -1,0 +1,307 @@
+import { DotcomPlans, SubscriptionBillPeriod } from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { differenceInCalendarDays } from 'date-fns';
+import Notice from '../../../components/notice';
+import { getRelativeTimeString } from '../../../utils/datetime';
+import {
+	isIncludedWithPlan,
+	isExpiring,
+	isCloseToExpiration,
+	isRecentMonthlyPurchase,
+	isTemporarySitePurchase,
+	isAkismetFreeProduct,
+	getRenewalUrlFromPurchase,
+} from '../../../utils/purchase';
+import { getPurchaseUrl } from '../urls';
+import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
+import type { Purchase } from '@automattic/api-core';
+
+export function shouldShowExpiringNotice(
+	purchase: Purchase,
+	purchaseAttachedTo: Purchase | undefined
+) {
+	const EXCLUDED_PRODUCTS: string[] = [
+		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
+		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
+		DotcomPlans.HOSTING_TRIAL_MONTHLY,
+	];
+
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase is used on this page when
+	// there are other upcoming renewals to display, so for consistency it
+	// should also be used here (where there are no upcoming renewals to
+	// display).
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	if (
+		! isExpiring( currentPurchase ) ||
+		EXCLUDED_PRODUCTS.includes( currentPurchase?.product_slug ) ||
+		isAkismetFreeProduct( currentPurchase )
+	) {
+		return false;
+	}
+
+	if ( purchase.is_hundred_year_domain ) {
+		return false;
+	}
+
+	if (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
+		! isCloseToExpiration( purchase )
+	) {
+		return false;
+	}
+
+	if ( usePlanInsteadOfIncludedPurchase && ! purchase.site_slug ) {
+		return false;
+	}
+	return true;
+}
+
+export function PurchaseExpiringNotice( {
+	purchase,
+	purchaseAttachedTo,
+}: {
+	purchase: Purchase;
+	purchaseAttachedTo: Purchase | undefined;
+} ) {
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase is used on this page when
+	// there are other upcoming renewals to display, so for consistency it
+	// should also be used here (where there are no upcoming renewals to
+	// display).
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	const includedPurchase = purchase;
+
+	if ( usePlanInsteadOfIncludedPurchase && purchase.site_slug ) {
+		// We can't show the action here, because it would try to renew the
+		// included purchase (rather than the plan that it is attached to).
+		// So we have to rely on the user going to the manage purchase page
+		// for the plan to renew it there.
+		return (
+			<Notice
+				variant={
+					isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
+						? 'error'
+						: 'info'
+				}
+			>
+				{ createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the plan, includedPurchaseName is the name of the subscription included in the plan and expiry is a formatted string like "in 3 months"
+						__(
+							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire and be removed from your site %(expiry)s.'
+						),
+						{
+							purchaseName: currentPurchase.is_domain
+								? currentPurchase.meta ?? ''
+								: currentPurchase.product_name,
+							includedPurchaseName: includedPurchase.is_domain
+								? includedPurchase.meta ?? ''
+								: includedPurchase.product_name,
+							expiry: getRelativeTimeString( new Date( currentPurchase.expiry_date ) ),
+						}
+					),
+					{
+						managePurchase: <Link to={ getPurchaseUrl( currentPurchase ) } />,
+					}
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice
+			variant={
+				isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
+					? 'error'
+					: 'info'
+			}
+			actions={
+				shouldShowRenewNoticeAction( purchase ) ? (
+					<RenewNoticeAction
+						purchase={ purchase }
+						onClick={ () => {
+							window.location.href = getRenewalUrlFromPurchase( purchase );
+						} }
+					/>
+				) : undefined
+			}
+		>
+			<ExpiringText purchase={ currentPurchase } />
+		</Notice>
+	);
+}
+
+function ExpiringText( { purchase }: { purchase: Purchase } ) {
+	if (
+		purchase.site_slug &&
+		purchase.expiry_status === 'manual-renew' &&
+		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
+	) {
+		return <ExpiringLaterText purchase={ purchase } />;
+	}
+
+	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
+
+	if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
+		const daysToExpiry = differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
+
+		if ( isTemporarySitePurchase( purchase ) ) {
+			return sprintf(
+				// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+				__( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.' ),
+				{
+					purchaseName,
+					daysToExpiry,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+			__( '%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.' ),
+			{
+				purchaseName,
+				daysToExpiry,
+			}
+		);
+	}
+
+	if ( isTemporarySitePurchase( purchase ) ) {
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		return sprintf( __( '%(purchaseName)s will expire and be removed %(expiry)s.' ), {
+			purchaseName,
+			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		} );
+	}
+
+	return sprintf(
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		__( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' ),
+		{
+			purchaseName,
+			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		}
+	);
+}
+
+function ExpiringLaterText( {
+	purchase,
+	autoRenewingUpgradesLink,
+}: {
+	purchase: Purchase;
+	autoRenewingUpgradesLink?: string;
+} ) {
+	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
+	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
+
+	if ( purchase.payment_type === 'credits' ) {
+		if ( autoRenewingUpgradesLink ) {
+			return createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					__(
+						"You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+					),
+					{ purchaseName, expiry }
+				),
+				{
+					link: <a href={ autoRenewingUpgradesLink } />,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			__(
+				"You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features!"
+			),
+			{ purchaseName, expiry }
+		);
+	}
+
+	if ( purchase.payment_type ) {
+		if ( purchase.is_rechargable ) {
+			if ( autoRenewingUpgradesLink ) {
+				return createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+						__(
+							"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+						),
+						{ purchaseName, expiry }
+					),
+					{
+						link: <a href={ autoRenewingUpgradesLink } />,
+					}
+				);
+			}
+
+			return sprintf(
+				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				__(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!"
+				),
+				{ purchaseName, expiry }
+			);
+		}
+
+		if ( autoRenewingUpgradesLink ) {
+			return createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					__(
+						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+					),
+					{ purchaseName, expiry }
+				),
+				{
+					link: <a href={ autoRenewingUpgradesLink } />,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			__(
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!"
+			),
+			{ purchaseName, expiry }
+		);
+	}
+
+	if ( autoRenewingUpgradesLink ) {
+		return createInterpolateElement(
+			sprintf(
+				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				__(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+				),
+				{ purchaseName, expiry }
+			),
+			{
+				link: <a href={ autoRenewingUpgradesLink } />,
+			}
+		);
+	}
+
+	return sprintf(
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		__(
+			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don't lose out on your paid features!"
+		),
+		{ purchaseName, expiry }
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -214,7 +214,7 @@ export function ExpiringLaterText( {
 				sprintf(
 					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 					__(
-						"You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+						'You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
 					),
 					{ purchaseName, expiry }
 				),
@@ -227,7 +227,7 @@ export function ExpiringLaterText( {
 		return sprintf(
 			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 			__(
-				"You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features!"
+				'You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don‘t lose out on your paid features!'
 			),
 			{ purchaseName, expiry }
 		);
@@ -240,7 +240,7 @@ export function ExpiringLaterText( {
 					sprintf(
 						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 						__(
-							"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+							'%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
 						),
 						{ purchaseName, expiry }
 					),
@@ -253,7 +253,7 @@ export function ExpiringLaterText( {
 			return sprintf(
 				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 				__(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!"
+					'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don‘t lose out on your paid features!'
 				),
 				{ purchaseName, expiry }
 			);
@@ -264,7 +264,7 @@ export function ExpiringLaterText( {
 				sprintf(
 					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 					__(
-						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+						'%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
 					),
 					{ purchaseName, expiry }
 				),
@@ -277,7 +277,7 @@ export function ExpiringLaterText( {
 		return sprintf(
 			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 			__(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!"
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don‘t lose out on your paid features!'
 			),
 			{ purchaseName, expiry }
 		);
@@ -288,7 +288,7 @@ export function ExpiringLaterText( {
 			sprintf(
 				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 				__(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+					'%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don‘t lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon.'
 				),
 				{ purchaseName, expiry }
 			),
@@ -301,7 +301,7 @@ export function ExpiringLaterText( {
 	return sprintf(
 		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
 		__(
-			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don't lose out on your paid features!"
+			'%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don‘t lose out on your paid features!'
 		),
 		{ purchaseName, expiry }
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -1,5 +1,6 @@
 import { DotcomPlans, SubscriptionBillPeriod } from '@automattic/api-core';
 import { Link } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { differenceInCalendarDays } from 'date-fns';
@@ -197,18 +198,18 @@ function ExpiringText( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function ExpiringLaterText( {
+export function ExpiringLaterText( {
 	purchase,
-	autoRenewingUpgradesLink,
+	autoRenewingUpgradesAction,
 }: {
 	purchase: Purchase;
-	autoRenewingUpgradesLink?: string;
+	autoRenewingUpgradesAction?: () => void;
 } ) {
 	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
 	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
 
 	if ( purchase.payment_type === 'credits' ) {
-		if ( autoRenewingUpgradesLink ) {
+		if ( autoRenewingUpgradesAction ) {
 			return createInterpolateElement(
 				sprintf(
 					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
@@ -218,7 +219,7 @@ function ExpiringLaterText( {
 					{ purchaseName, expiry }
 				),
 				{
-					link: <a href={ autoRenewingUpgradesLink } />,
+					link: <Button onClick={ autoRenewingUpgradesAction } />,
 				}
 			);
 		}
@@ -234,7 +235,7 @@ function ExpiringLaterText( {
 
 	if ( purchase.payment_type ) {
 		if ( purchase.is_rechargable ) {
-			if ( autoRenewingUpgradesLink ) {
+			if ( autoRenewingUpgradesAction ) {
 				return createInterpolateElement(
 					sprintf(
 						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
@@ -244,7 +245,7 @@ function ExpiringLaterText( {
 						{ purchaseName, expiry }
 					),
 					{
-						link: <a href={ autoRenewingUpgradesLink } />,
+						link: <Button onClick={ autoRenewingUpgradesAction } />,
 					}
 				);
 			}
@@ -258,7 +259,7 @@ function ExpiringLaterText( {
 			);
 		}
 
-		if ( autoRenewingUpgradesLink ) {
+		if ( autoRenewingUpgradesAction ) {
 			return createInterpolateElement(
 				sprintf(
 					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
@@ -268,7 +269,7 @@ function ExpiringLaterText( {
 					{ purchaseName, expiry }
 				),
 				{
-					link: <a href={ autoRenewingUpgradesLink } />,
+					link: <Button onClick={ autoRenewingUpgradesAction } />,
 				}
 			);
 		}
@@ -282,7 +283,7 @@ function ExpiringLaterText( {
 		);
 	}
 
-	if ( autoRenewingUpgradesLink ) {
+	if ( autoRenewingUpgradesAction ) {
 		return createInterpolateElement(
 			sprintf(
 				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
@@ -292,7 +293,7 @@ function ExpiringLaterText( {
 				{ purchaseName, expiry }
 			),
 			{
-				link: <a href={ autoRenewingUpgradesLink } />,
+				link: <Button onClick={ autoRenewingUpgradesAction } />,
 			}
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,0 +1,104 @@
+import { DomainProductSlugs, DotcomPlans } from '@automattic/api-core';
+import { Button } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { differenceInCalendarDays } from 'date-fns';
+import { useAnalytics } from '../../../app/analytics';
+import Notice from '../../../components/notice';
+import { isExpired } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
+	if ( purchase.async_pending_payment_block_is_set ) {
+		return (
+			<Notice variant="warning">
+				{ __(
+					'There is currently a payment processing for this subscription. Please wait for the payment to complete before attempting to make any changes.'
+				) }
+			</Notice>
+		);
+	}
+	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
+		return null;
+	}
+
+	if (
+		purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY ||
+		purchase.product_slug === DotcomPlans.MIGRATION_TRIAL_MONTHLY ||
+		purchase.product_slug === DotcomPlans.HOSTING_TRIAL_MONTHLY
+	) {
+		return <TrialNotice purchase={ purchase } />;
+	}
+
+	// FIXME: add all the other things in PurchaseNotice
+}
+
+function TrialNotice( { purchase }: { purchase: Purchase } ) {
+	const { recordTracksEvent } = useAnalytics();
+	const onClickUpgrade = () => {
+		const isEcommerceTrialMonthly = purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY;
+
+		if ( isEcommerceTrialMonthly ) {
+			recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
+				current_plan_slug: purchase.product_slug,
+				to_checkout: false,
+			} );
+
+			window.location.href = `/plans/${ purchase.site_slug ?? '' }`;
+			return;
+		}
+
+		recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
+			current_plan_slug: purchase.product_slug,
+			to_checkout: true,
+			upgrade_plan_slug: 'business',
+		} );
+
+		const siteSlug = purchase.site_slug ?? purchase.blog_id;
+		window.location.href = `/checkout/${ siteSlug }/business?redirectTo=/plans/my-plan/trial-upgraded/${ siteSlug }`;
+		return;
+	};
+
+	const daysToExpiry = isExpired( purchase )
+		? 0
+		: differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
+	const productType =
+		purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY
+			? __( 'ecommerce' )
+			: // translators: Business is a plan name
+			  __( 'Business' );
+	const noticeText = daysToExpiry
+		? sprintf(
+				// translators: %expiry is the number of days remaining on the trial, %productType is the type of product (e.g. ecommerce)
+				_n(
+					'You have %(expiry)s day remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
+					'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
+					daysToExpiry
+				),
+				{
+					expiry: daysToExpiry,
+					productType: productType as string,
+				}
+		  )
+		: sprintf(
+				// translators: %productType is the type of product (e.g. ecommerce)
+				__(
+					'Your free trial has expired. Upgrade your plan to keep your %(productType)s features.'
+				),
+				{
+					productType,
+				}
+		  );
+
+	return (
+		<Notice
+			variant="info"
+			actions={
+				<Button variant="primary" onClick={ onClickUpgrade }>
+					{ __( 'Upgrade now' ) }
+				</Button>
+			}
+		>
+			{ noticeText }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -12,6 +12,9 @@ import Notice from '../../../components/notice';
 import {
 	isExpired,
 	isIncludedWithPlan,
+	isOneTimePurchase,
+	isCloseToExpiration,
+	creditCardExpiresBeforeSubscription,
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
 import { getPurchaseUrl } from '../urls';
@@ -74,11 +77,9 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 
-	// FIXME: finish these
-	// const expiringCreditCardNotice = this.renderCreditCardExpiringNotice();
-	// if ( expiringCreditCardNotice ) {
-	// 	return expiringCreditCardNotice;
-	// }
+	if ( shouldShowCardExpiringNotice( purchase ) ) {
+		return <CreditCardExpiringNotice purchase={ purchase } />;
+	}
 }
 
 function shouldShowExpiredRenewNotice(
@@ -288,3 +289,56 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function shouldShowCardExpiringNotice( purchase: Purchase ): boolean {
+	if (
+		isExpired( purchase ) ||
+		isOneTimePurchase( purchase ) ||
+		isIncludedWithPlan( purchase ) ||
+		! purchase.site_slug ||
+		! purchase.payment_card_id ||
+		purchase.is_hundred_year_domain
+	) {
+		return false;
+	}
+
+	if ( creditCardExpiresBeforeSubscription( purchase ) ) {
+		return true;
+	}
+	return false;
+}
+
+export function shouldShowCardExpiringWarning( purchase: Purchase ): boolean {
+	return Boolean(
+		! isIncludedWithPlan( purchase ) &&
+			purchase.payment_card_id &&
+			creditCardExpiresBeforeSubscription( purchase ) &&
+			isCloseToExpiration( purchase )
+	);
+}
+
+function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
+	const siteSlug = purchase.site_slug ?? purchase.blog_id;
+	const changePaymentMethodPath = purchase.payment_card_id
+		? `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/change/${ purchase.payment_card_id }`
+		: `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/add`;
+	return (
+		<Notice variant={ shouldShowCardExpiringWarning( purchase ) ? 'error' : 'info' }>
+			{ createInterpolateElement(
+				sprintf(
+					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+					__(
+						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. Please {{a}}update your payment information{{/a}}.'
+					),
+					{
+						cardType: purchase.payment_card_type,
+						cardNumber: purchase.payment_card_id,
+						cardExpiry: purchase.payment_expiry,
+					}
+				),
+				{
+					a: <a href={ changePaymentMethodPath } />,
+				}
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,23 +1,34 @@
-import { DomainProductSlugs, DotcomPlans } from '@automattic/api-core';
+import { DomainProductSlugs, DotcomPlans, SubscriptionBillPeriod } from '@automattic/api-core';
+import { purchaseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
+import { useAuth } from '../../../app/auth';
 import Notice from '../../../components/notice';
-import { isExpired } from '../../../utils/purchase';
+import {
+	isExpired,
+	isIncludedWithPlan,
+	isCloseToExpiration,
+	getRenewalUrlFromPurchase,
+} from '../../../utils/purchase';
+import { getPurchaseUrl } from '../urls';
 import type { Purchase } from '@automattic/api-core';
 
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
+	const { user } = useAuth();
+	const { data: purchaseAttachedTo } = useQuery( {
+		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
+		enabled: Boolean( purchase.attached_to_purchase_id ),
+	} );
+
 	if ( purchase.async_pending_payment_block_is_set ) {
-		return (
-			<Notice variant="warning">
-				{ __(
-					'There is currently a payment processing for this subscription. Please wait for the payment to complete before attempting to make any changes.'
-				) }
-			</Notice>
-		);
+		return <AsyncPendingNotice />;
 	}
+
 	if ( purchase.product_slug === DomainProductSlugs.TRANSFER_IN ) {
 		return null;
 	}
@@ -31,21 +42,203 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	}
 
 	if ( purchase.is_locked && purchase.is_iap_purchase ) {
+		return <InAppPurchaseNotice purchase={ purchase } />;
+	}
+
+	if ( String( user.ID ) !== String( purchase.user_id ) ) {
+		return <NonProductOwnerNotice />;
+	}
+
+	if ( purchase.product_slug === 'concierge-session' && isExpired( purchase ) ) {
+		return <ConciergeConsumedNotice />;
+	}
+
+	// FIXME: add this one
+	// const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();
+	// if ( otherRenewablePurchasesNotice ) {
+	// 	return otherRenewablePurchasesNotice;
+	// }
+
+	if ( shouldShowExpiredRenewNotice( purchase, purchaseAttachedTo ) ) {
+		return <ExpiredRenewNotice purchase={ purchase } />;
+	}
+
+	if ( purchase.partner_type ) {
+		return null;
+	}
+
+	// FIXME: finish these
+	// const expiringNotice = this.renderPurchaseExpiringNotice();
+	// if ( expiringNotice ) {
+	// 	return expiringNotice;
+	// }
+	//
+	// const expiringCreditCardNotice = this.renderCreditCardExpiringNotice();
+	// if ( expiringCreditCardNotice ) {
+	// 	return expiringCreditCardNotice;
+	// }
+}
+
+function shouldShowExpiredRenewNotice(
+	purchase: Purchase,
+	purchaseAttachedTo: Purchase | undefined
+): boolean {
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	if ( ! isExpired( currentPurchase ) ) {
+		return false;
+	}
+
+	if ( purchase.is_renewable ) {
+		return true;
+	}
+
+	if ( ! usePlanInsteadOfIncludedPurchase ) {
+		return false;
+	}
+
+	if ( ! purchase.site_slug ) {
+		return false;
+	}
+
+	return true;
+}
+
+function ExpiredRenewNotice( { purchase }: { purchase: Purchase } ) {
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase is used on this page when
+	// there are other upcoming renewals to display, so for consistency it
+	// should also be used here (where there are no upcoming renewals to
+	// display).
+	const { data: purchaseAttachedTo } = useQuery( {
+		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
+		enabled: Boolean( purchase.attached_to_purchase_id ),
+	} );
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+	const includedPurchase = purchase;
+
+	if ( purchase.is_renewable ) {
 		return (
-			<Notice variant="info">
-				{ createInterpolateElement(
-					__(
-						'This product is an in-app purchase. You can manage it from within <managePurchase/>the app store</managePurchase>.'
-					),
-					{
-						managePurchase: <a href={ purchase.iap_purchase_management_link ?? undefined } />,
-					}
-				) }
+			<Notice
+				variant="error"
+				actions={
+					<RenewNoticeAction
+						purchase={ purchase }
+						onClick={ () => {
+							window.location.href = getRenewalUrlFromPurchase( purchase );
+						} }
+					/>
+				}
+			>
+				{ __( 'This purchase has expired and is no longer in use.' ) }
 			</Notice>
 		);
 	}
 
-	// FIXME: add all the other things in PurchaseNotice
+	// We can't show the action here, because it would try to renew the
+	// included purchase (rather than the plan that it is attached to).
+	// So we have to rely on the user going to the manage purchase page
+	// for the plan to renew it there.
+	return (
+		<Notice variant="error">
+			{ createInterpolateElement(
+				sprintf(
+					// translators: purchaseName ist he name of the plan, includedPurchaseName is the name of the subscription included in the plan
+					__(
+						'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) has expired and is no longer in use.'
+					),
+					{
+						purchaseName: currentPurchase.is_domain
+							? currentPurchase.meta ?? ''
+							: currentPurchase.product_name,
+						includedPurchaseName: includedPurchase.is_domain
+							? includedPurchase.meta ?? ''
+							: includedPurchase.product_name,
+					}
+				),
+				{
+					managePurchase: <Link to={ getPurchaseUrl( purchase ) } />,
+				}
+			) }
+		</Notice>
+	);
+}
+
+function RenewNoticeAction( { onClick, purchase }: { purchase: Purchase; onClick: () => void } ) {
+	const siteSlug = purchase.site_slug ?? purchase.blog_id;
+	const changePaymentMethodPath = purchase.payment_card_id
+		? `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/change/${ purchase.payment_card_id }`
+		: `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/add`;
+	const shouldAddPaymentSourceInsteadOfRenewingNow =
+		isCloseToExpiration( purchase ) ||
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
+	if (
+		! purchase.payment_type &&
+		( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow )
+	) {
+		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+	}
+
+	// isExpiring(), which leads here (along with isExpired()) returns true
+	// when expiring, when auto-renew is disabled, or when the payment method
+	// was credits but we don't want to show "Add Payment Method" if the
+	// subscription is actually expiring or expired; we want to show "Renew
+	// Now" in that case.
+	if ( purchase.payment_type === 'credits' && purchase.expiry_status === 'manual-renew' ) {
+		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+	}
+
+	if ( ! purchase.is_rechargable ) {
+		return <Button onClick={ onClick }>{ __( 'Renew now' ) }</Button>;
+	}
+	return null;
+}
+
+function ConciergeConsumedNotice() {
+	return <Notice variant="info">{ __( 'This session has been used.' ) }</Notice>;
+}
+
+function NonProductOwnerNotice() {
+	return (
+		<Notice variant="info">
+			{ __(
+				'This product was purchased by a different WordPress.com account. To manage this product, log in to that account or contact the account owner.'
+			) }
+		</Notice>
+	);
+}
+
+function AsyncPendingNotice() {
+	return (
+		<Notice variant="warning">
+			{ __(
+				'There is currently a payment processing for this subscription. Please wait for the payment to complete before attempting to make any changes.'
+			) }
+		</Notice>
+	);
+}
+
+function InAppPurchaseNotice( { purchase }: { purchase: Purchase } ) {
+	return (
+		<Notice variant="info">
+			{ createInterpolateElement(
+				__(
+					'This product is an in-app purchase. You can manage it from within <managePurchase/>the app store</managePurchase>.'
+				),
+				{
+					managePurchase: <a href={ purchase.iap_purchase_management_link ?? undefined } />,
+				}
+			) }
+		</Notice>
+	);
 }
 
 function TrialNotice( { purchase }: { purchase: Purchase } ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -268,7 +268,7 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 		: differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
 	const productType =
 		purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY
-			? __( 'ecommerce' )
+			? __( 'Ecommerce' )
 			: // translators: Business is a plan name
 			  __( 'Business' );
 	const noticeText = daysToExpiry

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,5 +1,5 @@
 import { DomainProductSlugs, DotcomPlans } from '@automattic/api-core';
-import { purchaseQuery } from '@automattic/api-queries';
+import { purchaseQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -14,6 +14,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isCloseToExpiration,
+	needsToRenewSoon,
 	creditCardExpiresBeforeSubscription,
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
@@ -32,6 +33,10 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
 		enabled: Boolean( purchase.attached_to_purchase_id ),
 	} );
+	const { data: sitePurchases } = useQuery( {
+		...sitePurchasesQuery( purchase.blog_id ?? 0 ),
+	} );
+	const renewableSitePurchases = sitePurchases?.filter( needsToRenewSoon );
 
 	if ( purchase.async_pending_payment_block_is_set ) {
 		return <AsyncPendingNotice />;
@@ -61,11 +66,18 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return <ConciergeConsumedNotice />;
 	}
 
-	if ( shouldShowOtherRenewablePurchasesNotice( purchase, purchaseAttachedTo ) ) {
+	if (
+		shouldShowOtherRenewablePurchasesNotice(
+			purchase,
+			purchaseAttachedTo,
+			renewableSitePurchases ?? []
+		)
+	) {
 		return (
 			<OtherRenewablePurchasesNotice
 				purchase={ purchase }
 				purchaseAttachedTo={ purchaseAttachedTo }
+				renewableSitePurchases={ renewableSitePurchases ?? [] }
 			/>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,5 +1,6 @@
 import { DomainProductSlugs, DotcomPlans } from '@automattic/api-core';
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
@@ -27,6 +28,21 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		purchase.product_slug === DotcomPlans.HOSTING_TRIAL_MONTHLY
 	) {
 		return <TrialNotice purchase={ purchase } />;
+	}
+
+	if ( purchase.is_locked && purchase.is_iap_purchase ) {
+		return (
+			<Notice variant="info">
+				{ createInterpolateElement(
+					__(
+						'This product is an in-app purchase. You can manage it from within <managePurchase/>the app store</managePurchase>.'
+					),
+					{
+						managePurchase: <a href={ purchase.iap_purchase_management_link ?? undefined } />,
+					}
+				) }
+			</Notice>
+		);
 	}
 
 	// FIXME: add all the other things in PurchaseNotice

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -18,6 +18,10 @@ import {
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
 import { getPurchaseUrl } from '../urls';
+import {
+	OtherRenewablePurchasesNotice,
+	shouldShowOtherRenewablePurchasesNotice,
+} from './other-renewable-purchases-notice';
 import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-expiring-notice';
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
@@ -57,11 +61,14 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return <ConciergeConsumedNotice />;
 	}
 
-	// FIXME: add this one
-	// const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();
-	// if ( otherRenewablePurchasesNotice ) {
-	// 	return otherRenewablePurchasesNotice;
-	// }
+	if ( shouldShowOtherRenewablePurchasesNotice( purchase, purchaseAttachedTo ) ) {
+		return (
+			<OtherRenewablePurchasesNotice
+				purchase={ purchase }
+				purchaseAttachedTo={ purchaseAttachedTo }
+			/>
+		);
+	}
 
 	if ( shouldShowExpiredRenewNotice( purchase, purchaseAttachedTo ) ) {
 		return <ExpiredRenewNotice purchase={ purchase } purchaseAttachedTo={ purchaseAttachedTo } />;

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -346,7 +346,7 @@ function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 				sprintf(
 					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
 					__(
-						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. Please {{a}}update your payment information{{/a}}.'
+						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
 					),
 					{
 						cardType: purchase.payment_card_type,
@@ -355,7 +355,7 @@ function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 					}
 				),
 				{
-					a: <a href={ changePaymentMethodPath } />,
+					link: <a href={ changePaymentMethodPath } />,
 				}
 			) }
 		</Notice>

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -9,10 +9,15 @@ import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Notice from '../../../components/notice';
+import { getRelativeTimeString } from '../../../utils/datetime';
 import {
 	isExpired,
+	isExpiring,
 	isIncludedWithPlan,
 	isCloseToExpiration,
+	isRecentMonthlyPurchase,
+	isAkismetFreeProduct,
+	isTemporarySitePurchase,
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
 import { getPurchaseUrl } from '../urls';
@@ -60,19 +65,20 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	// }
 
 	if ( shouldShowExpiredRenewNotice( purchase, purchaseAttachedTo ) ) {
-		return <ExpiredRenewNotice purchase={ purchase } />;
+		return <ExpiredRenewNotice purchase={ purchase } purchaseAttachedTo={ purchaseAttachedTo } />;
 	}
 
 	if ( purchase.partner_type ) {
 		return null;
 	}
 
+	if ( shouldShowExpiringNotice( purchase, purchaseAttachedTo ) ) {
+		return (
+			<PurchaseExpiringNotice purchase={ purchase } purchaseAttachedTo={ purchaseAttachedTo } />
+		);
+	}
+
 	// FIXME: finish these
-	// const expiringNotice = this.renderPurchaseExpiringNotice();
-	// if ( expiringNotice ) {
-	// 	return expiringNotice;
-	// }
-	//
 	// const expiringCreditCardNotice = this.renderCreditCardExpiringNotice();
 	// if ( expiringCreditCardNotice ) {
 	// 	return expiringCreditCardNotice;
@@ -108,16 +114,18 @@ function shouldShowExpiredRenewNotice(
 	return true;
 }
 
-function ExpiredRenewNotice( { purchase }: { purchase: Purchase } ) {
+function ExpiredRenewNotice( {
+	purchase,
+	purchaseAttachedTo,
+}: {
+	purchase: Purchase;
+	purchaseAttachedTo: Purchase | undefined;
+} ) {
 	// For purchases included with a plan (for example, a domain mapping
 	// bundled with the plan), the plan purchase is used on this page when
 	// there are other upcoming renewals to display, so for consistency it
 	// should also be used here (where there are no upcoming renewals to
 	// display).
-	const { data: purchaseAttachedTo } = useQuery( {
-		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
-		enabled: Boolean( purchase.attached_to_purchase_id ),
-	} );
 	const usePlanInsteadOfIncludedPurchase = Boolean(
 		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
 	);
@@ -309,5 +317,288 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 		>
 			{ noticeText }
 		</Notice>
+	);
+}
+
+function shouldShowExpiringNotice( purchase: Purchase, purchaseAttachedTo: Purchase | undefined ) {
+	const EXCLUDED_PRODUCTS: string[] = [
+		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
+		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
+		DotcomPlans.HOSTING_TRIAL_MONTHLY,
+	];
+
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase is used on this page when
+	// there are other upcoming renewals to display, so for consistency it
+	// should also be used here (where there are no upcoming renewals to
+	// display).
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	if (
+		! isExpiring( currentPurchase ) ||
+		EXCLUDED_PRODUCTS.includes( currentPurchase?.product_slug ) ||
+		isAkismetFreeProduct( currentPurchase )
+	) {
+		return false;
+	}
+
+	if ( purchase.is_hundred_year_domain ) {
+		return false;
+	}
+
+	if (
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
+		! isCloseToExpiration( purchase )
+	) {
+		return false;
+	}
+
+	if ( usePlanInsteadOfIncludedPurchase && ! purchase.site_slug ) {
+		return false;
+	}
+	return true;
+}
+
+function PurchaseExpiringNotice( {
+	purchase,
+	purchaseAttachedTo,
+}: {
+	purchase: Purchase;
+	purchaseAttachedTo: Purchase | undefined;
+} ) {
+	// For purchases included with a plan (for example, a domain mapping
+	// bundled with the plan), the plan purchase is used on this page when
+	// there are other upcoming renewals to display, so for consistency it
+	// should also be used here (where there are no upcoming renewals to
+	// display).
+	const usePlanInsteadOfIncludedPurchase = Boolean(
+		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
+	);
+	const currentPurchase: Purchase =
+		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
+
+	const includedPurchase = purchase;
+
+	if ( usePlanInsteadOfIncludedPurchase && purchase.site_slug ) {
+		// We can't show the action here, because it would try to renew the
+		// included purchase (rather than the plan that it is attached to).
+		// So we have to rely on the user going to the manage purchase page
+		// for the plan to renew it there.
+		return (
+			<Notice
+				variant={
+					isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
+						? 'error'
+						: 'info'
+				}
+			>
+				{ createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the plan, includedPurchaseName is the name of the subscription included in the plan and expiry is a formatted string like "in 3 months"
+						__(
+							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire and be removed from your site %(expiry)s.'
+						),
+						{
+							purchaseName: currentPurchase.is_domain
+								? currentPurchase.meta ?? ''
+								: currentPurchase.product_name,
+							includedPurchaseName: includedPurchase.is_domain
+								? includedPurchase.meta ?? ''
+								: includedPurchase.product_name,
+							expiry: getRelativeTimeString( new Date( currentPurchase.expiry_date ) ),
+						}
+					),
+					{
+						managePurchase: <Link to={ getPurchaseUrl( currentPurchase ) } />,
+					}
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice
+			variant={
+				isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
+					? 'error'
+					: 'info'
+			}
+			actions={
+				<RenewNoticeAction
+					purchase={ purchase }
+					onClick={ () => {
+						window.location.href = getRenewalUrlFromPurchase( purchase );
+					} }
+				/>
+			}
+		>
+			<ExpiringText purchase={ currentPurchase } />
+		</Notice>
+	);
+}
+
+function ExpiringText( { purchase }: { purchase: Purchase } ) {
+	if (
+		purchase.site_slug &&
+		purchase.expiry_status === 'manual-renew' &&
+		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
+	) {
+		return <ExpiringLaterText purchase={ purchase } />;
+	}
+
+	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
+
+	if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
+		const daysToExpiry = differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
+
+		if ( isTemporarySitePurchase( purchase ) ) {
+			return sprintf(
+				// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+				__( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.' ),
+				{
+					purchaseName,
+					daysToExpiry,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+			__( '%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.' ),
+			{
+				purchaseName,
+				daysToExpiry,
+			}
+		);
+	}
+
+	if ( isTemporarySitePurchase( purchase ) ) {
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		return sprintf( __( '%(purchaseName)s will expire and be removed %(expiry)s.' ), {
+			purchaseName,
+			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		} );
+	}
+
+	return sprintf(
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		__( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' ),
+		{
+			purchaseName,
+			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		}
+	);
+}
+
+function ExpiringLaterText( {
+	purchase,
+	autoRenewingUpgradesLink,
+}: {
+	purchase: Purchase;
+	autoRenewingUpgradesLink?: string;
+} ) {
+	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
+	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
+
+	if ( purchase.payment_type === 'credits' ) {
+		if ( autoRenewingUpgradesLink ) {
+			return createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					__(
+						"You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+					),
+					{ purchaseName, expiry }
+				),
+				{
+					link: <a href={ autoRenewingUpgradesLink } />,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			__(
+				"You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features!"
+			),
+			{ purchaseName, expiry }
+		);
+	}
+
+	if ( purchase.payment_type ) {
+		if ( purchase.is_rechargable ) {
+			if ( autoRenewingUpgradesLink ) {
+				return createInterpolateElement(
+					sprintf(
+						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+						__(
+							"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+						),
+						{ purchaseName, expiry }
+					),
+					{
+						link: <a href={ autoRenewingUpgradesLink } />,
+					}
+				);
+			}
+
+			return sprintf(
+				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				__(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!"
+				),
+				{ purchaseName, expiry }
+			);
+		}
+
+		if ( autoRenewingUpgradesLink ) {
+			return createInterpolateElement(
+				sprintf(
+					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+					__(
+						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+					),
+					{ purchaseName, expiry }
+				),
+				{
+					link: <a href={ autoRenewingUpgradesLink } />,
+				}
+			);
+		}
+
+		return sprintf(
+			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+			__(
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!"
+			),
+			{ purchaseName, expiry }
+		);
+	}
+
+	if ( autoRenewingUpgradesLink ) {
+		return createInterpolateElement(
+			sprintf(
+				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+				__(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
+				),
+				{ purchaseName, expiry }
+			),
+			{
+				link: <a href={ autoRenewingUpgradesLink } />,
+			}
+		);
+	}
+
+	return sprintf(
+		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
+		__(
+			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don't lose out on your paid features!"
+		),
+		{ purchaseName, expiry }
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,4 +1,4 @@
-import { DomainProductSlugs, DotcomPlans, SubscriptionBillPeriod } from '@automattic/api-core';
+import { DomainProductSlugs, DotcomPlans } from '@automattic/api-core';
 import { purchaseQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
@@ -9,18 +9,14 @@ import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Notice from '../../../components/notice';
-import { getRelativeTimeString } from '../../../utils/datetime';
 import {
 	isExpired,
-	isExpiring,
 	isIncludedWithPlan,
-	isCloseToExpiration,
-	isRecentMonthlyPurchase,
-	isAkismetFreeProduct,
-	isTemporarySitePurchase,
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
 import { getPurchaseUrl } from '../urls';
+import { PurchaseExpiringNotice, shouldShowExpiringNotice } from './purchase-expiring-notice';
+import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
 
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
@@ -138,12 +134,14 @@ function ExpiredRenewNotice( {
 			<Notice
 				variant="error"
 				actions={
-					<RenewNoticeAction
-						purchase={ purchase }
-						onClick={ () => {
-							window.location.href = getRenewalUrlFromPurchase( purchase );
-						} }
-					/>
+					shouldShowRenewNoticeAction( purchase ) ? (
+						<RenewNoticeAction
+							purchase={ purchase }
+							onClick={ () => {
+								window.location.href = getRenewalUrlFromPurchase( purchase );
+							} }
+						/>
+					) : undefined
 				}
 			>
 				{ __( 'This purchase has expired and is no longer in use.' ) }
@@ -178,36 +176,6 @@ function ExpiredRenewNotice( {
 			) }
 		</Notice>
 	);
-}
-
-function RenewNoticeAction( { onClick, purchase }: { purchase: Purchase; onClick: () => void } ) {
-	const siteSlug = purchase.site_slug ?? purchase.blog_id;
-	const changePaymentMethodPath = purchase.payment_card_id
-		? `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/change/${ purchase.payment_card_id }`
-		: `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/add`;
-	const shouldAddPaymentSourceInsteadOfRenewingNow =
-		isCloseToExpiration( purchase ) ||
-		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
-	if (
-		! purchase.payment_type &&
-		( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow )
-	) {
-		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
-	}
-
-	// isExpiring(), which leads here (along with isExpired()) returns true
-	// when expiring, when auto-renew is disabled, or when the payment method
-	// was credits but we don't want to show "Add Payment Method" if the
-	// subscription is actually expiring or expired; we want to show "Renew
-	// Now" in that case.
-	if ( purchase.payment_type === 'credits' && purchase.expiry_status === 'manual-renew' ) {
-		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
-	}
-
-	if ( ! purchase.is_rechargable ) {
-		return <Button onClick={ onClick }>{ __( 'Renew now' ) }</Button>;
-	}
-	return null;
 }
 
 function ConciergeConsumedNotice() {
@@ -320,285 +288,3 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function shouldShowExpiringNotice( purchase: Purchase, purchaseAttachedTo: Purchase | undefined ) {
-	const EXCLUDED_PRODUCTS: string[] = [
-		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
-		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
-		DotcomPlans.HOSTING_TRIAL_MONTHLY,
-	];
-
-	// For purchases included with a plan (for example, a domain mapping
-	// bundled with the plan), the plan purchase is used on this page when
-	// there are other upcoming renewals to display, so for consistency it
-	// should also be used here (where there are no upcoming renewals to
-	// display).
-	const usePlanInsteadOfIncludedPurchase = Boolean(
-		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
-	);
-	const currentPurchase: Purchase =
-		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
-
-	if (
-		! isExpiring( currentPurchase ) ||
-		EXCLUDED_PRODUCTS.includes( currentPurchase?.product_slug ) ||
-		isAkismetFreeProduct( currentPurchase )
-	) {
-		return false;
-	}
-
-	if ( purchase.is_hundred_year_domain ) {
-		return false;
-	}
-
-	if (
-		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD &&
-		! isCloseToExpiration( purchase )
-	) {
-		return false;
-	}
-
-	if ( usePlanInsteadOfIncludedPurchase && ! purchase.site_slug ) {
-		return false;
-	}
-	return true;
-}
-
-function PurchaseExpiringNotice( {
-	purchase,
-	purchaseAttachedTo,
-}: {
-	purchase: Purchase;
-	purchaseAttachedTo: Purchase | undefined;
-} ) {
-	// For purchases included with a plan (for example, a domain mapping
-	// bundled with the plan), the plan purchase is used on this page when
-	// there are other upcoming renewals to display, so for consistency it
-	// should also be used here (where there are no upcoming renewals to
-	// display).
-	const usePlanInsteadOfIncludedPurchase = Boolean(
-		isIncludedWithPlan( purchase ) && purchaseAttachedTo?.is_plan
-	);
-	const currentPurchase: Purchase =
-		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
-
-	const includedPurchase = purchase;
-
-	if ( usePlanInsteadOfIncludedPurchase && purchase.site_slug ) {
-		// We can't show the action here, because it would try to renew the
-		// included purchase (rather than the plan that it is attached to).
-		// So we have to rely on the user going to the manage purchase page
-		// for the plan to renew it there.
-		return (
-			<Notice
-				variant={
-					isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
-						? 'error'
-						: 'info'
-				}
-			>
-				{ createInterpolateElement(
-					sprintf(
-						// translators: purchaseName is the name of the plan, includedPurchaseName is the name of the subscription included in the plan and expiry is a formatted string like "in 3 months"
-						__(
-							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) will expire and be removed from your site %(expiry)s.'
-						),
-						{
-							purchaseName: currentPurchase.is_domain
-								? currentPurchase.meta ?? ''
-								: currentPurchase.product_name,
-							includedPurchaseName: includedPurchase.is_domain
-								? includedPurchase.meta ?? ''
-								: includedPurchase.product_name,
-							expiry: getRelativeTimeString( new Date( currentPurchase.expiry_date ) ),
-						}
-					),
-					{
-						managePurchase: <Link to={ getPurchaseUrl( currentPurchase ) } />,
-					}
-				) }
-			</Notice>
-		);
-	}
-
-	return (
-		<Notice
-			variant={
-				isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase )
-					? 'error'
-					: 'info'
-			}
-			actions={
-				<RenewNoticeAction
-					purchase={ purchase }
-					onClick={ () => {
-						window.location.href = getRenewalUrlFromPurchase( purchase );
-					} }
-				/>
-			}
-		>
-			<ExpiringText purchase={ currentPurchase } />
-		</Notice>
-	);
-}
-
-function ExpiringText( { purchase }: { purchase: Purchase } ) {
-	if (
-		purchase.site_slug &&
-		purchase.expiry_status === 'manual-renew' &&
-		purchase.bill_period_days !== SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD
-	) {
-		return <ExpiringLaterText purchase={ purchase } />;
-	}
-
-	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
-
-	if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD ) {
-		const daysToExpiry = differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
-
-		if ( isTemporarySitePurchase( purchase ) ) {
-			return sprintf(
-				// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
-				__( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.' ),
-				{
-					purchaseName,
-					daysToExpiry,
-				}
-			);
-		}
-
-		return sprintf(
-			// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
-			__( '%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.' ),
-			{
-				purchaseName,
-				daysToExpiry,
-			}
-		);
-	}
-
-	if ( isTemporarySitePurchase( purchase ) ) {
-		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-		return sprintf( __( '%(purchaseName)s will expire and be removed %(expiry)s.' ), {
-			purchaseName,
-			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-		} );
-	}
-
-	return sprintf(
-		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-		__( '%(purchaseName)s will expire and be removed from your site %(expiry)s.' ),
-		{
-			purchaseName,
-			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-		}
-	);
-}
-
-function ExpiringLaterText( {
-	purchase,
-	autoRenewingUpgradesLink,
-}: {
-	purchase: Purchase;
-	autoRenewingUpgradesLink?: string;
-} ) {
-	const purchaseName = purchase.is_domain ? purchase.meta ?? '' : purchase.product_name;
-	const expiry = getRelativeTimeString( new Date( purchase.expiry_date ) );
-
-	if ( purchase.payment_type === 'credits' ) {
-		if ( autoRenewingUpgradesLink ) {
-			return createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-					__(
-						"You purchased %(purchaseName)s with credits – please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
-					),
-					{ purchaseName, expiry }
-				),
-				{
-					link: <a href={ autoRenewingUpgradesLink } />,
-				}
-			);
-		}
-
-		return sprintf(
-			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-			__(
-				"You purchased %(purchaseName)s with credits. Please update your payment information before your plan expires %(expiry)s so that you don't lose out on your paid features!"
-			),
-			{ purchaseName, expiry }
-		);
-	}
-
-	if ( purchase.payment_type ) {
-		if ( purchase.is_rechargable ) {
-			if ( autoRenewingUpgradesLink ) {
-				return createInterpolateElement(
-					sprintf(
-						// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-						__(
-							"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
-						),
-						{ purchaseName, expiry }
-					),
-					{
-						link: <a href={ autoRenewingUpgradesLink } />,
-					}
-				);
-			}
-
-			return sprintf(
-				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-				__(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!"
-				),
-				{ purchaseName, expiry }
-			);
-		}
-
-		if ( autoRenewingUpgradesLink ) {
-			return createInterpolateElement(
-				sprintf(
-					// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-					__(
-						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
-					),
-					{ purchaseName, expiry }
-				),
-				{
-					link: <a href={ autoRenewingUpgradesLink } />,
-				}
-			);
-		}
-
-		return sprintf(
-			// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-			__(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!"
-			),
-			{ purchaseName, expiry }
-		);
-	}
-
-	if ( autoRenewingUpgradesLink ) {
-		return createInterpolateElement(
-			sprintf(
-				// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-				__(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s – update your payment information so you don't lose out on your paid features! You also have <link>other upgrades</link> on this site that are scheduled to renew soon."
-				),
-				{ purchaseName, expiry }
-			),
-			{
-				link: <a href={ autoRenewingUpgradesLink } />,
-			}
-		);
-	}
-
-	return sprintf(
-		// translators: purchaseName is the name of the plan and expiry is a formatted string like "in 3 months".
-		__(
-			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Update your payment information so you don't lose out on your paid features!"
-		),
-		{ purchaseName, expiry }
-	);
-}

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -4,6 +4,9 @@ import { __ } from '@wordpress/i18n';
 import { isCloseToExpiration } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
+/**
+ * Used to determine if we should render RenewNoticeAction.
+ */
 export function shouldShowRenewNoticeAction( purchase: Purchase ): boolean {
 	const shouldAddPaymentSourceInsteadOfRenewingNow =
 		isCloseToExpiration( purchase ) ||
@@ -31,6 +34,13 @@ export function shouldShowRenewNoticeAction( purchase: Purchase ): boolean {
 	return false;
 }
 
+/**
+ * Render the action button in ExpiredRenewNotice or PurchaseExpiringNotice
+ *
+ * IMPORTANT: call shouldShowRenewNoticeAction before rendering this. Otherwise
+ * there will be a space left for a button in the notice and nothing will be
+ * rendered there.
+ */
 export function RenewNoticeAction( {
 	onClick,
 	purchase,
@@ -69,12 +79,9 @@ export function RenewNoticeAction( {
 		);
 	}
 
-	if ( ! purchase.is_rechargable ) {
-		return (
-			<Button variant="primary" onClick={ onClick }>
-				{ __( 'Renew now' ) }
-			</Button>
-		);
-	}
-	return null;
+	return (
+		<Button variant="primary" onClick={ onClick }>
+			{ __( 'Renew now' ) }
+		</Button>
+	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -1,0 +1,68 @@
+import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { isCloseToExpiration } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+export function shouldShowRenewNoticeAction( purchase: Purchase ): boolean {
+	const shouldAddPaymentSourceInsteadOfRenewingNow =
+		isCloseToExpiration( purchase ) ||
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
+	if (
+		! purchase.payment_type &&
+		( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow )
+	) {
+		return true;
+	}
+
+	// isExpiring(), which leads here (along with isExpired()) returns true
+	// when expiring, when auto-renew is disabled, or when the payment method
+	// was credits but we don't want to show "Add Payment Method" if the
+	// subscription is actually expiring or expired; we want to show "Renew
+	// Now" in that case.
+	if ( purchase.payment_type === 'credits' && purchase.expiry_status === 'manual-renew' ) {
+		return true;
+	}
+
+	if ( ! purchase.is_rechargable ) {
+		return true;
+	}
+
+	return false;
+}
+
+export function RenewNoticeAction( {
+	onClick,
+	purchase,
+}: {
+	purchase: Purchase;
+	onClick: () => void;
+} ) {
+	const siteSlug = purchase.site_slug ?? purchase.blog_id;
+	const changePaymentMethodPath = purchase.payment_card_id
+		? `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/change/${ purchase.payment_card_id }`
+		: `/me/purchases/${ siteSlug }/${ purchase.ID }/payment-method/add`;
+	const shouldAddPaymentSourceInsteadOfRenewingNow =
+		isCloseToExpiration( purchase ) ||
+		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
+	if (
+		! purchase.payment_type &&
+		( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow )
+	) {
+		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+	}
+
+	// isExpiring(), which leads here (along with isExpired()) returns true
+	// when expiring, when auto-renew is disabled, or when the payment method
+	// was credits but we don't want to show "Add Payment Method" if the
+	// subscription is actually expiring or expired; we want to show "Renew
+	// Now" in that case.
+	if ( purchase.payment_type === 'credits' && purchase.expiry_status === 'manual-renew' ) {
+		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+	}
+
+	if ( ! purchase.is_rechargable ) {
+		return <Button onClick={ onClick }>{ __( 'Renew now' ) }</Button>;
+	}
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -70,7 +70,11 @@ export function RenewNoticeAction( {
 	}
 
 	if ( ! purchase.is_rechargable ) {
-		return <Button onClick={ onClick }>{ __( 'Renew now' ) }</Button>;
+		return (
+			<Button variant="primary" onClick={ onClick }>
+				{ __( 'Renew now' ) }
+			</Button>
+		);
 	}
 	return null;
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -49,7 +49,11 @@ export function RenewNoticeAction( {
 		! purchase.payment_type &&
 		( ! purchase.can_explicit_renew || shouldAddPaymentSourceInsteadOfRenewingNow )
 	) {
-		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+		return (
+			<Button variant="primary" href={ changePaymentMethodPath }>
+				{ __( 'Add payment method' ) }
+			</Button>
+		);
 	}
 
 	// isExpiring(), which leads here (along with isExpired()) returns true
@@ -58,7 +62,11 @@ export function RenewNoticeAction( {
 	// subscription is actually expiring or expired; we want to show "Renew
 	// Now" in that case.
 	if ( purchase.payment_type === 'credits' && purchase.expiry_status === 'manual-renew' ) {
-		return <Button href={ changePaymentMethodPath }>{ __( 'Add payment method' ) }</Button>;
+		return (
+			<Button variant="primary" href={ changePaymentMethodPath }>
+				{ __( 'Add payment method' ) }
+			</Button>
+		);
 	}
 
 	if ( ! purchase.is_rechargable ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -7,3 +7,10 @@
 	flex-grow: 1;
 	max-width: 318px;
 }
+
+// ConfirmDialog sets the z-index so high that the Popover used by DataViews
+// actions does not show up so we have to set this lower.
+// @see https://github.com/wordpress/gutenberg/issues/71463
+div.components-modal__screen-overlay.upcoming-renewals-dialog {
+	z-index: 500;
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,20 +1,20 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Link } from '@tanstack/react-router';
 import {
-	CheckboxControl,
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalDivider as Divider,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { getRelativeTimeString } from '../../../utils/datetime';
 import { getSubtitleForDisplay, isExpired, isRenewing } from '../../../utils/purchase';
 import { getPurchaseUrlForId } from '../urls';
 import type { Purchase } from '@automattic/api-core';
+import type { Field, View } from '@wordpress/dataviews';
 
 interface Props {
 	siteDomain: string;
@@ -44,6 +44,61 @@ function ExpiresText( { purchase }: { purchase: Purchase } ) {
 	} );
 }
 
+function getPurchaseFields( {
+	hideManagePurchaseLinks,
+	onClose,
+}: {
+	hideManagePurchaseLinks?: boolean;
+	onClose: () => void;
+} ): Field< Purchase >[] {
+	const fields: Field< Purchase >[] = [
+		{
+			id: 'product_name',
+			label: __( 'Product' ),
+			getValue: ( { item } ) => ( item.is_domain ? item.meta ?? '' : item.product_name ),
+			render: ( { item } ) => {
+				const purchaseTypeText = getSubtitleForDisplay( item );
+				return (
+					<VStack spacing={ 1 }>
+						<Text>{ item.is_domain ? item.meta ?? '' : item.product_name }</Text>
+						<Text variant="muted">
+							{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
+							<span>{ purchaseTypeText && <ExpiresText purchase={ item } /> }</span>
+						</Text>
+					</VStack>
+				);
+			},
+		},
+		{
+			id: 'amount',
+			label: __( 'Price' ),
+			getValue: ( { item } ) =>
+				formatCurrency( item.sale_amount ?? item.amount, item.currency_code, { stripZeros: true } ),
+			render: ( { item } ) => (
+				<Text>
+					{ formatCurrency( item.sale_amount ?? item.amount, item.currency_code, {
+						stripZeros: true,
+					} ) }
+				</Text>
+			),
+		},
+	];
+
+	if ( ! hideManagePurchaseLinks ) {
+		fields.push( {
+			id: 'manage',
+			label: __( 'Actions' ),
+			render: ( { item } ) => (
+				<Link to={ getPurchaseUrlForId( item.ID ) } onClick={ onClose }>
+					{ __( 'Manage purchase' ) }
+				</Link>
+			),
+		} );
+	}
+
+	return fields;
+}
+
 export function UpcomingRenewalsDialog( {
 	siteDomain,
 	purchases,
@@ -52,8 +107,6 @@ export function UpcomingRenewalsDialog( {
 	submitButtonText,
 	hideManagePurchaseLinks,
 }: Props ) {
-	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
-
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
 			[ ...purchases ].sort( ( a, b ) => {
@@ -64,17 +117,42 @@ export function UpcomingRenewalsDialog( {
 		[ purchases ]
 	);
 
+	const [ view, setView ] = useState< View >( {
+		type: 'table',
+		perPage: 100,
+		page: 1,
+		showTitle: true,
+		titleField: 'product_name',
+		fields: [ 'amount', 'manage' ],
+		layout: {},
+	} );
+
+	const [ selection, setSelection ] = useState< string[] >(
+		purchases.map( ( purchase ) => purchase.ID.toString() )
+	);
+
 	useEffect( () => {
-		setSelectedPurchases( purchases.map( ( purchase ) => purchase.ID ) );
+		setSelection( purchases.map( ( purchase ) => purchase.ID.toString() ) );
 	}, [ purchases ] );
+
+	const fields = useMemo(
+		() => getPurchaseFields( { hideManagePurchaseLinks, onClose } ),
+		[ hideManagePurchaseLinks, onClose ]
+	);
+
+	const handleConfirm = () => {
+		const selectedPurchaseIds = selection.map( Number );
+		const selectedPurchasesData = purchases.filter( ( purchase ) =>
+			selectedPurchaseIds.includes( purchase.ID )
+		);
+		onConfirm( selectedPurchasesData );
+	};
 
 	return (
 		<ConfirmDialog
 			size="large"
 			confirmButtonText={ submitButtonText ?? __( 'Renew now' ) }
-			onConfirm={ () =>
-				onConfirm( purchases.filter( ( purchase ) => selectedPurchases.includes( purchase.ID ) ) )
-			}
+			onConfirm={ handleConfirm }
 			onCancel={ onClose }
 		>
 			<VStack>
@@ -87,55 +165,21 @@ export function UpcomingRenewalsDialog( {
 				</Text>
 			</VStack>
 			<Divider margin={ 3 } />
-			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
-				const purchaseTypeText = getSubtitleForDisplay( purchase );
-				const onChange = () => {
-					if ( selectedPurchases.includes( purchase.ID ) ) {
-						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.ID ) );
-					} else {
-						setSelectedPurchases( selectedPurchases.concat( [ purchase.ID ] ) );
-					}
-				};
-				return (
-					<VStack key={ purchase.ID }>
-						<HStack alignment="top">
-							<HStack alignment="left">
-								<CheckboxControl
-									name={ `${ purchase.product_slug }-${ purchase.ID }` }
-									checked={ selectedPurchases.includes( purchase.ID ) }
-									onChange={ onChange }
-								/>
-								<VStack>
-									<Text>{ purchase.is_domain ? purchase.meta ?? '' : purchase.product_name }</Text>
-									<Text variant="muted">
-										{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
-										<span>{ purchaseTypeText && <ExpiresText purchase={ purchase } /> }</span>
-									</Text>
-								</VStack>
-							</HStack>
-							<HStack>
-								<Text>
-									{ formatCurrency(
-										purchase.sale_amount ?? purchase.amount,
-										purchase.currency_code,
-										{
-											stripZeros: true,
-										}
-									) }
-								</Text>
-								{ ! hideManagePurchaseLinks && (
-									<Text>
-										<Link to={ getPurchaseUrlForId( purchase.ID ) } onClick={ () => onClose() }>
-											{ __( 'Manage purchase' ) }
-										</Link>
-									</Text>
-								) }
-							</HStack>
-						</HStack>
-						<Divider margin={ 3 } />
-					</VStack>
-				);
-			} ) }
+			<DataViews
+				data={ purchasesSortByRecentExpiryDate }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.ID.toString() }
+				isLoading={ false }
+				paginationInfo={ {
+					totalItems: purchasesSortByRecentExpiryDate.length,
+					totalPages: 1,
+				} }
+				defaultLayouts={ { table: {} } }
+			/>
 		</ConfirmDialog>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -98,7 +98,7 @@ export function UpcomingRenewalsDialog( {
 				};
 				return (
 					<VStack key={ purchase.ID }>
-						<HStack>
+						<HStack alignment="top">
 							<HStack alignment="left">
 								<CheckboxControl
 									name={ `${ purchase.product_slug }-${ purchase.ID }` }

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -118,15 +118,6 @@ export function UpcomingRenewalsDialog( {
 
 	const fields = useMemo( () => getPurchaseFields(), [] );
 
-	const dataWithIds = useMemo(
-		() =>
-			purchasesSortByRecentExpiryDate.map( ( purchase ) => ( {
-				...purchase,
-				id: purchase.ID.toString(),
-			} ) ),
-		[ purchasesSortByRecentExpiryDate ]
-	);
-
 	const actions = useMemo( (): Action< Purchase >[] => {
 		const actionsList: Action< Purchase >[] = [
 			{
@@ -183,7 +174,7 @@ export function UpcomingRenewalsDialog( {
 			</VStack>
 			<Divider margin={ 3 } />
 			<DataViews
-				data={ dataWithIds }
+				data={ purchasesSortByRecentExpiryDate }
 				fields={ fields }
 				view={ view }
 				onChangeView={ setView }
@@ -193,7 +184,7 @@ export function UpcomingRenewalsDialog( {
 				getItemId={ ( item ) => item.ID.toString() }
 				isLoading={ false }
 				paginationInfo={ {
-					totalItems: dataWithIds.length,
+					totalItems: purchasesSortByRecentExpiryDate.length,
 					totalPages: 1,
 				} }
 				defaultLayouts={ { table: {} } }

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -125,7 +125,7 @@ export function UpcomingRenewalsDialog( {
 								</Text>
 								{ ! hideManagePurchaseLinks && (
 									<Text>
-										<Link to={ getPurchaseUrlForId( purchase.ID ) }>
+										<Link to={ getPurchaseUrlForId( purchase.ID ) } onClick={ () => onClose() }>
 											{ __( 'Manage purchase' ) }
 										</Link>
 									</Text>

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,0 +1,141 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { Link } from '@tanstack/react-router';
+import {
+	CheckboxControl,
+	__experimentalText as Text,
+	__experimentalConfirmDialog as ConfirmDialog,
+	__experimentalDivider as Divider,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useEffect, useMemo } from 'react';
+import { getRelativeTimeString } from '../../../utils/datetime';
+import { getSubtitleForDisplay, isExpired, isRenewing } from '../../../utils/purchase';
+import { getPurchaseUrlForId } from '../urls';
+import type { Purchase } from '@automattic/api-core';
+
+interface Props {
+	siteDomain: string;
+	purchases: Purchase[];
+	onClose: () => void;
+	onConfirm: ( purchases: Purchase[] ) => void;
+	submitButtonText?: string;
+	showManagePurchaseLinks?: boolean;
+}
+
+function ExpiresText( { purchase }: { purchase: Purchase } ) {
+	if ( isRenewing( purchase ) ) {
+		// translators: "renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"
+		return sprintf( __( 'renews %(renewDate)s' ), {
+			renewDate: getRelativeTimeString( new Date( purchase.renew_date ) ),
+		} );
+	}
+	if ( isExpired( purchase ) ) {
+		// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
+		return sprintf( __( 'expired %(expiry)s' ), {
+			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+		} );
+	}
+	// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
+	return sprintf( __( 'expires %(expiry)s' ), {
+		expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+	} );
+}
+
+export function UpcomingRenewalsDialog( {
+	siteDomain,
+	purchases,
+	onClose,
+	onConfirm,
+	submitButtonText,
+	showManagePurchaseLinks = true,
+}: Props ) {
+	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
+
+	const purchasesSortByRecentExpiryDate = useMemo(
+		() =>
+			[ ...purchases ].sort( ( a, b ) => {
+				const compareDateA = isRenewing( a ) ? a.renew_date : a.expiry_date;
+				const compareDateB = isRenewing( b ) ? b.renew_date : b.expiry_date;
+				return compareDateA?.localeCompare?.( compareDateB );
+			} ),
+		[ purchases ]
+	);
+
+	useEffect( () => {
+		setSelectedPurchases( purchases.map( ( purchase ) => purchase.ID ) );
+	}, [ purchases ] );
+
+	return (
+		<ConfirmDialog
+			size="large"
+			confirmButtonText={ submitButtonText ?? __( 'Renew now' ) }
+			onConfirm={ () =>
+				onConfirm( purchases.filter( ( purchase ) => selectedPurchases.includes( purchase.ID ) ) )
+			}
+			onCancel={ onClose }
+		>
+			<VStack>
+				<Heading>{ __( 'Upcoming renewals' ) }</Heading>
+				<Text variant="muted">
+					{
+						// translators: siteName is the URL of the site
+						sprintf( __( 'Site: %(siteName)s' ), { siteName: siteDomain } )
+					}
+				</Text>
+			</VStack>
+			<Divider margin={ 3 } />
+			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
+				const purchaseTypeText = getSubtitleForDisplay( purchase );
+				const onChange = () => {
+					if ( selectedPurchases.includes( purchase.ID ) ) {
+						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.ID ) );
+					} else {
+						setSelectedPurchases( selectedPurchases.concat( [ purchase.ID ] ) );
+					}
+				};
+				return (
+					<VStack key={ purchase.ID }>
+						<HStack>
+							<HStack alignment="left">
+								<CheckboxControl
+									name={ `${ purchase.product_slug }-${ purchase.ID }` }
+									checked={ selectedPurchases.includes( purchase.ID ) }
+									onChange={ onChange }
+								/>
+								<VStack>
+									<Text>{ purchase.is_domain ? purchase.meta ?? '' : purchase.product_name }</Text>
+									<Text variant="muted">
+										{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
+										<span>{ purchaseTypeText && <ExpiresText purchase={ purchase } /> }</span>
+									</Text>
+								</VStack>
+							</HStack>
+							<VStack>
+								<Text>
+									{ formatCurrency(
+										purchase.sale_amount ?? purchase.amount,
+										purchase.currency_code,
+										{
+											stripZeros: true,
+										}
+									) }
+								</Text>
+								{ showManagePurchaseLinks && (
+									<div className="upcoming-renewals-dialog__renewal-settings-link">
+										<Link to={ getPurchaseUrlForId( purchase.ID ) }>
+											{ __( 'Manage purchase' ) }
+										</Link>
+									</div>
+								) }
+							</VStack>
+						</HStack>
+						<Divider margin={ 3 } />
+					</VStack>
+				);
+			} ) }
+		</ConfirmDialog>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,5 +1,4 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { Link } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -44,13 +43,7 @@ function ExpiresText( { purchase }: { purchase: Purchase } ) {
 	} );
 }
 
-function getPurchaseFields( {
-	hideManagePurchaseLinks,
-	onClose,
-}: {
-	hideManagePurchaseLinks?: boolean;
-	onClose: () => void;
-} ): Field< Purchase >[] {
+function getPurchaseFields(): Field< Purchase >[] {
 	const fields: Field< Purchase >[] = [
 		{
 			id: 'product_name',
@@ -86,20 +79,6 @@ function getPurchaseFields( {
 		},
 	];
 
-	if ( ! hideManagePurchaseLinks ) {
-		fields.push( {
-			id: 'manage',
-			type: 'text',
-			label: __( 'Actions' ),
-			getValue: () => '',
-			render: ( { item } ) => (
-				<Link to={ getPurchaseUrlForId( item.ID ) } onClick={ onClose }>
-					{ __( 'Manage purchase' ) }
-				</Link>
-			),
-		} );
-	}
-
 	return fields;
 }
 
@@ -125,9 +104,7 @@ export function UpcomingRenewalsDialog( {
 		type: 'table',
 		perPage: 100,
 		page: 1,
-		fields: hideManagePurchaseLinks
-			? [ 'product_name', 'amount' ]
-			: [ 'product_name', 'amount', 'manage' ],
+		fields: [ 'product_name', 'amount' ],
 		layout: {},
 	} );
 
@@ -139,10 +116,7 @@ export function UpcomingRenewalsDialog( {
 		setSelection( purchases.map( ( purchase ) => purchase.ID.toString() ) );
 	}, [ purchases ] );
 
-	const fields = useMemo(
-		() => getPurchaseFields( { hideManagePurchaseLinks, onClose } ),
-		[ hideManagePurchaseLinks, onClose ]
-	);
+	const fields = useMemo( () => getPurchaseFields(), [] );
 
 	const dataWithIds = useMemo(
 		() =>
@@ -153,21 +127,34 @@ export function UpcomingRenewalsDialog( {
 		[ purchasesSortByRecentExpiryDate ]
 	);
 
-	const actions = useMemo(
-		(): Action< Purchase & { id: string } >[] => [
+	const actions = useMemo( (): Action< Purchase >[] => {
+		const actionsList: Action< Purchase >[] = [
 			{
 				id: 'select-for-renewal',
 				label: __( 'Select for renewal' ),
 				supportsBulk: true,
 				icon: () => null,
 				callback: () => {
-					// This action exists just to enable bulk selection checkboxes
-					// The actual renewal logic is handled by the dialog's confirm button
+					// This action exists just to enable bulk selection checkboxes.
+					// The actual renewal logic is handled by the dialog's confirm button.
 				},
 			},
-		],
-		[]
-	);
+		];
+
+		if ( ! hideManagePurchaseLinks ) {
+			actionsList.push( {
+				id: 'manage-purchase',
+				label: __( 'Manage purchase' ),
+				supportsBulk: false,
+				callback: ( [ item ] ) => {
+					onClose();
+					window.location.href = getPurchaseUrlForId( item.ID );
+				},
+			} );
+		}
+
+		return actionsList;
+	}, [ hideManagePurchaseLinks, onClose ] );
 
 	const handleConfirm = () => {
 		const selectedPurchaseIds = selection.map( Number );
@@ -202,7 +189,7 @@ export function UpcomingRenewalsDialog( {
 				selection={ selection }
 				onChangeSelection={ setSelection }
 				actions={ actions }
-				getItemId={ ( item ) => item.id }
+				getItemId={ ( item ) => item.ID.toString() }
 				isLoading={ false }
 				paginationInfo={ {
 					totalItems: dataWithIds.length,

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -22,7 +22,7 @@ interface Props {
 	onClose: () => void;
 	onConfirm: ( purchases: Purchase[] ) => void;
 	submitButtonText?: string;
-	showManagePurchaseLinks?: boolean;
+	hideManagePurchaseLinks?: boolean;
 }
 
 function ExpiresText( { purchase }: { purchase: Purchase } ) {
@@ -50,7 +50,7 @@ export function UpcomingRenewalsDialog( {
 	onClose,
 	onConfirm,
 	submitButtonText,
-	showManagePurchaseLinks = true,
+	hideManagePurchaseLinks,
 }: Props ) {
 	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
 
@@ -123,7 +123,7 @@ export function UpcomingRenewalsDialog( {
 										}
 									) }
 								</Text>
-								{ showManagePurchaseLinks && (
+								{ ! hideManagePurchaseLinks && (
 									<Text>
 										<Link to={ getPurchaseUrlForId( purchase.ID ) }>
 											{ __( 'Manage purchase' ) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -14,7 +14,7 @@ import { getRelativeTimeString } from '../../../utils/datetime';
 import { getSubtitleForDisplay, isExpired, isRenewing } from '../../../utils/purchase';
 import { getPurchaseUrlForId } from '../urls';
 import type { Purchase } from '@automattic/api-core';
-import type { Field, View } from '@wordpress/dataviews';
+import type { Field, View, Action } from '@wordpress/dataviews';
 
 interface Props {
 	siteDomain: string;
@@ -54,6 +54,7 @@ function getPurchaseFields( {
 	const fields: Field< Purchase >[] = [
 		{
 			id: 'product_name',
+			type: 'text',
 			label: __( 'Product' ),
 			getValue: ( { item } ) => ( item.is_domain ? item.meta ?? '' : item.product_name ),
 			render: ( { item } ) => {
@@ -71,6 +72,7 @@ function getPurchaseFields( {
 		},
 		{
 			id: 'amount',
+			type: 'text',
 			label: __( 'Price' ),
 			getValue: ( { item } ) =>
 				formatCurrency( item.sale_amount ?? item.amount, item.currency_code, { stripZeros: true } ),
@@ -87,7 +89,9 @@ function getPurchaseFields( {
 	if ( ! hideManagePurchaseLinks ) {
 		fields.push( {
 			id: 'manage',
+			type: 'text',
 			label: __( 'Actions' ),
+			getValue: () => '',
 			render: ( { item } ) => (
 				<Link to={ getPurchaseUrlForId( item.ID ) } onClick={ onClose }>
 					{ __( 'Manage purchase' ) }
@@ -121,9 +125,9 @@ export function UpcomingRenewalsDialog( {
 		type: 'table',
 		perPage: 100,
 		page: 1,
-		showTitle: true,
-		titleField: 'product_name',
-		fields: [ 'amount', 'manage' ],
+		fields: hideManagePurchaseLinks
+			? [ 'product_name', 'amount' ]
+			: [ 'product_name', 'amount', 'manage' ],
 		layout: {},
 	} );
 
@@ -138,6 +142,31 @@ export function UpcomingRenewalsDialog( {
 	const fields = useMemo(
 		() => getPurchaseFields( { hideManagePurchaseLinks, onClose } ),
 		[ hideManagePurchaseLinks, onClose ]
+	);
+
+	const dataWithIds = useMemo(
+		() =>
+			purchasesSortByRecentExpiryDate.map( ( purchase ) => ( {
+				...purchase,
+				id: purchase.ID.toString(),
+			} ) ),
+		[ purchasesSortByRecentExpiryDate ]
+	);
+
+	const actions = useMemo(
+		(): Action< Purchase & { id: string } >[] => [
+			{
+				id: 'select-for-renewal',
+				label: __( 'Select for renewal' ),
+				supportsBulk: true,
+				icon: () => null,
+				callback: () => {
+					// This action exists just to enable bulk selection checkboxes
+					// The actual renewal logic is handled by the dialog's confirm button
+				},
+			},
+		],
+		[]
 	);
 
 	const handleConfirm = () => {
@@ -166,16 +195,17 @@ export function UpcomingRenewalsDialog( {
 			</VStack>
 			<Divider margin={ 3 } />
 			<DataViews
-				data={ purchasesSortByRecentExpiryDate }
+				data={ dataWithIds }
 				fields={ fields }
 				view={ view }
 				onChangeView={ setView }
 				selection={ selection }
 				onChangeSelection={ setSelection }
-				getItemId={ ( item ) => item.ID.toString() }
+				actions={ actions }
+				getItemId={ ( item ) => item.id }
 				isLoading={ false }
 				paginationInfo={ {
-					totalItems: purchasesSortByRecentExpiryDate.length,
+					totalItems: dataWithIds.length,
 					totalPages: 1,
 				} }
 				defaultLayouts={ { table: {} } }

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -113,7 +113,7 @@ export function UpcomingRenewalsDialog( {
 									</Text>
 								</VStack>
 							</HStack>
-							<VStack>
+							<HStack>
 								<Text>
 									{ formatCurrency(
 										purchase.sale_amount ?? purchase.amount,
@@ -124,13 +124,13 @@ export function UpcomingRenewalsDialog( {
 									) }
 								</Text>
 								{ showManagePurchaseLinks && (
-									<div className="upcoming-renewals-dialog__renewal-settings-link">
+									<Text>
 										<Link to={ getPurchaseUrlForId( purchase.ID ) }>
 											{ __( 'Manage purchase' ) }
 										</Link>
-									</div>
+									</Text>
 								) }
-							</VStack>
+							</HStack>
 						</HStack>
 						<Divider margin={ 3 } />
 					</VStack>

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -166,6 +166,7 @@ export function UpcomingRenewalsDialog( {
 
 	return (
 		<ConfirmDialog
+			overlayClassName="upcoming-renewals-dialog"
 			size="large"
 			confirmButtonText={ submitButtonText ?? __( 'Renew now' ) }
 			onConfirm={ handleConfirm }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -372,3 +372,26 @@ export function getRenewalUrlFromPurchase(
 	const servicePath = getServicePathForCheckoutFromPurchase( purchase );
 	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchase.ID }/${ checkoutSiteSlug }`;
 }
+
+/**
+ * Determines if the purchase needs to renew soon.
+ *
+ * This will return true if the purchase is either already expired or
+ * expiring/renewing soon.
+ *
+ * The intention here is to identify purchases that the user might reasonably
+ * want to manually renew (regardless of whether they are also scheduled to
+ * auto-renew).
+ */
+export function needsToRenewSoon( purchase: Purchase ): boolean {
+	// Skip purchases that never need to renew or that can't be renewed.
+	if (
+		isOneTimePurchase( purchase ) ||
+		purchase.partner_type ||
+		! purchase.is_renewable ||
+		! purchase.can_explicit_renew
+	) {
+		return false;
+	}
+	return isCloseToExpiration( purchase );
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -361,16 +361,35 @@ function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
 	return '';
 }
 
+function getCheckoutProductSlugFromPurchase( purchase: Purchase ): string {
+	const productSlug = encodeProductForUrl( purchase.product_slug );
+	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
+	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
+	return checkoutProductSlug;
+}
+
 export function getRenewalUrlFromPurchase(
 	purchase: Purchase,
 	checkoutSiteSlugForUrl?: string
 ): string {
-	const productSlug = encodeProductForUrl( purchase.product_slug );
-	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
-	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
-	const checkoutSiteSlug = checkoutSiteSlugForUrl || purchase.site_slug || '';
-	const servicePath = getServicePathForCheckoutFromPurchase( purchase );
-	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchase.ID }/${ checkoutSiteSlug }`;
+	return getRenewUrlForPurchases( [ purchase ], checkoutSiteSlugForUrl );
+}
+
+export function getRenewUrlForPurchases(
+	purchases: Purchase[],
+	checkoutSiteSlugForUrl?: string
+): string {
+	if ( purchases.length < 1 ) {
+		throw new Error( 'Could not find product slug or purchase id for renewal.' );
+	}
+	const firstPurchase = purchases[ 0 ];
+	const checkoutProductSlug = purchases
+		.map( ( purchase ) => getCheckoutProductSlugFromPurchase( purchase ) )
+		.join( ',' );
+	const checkoutSiteSlug = checkoutSiteSlugForUrl || firstPurchase.site_slug || '';
+	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
+	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
+	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchaseIds }/${ checkoutSiteSlug }`;
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1081/add-purchasenotice-to-hosting-dashboard-purchase-settings

## Proposed Changes

This PR adds a notice component to the top of the purchase settings page which covers a number of scenarios. This just copies [the existing behavior from the calypso purchase settings page](https://github.com/Automattic/wp-calypso/blob/4d8f3fa385e796d0b57de640c67e34554bc3585e/client/me/purchases/manage-purchase/notices.tsx#L87).

Some examples:

<img width="711" height="430" alt="Screenshot 2025-09-02 at 4 07 42 PM" src="https://github.com/user-attachments/assets/2197ab6b-c9a2-420b-b8ed-0c898a07206a" />

<img width="745" height="465" alt="Screenshot 2025-09-02 at 4 29 37 PM" src="https://github.com/user-attachments/assets/116d5a20-7214-4d60-9ac0-472ca4f32750" />

<img width="790" height="450" alt="Screenshot 2025-09-01 at 4 35 09 PM" src="https://github.com/user-attachments/assets/f40548fb-7f5e-4443-a1a6-ddd33271f158" />

<img width="730" height="329" alt="Screenshot 2025-09-02 at 1 02 55 PM" src="https://github.com/user-attachments/assets/7051d453-3eac-4654-b411-201775bb6e3d" />

<img width="720" height="307" alt="Screenshot 2025-09-02 at 1 02 43 PM" src="https://github.com/user-attachments/assets/f9fe01d7-9a63-42b9-923d-aa7d14b0a657" />

<img width="708" height="341" alt="Screenshot 2025-09-02 at 1 02 32 PM" src="https://github.com/user-attachments/assets/fb8773d7-2c79-4ce7-b346-eb422d316f1b" />

<img width="698" height="299" alt="Screenshot 2025-09-02 at 2 55 03 PM" src="https://github.com/user-attachments/assets/063ada48-eed9-4fd2-9c8c-691128d2e237" />

<img width="691" height="293" alt="Screenshot 2025-09-26 at 1 02 08 PM" src="https://github.com/user-attachments/assets/1d563b14-a04a-4794-b86d-f58bedfe96be" />

<img width="699" height="298" alt="Screenshot 2025-09-26 at 1 02 33 PM" src="https://github.com/user-attachments/assets/ea8c12a1-828a-4484-ba0e-0b806e11c930" />

<img width="901" height="549" alt="Screenshot 2025-09-26 at 1 02 41 PM" src="https://github.com/user-attachments/assets/5863e2b1-fb00-468f-9439-fa109670df3e" />

## Testing Instructions

This is a little difficult to test as it requires having subscriptions that are in various states. Some scenarios to test this if you can arrange them:

- A used concierge session.
- An expired subscription (that's still active or it won't show in the list).
- An in-app purchase.
- An E-commerce plan trial.
- A subscription with a pending async payment.
- A subscription with an attached credit card that is expiring.
- A subscription without a payment method or in [one of the 8 similar notifications](https://github.com/Automattic/wp-calypso/blob/4d8f3fa385e796d0b57de640c67e34554bc3585e/client/me/purchases/manage-purchase/notices.tsx#L412-L836) some of which include a link to a dialog that shows other expiring subscriptions.
