### PR TITLE
Sync menu on HD overview uses DropdownMenu instead of raw Dropdown

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
@@ -108,49 +108,46 @@ export default function StagingSiteSyncDropdown( {
 
 	return (
 		<>
-			<Dropdown
+			<DropdownMenu
 				className={ className }
 				popoverProps={ { placement: 'bottom-end' } }
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						__next40pxDefaultSize
-						icon={ chevronDown }
-						iconPosition="right"
-						variant="secondary"
-						aria-expanded={ isOpen }
-						onClick={ () => onToggle() }
-						disabled={ isSyncing }
-					>
-						{ isSyncing ? __( 'Syncing…' ) : __( 'Sync' ) }
-					</Button>
+				toggleProps={ {
+					__next40pxDefaultSize: true,
+					iconPosition: 'right',
+					variant: 'secondary',
+					disabled: isSyncing,
+				} }
+				icon={ chevronDown }
+				text={ isSyncing ? __( 'Syncing…' ) : __( 'Sync' ) }
+				/* DropdownMenu prop types are too strict here. We don't need a label because our button has visible text. */
+				/* We can't pass the button's text to `label` because it causes a tooltip to appear. */
+				label={ null as any } // eslint-disable-line @typescript-eslint/no-explicit-any
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup className={ className }>
+						<MenuItem
+							onClick={ () => {
+								onClose();
+								handleOpenModal( 'pull' );
+							} }
+							icon={ cloudDownload }
+							iconPosition="left"
+						>
+							{ pullLabel }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								onClose();
+								handleOpenModal( 'push' );
+							} }
+							icon={ cloudUpload }
+							iconPosition="left"
+						>
+							{ pushLabel }
+						</MenuItem>
+					</MenuGroup>
 				) }
-				renderContent={ ( { onClose } ) => (
-					<div>
-						<MenuGroup className={ className }>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									handleOpenModal( 'pull' );
-								} }
-								icon={ cloudDownload }
-								iconPosition="left"
-							>
-								{ pullLabel }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									handleOpenModal( 'push' );
-								} }
-								icon={ cloudUpload }
-								iconPosition="left"
-							>
-								{ pushLabel }
-							</MenuItem>
-						</MenuGroup>
-					</div>
-				) }
-			/>
+			</DropdownMenu>
 			{ isModalOpen && renderModal() }
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

Similar to https://github.com/Automattic/wp-calypso/pull/105446

Keyboard navigation isn't working as expected in the sync dropdown menu. Using a `<DropdownMenu>` instead of the lower level `<Dropdown>` component means we get the expected a11y behaviour "for free".

https://github.com/user-attachments/assets/05d48fbe-03da-46d0-9a70-390e0720fe6b


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want the hosting dashboard to be accessible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The dropdown menu can be opened with enter/space/down-button. Navigate between items with arrow keys. Escape will close the menu.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
