### PR TITLE
StepContainerV2: Check for setup/domain manually to avoid Start flow clash

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -5,7 +5,6 @@ import {
 	NEW_HOSTED_SITE_FLOW,
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
-	DOMAIN_FLOW,
 } from '@automattic/onboarding';
 
 const FLOWS_USING_STEP_CONTAINER_V2 = [
@@ -15,7 +14,6 @@ const FLOWS_USING_STEP_CONTAINER_V2 = [
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	SITE_MIGRATION_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
-	DOMAIN_FLOW,
 ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -1,4 +1,4 @@
-import { Step, StepContainer } from '@automattic/onboarding';
+import { DOMAIN_FLOW, Step, StepContainer } from '@automattic/onboarding';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
@@ -9,7 +9,7 @@ const DomainSearchStep: StepType = function DomainSearchStep( { flow } ) {
 		return <WPCOMDomainSearch />;
 	};
 
-	if ( shouldUseStepContainerV2( flow ) ) {
+	if ( shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW ) {
 		return (
 			<Step.CenteredColumnLayout
 				topBar={ <Step.TopBar /> }


### PR DESCRIPTION
Part of DOMAINS-1604.

## Proposed Changes

In that issue, we added a new Stepper flow called `domain` which uses the domain step. However, there's also a Start flow called `domain` that uses the old Start wrapper. Because of the clash, we were rendering both wrappers:

<img width="1470" height="481" alt="image" src="https://github.com/user-attachments/assets/1f93de60-5824-401e-9c34-64f82ac85271" />


## Testing Instructions

Enter `/start/domain` and verify you don't see both wrappers anymore.