### PR TITLE
Notifications v2: Improve the note preview

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -1,0 +1,7 @@
+@import '@wordpress/base-styles/colors';
+
+.wpnc__note-list  .dataviews-view-list {
+	.dataviews-view-list__item-actions {
+		align-self: flex-start;
+	}
+}

--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -1,6 +1,36 @@
 @import '@wordpress/base-styles/colors';
 
-.wpnc__note-list  .dataviews-view-list {
+.wpnc__note-list .dataviews-view-list {
+	// When displaying fields in the DataViews, using the --wp-admin-theme-color color on hover is overwhelming.
+	// We override the hover color with the text color.
+	div[role="article"] {
+		.dataviews-view-list__item-wrapper {
+			.dataviews-view-list__fields {
+				color: $gray-700;
+			}
+		}
+	}
+
+	// We override styles with the selected styles for unread items.
+	div[role="article"]:has(.is-unread),
+	div[role="article"]:has(.is-unread):focus-within {
+		& + & {
+			border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+		}
+
+		.dataviews-view-list__item-wrapper {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		}
+	}
+
+	// We override hover styles for unread items.
+	div[role="article"]:where(.is-hovered):has(.is-unread),
+	div[role="article"]:where(.is-hovered):has(.is-unread):focus-within {
+		.dataviews-view-list__item-wrapper {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+		}
+	}
+
 	.dataviews-view-list__item-actions {
 		align-self: flex-start;
 	}

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -106,7 +106,7 @@ export function getActions( {
 		{
 			id: 'view',
 			isPrimary: true,
-			icon: <Icon icon={ isRTL() ? chevronLeft : chevronRight } />,
+			icon: <Icon icon={ isRTL() ? chevronLeft : chevronRight } style={ { color: '#757575' } } />,
 			label: __( 'View' ),
 			callback: ( items: Note[] ) => {
 				onSelect( items.map( ( item ) => item.id.toString() ) );

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,10 +1,13 @@
-import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { html } from '../../panel/indices-to-html';
 import noticon2gridicon from '../../panel/utils/noticon2gridicon';
 import Gridicon from '../templates/gridicons';
 import NoteIcon from '../templates/note-icon';
 import type { Note } from '../types';
-import type { Field } from '@wordpress/dataviews';
+import type { Action, Field } from '@wordpress/dataviews';
+import './dataviews-overrides.scss';
 
 const DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
 
@@ -50,7 +53,6 @@ export function getFields(): Field< Note >[] {
 				<div className="wpnc__text-summary">
 					<div
 						className="wpnc__subject"
-						style={ { whiteSpace: 'pre-wrap' } }
 						/* eslint-disable-next-line react/no-danger */
 						dangerouslySetInnerHTML={ { __html: field.getValue( { item } ) } }
 					/>
@@ -95,6 +97,24 @@ export function getFields(): Field< Note >[] {
 				}
 
 				return <div className="wpnc__excerpt">{ excerpt }</div>;
+			},
+		},
+	];
+}
+
+export function getActions( {
+	onSelect,
+}: {
+	onSelect: ( selection: string[] ) => void;
+} ): Action< Note >[] {
+	return [
+		{
+			id: 'view',
+			isPrimary: true,
+			icon: <Icon icon={ isRTL() ? chevronLeft : chevronRight } />,
+			label: __( 'View' ),
+			callback: ( items: Note[] ) => {
+				onSelect( items.map( ( item ) => item.id.toString() ) );
 			},
 		},
 	];

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -86,19 +86,6 @@ export function getFields(): Field< Note >[] {
 				return <div>{ groupTitles[ groupKey ] }</div>;
 			},
 		},
-		{
-			id: 'content',
-			label: __( 'Content' ),
-			getValue: ( { item } ) => ( item.subject.length > 1 ? item.subject[ 1 ].text : '' ),
-			render: ( { field, item } ) => {
-				const excerpt = field.getValue( { item } );
-				if ( ! excerpt ) {
-					return null;
-				}
-
-				return <div className="wpnc__excerpt">{ excerpt }</div>;
-			},
-		},
 	];
 }
 

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@wordpress/components';
+import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { html } from '../../panel/indices-to-html';
@@ -18,6 +18,27 @@ const groupTitles = [
 	__( 'Older than a week' ),
 	__( 'Older than a month' ),
 ];
+
+const RelativeDate = ( { timestamp }: { timestamp: string } ) => {
+	const now = new Date().setHours( 0, 0, 0, 0 );
+	const timeBoundaries = [
+		Infinity,
+		now,
+		new Date( now - DAY_MILLISECONDS ),
+		new Date( now - DAY_MILLISECONDS * 6 ),
+		new Date( now - DAY_MILLISECONDS * 30 ),
+		-Infinity,
+	];
+
+	const timeGroups = timeBoundaries
+		.slice( 0, -1 )
+		.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
+
+	const time = new Date( timestamp );
+	const groupKey = timeGroups.findIndex( ( [ after, before ] ) => before < time && time <= after );
+
+	return <span>{ groupTitles[ groupKey ] }</span>;
+};
 
 export function getFields(): Field< Note >[] {
 	return [
@@ -60,30 +81,16 @@ export function getFields(): Field< Note >[] {
 			),
 		},
 		{
-			id: 'date',
-			label: __( 'Date' ),
-			getValue: ( { item } ) => item.timestamp,
+			id: 'info',
+			label: __( 'Info' ),
 			render: ( { item } ) => {
-				const now = new Date().setHours( 0, 0, 0, 0 );
-				const timeBoundaries = [
-					Infinity,
-					now,
-					new Date( now - DAY_MILLISECONDS ),
-					new Date( now - DAY_MILLISECONDS * 6 ),
-					new Date( now - DAY_MILLISECONDS * 30 ),
-					-Infinity,
-				];
-
-				const timeGroups = timeBoundaries
-					.slice( 0, -1 )
-					.map( ( val, index ) => [ val, timeBoundaries[ index + 1 ] ] );
-
-				const time = new Date( item.timestamp );
-				const groupKey = timeGroups.findIndex(
-					( [ after, before ] ) => before < time && time <= after
+				return (
+					<HStack spacing={ 1 }>
+						<RelativeDate timestamp={ item.timestamp } />
+						<span>•</span>
+						<span>{ item.title }</span>
+					</HStack>
 				);
-
-				return <div>{ groupTitles[ groupKey ] }</div>;
 			},
 		},
 	];

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,6 +1,7 @@
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
+import clsx from 'clsx';
 import { html } from '../../panel/indices-to-html';
 import noticon2gridicon from '../../panel/utils/noticon2gridicon';
 import Gridicon from '../templates/gridicons';
@@ -71,7 +72,7 @@ export function getFields(): Field< Note >[] {
 					links: false,
 				} ),
 			render: ( { field, item } ) => (
-				<div className="wpnc__text-summary">
+				<div className={ clsx( 'wpnc__note-list-item', { 'is-unread': ! item.read } ) }>
 					<div
 						className="wpnc__subject"
 						/* eslint-disable-next-line react/no-danger */

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -64,10 +64,10 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	}, [ client, isLoading ] );
 
 	useEffect( () => {
-		if ( filterName !== 'all' && notes.length < 10 && ! isLoading ) {
+		if ( notes.length < 10 && ! isLoading ) {
 			infiniteScrollHandler();
 		}
-	}, [ filterName, notes.length, isLoading, infiniteScrollHandler ] );
+	}, [ notes.length, isLoading, infiniteScrollHandler ] );
 
 	return (
 		<div className="wpnc__note-list">

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -44,7 +44,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 		type: 'list',
 		titleField: 'title',
 		mediaField: 'icon',
-		fields: [ 'date' ],
+		fields: [ 'info' ],
 		page: 1,
 		infiniteScrollEnabled: true,
 	} );

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -12,7 +12,7 @@ import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
-import { getFields } from './dataviews';
+import { getFields, getActions } from './dataviews';
 import type { Note } from '../types';
 import type { View } from '@wordpress/dataviews';
 
