### PR TITLE
User profile menu uses DropdownMenu instead of Dropdown

### DIFF
--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
-	Dropdown,
+	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
@@ -66,32 +66,29 @@ function UserProfile() {
 	const openCommandPalette = useOpenCommandPalette();
 
 	return (
-		<Dropdown
+		<DropdownMenu
 			popoverProps={ {
 				placement: 'bottom-end',
 				offset: 8,
 			} }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					className="dashboard-secondary-menu__item"
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					variant="tertiary"
-					label={ __( 'My profile' ) }
-					icon={
-						user.avatar_URL ? (
-							<img
-								className="dashboard-secondary-menu__avatar"
-								src={ user.avatar_URL }
-								alt={ __( 'User avatar' ) }
-							/>
-						) : (
-							commentAuthorAvatar
-						)
-					}
-				/>
-			) }
-			renderContent={ ( { onClose } ) => (
+			label={ __( 'My profile' ) }
+			icon={
+				user.avatar_URL ? (
+					<img
+						className="dashboard-secondary-menu__avatar"
+						src={ user.avatar_URL }
+						alt={ __( 'User avatar' ) }
+					/>
+				) : (
+					commentAuthorAvatar
+				)
+			}
+			toggleProps={ {
+				className: 'dashboard-secondary-menu__item',
+				variant: 'tertiary',
+			} }
+		>
+			{ ( { onClose } ) => (
 				<VStack spacing={ 0 }>
 					<VStack style={ { padding: '16px', borderBottom: '1px solid #ccc' } } spacing={ 1 }>
 						<Text>{ user.display_name }</Text>
@@ -123,7 +120,7 @@ function UserProfile() {
 					</MenuGroup>
 				</VStack>
 			) }
-		/>
+		</DropdownMenu>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

Fixes keyboard navigation for the user profile menu

https://github.com/user-attachments/assets/8d68f289-d750-4ede-ab97-030d91707f67



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're relying on core components to get a11y. But that relies on us using the core components correctly 😃 

`<Dropdown>` is for low level stuff. `<DropdownMenu>` is higher level, uses `<Dropdown>` internally and makes sure all the correct accessibility stuff is done for menus.

E.g., the button now has the correct `aria-haspopup` attribute.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use enter/space/down to open the menu
Use arrow keys to navigate the menu
Escape will close the menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
