### PR TITLE
Hosting Dashboard > Security: Implement Account Recovery for SMS

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -6,6 +6,7 @@ import {
 	sitesQuery,
 	queryClient,
 	accountRecoveryQuery,
+	smsCountryCodesQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { rootRoute } from './root';
@@ -162,7 +163,12 @@ export const securityPasswordRoute = createRoute( {
 export const securityAccountRecoveryRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'security/account-recovery',
-	loader: () => queryClient.ensureQueryData( accountRecoveryQuery() ),
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( accountRecoveryQuery() ),
+			queryClient.ensureQueryData( smsCountryCodesQuery() ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../../me/security-account-recovery' ).then( ( d ) =>
 		createLazyRoute( 'security-account-recovery' )( {

--- a/client/dashboard/me/security-account-recovery/index.tsx
+++ b/client/dashboard/me/security-account-recovery/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import PageLayout from '../../components/page-layout';
 import SecurityPageHeader from '../security-page-header';
 import RecoveryEmail from './recovery-email';
+import RecoverySMS from './recovery-sms';
 
 export default function SecurityAccountRecovery() {
 	return (
@@ -17,6 +18,7 @@ export default function SecurityAccountRecovery() {
 			}
 		>
 			<RecoveryEmail />
+			<RecoverySMS />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security-account-recovery/phone-number-input.tsx
+++ b/client/dashboard/me/security-account-recovery/phone-number-input.tsx
@@ -6,7 +6,6 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
 import type { SecuritySMSNumber } from './types';
 
 import './style.scss';
@@ -29,21 +28,18 @@ export default function PhoneNumberInput( {
 			value: countryCode.code,
 		} ) ) ?? [];
 
-	const onChangeCountryCode = useCallback(
-		( value: string ) => {
-			const countryCode = smsCountryCodes?.find( ( countryCode ) => countryCode.code === value );
-			if ( ! countryCode ) {
-				return;
-			}
+	const onChangeCountryCode = ( value: string ) => {
+		const countryCode = smsCountryCodes?.find( ( countryCode ) => countryCode.code === value );
+		if ( ! countryCode ) {
+			return;
+		}
 
-			return onChange( {
-				...data,
-				countryCode: countryCode.code,
-				countryNumericCode: countryCode.numeric_code,
-			} );
-		},
-		[ data, onChange, smsCountryCodes ]
-	);
+		return onChange( {
+			...data,
+			countryCode: countryCode.code,
+			countryNumericCode: countryCode.numeric_code,
+		} );
+	};
 
 	return (
 		<HStack>

--- a/client/dashboard/me/security-account-recovery/phone-number-input.tsx
+++ b/client/dashboard/me/security-account-recovery/phone-number-input.tsx
@@ -1,12 +1,12 @@
 import { smsCountryCodesQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalInputControl as InputControl,
 	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { SecuritySMSNumber } from './types';
 
 import './style.scss';
@@ -21,9 +21,7 @@ export default function PhoneNumberInput( {
 	onChange: ( value: Partial< SecuritySMSNumber > ) => void;
 	isDisabled: boolean;
 } ) {
-	const { data: smsCountryCodes, isLoading: isLoadingSmsCountryCodes } = useQuery(
-		smsCountryCodesQuery()
-	);
+	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
 
 	const countryCodes =
 		smsCountryCodes?.map( ( countryCode ) => ( {
@@ -47,16 +45,6 @@ export default function PhoneNumberInput( {
 		[ data, onChange, smsCountryCodes ]
 	);
 
-	// Set the initial country code if it's not already set
-	useEffect( () => {
-		if ( ! smsCountryCodes?.length ) {
-			return;
-		}
-		if ( ! data.countryCode ) {
-			onChangeCountryCode( smsCountryCodes[ 0 ].code );
-		}
-	}, [ smsCountryCodes, onChangeCountryCode, data.countryCode ] );
-
 	return (
 		<HStack>
 			<SelectControl
@@ -66,7 +54,7 @@ export default function PhoneNumberInput( {
 				onChange={ onChangeCountryCode }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
-				disabled={ isLoadingSmsCountryCodes || isDisabled }
+				disabled={ isDisabled }
 			/>
 			<InputControl
 				className="phone-number-input__number-input"

--- a/client/dashboard/me/security-account-recovery/phone-number-input.tsx
+++ b/client/dashboard/me/security-account-recovery/phone-number-input.tsx
@@ -1,0 +1,87 @@
+import { smsCountryCodesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalInputControl as InputControl,
+	SelectControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useCallback } from 'react';
+import type { SecuritySMSNumber } from './types';
+
+import './style.scss';
+
+// TODO: We could potentially move this component to a shared place
+export default function PhoneNumberInput( {
+	data,
+	onChange,
+	isDisabled,
+}: {
+	data: SecuritySMSNumber;
+	onChange: ( value: Partial< SecuritySMSNumber > ) => void;
+	isDisabled: boolean;
+} ) {
+	const { data: smsCountryCodes, isLoading: isLoadingSmsCountryCodes } = useQuery(
+		smsCountryCodesQuery()
+	);
+
+	const countryCodes =
+		smsCountryCodes?.map( ( countryCode ) => ( {
+			label: countryCode.name,
+			value: countryCode.code,
+		} ) ) ?? [];
+
+	const onChangeCountryCode = useCallback(
+		( value: string ) => {
+			const countryCode = smsCountryCodes?.find( ( countryCode ) => countryCode.code === value );
+			if ( ! countryCode ) {
+				return;
+			}
+
+			return onChange( {
+				...data,
+				countryCode: countryCode.code,
+				countryNumericCode: countryCode.numeric_code,
+			} );
+		},
+		[ data, onChange, smsCountryCodes ]
+	);
+
+	// Set the initial country code if it's not already set
+	useEffect( () => {
+		if ( ! smsCountryCodes?.length ) {
+			return;
+		}
+		if ( ! data.countryCode ) {
+			onChangeCountryCode( smsCountryCodes[ 0 ].code );
+		}
+	}, [ smsCountryCodes, onChangeCountryCode, data.countryCode ] );
+
+	return (
+		<HStack>
+			<SelectControl
+				label={ __( 'Country code' ) }
+				value={ data.countryCode ?? '' }
+				options={ countryCodes }
+				onChange={ onChangeCountryCode }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				disabled={ isLoadingSmsCountryCodes || isDisabled }
+			/>
+			<InputControl
+				className="phone-number-input__number-input"
+				__next40pxDefaultSize
+				type="tel"
+				label={ __( 'Phone number' ) }
+				value={ data.phoneNumber ?? '' }
+				onChange={ ( value ) => {
+					return onChange( {
+						...data,
+						phoneNumber: value ?? '',
+					} );
+				} }
+				disabled={ isDisabled }
+			/>
+		</HStack>
+	);
+}

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -43,6 +43,7 @@ export default function RecoverySMS() {
 	const [ formData, setFormData ] = useState< SecuritySMSFormData >( initialFormData );
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 	const [ showResendButton, setShowResendButton ] = useState( true );
+	const [ showSuccessNotice, setShowSuccessNotice ] = useState( false );
 
 	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
 		accountRecoveryQuery()
@@ -105,9 +106,7 @@ export default function RecoverySMS() {
 	const handleValidateSMSCode = () => {
 		validateSMSCodeMutation( formData.smsCode, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery SMS code was validated successfully.' ), {
-					type: 'snackbar',
-				} );
+				setShowSuccessNotice( true );
 			},
 			onError: ( error: Error ) => {
 				createErrorNotice( error.message || __( 'Failed to validate recovery SMS code.' ), {
@@ -232,6 +231,11 @@ export default function RecoverySMS() {
 										accountRecoveryPhone.number_full
 									) }
 								</Notice>
+							</Spacer>
+						) }
+						{ showSuccessNotice && (
+							<Spacer marginBottom={ 4 }>
+								<Notice variant="success">{ __( 'Recovery SMS number validated' ) }</Notice>
 							</Spacer>
 						) }
 						<form onSubmit={ handleSubmit }>

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -5,11 +5,9 @@ import {
 	resendAccountRecoverySMSValidationMutation,
 	validateAccountRecoverySMSCodeMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
 	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalInputControl as InputControl,
 	Button,
@@ -20,10 +18,11 @@ import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
-import validatePhone from '../../utils/validate-phone';
+import { validatePhone } from '../../utils/phone-number';
 import PhoneNumberInput from './phone-number-input';
 import type { SecuritySMSFormData } from './types';
 import type { Field } from '@wordpress/dataviews';
@@ -38,48 +37,39 @@ const initialFormData: SecuritySMSFormData = {
 };
 
 export default function RecoverySMS() {
+	const { data: accountRecoveryData } = useSuspenseQuery( accountRecoveryQuery() );
+
+	const { mutate: validateSMS, isPending: isValidateSMSPending } = useMutation(
+		updateAccountRecoverySMSMutation()
+	);
+	const { mutate: removeSMS, isPending: isRemoveSMSPending } = useMutation(
+		removeAccountRecoverySMSMutation()
+	);
+	const { mutate: resendValidation, isPending: isResendValidationPending } = useMutation(
+		resendAccountRecoverySMSValidationMutation()
+	);
+	const { mutate: validateSMSCode, isPending: isValidateSMSCodePending } = useMutation(
+		validateAccountRecoverySMSCodeMutation()
+	);
+
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const [ formData, setFormData ] = useState< SecuritySMSFormData >( initialFormData );
+	const accountRecoveryPhone = accountRecoveryData.phone;
+
+	const [ formData, setFormData ] = useState< SecuritySMSFormData >( {
+		...initialFormData,
+		smsNumber: {
+			phoneNumber: accountRecoveryPhone?.number || '',
+			countryCode: accountRecoveryPhone?.country_code || '',
+			countryNumericCode: accountRecoveryPhone?.country_numeric_code || '',
+		},
+	} );
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 	const [ showResendButton, setShowResendButton ] = useState( true );
 	const [ showSuccessNotice, setShowSuccessNotice ] = useState( false );
 
-	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
-		accountRecoveryQuery()
-	);
-
-	const { mutate: validateSMSMutation, isPending: isValidateSMSPending } = useMutation(
-		updateAccountRecoverySMSMutation()
-	);
-
-	const { mutate: removeSMSMutation, isPending: isRemoveSMSPending } = useMutation(
-		removeAccountRecoverySMSMutation()
-	);
-
-	const { mutate: resendValidationMutation, isPending: isResendValidationPending } = useMutation(
-		resendAccountRecoverySMSValidationMutation()
-	);
-
-	const { mutate: validateSMSCodeMutation, isPending: isValidateSMSCodePending } = useMutation(
-		validateAccountRecoverySMSCodeMutation()
-	);
-
-	const accountRecoveryPhone = accountRecoveryData?.phone;
-	const shouldShowValidationNotice = accountRecoveryPhone && ! accountRecoveryData?.phone_validated;
-
+	const shouldShowValidationNotice = accountRecoveryPhone && ! accountRecoveryData.phone_validated;
 	const fullPhoneNumber = `${ formData.smsNumber.countryNumericCode }${ formData.smsNumber.phoneNumber }`;
-
-	useEffect( () => {
-		setFormData( {
-			smsNumber: {
-				phoneNumber: accountRecoveryPhone?.number || '',
-				countryCode: accountRecoveryPhone?.country_code || '',
-				countryNumericCode: accountRecoveryPhone?.country_numeric_code || '',
-			},
-			smsCode: '',
-		} );
-	}, [ accountRecoveryPhone ] );
 
 	const handleValidateSMS = () => {
 		const validation = validatePhone( fullPhoneNumber );
@@ -89,7 +79,7 @@ export default function RecoverySMS() {
 			} );
 			return;
 		}
-		validateSMSMutation( formData.smsNumber, {
+		validateSMS( formData.smsNumber, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery SMS number was saved successfully.' ), {
 					type: 'snackbar',
@@ -104,7 +94,7 @@ export default function RecoverySMS() {
 	};
 
 	const handleValidateSMSCode = () => {
-		validateSMSCodeMutation( formData.smsCode, {
+		validateSMSCode( formData.smsCode, {
 			onSuccess: () => {
 				setShowSuccessNotice( true );
 			},
@@ -127,7 +117,7 @@ export default function RecoverySMS() {
 
 	const handleRemove = () => {
 		setIsRemoveDialogOpen( false );
-		removeSMSMutation( undefined, {
+		removeSMS( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery SMS number was removed successfully.' ), {
 					type: 'snackbar',
@@ -144,7 +134,7 @@ export default function RecoverySMS() {
 
 	const handleResendValidation = () => {
 		setShowResendButton( false );
-		resendValidationMutation( undefined, {
+		resendValidation( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Your recovery SMS validation was resent successfully.' ), {
 					type: 'snackbar',
@@ -171,7 +161,7 @@ export default function RecoverySMS() {
 							onChange={ ( edits ) => {
 								onChange( { ...data, smsNumber: edits } );
 							} }
-							isDisabled={ isAccountRecoveryDataLoading || isValidateSMSPending }
+							isDisabled={ isValidateSMSPending }
 						/>
 					);
 				},
@@ -199,7 +189,7 @@ export default function RecoverySMS() {
 				isVisible: () => !! shouldShowValidationNotice,
 			},
 		],
-		[ isAccountRecoveryDataLoading, isValidateSMSPending, shouldShowValidationNotice ]
+		[ isValidateSMSPending, shouldShowValidationNotice ]
 	);
 
 	return (
@@ -209,34 +199,30 @@ export default function RecoverySMS() {
 					<VStack spacing={ 4 }>
 						<SectionHeader title={ __( 'Recovery SMS number' ) } level={ 3 } />
 						{ shouldShowValidationNotice && (
-							<Spacer marginBottom={ 4 }>
-								<Notice
-									variant="warning"
-									title={ __( 'Please validate your recovery SMS number' ) }
-									actions={
-										showResendButton && (
-											<Button
-												variant="link"
-												onClick={ handleResendValidation }
-												disabled={ isResendValidationPending }
-											>
-												{ __( 'Resend code' ) }
-											</Button>
-										)
-									}
-								>
-									{ sprintf(
-										/* translators: %s: phone number */
-										__( 'A validation code was sent to %s' ),
-										accountRecoveryPhone.number_full
-									) }
-								</Notice>
-							</Spacer>
+							<Notice
+								variant="warning"
+								title={ __( 'Please validate your recovery SMS number' ) }
+								actions={
+									showResendButton && (
+										<Button
+											variant="link"
+											onClick={ handleResendValidation }
+											disabled={ isResendValidationPending }
+										>
+											{ __( 'Resend code' ) }
+										</Button>
+									)
+								}
+							>
+								{ sprintf(
+									/* translators: %s: phone number */
+									__( 'A validation code was sent to %s' ),
+									accountRecoveryPhone.number_full
+								) }
+							</Notice>
 						) }
 						{ showSuccessNotice && (
-							<Spacer marginBottom={ 4 }>
-								<Notice variant="success">{ __( 'Recovery SMS number validated' ) }</Notice>
-							</Spacer>
+							<Notice variant="success">{ __( 'Recovery SMS number validated' ) }</Notice>
 						) }
 						<form onSubmit={ handleSubmit }>
 							<VStack spacing={ 4 }>
@@ -248,7 +234,7 @@ export default function RecoverySMS() {
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-								<HStack spacing={ 3 } justify="flex-start">
+								<ButtonStack justify="flex-start">
 									<Button
 										variant="primary"
 										type="submit"
@@ -275,7 +261,7 @@ export default function RecoverySMS() {
 											{ __( 'Remove SMS number' ) }
 										</Button>
 									) }
-								</HStack>
+								</ButtonStack>
 							</VStack>
 						</form>
 					</VStack>

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -4,12 +4,12 @@ import {
 	removeAccountRecoverySMSMutation,
 	resendAccountRecoverySMSValidationMutation,
 	validateAccountRecoverySMSCodeMutation,
+	smsCountryCodesQuery,
 } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
 	__experimentalConfirmDialog as ConfirmDialog,
-	__experimentalInputControl as InputControl,
 	Button,
 	Card,
 	CardBody,
@@ -38,6 +38,7 @@ const initialFormData: SecuritySMSFormData = {
 
 export default function RecoverySMS() {
 	const { data: accountRecoveryData } = useSuspenseQuery( accountRecoveryQuery() );
+	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
 
 	const { mutate: validateSMS, isPending: isValidateSMSPending } = useMutation(
 		updateAccountRecoverySMSMutation()
@@ -57,12 +58,13 @@ export default function RecoverySMS() {
 	const accountRecoveryPhone = accountRecoveryData.phone;
 
 	const [ formData, setFormData ] = useState< SecuritySMSFormData >( {
-		...initialFormData,
 		smsNumber: {
 			phoneNumber: accountRecoveryPhone?.number || '',
-			countryCode: accountRecoveryPhone?.country_code || '',
-			countryNumericCode: accountRecoveryPhone?.country_numeric_code || '',
+			countryCode: accountRecoveryPhone?.country_code || smsCountryCodes[ 0 ].code,
+			countryNumericCode:
+				accountRecoveryPhone?.country_numeric_code || smsCountryCodes[ 0 ].numeric_code,
 		},
+		smsCode: '',
 	} );
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 	const [ showResendButton, setShowResendButton ] = useState( true );
@@ -174,18 +176,6 @@ export default function RecoverySMS() {
 				id: 'smsCode',
 				label: __( 'SMS code' ),
 				type: 'text',
-				Edit: ( { field, data, onChange } ) => {
-					return (
-						<InputControl
-							__next40pxDefaultSize
-							label={ field.label }
-							value={ data.smsCode }
-							onChange={ ( value ) => {
-								onChange( { ...data, smsCode: value } );
-							} }
-						/>
-					);
-				},
 				isVisible: () => !! shouldShowValidationNotice,
 			},
 		],

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -1,0 +1,290 @@
+import {
+	accountRecoveryQuery,
+	updateAccountRecoverySMSMutation,
+	removeAccountRecoverySMSMutation,
+	resendAccountRecoverySMSValidationMutation,
+	validateAccountRecoverySMSCodeMutation,
+} from '@automattic/api-queries';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+	__experimentalConfirmDialog as ConfirmDialog,
+	__experimentalInputControl as InputControl,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState, useEffect } from 'react';
+import Notice from '../../components/notice';
+import { SectionHeader } from '../../components/section-header';
+import validatePhone from '../../utils/validate-phone';
+import PhoneNumberInput from './phone-number-input';
+import type { SecuritySMSFormData } from './types';
+import type { Field } from '@wordpress/dataviews';
+
+const initialFormData: SecuritySMSFormData = {
+	smsNumber: {
+		countryCode: '',
+		phoneNumber: '',
+		countryNumericCode: '',
+	},
+	smsCode: '',
+};
+
+export default function RecoverySMS() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const [ formData, setFormData ] = useState< SecuritySMSFormData >( initialFormData );
+	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
+	const [ showResendButton, setShowResendButton ] = useState( true );
+
+	const { data: accountRecoveryData, isLoading: isAccountRecoveryDataLoading } = useQuery(
+		accountRecoveryQuery()
+	);
+
+	const { mutate: validateSMSMutation, isPending: isValidateSMSPending } = useMutation(
+		updateAccountRecoverySMSMutation()
+	);
+
+	const { mutate: removeSMSMutation, isPending: isRemoveSMSPending } = useMutation(
+		removeAccountRecoverySMSMutation()
+	);
+
+	const { mutate: resendValidationMutation, isPending: isResendValidationPending } = useMutation(
+		resendAccountRecoverySMSValidationMutation()
+	);
+
+	const { mutate: validateSMSCodeMutation, isPending: isValidateSMSCodePending } = useMutation(
+		validateAccountRecoverySMSCodeMutation()
+	);
+
+	const accountRecoveryPhone = accountRecoveryData?.phone;
+	const shouldShowValidationNotice = accountRecoveryPhone && ! accountRecoveryData?.phone_validated;
+
+	const fullPhoneNumber = `${ formData.smsNumber.countryNumericCode }${ formData.smsNumber.phoneNumber }`;
+
+	useEffect( () => {
+		setFormData( {
+			smsNumber: {
+				phoneNumber: accountRecoveryPhone?.number || '',
+				countryCode: accountRecoveryPhone?.country_code || '',
+				countryNumericCode: accountRecoveryPhone?.country_numeric_code || '',
+			},
+			smsCode: '',
+		} );
+	}, [ accountRecoveryPhone ] );
+
+	const handleValidateSMS = () => {
+		const validation = validatePhone( fullPhoneNumber );
+		if ( validation.error ) {
+			createErrorNotice( validation.message, {
+				type: 'snackbar',
+			} );
+			return;
+		}
+		validateSMSMutation( formData.smsNumber, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery SMS number was saved successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to validate recovery SMS number.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleValidateSMSCode = () => {
+		validateSMSCodeMutation( formData.smsCode, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery SMS code was validated successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to validate recovery SMS code.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		if ( shouldShowValidationNotice ) {
+			handleValidateSMSCode();
+		} else {
+			handleValidateSMS();
+		}
+	};
+
+	const handleRemove = () => {
+		setIsRemoveDialogOpen( false );
+		removeSMSMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery SMS number was removed successfully.' ), {
+					type: 'snackbar',
+				} );
+				setFormData( initialFormData );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to remove recovery SMS number.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleResendValidation = () => {
+		setShowResendButton( false );
+		resendValidationMutation( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your recovery SMS validation was resent successfully.' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message || __( 'Failed to resend recovery SMS validation.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const fields: Field< SecuritySMSFormData >[] = useMemo(
+		() => [
+			{
+				id: 'smsNumber',
+				label: __( 'Phone number' ),
+				type: 'text',
+				Edit: ( { data, onChange } ) => {
+					return (
+						<PhoneNumberInput
+							data={ data.smsNumber }
+							onChange={ ( edits ) => {
+								onChange( { ...data, smsNumber: edits } );
+							} }
+							isDisabled={ isAccountRecoveryDataLoading || isValidateSMSPending }
+						/>
+					);
+				},
+				isVisible: () => ! shouldShowValidationNotice,
+				// TODO: Add validation via isValid.custom.
+				// There is currently a bug that prevents it from working.
+				// For now, we're using the handleSubmit to validate the phone number.
+			},
+			{
+				id: 'smsCode',
+				label: __( 'SMS code' ),
+				type: 'text',
+				Edit: ( { field, data, onChange } ) => {
+					return (
+						<InputControl
+							__next40pxDefaultSize
+							label={ field.label }
+							value={ data.smsCode }
+							onChange={ ( value ) => {
+								onChange( { ...data, smsCode: value } );
+							} }
+						/>
+					);
+				},
+				isVisible: () => !! shouldShowValidationNotice,
+			},
+		],
+		[ isAccountRecoveryDataLoading, isValidateSMSPending, shouldShowValidationNotice ]
+	);
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader title={ __( 'Recovery SMS number' ) } level={ 3 } />
+						{ shouldShowValidationNotice && (
+							<Spacer marginBottom={ 4 }>
+								<Notice
+									variant="warning"
+									title={ __( 'Please validate your recovery SMS number' ) }
+									actions={
+										showResendButton && (
+											<Button
+												variant="link"
+												onClick={ handleResendValidation }
+												disabled={ isResendValidationPending }
+											>
+												{ __( 'Resend code' ) }
+											</Button>
+										)
+									}
+								>
+									{ sprintf(
+										/* translators: %s: phone number */
+										__( 'A validation code was sent to %s' ),
+										accountRecoveryPhone.number_full
+									) }
+								</Notice>
+							</Spacer>
+						) }
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 4 }>
+								<DataForm< SecuritySMSFormData >
+									data={ formData }
+									fields={ fields }
+									form={ { layout: { type: 'regular' as const }, fields } }
+									onChange={ ( edits: Partial< SecuritySMSFormData > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack spacing={ 3 } justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isValidateSMSPending || isValidateSMSCodePending }
+										disabled={
+											isValidateSMSPending ||
+											isValidateSMSCodePending ||
+											( shouldShowValidationNotice
+												? ! formData.smsCode
+												: ! formData.smsNumber.phoneNumber ) ||
+											( ! shouldShowValidationNotice &&
+												accountRecoveryPhone?.number_full === fullPhoneNumber )
+										}
+									>
+										{ __( 'Validate' ) }
+									</Button>
+									{ accountRecoveryPhone && (
+										<Button
+											variant="tertiary"
+											onClick={ () => setIsRemoveDialogOpen( true ) }
+											isBusy={ isRemoveSMSPending }
+											disabled={ isRemoveSMSPending }
+										>
+											{ __( 'Remove SMS number' ) }
+										</Button>
+									) }
+								</HStack>
+							</VStack>
+						</form>
+					</VStack>
+				</CardBody>
+			</Card>
+			<ConfirmDialog
+				isOpen={ isRemoveDialogOpen }
+				confirmButtonText={ __( 'Remove SMS number' ) }
+				onCancel={ () => setIsRemoveDialogOpen( false ) }
+				onConfirm={ handleRemove }
+			>
+				{ __( 'Are you sure you want to remove this SMS number?' ) }
+			</ConfirmDialog>
+		</>
+	);
+}

--- a/client/dashboard/me/security-account-recovery/style.scss
+++ b/client/dashboard/me/security-account-recovery/style.scss
@@ -1,0 +1,3 @@
+.phone-number-input__number-input {
+	width: 100%;
+}

--- a/client/dashboard/me/security-account-recovery/types.ts
+++ b/client/dashboard/me/security-account-recovery/types.ts
@@ -1,0 +1,10 @@
+export type SecuritySMSNumber = {
+	phoneNumber: string;
+	countryCode: string;
+	countryNumericCode: string;
+};
+
+export type SecuritySMSFormData = {
+	smsNumber: SecuritySMSNumber;
+	smsCode: string;
+};

--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import phone from 'phone';
 
-export default function validatePhone( phoneNumber: string ) {
+export function validatePhone( phoneNumber: string ) {
 	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
 
 	if ( phoneNumberWithoutPlus.length === 0 ) {

--- a/client/dashboard/utils/validate-phone.ts
+++ b/client/dashboard/utils/validate-phone.ts
@@ -1,0 +1,47 @@
+import { __ } from '@wordpress/i18n';
+import phone from 'phone';
+
+export default function validatePhone( phoneNumber: string ) {
+	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
+
+	if ( phoneNumberWithoutPlus.length === 0 ) {
+		return {
+			error: 'phone_number_empty',
+			message: __( 'Please enter a phone number' ),
+		};
+	}
+
+	if ( phoneNumberWithoutPlus.length < 8 ) {
+		return {
+			error: 'phone_number_too_short',
+			message: __( 'This number is too short' ),
+		};
+	}
+
+	if ( phoneNumber.search( /[a-z,A-Z]/ ) > -1 ) {
+		return {
+			error: 'phone_number_contains_letters',
+			message: __( 'Phone numbers cannot contain letters' ),
+		};
+	}
+
+	if ( phoneNumber.search( /[^0-9,+]/ ) > -1 ) {
+		return {
+			error: 'phone_number_contains_special_characters',
+			message: __( 'Phone numbers cannot contain special characters' ),
+		};
+	}
+
+	// phone module validates mobile numbers
+	if ( ! phone( phoneNumber ).isValid ) {
+		return {
+			error: 'phone_number_invalid',
+			message: __( 'That phone number does not appear to be valid' ),
+		};
+	}
+
+	return {
+		info: 'phone_number_valid',
+		message: __( 'Valid phone number' ),
+	};
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -32,6 +32,7 @@ export * from './me-sites';
 export * from './me-sites-plugins';
 export * from './me-ssh';
 export * from './me-tax-details';
+export * from './meta-sms-country-codes';
 export * from './p2';
 export * from './purchase';
 export * from './read-teams';

--- a/packages/api-core/src/me-account-recovery/mutators.ts
+++ b/packages/api-core/src/me-account-recovery/mutators.ts
@@ -12,3 +12,30 @@ export async function removeAccountRecoveryEmail(): Promise< AccountRecoverySucc
 export async function resendAccountRecoveryEmailValidation(): Promise< AccountRecoverySuccess > {
 	return wpcom.req.post( '/me/account-recovery/email/validation/new' );
 }
+
+// SMS-related actions
+export async function updateAccountRecoverySMS(
+	countryCode: string,
+	phoneNumber: string
+): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/phone', {
+		country: countryCode,
+		phone_number: phoneNumber,
+	} );
+}
+
+export async function validateAccountRecoverySMSCode(
+	code: string
+): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/phone/validation', {
+		code: code.replace( /\s/g, '' ),
+	} );
+}
+
+export async function removeAccountRecoverySMS(): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/phone/delete' );
+}
+
+export async function resendAccountRecoverySMSValidation(): Promise< AccountRecoverySuccess > {
+	return wpcom.req.post( '/me/account-recovery/phone/validation/new' );
+}

--- a/packages/api-core/src/me-account-recovery/mutators.ts
+++ b/packages/api-core/src/me-account-recovery/mutators.ts
@@ -13,7 +13,6 @@ export async function resendAccountRecoveryEmailValidation(): Promise< AccountRe
 	return wpcom.req.post( '/me/account-recovery/email/validation/new' );
 }
 
-// SMS-related actions
 export async function updateAccountRecoverySMS(
 	countryCode: string,
 	phoneNumber: string

--- a/packages/api-core/src/me-account-recovery/types.ts
+++ b/packages/api-core/src/me-account-recovery/types.ts
@@ -1,7 +1,12 @@
 export interface AccountRecovery {
 	email: string;
 	email_validated: boolean;
-	phone: string;
+	phone: {
+		country_code: string;
+		country_numeric_code: string;
+		number: string;
+		number_full: string;
+	} | null;
 	phone_validated: boolean;
 }
 

--- a/packages/api-core/src/meta-sms-country-codes/fetchers.ts
+++ b/packages/api-core/src/meta-sms-country-codes/fetchers.ts
@@ -1,0 +1,9 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { SMSCountryCode } from './types';
+
+export async function fetchSMSCountryCodes(): Promise< SMSCountryCode[] > {
+	return wpcom.req.get( {
+		apiVersion: '1.1',
+		path: '/meta/sms-country-codes/',
+	} );
+}

--- a/packages/api-core/src/meta-sms-country-codes/index.tsx
+++ b/packages/api-core/src/meta-sms-country-codes/index.tsx
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/meta-sms-country-codes/types.ts
+++ b/packages/api-core/src/meta-sms-country-codes/types.ts
@@ -1,0 +1,6 @@
+export interface SMSCountryCode {
+	code: string;
+	country_name: string;
+	name: string;
+	numeric_code: string;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -24,6 +24,7 @@ export * from './me-preferences';
 export * from './me-purchases';
 export * from './me-settings';
 export * from './me-tax-details';
+export * from './meta-sms-country-codes';
 export * from './p2';
 export * from './performance';
 export * from './purchase';

--- a/packages/api-queries/src/me-account-recovery.ts
+++ b/packages/api-queries/src/me-account-recovery.ts
@@ -11,7 +11,6 @@ import {
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
-// Email-related queries and mutations
 export const accountRecoveryQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'account-recovery' ],
@@ -44,8 +43,6 @@ export const resendAccountRecoveryEmailValidationMutation = () =>
 	mutationOptions( {
 		mutationFn: resendAccountRecoveryEmailValidation,
 	} );
-
-// SMS-related mutations
 
 type UpdateAccountRecoverySMSMutationParams = {
 	countryCode: string;
@@ -81,7 +78,7 @@ export const removeAccountRecoverySMSMutation = () =>
 		onSuccess: () => {
 			queryClient.setQueryData(
 				accountRecoveryQuery().queryKey,
-				( oldData ) => oldData && { ...oldData, phone: null }
+				( oldData ) => oldData && { ...oldData, phone: null, phone_validated: false }
 			);
 		},
 	} );

--- a/packages/api-queries/src/me-account-recovery.ts
+++ b/packages/api-queries/src/me-account-recovery.ts
@@ -3,10 +3,15 @@ import {
 	updateAccountRecoveryEmail,
 	removeAccountRecoveryEmail,
 	resendAccountRecoveryEmailValidation,
+	updateAccountRecoverySMS,
+	validateAccountRecoverySMSCode,
+	removeAccountRecoverySMS,
+	resendAccountRecoverySMSValidation,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
+// Email-related queries and mutations
 export const accountRecoveryQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'account-recovery' ],
@@ -38,4 +43,61 @@ export const removeAccountRecoveryEmailMutation = () =>
 export const resendAccountRecoveryEmailValidationMutation = () =>
 	mutationOptions( {
 		mutationFn: resendAccountRecoveryEmailValidation,
+	} );
+
+// SMS-related mutations
+
+type UpdateAccountRecoverySMSMutationParams = {
+	countryCode: string;
+	phoneNumber: string;
+	countryNumericCode: string;
+};
+
+export const updateAccountRecoverySMSMutation = () =>
+	mutationOptions( {
+		mutationFn: ( { countryCode, phoneNumber }: UpdateAccountRecoverySMSMutationParams ) =>
+			updateAccountRecoverySMS( countryCode, phoneNumber ),
+		onSuccess: ( _, sms ) => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) =>
+					oldData && {
+						...oldData,
+						phone: {
+							country_code: sms.countryCode,
+							country_numeric_code: sms.countryNumericCode,
+							number: sms.phoneNumber,
+							number_full: `${ sms.countryNumericCode }${ sms.phoneNumber }`,
+						},
+						phone_validated: false,
+					}
+			);
+		},
+	} );
+
+export const removeAccountRecoverySMSMutation = () =>
+	mutationOptions( {
+		mutationFn: removeAccountRecoverySMS,
+		onSuccess: () => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, phone: null }
+			);
+		},
+	} );
+
+export const resendAccountRecoverySMSValidationMutation = () =>
+	mutationOptions( {
+		mutationFn: resendAccountRecoverySMSValidation,
+	} );
+
+export const validateAccountRecoverySMSCodeMutation = () =>
+	mutationOptions( {
+		mutationFn: validateAccountRecoverySMSCode,
+		onSuccess: () => {
+			queryClient.setQueryData(
+				accountRecoveryQuery().queryKey,
+				( oldData ) => oldData && { ...oldData, phone_validated: true }
+			);
+		},
 	} );

--- a/packages/api-queries/src/meta-sms-country-codes.ts
+++ b/packages/api-queries/src/meta-sms-country-codes.ts
@@ -1,0 +1,8 @@
+import { fetchSMSCountryCodes } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const smsCountryCodesQuery = () =>
+	queryOptions( {
+		queryKey: [ 'meta', 'sms-country-codes' ],
+		queryFn: fetchSMSCountryCodes,
+	} );


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/105504. So, please review that first. 

Resolves https://linear.app/a8c/issue/DOTDASH-172/implement-account-security-recover-sms-number-to-the-hosting-dashboard

## Proposed Changes

This PR implements the account recovery feature for SMS on the "Security" section in the Hosting Dashboard.

## Why are these changes being made?

* To allow users to use the SMS account recovery in the Hosting Dashboard.

## Testing Instructions

* Open the Calypso Live link
* Append the URL with `/v2/me/security`
* Click the "Account recovery" section 
* Verify that the screen below is displayed when there is no SMS set

<img width="1920" height="779" alt="Screenshot 2025-09-03 at 2 55 03 PM" src="https://github.com/user-attachments/assets/2b6f428e-9599-48fc-b8a5-0eb371c5d784" />

<img width="406" height="84" alt="Screenshot 2025-09-03 at 2 55 18 PM" src="https://github.com/user-attachments/assets/7fd6ba21-cb32-470a-b137-11c4efac464c" />

* Select the country code and enter the phone number (We do have the validations in place, which will be moved to the input once it is supported) > Click the "Validate" button > Verify that the below screen is displayed to enter the code

<img width="1920" height="884" alt="Screenshot 2025-09-03 at 2 57 12 PM" src="https://github.com/user-attachments/assets/7f0e8b4d-76c6-42c7-863a-cd73c5f36c35" />

* Verify the "Resend code" button works as expected, and the button is hidden until you refresh or leave the page and come back.

<img width="394" height="65" alt="Screenshot 2025-09-03 at 2 57 35 PM" src="https://github.com/user-attachments/assets/5ea5f489-5a79-4498-838d-b2f8a8b6f1b8" />

* Validate the code > Verify the notice is hidden once it is validated and changes to this. Refresh the page and verify it is hidden.

<img width="1920" height="838" alt="Screenshot 2025-09-03 at 3 24 21 PM" src="https://github.com/user-attachments/assets/fcb1c24e-af0c-4a25-8903-55d874a2ae56" />


* Click the "Remove SMS number" button and verify that a confirmation dialog is shown, and the SMS number is removed once you confirm

<img width="1920" height="884" alt="Screenshot 2025-09-03 at 2 57 19 PM" src="https://github.com/user-attachments/assets/ce26615c-e88c-4096-b8c2-8da2dbc9bb10" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
