### PR TITLE
Hosting Dashboard: Implement action button and event tracking

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
@@ -2,6 +2,7 @@ import { Button, Card, CardBody, SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Text } from '../../components/text';
 
@@ -34,6 +35,7 @@ interface DataCenterFormProps {
 }
 
 export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
+	const { recordTracksEvent } = useAnalytics();
 	const [ shouldShowForm, setShouldShowForm ] = useState( false );
 
 	if ( ! shouldShowForm ) {
@@ -44,7 +46,17 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 						'Your site will be placed in the optimal data center, but you can <button>change it</button>.'
 					),
 					{
-						button: <Button variant="link" onClick={ () => setShouldShowForm( true ) } />,
+						button: (
+							<Button
+								variant="link"
+								onClick={ () => {
+									setShouldShowForm( true );
+									recordTracksEvent(
+										'calypso_dashboard_hosting_feature_activation_modal_data_center_form_show'
+									);
+								} }
+							/>
+						),
 					}
 				) }
 			</Text>
@@ -75,7 +87,13 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 						label: option.label,
 						value: option.value,
 					} ) ) }
-					onChange={ ( value ) => onChange( value ) }
+					onChange={ ( value ) => {
+						onChange( value );
+						recordTracksEvent(
+							'calypso_dashboard_hosting_feature_activation_modal_data_center_form_change',
+							{ value }
+						);
+					} }
 					value={ value }
 				/>
 			</CardBody>

--- a/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
@@ -1,19 +1,30 @@
 import { siteAutomatedTransfersEligibilityQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
+import { ButtonStack } from '../../components/button-stack';
+import ComponentViewTracker from '../../components/component-view-tracker';
 import { Notice } from '../../components/notice';
 import { DataCenterForm } from './data-center-form';
-import { hasBlockingError as getHasBlockingError, ErrorContentInfo } from './error-content-info';
+import {
+	hasAnyBlockingError as getHasAnyBlockingError,
+	hasHoldingError as getHasHoldingError,
+	EligibilityErrors,
+	ErrorContentInfo,
+} from './error-content-info';
 import { WarningContentInfo } from './warning-content-info';
 
-export default function HostingFeatureActivationModal( { siteId }: { siteId: number } ) {
+export default function HostingFeatureActivationModal( {
+	siteId,
+	onProceed,
+}: {
+	siteId: number;
+	onProceed: ( options: { geo_affinity?: string } ) => void;
+} ) {
+	const { recordTracksEvent } = useAnalytics();
 	const { data } = useSuspenseQuery( siteAutomatedTransfersEligibilityQuery( siteId ) );
 	const { setShowHelpCenter } = useHelpCenter();
 	const [ selectedGeoAffinity, setSelectedGeoAffinity ] = useState( '' );
@@ -24,40 +35,63 @@ export default function HostingFeatureActivationModal( { siteId }: { siteId: num
 
 	const errors = data.errors;
 	const warnings = data.warnings;
-	const flattenedWarnings = Object.values( data.warnings ).flat();
-	const hasBlockingError = getHasBlockingError( errors );
-	const isEligibleAndNoIssues =
-		data.is_eligible && errors.length === 0 && flattenedWarnings.length === 0;
+	const isEligible = data.is_eligible;
+	const needsPlanUpgrade = getHasHoldingError( errors, EligibilityErrors.NO_BUSINESS_PLAN );
+	const hasAnyBlockingError = getHasAnyBlockingError( errors );
 
 	function getContent() {
-		if ( isEligibleAndNoIssues ) {
+		const flattenedWarnings = Object.values( warnings ).flat();
+		if ( isEligible && errors.length === 0 && flattenedWarnings.length === 0 ) {
 			return <Notice variant="success">{ __( 'This site is eligible to continue.' ) }</Notice>;
 		}
 
 		return (
 			<>
 				{ errors.length > 0 && <ErrorContentInfo errors={ errors } /> }
-				{ flattenedWarnings.length > 0 && ! hasBlockingError && (
+				{ flattenedWarnings.length > 0 && ! hasAnyBlockingError && (
 					<WarningContentInfo warnings={ warnings } />
 				) }
 			</>
 		);
 	}
 
+	function handleClick() {
+		onProceed( { geo_affinity: selectedGeoAffinity } );
+	}
+
 	return (
-		<VStack spacing={ 6 }>
-			{ getContent() }
-			{ data.is_eligible && ! hasBlockingError && (
-				<DataCenterForm
-					value={ selectedGeoAffinity }
-					onChange={ ( value ) => setSelectedGeoAffinity( value ) }
-				/>
-			) }
-			<HStack>
-				<Button variant="link" onClick={ () => setShowHelpCenter( true ) }>
-					{ __( 'Need help?' ) }
-				</Button>
-			</HStack>
-		</VStack>
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_hosting_feature_activation_modal_impression" />
+			<VStack spacing={ 6 }>
+				{ getContent() }
+				{ isEligible && ! hasAnyBlockingError && (
+					<DataCenterForm
+						value={ selectedGeoAffinity }
+						onChange={ ( value ) => setSelectedGeoAffinity( value ) }
+					/>
+				) }
+				<ButtonStack justify="space-between">
+					<Button
+						variant="link"
+						onClick={ () => {
+							setShowHelpCenter( true );
+							recordTracksEvent(
+								'calypso_dashboard_hosting_feature_activation_modal_help_center_click'
+							);
+						} }
+					>
+						{ __( 'Need help?' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						disabled={ ! isEligible && ! needsPlanUpgrade }
+						onClick={ handleClick }
+					>
+						{ needsPlanUpgrade ? __( 'Upgrade and continue' ) : __( 'Activate hosting features' ) }
+					</Button>
+				</ButtonStack>
+			</VStack>
+		</>
 	);
 }

--- a/client/dashboard/sites/hosting-feature-gate/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/activation.tsx
@@ -65,7 +65,7 @@ export default function HostingFeatureActivation( {
 						onRequestClose={ () => setIsModalOpen( false ) }
 						size="medium"
 					>
-						<HostingFeatureActivationModal siteId={ site.ID } />
+						<HostingFeatureActivationModal siteId={ site.ID } onProceed={ handleConfirm } />
 					</Modal>
 				</Suspense>
 			) }


### PR DESCRIPTION
Ref DOTDASH-72

## Proposed Changes

This PR implements the action button, also event tracking.

| Event name | Description |
| --- | --- |
| calypso_dashboard_hosting_feature_activation_modal_data_center_form_show | Clicks the button that displays the data center picker |
| calypso_dashboard_hosting_feature_activation_modal_data_center_form_change | Selects a data center option |
| calypso_dashboard_hosting_feature_activation_modal_blocking_error_impression | Records blocking errors |
| calypso_dashboard_hosting_feature_activation_modal_holding_error_impression | Records holding errors |
| calypso_dashboard_hosting_feature_activation_modal_impression | Records activation modal impression |
| calypso_dashboard_hosting_feature_activation_modal_help_center_click | Clicks on the "Need help?" button |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a Business site and ensure that the atomic transfer works as intended
* Also ensure that event tracking works as intended 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
