### PR TITLE
Domain Search Rewrite: Add /setup/domain flow and link to it within Hosting Dashboard

### DIFF
--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,4 +1,5 @@
 import { domainsQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -38,7 +39,11 @@ function Domains() {
 				<PageHeader
 					title={ __( 'Domains' ) }
 					actions={
-						<Button variant="primary" __next40pxDefaultSize href="/start/domain">
+						<Button
+							variant="primary"
+							__next40pxDefaultSize
+							href={ isEnabled( 'domain-search-rewrite' ) ? '/setup/domain' : '/start/domain' }
+						>
 							{ __( 'Add New Domain' ) }
 						</Button>
 					}

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,8 +1,10 @@
 import { siteDomainsQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { siteRoute } from '../../app/router/sites';
@@ -45,7 +47,15 @@ function SiteDomains() {
 				<PageHeader
 					title={ __( 'Domains' ) }
 					actions={
-						<Button href={ `/domains/add/${ site.slug }` } variant="primary" __next40pxDefaultSize>
+						<Button
+							href={
+								isEnabled( 'domain-search-rewrite' )
+									? addQueryArgs( '/setup/domain', { siteSlug: site.slug } )
+									: `/domains/add/${ site.slug }`
+							}
+							variant="primary"
+							__next40pxDefaultSize
+						>
 							{ __( 'Add New Domain' ) }
 						</Button>
 					}

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -1,0 +1,161 @@
+import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
+import { DOMAIN_FLOW, clearStepPersistedState } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { useState, useEffect } from 'react';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
+import {
+	clearSignupCompleteSlug,
+	clearSignupCompleteFlowName,
+	clearSignupDestinationCookie,
+	clearSignupCompleteSiteID,
+} from 'calypso/signup/storageUtils';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
+import { ONBOARD_STORE } from '../../../stores';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
+import { STEPS } from '../../internals/steps';
+import { type FlowV2, type SubmitHandler } from '../../internals/types';
+import type { DomainSuggestion } from '@automattic/api-core';
+
+const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
+	const isDomainsStep = currentStepSlug === 'domains';
+	const isPlansStepWithQuery =
+		currentStepSlug === 'plans' && getQueryArg( window.location.href, 'step' );
+
+	if ( isDomainsStep || isPlansStepWithQuery ) {
+		const { pathname, search } = window.location;
+		const newURL = removeQueryArgs( pathname + search, 'step', 'initialQuery', 'lastQuery' );
+		window.history.replaceState( {}, document.title, newURL );
+	}
+};
+
+function initialize() {
+	const steps = [ STEPS.DOMAIN_SEARCH, STEPS.USE_MY_DOMAIN ];
+
+	return stepsWithRequiredLogin( steps );
+}
+
+/**
+ * Domain purchase flow for existing sites (siteSlug query parameter) or domain-only purchases.
+ *
+ * TODO: Redirect to checkout, and migrate site-or-domain step from Start.
+ */
+const domain: FlowV2< typeof initialize > = {
+	name: DOMAIN_FLOW,
+	isSignupFlow: false,
+	__experimentalUseBuiltinAuth: true,
+	initialize,
+	useStepNavigation( currentStepSlug, navigate ) {
+		const { setDomain, setDomainCartItem, setDomainCartItems, setSiteUrl, setSignupDomainOrigin } =
+			useDispatch( ONBOARD_STORE ) as OnboardActions;
+
+		const { signupDomainOrigin } = useSelect(
+			( select ) => ( {
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+			} ),
+			[]
+		);
+
+		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
+
+		clearUseMyDomainsQueryParams( currentStepSlug );
+
+		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
+			const { slug, providedDependencies } = submittedStep;
+			switch ( slug ) {
+				case 'domains':
+					if ( ! providedDependencies ) {
+						throw new Error( 'No provided dependencies found' );
+					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = ( providedDependencies?.domainForm as { lastQuery?: string } )
+							?.lastQuery;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						setUseMyDomainTracksEventProps( {
+							site_url: providedDependencies.siteUrl,
+							signup_domain_origin: signupDomainOrigin,
+							domain_item: providedDependencies.domainItem,
+						} );
+						return navigate( useMyDomainURL as typeof currentStepSlug );
+					}
+
+					return;
+				case 'use-my-domain':
+					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+					if ( providedDependencies?.mode && providedDependencies?.domain ) {
+						setUseMyDomainTracksEventProps( {
+							...useMyDomainTracksEventProps,
+							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
+							site_url: providedDependencies.domain,
+						} );
+						const destination = addQueryArgs( '/use-my-domain', {
+							...getQueryArgs( window.location.href ),
+							step: providedDependencies.mode,
+							initialQuery: providedDependencies.domain,
+						} );
+						return navigate( destination as typeof currentStepSlug );
+					}
+
+					// We trigger the event here, because we skip it in the domains step if
+					// the user chose use-my-domain
+					recordStepNavigation( {
+						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+						flow: this.name,
+						intent: '',
+						step: 'domains',
+						providedDependencies: useMyDomainTracksEventProps,
+					} );
+
+					return;
+				default:
+					return;
+			}
+		};
+
+		return { submit };
+	},
+	useSideEffect( currentStepSlug ) {
+		const reduxDispatch = useReduxDispatch();
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		/**
+		 * Clears every state we're persisting during the flow
+		 * when entering it. This is to ensure that the user
+		 * starts on a clean slate.
+		 */
+		useEffect( () => {
+			if ( ! currentStepSlug ) {
+				resetOnboardStore();
+				reduxDispatch( setSelectedSiteId( null ) );
+				clearStepPersistedState( this.name );
+				clearSignupDestinationCookie();
+				clearSignupCompleteFlowName();
+				clearSignupCompleteSlug();
+				clearSignupCompleteSiteID();
+			}
+		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+	},
+};
+
+export default domain;

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -5,6 +5,7 @@ import {
 	NEW_HOSTED_SITE_FLOW,
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	DOMAIN_FLOW,
 } from '@automattic/onboarding';
 
 const FLOWS_USING_STEP_CONTAINER_V2 = [
@@ -14,6 +15,7 @@ const FLOWS_USING_STEP_CONTAINER_V2 = [
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	SITE_MIGRATION_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	DOMAIN_FLOW,
 ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import {
 	START_WRITING_FLOW,
 	CONNECT_DOMAIN_FLOW,
+	DOMAIN_FLOW,
 	NEW_HOSTED_SITE_FLOW,
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	DOMAIN_TRANSFER,
@@ -39,6 +40,8 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 		import(
 			/* webpackChunkName: "onboarding-unified-flow" */ './flows/onboarding-unified/onboarding-unified'
 		),
+
+	[ DOMAIN_FLOW ]: () => import( /* webpackChunkName: "domain-flow" */ './flows/domain/domain' ),
 };
 
 /**

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -4,6 +4,7 @@ export const HOSTING_LP_FLOW = 'hosting-start';
 export const NEW_HOSTED_SITE_FLOW = 'new-hosted-site';
 export const TRANSFERRING_HOSTED_SITE_FLOW = 'transferring-hosted-site';
 export const CONNECT_DOMAIN_FLOW = 'connect-domain';
+export const DOMAIN_FLOW = 'domain';
 export const ENTREPRENEUR_FLOW = 'entrepreneur';
 export const FREE_FLOW = 'free';
 export const SITE_MIGRATION_FLOW = 'site-migration';


### PR DESCRIPTION
Closes DOMAINS-1604. Closes DOMAINS-1614. 

## Proposed Changes

As discussed on Slack, let's add a new Stepper flow that will be responsible for adding domains to the cart and sending the user to checkout, even on existing sites. This flow will later replace `/start/domain` and also accept a `siteSlug` parameter.

For now, it doesn't do much. Sending the user to checkout, as well as the whole domain purchase logic, will be added later.

## Testing Instructions

Enable the `domain-search-rewrite` feature flag and verify you can enter the `/setup/domain` flow from `/v2/domains` and `/v2/sites/%s/domains`.
