### PR TITLE
Staging Sites: Add spinner for when the staging site is being created

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -1,6 +1,6 @@
 import { siteByIdQuery } from '@automattic/api-queries';
 import { useQueryClient, useQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -202,7 +202,21 @@ export default function HeaderStagingSiteButton( {
 			label={ disabledReason }
 			tooltipPosition="top"
 		>
-			{ isAddingStagingSite ? __( 'Adding staging site…' ) : __( 'Add staging site' ) }
+			{ isAddingStagingSite ? (
+				<>
+					<Spinner
+						style={ {
+							width: '18px !important',
+							height: '18px !important',
+							paddingRight: '2px',
+							margin: 0,
+						} }
+					/>
+					{ __( 'Adding staging site…' ) }
+				</>
+			) : (
+				__( 'Add staging site' )
+			) }
 		</Button>
 	);
 }

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -204,14 +204,7 @@ export default function HeaderStagingSiteButton( {
 		>
 			{ isAddingStagingSite ? (
 				<>
-					<Spinner
-						style={ {
-							width: '18px !important',
-							height: '18px !important',
-							paddingRight: '2px',
-							margin: 0,
-						} }
-					/>
+					<Spinner />
 					{ __( 'Adding staging site…' ) }
 				</>
 			) : (

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -51,6 +51,13 @@ $blueberry-color: #3858e9;
 					padding: 0 0 0 2px;
 				}
 			}
+
+			.components-spinner {
+				width: 18px !important;
+				height: 18px !important;
+				margin-right: 5px !important;
+				padding: 0 !important;
+			}
 		}
 
 		.hosting-dashboard-item-view__close,

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -53,8 +53,8 @@ $blueberry-color: #3858e9;
 			}
 
 			.components-spinner {
-				margin: 0 !important;
-				padding-right: 5px !important;
+				margin: 0;
+				padding-right: 5px;
 			}
 		}
 

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -53,10 +53,8 @@ $blueberry-color: #3858e9;
 			}
 
 			.components-spinner {
-				width: 18px !important;
-				height: 18px !important;
-				margin-right: 5px !important;
-				padding: 0 !important;
+				margin: 0 !important;
+				padding-right: 5px !important;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STU-733

## Proposed Changes

This PR adds a spinner to the interim dashboard for when the staging site is being created:

<img width="1220" height="118" alt="Screenshot 2025-09-03 at 3 03 00 PM" src="https://github.com/user-attachments/assets/77f677c0-bd25-49c2-b6b0-be99a6552bf8" />

We don't have specific design for this but I saw that we are using this spinner in the new dashboard so I think it makes sense that we use the same in the interim state. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site
* Navigate to `/sites/{yourAtomicSite}`
* Click on `Add staging site` button
* Ensure you see the spinner during the process while the staging site is being added 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
