### PR TITLE
e2e tests: Configure Team City builds for Playwright Test: part 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,6 @@ packages/plans-grid-next/static/mockServiceWorker.js
 .docusaurus
 
 # Playwright
-/test/e2e/playwright-report
-/test/e2e/test-results
+playwright-report/
+/test/e2e/test-results/
 /cookies
-test/e2e/results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,5 @@ packages/plans-grid-next/static/mockServiceWorker.js
 
 # Playwright
 playwright-report/
-/test/e2e/test-results/
 /cookies
+output/

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -973,7 +973,6 @@ object PlaywrightTestPRMatrix : BuildType({
 		param("env.DEBUG", "")
 		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
 		param("env.LIVEBRANCHES", "true")
-		param("env.VIEWPORT_NAME", "$targetDevice")
 	}
 
 	steps {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1006,9 +1006,9 @@ object PlaywrightTestPRMatrix : BuildType({
 					exit 1
 				fi
 
-				echo "Running Playwright tests for project: %playwrightProject%"
 				cd test/e2e
-				yarn playwright:%playwrightProject% --list
+				echo "Running Playwright tests for project: %playwrightProject%"
+				yarn test:pw:%playwrightProject%
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -973,9 +973,7 @@ object PlaywrightTestPRMatrix : BuildType({
 	params {
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
-		param("env.DEBUG", "")
 		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
 		param("env.LIVEBRANCHES", "true")
 	}
@@ -990,7 +988,6 @@ object PlaywrightTestPRMatrix : BuildType({
 				yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
 
 				# Decrypt secrets
-				# Must do before build so the secrets are in the dist output
 				E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
 
 				# Build packages

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -933,6 +933,17 @@ object PlaywrightTestPRMatrix : BuildType({
 				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 			}
 		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+		perfmon {
+		}
 	}
 
 	triggers {
@@ -954,10 +965,48 @@ object PlaywrightTestPRMatrix : BuildType({
 		}
 	}
 
+	params {
+		param("env.NODE_CONFIG_ENV", "test")
+		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
+		param("env.HEADLESS", "true")
+		param("env.LOCALE", "en")
+		param("env.DEBUG", "")
+		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
+		param("env.LIVEBRANCHES", "true")
+		param("env.VIEWPORT_NAME", "$targetDevice")
+	}
+
 	steps {
+		mergeTrunk( skipIfConflict = true )
+		
 		bashNodeScript {
-			name = "Test step"
+			name = "Prepare environment"
 			scriptContent = """
+				# Install deps
+				yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
+
+				# Decrypt secrets
+				# Must do before build so the secrets are in the dist output
+				E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
+
+				# Build packages
+				yarn workspace @automattic/calypso-e2e build
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Run e2e tests"
+			scriptContent = """
+				echo "Getting Calypso url for build ${BuildDockerImage.depParamRefs.buildNumber}"
+				chmod +x ./bin/get-calypso-live-url.sh
+				CALYPSO_LIVE_URL=${'$'}(./bin/get-calypso-live-url.sh ${BuildDockerImage.depParamRefs.buildNumber})
+				if [[ ${'$'}? -ne 0 ]]; then
+					// Command failed. CALYPSO_LIVE_URL contains stderr
+					echo ${'$'}CALYPSO_LIVE_URL
+					exit 1
+				fi
+
 				echo "Running Playwright tests for project: %playwrightProject%"
 				cd test/e2e
 				yarn playwright:%playwrightProject% --list

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1008,7 +1008,7 @@ object PlaywrightTestPRMatrix : BuildType({
 
 				cd test/e2e
 				echo "Running Playwright tests for project: %playwrightProject%"
-				yarn test:pw:%playwrightProject%
+				yarn test:pw:%playwrightProject% --grep=@calypso-pr
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -959,10 +959,8 @@ object PlaywrightTestPRMatrix : BuildType({
 			name = "Test step"
 			scriptContent = """
 				echo "Running Playwright tests for project: %playwrightProject%"
-				pwd
-				ls -la
-				# cd test/e2e
-				# yarn playwright:%playwrightProject% --list
+				cd test/e2e
+				yarn playwright:%playwrightProject% --list
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -944,6 +944,11 @@ object PlaywrightTestPRMatrix : BuildType({
 		}
 		perfmon {
 		}
+		xmlReport {
+          reportType = XmlReport.XmlReportType.JUNIT
+          rules = "+:test/e2e/output/results.xml"
+		  verbose = true
+         }
 	}
 
 	triggers {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -976,6 +976,7 @@ object PlaywrightTestPRMatrix : BuildType({
 		param("env.LOCALE", "en")
 		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
 		param("env.LIVEBRANCHES", "true")
+		param("env.CI", "true")
 	}
 
 	steps {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -57,7 +57,6 @@ project {
 	buildType(SmartBuildLauncher)
 
 	params {
-		param("env.CI", "1")
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -57,6 +57,7 @@ project {
 	buildType(SmartBuildLauncher)
 
 	params {
+		param("env.CI", "1")
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -183,4 +183,13 @@ export const test = base.extend< {
 	},
 } );
 
+export const tags = {
+	AUTHENTICATION: '@authentication',
+	CALYPSO_PR: '@calypso-pr',
+	CALYPSO_RELEASE: '@calypso-release',
+	GUTENBERG: '@gutenberg',
+	I18N: '@i18n',
+	JETPACK_REMOTE_SITE: '@jetpack-remote-site',
+};
+
 export { expect };

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -23,11 +23,10 @@
 		"test:mobile": "VIEWPORT_NAME=mobile yarn jest",
 		"debug": "PWDEBUG=1 DEBUG=pw:api yarn run test",
 		"debug:mobile": "PWDEBUG=1 DEBUG=pw:api yarn run test:mobile",
-		"playwright": "npx playwright test --project=chrome --project=pixel",
-		"playwright:mobile": "npx playwright test --project=pixel",
-		"playwright:desktop": "yarn playwright test --project=chrome",
-		"playwright:all": "npx playwright test",
-		"playwright:i18n": "npx playwright test --project=chrome --grep @i18n"
+		"test:pw:mobile": "yarn playwright test --project=pixel",
+		"test:pw:desktop": "yarn playwright test --project=chrome",
+		"test:pw": "yarn playwright test",
+		"test:pw:i18n": "yarn playwright test --project=chrome --grep @i18n"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"debug:mobile": "PWDEBUG=1 DEBUG=pw:api yarn run test:mobile",
 		"playwright": "npx playwright test --project=chrome --project=pixel",
 		"playwright:mobile": "npx playwright test --project=pixel",
-		"playwright:desktop": "npx playwright test --project=chrome",
+		"playwright:desktop": "yarn playwright test --project=chrome",
 		"playwright:all": "npx playwright test",
 		"playwright:i18n": "npx playwright test --project=chrome --grep @i18n"
 	},

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -9,6 +9,11 @@ const reporter: ReporterDescription[] = [
 	],
 ];
 
+if ( process.env.CI ) {
+	console.log( 'Running in CI, adding list reporter.' );
+	reporter.push( [ 'list' ] );
+}
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig, devices, type ReporterDescription } from 'playwright/test';
 
 const reporter: ReporterDescription[] = [
-	[ 'junit', { outputFile: 'output/results.xml' } ],
-	[ 'html', { outputFolder: 'output', open: process.env.CI ? 'never' : 'on-failure' } ],
+	[ 'junit', { outputFile: 'test-results/results.xml' } ],
+	[ 'html', { outputFolder: 'test-results/html', open: process.env.CI ? 'never' : 'on-failure' } ],
 ];
 
 /**

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig, devices, type ReporterDescription } from 'playwright/test';
 
+const outputPath = './output';
 const reporter: ReporterDescription[] = [
-	[ 'junit', { outputFile: 'test-results/results.xml' } ],
-	[ 'html', { outputFolder: 'test-results/html', open: process.env.CI ? 'never' : 'on-failure' } ],
+	[ 'junit', { outputFile: `${ outputPath }/results.xml` } ],
+	[
+		'html',
+		{ outputFolder: `${ outputPath }/html`, open: process.env.CI ? 'never' : 'on-failure' },
+	],
 ];
 
 /**
@@ -21,6 +25,7 @@ export default defineConfig( {
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	outputDir: `${ outputPath }/test-results`,
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
 		// baseURL: 'http://localhost:3000',

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -1,4 +1,9 @@
-import { defineConfig, devices } from 'playwright/test';
+import { defineConfig, devices, type ReporterDescription } from 'playwright/test';
+
+const reporter: ReporterDescription[] = [
+	[ 'junit', { outputFile: 'output/results.xml' } ],
+	[ 'html', { outputFolder: 'output', open: process.env.CI ? 'never' : 'on-failure' } ],
+];
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -12,9 +17,9 @@ export default defineConfig( {
 	/* Retry on CI only */
 	retries: process.env.CI ? 1 : 0,
 	/* Workers should use what is available */
-	workers: '100%',
+	workers: 1,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: process.env.CI ? [ [ 'junit', { outputFile: 'results.xml' } ], [ 'html' ] ] : 'html',
+	reporter,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */

--- a/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
+++ b/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect } from '../../lib/pw-base';
+import { test, expect, tags } from '../../lib/pw-base';
 
 const A4A_URL = 'https://agencies.automattic.com';
 
 /**
  * Verify the A4A > Signup page loads
  */
-test.describe( 'Automattic For Agencies: Sign Up Page', () => {
+test.describe( 'Automattic For Agencies: Sign Up Page', { tag: [ tags.CALYPSO_PR ] }, () => {
 	test( 'As an unauthenticated web agency owner, I can enter my agency details and see these displayed', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/appearance/theme__details-preview.spec.ts
+++ b/test/e2e/specs/appearance/theme__details-preview.spec.ts
@@ -1,50 +1,54 @@
-import { test } from '../../lib/pw-base';
+import { tags, test } from '../../lib/pw-base';
 
-test.describe( 'Appearance: Theme Details Preview', () => {
-	test( 'As a gutenberg simple site user, I can preview a different theme on my site', async ( {
-		page,
-		accountGutenbergSimple,
-		componentSidebar,
-		componentSiteSelect,
-		pageThemes,
-		pageThemeDetails,
-		componentPreview,
-	} ) => {
-		const testAccountSiteDomain = accountGutenbergSimple.getSiteURL( { protocol: false } );
+test.describe(
+	'Appearance: Theme Details Preview',
+	{ tag: [ tags.CALYPSO_PR, tags.JETPACK_REMOTE_SITE ] },
+	() => {
+		test( 'As a gutenberg simple site user, I can preview a different theme on my site', async ( {
+			page,
+			accountGutenbergSimple,
+			componentSidebar,
+			componentSiteSelect,
+			pageThemes,
+			pageThemeDetails,
+			componentPreview,
+		} ) => {
+			const testAccountSiteDomain = accountGutenbergSimple.getSiteURL( { protocol: false } );
 
-		// This test will use partial matching names to cycle between available themes.
-		const themeName = 'Twenty Twen';
+			// This test will use partial matching names to cycle between available themes.
+			const themeName = 'Twenty Twen';
 
-		await test.step( `Given I am authenticated as '${ accountGutenbergSimple.accountName }'`, async function () {
-			await accountGutenbergSimple.authenticate( page );
+			await test.step( `Given I am authenticated as '${ accountGutenbergSimple.accountName }'`, async function () {
+				await accountGutenbergSimple.authenticate( page );
+			} );
+
+			await test.step( 'When I navigate to Appearance > Themes', async function () {
+				await componentSidebar.navigate( 'Appearance', 'Themes' );
+			} );
+
+			await test.step( `And I choose the test site ${ testAccountSiteDomain } if the site selector is shown`, async function () {
+				if ( await componentSiteSelect.isSiteSelectorVisible() ) {
+					await componentSiteSelect.selectSite( testAccountSiteDomain );
+				}
+			} );
+
+			await test.step( `And I search for a theme with my keyword ${ themeName }`, async function () {
+				await pageThemes.search( themeName );
+			} );
+
+			await test.step( `And I select and view details of a theme starting with ${ themeName }`, async function () {
+				const selectedTheme = await pageThemes.select( themeName );
+				await pageThemes.hoverThenClick( selectedTheme );
+			} );
+
+			await test.step( 'Then I can preview the theme', async function () {
+				await pageThemeDetails.preview();
+				await componentPreview.previewReady();
+			} );
+
+			await test.step( 'And I can close the theme preview', async function () {
+				await componentPreview.closePreview();
+			} );
 		} );
-
-		await test.step( 'When I navigate to Appearance > Themes', async function () {
-			await componentSidebar.navigate( 'Appearance', 'Themes' );
-		} );
-
-		await test.step( `And I choose the test site ${ testAccountSiteDomain } if the site selector is shown`, async function () {
-			if ( await componentSiteSelect.isSiteSelectorVisible() ) {
-				await componentSiteSelect.selectSite( testAccountSiteDomain );
-			}
-		} );
-
-		await test.step( `And I search for a theme with my keyword ${ themeName }`, async function () {
-			await pageThemes.search( themeName );
-		} );
-
-		await test.step( `And I select and view details of a theme starting with ${ themeName }`, async function () {
-			const selectedTheme = await pageThemes.select( themeName );
-			await pageThemes.hoverThenClick( selectedTheme );
-		} );
-
-		await test.step( 'Then I can preview the theme', async function () {
-			await pageThemeDetails.preview();
-			await componentPreview.previewReady();
-		} );
-
-		await test.step( 'And I can close the theme preview', async function () {
-			await componentPreview.closePreview();
-		} );
-	} );
-} );
+	}
+);

--- a/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
@@ -1,6 +1,6 @@
-import { test } from '../../lib/pw-base';
+import { tags, test } from '../../lib/pw-base';
 
-test.describe( 'Appearance: Theme Widgets (Legacy)', () => {
+test.describe( 'Appearance: Theme Widgets (Legacy)', { tag: [ tags.GUTENBERG ] }, () => {
 	test( 'As a non-atomic site user, I can use widgets on my site', async ( {
 		page,
 		accountGivenByEnvironment,

--- a/test/e2e/specs/authentication/authentication__apple.spec.ts
+++ b/test/e2e/specs/authentication/authentication__apple.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from '../../lib/pw-base';
+import { tags, test, expect } from '../../lib/pw-base';
 
-test.describe( 'Authentication: Apple', () => {
+test.describe( 'Authentication: Apple', { tag: [ tags.AUTHENTICATION ] }, () => {
 	test.describe.configure( { mode: 'serial' } ); // Since both tests use the same Apple ID, they should not be run at the same time
 
 	let code: string;

--- a/test/e2e/specs/authentication/authentication__magic-link.spec.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.spec.ts
@@ -1,7 +1,7 @@
 import { Message } from 'mailosaur/lib/models';
-import { test, expect } from '../../lib/pw-base';
+import { tags, test, expect } from '../../lib/pw-base';
 
-test.describe( 'Authentication: Magic Link', () => {
+test.describe( 'Authentication: Magic Link', { tag: [ tags.AUTHENTICATION ] }, () => {
 	test( 'As a WordPress.com user, I can use a magic link to login to WordPress.com', async ( {
 		clientEmail,
 		page,

--- a/test/e2e/specs/i18n/i18n__editor.spec.ts
+++ b/test/e2e/specs/i18n/i18n__editor.spec.ts
@@ -1,5 +1,5 @@
 import { RestAPIClient } from '@automattic/calypso-e2e';
-import { test, expect } from '../../lib/pw-base';
+import { tags, test, expect } from '../../lib/pw-base';
 import { locale } from '../../lib/types-shared';
 
 const localesToTest: Array< locale > = [
@@ -21,7 +21,7 @@ const localesToTest: Array< locale > = [
 	'zh-cn',
 	'zh-tw',
 ];
-test.describe( 'I18N: Editor', { tag: '@i18n' }, () => {
+test.describe( 'I18N: Editor', { tag: tags.I18N }, () => {
 	test.describe.configure( { mode: 'serial' } ); // Since all tests use the same account which changes its locale, they should not be run in parallel
 	for ( const locale of localesToTest ) {
 		test( `As an i18n visitor using '${ locale }' as my locale I can see localised editor content`, async ( {

--- a/test/e2e/specs/i18n/i18n__logged-out-redirect.spec.ts
+++ b/test/e2e/specs/i18n/i18n__logged-out-redirect.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../lib/pw-base';
+import { tags, test, expect } from '../../lib/pw-base';
 import { locale } from '../../lib/types-shared';
 
 const localesToTest: Array< locale > = [
@@ -22,7 +22,7 @@ const localesToTest: Array< locale > = [
 ];
 
 for ( const locale of localesToTest ) {
-	test.describe( `I18N: Homepage Redirect ${ locale }`, { tag: '@i18n' }, () => {
+	test.describe( `I18N: Homepage Redirect ${ locale }`, { tag: tags.I18N }, () => {
 		// TODO: Try to use `addLocaleToPathLocaleInFront` from `@automattic/i18n-utils` here instead of `helperData.getLocalePath`
 		// need to resolve ESM/CJS interop issues first
 		test.use( { locale: locale } );


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/105466 / DOTCOM-14356

## Proposed Changes

Enhance the TeamCity configuration for Playwright e2e tests by adding test execution and reporting steps.

Updated Playwright configuration with reporters, output paths, and test tags for better organization and CI.

## Testing Instructions

Check the TeamCity builds E2E Tests (Playwright Test)
