### PR TITLE
A4A: Add to the subscriptions on cancelled status a info popover

### DIFF
--- a/client/a8c-for-agencies/components/a4a-info-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-info-modal/index.tsx
@@ -1,4 +1,5 @@
 import { Modal } from '@wordpress/components';
+import clsx from 'clsx';
 import React from 'react';
 
 import './style.scss';
@@ -7,12 +8,13 @@ type InfoModalProps = {
 	title: string;
 	onClose: () => void;
 	children?: React.ReactNode;
+	className?: string;
 };
 
-const InfoModal = ( { onClose, children, title }: InfoModalProps ) => {
+const InfoModal = ( { onClose, children, title, className }: InfoModalProps ) => {
 	return (
 		<Modal
-			className="consolidated-view-info-modal__wrapper"
+			className={ clsx( 'a4a-info-modal', className ) }
 			onRequestClose={ onClose }
 			title={ title }
 		>

--- a/client/a8c-for-agencies/components/a4a-info-modal/style.scss
+++ b/client/a8c-for-agencies/components/a4a-info-modal/style.scss
@@ -1,4 +1,4 @@
-.consolidated-view-info-modal__wrapper {
+.a4a-info-modal {
 	width: 90%;
 	left: 5%;
 	position: fixed;

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -4,9 +4,9 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
+import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import InfoModal from './info-modal';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/hooks/use-subscription-details.ts
+++ b/client/a8c-for-agencies/hooks/use-subscription-details.ts
@@ -1,0 +1,39 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useMemo } from 'react';
+import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
+import { formatDate } from 'calypso/dashboard/utils/datetime';
+import { useSelector } from 'calypso/state';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { ReferralProduct } from '../sections/client/types';
+
+export const useSubscriptionDetails = ( subscription?: ReferralProduct ) => {
+	const locale = useLocale();
+	const { data: products, isFetching: isFetchingProductInfo } = useFetchClientProducts( false );
+	const isBillingTypeBD = useSelector( getUserBillingType ) === 'billingdragon';
+
+	const storeSubscription = subscription?.subscription;
+
+	const productName = useMemo( () => {
+		return isBillingTypeBD && storeSubscription?.product_name
+			? storeSubscription.product_name
+			: products?.find( ( product ) => product.product_id === subscription?.product_id )?.name ??
+					'';
+	}, [ isBillingTypeBD, storeSubscription?.product_name, products, subscription?.product_id ] );
+
+	const expiryDate = useMemo( () => {
+		return storeSubscription?.expiry
+			? formatDate( new Date( storeSubscription.expiry ), locale, { dateStyle: 'long' } )
+			: '';
+	}, [ storeSubscription?.expiry, locale ] );
+
+	return {
+		products,
+		isFetchingProductInfo,
+		storeSubscription,
+		productName,
+		expiryDate,
+		isBillingTypeBD,
+	};
+};
+
+export type UseSubscriptionDetailsReturn = ReturnType< typeof useSubscriptionDetails >;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -1,7 +1,13 @@
-import { BadgeType, Button } from '@automattic/components';
+import { BadgeType, Button, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useRef, useEffect } from 'react';
+import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import { useSubscriptionDetails } from 'calypso/a8c-for-agencies/hooks/use-subscription-details';
 import { isWPCOMHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -38,11 +44,11 @@ function getPurchaseStatus(
 
 const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props ) => {
 	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 	const isPressable = product?.slug.startsWith( 'pressable' );
 	const licenseKey = purchase.license?.license_key || '';
 	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
-
 	const redirectUrl =
 		purchase.license &&
 		( isWPCOMLicense
@@ -51,16 +57,17 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 
 	const showAssignButton = purchase.status === 'active' && redirectUrl;
 	const [ statusType, statusText ] = getPurchaseStatus( purchase, translate );
+	const { expiryDate, isFetchingProductInfo } = useSubscriptionDetails( purchase );
+	const [ showPopover, setShowPopover ] = useState( false );
 
-	let tooltip = '';
+	const wrapperRef = useRef< HTMLDivElement >( null );
+	const popoverContentRef = useRef< HTMLDivElement >( null );
 
-	const isAwaitingPayment = purchase.status === 'pending';
-
-	if ( isAwaitingPayment ) {
-		tooltip = isWPCOMLicense
-			? translate( 'When your client pays, you can initiate this site.' )
-			: translate( 'When your client pays, you can assign this product to a site.' );
-	}
+	useEffect( () => {
+		if ( showPopover && popoverContentRef.current ) {
+			popoverContentRef.current.focus();
+		}
+	}, [ showPopover ] );
 
 	if ( purchase.site_assigned ) {
 		return isPressable ? (
@@ -81,8 +88,64 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 		);
 	}
 
+	let tooltip = '';
+
+	let cancellationInfo = null;
+
+	// If the purchase has a subscription we can get the information from the object.
+	if ( purchase.subscription && ! purchase.subscription.is_refundable ) {
+		cancellationInfo = (
+			<>
+				<p>
+					{ translate(
+						'Your client canceled this product, but it will remain active until {{b}}%(expiryDate)s{{/b}}. After that, it will not renew.',
+						{
+							args: {
+								expiryDate: isFetchingProductInfo ? '...' : expiryDate || 'N/A',
+							},
+							components: {
+								b: <b />,
+							},
+							comment:
+								'%(cancellationDate)s is the date when the client canceled the product. %(expiryDate)s is the date when the product will expire.',
+						}
+					) }
+				</p>
+				<p>
+					{ translate( '{{link}}Learn more about cancelations ↗{{/link}}', {
+						components: {
+							link: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/manage-purchases/cancel-a-purchase/'
+									) }
+									target="_blank"
+									rel="noreferrer noopener"
+								>
+									{  }
+								</a>
+							),
+						},
+					} ) }
+				</p>
+			</>
+		);
+	} else if ( purchase.subscription && purchase.subscription.is_refundable ) {
+		cancellationInfo = (
+			<p>{ translate( 'Your client canceled this product, and was refunded.' ) }</p>
+		);
+	}
+
+	const isAwaitingPayment = purchase.status === 'pending';
+
+	if ( isAwaitingPayment ) {
+		tooltip = isWPCOMLicense
+			? translate( 'When your client pays, you can initiate this site.' )
+			: translate( 'When your client pays, you can assign this product to a site.' );
+	}
+
 	return (
-		<>
+		<div className="badge-assigned-to">
 			<StatusBadge
 				statusProps={ {
 					children: statusText,
@@ -90,6 +153,41 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 					tooltip,
 				} }
 			/>
+			{ purchase.status === 'canceled' && cancellationInfo && (
+				<span
+					className="status-card__info-icon"
+					onClick={ () => setShowPopover( ! showPopover ) }
+					role="button"
+					tabIndex={ 0 }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' ) {
+							setShowPopover( ! showPopover );
+						}
+					} }
+					ref={ wrapperRef }
+				>
+					<Gridicon icon="info-outline" size={ 18 } />
+				</span>
+			) }
+			{ purchase.status === 'canceled' &&
+				cancellationInfo &&
+				showPopover &&
+				( isMobile ? (
+					<InfoModal title="" onClose={ () => setShowPopover( false ) }>
+						{ cancellationInfo }
+					</InfoModal>
+				) : (
+					<A4APopover
+						title=""
+						wrapperRef={ wrapperRef }
+						offset={ 8 }
+						onFocusOutside={ () => setShowPopover( false ) }
+					>
+						<div tabIndex={ -1 } ref={ popoverContentRef }>
+							{ cancellationInfo }
+						</div>
+					</A4APopover>
+				) ) }
 			{ showAssignButton && (
 				<Button
 					disabled={ isFetching }
@@ -100,7 +198,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 					{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
 				</Button>
 			) }
-		</>
+		</div>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -151,7 +151,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 					tooltip,
 				} }
 			/>
-			{ purchase.status === 'canceled' && cancellationInfo && (
+			{ cancellationInfo && (
 				<span
 					className="status-card__info-icon"
 					onClick={ () => setShowPopover( ! showPopover ) }
@@ -167,8 +167,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 					<Gridicon icon="info-outline" size={ 18 } />
 				</span>
 			) }
-			{ purchase.status === 'canceled' &&
-				cancellationInfo &&
+			{ cancellationInfo &&
 				showPopover &&
 				( isMobile ? (
 					<InfoModal title="" onClose={ () => setShowPopover( false ) }>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -98,7 +98,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 			<>
 				<p>
 					{ translate(
-						'Your client canceled this product, but it will remain active until {{b}}%(expiryDate)s{{/b}}. After that, it will not renew.',
+						'This product was cancelled, but it will remain active until {{b}}%(expiryDate)s{{/b}}. After that, it will not renew.',
 						{
 							args: {
 								expiryDate: isFetchingProductInfo ? '...' : expiryDate || 'N/A',
@@ -130,9 +130,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 			</>
 		);
 	} else if ( purchase.subscription && purchase.subscription.is_refundable ) {
-		cancellationInfo = (
-			<p>{ translate( 'Your client canceled this product, and was refunded.' ) }</p>
-		);
+		cancellationInfo = <p>{ translate( 'This product was cancelled, and was refunded.' ) }</p>;
 	}
 
 	const isAwaitingPayment = purchase.status === 'pending';

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -92,8 +92,11 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 
 	let cancellationInfo = null;
 
-	// If the purchase has a subscription we can get the information from the object.
-	if ( purchase.subscription && ! purchase.subscription.is_refundable ) {
+	// If the purchase has a subscription, get details and check the status.
+	const subscription = purchase?.subscription;
+
+	if ( subscription && subscription.status === 'active' && ! subscription.is_auto_renew_enabled ) {
+		// If the subscription is still active but auto-renew is disabled, show the expiration info.
 		cancellationInfo = (
 			<>
 				<p>
@@ -129,8 +132,6 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 				</p>
 			</>
 		);
-	} else if ( purchase.subscription && purchase.subscription.is_refundable ) {
-		cancellationInfo = <p>{ translate( 'This product was cancelled, and was refunded.' ) }</p>;
 	}
 
 	const isAwaitingPayment = purchase.status === 'pending';

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -106,8 +106,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 							components: {
 								b: <b />,
 							},
-							comment:
-								'%(cancellationDate)s is the date when the client canceled the product. %(expiryDate)s is the date when the product will expire.',
+							comment: '%(expiryDate)s is the date when the product will expire.',
 						}
 					) }
 				</p>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -26,9 +26,9 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 	let interval = 'month';
 
 	if ( purchase.subscription?.purchase_price ) {
-		amount = purchase.subscription.purchase_price;
-		currency = purchase.subscription.purchase_currency;
-		interval = purchase.subscription.billing_interval_unit;
+		amount = Number( purchase.subscription.purchase_price );
+		currency = purchase.subscription.purchase_currency ?? '';
+		interval = purchase.subscription.billing_interval_unit ?? '';
 	}
 
 	if ( ! amount ) {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -30,6 +30,17 @@
 	}
 }
 
+.a4a-popover__content p{
+	color: var( --color-neutral-50 );
+	@include body-small;
+	margin-bottom: 0;
+}
+
+.badge-assigned-to .status-card__info-icon{
+	vertical-align: bottom;
+	margin-left: 4px;
+}
+
 // TODO: remove when the list view declares a proper primary field.
 //
 // The issue here is that the email is not provided as a primary field,

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -1,3 +1,5 @@
+import { ReferralProduct } from '../client/types';
+
 interface ReferralPurchaseAPIResponse {
 	status: string;
 	product_id: number;
@@ -9,12 +11,7 @@ interface ReferralPurchaseAPIResponse {
 		revoked_at: string | null;
 	};
 	site_assigned: string;
-	subscription?: {
-		product_name: string;
-		purchase_price: number;
-		purchase_currency: string;
-		billing_interval_unit: string;
-	};
+	subscription?: ReferralProduct[ 'subscription' ];
 	commissions?: {
 		estimated_commission_current_quarter: number;
 		estimated_commission_previous_quarter: number;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/automattic-for-agencies-dev/issues/2675

L-issue: A4A-1394

## Proposed Changes

This PR adds cancellation information using a tooltip popover. The original design includes the cancellation date, but we don't have that information from the endpoint, so we omit it for now.

- Not refundable:

<img width="488" height="163" alt="image" src="https://github.com/user-attachments/assets/458bfbdb-68ec-498f-ada4-6bb58a8c6ca4" />

- Refunded license:

We don't display any message with extra information. The license has already been canceled, and the product/plan has been deactivated.

**Follow-up task**

- [ ] On the Client app, in the Subscription section, we have to add the tooltip popover.


## Why are these changes being made?

* A4A-1394

## Testing Instructions

- As an agency, with cancelled referrals, go to the `Referrals` section.
- Click on multiple referrals to check the status (canceled, and others). Click on the actions button (chevron) and select the `Purchases` tab. In the `ASSIGNED TO` column you will see the `Canceled` label and info tooltip.
- Click on the tooltip, and you will see the message.
- If you have different cancellation types (refund, not refundable), check both cases. If you don't have a subscription with the proper state (canceled outside the refund period), you can edit the code with this:

`client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx` line 97

```tsc
	subscription && ( subscription.status = 'active' );
	subscription && ( subscription.is_auto_renew_enabled = false );
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
