### PR TITLE
Notifications v2: bring last notification in view when going back to note list (2nd try)

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -33,22 +33,26 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const { client } = useAppContext();
 
-	const [ view, setView ] = useState< View >( {
+	const [ initialView, setView ] = useState< View >( {
 		type: 'list',
 		titleField: 'title',
 		mediaField: 'icon',
 		fields: [ 'content', 'date' ],
 		page: 1,
-		perPage: 10,
 		infiniteScrollEnabled: true,
 	} );
+
+	const view = { ...initialView, perPage: notes.length };
 
 	const fields = getFields();
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
 
 	const onChangeSelection = ( selection: string[] ) => {
-		goTo( `/${ filterName }/notes/${ selection[ 0 ] }` );
+		const noteId = selection[ 0 ];
+		goTo( `/${ filterName }/notes/${ noteId }`, {
+			focusTargetSelector: `.dataviews-view-list__item[id$="-${ noteId }-item-wrapper"]`,
+		} );
 	};
 
 	const infiniteScrollHandler = useCallback( () => {
@@ -56,10 +60,6 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 			client?.loadMore();
 		}
 	}, [ client, isLoading ] );
-
-	useEffect( () => {
-		setView( ( currentView ) => ( { ...currentView, perPage: notes.length } ) );
-	}, [ notes.length ] );
 
 	useEffect( () => {
 		if ( filterName !== 'all' && notes.length < 10 && ! isLoading ) {


### PR DESCRIPTION
Fixes DOTCOM-14362.

## Proposed Changes

This PR restores the last seen notification in the popover viewport when we go back to the notification list.

It works by focusing to the notification row, by using the `focusTargetSelector` when navigating to the note details route.

### Before


https://github.com/user-attachments/assets/b416757d-93ae-463b-a096-5137f43aac45

### After


https://github.com/user-attachments/assets/3aff92b9-500c-449a-943d-d8b6dcdbf044

## Testing Instructions

1. Go to /v2
2. Open notifications
3. Scroll down
4. Click a notification
5. Click the back button
6. Verify you can see the previous notification without scrolling

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?