### PR TITLE
Hosting dashboard: Add confirmation dialogs to "Transfer to any user"

### DIFF
--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -12,6 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
+	Modal,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, isItemValid } from '@wordpress/dataviews';
@@ -67,6 +68,8 @@ export default function TransferDomainToAnyUser() {
 	const [ formData, setFormData ] = useState( {
 		email: '',
 	} );
+	const [ isTransferDialogOpen, setIsTransferDialogOpen ] = useState( false );
+	const [ isCancelDialogOpen, setIsCancelDialogOpen ] = useState( false );
 
 	const hasEmailWithUs = hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain );
 
@@ -74,14 +77,20 @@ export default function TransferDomainToAnyUser() {
 
 	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
+		setIsTransferDialogOpen( true );
+	};
+
+	const onConfirm = () => {
 		updateDomainTransferRequest( formData.email, {
 			onSuccess: () => {
 				createSuccessNotice(
 					__( 'A domain transfer request has been emailed to the recipient’s address.' )
 				);
+				setIsTransferDialogOpen( false );
 			},
 			onError: () => {
 				createErrorNotice( __( 'An error occurred while initiating the domain transfer.' ) );
+				setIsTransferDialogOpen( false );
 			},
 			onSettled: () => {
 				setFormData( { email: '' } );
@@ -90,12 +99,18 @@ export default function TransferDomainToAnyUser() {
 	};
 
 	const handleCancelTransfer = () => {
+		setIsCancelDialogOpen( true );
+	};
+
+	const onConfirmCancel = () => {
 		deleteDomainTransferRequest( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your domain transfer has been cancelled.' ) );
+				setIsCancelDialogOpen( false );
 			},
 			onError: () => {
 				createErrorNotice( __( 'The domain transfer cannot be cancelled at this time.' ) );
+				setIsCancelDialogOpen( false );
 			},
 		} );
 	};
@@ -168,6 +183,87 @@ export default function TransferDomainToAnyUser() {
 		);
 	};
 
+	const renderConfirmationDialog = () => {
+		return (
+			<Modal
+				title={ __( 'Confirm Transfer' ) }
+				onRequestClose={ () => setIsTransferDialogOpen( false ) }
+			>
+				<VStack spacing={ 6 }>
+					<Text>
+						{ createInterpolateElement(
+							__( 'Do you want to transfer the ownership of <domainName/> to <recipientEmail/>?' ),
+							{
+								domainName: <strong>{ domainName }</strong>,
+								recipientEmail: <strong>{ formData.email }</strong>,
+							}
+						) }
+					</Text>
+					<HStack justify="flex-end" spacing={ 2 }>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsTransferDialogOpen( false ) }
+							disabled={ isUpdatingDomainTransferRequest }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							isDestructive
+							isBusy={ isUpdatingDomainTransferRequest }
+							onClick={ onConfirm }
+							disabled={ isUpdatingDomainTransferRequest }
+						>
+							{ __( 'Confirm Transfer' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</Modal>
+		);
+	};
+
+	const renderCancelConfirmationDialog = () => {
+		return (
+			<Modal
+				title={ __( 'Confirm Cancel Transfer' ) }
+				onRequestClose={ () => setIsCancelDialogOpen( false ) }
+			>
+				<VStack spacing={ 6 }>
+					<Text>
+						{ createInterpolateElement(
+							__( 'Are you sure you want to cancel the transfer request for <domainName/>?' ),
+							{
+								domainName: <strong>{ domainName }</strong>,
+							}
+						) }
+					</Text>
+					<HStack justify="flex-end" spacing={ 2 }>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsCancelDialogOpen( false ) }
+							disabled={ isDeletingDomainTransferRequest }
+						>
+							{ __( 'Keep Transfer' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							isDestructive
+							isBusy={ isDeletingDomainTransferRequest }
+							onClick={ onConfirmCancel }
+							disabled={ isDeletingDomainTransferRequest }
+						>
+							{ __( 'Cancel Transfer' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</Modal>
+		);
+	};
+
 	const renderCancelTransfer = () => {
 		const expiresAt = new Date( requestedAt || '' );
 		expiresAt.setHours( expiresAt.getHours() + 24 );
@@ -227,6 +323,8 @@ export default function TransferDomainToAnyUser() {
 					</VStack>
 				</CardBody>
 			</Card>
+			{ isTransferDialogOpen && renderConfirmationDialog() }
+			{ isCancelDialogOpen && renderCancelConfirmationDialog() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -22,6 +22,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -199,7 +200,7 @@ export default function TransferDomainToAnyUser() {
 							}
 						) }
 					</Text>
-					<HStack justify="flex-end" spacing={ 2 }>
+					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
@@ -218,7 +219,7 @@ export default function TransferDomainToAnyUser() {
 						>
 							{ __( 'Confirm Transfer' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</Modal>
 		);
@@ -239,7 +240,7 @@ export default function TransferDomainToAnyUser() {
 							}
 						) }
 					</Text>
-					<HStack justify="flex-end" spacing={ 2 }>
+					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
@@ -258,7 +259,7 @@ export default function TransferDomainToAnyUser() {
 						>
 							{ __( 'Cancel Transfer' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</Modal>
 		);

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -20,6 +20,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { domainRoute, domainsRoute } from '../../app/router/domains';
+import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -207,7 +208,7 @@ export default function TransferDomainToOtherUser() {
 							}
 						) }
 					</Text>
-					<HStack justify="flex-end" spacing={ 2 }>
+					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
 							variant="secondary"
@@ -226,7 +227,7 @@ export default function TransferDomainToOtherUser() {
 						>
 							{ __( 'Confirm Transfer' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				</VStack>
 			</Modal>
 		);


### PR DESCRIPTION
Closes [DOTDASH380](https://linear.app/a8c/issue/DOTDASH-380/add-confirmation-dialog-in-transfer-to-other-user-flow).

## Proposed Changes
Enhanced user experience by preventing accidental domain transfers and cancellations:
- Added confirmation dialog for domain transfer to any user action
- Added confirmation dialog for cancel domain transfer action

## Why are these changes being made?
Domain transfers are critical actions that can have significant consequences for users. Without confirmation dialogs, users could accidentally initiate or cancel domain transfers with a single click, potentially causing confusion or disruption to their website operations. 

## Testing Instructions
You need a domain-only domain to test the PR.

![Screenshot 2025-09-03 alle 10 27 02](https://github.com/user-attachments/assets/79cf77c6-1b10-4499-b2f1-3737cbd1ba84)

![Screenshot 2025-09-03 alle 10 26 22](https://github.com/user-attachments/assets/133abf4b-c982-4bcc-83c8-dc439c0281a7)

### Testing Domain Transfer Confirmation
- Visit `v2/domains/[YOUR DOMAIN]/transfer/any-user`
- Enter a valid email address in the transfer form 
- Click "Transfer Domain" button
- Verify that a confirmation dialog appears asking "Do you want to transfer the ownership of [domain] to [email]?"
- Test both "Cancel" and "Confirm Transfer" buttons work correctly
- Verify the dialog shows loading states when the transfer is in progress
- Confirm the dialog closes and shows appropriate success/error messages

### Testing Cancel Transfer Confirmation
- Navigate to a domain that has a pending transfer request
- Click "Cancel Transfer" button
- Verify that a confirmation dialog appears asking "Are you sure you want to cancel the transfer request for [domain]?"
- Test both "Keep Transfer" and "Cancel Transfer" buttons work correctly
- Verify the dialog shows loading states when the cancellation is in progress
- Confirm the dialog closes and shows appropriate success/error messages

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
