### PR TITLE
Hosting Dashboard: Implement ButtonGroup component

### DIFF
--- a/client/dashboard/components/action-list/action-item.tsx
+++ b/client/dashboard/components/action-list/action-item.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { forwardRef } from 'react';
+import { ButtonStack } from '../button-stack';
 import type { ActionItemProps } from './types';
 import './action-item.scss';
 
@@ -26,15 +27,14 @@ function UnforwardedActionItem(
 							</Text>
 						) }
 					</VStack>
-					<HStack
+					<ButtonStack
 						className="action-item__actions"
-						spacing={ 2 }
 						justify="flex-end"
 						expanded={ false }
 						as="span"
 					>
 						{ actions }
-					</HStack>
+					</ButtonStack>
 				</HStack>
 			</HStack>
 		</VStack>

--- a/client/dashboard/components/button-group/index.tsx
+++ b/client/dashboard/components/button-group/index.tsx
@@ -1,0 +1,18 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { ReactNode } from 'react';
+import type { ComponentProps } from 'react';
+
+type ButtonGroupProps = {
+	children: ReactNode;
+};
+
+export default function ButtonGroup( {
+	children,
+	...hStackProps
+}: ButtonGroupProps & ComponentProps< typeof HStack > ) {
+	return (
+		<HStack { ...hStackProps } spacing={ 3 }>
+			{ children }
+		</HStack>
+	);
+}

--- a/client/dashboard/components/button-stack/index.tsx
+++ b/client/dashboard/components/button-stack/index.tsx
@@ -2,14 +2,14 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { ReactNode } from 'react';
 import type { ComponentProps } from 'react';
 
