### PR TITLE
A4A: Add download commissions report option

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -121,7 +121,6 @@ export default function SitesWithWooPayments() {
 				await downloadCommissionsReport( selectedSite.blogId );
 				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_download_commissions_report' ) );
 			} catch ( error ) {
-				setDownloadModal( ( prev ) => ( { ...prev, isLoading: false } ) );
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_woopayments_download_commissions_report_error' )
 				);

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -120,9 +120,13 @@ export default function SitesWithWooPayments() {
 			try {
 				await downloadCommissionsReport( selectedSite.blogId );
 				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_download_commissions_report' ) );
-				setDownloadModal( { isVisible: false, isLoading: false } );
 			} catch ( error ) {
 				setDownloadModal( ( prev ) => ( { ...prev, isLoading: false } ) );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_woopayments_download_commissions_report_error' )
+				);
+			} finally {
+				setDownloadModal( { isVisible: false, isLoading: false } );
 			}
 		},
 		[ downloadCommissionsReport, dispatch ]

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -1,8 +1,9 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { Button, Modal, Spinner } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { external } from '@wordpress/icons';
+import { Icon, external, download, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -10,6 +11,7 @@ import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholde
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useWooPaymentsContext } from '../context';
+import { useDownloadCommissionsReport } from '../hooks/use-download-commissions-report';
 import { getSiteData } from '../lib/site-data';
 import SitesWithWooPaymentsMobileView from './mobile-view';
 import {
@@ -28,8 +30,19 @@ export default function SitesWithWooPayments() {
 		isLoadingWooPaymentsData,
 	} = useWooPaymentsContext();
 	const dispatch = useDispatch();
+	const { downloadCommissionsReport } = useDownloadCommissionsReport();
 
 	const isDesktop = useDesktopBreakpoint();
+
+	const [ downloadModal, setDownloadModal ] = useState< {
+		isVisible: boolean;
+		isLoading: boolean;
+		siteId?: number;
+		siteUrl?: string;
+	} >( {
+		isVisible: false,
+		isLoading: false,
+	} );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -94,11 +107,36 @@ export default function SitesWithWooPayments() {
 		return filterSortAndPaginate( items, dataViewsState, fields );
 	}, [ items, dataViewsState, fields ] );
 
+	const handleDownloadCommissionsReport = useCallback(
+		async ( selectedItems: SitesWithWooPaymentsState[] ) => {
+			const selectedSite = selectedItems[ 0 ];
+			setDownloadModal( {
+				isVisible: true,
+				isLoading: true,
+				siteId: selectedSite.blogId,
+				siteUrl: selectedSite.siteUrl,
+			} );
+
+			try {
+				await downloadCommissionsReport( selectedSite.blogId );
+				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_download_commissions_report' ) );
+				setDownloadModal( { isVisible: false, isLoading: false } );
+			} catch ( error ) {
+				setDownloadModal( ( prev ) => ( { ...prev, isLoading: false } ) );
+			}
+		},
+		[ downloadCommissionsReport, dispatch ]
+	);
+
+	const handleCancelDownload = useCallback( () => {
+		setDownloadModal( { isVisible: false, isLoading: false } );
+	}, [] );
+
 	const actions = useMemo(
 		() => [
 			{
 				id: 'visit-wp-admin',
-				label: translate( 'Visit WP-Admin' ),
+				label: translate( 'Visit WP Admin' ),
 				icon: external,
 				callback( items: SitesWithWooPaymentsState[] ) {
 					const isInstalled = items[ 0 ].state === 'active';
@@ -113,29 +151,68 @@ export default function SitesWithWooPayments() {
 					return item.state !== 'disconnected';
 				},
 			},
+			{
+				id: 'download-commissions-report',
+				label: translate( 'Download commissions report' ),
+				icon: download,
+				callback: handleDownloadCommissionsReport,
+				isEligible( item: SitesWithWooPaymentsState ) {
+					return item.state === 'active';
+				},
+			},
 		],
-		[ translate, dispatch ]
+		[ translate, dispatch, handleDownloadCommissionsReport ]
 	);
 
-	if ( ! isDesktop ) {
-		return <SitesWithWooPaymentsMobileView items={ items } actions={ actions } />;
-	}
-
 	return (
-		<div className="redesigned-a8c-table full-width">
-			<ItemsDataViews
-				data={ {
-					items: data,
-					getItemId: ( item: SitesWithWooPaymentsState ) => `${ item.blogId }`,
-					pagination: paginationInfo,
-					enableSearch: false,
-					fields,
-					actions,
-					setDataViewsState,
-					dataViewsState,
-					defaultLayouts: { table: {} },
-				} }
-			/>
-		</div>
+		<>
+			{ ! isDesktop ? (
+				<SitesWithWooPaymentsMobileView items={ items } actions={ actions } />
+			) : (
+				<div className="redesigned-a8c-table full-width">
+					<ItemsDataViews
+						data={ {
+							items: data,
+							getItemId: ( item: SitesWithWooPaymentsState ) => `${ item.blogId }`,
+							pagination: paginationInfo,
+							enableSearch: false,
+							fields,
+							actions,
+							setDataViewsState,
+							dataViewsState,
+							defaultLayouts: { table: {} },
+						} }
+					/>
+				</div>
+			) }
+
+			{ downloadModal.isVisible && (
+				<Modal
+					className="download-commissions-modal"
+					onRequestClose={ handleCancelDownload }
+					__experimentalHideHeader
+				>
+					<Button
+						className="download-commissions-modal__close-button"
+						onClick={ handleCancelDownload }
+						aria-label={ translate( 'Close' ) }
+					>
+						<Icon size={ 24 } icon={ close } />
+					</Button>
+					<h1 className="download-commissions-modal__title">
+						{ translate( 'Generating commissions report' ) }
+					</h1>
+
+					<div className="download-commissions-modal__instruction">
+						<Spinner />
+						<div className="download-commissions-modal__instruction-text">
+							{ translate( 'Your report is being prepared.' ) }
+							<br />
+							{ translate( 'The download will begin automatically.' ) }
+						</div>
+					</div>
+				</Modal>
+			) }
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -30,3 +30,58 @@
 	}
 }
 
