### PR TITLE
A4A: An agency cannot revoke a client license

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -156,6 +156,7 @@ export default function LicenseDetailsActions( {
 				) }
 
 			{ canRevoke &&
+				! isClientLicense &&
 				( isChildLicense
 					? licenseState === LicenseState.Attached
 					: licenseState !== LicenseState.Revoked ) &&


### PR DESCRIPTION
Part of https://github.com/Automattic/automattic-for-agencies-dev/issues/2750

## Proposed Changes

This PR removes the `Revoke` button from the `Purchases` page for any referral subscription. The agencies cannot revoke licenses from their referral clients (the real owners of the license).

- Before:

<img width="714" height="266" alt="image" src="https://github.com/user-attachments/assets/95472b40-106b-4131-b98a-ac9bce5f4925" />

- After:

<img width="729" height="273" alt="image" src="https://github.com/user-attachments/assets/c9aa814c-5190-48d3-b902-32e371abe72c" />


## Why are these changes being made?

- L-issue: `A4A-1394`

## Testing Instructions

- As an agency, with referrals (any type), go to the `Purchases` page and expand a referral subscription line (Chevron icon).
  - In trunk, you will see the `Revoke` button.
  - In this branch, you won't see it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
