### PR TITLE
A4A: WPCOM Hosting Referral (monthly) display "Assign" instead of "Create site"

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -2,6 +2,7 @@ import { BadgeType, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import { isWPCOMHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
@@ -39,12 +40,14 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 	const translate = useTranslate();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 	const isPressable = product?.slug.startsWith( 'pressable' );
-	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
+	const licenseKey = purchase.license?.license_key || '';
+	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
+
 	const redirectUrl =
 		purchase.license &&
 		( isWPCOMLicense
-			? addQueryArgs( { license_key: purchase.license.license_key }, A4A_SITES_LINK_NEEDS_SETUP )
-			: addQueryArgs( { key: purchase.license.license_key }, '/marketplace/assign-license' ) );
+			? addQueryArgs( { license_key: licenseKey }, A4A_SITES_LINK_NEEDS_SETUP )
+			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' ) );
 
 	const showAssignButton = purchase.status === 'active' && redirectUrl;
 	const [ statusType, statusText ] = getPurchaseStatus( purchase, translate );


### PR DESCRIPTION
Resolve https://github.com/Automattic/automattic-for-agencies-dev/issues/2788
L-issue: `A4A-1509`

## Proposed Changes

This PR fixes an issue in the Referral section with WordPress Hosting products (monthly). We were comparing the `product?.family_slug === 'wpcom-hosting'` slug, and for WPCOM Hosting products, the Jetpack Start Billing Scheme only has in the response the yearly WPCOM Hosting product (1008) and not the monthly one (1018), which is the reason why the conditional was failing to detect it because the product was`null`. We already have a helper `isWPCOMHostingProduct` to check the license instead of the product.

**Before:**

<img width="1837" height="649" alt="image" src="https://github.com/user-attachments/assets/db259f27-d8f6-474a-82c2-25ca1850a662" />


**After:**

<img width="807" height="295" alt="image" src="https://github.com/user-attachments/assets/8e300de2-2edd-4414-834e-f075d2f8487a" />


## Why are these changes being made?

- Inconsistency in the UI for the Referral section with WordPress Hosting products (monthly) and yearly.

## Testing Instructions

- Set the `USE_STORE_SANDBOX` to `true`.
- Point `public-api.wordpress.com` to your sandbox.
- As an agency, send a WPCOM Hosting Referral to a client
- As the client, click on the email button to purchase the product. ( open it on an incognito tab)
- Select the monthly option instead of the yearly one.
- Purchase it using the testing card (4242...)
- As an agency, got to the Referral section and click on given referral and open the `Purchases`tab (see screenshot above)
  - In trunk, you will see `Assign to site`
  - In this branch, you will see `Create site` (use the A4A live-link)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