+.download-commissions-modal {
+	@include break-medium {
+		min-width: 400px;
+	}
+
+	@include break-large {
+		min-width: 512px;
+	}
+
+	.download-commissions-modal__title {
+		@include heading-x-large;
+		margin: 0 0 20px;
+		padding: 0;
+	}
+
+	.download-commissions-modal__instruction {
+		@include body-medium;
+		margin: 0;
+		color: var(--color-accent-60);
+		display: flex;
+		align-items: center;
+		gap: 16px;
+	}
+
+	.download-commissions-modal__instruction-text {
+		flex: 1;
+		line-height: 1.4;
+	}
+
+	.download-commissions-modal__close-button {
+		position: absolute;
+		inset-inline-end: 1rem;
+		inset-block-start: 1rem;
+		cursor: pointer;
+		transition: scale 0.2s ease-in;
+		max-height: 24px;
+
+		&:hover {
+			scale: 1.2;
+		}
+
+		&:focus-visible {
+			border-color: var(--color-primary);
+			outline: none;
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			border-radius: 4px;
+		}
+	}
+
+	.components-spinner {
+		width: 24px;
+		height: 24px;
+		margin: 0;
+	}
+}

--- a/client/a8c-for-agencies/sections/woopayments/hooks/use-download-commissions-report.ts
+++ b/client/a8c-for-agencies/sections/woopayments/hooks/use-download-commissions-report.ts
@@ -1,0 +1,52 @@
+import debugFactory from 'debug';
+import { useCallback } from 'react';
+import { addQueryArgs } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+const debug = debugFactory( 'calypso:a4a:use-download-commissions-report' );
+
+export function useDownloadCommissionsReport() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const downloadCommissionsReport = useCallback(
+		async ( siteId: number ): Promise< void > => {
+			try {
+				const response = await wpcom.req.get( {
+					apiNamespace: 'wpcom/v2',
+					path: addQueryArgs(
+						{ format: 'csv' },
+						`/agency/${ agencyId }/woocommerce/woopayments/${ siteId }`
+					),
+				} );
+
+				// CSV content is in response.data as a string
+				const csvContent = response.data as string;
+
+				// Convert string to Blob with CSV MIME type
+				const blob = new Blob( [ csvContent ], { type: 'text/csv;charset=utf-8;' } );
+
+				// Create download link
+				const url = window.URL.createObjectURL( blob );
+				const link = document.createElement( 'a' );
+				link.href = url;
+				link.download = response.filename as string;
+
+				// Trigger download
+				document.body.appendChild( link );
+				link.click();
+				document.body.removeChild( link );
+
+				// Clean up
+				window.URL.revokeObjectURL( url );
+			} catch ( error ) {
+				debug( 'Failed to download commissions report:', error );
+				throw error;
+			}
+		},
+		[ agencyId ]
+	);
+
+	return { downloadCommissionsReport };
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1498/frontend-download-commissions-report-as-csv

## Proposed Changes

* Add an option to download a commissions report for a site
* Commissions report is generated and made available as a CSV for the user

<img width="228" height="101" alt="Screenshot 2025-09-02 at 13 03 44" src="https://github.com/user-attachments/assets/dbf44c25-4382-4e3c-b868-272b193bece5" />

![Untitled](https://github.com/user-attachments/assets/b063b91b-6083-474c-aa4d-703e59470899)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This will give the agency owner a more detailed breakdown of all the commissions they are eligible for

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to your sandbox if it hasn’t been merged yet: 191695-ghe-Automattic/wpcom
* Follow the instructions in that PR (even if merged, follow the instructions in that PR to get test data)
* Open the live link and go to **WooPayments > Dashboard**
* On any active WooPayments site, click **Download commissions report** from the 3-dot menu
* Confirm a modal appears
* Confirm the download starts automatically
* Open the CSV and verify the formatting and data are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?