### PR TITLE
Domain Search Rewrite: Fetch available TLDs from the backend in the Filter component

### DIFF
--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -45,3 +45,23 @@ export async function fetchFreeDomainSuggestion( search: string ): Promise< Free
 
 	return suggestion;
 }
+
+export async function fetchAvailableTlds( search?: string, vendor?: string ): Promise< string[] > {
+	const defaultAvailableTldsQuery = {
+		vendor: 'variation2_front',
+	};
+
+	const tlds = await wpcom.req.get(
+		{
+			apiVersion: '1.1',
+			path: '/domains/suggestions/tlds',
+		},
+		{
+			...defaultAvailableTldsQuery,
+			search,
+			vendor,
+		}
+	);
+
+	return tlds;
+}

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -10,6 +10,11 @@ export type DomainSuggestionQueryVendor =
 
 export interface DomainSuggestionQuery {
 	/**
+	 * True to only provide exact domain matches
+	 */
+	exact_sld_matches_only?: boolean;
+
+	/**
 	 * True to include .blog subdomain suggestions
 	 * @example
 	 * example.photo.blog

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -10,7 +10,7 @@ export type DomainSuggestionQueryVendor =
 
 export interface DomainSuggestionQuery {
 	/**
-	 * True to only provide exact domain matches
+	 * True to only provide exact domain name match suggestions
 	 */
 	exact_sld_matches_only?: boolean;
 

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -1,4 +1,5 @@
 import {
+	fetchAvailableTlds,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
 	type DomainSuggestionQuery,
@@ -26,4 +27,10 @@ export const freeSuggestionQuery = ( query: string ) =>
 	queryOptions( {
 		queryKey: [ 'free-suggestion', query ],
 		queryFn: () => fetchFreeDomainSuggestion( query ),
+	} );
+
+export const availableTldsQuery = ( query?: string, vendor?: string ) =>
+	queryOptions( {
+		queryKey: [ 'available-tlds', query, vendor ],
+		queryFn: () => fetchAvailableTlds( query, vendor ),
 	} );

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -12,7 +12,7 @@ const emptyFilter: FilterState = {
 
 export const Filter = () => {
 	const { filter, setFilter, query, queries } = useDomainSearch();
-	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery< string[] >( {
+	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery( {
 		...queries.availableTlds( query ),
 		enabled: true,
 	} ) as { data: string[]; isFetching: boolean };

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { Dropdown } from '@wordpress/components';
 import { useCallback, useMemo } from 'react';
 import { useDomainSearch } from '../../page/context';
@@ -10,13 +11,11 @@ const emptyFilter: FilterState = {
 };
 
 export const Filter = () => {
-	const { filter, setFilter } = useDomainSearch();
-
-	// TODO: Hardcoded for testing, should get those from the https://public-api.wordpress.com/rest/v1.1/domains/suggestions/tlds endpoint
-	const availableTlds = useMemo(
-		() => [ 'com', 'net', 'org', 'blog', 'dev', 'io', 'co', 'co.uk', 'com.br', 'de' ],
-		[]
-	);
+	const { filter, setFilter, query, queries } = useDomainSearch();
+	const { data: availableTlds = [] } = useQuery( {
+		...queries.availableTlds( query ),
+		enabled: true,
+	} );
 
 	const resetFilter = useCallback( () => {
 		setFilter( emptyFilter );

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -26,6 +26,10 @@ export const Filter = () => {
 		[ filter ]
 	);
 
+	if ( ! isFetchingTlds && ( ! availableTlds || availableTlds.length === 0 ) ) {
+		return null;
+	}
+
 	return (
 		<Dropdown
 			showArrow={ false }

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -15,7 +15,7 @@ export const Filter = () => {
 	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery< string[] >( {
 		...queries.availableTlds( query ),
 		enabled: true,
-	} );
+	} ) as { data: string[]; isFetching: boolean };
 
 	const resetFilter = useCallback( () => {
 		setFilter( emptyFilter );

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -12,7 +12,7 @@ const emptyFilter: FilterState = {
 
 export const Filter = () => {
 	const { filter, setFilter, query, queries } = useDomainSearch();
-	const { data: availableTlds = [] } = useQuery( {
+	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery< string[] >( {
 		...queries.availableTlds( query ),
 		enabled: true,
 	} );
@@ -35,7 +35,13 @@ export const Filter = () => {
 			showArrow={ false }
 			popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false, inline: true } }
 			renderToggle={ ( { onToggle } ) => {
-				return <DomainSearchControls.FilterButton count={ filterCount } onClick={ onToggle } />;
+				return (
+					<DomainSearchControls.FilterButton
+						count={ filterCount }
+						onClick={ onToggle }
+						disabled={ isFetchingTlds }
+					/>
+				);
 			} }
 			renderContent={ ( { onClose } ) => {
 				return (

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -2,10 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { useDomainSearch } from '../page/context';
 
 export const useSuggestion = ( domainName: string ) => {
-	const { query, queries } = useDomainSearch();
+	const { query, queries, filter } = useDomainSearch();
 
 	const { data: suggestion } = useQuery( {
-		...queries.domainSuggestions( query ),
+		...queries.domainSuggestions( query, {
+			tlds: filter.tlds,
+			exact_sld_matches_only: filter.exactSldMatchesOnly,
+		} ),
 		select: ( data ) => {
 			const suggestion = data.find( ( suggestion ) => suggestion.domain_name === domainName );
 

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -5,10 +5,13 @@ import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from '../page/context';
 
 export const useSuggestionsList = () => {
-	const { query, queries, config } = useDomainSearch();
+	const { query, queries, config, filter } = useDomainSearch();
 
 	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery( {
-		...queries.domainSuggestions( query ),
+		...queries.domainSuggestions( query, {
+			tlds: filter.tlds,
+			exact_sld_matches_only: filter.exactSldMatchesOnly,
+		} ),
 		enabled: true,
 	} );
 

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -23,7 +23,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	},
 	queries: {
 		availableTlds: ( search?: string, vendor?: string ) => availableTldsQuery( vendor, search ),
-		domainSuggestions: ( query: string ) => domainSuggestionsQuery( query ),
+		domainSuggestions: ( query: string, params?: Partial< typeof domainSuggestionsQuery > ) =>
+			domainSuggestionsQuery( query, params ),
 		domainAvailability: ( domainName: string ) => domainAvailabilityQuery( domainName ),
 		freeSuggestion: ( query: string ) => freeSuggestionQuery( query ),
 	},
@@ -103,7 +104,7 @@ export const useDomainSearchContextValue = (
 			events: normalizedEvents,
 			config: normalizedConfig,
 			queries: {
-				domainSuggestions: ( query, params ) => ( {
+				domainSuggestions: ( query, params = {} ) => ( {
 					...domainSuggestionsQuery( query, {
 						...params,
 						quantity: 30,

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -1,4 +1,5 @@
 import {
+	availableTldsQuery,
 	domainAvailabilityQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
@@ -21,6 +22,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onMapDomainClick: noop,
 	},
 	queries: {
+		availableTlds: ( search?: string, vendor?: string ) => availableTldsQuery( vendor, search ),
 		domainSuggestions: ( query: string ) => domainSuggestionsQuery( query ),
 		domainAvailability: ( domainName: string ) => domainAvailabilityQuery( domainName ),
 		freeSuggestion: ( query: string ) => freeSuggestionQuery( query ),
@@ -114,6 +116,10 @@ export const useDomainSearchContextValue = (
 				} ),
 				domainAvailability: ( domainName ) => ( {
 					...domainAvailabilityQuery( domainName ),
+					enabled: false,
+				} ),
+				availableTlds: ( vendor, search ) => ( {
+					...availableTldsQuery( vendor, search ),
 					enabled: false,
 				} ),
 			},

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -103,8 +103,9 @@ export const useDomainSearchContextValue = (
 			events: normalizedEvents,
 			config: normalizedConfig,
 			queries: {
-				domainSuggestions: ( query ) => ( {
+				domainSuggestions: ( query, params ) => ( {
 					...domainSuggestionsQuery( query, {
+						...params,
 						quantity: 30,
 						vendor: normalizedConfig.vendor,
 					} ),

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -74,7 +74,10 @@ export interface DomainSearchContextType
 	setFilter: ( filter: FilterState ) => void;
 	queries: {
 		availableTlds: ( query?: string, vendor?: string ) => ReturnType< typeof availableTldsQuery >;
-		domainSuggestions: ( query: string ) => ReturnType< typeof domainSuggestionsQuery >;
+		domainSuggestions: (
+			query: string,
+			params?: Partial< typeof domainSuggestionsQuery >
+		) => ReturnType< typeof domainSuggestionsQuery >;
 		domainAvailability: ( domainName: string ) => ReturnType< typeof domainAvailabilityQuery >;
 		freeSuggestion: ( query: string ) => ReturnType< typeof freeSuggestionQuery >;
 	};

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -1,4 +1,5 @@
 import {
+	availableTldsQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
 	domainAvailabilityQuery,
@@ -72,6 +73,7 @@ export interface DomainSearchContextType
 	filter: FilterState;
 	setFilter: ( filter: FilterState ) => void;
 	queries: {
+		availableTlds: ( query?: string, vendor?: string ) => ReturnType< typeof availableTldsQuery >;
 		domainSuggestions: ( query: string ) => ReturnType< typeof domainSuggestionsQuery >;
 		domainAvailability: ( domainName: string ) => ReturnType< typeof domainAvailabilityQuery >;
 		freeSuggestion: ( query: string ) => ReturnType< typeof freeSuggestionQuery >;

--- a/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
@@ -9,10 +9,11 @@ type Props = {
 	count: number;
 	onClick: () => void;
 	children?: React.ReactNode;
+	disabled?: boolean;
 };
 
 export const DomainSearchControlsFilterButton = forwardRef(
-	( { count, onClick, children }: Props, ref: Ref< HTMLButtonElement > ) => {
+	( { count, onClick, disabled, children }: Props, ref: Ref< HTMLButtonElement > ) => {
 		const { __, _n } = useI18n();
 
 		let ariaLabel = '';
@@ -32,7 +33,14 @@ export const DomainSearchControlsFilterButton = forwardRef(
 
 		return (
 			<div className="domain-search-controls__filters">
-				<Button icon={ funnel } variant="secondary" showTooltip onClick={ onClick } ref={ ref } />
+				<Button
+					icon={ funnel }
+					variant="secondary"
+					showTooltip
+					onClick={ onClick }
+					ref={ ref }
+					disabled={ disabled }
+				/>
 				{ !! count && (
 					<div
 						className="domain-search-controls__filters-count"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOMAINS-1620

## Proposed Changes

This PR:
- Updates the `Filter` component used in domain search to fetch the available TLDs from the backend and
- Adds the filter properties to the domain suggestions query, meaning the filter is now functional

### Screenshot

<img width="1177" height="707" alt="Screenshot 2025-09-03 at 20 39 16" src="https://github.com/user-attachments/assets/3de8f84a-f2d0-4ff1-981e-935f13047823" />

### Demo

https://github.com/user-attachments/assets/9a54138a-8c33-41dc-90ff-ee8f5e67de08

## Why are these changes being made?

This is part of the Domain Search Rewrite project, which aims to rewrite domain search components in a provider-agnostic way.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to `/setup/onboarding/domains?flags=domain-search-rewrite`
- Ensure the filter has all TLDs that we offer in the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
