### PR TITLE
Notifications v2: bring last notification in view when going back to note list

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
+import getSelectedNoteId from '../../panel/state/selectors/get-selected-note-id';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
 import { getFields } from './dataviews';
@@ -29,6 +30,8 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 			( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
 		)
 	);
+
+	const selectedNoteId = useSelector( getSelectedNoteId );
 
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const { client } = useAppContext();
@@ -88,6 +91,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 			}
 			getItemId={ ( item ) => item.id.toString() }
 			onChangeView={ setView }
+			selection={ selectedNoteId ? [ selectedNoteId ] : undefined }
 			onChangeSelection={ onChangeSelection }
 		>
 			<>

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -11,8 +11,10 @@ import {
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
+import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
@@ -73,6 +75,14 @@ const Note = () => {
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
+
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( noteId ) {
+			dispatch( actions.ui.selectNote( noteId ) );
+		}
+	}, [ noteId, dispatch ] );
 
 	if ( ! note ) {
 		return null;


### PR DESCRIPTION
Good enough for DOTCOM-14362.

## Proposed Changes

This PR restores the last seen notification in the popover viewport when we go back to the notification list.

It works by actually "selecting" the row in the DataViews. Using its default mechanism, it will bring the currently selected row in view. It's also nice because it will show that in the "selected" state which is highlighted.

Note that the actual scrollY might not be accurately restored, but I think it's sufficient solution for now. Also, I will need this logic (row selection) anyway for implementing the keyboard shortcuts later 😄 

### Before


https://github.com/user-attachments/assets/b416757d-93ae-463b-a096-5137f43aac45

### After


https://github.com/user-attachments/assets/3aff92b9-500c-449a-943d-d8b6dcdbf044

## Testing Instructions

1. Go to /v2
2. Open notifications
3. Scroll down
4. Click a notification
5. Click the back button
6. Verify you can see the previous notification without scrolling

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?