@@ -33,6 +33,13 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const { client } = useAppContext();
 
+	const onChangeSelection = ( selection: string[] ) => {
+		const noteId = selection[ 0 ];
+		goTo( `/${ filterName }/notes/${ noteId }`, {
+			focusTargetSelector: `.dataviews-view-list__item[id$="-${ noteId }-item-wrapper"]`,
+		} );
+	};
+
 	const [ initialView, setView ] = useState< View >( {
 		type: 'list',
 		titleField: 'title',
@@ -46,14 +53,9 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 
 	const fields = getFields();
 
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
+	const actions = getActions( { onSelect: onChangeSelection } );
 
-	const onChangeSelection = ( selection: string[] ) => {
-		const noteId = selection[ 0 ];
-		goTo( `/${ filterName }/notes/${ noteId }`, {
-			focusTargetSelector: `.dataviews-view-list__item[id$="-${ noteId }-item-wrapper"]`,
-		} );
-	};
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
 
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
@@ -68,32 +70,33 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	}, [ filterName, notes.length, isLoading, infiniteScrollHandler ] );
 
 	return (
-		<DataViews< Note >
-			data={ filteredData }
-			fields={ fields }
-			view={ view }
-			isLoading={ isLoading }
-			defaultLayouts={ { table: {} } }
-			paginationInfo={ {
-				...paginationInfo,
-				infiniteScrollHandler,
-			} }
-			empty={
-				<VStack alignment="center">
-					<Text size={ 15 } weight={ 500 }>
-						{ filter.emptyMessage }
-					</Text>
-					<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
-				</VStack>
-			}
-			getItemId={ ( item ) => item.id.toString() }
-			onChangeView={ setView }
-			onChangeSelection={ onChangeSelection }
-		>
-			<>
+		<div className="wpnc__note-list">
+			<DataViews< Note >
+				data={ filteredData }
+				fields={ fields }
+				actions={ actions }
+				view={ view }
+				isLoading={ isLoading }
+				defaultLayouts={ { table: {} } }
+				paginationInfo={ {
+					...paginationInfo,
+					infiniteScrollHandler,
+				} }
+				empty={
+					<VStack alignment="center">
+						<Text size={ 15 } weight={ 500 }>
+							{ filter.emptyMessage }
+						</Text>
+						<ExternalLink href={ filter.emptyLink }>{ filter.emptyLinkMessage }</ExternalLink>
+					</VStack>
+				}
+				getItemId={ ( item ) => item.id.toString() }
+				onChangeView={ setView }
+				onChangeSelection={ onChangeSelection }
+			>
 				<DataViews.Layout />
-			</>
-		</DataViews>
+			</DataViews>
+		</div>
 	);
 };
 

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -44,7 +44,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 		type: 'list',
 		titleField: 'title',
 		mediaField: 'icon',
-		fields: [ 'content', 'date' ],
+		fields: [ 'date' ],
 		page: 1,
 		infiniteScrollEnabled: true,
 	} );

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,7 +1,7 @@
 .wpnc__note-list {
 	overflow: hidden;
 
-	.wpnc__text-summary .wpnc__subject {
+	.wpnc__note-list-item {
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,3 +1,16 @@
-.wpnc__text-summary .wpnc__subject .wpnc__gridicon {
-	vertical-align: top;
+.wpnc__note-list {
+	overflow: hidden;
+
+	.wpnc__text-summary .wpnc__subject {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		white-space: pre-wrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		.wpnc__gridicon {
+			vertical-align: top;
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-294

## Proposed Changes

* Limit the line of the title to 2
* Add the action icon, `>`
* Don't show the content to follow the spec on Figma
* Show the title of the note to follow the spec on Figma
* Show the unread styles

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notifications
* Ensure the preview shows
  * The summary of the note, and the max line is 2
  * The info of the note, including relative date and the title of the note
  * The action icon, `>`
  * The unread styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
