### PR TITLE
Hosting Dashboard > Security: Implement Account Recovery for Email

### DIFF
--- a/client/dashboard/app/queries/me-account-recovery.ts
+++ b/client/dashboard/app/queries/me-account-recovery.ts
@@ -1,0 +1,41 @@
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import {
+	fetchAccountRecovery,
+	updateAccountRecoveryEmail,
+	removeAccountRecoveryEmail,
+	resendAccountRecoveryEmailValidation,
+} from '../../data/me-account-recovery';
+import { queryClient } from '../query-client';
+
+export const accountRecoveryQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'account-recovery' ],
+		queryFn: fetchAccountRecovery,
+	} );
+
+export const updateAccountRecoveryEmailMutation = () =>
+	mutationOptions( {
+		mutationFn: updateAccountRecoveryEmail,
+		onSuccess: ( _, email ) => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, email }
+			);
+		},
+	} );
+
+export const removeAccountRecoveryEmailMutation = () =>
+	mutationOptions( {
+		mutationFn: removeAccountRecoveryEmail,
+		onSuccess: () => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, email: '' }
+			);
+		},
+	} );
+
+export const resendAccountRecoveryEmailValidationMutation = () =>
+	mutationOptions( {
+		mutationFn: resendAccountRecoveryEmailValidation,
+	} );

--- a/client/dashboard/data/me-account-recovery.ts
+++ b/client/dashboard/data/me-account-recovery.ts
@@ -1,0 +1,25 @@
+import wpcom from 'calypso/lib/wp';
+
+export interface AccountRecovery {
+	email: string;
+	email_validated: boolean;
+	phone: string;
+	phone_validated: boolean;
+}
+
+export async function fetchAccountRecovery(): Promise< AccountRecovery > {
+	return wpcom.req.get( '/me/account-recovery' );
+}
+
+// Email-related actions
+export async function updateAccountRecoveryEmail( email: string ): Promise< AccountRecovery > {
+	return wpcom.req.post( '/me/account-recovery/email', { email } );
+}
+
+export async function removeAccountRecoveryEmail(): Promise< AccountRecovery > {
+	return wpcom.req.post( '/me/account-recovery/email/delete' );
+}
+
+export async function resendAccountRecoveryEmailValidation(): Promise< AccountRecovery > {
+	return wpcom.req.post( '/me/account-recovery/email/validation/new' );
+}

--- a/client/dashboard/me/security-account-recovery/index.tsx
+++ b/client/dashboard/me/security-account-recovery/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
 import SecurityPageHeader from '../security-page-header';
