### PR TITLE
Hosting Dashboard: Monitoring header

### DIFF
--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -133,7 +133,6 @@ function SiteMonitoring() {
 								__nextHasNoMarginBottom
 								__next40pxDefaultSize
 								onChange={ handleTimeRangeChange }
-								className={ clsx( 'site-monitoring-header-range' ) }
 								label={ __( 'Time period' ) }
 								hideLabelFromVision
 							>

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -106,8 +106,12 @@ function SiteMonitoring() {
 		return;
 	}
 
-	const handleTimeRangeChange = ( value: string ) => {
-		setTimeRange( value );
+	const handleTimeRangeChange = ( value: string | number | undefined ) => {
+		if ( ! value ) {
+			return;
+		}
+
+		setTimeRange( value.toString() );
 	};
 
 	return (
@@ -117,7 +121,7 @@ function SiteMonitoring() {
 					<HStack
 						justify="space-between"
 						alignment="stretch"
-						wrap="wrap"
+						wrap
 						spacing={ isSmallViewport ? 5 : 10 }
 						className={ clsx( 'site-monitoring-header' ) }
 					>

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -126,25 +126,23 @@ function SiteMonitoring() {
 						spacing={ isSmallViewport ? 5 : 10 }
 						className={ clsx( 'site-monitoring-header' ) }
 					>
-						<PageHeader
-							title={ __( 'Monitoring' ) }
-							actions={
-								<ToggleGroupControl
-									value={ timeRange }
-									isBlock
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-									onChange={ handleTimeRangeChange }
-									label={ __( 'Time period' ) }
-									hideLabelFromVision
-								>
-									<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
-									<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
-									<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
-									<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
-								</ToggleGroupControl>
-							}
-						/>
+						<PageHeader title={ __( 'Monitoring' ) } />
+						<div>
+							<ToggleGroupControl
+								value={ timeRange }
+								isBlock
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								onChange={ handleTimeRangeChange }
+								label={ __( 'Time period' ) }
+								hideLabelFromVision
+							>
+								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
+								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
+								<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
+								<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
+							</ToggleGroupControl>
+						</div>
 					</HStack>
 				</>
 			}

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -134,6 +134,8 @@ function SiteMonitoring() {
 								__next40pxDefaultSize
 								onChange={ handleTimeRangeChange }
 								className={ clsx( 'site-monitoring-header-range' ) }
+								label={ __( 'Time period' ) }
+								hideLabelFromVision
 							>
 								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
 								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -1,9 +1,18 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
+import clsx from 'clsx';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
@@ -12,6 +21,7 @@ import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { hasHostingFeature } from '../../utils/site-features';
 import illustrationUrl from './monitoring-callout-illustration.svg';
+import './style.scss';
 
 export function SiteMonitoringCallout( {
 	siteSlug,
@@ -50,20 +60,92 @@ export function SiteMonitoringCallout( {
 	);
 }
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+function SiteMonitoringBody( { site, timeRange }: { site: object; timeRange: string } ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+
+	return (
+		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+			Main Content ({ timeRange }).
+		</VStack>
+	);
+}
+
+const hoursMap: Record< string, number > = {
+	'6-hours': 6,
+	'24-hours': 24,
+	'3-days': 72,
+	'7-days': 168,
+};
+
+const getDateRange = ( range: string ) => {
+	const now = new Date();
+
+	const hours = hoursMap[ range ] || 24;
+	const start = new Date( now.getTime() - hours * 60 * 60 * 1000 );
+
+	const formatDate = ( date: Date ) => {
+		return date.toLocaleDateString( 'en-US', {
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric',
+		} );
+	};
+
+	return `${ formatDate( start ) }–${ formatDate( now ) }`;
+};
+
 function SiteMonitoring() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const [ timeRange, setTimeRange ] = useState( '24-hours' );
 
 	if ( ! site ) {
 		return;
 	}
 
+	const handleTimeRangeChange = ( value: string ) => {
+		setTimeRange( value );
+	};
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Monitoring' ) } /> }>
+		<PageLayout
+			header={
+				<>
+					<HStack
+						justify="space-between"
+						alignment="stretch"
+						wrap="wrap"
+						spacing={ isSmallViewport ? 5 : 10 }
+						className={ clsx( 'site-monitoring-header' ) }
+					>
+						<PageHeader title={ __( 'Monitoring' ) } />
+						<div>
+							<ToggleGroupControl
+								value={ timeRange }
+								isBlock
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								onChange={ handleTimeRangeChange }
+								className={ clsx( 'site-monitoring-header-range' ) }
+							>
+								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
+								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
+								<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
+								<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
+							</ToggleGroupControl>
+						</div>
+					</HStack>
+					<Text className={ clsx( 'site-monitoring-dates' ) }>{ getDateRange( timeRange ) }</Text>
+				</>
+			}
+		>
 			<CalloutOverlay
 				showCallout={ ! hasHostingFeature( site, HostingFeatures.MONITOR ) }
 				callout={ <SiteMonitoringCallout siteSlug={ site.slug } /> }
-				main={ null }
+				main={ <SiteMonitoringBody timeRange={ timeRange } site={ site } /> }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -66,7 +66,7 @@ function SiteMonitoringBody( { site, timeRange }: { site: object; timeRange: str
 
 	return (
 		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
-			Main Content ({ timeRange }).
+			<div>Main Content ({ timeRange }).</div>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -60,17 +60,6 @@ export function SiteMonitoringCallout( {
 	);
 }
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-function SiteMonitoringBody( { site, timeRange }: { site: object; timeRange: string } ) {
-	const isSmallViewport = useViewportMatch( 'medium', '<' );
-
-	return (
-		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
-			<div>Main Content ({ timeRange }).</div>
-		</VStack>
-	);
-}
-
 const hoursMap: Record< string, number > = {
 	'6-hours': 6,
 	'24-hours': 24,
@@ -94,6 +83,18 @@ const getDateRange = ( range: string ) => {
 
 	return `${ formatDate( start ) }–${ formatDate( now ) }`;
 };
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+function SiteMonitoringBody( { site, timeRange }: { site: object; timeRange: string } ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+
+	return (
+		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+			<Text className={ clsx( 'site-monitoring-dates' ) }>{ getDateRange( timeRange ) }</Text>
+			<div>Main Content ({ timeRange }).</div>
+		</VStack>
+	);
+}
 
 function SiteMonitoring() {
 	const { siteSlug } = siteRoute.useParams();
@@ -143,7 +144,6 @@ function SiteMonitoring() {
 							</ToggleGroupControl>
 						</div>
 					</HStack>
-					<Text className={ clsx( 'site-monitoring-dates' ) }>{ getDateRange( timeRange ) }</Text>
 				</>
 			}
 		>

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -126,23 +126,25 @@ function SiteMonitoring() {
 						spacing={ isSmallViewport ? 5 : 10 }
 						className={ clsx( 'site-monitoring-header' ) }
 					>
-						<PageHeader title={ __( 'Monitoring' ) } />
-						<div>
-							<ToggleGroupControl
-								value={ timeRange }
-								isBlock
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								onChange={ handleTimeRangeChange }
-								label={ __( 'Time period' ) }
-								hideLabelFromVision
-							>
-								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
-								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
-								<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
-								<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
-							</ToggleGroupControl>
-						</div>
+						<PageHeader
+							title={ __( 'Monitoring' ) }
+							actions={
+								<ToggleGroupControl
+									value={ timeRange }
+									isBlock
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									onChange={ handleTimeRangeChange }
+									label={ __( 'Time period' ) }
+									hideLabelFromVision
+								>
+									<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
+									<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
+									<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
+									<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
+								</ToggleGroupControl>
+							}
+						/>
 					</HStack>
 				</>
 			}

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -1,6 +1,14 @@
 @import '@wordpress/base-styles/variables';
 
 .dashboard-page-layout {
+	.site-monitoring-header .dashboard-section-header {
+		width: 100%;
+
+		.dashboard-section-header__heading-row > .components-flex {
+			flex-wrap: wrap;
+		}
+	}
+
 	.site-monitoring-dates {
 		color: var(--Scales-Grays-gray-700, #757575);
 	}

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -48,6 +48,10 @@
 					font-weight: 600;
 				}
 			}
+
+			.components-toggle-group-control-option-base {
+				z-index: 1;
+			}
 		}
 	}
 

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -10,49 +10,6 @@
 				justify-content: flex-end;
 			}
 		}
-
-		.site-monitoring-header-range {
-			width: 281px;
-			height: 40px;
-			text-wrap: nowrap;
-
-			&, &:focus, &:hover {
-				border-radius: var(--radius-s, 2px);
-				border: var(--Input-Default, 1px) solid var(--Scales-Grays-gray-200, #E0E0E0);
-				box-shadow: none;
-			}
-
-			background: var(--scales-black-white-white, #FFF);
-			padding: 0;
-
-			&::before {
-				border: 1px solid var(--Scales-Grays-gray-600, #949494);
-				background: #FCFCFC;
-			}
-
-			& > div {
-				text-align: center;
-				padding: 0 12px;
-				flex-basis: content;
-
-				button div {
-					font-size: var(--m, 13px);
-					font-style: normal;
-					font-weight: var(--Regular, 400);
-					line-height: var(--s, 20px); /* 153.846% */
-					color: var(--Scales-Grays-gray-700, #757575);
-				}
-
-				button[aria-checked="true"] div {
-					color: var(--Scales-Grays-gray-900, #1E1E1E);
-					font-weight: 600;
-				}
-			}
-
-			.components-toggle-group-control-option-base {
-				z-index: 1;
-			}
-		}
 	}
 
 	.site-monitoring-dates {

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -1,14 +1,6 @@
 @import '@wordpress/base-styles/variables';
 
 .dashboard-page-layout {
-	.site-monitoring-header .dashboard-section-header {
-		width: 100%;
-
-		.dashboard-section-header__heading-row > .components-flex {
-			flex-wrap: wrap;
-		}
-	}
-
 	.site-monitoring-dates {
 		color: var(--Scales-Grays-gray-700, #757575);
 	}

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -1,24 +1,7 @@
 @import '@wordpress/base-styles/variables';
 
 .dashboard-page-layout {
-	.site-monitoring-header {
-		& > * {
-			flex-grow: 1;
-
-			&:last-child {
-				display: flex;
-				justify-content: flex-end;
-			}
-		}
-	}
-
 	.site-monitoring-dates {
 		color: var(--Scales-Grays-gray-700, #757575);
-
-		/* Body MD */
-		font-size: var(--m, 13px);
-		font-style: normal;
-		font-weight: var(--Regular, 400);
-		line-height: var(--s, 20px); /* 153.846% */
 	}
 }

--- a/client/dashboard/sites/monitoring/style.scss
+++ b/client/dashboard/sites/monitoring/style.scss
@@ -1,0 +1,63 @@
+@import '@wordpress/base-styles/variables';
+
+.dashboard-page-layout {
+	.site-monitoring-header {
+		& > * {
+			flex-grow: 1;
+
+			&:last-child {
+				display: flex;
+				justify-content: flex-end;
+			}
+		}
+
+		.site-monitoring-header-range {
+			width: 281px;
+			height: 40px;
+			text-wrap: nowrap;
+
+			&, &:focus, &:hover {
+				border-radius: var(--radius-s, 2px);
+				border: var(--Input-Default, 1px) solid var(--Scales-Grays-gray-200, #E0E0E0);
+				box-shadow: none;
+			}
+
+			background: var(--scales-black-white-white, #FFF);
+			padding: 0;
+
+			&::before {
+				border: 1px solid var(--Scales-Grays-gray-600, #949494);
+				background: #FCFCFC;
+			}
+
+			& > div {
+				text-align: center;
+				padding: 0 12px;
+				flex-basis: content;
+
+				button div {
+					font-size: var(--m, 13px);
+					font-style: normal;
+					font-weight: var(--Regular, 400);
+					line-height: var(--s, 20px); /* 153.846% */
+					color: var(--Scales-Grays-gray-700, #757575);
+				}
+
+				button[aria-checked="true"] div {
+					color: var(--Scales-Grays-gray-900, #1E1E1E);
+					font-weight: 600;
+				}
+			}
+		}
+	}
+
+	.site-monitoring-dates {
+		color: var(--Scales-Grays-gray-700, #757575);
+
+		/* Body MD */
+		font-size: var(--m, 13px);
+		font-style: normal;
+		font-weight: var(--Regular, 400);
+		line-height: var(--s, 20px); /* 153.846% */
+	}
+}


### PR DESCRIPTION
## Proposed Changes
The first PR for the Hosting Dashboard "Monitoring" page:
* Header.
* Time period switcher.

Extracted from the main PR: https://github.com/Automattic/wp-calypso/pull/105293

## Why are these changes being made?
https://linear.app/a8c/issue/DOTDASH-156

## Testing Instructions
1. Load the page `/v2/sites/your-site-slug/monitoring` for a site that doesn't have a plan that supports Monitoring. Confirm you see the "Upgrade plan" modal.
2. Get a required plan (Business or Commerce), and get back to the page.
3. Confirm the design looks right on different screen sizes.
4. Click on the time period buttons, confirm the dates and the main content placeholder reflect the changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
