### PR TITLE
Dashboard v2: User Profile - Account deletion

### DIFF
--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -92,7 +92,7 @@ export default function AccountDeletionConfirmModal( {
 									key={ option.href }
 									title={ option.text }
 									actions={
-										<HStack spacing={ 2 } expanded={ false }>
+										<HStack spacing={ 0 } expanded={ false }>
 											{ option.supportLink && (
 												<Button
 													variant="tertiary"

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -156,37 +156,46 @@ export default function AccountDeletionConfirmModal( {
 
 	const isConfirmDisabled = ! isItemValid( formData, fields, form ) || isDeleting;
 
+	const handleSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		if ( ! isConfirmDisabled ) {
+			onConfirm();
+		}
+	};
+
 	return (
 		<Modal title={ __( 'Confirm account deletion' ) } onRequestClose={ onClose }>
-			<VStack spacing={ 6 }>
-				<Text>
-					{ __(
-						'Please type your username in the field below to confirm. Your account will then be gone forever.'
-					) }
-				</Text>
-				<DataForm< ConfirmationFormData >
-					data={ formData }
-					fields={ fields }
-					form={ form }
-					onChange={ ( edits: Partial< ConfirmationFormData > ) => {
-						setFormData( ( data ) => ( { ...data, ...edits } ) );
-					} }
-				/>
-				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						variant="primary"
-						isDestructive
-						onClick={ onConfirm }
-						disabled={ isConfirmDisabled }
-						isBusy={ isDeleting }
-					>
-						{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
-					</Button>
-				</ButtonStack>
-			</VStack>
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 6 }>
+					<Text>
+						{ __(
+							'Please type your username in the field below to confirm. Your account will then be gone forever.'
+						) }
+					</Text>
+					<DataForm< ConfirmationFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< ConfirmationFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							type="submit"
+							disabled={ isConfirmDisabled }
+							isBusy={ isDeleting }
+						>
+							{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</form>
 		</Modal>
 	);
 }

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	Button,
 	Modal,
@@ -8,6 +9,15 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronRight, help } from '@wordpress/icons';
+import ActionList from '../../components/action-list';
+import { ButtonStack } from '../../components/button-stack';
+
+interface AlternativeOption {
+	text: string;
+	href: string;
+	supportLink?: string;
+}
 
 interface AccountDeletionConfirmModalProps {
 	isOpen: boolean;
@@ -15,6 +25,7 @@ interface AccountDeletionConfirmModalProps {
 	onConfirm: () => void;
 	username: string;
 	isDeleting: boolean;
+	siteCount?: number;
 }
 
 export default function AccountDeletionConfirmModal( {
@@ -23,55 +34,146 @@ export default function AccountDeletionConfirmModal( {
 	onConfirm,
 	username,
 	isDeleting,
+	siteCount = 0,
 }: AccountDeletionConfirmModalProps ) {
+	const [ showAlternatives, setShowAlternatives ] = useState( true );
 	const [ confirmText, setConfirmText ] = useState( '' );
 	const isConfirmDisabled = confirmText !== username || isDeleting;
+
+	// Alternative options to show before account deletion
+	const alternativeOptions: AlternativeOption[] = [
+		...( siteCount > 0
+			? [
+					{
+						text: __( "Change your site's address" ),
+						href: '/v2/domains',
+						supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
+					},
+					{
+						text: __( 'Delete a site' ),
+						href: '/v2/sites',
+						supportLink: localizeUrl( 'https://wordpress.com/support/delete-site/' ),
+					},
+			  ]
+			: [] ),
+		{
+			text: __( 'Start a new site' ),
+			href: '/start?ref=me-account-close',
+			supportLink: localizeUrl( 'https://wordpress.com/support/create-a-blog/' ),
+		},
+		{
+			text: __( 'Change your username' ),
+			href: '/v2/me/account',
+			supportLink: localizeUrl( 'https://wordpress.com/support/change-your-username/' ),
+		},
+		{
+			text: __( 'Change your password' ),
+			href: '/v2/me/security',
+			supportLink: localizeUrl( 'https://wordpress.com/support/passwords/' ),
+		},
+	];
 
 	// If not open, render nothing
 	if ( ! isOpen ) {
 		return null;
 	}
 
-	// Reset confirm text when modal closes
+	// Reset state when modal closes
 	const handleClose = () => {
 		setConfirmText( '' );
+		setShowAlternatives( true );
 		onClose();
+	};
+
+	const handleContinue = () => {
+		setShowAlternatives( false );
 	};
 
 	return (
 		<Modal
-			title={ __( 'Confirm account deletion' ) }
+			title={ showAlternatives ? __( 'Are you sure?' ) : __( 'Confirm account deletion' ) }
 			onRequestClose={ handleClose }
-			className="account-deletion-confirm-modal"
 		>
 			<VStack spacing={ 4 }>
-				<Text>
-					{ __(
-						'Please type your username in the field below to confirm. Your account will then be gone forever.'
-					) }
-				</Text>
-				<TextControl
-					label={ __( 'Type your username to confirm' ) }
-					value={ confirmText }
-					onChange={ setConfirmText }
-					placeholder={ username }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-				<HStack justify="flex-end" spacing={ 2 }>
-					<Button variant="tertiary" onClick={ handleClose } disabled={ isDeleting }>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						variant="primary"
-						isDestructive
-						onClick={ onConfirm }
-						disabled={ isConfirmDisabled }
-						isBusy={ isDeleting }
-					>
-						{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
-					</Button>
-				</HStack>
+				{ showAlternatives ? (
+					<>
+						<Text>
+							{ __( "Here's a few options to try before you permanently delete your account." ) }
+						</Text>
+						<ActionList>
+							{ alternativeOptions.map( ( option ) => (
+								<ActionList.ActionItem
+									key={ option.href }
+									title={ option.text }
+									actions={
+										<HStack spacing={ 2 } expanded={ false }>
+											{ option.supportLink && (
+												<Button
+													variant="tertiary"
+													icon={ help }
+													size="compact"
+													href={ option.supportLink }
+													target="_blank"
+													rel="noopener noreferrer"
+													aria-label={ __( 'Get help' ) }
+													style={ { minWidth: 'auto' } }
+												/>
+											) }
+											<Button
+												variant="tertiary"
+												icon={ chevronRight }
+												size="compact"
+												href={ option.href }
+												target="_blank"
+												rel="noopener noreferrer"
+												aria-label={ option.text }
+												style={ { minWidth: 'auto' } }
+											/>
+										</HStack>
+									}
+								/>
+							) ) }
+						</ActionList>
+						<ButtonStack justify="flex-end">
+							<Button variant="tertiary" onClick={ handleClose }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button variant="primary" onClick={ handleContinue }>
+								{ __( 'Continue' ) }
+							</Button>
+						</ButtonStack>
+					</>
+				) : (
+					<>
+						<Text>
+							{ __(
+								'Please type your username in the field below to confirm. Your account will then be gone forever.'
+							) }
+						</Text>
+						<TextControl
+							label={ __( 'Type your username to confirm' ) }
+							value={ confirmText }
+							onChange={ setConfirmText }
+							placeholder={ username }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<ButtonStack justify="flex-end">
+							<Button variant="tertiary" onClick={ handleClose } disabled={ isDeleting }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ onConfirm }
+								disabled={ isConfirmDisabled }
+								isBusy={ isDeleting }
+							>
+								{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
+							</Button>
+						</ButtonStack>
+					</>
+				) }
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -20,7 +20,6 @@ interface AlternativeOption {
 }
 
 interface AccountDeletionConfirmModalProps {
-	isOpen: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
 	username: string;
@@ -29,7 +28,6 @@ interface AccountDeletionConfirmModalProps {
 }
 
 export default function AccountDeletionConfirmModal( {
-	isOpen,
 	onClose,
 	onConfirm,
 	username,
@@ -72,11 +70,6 @@ export default function AccountDeletionConfirmModal( {
 			supportLink: localizeUrl( 'https://wordpress.com/support/passwords/' ),
 		},
 	];
-
-	// If not open, render nothing
-	if ( ! isOpen ) {
-		return null;
-	}
 
 	// Reset state when modal closes
 	const handleClose = () => {

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -1,0 +1,78 @@
+import {
+	Button,
+	Modal,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+interface AccountDeletionConfirmModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	username: string;
+	isDeleting: boolean;
+}
+
+export default function AccountDeletionConfirmModal( {
+	isOpen,
+	onClose,
+	onConfirm,
+	username,
+	isDeleting,
+}: AccountDeletionConfirmModalProps ) {
+	const [ confirmText, setConfirmText ] = useState( '' );
+	const isConfirmDisabled = confirmText !== username || isDeleting;
+
+	// If not open, render nothing
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	// Reset confirm text when modal closes
+	const handleClose = () => {
+		setConfirmText( '' );
+		onClose();
+	};
+
+	return (
+		<Modal
+			title={ __( 'Confirm account deletion' ) }
+			onRequestClose={ handleClose }
+			className="account-deletion-confirm-modal"
+		>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ __(
+						'Please type your username in the field below to confirm. Your account will then be gone forever.'
+					) }
+				</Text>
+				<TextControl
+					label={ __( 'Type your username to confirm' ) }
+					value={ confirmText }
+					onChange={ setConfirmText }
+					placeholder={ username }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+				<HStack justify="flex-end" spacing={ 2 }>
+					<Button variant="tertiary" onClick={ handleClose } disabled={ isDeleting }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						isDestructive
+						onClick={ onConfirm }
+						disabled={ isConfirmDisabled }
+						isBusy={ isDeleting }
+					>
+						{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -12,10 +12,11 @@ import { __ } from '@wordpress/i18n';
 import { chevronRight, help } from '@wordpress/icons';
 import ActionList from '../../components/action-list';
 import { ButtonStack } from '../../components/button-stack';
+import RouterLinkButton from '../../components/router-link-button';
 
 interface AlternativeOption {
 	text: string;
-	href: string;
+	to: string;
 	supportLink?: string;
 }
 
@@ -44,29 +45,29 @@ export default function AccountDeletionConfirmModal( {
 			? [
 					{
 						text: __( "Change your site's address" ),
-						href: '/v2/domains',
+						to: '/v2/domains',
 						supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
 					},
 					{
 						text: __( 'Delete a site' ),
-						href: '/v2/sites',
+						to: '/v2/sites',
 						supportLink: localizeUrl( 'https://wordpress.com/support/delete-site/' ),
 					},
 			  ]
 			: [] ),
 		{
 			text: __( 'Start a new site' ),
-			href: '/start?ref=me-account-close',
+			to: '/start?ref=me-account-close',
 			supportLink: localizeUrl( 'https://wordpress.com/support/create-a-blog/' ),
 		},
 		{
 			text: __( 'Change your username' ),
-			href: '/v2/me/account',
+			to: '/v2/me/account',
 			supportLink: localizeUrl( 'https://wordpress.com/support/change-your-username/' ),
 		},
 		{
 			text: __( 'Change your password' ),
-			href: '/v2/me/security',
+			to: '/v2/me/security',
 			supportLink: localizeUrl( 'https://wordpress.com/support/passwords/' ),
 		},
 	];
@@ -104,12 +105,12 @@ export default function AccountDeletionConfirmModal( {
 													aria-label={ __( 'Get help' ) }
 												/>
 											) }
-											<Button
+											<RouterLinkButton
+												__next40pxDefaultSize
 												variant="tertiary"
 												icon={ chevronRight }
 												size="compact"
-												href={ option.href }
-												target="_blank"
+												to={ option.to }
 												rel="noopener noreferrer"
 												aria-label={ option.text }
 											/>

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -90,7 +90,7 @@ export default function AccountDeletionConfirmModal( {
 						<ActionList>
 							{ alternativeOptions.map( ( option ) => (
 								<ActionList.ActionItem
-									key={ option.href }
+									key={ option.to }
 									title={ option.text }
 									actions={
 										<HStack spacing={ 0 } expanded={ false }>

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -71,13 +71,6 @@ export default function AccountDeletionConfirmModal( {
 		},
 	];
 
-	// Reset state when modal closes
-	const handleClose = () => {
-		setConfirmText( '' );
-		setShowAlternatives( true );
-		onClose();
-	};
-
 	const handleContinue = () => {
 		setShowAlternatives( false );
 	};
@@ -85,7 +78,7 @@ export default function AccountDeletionConfirmModal( {
 	return (
 		<Modal
 			title={ showAlternatives ? __( 'Are you sure?' ) : __( 'Confirm account deletion' ) }
-			onRequestClose={ handleClose }
+			onRequestClose={ onClose }
 		>
 			<VStack spacing={ 4 }>
 				{ showAlternatives ? (
@@ -128,7 +121,7 @@ export default function AccountDeletionConfirmModal( {
 							) ) }
 						</ActionList>
 						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ handleClose }>
+							<Button variant="tertiary" onClick={ onClose }>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button variant="primary" onClick={ handleContinue }>
@@ -152,7 +145,7 @@ export default function AccountDeletionConfirmModal( {
 							__nextHasNoMarginBottom
 						/>
 						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ handleClose } disabled={ isDeleting }>
+							<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -2,11 +2,11 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	Button,
 	Modal,
-	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { DataForm, Field, isItemValid } from '@wordpress/dataviews';
 import { useState } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, help } from '@wordpress/icons';
@@ -18,6 +18,10 @@ interface AlternativeOption {
 	text: string;
 	to: string;
 	supportLink?: string;
+}
+
+interface ConfirmationFormData {
+	confirmText: string;
 }
 
 interface AccountDeletionConfirmModalProps {
@@ -36,8 +40,7 @@ export default function AccountDeletionConfirmModal( {
 	siteCount = 0,
 }: AccountDeletionConfirmModalProps ) {
 	const [ showAlternatives, setShowAlternatives ] = useState( true );
-	const [ confirmText, setConfirmText ] = useState( '' );
-	const isConfirmDisabled = confirmText !== username || isDeleting;
+	const [ formData, setFormData ] = useState< ConfirmationFormData >( { confirmText: '' } );
 
 	// Alternative options to show before account deletion
 	const alternativeOptions: AlternativeOption[] = [
@@ -128,6 +131,31 @@ export default function AccountDeletionConfirmModal( {
 		);
 	}
 
+	// DataForm configuration for the confirmation form
+	const fields: Field< ConfirmationFormData >[] = [
+		{
+			id: 'confirmText',
+			type: 'text',
+			label: __( 'Type your username to confirm' ),
+			placeholder: username,
+			isValid: {
+				required: true,
+				custom: ( data: ConfirmationFormData ) => {
+					return data.confirmText === username
+						? null
+						: __( 'Please type your username exactly as shown' );
+				},
+			},
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'confirmText' ],
+	};
+
+	const isConfirmDisabled = ! isItemValid( formData, fields, form ) || isDeleting;
+
 	return (
 		<Modal title={ __( 'Confirm account deletion' ) } onRequestClose={ onClose }>
 			<VStack spacing={ 6 }>
@@ -136,13 +164,13 @@ export default function AccountDeletionConfirmModal( {
 						'Please type your username in the field below to confirm. Your account will then be gone forever.'
 					) }
 				</Text>
-				<TextControl
-					label={ __( 'Type your username to confirm' ) }
-					value={ confirmText }
-					onChange={ setConfirmText }
-					placeholder={ username }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
+				<DataForm< ConfirmationFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits: Partial< ConfirmationFormData > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
 				/>
 				<ButtonStack justify="flex-end">
 					<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -8,8 +8,8 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { chevronRight, help } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight, help } from '@wordpress/icons';
 import ActionList from '../../components/action-list';
 import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
@@ -108,7 +108,7 @@ export default function AccountDeletionConfirmModal( {
 											<RouterLinkButton
 												__next40pxDefaultSize
 												variant="tertiary"
-												icon={ chevronRight }
+												icon={ isRTL() ? chevronLeft : chevronRight }
 												size="compact"
 												to={ option.to }
 												rel="noopener noreferrer"

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -102,7 +102,6 @@ export default function AccountDeletionConfirmModal( {
 													target="_blank"
 													rel="noopener noreferrer"
 													aria-label={ __( 'Get help' ) }
-													style={ { minWidth: 'auto' } }
 												/>
 											) }
 											<Button
@@ -113,7 +112,6 @@ export default function AccountDeletionConfirmModal( {
 												target="_blank"
 												rel="noopener noreferrer"
 												aria-label={ option.text }
-												style={ { minWidth: 'auto' } }
 											/>
 										</HStack>
 									}

--- a/client/dashboard/me/profile-deletion/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/confirmation-modal.tsx
@@ -76,89 +76,88 @@ export default function AccountDeletionConfirmModal( {
 		setShowAlternatives( false );
 	};
 
-	return (
-		<Modal
-			title={ showAlternatives ? __( 'Are you sure?' ) : __( 'Confirm account deletion' ) }
-			onRequestClose={ onClose }
-		>
-			<VStack spacing={ 4 }>
-				{ showAlternatives ? (
-					<>
-						<Text>
-							{ __( "Here's a few options to try before you permanently delete your account." ) }
-						</Text>
-						<ActionList>
-							{ alternativeOptions.map( ( option ) => (
-								<ActionList.ActionItem
-									key={ option.to }
-									title={ option.text }
-									actions={
-										<HStack spacing={ 0 } expanded={ false }>
-											{ option.supportLink && (
-												<Button
-													variant="tertiary"
-													icon={ help }
-													size="compact"
-													href={ option.supportLink }
-													target="_blank"
-													rel="noopener noreferrer"
-													aria-label={ __( 'Get help' ) }
-												/>
-											) }
-											<RouterLinkButton
-												__next40pxDefaultSize
+	if ( showAlternatives ) {
+		return (
+			<Modal title={ __( 'Are you sure?' ) } onRequestClose={ onClose }>
+				<VStack spacing={ 6 }>
+					<Text>
+						{ __( "Here's a few options to try before you permanently delete your account." ) }
+					</Text>
+					<ActionList>
+						{ alternativeOptions.map( ( option ) => (
+							<ActionList.ActionItem
+								key={ option.to }
+								title={ option.text }
+								actions={
+									<HStack spacing={ 0 } expanded={ false }>
+										{ option.supportLink && (
+											<Button
 												variant="tertiary"
-												icon={ isRTL() ? chevronLeft : chevronRight }
+												icon={ help }
 												size="compact"
-												to={ option.to }
+												href={ option.supportLink }
+												target="_blank"
 												rel="noopener noreferrer"
-												aria-label={ option.text }
+												aria-label={ __( 'Get help' ) }
 											/>
-										</HStack>
-									}
-								/>
-							) ) }
-						</ActionList>
-						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ onClose }>
-								{ __( 'Cancel' ) }
-							</Button>
-							<Button variant="primary" onClick={ handleContinue }>
-								{ __( 'Continue' ) }
-							</Button>
-						</ButtonStack>
-					</>
-				) : (
-					<>
-						<Text>
-							{ __(
-								'Please type your username in the field below to confirm. Your account will then be gone forever.'
-							) }
-						</Text>
-						<TextControl
-							label={ __( 'Type your username to confirm' ) }
-							value={ confirmText }
-							onChange={ setConfirmText }
-							placeholder={ username }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
-								{ __( 'Cancel' ) }
-							</Button>
-							<Button
-								variant="primary"
-								isDestructive
-								onClick={ onConfirm }
-								disabled={ isConfirmDisabled }
-								isBusy={ isDeleting }
-							>
-								{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
-							</Button>
-						</ButtonStack>
-					</>
-				) }
+										) }
+										<RouterLinkButton
+											__next40pxDefaultSize
+											variant="tertiary"
+											icon={ isRTL() ? chevronLeft : chevronRight }
+											size="compact"
+											to={ option.to }
+											rel="noopener noreferrer"
+											aria-label={ option.text }
+										/>
+									</HStack>
+								}
+							/>
+						) ) }
+					</ActionList>
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button variant="primary" onClick={ handleContinue }>
+							{ __( 'Continue' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</Modal>
+		);
+	}
+
+	return (
+		<Modal title={ __( 'Confirm account deletion' ) } onRequestClose={ onClose }>
+			<VStack spacing={ 6 }>
+				<Text>
+					{ __(
+						'Please type your username in the field below to confirm. Your account will then be gone forever.'
+					) }
+				</Text>
+				<TextControl
+					label={ __( 'Type your username to confirm' ) }
+					value={ confirmText }
+					onChange={ setConfirmText }
+					placeholder={ username }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+				<ButtonStack justify="flex-end">
+					<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						isDestructive
+						onClick={ onConfirm }
+						disabled={ isConfirmDisabled }
+						isBusy={ isDeleting }
+					>
+						{ isDeleting ? __( 'Deleting account…' ) : __( 'Delete account' ) }
+					</Button>
+				</ButtonStack>
 			</VStack>
 		</Modal>
 	);

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -1,0 +1,83 @@
+import { closeAccountMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { Button, Card, CardBody, Icon } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useAuth } from '../../app/auth';
+import ActionItem from '../../components/action-list/action-item';
+import AccountDeletionConfirmModal from './confirmation-modal';
+
+export default function AccountDeletionSection() {
+	const { user } = useAuth();
+	const navigate = useNavigate();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
+	const mutation = useMutation( closeAccountMutation() );
+
+	// Ensure we have a username before rendering
+	if ( ! user?.username ) {
+		return null;
+	}
+
+	const handleDeleteClick = () => {
+		setShowConfirmModal( true );
+	};
+
+	const handleConfirmDelete = () => {
+		mutation.mutate( void 0, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Account deletion initiated.' ), { type: 'snackbar' } );
+				navigate( {
+					to: '/me/account/closed',
+				} );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to delete account.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleCloseModal = () => {
+		setShowConfirmModal( false );
+	};
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<ActionItem
+						actions={
+							<Button
+								disabled={ mutation.isPending }
+								onClick={ handleDeleteClick }
+								isDestructive
+								variant="secondary"
+								size="compact"
+								style={ { minWidth: 'fit-content' } }
+							>
+								{ __( 'Delete account' ) }
+							</Button>
+						}
+						decoration={ <Icon icon={ trash } size={ 24 } /> }
+						description={ __( 'Delete all of your sites and close your account completely.' ) }
+						title={ __( 'Delete your account permanently' ) }
+					/>
+				</CardBody>
+			</Card>
+
+			<AccountDeletionConfirmModal
+				isOpen={ showConfirmModal }
+				onClose={ handleCloseModal }
+				onConfirm={ handleConfirmDelete }
+				username={ user.username }
+				isDeleting={ mutation.isPending }
+			/>
+		</>
+	);
+}

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -18,11 +18,6 @@ export default function AccountDeletionSection() {
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const mutation = useMutation( closeAccountMutation() );
 
-	// Ensure we have a username before rendering
-	if ( ! user?.username ) {
-		return null;
-	}
-
 	const handleDeleteClick = () => {
 		setShowConfirmModal( true );
 	};

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -71,14 +71,15 @@ export default function AccountDeletionSection() {
 				</CardBody>
 			</Card>
 
-			<AccountDeletionConfirmModal
-				isOpen={ showConfirmModal }
-				onClose={ handleCloseModal }
-				onConfirm={ handleConfirmDelete }
-				username={ user.username }
-				isDeleting={ mutation.isPending }
-				siteCount={ user.site_count || 0 }
-			/>
+			{ showConfirmModal && (
+				<AccountDeletionConfirmModal
+					onClose={ handleCloseModal }
+					onConfirm={ handleConfirmDelete }
+					username={ user.username }
+					isDeleting={ mutation.isPending }
+					siteCount={ user.site_count || 0 }
+				/>
+			) }
 		</>
 	);
 }

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -77,6 +77,7 @@ export default function AccountDeletionSection() {
 				onConfirm={ handleConfirmDelete }
 				username={ user.username }
 				isDeleting={ mutation.isPending }
+				siteCount={ user.site_count || 0 }
 			/>
 		</>
 	);

--- a/client/dashboard/me/profile-deletion/test/confirmation-modal.test.tsx
+++ b/client/dashboard/me/profile-deletion/test/confirmation-modal.test.tsx
@@ -1,12 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render } from '../../../test-utils';
 import AccountDeletionConfirmModal from '../confirmation-modal';
 
 const defaultProps = {
-	isOpen: true,
 	onClose: jest.fn(),
 	onConfirm: jest.fn(),
 	username: 'testuser',
@@ -49,7 +49,7 @@ describe( 'AccountDeletionConfirmModal', () => {
 				'Please type your username in the field below to confirm. Your account will then be gone forever.'
 			)
 		).toBeInTheDocument();
-		expect( screen.getByLabelText( 'Type your username to confirm' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( /Type your username to confirm/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'enables delete button only when username is correctly typed', () => {
@@ -59,7 +59,7 @@ describe( 'AccountDeletionConfirmModal', () => {
 		fireEvent.click( screen.getByText( 'Continue' ) );
 
 		const deleteButton = screen.getByText( 'Delete account' );
-		const usernameInput = screen.getByLabelText( 'Type your username to confirm' );
+		const usernameInput = screen.getByLabelText( /Type your username to confirm/ );
 
 		expect( deleteButton ).toBeDisabled();
 
@@ -86,17 +86,11 @@ describe( 'AccountDeletionConfirmModal', () => {
 		// Go to confirmation screen
 		fireEvent.click( screen.getByText( 'Continue' ) );
 
-		const usernameInput = screen.getByLabelText( 'Type your username to confirm' );
+		const usernameInput = screen.getByLabelText( /Type your username to confirm/ );
 		fireEvent.change( usernameInput, { target: { value: 'testuser' } } );
 
 		fireEvent.click( screen.getByText( 'Delete account' ) );
 
 		expect( onConfirm ).toHaveBeenCalled();
-	} );
-
-	it( 'does not render when isOpen is false', () => {
-		render( <AccountDeletionConfirmModal { ...defaultProps } isOpen={ false } /> );
-
-		expect( screen.queryByText( 'Are you sure?' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/me/profile-deletion/test/confirmation-modal.test.tsx
+++ b/client/dashboard/me/profile-deletion/test/confirmation-modal.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AccountDeletionConfirmModal from '../confirmation-modal';
+
+const defaultProps = {
+	isOpen: true,
+	onClose: jest.fn(),
+	onConfirm: jest.fn(),
+	username: 'testuser',
+	isDeleting: false,
+	siteCount: 2,
+};
+
+describe( 'AccountDeletionConfirmModal', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the alternatives screen by default', () => {
+		render( <AccountDeletionConfirmModal { ...defaultProps } /> );
+
+		// Check that the correct title is present
+		expect( screen.getByText( 'Are you sure?' ) ).toBeInTheDocument();
+
+		// Check that the ActionList and ActionItem components are present
+		expect( document.querySelector( '.action-list' ) ).toBeInTheDocument();
+		expect( document.querySelector( '.action-item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows site-specific options only when user has sites', () => {
+		render( <AccountDeletionConfirmModal { ...defaultProps } siteCount={ 0 } /> );
+
+		expect( screen.queryByText( "Change your site's address" ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Delete a site' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Start a new site' ) ).toBeInTheDocument();
+	} );
+
+	it( 'transitions to confirmation screen when Continue is clicked', () => {
+		render( <AccountDeletionConfirmModal { ...defaultProps } /> );
+
+		fireEvent.click( screen.getByText( 'Continue' ) );
+
+		expect( screen.getByText( 'Confirm account deletion' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Please type your username in the field below to confirm. Your account will then be gone forever.'
+			)
+		).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Type your username to confirm' ) ).toBeInTheDocument();
+	} );
+
+	it( 'enables delete button only when username is correctly typed', () => {
+		render( <AccountDeletionConfirmModal { ...defaultProps } /> );
+
+		// Go to confirmation screen
+		fireEvent.click( screen.getByText( 'Continue' ) );
+
+		const deleteButton = screen.getByText( 'Delete account' );
+		const usernameInput = screen.getByLabelText( 'Type your username to confirm' );
+
+		expect( deleteButton ).toBeDisabled();
+
+		fireEvent.change( usernameInput, { target: { value: 'wrongusername' } } );
+		expect( deleteButton ).toBeDisabled();
+
+		fireEvent.change( usernameInput, { target: { value: 'testuser' } } );
+		expect( deleteButton ).not.toBeDisabled();
+	} );
+
+	it( 'calls onClose when Cancel is clicked', () => {
+		const onClose = jest.fn();
+		render( <AccountDeletionConfirmModal { ...defaultProps } onClose={ onClose } /> );
+
+		fireEvent.click( screen.getByText( 'Cancel' ) );
+
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'calls onConfirm when Delete account is clicked with correct username', () => {
+		const onConfirm = jest.fn();
+		render( <AccountDeletionConfirmModal { ...defaultProps } onConfirm={ onConfirm } /> );
+
+		// Go to confirmation screen
+		fireEvent.click( screen.getByText( 'Continue' ) );
+
+		const usernameInput = screen.getByLabelText( 'Type your username to confirm' );
+		fireEvent.change( usernameInput, { target: { value: 'testuser' } } );
+
+		fireEvent.click( screen.getByText( 'Delete account' ) );
+
+		expect( onConfirm ).toHaveBeenCalled();
+	} );
+
+	it( 'does not render when isOpen is false', () => {
+		render( <AccountDeletionConfirmModal { ...defaultProps } isOpen={ false } /> );
+
+		expect( screen.queryByText( 'Are you sure?' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/profile/index.tsx
+++ b/client/dashboard/me/profile/index.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import AccountDeletionSection from '../profile-deletion';
 import GravatarProfileSection from '../profile-gravatar';
 import PersonalDetailsSection from '../profile-personal-details';
 
@@ -32,6 +33,8 @@ export default function Profile() {
 			<PersonalDetailsSection profile={ serverData } />
 
 			<GravatarProfileSection profile={ serverData } />
+
+			<AccountDeletionSection />
 		</PageLayout>
 	);
 }

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -19,6 +19,7 @@ export * from './domains';
 export * from './emails';
 export * from './geo';
 export * from './me';
+export * from './me-account';
 export * from './me-blocked-sites';
 export * from './me-dpa';
 export * from './me-payment-methods';

--- a/packages/api-core/src/me-account/index.ts
+++ b/packages/api-core/src/me-account/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/me-account/mutators.ts
+++ b/packages/api-core/src/me-account/mutators.ts
@@ -1,0 +1,27 @@
+import { wpcom } from '../wpcom-fetcher';
+import { AccountClosureResponse } from './types';
+
+/**
+ * Closes the current user's account
+ * @returns Promise<AccountClosureResponse>
+ */
+export async function closeAccount(): Promise< AccountClosureResponse > {
+	return wpcom.req.post( {
+		path: '/me/account/close',
+		apiVersion: '1.1',
+		body: {}, // Empty body required by wpcom-http
+	} );
+}
+
+/**
+ * Restores a closed account using a restoration token
+ * @param token - The restoration token received when account was closed
+ * @returns Promise<void>
+ */
+export async function restoreAccount( token: string ): Promise< void > {
+	return wpcom.req.post( {
+		path: '/me/account/restore',
+		apiVersion: '1.1',
+		body: { token },
+	} );
+}

--- a/packages/api-core/src/me-account/types.ts
+++ b/packages/api-core/src/me-account/types.ts
@@ -1,0 +1,4 @@
+export interface AccountClosureResponse {
+	success: boolean;
+	token?: string;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -14,6 +14,7 @@ export * from './domain';
 export * from './domains';
 export * from './emails';
 export * from './me-a8c';
+export * from './me-account';
 export * from './me-blocked-sites';
 export * from './me-dpa';
 export * from './me-payment-methods';

--- a/packages/api-queries/src/me-account.ts
+++ b/packages/api-queries/src/me-account.ts
@@ -1,0 +1,21 @@
+import { closeAccount, restoreAccount } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+
+export const closeAccountMutation = () =>
+	mutationOptions( {
+		mutationFn: closeAccount,
+		onSuccess: () => {
+			// Clear all cached data when account is closed
+			queryClient.clear();
+		},
+	} );
+
+export const restoreAccountMutation = () =>
+	mutationOptions( {
+		mutationFn: ( token: string ) => restoreAccount( token ),
+		onSuccess: () => {
+			// Invalidate all queries to refresh data after account restoration
+			queryClient.invalidateQueries();
+		},
+	} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-369/implement-profile-account-deletion-section

## Proposed Changes

This is a follow-up on https://github.com/Automattic/wp-calypso/pull/105491

Continuing the work on the user profile page, this PR adds the account deletion card proposed by the new designs:

<img width="693" height="134" alt="Screenshot 2025-09-03 at 14 57 33" src="https://github.com/user-attachments/assets/07c1dd1e-95c9-4b88-b844-780faca9a2f3" />

<img width="523" height="537" alt="Screenshot 2025-09-03 at 14 57 42" src="https://github.com/user-attachments/assets/56ff76ae-e388-450d-95b6-08ab5209ae16" />

<img width="660" height="275" alt="Screenshot 2025-09-03 at 14 57 49" src="https://github.com/user-attachments/assets/4ca77a20-d60b-43f0-b1d6-60cdb17b5834" />

### The "Are you sure?" modal

I couldn't find the respective designs for this modal, so I asked on `#hosting-dashboard-pair-programming` and @taipeicoder suggested porting over the functionality, using new components when possible. I went with `<ActionList>` and `<ActionItem>`, which felt appropriate for this use case IMO.

#### The links

I tried to map the old links to their corresponding mapping on v2, but I couldn't find one for `http://calypso.localhost:3000/start?ref=me-account-close` so I kept the old link for now.

After confirming you want to delete your account, following the same pattern of v1, you get redirected to `/me/account/closed` - which is a route we don't have implemented yet, and I don't see it yet on the new designs. I've created [DOTDASH-381](https://linear.app/a8c/issue/DOTDASH-381/implement-the-meaccountclosed-page) to track this work.

## Why are these changes being made?

To implement the proposed designs for the new account profile page.

## Testing Instructions

⚠️ Do this with a test account to make sure you don't delete your personal account.

1. Navigate to http://calypso.localhost:3000/v2/me/profile
2. Scroll to the bottom of the page
3. Assert that you see the account deletion section:

<img width="693" height="134" alt="Screenshot 2025-09-03 at 14 57 33" src="https://github.com/user-attachments/assets/43ca7311-066c-4d11-b6f1-90bbb4453d18" />

4. Click "Delete account"
5. Assert that you see the "Are you sure" modal:

<img width="523" height="537" alt="Screenshot 2025-09-03 at 14 57 42" src="https://github.com/user-attachments/assets/66626b98-74fc-4084-8298-49cf272ab459" />

6. Click "Continue"
7. Assert that you see the confirmation modal:

<img width="660" height="275" alt="Screenshot 2025-09-03 at 14 57 49" src="https://github.com/user-attachments/assets/6fae4f0e-9798-4e19-a038-2636cc5a88b6" />

8. Type you user name and click "Delete account"
8. Assert that your account is deleted and that you are redirected to `/me/account/closed`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