+import RecoveryEmail from './recovery-email';
 
 export default function SecurityAccountRecovery() {
 	return (
@@ -16,7 +16,7 @@ export default function SecurityAccountRecovery() {
 				/>
 			}
 		>
-			<Text>Content goes here</Text>
+			<RecoveryEmail />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -1,0 +1,220 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalInputControl as InputControl,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+	__experimentalConfirmDialog as ConfirmDialog,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState, useEffect } from 'react';
+import {
+	accountRecoveryQuery,
+	updateAccountRecoveryEmailMutation,
+	removeAccountRecoveryEmailMutation,
+	resendAccountRecoveryEmailValidationMutation,
+} from '../../app/queries/me-account-recovery';
+import { profileQuery } from '../../app/queries/me-profile';
+import Notice from '../../components/notice';
+import { SectionHeader } from '../../components/section-header';
+import type { Field } from '@wordpress/dataviews';
+
+type SecurityEmailFormData = {
+	email: string;
+};
+
+export default function RecoveryEmail() {
+	const [ formData, setFormData ] = useState< SecurityEmailFormData >( {
+		email: '',
+	} );
+	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
+	const [ showResendButton, setShowResendButton ] = useState( true );
+
+	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
+		accountRecoveryQuery()
+	);
+
+	const { mutate: validateEmailMutation, isPending: isValidateEmailPending } = useMutation(
+		updateAccountRecoveryEmailMutation()
+	);
+
+	const { mutate: removeEmailMutation, isPending: isRemoveEmailPending } = useMutation(
+		removeAccountRecoveryEmailMutation()
+	);
+
+	const { mutate: resendValidationMutation, isPending: isResendValidationPending } = useMutation(
+		resendAccountRecoveryEmailValidationMutation()
+	);
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const accountRecoveryEmail = accountRecoveryData?.email;
+
+	useEffect( () => {
+		setFormData( { email: accountRecoveryEmail || '' } );
+	}, [ accountRecoveryEmail ] );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		validateEmailMutation( formData.email, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email was saved successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to save recovery email.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleRemove = () => {
+		setIsRemoveDialogOpen( false );
+		removeEmailMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email was removed successfully.' ), {
+					type: 'snackbar',
+				} );
+				setFormData( { email: '' } );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to remove recovery email.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleResendValidation = () => {
+		setShowResendButton( false );
+		resendValidationMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email validation was resent successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to resend recovery email validation.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const { data: serverData } = useQuery( profileQuery() );
+
+	const shouldShowValidationNotice = accountRecoveryEmail && ! accountRecoveryData?.email_validated;
+
+	const fields: Field< SecurityEmailFormData >[] = useMemo(
+		() => [
+			{
+				id: 'email',
+				label: __( 'Email address' ),
+				description:
+					/* translators: %s: email address */
+					__( 'Your primary email address is %s', serverData?.user_email ),
+				type: 'text' as const,
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					return (
+						<InputControl
+							__next40pxDefaultSize
+							type="email"
+							label={ field.label }
+							placeholder={ field.placeholder }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => {
+								return onChange( { [ id ]: value ?? '' } );
+							} }
+							disabled={ isAccountRecoveryDataLoading || isValidateEmailPending }
+						/>
+					);
+				},
+			},
+		],
+		[ serverData?.user_email, isAccountRecoveryDataLoading, isValidateEmailPending ]
+	);
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader title={ __( 'Recovery email' ) } level={ 3 } />
+						{ shouldShowValidationNotice && (
+							<Spacer marginBottom={ 4 }>
+								<Notice
+									variant="warning"
+									title={ __( 'Please validate your email address' ) }
+									actions={
+										showResendButton && (
+											<Button
+												variant="link"
+												onClick={ handleResendValidation }
+												disabled={ isResendValidationPending }
+											>
+												{ __( 'Resend validation email' ) }
+											</Button>
+										)
+									}
+								>
+									{ __(
+										"We've sent you an email with a validation link to click. Check spam or junk folders if you're unable to find it."
+									) }
+								</Notice>
+							</Spacer>
+						) }
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 4 }>
+								<DataForm< SecurityEmailFormData >
+									data={ formData }
+									fields={ fields }
+									form={ { layout: { type: 'regular' as const }, fields } }
+									onChange={ ( edits: Partial< SecurityEmailFormData > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack spacing={ 3 } justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isValidateEmailPending }
+										disabled={ isValidateEmailPending || ! formData.email }
+									>
+										{ __( 'Validate' ) }
+									</Button>
+									{ accountRecoveryEmail && (
+										<Button
+											variant="tertiary"
+											onClick={ () => setIsRemoveDialogOpen( true ) }
+											isBusy={ isRemoveEmailPending }
+											disabled={ isRemoveEmailPending }
+										>
+											{ __( 'Remove email' ) }
+										</Button>
+									) }
+								</HStack>
+							</VStack>
+						</form>
+					</VStack>
+				</CardBody>
+			</Card>
+			<ConfirmDialog
+				isOpen={ isRemoveDialogOpen }
+				confirmButtonText={ __( 'Remove email' ) }
+				onCancel={ () => setIsRemoveDialogOpen( false ) }
+				onConfirm={ handleRemove }
+			>
+				{ __( 'Are you sure you want to remove this email?' ) }
+			</ConfirmDialog>
+		</>
+	);
+}


### PR DESCRIPTION
# [Update: Notice some changes were merged and there are conflicts, created a new [PR](https://github.com/Automattic/wp-calypso/pull/105504)] 

Resolves https://linear.app/a8c/issue/DOTDASH-171/implement-account-security-recovery-email-to-the-hosting-dashboard

## Proposed Changes

This PR implements the account recovery feature for email on the "Security" section in the Hosting Dashboard.

## Why are these changes being made?

* To allow users to use the email account recovery in the Hosting Dashboard.

## Testing Instructions

* Open the Calypso Live link
* Append the URL with `/v2/me/security`
* Click the "Account recovery" section 
* Verify that the screen below is displayed when there is no email set

<img width="1919" height="626" alt="Screenshot 2025-09-02 at 3 33 40 PM" src="https://github.com/user-attachments/assets/57a9d43e-d725-470c-90e7-5318e7f8b923" />

* Enter a secondary email ID > Click the "Validate" button > Verify the email is saved and screen updates to:

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 06 PM" src="https://github.com/user-attachments/assets/114288f2-119c-4a8d-8f51-571b105f2620" />

* Verify the "Resend validation email" button works as expected, and the button is hidden until you refresh or leave the page and come back.

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 24 PM" src="https://github.com/user-attachments/assets/9f8754a3-d259-40b8-b692-5c17605afe74" />

* Validate the email > Verify the notice is hidden

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 52 51 PM" src="https://github.com/user-attachments/assets/5b977b53-a858-45f6-95bc-a44aa69b71dc" />

* Click the "Remove email" button and verify a confirm dialog is shown and the email is removed once you confirm

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 14 PM" src="https://github.com/user-attachments/assets/ed5bcef7-dca6-4ee1-9f0f-8036994ee9d8" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
