### PR TITLE
A4A: Add "Not Eligible" badge for WooPayments sites that are not eligible for commissions

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -61,7 +61,11 @@ export default function SitesWithWooPaymentsMobileView( {
 							</div>
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Review status' ) }>
-							<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
+							<WooPaymentsStatusColumn
+								state={ item.state }
+								siteId={ item.blogId }
+								woopaymentsData={ woopaymentsData }
+							/>
 						</ListItemCardContent>
 					</ListItemCard>
 				) ) }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -8,6 +8,7 @@ import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/s
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { WooPaymentsData } from '../types';
 
 export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
@@ -29,9 +30,15 @@ export const TimeframeCommissionsColumn = memo(
 );
 TimeframeCommissionsColumn.displayName = 'TimeframeCommissionsColumn';
 
-CommissionsPaidColumn.displayName = 'CommissionsPaidColumn';
-
-export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; siteId: number } ) => {
+export const WooPaymentsStatusColumn = ( {
+	state,
+	siteId,
+	woopaymentsData,
+}: {
+	state: string;
+	siteId: number;
+	woopaymentsData?: WooPaymentsData;
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -50,6 +57,17 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 	}
 
 	const getStatusProps = () => {
+		// Check if site exists in woopaymentsData
+		const siteExistsInWooPaymentsData = woopaymentsData?.data?.total?.sites?.[ siteId ];
+
+		// If site is active but not in woopaymentsData, it's not eligible
+		if ( state === 'active' && ! siteExistsInWooPaymentsData ) {
+			return {
+				statusText: translate( 'Not eligible' ),
+				statusType: 'error',
+			};
+		}
+
 		switch ( state ) {
 			case 'active':
 				return {

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -107,7 +107,9 @@ export const WooPaymentsStatusColumn = ( {
 				) }
 			</p>
 			<a
-				href={ localizeUrl( 'https://wordpress.com/support/woopayments-commissions/' ) }
+				href={ localizeUrl(
+					'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/'
+				) }
 				className="woopayments-status-popover__link"
 				target="_blank"
 				rel="noopener noreferrer"

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -2,6 +2,7 @@ import { BadgeType, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { memo, useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
@@ -107,18 +108,18 @@ export const WooPaymentsStatusColumn = ( {
 				) }
 			</p>
 			<Button
-					variant="link"
-					className="woopayments-status-popover__link"
-					href={ localizeUrl(
+				variant="link"
+				className="woopayments-status-popover__link"
+				href={ localizeUrl(
 					'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/'
-				    ) }
-					target="_blank"
-				>
-					<>
-						{ translate( 'Learn more about the incentive' ) }
-						<Icon icon={ external } size={ 18 } />
-					</>
-				</Button>
+				) }
+				target="_blank"
+			>
+				<>
+					{ translate( 'Learn more about the incentive' ) }
+					<Icon icon={ external } size={ 18 } />
+				</>
+			</Button>
 		</div>
 	);
 

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -106,17 +106,19 @@ export const WooPaymentsStatusColumn = ( {
 					'This WooPayments site is not eligible for commission since it was connected after the incentive expiration date.'
 				) }
 			</p>
-			<a
-				href={ localizeUrl(
+			<Button
+					variant="link"
+					className="woopayments-status-popover__link"
+					href={ localizeUrl(
 					'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/'
-				) }
-				className="woopayments-status-popover__link"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{ translate( 'Learn more about the incentive' ) }
-				<Gridicon icon="external" size={ 16 } />
-			</a>
+				    ) }
+					target="_blank"
+				>
+					<>
+						{ translate( 'Learn more about the incentive' ) }
+						<Icon icon={ external } size={ 18 } />
+					</>
+				</Button>
 		</div>
 	);
 

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -1,14 +1,18 @@
 import { BadgeType, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { memo } from 'react';
+import { memo, useState, useRef } from 'react';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { WooPaymentsData } from '../types';
+
+import './style.scss';
 
 export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
@@ -41,6 +45,8 @@ export const WooPaymentsStatusColumn = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const [ showPopover, setShowPopover ] = useState( false );
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
 
 	if ( ! state ) {
 		return (
@@ -65,6 +71,7 @@ export const WooPaymentsStatusColumn = ( {
 			return {
 				statusText: translate( 'Not eligible' ),
 				statusType: 'error',
+				showInfoIcon: true,
 			};
 		}
 
@@ -73,11 +80,13 @@ export const WooPaymentsStatusColumn = ( {
 				return {
 					statusText: translate( 'Active' ),
 					statusType: 'success',
+					showInfoIcon: false,
 				};
 			case 'disconnected':
 				return {
 					statusText: translate( 'Disconnected' ),
 					statusType: 'error',
+					showInfoIcon: false,
 				};
 			default:
 				return null;
@@ -90,12 +99,60 @@ export const WooPaymentsStatusColumn = ( {
 		return null;
 	}
 
+	const popoverContent = (
+		<div className="woopayments-status-popover">
+			<p className="woopayments-status-popover__text">
+				{ translate(
+					'This WooPayments site is not eligible for commission since it was connected after the incentive expiration date.'
+				) }
+			</p>
+			<a
+				href={ localizeUrl( 'https://wordpress.com/support/woopayments-commissions/' ) }
+				className="woopayments-status-popover__link"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ translate( 'Learn more about the incentive' ) }
+				<Gridicon icon="external" size={ 16 } />
+			</a>
+		</div>
+	);
+
 	return (
-		<StatusBadge
-			statusProps={ {
-				children: statusProps.statusText,
-				type: statusProps.statusType as BadgeType,
-			} }
-		/>
+		<div ref={ wrapperRef } className="woopayments-status-column">
+			<StatusBadge
+				statusProps={ {
+					children: statusProps.statusText,
+					type: statusProps.statusType as BadgeType,
+				} }
+			/>
+			{ statusProps.showInfoIcon && (
+				<>
+					<span
+						className="woopayments-status-column__info-icon"
+						onClick={ () => setShowPopover( true ) }
+						role="button"
+						tabIndex={ 0 }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Enter' ) {
+								setShowPopover( true );
+							}
+						} }
+					>
+						<Gridicon icon="info-outline" size={ 16 } />
+					</span>
+					{ showPopover && (
+						<A4APopover
+							title=""
+							offset={ 12 }
+							wrapperRef={ wrapperRef }
+							onFocusOutside={ () => setShowPopover( false ) }
+						>
+							{ popoverContent }
+						</A4APopover>
+					) }
+				</>
+			) }
+		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -94,7 +94,11 @@ export default function SitesWithWooPayments() {
 				label: translate( 'WooPayments Status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => (
-					<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
+					<WooPaymentsStatusColumn
+						state={ item.state }
+						siteId={ item.blogId }
+						woopaymentsData={ woopaymentsData }
+					/>
 				),
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -85,3 +85,62 @@
 		margin: 0;
 	}
 }
+
+.woopayments-status-column {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	position: relative;
+
+	.woopayments-status-column__info-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		color: var(--color-neutral-60);
+		transition: color 0.2s ease;
+
+		&:hover {
+			color: var(--color-neutral-80);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary);
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
+	}
+}
+
+.woopayments-status-popover {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+
+	.woopayments-status-popover__text {
+		@include body-medium;
+		margin: 0;
+		color: var(--color-text-black);
+		line-height: 1.4;
+	}
+
+	.woopayments-status-popover__link {
+		@include body-medium;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		color: var(--color-primary);
+		text-decoration: underline;
+		transition: color 0.2s ease;
+
+		&:hover {
+			color: var(--color-primary-dark);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary);
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -127,20 +127,12 @@
 	.woopayments-status-popover__link {
 		@include body-medium;
 		display: inline-flex;
-		align-items: center;
+		justify-content: left;
 		gap: 4px;
 		color: var(--color-primary);
-		text-decoration: underline;
-		transition: color 0.2s ease;
 
 		&:hover {
 			color: var(--color-primary-dark);
-		}
-
-		&:focus-visible {
-			outline: 2px solid var(--color-primary);
-			outline-offset: 2px;
-			border-radius: 2px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1499/frontend-add-not-eligible-badge-to-sites-that-cant-get-incentives

## Proposed Changes

* For a site to be eligible for incentives, it must meet the incentive rules. With this change, if a site appears in the response from the `woocommerce/woopayments` endpoint, we can assume it’s eligible for commissions, since the underlying table only contains data for sites that have earned commissions (see 191763-ghe-Automattic/wpcom).


<img width="421" height="251" alt="Screenshot 2025-09-03 at 19 40 06" src="https://github.com/user-attachments/assets/4bc29693-f98d-4a44-b103-1784ed2a5c92" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

* Apply 191763-ghe-Automattic/wpcom to your sandbox if not merged yet.
* Sandbox public-api.wordpress.com
* Go to the Referrals dashboard and find an agency with sites that are not eligible for incentives (sort by Total Referred Amount).
* Go to the agency owner profile, click the Switch to A4A button 
* Open the live link on the window impersonating the agency owner
* Go to WooPayments > Dashboard and confirm the site displays as **not eligible**.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?