### PR TITLE
Hosting Dashboard > Security: Implement Account Recovery for Email

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -5,6 +5,7 @@ import {
 	purchaseQuery,
 	sitesQuery,
 	queryClient,
+	accountRecoveryQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { rootRoute } from './root';
@@ -161,6 +162,7 @@ export const securityPasswordRoute = createRoute( {
 export const securityAccountRecoveryRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'security/account-recovery',
+	loader: () => queryClient.ensureQueryData( accountRecoveryQuery() ),
 } ).lazy( () =>
 	import( '../../me/security-account-recovery' ).then( ( d ) =>
 		createLazyRoute( 'security-account-recovery' )( {

--- a/client/dashboard/me/security-account-recovery/index.tsx
+++ b/client/dashboard/me/security-account-recovery/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
 import SecurityPageHeader from '../security-page-header';
+import RecoveryEmail from './recovery-email';
 
 export default function SecurityAccountRecovery() {
 	return (
@@ -16,7 +16,7 @@ export default function SecurityAccountRecovery() {
 				/>
 			}
 		>
-			<Text>Content goes here</Text>
+			<RecoveryEmail />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -1,0 +1,224 @@
+import {
+	profileQuery,
+	accountRecoveryQuery,
+	updateAccountRecoveryEmailMutation,
+	removeAccountRecoveryEmailMutation,
+	resendAccountRecoveryEmailValidationMutation,
+} from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalInputControl as InputControl,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+	__experimentalConfirmDialog as ConfirmDialog,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState, useEffect } from 'react';
+import Notice from '../../components/notice';
+import { SectionHeader } from '../../components/section-header';
+import type { Field } from '@wordpress/dataviews';
+
+type SecurityEmailFormData = {
+	email: string;
+};
+
+export default function RecoveryEmail() {
+	const [ formData, setFormData ] = useState< SecurityEmailFormData >( {
+		email: '',
+	} );
+	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
+	const [ showResendButton, setShowResendButton ] = useState( true );
+
+	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
+		accountRecoveryQuery()
+	);
+
+	const { mutate: validateEmailMutation, isPending: isValidateEmailPending } = useMutation(
+		updateAccountRecoveryEmailMutation()
+	);
+
+	const { mutate: removeEmailMutation, isPending: isRemoveEmailPending } = useMutation(
+		removeAccountRecoveryEmailMutation()
+	);
+
+	const { mutate: resendValidationMutation, isPending: isResendValidationPending } = useMutation(
+		resendAccountRecoveryEmailValidationMutation()
+	);
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const accountRecoveryEmail = accountRecoveryData?.email;
+
+	useEffect( () => {
+		setFormData( { email: accountRecoveryEmail || '' } );
+	}, [ accountRecoveryEmail ] );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		validateEmailMutation( formData.email, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email was saved successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to save recovery email.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleRemove = () => {
+		setIsRemoveDialogOpen( false );
+		removeEmailMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email was removed successfully.' ), {
+					type: 'snackbar',
+				} );
+				setFormData( { email: '' } );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to remove recovery email.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleResendValidation = () => {
+		setShowResendButton( false );
+		resendValidationMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery email validation was resent successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to resend recovery email validation.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const { data: serverData } = useQuery( profileQuery() );
+
+	const shouldShowValidationNotice = accountRecoveryEmail && ! accountRecoveryData?.email_validated;
+
+	const fields: Field< SecurityEmailFormData >[] = useMemo(
+		() => [
+			{
+				id: 'email',
+				label: __( 'Email address' ),
+				description:
+					/* translators: %s: email address */
+					__( 'Your primary email address is %s', serverData?.user_email ),
+				type: 'text' as const,
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					return (
+						<InputControl
+							__next40pxDefaultSize
+							type="email"
+							label={ field.label }
+							placeholder={ field.placeholder }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => {
+								return onChange( { [ id ]: value ?? '' } );
+							} }
+							disabled={ isAccountRecoveryDataLoading || isValidateEmailPending }
+						/>
+					);
+				},
+			},
+		],
+		[ serverData?.user_email, isAccountRecoveryDataLoading, isValidateEmailPending ]
+	);
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader title={ __( 'Recovery email' ) } level={ 3 } />
+						{ shouldShowValidationNotice && (
+							<Spacer marginBottom={ 4 }>
+								<Notice
+									variant="warning"
+									title={ __( 'Please validate your email address' ) }
+									actions={
+										showResendButton && (
+											<Button
+												variant="link"
+												onClick={ handleResendValidation }
+												disabled={ isResendValidationPending }
+											>
+												{ __( 'Resend validation email' ) }
+											</Button>
+										)
+									}
+								>
+									{ __(
+										"We've sent you an email with a validation link to click. Check spam or junk folders if you're unable to find it."
+									) }
+								</Notice>
+							</Spacer>
+						) }
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 4 }>
+								<DataForm< SecurityEmailFormData >
+									data={ formData }
+									fields={ fields }
+									form={ { layout: { type: 'regular' as const }, fields } }
+									onChange={ ( edits: Partial< SecurityEmailFormData > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack spacing={ 3 } justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isValidateEmailPending }
+										disabled={
+											isValidateEmailPending ||
+											! formData.email ||
+											accountRecoveryEmail === formData.email
+										}
+									>
+										{ __( 'Validate' ) }
+									</Button>
+									{ accountRecoveryEmail && (
+										<Button
+											variant="tertiary"
+											onClick={ () => setIsRemoveDialogOpen( true ) }
+											isBusy={ isRemoveEmailPending }
+											disabled={ isRemoveEmailPending }
+										>
+											{ __( 'Remove email' ) }
+										</Button>
+									) }
+								</HStack>
+							</VStack>
+						</form>
+					</VStack>
+				</CardBody>
+			</Card>
+			<ConfirmDialog
+				isOpen={ isRemoveDialogOpen }
+				confirmButtonText={ __( 'Remove email' ) }
+				onCancel={ () => setIsRemoveDialogOpen( false ) }
+				onConfirm={ handleRemove }
+			>
+				{ __( 'Are you sure you want to remove this email?' ) }
+			</ConfirmDialog>
+		</>
+	);
+}

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -1,5 +1,5 @@
 import {
-	profileQuery,
+	userSettingsQuery,
 	accountRecoveryQuery,
 	updateAccountRecoveryEmailMutation,
 	removeAccountRecoveryEmailMutation,
@@ -30,7 +30,7 @@ type SecurityEmailFormData = {
 
 export default function RecoveryEmail() {
 	const { data: accountRecoveryData } = useSuspenseQuery( accountRecoveryQuery() );
-	const { data: serverData } = useQuery( profileQuery() );
+	const { data: serverData } = useQuery( userSettingsQuery() );
 
 	const { mutate: validateEmail, isPending: isValidateEmailPending } = useMutation(
 		updateAccountRecoveryEmailMutation()

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -29,9 +29,7 @@ type SecurityEmailFormData = {
 };
 
 export default function RecoveryEmail() {
-	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useSuspenseQuery(
-		accountRecoveryQuery()
-	);
+	const { data: accountRecoveryData } = useSuspenseQuery( accountRecoveryQuery() );
 	const { data: serverData } = useQuery( profileQuery() );
 
 	const { mutate: validateEmail, isPending: isValidateEmailPending } = useMutation(
@@ -46,7 +44,7 @@ export default function RecoveryEmail() {
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const accountRecoveryEmail = accountRecoveryData?.email;
+	const accountRecoveryEmail = accountRecoveryData.email;
 
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 	const [ showResendButton, setShowResendButton ] = useState( true );
@@ -103,7 +101,7 @@ export default function RecoveryEmail() {
 		} );
 	};
 
-	const shouldShowValidationNotice = accountRecoveryEmail && ! accountRecoveryData?.email_validated;
+	const shouldShowValidationNotice = accountRecoveryEmail && ! accountRecoveryData.email_validated;
 
 	const fields: Field< SecurityEmailFormData >[] = useMemo(
 		() => [
@@ -127,13 +125,13 @@ export default function RecoveryEmail() {
 							onChange={ ( value ) => {
 								return onChange( { [ id ]: value ?? '' } );
 							} }
-							disabled={ isAccountRecoveryDataLoading || isValidateEmailPending }
+							disabled={ isValidateEmailPending }
 						/>
 					);
 				},
 			},
 		],
-		[ serverData?.user_email, isAccountRecoveryDataLoading, isValidateEmailPending ]
+		[ serverData?.user_email, isValidateEmailPending ]
 	);
 
 	return (

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -121,7 +121,7 @@ export default function RecoveryEmail() {
 				description:
 					/* translators: %s: email address */
 					__( 'Your primary email address is %s', serverData?.user_email ),
-				type: 'text' as const,
+				type: 'email',
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;
 					return (

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -5,12 +5,10 @@ import {
 	removeAccountRecoveryEmailMutation,
 	resendAccountRecoveryEmailValidationMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 	Card,
@@ -18,9 +16,10 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
 import type { Field } from '@wordpress/dataviews';
@@ -30,25 +29,18 @@ type SecurityEmailFormData = {
 };
 
 export default function RecoveryEmail() {
-	const [ formData, setFormData ] = useState< SecurityEmailFormData >( {
-		email: '',
-	} );
-	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
-	const [ showResendButton, setShowResendButton ] = useState( true );
-
-	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
+	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useSuspenseQuery(
 		accountRecoveryQuery()
 	);
+	const { data: serverData } = useQuery( profileQuery() );
 
-	const { mutate: validateEmailMutation, isPending: isValidateEmailPending } = useMutation(
+	const { mutate: validateEmail, isPending: isValidateEmailPending } = useMutation(
 		updateAccountRecoveryEmailMutation()
 	);
-
-	const { mutate: removeEmailMutation, isPending: isRemoveEmailPending } = useMutation(
+	const { mutate: removeEmail, isPending: isRemoveEmailPending } = useMutation(
 		removeAccountRecoveryEmailMutation()
 	);
-
-	const { mutate: resendValidationMutation, isPending: isResendValidationPending } = useMutation(
+	const { mutate: resendValidation, isPending: isResendValidationPending } = useMutation(
 		resendAccountRecoveryEmailValidationMutation()
 	);
 
@@ -56,13 +48,15 @@ export default function RecoveryEmail() {
 
 	const accountRecoveryEmail = accountRecoveryData?.email;
 
-	useEffect( () => {
-		setFormData( { email: accountRecoveryEmail || '' } );
-	}, [ accountRecoveryEmail ] );
+	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
+	const [ showResendButton, setShowResendButton ] = useState( true );
+	const [ formData, setFormData ] = useState< SecurityEmailFormData >( {
+		email: accountRecoveryEmail || '',
+	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		validateEmailMutation( formData.email, {
+		validateEmail( formData.email, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery email was saved successfully.' ), {
 					type: 'snackbar',
@@ -78,7 +72,7 @@ export default function RecoveryEmail() {
 
 	const handleRemove = () => {
 		setIsRemoveDialogOpen( false );
-		removeEmailMutation( undefined, {
+		removeEmail( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery email was removed successfully.' ), {
 					type: 'snackbar',
@@ -95,7 +89,7 @@ export default function RecoveryEmail() {
 
 	const handleResendValidation = () => {
 		setShowResendButton( false );
-		resendValidationMutation( undefined, {
+		resendValidation( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery email validation was resent successfully.' ), {
 					type: 'snackbar',
@@ -109,8 +103,6 @@ export default function RecoveryEmail() {
 		} );
 	};
 
-	const { data: serverData } = useQuery( profileQuery() );
-
 	const shouldShowValidationNotice = accountRecoveryEmail && ! accountRecoveryData?.email_validated;
 
 	const fields: Field< SecurityEmailFormData >[] = useMemo(
@@ -120,7 +112,7 @@ export default function RecoveryEmail() {
 				label: __( 'Email address' ),
 				description:
 					/* translators: %s: email address */
-					__( 'Your primary email address is %s', serverData?.user_email ),
+					sprintf( __( 'Your primary email address is %s' ), serverData?.user_email ),
 				type: 'email',
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;
@@ -129,6 +121,7 @@ export default function RecoveryEmail() {
 							__next40pxDefaultSize
 							type="email"
 							label={ field.label }
+							help={ field.description }
 							placeholder={ field.placeholder }
 							value={ getValue( { item: data } ) }
 							onChange={ ( value ) => {
@@ -150,27 +143,25 @@ export default function RecoveryEmail() {
 					<VStack spacing={ 4 }>
 						<SectionHeader title={ __( 'Recovery email' ) } level={ 3 } />
 						{ shouldShowValidationNotice && (
-							<Spacer marginBottom={ 4 }>
-								<Notice
-									variant="warning"
-									title={ __( 'Please validate your email address' ) }
-									actions={
-										showResendButton && (
-											<Button
-												variant="link"
-												onClick={ handleResendValidation }
-												disabled={ isResendValidationPending }
-											>
-												{ __( 'Resend validation email' ) }
-											</Button>
-										)
-									}
-								>
-									{ __(
-										"We've sent you an email with a validation link to click. Check spam or junk folders if you're unable to find it."
-									) }
-								</Notice>
-							</Spacer>
+							<Notice
+								variant="warning"
+								title={ __( 'Please validate your email address' ) }
+								actions={
+									showResendButton && (
+										<Button
+											variant="link"
+											onClick={ handleResendValidation }
+											disabled={ isResendValidationPending }
+										>
+											{ __( 'Resend validation email' ) }
+										</Button>
+									)
+								}
+							>
+								{ __(
+									'We’ve sent you an email with a validation link to click. Check spam or junk folders if you’re unable to find it.'
+								) }
+							</Notice>
 						) }
 						<form onSubmit={ handleSubmit }>
 							<VStack spacing={ 4 }>
@@ -182,7 +173,7 @@ export default function RecoveryEmail() {
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack spacing={ 3 } justify="flex-start">
+								<ButtonStack justify="flex-start">
 									<Button
 										variant="primary"
 										type="submit"
@@ -205,7 +196,7 @@ export default function RecoveryEmail() {
 											{ __( 'Remove email' ) }
 										</Button>
 									) }
-								</HStack>
+								</ButtonStack>
 							</VStack>
 						</form>
 					</VStack>

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -20,6 +20,7 @@ export * from './emails';
 export * from './geo';
 export * from './me';
 export * from './me-account';
+export * from './me-account-recovery';
 export * from './me-blocked-sites';
 export * from './me-dpa';
 export * from './me-payment-methods';

--- a/packages/api-core/src/me-account-recovery/fetchers.ts
+++ b/packages/api-core/src/me-account-recovery/fetchers.ts
@@ -1,0 +1,6 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AccountRecovery } from './types';
+
+export async function fetchAccountRecovery(): Promise< AccountRecovery > {
+	return wpcom.req.get( '/me/account-recovery' );
+}

--- a/packages/api-core/src/me-account-recovery/index.tsx
+++ b/packages/api-core/src/me-account-recovery/index.tsx
@@ -1,0 +1,3 @@
+export * from './fetchers';
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/me-account-recovery/mutators.ts
+++ b/packages/api-core/src/me-account-recovery/mutators.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AccountRecovery, AccountRecoverySuccess } from './types';
+
+// Email-related actions
+export async function updateAccountRecoveryEmail( email: string ): Promise< AccountRecovery > {
+	return wpcom.req.post( '/me/account-recovery/email', { email } );
+}
+
+export async function removeAccountRecoveryEmail(): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/email/delete' );
+}
+
+export async function resendAccountRecoveryEmailValidation(): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/email/validation/new' );
+}

--- a/packages/api-core/src/me-account-recovery/mutators.ts
+++ b/packages/api-core/src/me-account-recovery/mutators.ts
@@ -1,7 +1,6 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { AccountRecovery, AccountRecoverySuccess } from './types';
 
-// Email-related actions
 export async function updateAccountRecoveryEmail( email: string ): Promise< AccountRecovery > {
 	return wpcom.req.post( '/me/account-recovery/email', { email } );
 }

--- a/packages/api-core/src/me-account-recovery/types.ts
+++ b/packages/api-core/src/me-account-recovery/types.ts
@@ -1,0 +1,10 @@
+export interface AccountRecovery {
+	email: string;
+	email_validated: boolean;
+	phone: string;
+	phone_validated: boolean;
+}
+
+export interface AccountRecoverySuccess {
+	success: true;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -16,6 +16,7 @@ export * from './emails';
 export * from './geo';
 export * from './me-a8c';
 export * from './me-account';
+export * from './me-account-recovery';
 export * from './me-blocked-sites';
 export * from './me-dpa';
 export * from './me-payment-methods';

--- a/packages/api-queries/src/me-account-recovery.ts
+++ b/packages/api-queries/src/me-account-recovery.ts
@@ -1,0 +1,41 @@
+import {
+	fetchAccountRecovery,
+	updateAccountRecoveryEmail,
+	removeAccountRecoveryEmail,
+	resendAccountRecoveryEmailValidation,
+} from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+
+export const accountRecoveryQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'account-recovery' ],
+		queryFn: fetchAccountRecovery,
+	} );
+
+export const updateAccountRecoveryEmailMutation = () =>
+	mutationOptions( {
+		mutationFn: updateAccountRecoveryEmail,
+		onSuccess: ( _, email ) => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, email }
+			);
+		},
+	} );
+
+export const removeAccountRecoveryEmailMutation = () =>
+	mutationOptions( {
+		mutationFn: removeAccountRecoveryEmail,
+		onSuccess: () => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, email: '' }
+			);
+		},
+	} );
+
+export const resendAccountRecoveryEmailValidationMutation = () =>
+	mutationOptions( {
+		mutationFn: resendAccountRecoveryEmailValidation,
+	} );

--- a/packages/api-queries/src/me-account-recovery.ts
+++ b/packages/api-queries/src/me-account-recovery.ts
@@ -19,7 +19,7 @@ export const updateAccountRecoveryEmailMutation = () =>
 		onSuccess: ( _, email ) => {
 			queryClient.setQueryData(
 				accountRecoveryQuery().queryKey,
-				( oldData ) => oldData && { ...oldData, email }
+				( oldData ) => oldData && { ...oldData, email, email_validated: false }
 			);
 		},
 	} );
@@ -30,7 +30,7 @@ export const removeAccountRecoveryEmailMutation = () =>
 		onSuccess: () => {
 			queryClient.setQueryData(
 				accountRecoveryQuery().queryKey,
-				( oldData ) => oldData && { ...oldData, email: '' }
+				( oldData ) => oldData && { ...oldData, email: '', email_validated: false }
 			);
 		},
 	} );


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/DOTDASH-171/implement-account-security-recovery-email-to-the-hosting-dashboard

## Proposed Changes

This PR implements the account recovery feature for email on the "Security" section in the Hosting Dashboard.

## Why are these changes being made?

* To allow users to use the email account recovery in the Hosting Dashboard.

## Testing Instructions

* Open the Calypso Live link
* Append the URL with `/v2/me/security`
* Click the "Account recovery" section 
* Verify that the screen below is displayed when there is no email set

<img width="1920" height="651" alt="Screenshot 2025-09-09 at 8 08 56 AM" src="https://github.com/user-attachments/assets/1451934b-4e10-4f07-951d-783d6578d990" />

* Enter a secondary email ID > Click the "Validate" button > Verify the email is saved and screen updates to:

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 06 PM" src="https://github.com/user-attachments/assets/114288f2-119c-4a8d-8f51-571b105f2620" />

* Verify the "Resend validation email" button works as expected, and the button is hidden until you refresh or leave the page and come back.

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 24 PM" src="https://github.com/user-attachments/assets/9f8754a3-d259-40b8-b692-5c17605afe74" />

* Validate the email > Verify the notice is hidden

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 52 51 PM" src="https://github.com/user-attachments/assets/5b977b53-a858-45f6-95bc-a44aa69b71dc" />

* Click the "Remove email" button and verify that a confirmation dialog is shown and the email is removed once you confirm

<img width="1919" height="717" alt="Screenshot 2025-09-02 at 3 35 14 PM" src="https://github.com/user-attachments/assets/ed5bcef7-dca6-4ee1-9f0f-8036994ee9d8" />

<img width="462" height="86" alt="Screenshot 2025-09-03 at 3 14 41 PM" src="https://github.com/user-attachments/assets/9515c4b7-5116-4c5a-a7de-cf330b37cc32" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
