### PR TITLE
Enable streamlined pricing for the onboarding-pm flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -232,7 +232,7 @@ function UnifiedPlansStep( {
 		getCurrentUserSiteCount( state ) ? '/sites/' : null
 	);
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment( flowName );
+		useStreamlinedPriceExperiment();
 
 	useSiteGlobalStylesOnPersonal();
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -17,7 +17,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
+import { has100YearPlan, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import {
@@ -280,7 +280,6 @@ function LineItemWrapper( {
 	onRemoveProductCancel,
 	hasPartnerCoupon,
 	isDisabled,
-	initialVariantTerm,
 	toggleVariantSelector,
 	variantOpenId,
 	isAkPro500Cart,
@@ -402,11 +401,9 @@ function LineItemWrapper( {
 
 	const variantsFilterCallback: ( variant: WPCOMProductVariant ) => boolean = ( variant ) => {
 		if ( signupFlowName === 'onboarding-pm' && isWpComPlan( product.product_slug ) ) {
-			// Hide monthly variant in onboarding-pm flow if not already selected
-			if (
-				variant.termIntervalInMonths === 1 &&
-				variant.termIntervalInMonths !== initialVariantTerm
-			) {
+			const domainRegistrations = getDomainRegistrations( responseCart );
+			// Hide monthly variant when a paid domain is in the cart
+			if ( variant.termIntervalInMonths === 1 && domainRegistrations.length > 0 ) {
 				return false;
 			}
 		}

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -1,10 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	isAkismetProduct,
-	isJetpackPurchasableItem,
-	AKISMET_PRO_500_PRODUCTS,
-	isWpComPlan,
-} from '@automattic/calypso-products';
+import { AKISMET_PRO_500_PRODUCTS, isWpComPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
@@ -405,31 +400,20 @@ function LineItemWrapper( {
 		return true;
 	} )();
 
-	const isJetpack = responseCart.products.some( ( product ) =>
-		isJetpackPurchasableItem( product.product_slug )
-	);
-	const variantsFilterCallback = ( variant: WPCOMProductVariant ) => {
-		// Only show term variants which are equal to or longer than the variant that
-		// was in the cart when checkout finished loading (not necessarily the
-		// current variant). For WordPress.com only, not Jetpack, Akismet or Marketplace.
-		// See https://github.com/Automattic/wp-calypso/issues/69633
-		if ( ! initialVariantTerm ) {
-			return true;
-		}
-		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
-		const isMarketplace = product.extra?.is_marketplace_product;
-		const isA4A = product.extra?.isA4ASitelessCheckout;
-
-		if ( isJetpack || isAkismet || isMarketplace || isA4A ) {
-			return true;
+	const variantsFilterCallback: ( variant: WPCOMProductVariant ) => boolean = ( variant ) => {
+		if ( signupFlowName === 'onboarding-pm' && isWpComPlan( product.product_slug ) ) {
+			// Hide monthly variant in onboarding-pm flow if not already selected
+			if (
+				variant.termIntervalInMonths === 1 &&
+				variant.termIntervalInMonths !== initialVariantTerm
+			) {
+				return false;
+			}
 		}
 
-		return variant.termIntervalInMonths >= initialVariantTerm;
+		return true;
 	};
-	const variants = useGetProductVariants(
-		product,
-		! isStreamlinedPrice ? variantsFilterCallback : undefined
-	);
+	const variants = useGetProductVariants( product, variantsFilterCallback );
 
 	const areThereVariants = variants.length > 1;
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -280,6 +280,7 @@ function LineItemWrapper( {
 	onRemoveProductCancel,
 	hasPartnerCoupon,
 	isDisabled,
+	initialVariantTerm,
 	toggleVariantSelector,
 	variantOpenId,
 	isAkPro500Cart,
@@ -403,7 +404,11 @@ function LineItemWrapper( {
 		if ( signupFlowName === 'onboarding-pm' && isWpComPlan( product.product_slug ) ) {
 			const domainRegistrations = getDomainRegistrations( responseCart );
 			// Hide monthly variant when a paid domain is in the cart
-			if ( variant.termIntervalInMonths === 1 && domainRegistrations.length > 0 ) {
+			if (
+				variant.termIntervalInMonths === 1 &&
+				variant.termIntervalInMonths !== initialVariantTerm &&
+				domainRegistrations.length > 0
+			) {
 				return false;
 			}
 		}

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,23 +1,15 @@
-import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
-import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
-export function useStreamlinedPriceExperiment(
-	flowName?: string | null
-): [ boolean, string | null ] {
-	const variationName = isEligibleForExperiment( flowName ) ? 'plans_1Y_checkout_radio' : null;
+export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
+	const variationName = isEligibleForExperiment() ? 'plans_1Y_checkout_radio' : null;
 
 	return [ false, variationName ];
 }
 
-function isEligibleForExperiment( flowName?: string | null ): boolean {
-	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
-	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
-	const flow = flowName || flowFromStorage || flowFromURL;
-
+function isEligibleForExperiment(): boolean {
 	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
-	return flow !== 'onboarding-pm' && ! isAkismetCheckout() && ! isJetpackCheckout();
+	return ! isAkismetCheckout() && ! isJetpackCheckout();
 }
 
 export function isStreamlinedPricePlansTreatment( variationName?: string | null ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -478,7 +478,7 @@ const PlansFeaturesMain = ( {
 		gridPlansForFeaturesGridRaw?.some( ( { planSlug } ) => planSlug === PLAN_FREE );
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment( flowName );
+		useStreamlinedPriceExperiment();
 
 	const showStreamlinedPriceExperiment =
 		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1035](https://linear.app/a8c/issue/M4R73CH-1035/enable-streamlined-pricing-for-the-onboarding-pm)

## Proposed Changes

* removes the restriction of using the streamlined pricing on the onboarding-pm flow
* hides the WPCOM monthly plan interval on checkout for the onboarding-pm flow if there is a paid domain selected (as on the plans step)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the `/start/onboarding-pm` flow
* Select a domain
* On the plans step, you should see the new streamlined pricing 

| Before | After |
|--------|--------|
| <img width="1834" height="1090" alt="Screenshot 2025-09-03 at 14 30 40" src="https://github.com/user-attachments/assets/024f6ca8-8426-4584-8b9e-f1e18cfea9bc" /> | <img width="1869" height="1109" alt="Screenshot 2025-09-03 at 14 31 20" src="https://github.com/user-attachments/assets/51e304b4-fc26-4257-9b64-c2cbba12931c" /> | 


* Select a plan
* On the checkout, you should see the new streamlined pricing. The monthly interval should not be available.

| Before | After |
|--------|--------|
| <img width="1538" height="735" alt="Screenshot 2025-09-03 at 14 29 24" src="https://github.com/user-attachments/assets/1adffbc2-e71d-4dcc-9588-436524ef0a37" /> | <img width="1652" height="861" alt="Screenshot 2025-09-03 at 14 28 24" src="https://github.com/user-attachments/assets/a313023e-8df8-4f52-b585-06337d1462e6" /> | 

* Go through the flow again, without a paid plan
* On checkout, the monthly interval should be available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