-type ButtonGroupProps = {
+type ButtonStackProps = {
 	children: ReactNode;
 };
 
-export default function ButtonGroup( {
+export function ButtonStack( {
 	children,
 	...hStackProps
-}: ButtonGroupProps & ComponentProps< typeof HStack > ) {
+}: ButtonStackProps & Omit< ComponentProps< typeof HStack >, 'spacing' > ) {
 	return (
 		<HStack { ...hStackProps } spacing={ 3 }>
 			{ children }

--- a/client/dashboard/components/dataviews-empty-state/index.tsx
+++ b/client/dashboard/components/dataviews-empty-state/index.tsx
@@ -1,5 +1,5 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import ButtonGroup from '../button-group';
+import { ButtonStack } from '../button-stack';
 import './styles.scss';
 import { Text } from '../text';
 import type { ReactNode } from 'react';
@@ -31,9 +31,9 @@ export function DataViewsEmptyState( {
 				</Text>
 			</VStack>
 			{ actions && (
-				<ButtonGroup justify="center" wrap>
+				<ButtonStack justify="center" wrap>
 					{ actions }
-				</ButtonGroup>
+				</ButtonStack>
 			) }
 		</VStack>
 	);

--- a/client/dashboard/components/dataviews-empty-state/index.tsx
+++ b/client/dashboard/components/dataviews-empty-state/index.tsx
@@ -1,7 +1,5 @@
-import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import ButtonGroup from '../button-group';
 import './styles.scss';
 import { Text } from '../text';
 import type { ReactNode } from 'react';
@@ -33,9 +31,9 @@ export function DataViewsEmptyState( {
 				</Text>
 			</VStack>
 			{ actions && (
-				<HStack spacing={ 4 } justify="center" wrap>
+				<ButtonGroup justify="center" wrap>
 					{ actions }
-				</HStack>
+				</ButtonGroup>
 			) }
 		</VStack>
 	);

--- a/client/dashboard/components/date-range-picker/date-range-content.tsx
+++ b/client/dashboard/components/date-range-picker/date-range-content.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 import { formatYmd } from '../../utils/datetime';
 import { DateInputs } from './date-inputs';
 import { PresetsListbox } from './presets-listbox';
@@ -213,14 +214,14 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 				</div>
 			</HStack>
 
-			<HStack as="div" spacing={ 2 } justify="flex-end">
+			<ButtonStack as="div" justify="flex-end">
 				<Button variant="secondary" onClick={ clear }>
 					{ __( 'Clear' ) }
 				</Button>
 				<Button variant="primary" onClick={ apply } disabled={ ! fromDraft || ! toDraft }>
 					{ __( 'Apply' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		</VStack>
 	);
 }

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { info, published, error, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
+import { ButtonStack } from '../button-stack';
 import { caution } from './icons';
 import type { NoticeVariant, NoticeProps } from './types';
 import './style.scss';
@@ -64,9 +65,9 @@ function UnforwardedNotice(
 							<span className="dashboard-notice__description">{ children }</span>
 						</VStack>
 						{ actions && (
-							<HStack className="dashboard-notice__actions" spacing={ 3 } justify="flex-start">
+							<ButtonStack className="dashboard-notice__actions" justify="flex-start">
 								{ actions }
-							</HStack>
+							</ButtonStack>
 						) }
 					</VStack>
 					{ !! onClose && (

--- a/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
+++ b/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
@@ -4,7 +4,6 @@ import {
 	Button,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -12,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from 'react';
 import { domainTransferRoute } from '../../app/router/domains';
 import { profileRoute } from '../../app/router/me';
+import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
 import type { User } from '@automattic/api-core';
 
@@ -160,7 +160,7 @@ export default function RemoveDomainDialog( {
 						</div>
 					</>
 				) }
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button variant="tertiary" onClick={ onCancel }>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -179,7 +179,7 @@ export default function RemoveDomainDialog( {
 							{ __( 'Delete' ) }
 						</Button>
 					) }
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -4,8 +4,8 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import clsx from 'clsx';
+import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
-
 import './style.scss';
 
 /**
@@ -41,15 +41,14 @@ export const SectionHeader = ( {
 						{ title }
 					</HeadingTag>
 					{ /* The wrapper is always needed for view transitions. */ }
-					<HStack
+					<ButtonStack
 						justify="flex-end"
 						expanded={ false }
 						alignment="center"
 						className="dashboard-section-header__actions"
-						spacing={ 3 }
 					>
 						{ actions }
-					</HStack>
+					</ButtonStack>
 				</HStack>
 			</HStack>
 			{ description && (

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -1,13 +1,8 @@
-import {
-	Card,
-	CardBody,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { Card, CardBody, __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import RequiredSelect from '../../components/required-select';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
@@ -138,14 +133,14 @@ export default function DNSRecordForm( {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button variant="primary" type="submit" isBusy={ isBusy } disabled={ isBusy }>
 								{ submitButtonText }
 							</Button>
 							<Button type="button" disabled={ isBusy } onClick={ handleCancel }>
 								{ __( 'Cancel' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -8,7 +8,6 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
 	ExternalLink,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -21,6 +20,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { getContactFormFields } from './contact-form-fields';
@@ -186,7 +186,7 @@ export default function ContactForm( {
 							</VStack>
 						</Notice>
 						<form onSubmit={ handleSubmit }>
-							<HStack justify="flex-start" spacing={ 2 }>
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -198,7 +198,7 @@ export default function ContactForm( {
 								<Button variant="secondary" onClick={ onCancel }>
 									{ __( 'Cancel' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</form>
 					</VStack>
 				</CardBody>

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -4,7 +4,6 @@ import {
 	Modal,
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	CheckboxControl,
 	__experimentalDivider as Divider,
@@ -13,6 +12,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import type { DnsRecord } from '@automattic/api-core';
 
 interface DnsImportDialogProps {
@@ -170,7 +170,7 @@ export default function DnsImportDialog( {
 					<Text>{ __( 'We couldn’t find valid DNS records to import.' ) }</Text>
 				) }
 
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button onClick={ onCancel } disabled={ updateDnsMutation.isPending }>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -182,7 +182,7 @@ export default function DnsImportDialog( {
 					>
 						{ __( 'Import Selected Records' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -1,17 +1,14 @@
 import { type DnsTemplateVariables } from '@automattic/api-core';
 import { domainDnsApplyTemplateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, Field, isItemValid } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { domainRoute } from '../../app/router/domains';
+import { ButtonStack } from '../../components/button-stack';
 
 export type EmailSetupFormData = {
 	record: string;
@@ -118,7 +115,7 @@ export default function EmailSetupForm( {
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
-					<HStack justify="flex-start">
+					<ButtonStack justify="flex-start">
 						<Button
 							type="submit"
 							variant="primary"
@@ -134,7 +131,7 @@ export default function EmailSetupForm( {
 								} )
 							}
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</form>
 		</div>

--- a/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
@@ -2,10 +2,10 @@ import {
 	Modal,
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 
 interface RestoreDefaultARecordsProps {
 	onConfirm: () => void;
@@ -32,14 +32,14 @@ export default function RestoreDefaultARecords( {
 		<Modal title={ __( 'Restore A records' ) } onRequestClose={ onCancel }>
 			<VStack spacing={ 6 }>
 				<Text>{ targetPlatformMessage }</Text>
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button onClick={ onCancel } isBusy={ isBusy }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
@@ -2,10 +2,10 @@ import {
 	Modal,
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 
 interface RestoreDefaultCnameRecordProps {
 	onConfirm: () => void;
@@ -27,12 +27,12 @@ export default function RestoreDefaultCnameRecord( {
 		<Modal title={ __( 'Restore CNAME record' ) } onRequestClose={ onCancel }>
 			<VStack spacing={ 6 }>
 				<Text>{ __( 'In case a www CNAME record already exists, it will be deleted.' ) }</Text>
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button onClick={ onCancel }>{ __( 'Cancel' ) }</Button>
 					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
@@ -2,10 +2,10 @@ import {
 	Modal,
 	Button,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 
 interface RestoreDefaultEmailRecordsProps {
 	onConfirm: () => void;
@@ -29,12 +29,12 @@ export default function RestoreDefaultEmailRecords( {
 				<Text>
 					{ __( 'This will restore SPF, DKIM and DMARC records to their default configurations.' ) }
 				</Text>
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button onClick={ onCancel }>{ __( 'Cancel' ) }</Button>
 					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/domains/domain-forwardings/form.tsx
+++ b/client/dashboard/domains/domain-forwardings/form.tsx
@@ -1,7 +1,6 @@
 import {
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Panel,
@@ -12,6 +11,7 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 import { isTargetUrlValid, isSubdomainValid } from './utils';
 import type { DomainForwarding } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -220,8 +220,7 @@ export default function DomainForwardingForm( {
 								</PanelRow>
 							</PanelBody>
 						</Panel>
-
-						<HStack justify="start" spacing={ 4 }>
+						<ButtonStack justify="start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -230,7 +229,7 @@ export default function DomainForwardingForm( {
 							>
 								{ submitButtonText }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/domains/domain-glue-records/form.tsx
+++ b/client/dashboard/domains/domain-glue-records/form.tsx
@@ -1,7 +1,6 @@
 import {
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
@@ -10,6 +9,7 @@ import {
 import { DataForm, isItemValid } from '@wordpress/dataviews';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 import { Text } from '../../components/text';
 import { isValidIpAddress, isValidNameServerSubdomain } from '../../utils/domain';
 import type { DomainGlueRecord } from '@automattic/api-core';
@@ -142,7 +142,7 @@ export default function DomainGlueRecordsForm( {
 							} }
 						/>
 
-						<HStack justify="start" spacing={ 4 }>
+						<ButtonStack justify="start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -151,7 +151,7 @@ export default function DomainGlueRecordsForm( {
 							>
 								{ submitButtonText }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { ReactElement } from 'react';
 import { domainSecurityRoute } from '../../app/router/domains';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 import type { Domain, SslDetails } from '@automattic/api-core';
@@ -166,7 +167,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 							</Text>
 						) }
 						{ shouldShowProvisionButton && (
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									__next40pxDefaultSize
 									variant="primary"
@@ -176,7 +177,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 								>
 									{ __( 'Provision certificate' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						) }
 					</VStack>
 				</VStack>

--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -153,7 +154,7 @@ export default function DomainTransfer() {
 
 	const renderAuthCodeButton = () => {
 		return (
-			<HStack alignment="left">
+			<ButtonStack alignment="left">
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"
@@ -163,7 +164,7 @@ export default function DomainTransfer() {
 				>
 					{ __( 'Get authorization code' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		);
 	};
 

--- a/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
+++ b/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
@@ -4,7 +4,6 @@ import {
 	Button,
 	FormTokenField,
 	Modal,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ExternalLink,
@@ -12,6 +11,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 
 interface SelectIpsTagProps {
@@ -76,7 +76,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 								'control of the domain.'
 						) }
 					</Text>
-					<HStack justify="flex-end" spacing={ 2 }>
+					<ButtonStack justify="flex-end">
 						<Button
 							onClick={ () => setIsDialogOpen( false ) }
 							disabled={ saveIpsTagMutation.isPending }
@@ -92,7 +92,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 						>
 							{ __( 'Submit' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</Modal>
 		);
@@ -124,7 +124,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 						}
 					) }
 				</Text>
-				<HStack alignment="left">
+				<ButtonStack alignment="left">
 					<Button
 						__next40pxDefaultSize
 						variant="secondary"
@@ -133,7 +133,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 					>
 						{ __( 'Submit' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</>
 		);
 	};

--- a/client/dashboard/me/privacy/dpa-card.tsx
+++ b/client/dashboard/me/privacy/dpa-card.tsx
@@ -2,7 +2,6 @@ import { isWpError } from '@automattic/api-core';
 import { requestDpaMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Card,
@@ -13,6 +12,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 
@@ -64,7 +64,7 @@ export default function DpaCard() {
 						}
 						level={ 3 }
 					/>
-					<HStack justify="flex-start">
+					<ButtonStack justify="flex-start">
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
@@ -73,7 +73,7 @@ export default function DpaCard() {
 						>
 							{ __( 'Request a DPA' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</CardBody>
 		</Card>

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -2,7 +2,6 @@ import { profileMutation } from '@automattic/api-queries';
 import { generatePassword } from '@automattic/generate-password';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	__experimentalVStack as VStack,
@@ -16,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { seen, unseen } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useMemo, useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
 import SecurityPageHeader from '../security-page-header';
 import type { Field } from '@wordpress/dataviews';
@@ -142,7 +142,7 @@ export default function SecurityPassword() {
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
-							<HStack spacing={ 3 } justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -154,7 +154,7 @@ export default function SecurityPassword() {
 								<Button variant="secondary" onClick={ handleGeneratePassword }>
 									{ __( 'Generate strong password' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -1,10 +1,6 @@
 import { siteBackupDownloadInitiateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import {
-	Button,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -12,6 +8,7 @@ import { download } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
+import { ButtonStack } from '../../components/button-stack';
 import type { DownloadConfig } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
@@ -120,7 +117,7 @@ function SiteBackupDownloadForm( {
 					onChange={ handleFormChange }
 				/>
 
-				<HStack justify="flex-start">
+				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
 						icon={ download }
@@ -130,7 +127,7 @@ function SiteBackupDownloadForm( {
 					>
 						{ __( 'Generate download' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, download, check } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupsRoute } from '../../app/router/sites';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import type { Site } from '@automattic/api-core';
 
@@ -48,7 +49,7 @@ function SiteBackupDownloadSuccess( {
 						</Text>
 					</VStack>
 				</HStack>
-				<HStack justify="flex-end">
+				<ButtonStack justify="flex-end">
 					<Button
 						variant="tertiary"
 						text={ __( 'All backups' ) }
@@ -60,7 +61,7 @@ function SiteBackupDownloadSuccess( {
 						text={ __( 'Download file' ) + ( fileSizeBytes ? ` (${ fileSizeBytes })` : '' ) }
 						onClick={ handleDownloadClick }
 					/>
-				</HStack>
+				</ButtonStack>
 			</HStack>
 
 			<Notice variant="info" title={ __( 'Check your email' ) }>

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -8,7 +8,7 @@ import { rotateLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
-import ButtonGroup from '../../components/button-group';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import type { RestoreConfig } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -130,7 +130,7 @@ function SiteBackupRestoreForm( {
 					{ restoreWarning }
 				</Notice>
 
-				<ButtonGroup justify="flex-start">
+				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
 						icon={ rotateLeft }
@@ -140,7 +140,7 @@ function SiteBackupRestoreForm( {
 					>
 						{ __( 'Restore now' ) }
 					</Button>
-				</ButtonGroup>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -1,10 +1,6 @@
 import { siteBackupRestoreInitiateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import {
-	Button,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -12,6 +8,7 @@ import { rotateLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
+import ButtonGroup from '../../components/button-group';
 import Notice from '../../components/notice';
 import type { RestoreConfig } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -133,7 +130,7 @@ function SiteBackupRestoreForm( {
 					{ restoreWarning }
 				</Notice>
 
-				<HStack justify="flex-start">
+				<ButtonGroup justify="flex-start">
 					<Button
 						variant="primary"
 						icon={ rotateLeft }
@@ -143,7 +140,7 @@ function SiteBackupRestoreForm( {
 					>
 						{ __( 'Restore now' ) }
 					</Button>
-				</HStack>
+				</ButtonGroup>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/backup-restore/success.tsx
+++ b/client/dashboard/sites/backup-restore/success.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupsRoute } from '../../app/router/sites';
+import { ButtonStack } from '../../components/button-stack';
 import type { Site } from '@automattic/api-core';
 
 const SiteBackupRestoreSuccess = ( {
@@ -42,14 +43,14 @@ const SiteBackupRestoreSuccess = ( {
 					</Text>
 				</VStack>
 			</HStack>
-			<HStack justify="flex-end">
+			<ButtonStack justify="flex-end">
 				<Button variant="tertiary" text={ __( 'All backups' ) } onClick={ handleAllBackupsClick } />
 				<Button
 					variant="primary"
 					text={ __( 'View website ↗' ) }
 					onClick={ handleViewWebsiteClick }
 				/>
-			</HStack>
+			</ButtonStack>
 		</HStack>
 	);
 };

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -12,6 +12,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { rotateLeft, download } from '@wordpress/icons';
 import { siteBackupRestoreRoute, siteBackupDownloadRoute } from '../../app/router/sites';
+import { ButtonStack } from '../../components/button-stack';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
@@ -46,7 +47,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
 					actions={
 						backup.rewind_id && (
-							<HStack spacing={ 2 }>
+							<ButtonStack>
 								<Button
 									variant="secondary"
 									size="compact"
@@ -63,7 +64,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 								>
 									{ __( 'Restore to this point' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						)
 					}
 				/>

--- a/client/dashboard/sites/difm-lite-in-progress/index.tsx
+++ b/client/dashboard/sites/difm-lite-in-progress/index.tsx
@@ -11,6 +11,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { addDays, isPast } from 'date-fns';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
+import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -111,14 +112,14 @@ function WebsiteContentSubmissionPending( { site }: { site: Site } ) {
 			}
 			size="small"
 		>
-			<HStack spacing={ 4 } justify="start">
+			<ButtonStack justify="start">
 				<Button
 					variant="primary"
 					href={ `/start/site-content-collection/website-content?siteSlug=${ site.slug }` }
 				>
 					{ __( 'Provide website content' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -7,7 +7,6 @@ import {
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Card,
@@ -21,6 +20,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
@@ -120,7 +120,7 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -129,7 +129,7 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -13,7 +13,6 @@ import { Link } from '@tanstack/react-router';
 import {
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -26,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useState } from 'react';
 import { ActionList } from '../../components/action-list';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
@@ -180,7 +180,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 								} }
 							/>
 
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -189,7 +189,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -3,7 +3,6 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -16,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { blockTable } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
@@ -117,7 +117,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 									) }
 								</Notice>
 							</VStack>
-							<HStack justify="flex-start" expanded={ false } as="span">
+							<ButtonStack justify="flex-start" expanded={ false } as="span">
 								<Button
 									variant="primary"
 									isBusy={ isFetchingToken }
@@ -125,7 +125,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 								>
 									{ __( 'Open phpMyAdmin ↗' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 							<Text variant="muted" lineHeight="20px">
 								{ createInterpolateElement(
 									__( 'Having problems with access? Try <link>resetting the password</link>.' ),

--- a/client/dashboard/sites/settings-database/reset-password-modal.tsx
+++ b/client/dashboard/sites/settings-database/reset-password-modal.tsx
@@ -1,6 +1,5 @@
 import { restoreDatabasePassword } from '@automattic/api-core';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -8,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 
 interface ResetPasswordModalProps {
 	siteId: number;
@@ -43,12 +43,12 @@ export default function ResetPasswordModal( {
 				<Text>
 					{ __( 'Are you sure you want to restore the default password of your database?' ) }
 				</Text>
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
 					<Button variant="primary" isBusy={ isRestoring } onClick={ handleRestore }>
 						{ __( 'Restore' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -9,7 +9,6 @@ import {
 	Card,
 	CardBody,
 	ExternalLink,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -20,6 +19,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
@@ -191,7 +191,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack justify="flex-start">
+								<ButtonStack justify="flex-start">
 									<Button
 										__next40pxDefaultSize
 										variant="primary"
@@ -201,7 +201,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 									>
 										{ __( 'Enable' ) }
 									</Button>
-								</HStack>
+								</ButtonStack>
 							</VStack>
 						</form>
 					</CardBody>

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -2,7 +2,6 @@ import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@autom
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Card,
@@ -15,6 +14,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { canViewHundredYearPlanSettings } from '../features';
@@ -119,7 +119,7 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -128,7 +128,7 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -5,19 +5,14 @@ import {
 	siteBySlugQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import {
-	Card,
-	CardBody,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { Card, CardBody, __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
+import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
 import RequiredSelect from '../../components/required-select';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
@@ -108,7 +103,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack justify="flex-start">
+								<ButtonStack justify="flex-start">
 									<Button
 										variant="primary"
 										type="submit"
@@ -117,7 +112,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 									>
 										{ __( 'Save' ) }
 									</Button>
-								</HStack>
+								</ButtonStack>
 							</VStack>
 						</form>
 					</CardBody>

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -1,7 +1,6 @@
 import { siteSftpUsersCreateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -15,6 +14,7 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 
@@ -104,7 +104,7 @@ export default function EnableSftpCard( {
 							}
 						) }
 					</Text>
-					<HStack justify="flex-start">
+					<ButtonStack justify="flex-start">
 						<Button
 							variant="primary"
 							isBusy={ mutation.isPending }
@@ -112,7 +112,7 @@ export default function EnableSftpCard( {
 						>
 							{ __( 'Create credentials' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</CardBody>
 		</Card>

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -2,7 +2,6 @@ import { siteSftpUsersResetPasswordMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	BaseControl,
 	Button,
@@ -15,6 +14,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import React, { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
@@ -172,7 +172,7 @@ export default function SftpCard( {
 						onChange={ noop }
 					/>
 					{ ! password && (
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="secondary"
 								isBusy={ mutation.isPending }
@@ -180,7 +180,7 @@ export default function SftpCard( {
 							>
 								{ __( 'Reset password' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					) }
 				</VStack>
 			</CardBody>

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -29,6 +29,7 @@ import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { ButtonStack } from '../../components/button-stack';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
@@ -321,7 +322,7 @@ export default function SshCard( {
 						/>
 					) }
 					{ sshEnabled && ! userKeyIsAttached && (
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								isBusy={ attachSshKeyMutation.isPending }
@@ -338,7 +339,7 @@ export default function SshCard( {
 							>
 								{ __( 'Add new SSH key ↗' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					) }
 				</VStack>
 			</CardBody>

--- a/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/settings-site-visibility/agency-development-site-launch-modal.tsx
@@ -1,11 +1,11 @@
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
 	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 
 interface AgencyDevelopmentSiteLaunchModalProps {
 	isLaunching: boolean;
@@ -24,14 +24,14 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 				<Text as="p">
 					{ __( 'After launch, we’ll bill your agency in the next billing cycle.' ) }
 				</Text>
-				<HStack justify="flex-end" spacing={ 2 }>
+				<ButtonStack justify="flex-end">
 					<Button disabled={ isLaunching } onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button variant="primary" isBusy={ isLaunching } onClick={ onLaunch }>
 						{ __( 'Launch site' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -1,7 +1,6 @@
 import { siteDomainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Card,
 	CardBody,
@@ -15,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { ShareSiteForm } from './share-site-form';
@@ -244,7 +244,7 @@ export function PrivacyForm( {
 								form={ robotForm }
 								onChange={ ( { isPrimaryDomainStaging, ...edits } ) => handleChange( edits ) }
 							/>
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									__next40pxDefaultSize
@@ -254,7 +254,7 @@ export function PrivacyForm( {
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -5,18 +5,13 @@ import {
 	siteStaticFile404SettingMutation,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Card,
-	CardBody,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Card, CardBody, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
@@ -114,7 +109,7 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack justify="flex-start">
+								<ButtonStack justify="flex-start">
 									<Button
 										variant="primary"
 										type="submit"
@@ -123,7 +118,7 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 									>
 										{ __( 'Save' ) }
 									</Button>
-								</HStack>
+								</ButtonStack>
 							</VStack>
 						</form>
 					</CardBody>

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -3,7 +3,6 @@ import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@autom
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	Card,
@@ -16,6 +15,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import PageLayout from '../../components/page-layout';
 import { hasPlanFeature } from '../../utils/site-features';
@@ -123,7 +123,7 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -132,7 +132,7 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -1,7 +1,6 @@
 import { siteOwnerTransferEligibilityCheckMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -12,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -104,7 +104,7 @@ export function ConfirmNewOwnerForm( {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>
-				<HStack justify="flex-start">
+				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
 						type="submit"
@@ -113,7 +113,7 @@ export function ConfirmNewOwnerForm( {
 					>
 						{ __( 'Continue' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/start-site-transfer-form.tsx
@@ -1,7 +1,6 @@
 import { siteOwnerTransferMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -12,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import React, { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
 import type { Site, SiteOwnerTransferContext } from '@automattic/api-core';
@@ -196,7 +196,7 @@ export function StartSiteTransferForm( {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>
-				<HStack justify="flex-start">
+				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
 						type="submit"
@@ -208,7 +208,7 @@ export function StartSiteTransferForm( {
 					<Button variant="tertiary" onClick={ onBack } disabled={ mutation.isPending }>
 						{ __( 'Back' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -4,7 +4,6 @@ import {
 	Card,
 	CardBody,
 	TextareaControl,
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -15,6 +14,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import type { JetpackSettings, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -119,7 +119,7 @@ export default function AllowListForm( { site }: { site: Site } ) {
 								{ strong: <strong /> }
 							) }
 						</Text>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -128,7 +128,7 @@ export default function AllowListForm( { site }: { site: Site } ) {
 							>
 								{ __( 'Save' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/automatic-rules-form.tsx
@@ -1,18 +1,13 @@
 import { HostingFeatures, JetpackModules } from '@automattic/api-core';
 import { siteJetpackSettingsQuery, siteJetpackSettingsMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import {
-	Card,
-	CardBody,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { Card, CardBody, __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -105,7 +100,7 @@ export default function AutomaticRulesForm( { site }: { site: Site } ) {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -114,7 +109,7 @@ export default function AutomaticRulesForm( { site }: { site: Site } ) {
 							>
 								{ __( 'Save' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -5,7 +5,6 @@ import {
 	Card,
 	CardBody,
 	TextareaControl,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
@@ -14,6 +13,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import { hasJetpackModule } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -118,7 +118,7 @@ export default function BlockListForm( { site }: { site: Site } ) {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -127,7 +127,7 @@ export default function BlockListForm( { site }: { site: Site } ) {
 							>
 								{ __( 'Save' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/protect-form.tsx
@@ -1,18 +1,13 @@
 import { JetpackModules } from '@automattic/api-core';
 import { siteJetpackModulesQuery, siteJetpackModulesMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import {
-	Card,
-	CardBody,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { Card, CardBody, __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import { isJetpackModuleActivated } from '../../utils/site-jetpack-modules';
 import type { Site } from '@automattic/api-core';
@@ -89,7 +84,7 @@ export default function ProtectForm( { site }: { site: Site } ) {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -98,7 +93,7 @@ export default function ProtectForm( { site }: { site: Site } ) {
 							>
 								{ __( 'Save' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -7,7 +7,6 @@ import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
@@ -18,6 +17,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import PageLayout from '../../components/page-layout';
 import RequiredSelect from '../../components/required-select';
@@ -89,7 +89,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
-							<HStack justify="flex-start">
+							<ButtonStack justify="flex-start">
 								<Button
 									variant="primary"
 									type="submit"
@@ -98,7 +98,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 								>
 									{ __( 'Save' ) }
 								</Button>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</form>
 				</CardBody>

--- a/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/sso-form.tsx
@@ -9,7 +9,6 @@ import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Card,
 	CardBody,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
 	CheckboxControl,
@@ -19,6 +18,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { isJetpackModuleActivated } from '../../utils/site-jetpack-modules';
 import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -167,7 +167,7 @@ export default function SsoForm( { site }: { site: Site } ) {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-						<HStack justify="flex-start">
+						<ButtonStack justify="flex-start">
 							<Button
 								variant="primary"
 								type="submit"
@@ -176,7 +176,7 @@ export default function SsoForm( { site }: { site: Site } ) {
 							>
 								{ __( 'Save' ) }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</VStack>
 				</form>
 			</CardBody>

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -6,13 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-	ExternalLink,
-	Icon,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button, ExternalLink, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -20,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import SuffixInputControl from '../../components/input-control/suffix-input-control';
 import Notice from '../../components/notice';
 import { Text } from '../../components/text';
@@ -157,7 +152,7 @@ const NewSiteAddressForm = ( {
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
-					<HStack justify="flex-end">
+					<ButtonStack justify="flex-end">
 						<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onCancel }>
 							{ __( 'Cancel' ) }
 						</Button>
@@ -169,7 +164,7 @@ const NewSiteAddressForm = ( {
 						>
 							{ __( 'Next' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</form>
 		</VStack>
@@ -282,7 +277,7 @@ const ConfirmNewSiteAddressForm = ( {
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
-					<HStack justify="flex-end">
+					<ButtonStack justify="flex-end">
 						<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onBack }>
 							{ __( 'Back' ) }
 						</Button>
@@ -294,7 +289,7 @@ const ConfirmNewSiteAddressForm = ( {
 						>
 							{ __( 'Confirm' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</form>
 		</VStack>

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -6,7 +6,6 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -20,6 +19,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -112,14 +112,14 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 	return (
 		<>
 			<Text as="p">{ renderWarningContent() }</Text>
-			<HStack justify="flex-end">
+			<ButtonStack justify="flex-end">
 				{ ! isAtomicRemovalInProgress && (
 					<Button variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 				) }
 				{ renderPrimaryButton() }
-			</HStack>
+			</ButtonStack>
 		</>
 	);
 }
@@ -207,7 +207,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
-					<HStack justify="flex-end">
+					<ButtonStack justify="flex-end">
 						<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
@@ -220,7 +220,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 						>
 							{ __( 'Delete site' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</form>
 		</>

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -7,7 +7,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -19,6 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
 import type { Site, User } from '@automattic/api-core';
 
@@ -45,7 +45,7 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 					) }
 				</Text>
 			</VStack>
-			<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+			<ButtonStack justify="flex-end" expanded={ false }>
 				<Button variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
@@ -58,7 +58,7 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 				>
 					{ __( 'Manage purchases' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		</>
 	);
 }
@@ -73,7 +73,7 @@ function ContentSiteOwner( { site, onClose }: ContentInfoProps ) {
 					) }
 				</Text>
 			</VStack>
-			<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+			<ButtonStack justify="flex-end" expanded={ false }>
 				<Button variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
@@ -86,7 +86,7 @@ function ContentSiteOwner( { site, onClose }: ContentInfoProps ) {
 				>
 					{ __( 'Transfer ownership' ) }
 				</RouterLinkButton>
-			</HStack>
+			</ButtonStack>
 		</>
 	);
 }
@@ -173,7 +173,7 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>
-				<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+				<ButtonStack justify="flex-end" expanded={ false }>
 					<Button variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -185,7 +185,7 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 					>
 						{ __( 'Leave site' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -19,6 +19,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useState, useCallback } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import ContentInfo from './content-info';
 import type { Site, SiteResetContentSummary, SiteResetStatus } from '@automattic/api-core';
@@ -34,11 +35,11 @@ function ErrorContent( { message, onClose }: { message: string; onClose: () => v
 	return (
 		<VStack spacing={ 6 }>
 			<Text>{ message }</Text>
-			<HStack justify="flex-end">
+			<ButtonStack justify="flex-end">
 				<Button variant="primary" onClick={ onClose }>
 					{ __( 'OK' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/site-restore-modal/content-info.tsx
+++ b/client/dashboard/sites/site-restore-modal/content-info.tsx
@@ -1,7 +1,6 @@
 import { siteRestoreMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -10,6 +9,7 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../components/button-stack';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
@@ -62,14 +62,14 @@ export default function SiteRestoreContentInfo( { site, onClose }: ContentInfoPr
 						}
 					) }
 				</Text>
-				<HStack spacing={ 4 } justify="flex-end" expanded={ false }>
+				<ButtonStack justify="flex-end" expanded={ false }>
 					<Button variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button variant="primary" type="submit" isBusy={ mutation.isPending }>
 						{ __( 'Restore site' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</form>
 	);

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -3,7 +3,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -12,6 +11,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../components/button-stack';
 import type { Site } from '@automattic/api-core';
 
 export default function StagingSiteDeleteModal( {
@@ -70,7 +70,7 @@ export default function StagingSiteDeleteModal( {
 						'Are you sure you want to delete this staging site? This action cannot be undone and will permanently remove all staging site content.'
 					) }
 				</Text>
-				<HStack justify="flex-end">
+				<ButtonStack justify="flex-end">
 					<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -83,7 +83,7 @@ export default function StagingSiteDeleteModal( {
 					>
 						{ __( 'Delete staging site' ) }
 					</Button>
-				</HStack>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -18,6 +18,7 @@ import {
 import { createInterpolateElement, useState, useCallback } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
@@ -300,7 +301,7 @@ export default function StagingSiteSyncModal( {
 							</Text>
 						</HStack>
 
-						<HStack justify="flex-end" spacing={ 4 }>
+						<ButtonStack justify="flex-end">
 							<Button variant="tertiary" onClick={ handleClose }>
 								{ __( 'Cancel' ) }
 							</Button>
@@ -312,7 +313,7 @@ export default function StagingSiteSyncModal( {
 							>
 								{ syncConfig.submit }
 							</Button>
-						</HStack>
+						</ButtonStack>
 					</HStack>
 				</VStack>
 			</VStack>

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -12,6 +12,7 @@ import {
 import { sprintf, __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState, Suspense, lazy } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
@@ -98,7 +99,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 									</Text>
 								</VStack>
 							</HStack>
-							<HStack>
+							<ButtonStack>
 								<UpsellCTAButton
 									text={ __( 'Purchase plan' ) }
 									tracksId="trial"
@@ -108,7 +109,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 										redirect_to: backUrl,
 									} ) }
 								/>
-							</HStack>
+							</ButtonStack>
 						</VStack>
 					</CardBody>
 				</Card>


### PR DESCRIPTION
## Proposed Changes

The Hosting Dashboard has many instances of `<HStack>` to group buttons with inconsistent usage of spacing between buttons. This PR proposed a component `<ButtonGroup>` to make the spacing consistent. I only replaced a couple of instances for now. If we agree on this direction, I'll update the rest of the instances.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The spacing between buttons should be consistently 12px.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
