### PR TITLE
A4A: Update the BD subscription cancelation notification

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -59,7 +59,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		onSuccess: () => {
 			let successMessage;
 
-			if ( storeSubscription?.is_refundable ) {
+			if ( storeSubscription && storeSubscription.is_refundable ) {
 				successMessage = translate(
 					"%(productName)s has been cancelled and we'll refund you %(amount)s %(currency)s. We've emailed you a receipt.",
 					{
@@ -72,7 +72,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 							'%(productName)s is the name of the product, %(amount)s is the refund amount, %(currency)s is the currency code.',
 					}
 				);
-			} else {
+			} else if ( storeSubscription && ! storeSubscription.is_refundable ) {
 				successMessage = translate(
 					'%(productName)s has been canceled, but it will remain active until %(date)s. After that, it will not renew. {{link}}Learn more{{/link}}',
 					{
@@ -94,6 +94,9 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 						comment: '%(productName)s is the name of the product, %(date)s is the expiry date.',
 					}
 				);
+			} else {
+				// Not BD subscription, fallback to old message.
+				successMessage = translate( 'The subscription was successfully canceled.' );
 			}
 
 			dispatch(

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useCancelClientSubscription from 'calypso/a8c-for-agencies/data/client/use-cancel-client-subscription';
@@ -18,16 +18,86 @@ type Props = {
 	onCancelSubscription: ( subscription: Subscription ) => void;
 };
 
+// Custom hook to fetch and memoize subscription details
+export function useSubscriptionDetails( subscription: Subscription ) {
+	const locale = useLocale();
+	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
+
+	const storeSubscription = subscription.subscription;
+
+	const productName = useMemo( () => {
+		return isBillingTypeBD && storeSubscription?.product_name
+			? storeSubscription.product_name
+			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
+	}, [ isBillingTypeBD, storeSubscription?.product_name, products, subscription.product_id ] );
+
+	const expiryDate = useMemo( () => {
+		return storeSubscription?.expiry
+			? formatDate( new Date( storeSubscription.expiry ), locale, { dateStyle: 'long' } )
+			: '';
+	}, [ storeSubscription?.expiry, locale ] );
+
+	return {
+		products,
+		isFetchingProductInfo,
+		storeSubscription,
+		productName,
+		expiryDate,
+		isBillingTypeBD,
+	};
+}
+
 export default function CancelSubscriptionAction( { subscription, onCancelSubscription }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ isVisible, setIsVisible ] = useState( false );
+	const { storeSubscription, productName, expiryDate } = useSubscriptionDetails( subscription );
 
 	const { mutate: cancelSubscription, isPending } = useCancelClientSubscription( {
 		onSuccess: () => {
+			let successMessage;
+
+			if ( storeSubscription?.is_refundable ) {
+				successMessage = translate(
+					"%(productName)s has been cancelled and we'll refund you %(amount)s %(currency)s. We've emailed you a receipt.",
+					{
+						args: {
+							productName,
+							amount: storeSubscription.purchase_price ?? '',
+							currency: storeSubscription.purchase_currency ?? '',
+						},
+						comment:
+							'%(productName)s is the name of the product, %(amount)s is the refund amount, %(currency)s is the currency code.',
+					}
+				);
+			} else {
+				successMessage = translate(
+					'%(productName)s has been canceled, but it will remain active until %(date)s. After that, it will not renew. {{link}}Learn more{{/link}}',
+					{
+						args: {
+							productName,
+							date: expiryDate,
+						},
+						components: {
+							link: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
+									) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+						comment: '%(productName)s is the name of the product, %(date)s is the expiry date.',
+					}
+				);
+			}
+
 			dispatch(
-				successNotice( translate( 'The subscription was successfully canceled.' ), {
+				successNotice( successMessage, {
 					id: 'a8c-cancel-subscription-success',
 				} )
 			);
@@ -87,25 +157,14 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 function A4ACancelSubscriptionContent( { subscription }: { subscription: Subscription } ) {
 	const translate = useTranslate();
-	const locale = useLocale();
-	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
-	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
+	const { isFetchingProductInfo, storeSubscription, productName, expiryDate } =
+		useSubscriptionDetails( subscription );
 
 	if ( isFetchingProductInfo ) {
 		return <TextPlaceholder />;
 	}
 
-	const storeSubscription = subscription.subscription;
-
-	const productName =
-		isBillingTypeBD && storeSubscription?.product_name
-			? storeSubscription.product_name
-			: products?.find( ( product ) => product.product_id === subscription.product_id )?.name ?? '';
-
 	if ( storeSubscription ) {
-		const expiryDate = storeSubscription.expiry
-			? formatDate( new Date( storeSubscription.expiry ), locale, { dateStyle: 'long' } )
-			: '';
 		return (
 			<>
 				<div>

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -61,15 +61,12 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 			if ( storeSubscription && storeSubscription.is_refundable ) {
 				successMessage = translate(
-					"%(productName)s has been cancelled and we'll refund you %(amount)s %(currency)s. We've emailed you a receipt.",
+					"%(productName)s has been cancelled, and we'll refund you the amount paid. We've emailed you a receipt.",
 					{
 						args: {
 							productName,
-							amount: storeSubscription.purchase_price ?? '',
-							currency: storeSubscription.purchase_currency ?? '',
 						},
-						comment:
-							'%(productName)s is the name of the product, %(amount)s is the refund amount, %(currency)s is the currency code.',
+						comment: '%(productName)s is the name of the product.',
 					}
 				);
 			} else if ( storeSubscription && ! storeSubscription.is_refundable ) {


### PR DESCRIPTION
Part of https://github.com/Automattic/automattic-for-agencies-dev/issues/2788

## Proposed Changes

This PR updates the Billing Dragon subscription cancellation notification to include more details about the cancellation and the subscription status.

- Refundable case:

<img width="776" height="64" alt="image" src="https://github.com/user-attachments/assets/cff6b804-d5cb-431a-b0ee-10c2dac5ab94" />

- Not refundable case:

<img width="940" height="60" alt="image" src="https://github.com/user-attachments/assets/fc74da54-e4cb-49cb-9a1b-bd2fd97892fc" />

Also, this PR adds a hook to share logic between the notification and the modal code.

## Why are these changes being made?

- L-issue: A4A-1509

## Testing Instructions

If you already have a BD subscription, you can cancel it and see the notification copy.

Also, if you test it in local, you can mock the cancellation and test the different scenarios explained above. This is the fastest way to test all the scenarios. You have to update this file to mock the request: `client/a8c-for-agencies/data/client/use-cancel-client-subscription.ts`

```typescript
function mutationCancelClientSubscription( { licenseKey }: Params ): Promise< Subscription > {
	return new Promise( ( resolve ) => {
		setTimeout(
			() =>
				resolve( {
					id: 1,
					status: 'canceled',
					referral_id: 123,
					product_id: 456,
					quantity: 1,
					license: {
						license_key: licenseKey,
					},
					subscription: {
						id: 'sub_123',
						product_name: 'Pro Plan',
						purchase_price: '99.99',
						purchase_currency: 'USD',
						billing_interval_unit: 'month',
						status: 'active',
						expiry: '2023-12-31',
						is_auto_renew_enabled: true,
						is_refundable: false,
					},
					site_assigned: 'example.com',
				} ),
			1000
		);
	} );
	/*return wpcom.req.post( {
		method: 'DELETE',
		apiNamespace: 'wpcom/v2',
		path: '/agency-client/license',
		body: { license_key: licenseKey },
	} );*/
}
```
- Ensure you set USE_STORE_SANDBOX to true and point the endpoint to your sandbox.
- In your local code (Calypso), add this line: 
- As a client, if you don't have a referral subscription, you have (as agency) send a referral (WPCOM hosting).
- Once you have an active subscription, as a client, go to `Your subscriptions` and click on `Cancel the subscription`.
- You will see one of the notification messages (Depending on your subscription), probably will ve the refundable one if your subscription is new.
- To check the other message, just add this line in `client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx` => L62: `storeSubscription && ( storeSubscription.is_refundable = false );`
- Reload and click on `Cancel the subscription` You will see the other message.

- Extra check, since the modal code was update, ensure that the modal content is the same like before:

<img width="963" height="278" alt="image" src="https://github.com/user-attachments/assets/c1f132cc-1b0b-4b1c-b32a-3b0254db202e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
