### PR TITLE
Domain Search: Close trademark claim notice upon accepting it

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -857,7 +857,7 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
-	rejectTrademarkClaim = () => {
+	clearTrademarkClaimState = () => {
 		this.setState( {
 			selectedSuggestion: null,
 			selectedSuggestionPosition: null,
@@ -865,8 +865,9 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	acceptTrademarkClaim = () => {
+	acceptTrademarkClaim = async () => {
 		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
+		this.clearTrademarkClaimState();
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -880,8 +881,8 @@ class RegisterDomainStep extends Component {
 				isLoading={ isLoading }
 				isSignupStep={ isSignupStep }
 				onAccept={ this.acceptTrademarkClaim }
-				onGoBack={ this.rejectTrademarkClaim }
-				onReject={ this.rejectTrademarkClaim }
+				onGoBack={ this.clearTrademarkClaimState }
+				onReject={ this.clearTrademarkClaimState }
 				suggestion={ selectedSuggestion }
 				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
 			/>
@@ -1744,11 +1745,6 @@ class RegisterDomainStep extends Component {
 
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
-			// For Multi-domain flows, add the domain first, than check availability
-			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				this.props.onAddDomain( suggestion, position, previousState );
-			}
-
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => {
@@ -1782,7 +1778,6 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-						this.props.onMappingError( domain, status );
 					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -653,7 +653,7 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
-	rejectTrademarkClaim = () => {
+	clearTrademarkClaimState = () => {
 		this.setState( {
 			selectedSuggestion: null,
 			selectedSuggestionPosition: null,
@@ -663,6 +663,7 @@ class RegisterDomainStep extends Component {
 
 	acceptTrademarkClaim = () => {
 		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
+		this.clearTrademarkClaimState();
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -676,8 +677,8 @@ class RegisterDomainStep extends Component {
 				isLoading={ isLoading }
 				isSignupStep={ isSignupStep }
 				onAccept={ this.acceptTrademarkClaim }
-				onGoBack={ this.rejectTrademarkClaim }
-				onReject={ this.rejectTrademarkClaim }
+				onGoBack={ this.clearTrademarkClaimState }
+				onReject={ this.clearTrademarkClaimState }
 				suggestion={ selectedSuggestion }
 				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
 			/>
@@ -1583,11 +1584,6 @@ class RegisterDomainStep extends Component {
 
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
-			// For Multi-domain flows, add the domain first, than check availability
-			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				this.props.onAddDomain( suggestion, position, previousState );
-			}
-
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => [] )
@@ -1619,7 +1615,6 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-						this.props.onMappingError( domain, status );
 					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}


### PR DESCRIPTION
## Proposed Changes

While working on DOMAINS-1621, I noticed that clicking "accept" in the trademark notice doesn't close it. This PR fixes that behavior.

## Testing Instructions

In production, enter `/setup` and add `parmalat.dev` to the cart. Verify you see the trademark notice when you click add to cart, but it doesn't go away once you accept it.

In this branch, you should see the notice go away once you accept it.