### PR TITLE
Odie: Add the current page path to context

### DIFF
--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -143,6 +143,7 @@ export const useSendOdieMessage = () => {
 	return useMutation< ReturnedChat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
 			const chatIdSegment = odieId ? `/${ odieId }` : '';
+			const path = window.location.pathname + window.location.search;
 			return canAccessWpcomApis()
 				? await wpcomRequest( {
 						method: 'POST',
@@ -151,7 +152,7 @@ export const useSendOdieMessage = () => {
 						body: {
 							message: message.content,
 							...( version && { version } ),
-							context: { selectedSiteId },
+							context: { selectedSiteId, path },
 						},
 				  } )
 				: await apiFetch( {
@@ -160,7 +161,7 @@ export const useSendOdieMessage = () => {
 						data: {
 							message: message.content,
 							...( version && { version } ),
-							context: { selectedSiteId },
+							context: { selectedSiteId, path },
 						},
 				  } );
 		},


### PR DESCRIPTION
Fixes DOTCOM-14388

## Proposed Changes

Includes the path of the current page in the context sent to Odie.

<img width="1279" height="855" alt="Screenshot 2025-09-03 at 14 09 10" src="https://github.com/user-attachments/assets/0589b76d-22d8-4b2b-a754-37b0bf2432f8" />


## Why are these changes being made?

This way, Odie can be instructed to provide instructions based on what the user is currently looking at.

## Testing Instructions

- Use the Calypso live link below
- Monitor the network requests in your browser devtools
- Open the Help Center and start a chat with Odie
- After sending a message, check the request to the `/odie/chat` endpoint
- Make sure that the `context` param includes the current path.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
