### PR TITLE
 Domain Search: Close trademark claim notice upon acceptance

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -857,7 +857,7 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
-	rejectTrademarkClaim = () => {
+	clearTrademarkClaimState = () => {
 		this.setState( {
 			selectedSuggestion: null,
 			selectedSuggestionPosition: null,
@@ -865,8 +865,9 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	acceptTrademarkClaim = () => {
+	acceptTrademarkClaim = async () => {
 		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
+		this.clearTrademarkClaimState();
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -880,8 +881,8 @@ class RegisterDomainStep extends Component {
 				isLoading={ isLoading }
 				isSignupStep={ isSignupStep }
 				onAccept={ this.acceptTrademarkClaim }
-				onGoBack={ this.rejectTrademarkClaim }
-				onReject={ this.rejectTrademarkClaim }
+				onGoBack={ this.clearTrademarkClaimState }
+				onReject={ this.clearTrademarkClaimState }
 				suggestion={ selectedSuggestion }
 				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
 			/>
@@ -1744,11 +1745,6 @@ class RegisterDomainStep extends Component {
 
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
-			// For Multi-domain flows, add the domain first, than check availability
-			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				this.props.onAddDomain( suggestion, position, previousState );
-			}
-
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => {
@@ -1782,7 +1778,6 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-						this.props.onMappingError( domain, status );
 					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -1747,11 +1747,7 @@ class RegisterDomainStep extends Component {
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
-				.catch( () => {
-					this.setState( { pendingCheckSuggestion: null } );
-				} )
 				.then( ( { status, trademarkClaimsNoticeInfo } ) => {
-					this.setState( { pendingCheckSuggestion: null } );
 					this.props.recordDomainAddAvailabilityPreCheck(
 						domain,
 						status,
@@ -1778,9 +1774,12 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-						this.props.onAddDomain( suggestion, position, previousState );
+					} else {
+						return this.props.onAddDomain( suggestion, position, previousState );
 					}
+				} )
+				.finally( () => {
+					this.setState( { pendingCheckSuggestion: null } );
 				} );
 			this.props.checkDomainAvailabilityPromises?.push( promise );
 		} else {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -653,7 +653,7 @@ class RegisterDomainStep extends Component {
 		);
 	}
 
-	rejectTrademarkClaim = () => {
+	clearTrademarkClaimState = () => {
 		this.setState( {
 			selectedSuggestion: null,
 			selectedSuggestionPosition: null,
@@ -663,6 +663,7 @@ class RegisterDomainStep extends Component {
 
 	acceptTrademarkClaim = () => {
 		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
+		this.clearTrademarkClaimState();
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -676,8 +677,8 @@ class RegisterDomainStep extends Component {
 				isLoading={ isLoading }
 				isSignupStep={ isSignupStep }
 				onAccept={ this.acceptTrademarkClaim }
-				onGoBack={ this.rejectTrademarkClaim }
-				onReject={ this.rejectTrademarkClaim }
+				onGoBack={ this.clearTrademarkClaimState }
+				onReject={ this.clearTrademarkClaimState }
 				suggestion={ selectedSuggestion }
 				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
 			/>
@@ -1583,11 +1584,6 @@ class RegisterDomainStep extends Component {
 
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
-			// For Multi-domain flows, add the domain first, than check availability
-			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				this.props.onAddDomain( suggestion, position, previousState );
-			}
-
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => [] )
@@ -1619,7 +1615,6 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-						this.props.onMappingError( domain, status );
 					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -75,7 +75,6 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
-import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
@@ -1615,7 +1614,7 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+					} else {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}
 				} );


### PR DESCRIPTION
Supersedes #105546, which got reverted due to a bug.

## Testing Instructions

- Follow the instructions from the previous PR;
- Verify you can still add regular, non-trademarked domains to the cart in single-domain flows such as `/setup/newsletter`, as well as multiple domain flows such as `/setup/onboarding` and `/start/domain`.
- Test the old version as well by turning the `domains/ui-redesign` feature flag off and entering `/start/domain`.