### PR TITLE
Notifications v2: Implement edit comment and answer prompt action

### DIFF
--- a/apps/notifications/src/app/templates/actions.jsx
+++ b/apps/notifications/src/app/templates/actions.jsx
@@ -50,9 +50,13 @@ const ActionsPane = ( { isApproved, isLiked, note, goBack } ) => {
 	return (
 		<VStack spacing={ 4 } style={ { width: '100%' } }>
 			<HStack spacing={ 2 }>
-				{ hasAction( 'approve-comment' ) && <ApproveButton { ...{ note, isApproved } } /> }
+				{ hasAction( 'approve-comment' ) && (
+					<ApproveButton note={ note } isApproved={ isApproved } />
+				) }
 				{ hasAction( 'spam-comment' ) && <SpamButton note={ note } goBack={ goBack } /> }
-				{ hasAction( [ 'like-post', 'like-comment' ] ) && <LikeButton { ...{ note, isLiked } } /> }
+				{ hasAction( [ 'like-post', 'like-comment' ] ) && (
+					<LikeButton note={ note } isLiked={ isLiked } />
+				) }
 				{ hasAction( 'edit-comment' ) && <EditButton note={ note } /> }
 				{ hasAction( 'answer-prompt' ) && <AnswerPromptButton note={ note } /> }
 			</HStack>

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -28,7 +28,7 @@ export default function Notifications( { className }: { className: string } ) {
 
 	const actionHandlers = {
 		APP_RENDER_NOTES: [
-			( store: any, { newNoteCount }: { newNoteCount: number } ) => {
+			( store: unknown, { newNoteCount }: { newNoteCount: number } ) => {
 				setHasUnseenNotifications( newNoteCount > 0 );
 			},
 		],
@@ -36,6 +36,11 @@ export default function Notifications( { className }: { className: string } ) {
 			() => {
 				handleClose();
 				navigate( { to: '/me/notifications' } );
+			},
+		],
+		EDIT_COMMENT: [
+			( store: unknown, { href }: { href: string } ) => {
+				window.open( href, '_blank' );
 			},
 		],
 		CLOSE_PANEL: [ handleClose ],

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -43,6 +43,11 @@ export default function Notifications( { className }: { className: string } ) {
 				window.open( href, '_blank' );
 			},
 		],
+		ANSWER_PROMPT: [
+			( store: unknown, { href }: { href: string } ) => {
+				window.open( href, '_blank' );
+			},
+		],
 		CLOSE_PANEL: [ handleClose ],
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-296

## Proposed Changes
 
* Implement edit comment action
* Implement answer prompt action - Sending notification via sandbox didn't seem to work so I'm still not sure how to get it 🙈

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open Notifications
* Switch to Comment tab and select notification
* Click the `Edit` action
* Ensure it opens the edit comment page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
