### PR TITLE
Notifications v2: Show fullscreen on the mobile view

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -49,11 +49,13 @@ const defaultHandlers = {
 
 const NotificationApp = ( {
 	locale = 'en',
+	showCloseButton = false,
 	customEnhancer,
 	actionHandlers = {},
 	wpcom,
 }: {
 	locale?: string;
+	showCloseButton?: boolean;
 	customEnhancer?: any;
 	actionHandlers?: any;
 	wpcom: any;
@@ -144,13 +146,13 @@ const NotificationApp = ( {
 						path="/:filterName"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<NotePanel />
+						<NotePanel showCloseButton={ showCloseButton } />
 					</Navigator.Screen>
 					<Navigator.Screen
 						path="/:filterName/notes/:noteId"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<Note />
+						<Note showCloseButton={ showCloseButton } />
 					</Navigator.Screen>
 				</Navigator>
 			</AppProvider>

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -49,13 +49,13 @@ const defaultHandlers = {
 
 const NotificationApp = ( {
 	locale = 'en',
-	showCloseButton = false,
+	isDismissible = false,
 	customEnhancer,
 	actionHandlers = {},
 	wpcom,
 }: {
 	locale?: string;
-	showCloseButton?: boolean;
+	isDismissible?: boolean;
 	customEnhancer?: any;
 	actionHandlers?: any;
 	wpcom: any;
@@ -146,13 +146,13 @@ const NotificationApp = ( {
 						path="/:filterName"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<NotePanel showCloseButton={ showCloseButton } />
+						<NotePanel isDismissible={ isDismissible } />
 					</Navigator.Screen>
 					<Navigator.Screen
 						path="/:filterName/notes/:noteId"
 						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
 					>
-						<Note showCloseButton={ showCloseButton } />
+						<Note isDismissible={ isDismissible } />
 					</Navigator.Screen>
 				</Navigator>
 			</AppProvider>

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -14,6 +14,7 @@ import { useEffect } from 'react';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
+import CloseButton from '../templates/close-button';
 import NotePanelActions from './actions';
 
 type FilterName = keyof ReturnType< typeof getFilters >;
@@ -23,7 +24,7 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 	title: label,
 } ) );
 
-const NotePanel = () => {
+const NotePanel = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
 	const { params, goTo } = useNavigator();
 	const { filterName = 'all' } = params;
 
@@ -65,7 +66,7 @@ const NotePanel = () => {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [] );
+	}, [ goTo ] );
 
 	return (
 		<>
@@ -75,13 +76,16 @@ const NotePanel = () => {
 			>
 				<VStack>
 					<HStack>
-						<Icon icon={ bell } />
-						<Heading level={ 3 } size={ 15 } weight={ 500 }>
-							{ __( 'Notifications' ) }
-						</Heading>
-						<div style={ { marginInlineStart: 'auto' } }>
+						<HStack justify="flex-start">
+							<Icon icon={ bell } />
+							<Heading level={ 3 } size={ 15 } weight={ 500 }>
+								{ __( 'Notifications' ) }
+							</Heading>
+						</HStack>
+						<HStack justify="flex-end">
 							<NotePanelActions />
-						</div>
+							{ showCloseButton && <CloseButton /> }
+						</HStack>
 					</HStack>
 					<TabPanel
 						activeClass="is-active"

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -24,7 +24,7 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 	title: label,
 } ) );
 
-const NotePanel = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
+const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const { params, goTo } = useNavigator();
 	const { filterName = 'all' } = params;
 
@@ -84,7 +84,7 @@ const NotePanel = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
 						</HStack>
 						<HStack justify="flex-end">
 							<NotePanelActions />
-							{ showCloseButton && <CloseButton /> }
+							{ isDismissible && <CloseButton /> }
 						</HStack>
 					</HStack>
 					<TabPanel

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -20,6 +20,7 @@ import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved'
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
 import ActionDropdown from '../templates/action-dropdown';
 import { NoteBody, ActionBlock } from '../templates/body';
+import CloseButton from '../templates/close-button';
 import NoteSummary from '../templates/note-summary';
 import './style.scss';
 import type { Note as NoteObject, Block } from '../types';
@@ -66,7 +67,7 @@ const getClasses = ( {
 	} );
 };
 
-const Note = () => {
+const Note = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
 	const dispatch = useDispatch();
 	const { params, goBack } = useNavigator();
 	const { noteId } = params;
@@ -93,13 +94,16 @@ const Note = () => {
 				<HStack>
 					<Navigator.BackButton
 						icon={ isRTL() ? chevronRight : chevronLeft }
-						style={ { padding: 0 } }
+						style={ { flexShrink: 0, padding: 0 } }
 					>
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ note.title }
 						</Heading>
 					</Navigator.BackButton>
-					<ActionDropdown note={ note } goBack={ goBack } />
+					<HStack justify="flex-end">
+						<ActionDropdown note={ note } goBack={ goBack } />
+						{ showCloseButton && <CloseButton /> }
+					</HStack>
 				</HStack>
 			</CardHeader>
 			<CardBody size="small" style={ { maxHeight: 'unset' } }>

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -67,7 +67,7 @@ const getClasses = ( {
 	} );
 };
 
-const Note = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
+const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const dispatch = useDispatch();
 	const { params, goBack } = useNavigator();
 	const { noteId } = params;
@@ -102,7 +102,7 @@ const Note = ( { showCloseButton }: { showCloseButton?: boolean } ) => {
 					</Navigator.BackButton>
 					<HStack justify="flex-end">
 						<ActionDropdown note={ note } goBack={ goBack } />
-						{ showCloseButton && <CloseButton /> }
+						{ isDismissible && <CloseButton /> }
 					</HStack>
 				</HStack>
 			</CardHeader>

--- a/apps/notifications/src/app/templates/close-button.tsx
+++ b/apps/notifications/src/app/templates/close-button.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { useDispatch } from 'react-redux';
+import actions from '../../panel/state/actions';
+
+const CloseButton = () => {
+	const dispatch = useDispatch();
+	const handleClose = () => {
+		dispatch( actions.ui.closePanel() );
+	};
+
+	return <Button size="small" icon={ close } label={ __( 'Close' ) } onClick={ handleClose } />;
+};
+
+export default CloseButton;

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Dropdown } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -15,6 +16,7 @@ export default function Notifications( { className }: { className: string } ) {
 	const navigate = useNavigate();
 	const { user } = useAuth();
 	const locale = useLocale();
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 
@@ -75,11 +77,13 @@ export default function Notifications( { className }: { className: string } ) {
 	return (
 		<Dropdown
 			popoverProps={ {
+				className: 'dashboard-notifications',
 				placement: 'bottom-end',
 				offset: 8,
 				focusOnMount: true,
 			} }
 			open={ isOpen }
+			expandOnMobile={ isMobileViewport }
 			onToggle={ handleToggle }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
@@ -92,10 +96,19 @@ export default function Notifications( { className }: { className: string } ) {
 				/>
 			) }
 			renderContent={ () => (
-				<div style={ { width: '448px', height: '100vh', maxHeight: 'inherit', margin: '-8px' } }>
+				<div
+					style={ {
+						width: '100vw',
+						height: '100vh',
+						maxWidth: '448px',
+						maxHeight: 'inherit',
+						margin: '-8px',
+					} }
+				>
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp
 							locale={ locale }
+							showCloseButton={ isMobileViewport }
 							actionHandlers={ actionHandlers }
 							wpcom={ wpcom }
 						/>

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -16,7 +16,7 @@ export default function Notifications( { className }: { className: string } ) {
 	const navigate = useNavigate();
 	const { user } = useAuth();
 	const locale = useLocale();
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
 
@@ -100,7 +100,7 @@ export default function Notifications( { className }: { className: string } ) {
 					style={ {
 						width: '100vw',
 						height: '100vh',
-						maxWidth: '448px',
+						maxWidth: ! isMobileViewport ? '448px' : undefined,
 						maxHeight: 'inherit',
 						margin: '-8px',
 					} }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -108,7 +108,7 @@ export default function Notifications( { className }: { className: string } ) {
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp
 							locale={ locale }
-							showCloseButton={ isMobileViewport }
+							isDismissible={ isMobileViewport }
 							actionHandlers={ actionHandlers }
 							wpcom={ wpcom }
 						/>

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,3 +1,14 @@
+// The Dropdown component doesn't support to hide the header if the `expandOnMobile` is enabled.
+.dashboard-notifications.components-popover.is-expanded {
+	.components-popover__header {
+		display: none;
+	}
+
+	.components-popover__content {
+		height: 100%;
+	}
+}
+
 .dashboard-notifications__icon {
 	svg {
 		circle {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-302

## Proposed Changes

* Show fullscreen notifications with the close button on the mobile view

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2 on the mobile view
* Open the notifications
* Ensure it shows in the fullscreen mode
* Select any note
* Ensure the UI looks good
* Click the close button
* Ensure it closes the notifications

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
