### PR TITLE
Sync: Increase left padding on Sync button

### DIFF
--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.scss
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.scss
@@ -7,7 +7,7 @@
 
 		&.has-icon.has-text {
 			padding-right: 8px;
-			padding-left: 8px;
+			padding-left: 12px;
 			gap: 0;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14367

## Proposed Changes

* Increase left padding on the Sync button so it has the same space on both sides

|Before | After|
|-------|------|
| <img width="526" height="202" alt="CleanShot 2025-09-02 at 14 17 46@2x" src="https://github.com/user-attachments/assets/23db4857-e594-44e6-8638-28f49ed3ebfc" />|<img width="526" height="202" alt="CleanShot 2025-09-02 at 14 17 36@2x" src="https://github.com/user-attachments/assets/fb0c5d02-b60f-47a9-9c0a-56b91af5ed90" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There is some misalignment 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes and start Calypso locally or use the Calypso Live link below
* Open a site that has a Staging site, or create a Staging site on a site
* Open the `/sites/:siteSlug` and check the Sync button has the same space on the right and on the left


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
