### PR TITLE
Stats: better error checks for archive data process 

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -439,10 +439,21 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
-		const archivesData = get( data, dataPath, [] );
+		const archivesData = get( data, dataPath, {} );
+
+		// Add null check for archivesData
+		// TODO: ensure API always returns an object here. Now it return an empty array when there's no items.
+		if ( ! archivesData || typeof archivesData !== 'object' || Array.isArray( archivesData ) ) {
+			return [];
+		}
 
 		const archives = Object.keys( archivesData ).reduce( ( accumulatedArchives, archiveKey ) => {
 			const archiveItems = archivesData[ archiveKey ];
+
+			// Add null check for archiveItems
+			if ( ! archiveItems ) {
+				return accumulatedArchives;
+			}
 
 			// Taxonomy items are grouped by taxonomy term.
 			if ( 'tax' === archiveKey ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Added type and empty checks

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Robustness fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build locally and open `http://calypso.localhost:300/stats/day/{a-pretty-empty-site}`
* Choose last 30 days
* Use arrows to navigate to previous periods
* Ensure the app doesn't crash

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
