### PR TITLE
Notifications v2: Mark note as read when selecting it

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -6,7 +6,8 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
@@ -19,6 +20,7 @@ import type { View } from '@wordpress/dataviews';
 import './style.scss';
 
 const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
+	const dispatch = useDispatch();
 	const { goTo } = useNavigator();
 	const filter = getFilters()[ filterName ];
 	const isNoteHidden = useSelector(
@@ -48,6 +50,8 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
 
 	const onChangeSelection = ( selection: string[] ) => {
+		const noteId = selection[ 0 ];
+		dispatch( actions.ui.selectNote( noteId ) );
 		goTo( `/${ filterName }/notes/${ selection[ 0 ] }` );
 	};
 

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -6,8 +6,7 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import actions from '../../panel/state/actions';
+import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
@@ -20,7 +19,6 @@ import type { View } from '@wordpress/dataviews';
 import './style.scss';
 
 const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
-	const dispatch = useDispatch();
 	const { goTo } = useNavigator();
 	const filter = getFilters()[ filterName ];
 	const isNoteHidden = useSelector(
@@ -50,8 +48,6 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
 
 	const onChangeSelection = ( selection: string[] ) => {
-		const noteId = selection[ 0 ];
-		dispatch( actions.ui.selectNote( noteId ) );
 		goTo( `/${ filterName }/notes/${ selection[ 0 ] }` );
 	};
 

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -11,8 +11,10 @@ import {
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
+import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
@@ -65,6 +67,7 @@ const getClasses = ( {
 };
 
 const Note = () => {
+	const dispatch = useDispatch();
 	const { params, goBack } = useNavigator();
 	const { noteId } = params;
 	const note = useSelector( ( state ) =>
@@ -73,6 +76,12 @@ const Note = () => {
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
+
+	useEffect( () => {
+		if ( note?.id ) {
+			dispatch( actions.ui.selectNote( note.id ) );
+		}
+	}, [ note?.id, dispatch ] );
 
 	if ( ! note ) {
 		return null;

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -34,9 +34,14 @@ const ReplyBlock = ( { note }: { note: Note } ) => {
 			return;
 		}
 
+		const { site: siteId, reply_comment: replyCommentId } = note.meta.ids;
+		if ( ! siteId || ! replyCommentId ) {
+			return;
+		}
+
 		wpcom()
-			.site( note.meta.ids.site )
-			.comment( note.meta.ids.reply_comment )
+			.site( siteId )
+			.comment( replyCommentId )
 			.get( ( error: Error | null, data: { URL: string } ) => {
 				if ( ! error ) {
 					setReplyURL( data.URL );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-296

## Proposed Changes

* Mark note as read when selecting it

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open Notifications
* Select any unread note
* Ensure `/rest/v1.1/notifications/read` request is sent with the selected note id

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
