### PR TITLE
Grid: Introduce size providers

### DIFF
--- a/packages/grid/src/contexts/grid-item-size.tsx
+++ b/packages/grid/src/contexts/grid-item-size.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react';
+
+export type GridItemSize = {
+	widthPx: number;
+	heightPx: number;
+	cols: number;
+	rows: number;
+};
+
+type GridItemCtx = { id: string; size: GridItemSize };
+
+const GridItemContext = createContext< GridItemCtx | null >( null );
+
+export function GridItemSizeProvider( p: React.PropsWithChildren< GridItemCtx > ) {
+	return <GridItemContext.Provider value={ p }>{ p.children }</GridItemContext.Provider>;
+}
+
+export function useGridItemSize(): GridItemSize {
+	const v = useContext( GridItemContext );
+	if ( ! v ) {
+		throw new Error( 'useGridItemSize must be used within a GridItem' );
+	}
+	return v.size;
+}

--- a/packages/grid/src/contexts/grid-item-size.tsx
+++ b/packages/grid/src/contexts/grid-item-size.tsx
@@ -11,8 +11,8 @@ type GridItemCtx = { id: string; size: GridItemSize };
 
 const GridItemContext = createContext< GridItemCtx | null >( null );
 
-export function GridItemSizeProvider( p: React.PropsWithChildren< GridItemCtx > ) {
-	return <GridItemContext.Provider value={ p }>{ p.children }</GridItemContext.Provider>;
+export function GridItemSizeProvider( props: React.PropsWithChildren< GridItemCtx > ) {
+	return <GridItemContext.Provider value={ props }>{ props.children }</GridItemContext.Provider>;
 }
 
 export function useGridItemSize(): GridItemSize {

--- a/packages/grid/src/contexts/grid-metrics.tsx
+++ b/packages/grid/src/contexts/grid-metrics.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useMemo } from 'react';
+
+type GridMetrics = {
+	columns: number;
+	columnWidth: number;
+	gapPx: number;
+	rowHeight: number | 'auto';
+	spanToPxX: ( span: number ) => number;
+	spanToPxY: ( span: number ) => number; // 0 if 'auto'
+};
+
+const GridMetricsCtx = createContext< GridMetrics | null >( null );
+
+export function GridMetricsProvider(
+	p: React.PropsWithChildren< {
+		columns: number;
+		columnWidth: number;
+		gapPx: number;
+		rowHeight: number | 'auto';
+	} >
+) {
+	const value = useMemo< GridMetrics >(
+		() => ( {
+			columns: p.columns,
+			columnWidth: p.columnWidth,
+			gapPx: p.gapPx,
+			rowHeight: p.rowHeight,
+			spanToPxX: ( s ) => s * p.columnWidth + ( s - 1 ) * p.gapPx,
+			spanToPxY: ( s ) =>
+				p.rowHeight === 'auto' ? 0 : s * ( p.rowHeight as number ) + ( s - 1 ) * p.gapPx,
+		} ),
+		[ p.columns, p.columnWidth, p.gapPx, p.rowHeight ]
+	);
+
+	return <GridMetricsCtx.Provider value={ value }>{ p.children }</GridMetricsCtx.Provider>;
+}
+
+export function useGridMetrics() {
+	const v = useContext( GridMetricsCtx );
+	if ( ! v ) {
+		throw new Error( 'useGridMetrics must be used within GridMetricsProvider' );
+	}
+	return v;
+}

--- a/packages/grid/src/contexts/grid-metrics.tsx
+++ b/packages/grid/src/contexts/grid-metrics.tsx
@@ -42,7 +42,3 @@ export function useGridMetrics() {
 	}
 	return v;
 }
-
-export function useOptionalGridMetrics() {
-	return useContext( GridMetricsCtx );
-}

--- a/packages/grid/src/contexts/grid-metrics.tsx
+++ b/packages/grid/src/contexts/grid-metrics.tsx
@@ -42,3 +42,7 @@ export function useGridMetrics() {
 	}
 	return v;
 }
+
+export function useOptionalGridMetrics() {
+	return useContext( GridMetricsCtx );
+}

--- a/packages/grid/src/contexts/index.tsx
+++ b/packages/grid/src/contexts/index.tsx
@@ -1,2 +1,2 @@
-export { GridMetricsProvider, useGridMetrics, useOptionalGridMetrics } from './grid-metrics';
+export { GridMetricsProvider, useGridMetrics } from './grid-metrics';
 export { GridItemSizeProvider, useGridItemSize } from './grid-item-size';

--- a/packages/grid/src/contexts/index.tsx
+++ b/packages/grid/src/contexts/index.tsx
@@ -1,0 +1,2 @@
+export { GridMetricsProvider, useGridMetrics } from './grid-metrics';
+export { GridItemSizeProvider, useGridItemSize } from './grid-item-size';

--- a/packages/grid/src/contexts/index.tsx
+++ b/packages/grid/src/contexts/index.tsx
@@ -1,2 +1,2 @@
-export { GridMetricsProvider, useGridMetrics } from './grid-metrics';
+export { GridMetricsProvider, useGridMetrics, useOptionalGridMetrics } from './grid-metrics';
 export { GridItemSizeProvider, useGridItemSize } from './grid-item-size';

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -101,8 +101,7 @@ export function GridItem( {
 
 	let heightPx = 0;
 	if ( exposeItemSize && gridMetrics ) {
-		heightPx =
-			gridMetrics.rowHeight === 'auto' ? measuredHeightPx : gridMetrics.spanToPxY( rows );
+		heightPx = gridMetrics.rowHeight === 'auto' ? measuredHeightPx : gridMetrics.spanToPxY( rows );
 	}
 
 	const size = useMemo(

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -127,7 +127,15 @@ export function GridItem( {
 					{ previewOverlay }
 				</GridItemSizeProvider>
 			) : (
-				<div style={ contentStyle }>{ children }</div>
+				<div ref={ contentMeasureRef } style={ contentStyle }>
+					{ children }
+					<ResizeHandle
+						disabled={ disabled }
+						itemId={ item.key }
+						onResize={ handleResize }
+						onResizeEnd={ handleResizeEnd }
+					/>
+				</div>
 			) }
 		</div>
 	);

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -1,6 +1,14 @@
+/**
+ * External dependencies.
+ */
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useState } from 'react';
+import { useResizeObserver } from '@wordpress/compose';
+import { useState, useMemo } from 'react';
+/**
+ * Internal dependencies.
+ */
+import { useOptionalGridMetrics, GridItemSizeProvider } from './contexts';
 import ResizeHandle from './resize-handle';
 import type { GridLayoutItem } from './types';
 
@@ -11,6 +19,7 @@ export function GridItem( {
 	children,
 	onResize,
 	onResizeEnd,
+	exposeItemSize,
 }: {
 	item: GridLayoutItem;
 	maxColumns: number;
@@ -18,6 +27,7 @@ export function GridItem( {
 	children: React.ReactNode;
 	onResize: ( delta: { width: number; height: number } ) => void;
 	onResizeEnd: () => void;
+	exposeItemSize?: boolean;
 } ) {
 	const [ previewDelta, setPreviewDelta ] = useState< { width: number; height: number } | null >(
 		null
@@ -77,18 +87,49 @@ export function GridItem( {
 		/>
 	) : null;
 
+	const gridMetrics = useOptionalGridMetrics();
+
+	const cols = item.fullWidth ? maxColumns : Math.min( item.width ?? 1, maxColumns );
+	const rows = item.height ?? 1;
+
+	const [ measuredHeightPx, setMeasuredHeightPx ] = useState( 0 );
+	const contentMeasureRef = useResizeObserver( ( [ { contentRect } ] ) => {
+		setMeasuredHeightPx( contentRect.height );
+	} );
+
+	const widthPx = exposeItemSize && gridMetrics ? gridMetrics.spanToPxX( cols ) : 0;
+
+	let heightPx = 0;
+	if ( exposeItemSize && gridMetrics ) {
+		heightPx =
+			gridMetrics.rowHeight === 'auto' ? measuredHeightPx : gridMetrics.spanToPxY( rows );
+	}
+
+	const size = useMemo(
+		() => ( { widthPx, heightPx, cols, rows } ),
+		[ widthPx, heightPx, cols, rows ]
+	);
+
+	const shouldProvideSize = exposeItemSize && !! gridMetrics;
+
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
-			<div style={ contentStyle }>
-				{ children }
-				<ResizeHandle
-					disabled={ disabled }
-					itemId={ item.key }
-					onResize={ handleResize }
-					onResizeEnd={ handleResizeEnd }
-				/>
-			</div>
-			{ previewOverlay }
+			{ shouldProvideSize ? (
+				<GridItemSizeProvider id={ item.key } size={ size }>
+					<div ref={ contentMeasureRef } style={ contentStyle }>
+						{ children }
+						<ResizeHandle
+							disabled={ disabled }
+							itemId={ item.key }
+							onResize={ handleResize }
+							onResizeEnd={ handleResizeEnd }
+						/>
+					</div>
+					{ previewOverlay }
+				</GridItemSizeProvider>
+			) : (
+				<div style={ contentStyle }>{ children }</div>
+			) }
 		</div>
 	);
 }

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -8,34 +8,46 @@ import { useState, useMemo } from 'react';
 /**
  * Internal dependencies.
  */
-import { useOptionalGridMetrics, GridItemSizeProvider } from './contexts';
+import { useGridMetrics, GridItemSizeProvider } from './contexts';
 import ResizeHandle from './resize-handle';
+/**
+ * Types
+ */
 import type { GridLayoutItem } from './types';
+import type { CSSProperties, ReactNode } from 'react';
 
-export function GridItem( {
+type RenderArgs = {
+	contentRef: ( el: HTMLDivElement | null ) => void;
+	contentStyle: CSSProperties;
+	resizeHandle: ReactNode;
+};
+
+export function GridItemBase( {
 	item,
 	maxColumns,
 	disabled = false,
 	children,
 	onResize,
 	onResizeEnd,
-	exposeItemSize,
+	renderContent,
 }: {
 	item: GridLayoutItem;
 	maxColumns: number;
 	disabled?: boolean;
-	children: React.ReactNode;
+	children: ReactNode;
 	onResize: ( delta: { width: number; height: number } ) => void;
 	onResizeEnd: () => void;
-	exposeItemSize?: boolean;
+	renderContent?: ( args: RenderArgs ) => ReactNode;
 } ) {
 	const [ previewDelta, setPreviewDelta ] = useState< { width: number; height: number } | null >(
 		null
 	);
+
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable( {
 		id: item.key,
 		disabled,
 	} );
+
 	const dragCursor = isDragging ? 'grabbing' : 'grab';
 	const style = {
 		transform: CSS.Translate.toString( transform ),
@@ -49,11 +61,8 @@ export function GridItem( {
 		zIndex: isDragging ? 2 : undefined,
 	};
 
-	// Inner content style with scaling effect
-	// The reason we need a separate "content" div is because the scaling animation
-	// impacts the computation done by useSortable if they're applied to the same div.
-	const contentStyle = {
-		position: 'relative' as const,
+	const contentStyle: CSSProperties = {
+		position: 'relative',
 		transition: 'transform 200ms ease, box-shadow 200ms ease',
 		transform: isDragging ? 'scale(1.05)' : undefined,
 		boxShadow: isDragging ? '0 5px 10px rgba(0,0,0,0.15)' : undefined,
@@ -70,7 +79,15 @@ export function GridItem( {
 		onResizeEnd();
 	};
 
-	// Preview overlay element (rendered directly in the GridItem)
+	const resizeHandle = (
+		<ResizeHandle
+			disabled={ disabled }
+			itemId={ item.key }
+			onResize={ handleResize }
+			onResizeEnd={ handleResizeEnd }
+		/>
+	);
+
 	const previewOverlay = previewDelta ? (
 		<div
 			style={ {
@@ -87,56 +104,93 @@ export function GridItem( {
 		/>
 	) : null;
 
-	const gridMetrics = useOptionalGridMetrics();
+	const contentRefCb: ( el: HTMLDivElement | null ) => void = () => {};
 
-	const cols = item.fullWidth ? maxColumns : Math.min( item.width ?? 1, maxColumns );
-	const rows = item.height ?? 1;
+	return (
+		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
+			{ renderContent ? (
+				renderContent( { contentRef: ( el ) => contentRefCb( el ), contentStyle, resizeHandle } )
+			) : (
+				<div ref={ contentRefCb } style={ contentStyle }>
+					{ children }
+					{ resizeHandle }
+				</div>
+			) }
+			{ previewOverlay }
+		</div>
+	);
+}
 
-	const [ measuredHeightPx, setMeasuredHeightPx ] = useState( 0 );
+export function GridItemBasic( props: {
+	item: GridLayoutItem;
+	maxColumns: number;
+	disabled?: boolean;
+	children: ReactNode;
+	onResize: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd: () => void;
+} ) {
+	return (
+		<GridItemBase
+			{ ...props }
+			renderContent={ ( { contentRef, contentStyle, resizeHandle } ) => (
+				<div ref={ contentRef } style={ contentStyle }>
+					{ props.children }
+					{ resizeHandle }
+				</div>
+			) }
+		/>
+	);
+}
+
+export function GridItemMeasured( props: {
+	item: GridLayoutItem;
+	maxColumns: number;
+	disabled?: boolean;
+	children: ReactNode;
+	onResize: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd: () => void;
+} ) {
+	const metrics = useGridMetrics();
+	const cols = props.item.fullWidth
+		? props.maxColumns
+		: Math.min( props.item.width ?? 1, props.maxColumns );
+	const rows = props.item.height ?? 1;
+
+	const needMeasure = !! metrics && metrics.rowHeight === 'auto';
+	const [ heightPxMeasured, setHeightPxMeasured ] = useState( 0 );
 	const contentMeasureRef = useResizeObserver( ( [ { contentRect } ] ) => {
-		setMeasuredHeightPx( contentRect.height );
+		if ( ! needMeasure ) {
+			return;
+		}
+		setHeightPxMeasured( contentRect.height );
 	} );
 
-	const widthPx = exposeItemSize && gridMetrics ? gridMetrics.spanToPxX( cols ) : 0;
-
-	let heightPx = 0;
-	if ( exposeItemSize && gridMetrics ) {
-		heightPx = gridMetrics.rowHeight === 'auto' ? measuredHeightPx : gridMetrics.spanToPxY( rows );
-	}
+	const widthPx = metrics ? metrics.spanToPxX( cols ) : 0;
+	const baseHeightPx = metrics ? metrics.spanToPxY( rows ) : 0;
+	const heightPx = needMeasure ? heightPxMeasured : baseHeightPx;
 
 	const size = useMemo(
 		() => ( { widthPx, heightPx, cols, rows } ),
 		[ widthPx, heightPx, cols, rows ]
 	);
 
-	const shouldProvideSize = exposeItemSize && !! gridMetrics;
-
 	return (
-		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
-			{ shouldProvideSize ? (
-				<GridItemSizeProvider id={ item.key } size={ size }>
-					<div ref={ contentMeasureRef } style={ contentStyle }>
-						{ children }
-						<ResizeHandle
-							disabled={ disabled }
-							itemId={ item.key }
-							onResize={ handleResize }
-							onResizeEnd={ handleResizeEnd }
-						/>
+		<GridItemBase
+			{ ...props }
+			renderContent={ ( { contentRef, contentStyle, resizeHandle } ) => (
+				<GridItemSizeProvider id={ props.item.key } size={ size }>
+					<div
+						ref={ ( el ) => {
+							contentRef( el );
+							contentMeasureRef( needMeasure ? el : null );
+						} }
+						style={ contentStyle }
+					>
+						{ props.children }
+						{ resizeHandle }
 					</div>
-					{ previewOverlay }
 				</GridItemSizeProvider>
-			) : (
-				<div ref={ contentMeasureRef } style={ contentStyle }>
-					{ children }
-					<ResizeHandle
-						disabled={ disabled }
-						itemId={ item.key }
-						onResize={ handleResize }
-						onResizeEnd={ handleResizeEnd }
-					/>
-				</div>
 			) }
-		</div>
+		/>
 	);
 }

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -14,12 +14,16 @@ import ResizeHandle from './resize-handle';
  * Types
  */
 import type { GridLayoutItem } from './types';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactNode, Ref } from 'react';
 
-type RenderArgs = {
-	contentRef: ( el: HTMLDivElement | null ) => void;
-	contentStyle: CSSProperties;
-	resizeHandle: ReactNode;
+type GridItemBaseProps = {
+	item: GridLayoutItem;
+	maxColumns: number;
+	disabled?: boolean;
+	children: ReactNode;
+	onResize: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd: () => void;
+	contentRef?: Ref< HTMLDivElement >;
 };
 
 export function GridItemBase( {
@@ -29,16 +33,8 @@ export function GridItemBase( {
 	children,
 	onResize,
 	onResizeEnd,
-	renderContent,
-}: {
-	item: GridLayoutItem;
-	maxColumns: number;
-	disabled?: boolean;
-	children: ReactNode;
-	onResize: ( delta: { width: number; height: number } ) => void;
-	onResizeEnd: () => void;
-	renderContent?: ( args: RenderArgs ) => ReactNode;
-} ) {
+	contentRef,
+}: GridItemBaseProps ) {
 	const [ previewDelta, setPreviewDelta ] = useState< { width: number; height: number } | null >(
 		null
 	);
@@ -79,15 +75,6 @@ export function GridItemBase( {
 		onResizeEnd();
 	};
 
-	const resizeHandle = (
-		<ResizeHandle
-			disabled={ disabled }
-			itemId={ item.key }
-			onResize={ handleResize }
-			onResizeEnd={ handleResizeEnd }
-		/>
-	);
-
 	const previewOverlay = previewDelta ? (
 		<div
 			style={ {
@@ -104,18 +91,18 @@ export function GridItemBase( {
 		/>
 	) : null;
 
-	const contentRefCb: ( el: HTMLDivElement | null ) => void = () => {};
-
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
-			{ renderContent ? (
-				renderContent( { contentRef: ( el ) => contentRefCb( el ), contentStyle, resizeHandle } )
-			) : (
-				<div ref={ contentRefCb } style={ contentStyle }>
-					{ children }
-					{ resizeHandle }
-				</div>
-			) }
+			<div ref={ contentRef } style={ contentStyle }>
+				{ children }
+				<ResizeHandle
+					disabled={ disabled }
+					itemId={ item.key }
+					onResize={ handleResize }
+					onResizeEnd={ handleResizeEnd }
+				/>
+			</div>
+
 			{ previewOverlay }
 		</div>
 	);
@@ -129,17 +116,7 @@ export function GridItemBasic( props: {
 	onResize: ( delta: { width: number; height: number } ) => void;
 	onResizeEnd: () => void;
 } ) {
-	return (
-		<GridItemBase
-			{ ...props }
-			renderContent={ ( { contentRef, contentStyle, resizeHandle } ) => (
-				<div ref={ contentRef } style={ contentStyle }>
-					{ props.children }
-					{ resizeHandle }
-				</div>
-			) }
-		/>
-	);
+	return <GridItemBase { ...props } />;
 }
 
 export function GridItemMeasured( props: {
@@ -175,22 +152,8 @@ export function GridItemMeasured( props: {
 	);
 
 	return (
-		<GridItemBase
-			{ ...props }
-			renderContent={ ( { contentRef, contentStyle, resizeHandle } ) => (
-				<GridItemSizeProvider id={ props.item.key } size={ size }>
-					<div
-						ref={ ( el ) => {
-							contentRef( el );
-							contentMeasureRef( needMeasure ? el : null );
-						} }
-						style={ contentStyle }
-					>
-						{ props.children }
-						{ resizeHandle }
-					</div>
-				</GridItemSizeProvider>
-			) }
-		/>
+		<GridItemSizeProvider id={ props.item.key } size={ size }>
+			<GridItemBase { ...props } contentRef={ contentMeasureRef } />
+		</GridItemSizeProvider>
 	);
 }

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -9,7 +9,7 @@ import { useMemo, Children, isValidElement, useState } from 'react';
  * Internal dependencies.
  */
 import { GridMetricsProvider } from './contexts';
-import { GridItem } from './grid-item';
+import { GridItemBasic, GridItemMeasured } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
 
@@ -147,6 +147,8 @@ export function Grid( {
 		}
 	}
 
+	const ItemComponent = exposeItemSize ? GridItemMeasured : GridItemBasic;
+
 	const gridContent = (
 		<div
 			ref={ resizeObserverRef }
@@ -159,17 +161,16 @@ export function Grid( {
 			} }
 		>
 			{ items.map( ( id ) => (
-				<GridItem
+				<ItemComponent
 					key={ id }
 					item={ layoutMap.get( id ) as GridLayoutItem }
 					maxColumns={ effectiveColumns }
 					disabled={ ! editMode }
 					onResize={ ( delta ) => handleResize( id, delta ) }
 					onResizeEnd={ persistTemporaryLayout }
-					exposeItemSize={ exposeItemSize }
 				>
 					{ childrenMap.get( id ) }
-				</GridItem>
+				</ItemComponent>
 			) ) }
 			{ remaining }
 		</div>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,7 +1,14 @@
+/**
+ * External dependencies.
+ */
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useResizeObserver, useDebounce, useEvent } from '@wordpress/compose';
 import { useMemo, Children, isValidElement, useState } from 'react';
+/**
+ * Internal dependencies.
+ */
+import { GridMetricsProvider } from './contexts';
 import { GridItem } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
@@ -16,6 +23,7 @@ export function Grid( {
 	minColumnWidth,
 	editMode = false,
 	onChangeLayout,
+	exposeItemSize = false,
 }: GridProps ) {
 	// Temporary layout to avoid updating the layout while dragging
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
@@ -36,7 +44,9 @@ export function Grid( {
 		const maxColumns = Math.floor( ( containerWidth + gapPx ) / totalWidthPerColumn );
 		return Math.max( 1, maxColumns );
 	}, [ minColumnWidth, gapPx, containerWidth, columns ] );
-	const columnWidth = ( containerWidth - gapPx ) / effectiveColumns;
+
+	const totalGaps = Math.max( 0, ( effectiveColumns - 1 ) * gapPx );
+	const columnWidth = ( containerWidth - totalGaps ) / effectiveColumns;
 
 	const layoutMap = useMemo( () => {
 		const map = new Map< string, GridLayoutItem >();
@@ -137,6 +147,33 @@ export function Grid( {
 		}
 	}
 
+	const gridContent = (
+		<div
+			ref={ resizeObserverRef }
+			className={ className }
+			style={ {
+				display: 'grid',
+				gridTemplateColumns: `repeat(${ effectiveColumns }, 1fr)`,
+				gridAutoRows: rowHeight,
+				gap: gapPx,
+			} }
+		>
+			{ items.map( ( id ) => (
+				<GridItem
+					key={ id }
+					item={ layoutMap.get( id ) as GridLayoutItem }
+					maxColumns={ effectiveColumns }
+					disabled={ ! editMode }
+					onResize={ ( delta ) => handleResize( id, delta ) }
+					onResizeEnd={ persistTemporaryLayout }
+				>
+					{ childrenMap.get( id ) }
+				</GridItem>
+			) ) }
+			{ remaining }
+		</div>
+	);
+
 	return (
 		<DndContext
 			sensors={ sensors }
@@ -147,30 +184,18 @@ export function Grid( {
 			} }
 		>
 			<SortableContext items={ items } strategy={ () => null }>
-				<div
-					ref={ resizeObserverRef }
-					className={ className }
-					style={ {
-						display: 'grid',
-						gridTemplateColumns: `repeat(${ effectiveColumns }, 1fr)`,
-						gridAutoRows: rowHeight,
-						gap: gapPx,
-					} }
-				>
-					{ items.map( ( id ) => (
-						<GridItem
-							key={ id }
-							item={ layoutMap.get( id ) as GridLayoutItem }
-							maxColumns={ effectiveColumns }
-							disabled={ ! editMode }
-							onResize={ ( delta ) => handleResize( id, delta ) }
-							onResizeEnd={ persistTemporaryLayout }
-						>
-							{ childrenMap.get( id ) }
-						</GridItem>
-					) ) }
-					{ remaining }
-				</div>
+				{ exposeItemSize ? (
+					<GridMetricsProvider
+						columns={ effectiveColumns }
+						columnWidth={ columnWidth }
+						gapPx={ gapPx }
+						rowHeight={ rowHeight }
+					>
+						{ gridContent }
+					</GridMetricsProvider>
+				) : (
+					gridContent
+				) }
 			</SortableContext>
 		</DndContext>
 	);

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -166,6 +166,7 @@ export function Grid( {
 					disabled={ ! editMode }
 					onResize={ ( delta ) => handleResize( id, delta ) }
 					onResizeEnd={ persistTemporaryLayout }
+					exposeItemSize={ exposeItemSize }
 				>
 					{ childrenMap.get( id ) }
 				</GridItem>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -17,7 +17,7 @@ export function Grid( {
 	editMode = false,
 	onChangeLayout,
 }: GridProps ) {
-	// Temporary layout to avoid updaing the layout while dragging
+	// Temporary layout to avoid updating the layout while dragging
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
 		layout
 	);

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -1,3 +1,5 @@
 export * from './grid';
 export * from './resize-handle';
 export * from './types';
+
+export { useGridItemSize } from './contexts';

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -225,24 +225,10 @@ function CardWithSize( {
 	...props
 }: { color: string; children: React.ReactNode } & HTMLAttributes< HTMLDivElement > ) {
 	return (
-		<div
-			{ ...props }
-			style={ {
-				backgroundColor: color,
-				color: 'white',
-				padding: '20px',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-				height: '100%',
-				boxSizing: 'border-box',
-				position: 'relative',
-				...props?.style,
-			} }
-		>
+		<Card { ...props } color={ color }>
 			{ children }
 			<SizeBadge />
-		</div>
+		</Card>
 	);
 }
 
@@ -265,7 +251,7 @@ export const EditableGridWithSizes: StoryObj< typeof Grid > = {
 			<Grid
 				layout={ layout }
 				minColumnWidth={ 160 }
-				rowHeight={ args.rowHeight }
+				rowHeight={ args.rowHeight ?? 128 }
 				spacing={ 2 }
 				editMode
 				onChangeLayout={ ( nl ) => setLayout( nl ) }

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useGridItemSize } from '../';
 import { Grid } from '../grid';
 import type { GridLayoutItem } from '../types';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -14,6 +15,11 @@ const meta: Meta< typeof Grid > = {
 	argTypes: {
 		children: { control: false },
 		exposeItemSize: { control: 'boolean' },
+		rowHeight: {
+			control: { type: 'select' },
+			options: [ 'auto', 128, 256, 512 ],
+			defaultValue: 128,
+		},
 	},
 };
 
@@ -183,6 +189,125 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 			description: {
 				story:
 					'This example demonstrates the Grid component in edit mode with drag, drop, and resize functionality. Use the edit mode to reorder and resize the cards. Grab and drag the handle in the bottom-right corner of each card to resize it. The layout and edit mode are managed with local state.',
+			},
+		},
+		layout: '',
+	},
+};
+
+function SizeBadge() {
+	const { widthPx, heightPx, cols, rows } = useGridItemSize();
+	const w = Math.round( widthPx );
+	const h = Math.round( heightPx );
+	return (
+		<div
+			style={ {
+				position: 'absolute',
+				right: 6,
+				bottom: 6,
+				padding: '2px 6px',
+				fontSize: 11,
+				fontFamily: 'monospace',
+				background: 'rgba(0,0,0,0.7)',
+				color: 'white',
+				borderRadius: 4,
+				pointerEvents: 'none',
+			} }
+		>
+			{ w }x{ h || '—' } px · { cols }x{ rows }
+		</div>
+	);
+}
+
+function CardWithSize( {
+	color,
+	children,
+	...props
+}: { color: string; children: React.ReactNode } & HTMLAttributes< HTMLDivElement > ) {
+	return (
+		<div
+			{ ...props }
+			style={ {
+				backgroundColor: color,
+				color: 'white',
+				padding: '20px',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				height: '100%',
+				boxSizing: 'border-box',
+				position: 'relative',
+				...props?.style,
+			} }
+		>
+			{ children }
+			<SizeBadge />
+		</div>
+	);
+}
+
+export const EditableGridWithSizes: StoryObj< typeof Grid > = {
+	render: function EditableGridWithSizes( args ) {
+		const [ layout, setLayout ] = useState< GridLayoutItem[] >( [
+			{ key: 'a', width: 1, height: 1 },
+			{ key: 'b', width: 2, height: 1 },
+			{ key: 'c', width: 1, height: 1 },
+			{ key: 'd', width: 2, height: 1 },
+			{ key: 'e', width: 1, height: 1 },
+			{ key: 'f', width: 1, height: 1 },
+			{ key: 'g', width: 2, height: 1, fullWidth: true },
+			{ key: 'h', width: 1, height: 1 },
+			{ key: 'i', width: 1, height: 1 },
+			{ key: 'j', width: 1, height: 1 },
+		] );
+
+		return (
+			<Grid
+				layout={ layout }
+				minColumnWidth={ 160 }
+				rowHeight={ args.rowHeight }
+				spacing={ 2 }
+				editMode
+				onChangeLayout={ ( nl ) => setLayout( nl ) }
+				exposeItemSize
+			>
+				<CardWithSize key="a" color="#f44336">
+					Card A
+				</CardWithSize>
+				<CardWithSize key="b" color="#2196f3">
+					Card B
+				</CardWithSize>
+				<CardWithSize key="c" color="#4caf50">
+					Card C
+				</CardWithSize>
+				<CardWithSize key="d" color="#ff9800">
+					Card D
+				</CardWithSize>
+				<CardWithSize key="e" color="#9c27b0">
+					Card E
+				</CardWithSize>
+				<CardWithSize key="f" color="#607d8b">
+					Card F
+				</CardWithSize>
+				<CardWithSize key="g" color="#3f51b5">
+					Card G with full width
+				</CardWithSize>
+				<CardWithSize key="h" color="#8bc34a">
+					Card H
+				</CardWithSize>
+				<CardWithSize key="i" color="#cddc39">
+					Card I
+				</CardWithSize>
+				<CardWithSize key="j" color="#ffeb3b">
+					Card J
+				</CardWithSize>
+			</Grid>
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Overlay with current tile dimensions (px and spans) using useGridItemSize().',
 			},
 		},
 		layout: '',

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -13,8 +13,10 @@ const meta: Meta< typeof Grid > = {
 	},
 	argTypes: {
 		children: { control: false },
+		exposeItemSize: { control: 'boolean' },
 	},
 };
+
 export default meta;
 
 function Card( {
@@ -141,6 +143,7 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 				spacing={ 2 }
 				editMode
 				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
+				exposeItemSize
 			>
 				<Card key="a" color="#f44336">
 					Card A

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -74,6 +74,12 @@ interface BaseGridProps {
 	 * Callback fired when layout changes due to item dragging
 	 */
 	onChangeLayout?: ( newLayout: GridLayoutItem[] ) => void;
+
+	/**
+	 * Whether to expose the item size to the GridMetricsProvider
+	 * @default false
+	 */
+	exposeItemSize?: boolean;
 }
 
 interface StandardGridProps extends BaseGridProps {


### PR DESCRIPTION
Several widgets (especially SVG/charts) need the **actual tile size** to lay out axes/padding/scales without hacks. This adds a first-class way to read `{ widthPx, heightPx, cols, rows }` from within each tile’s children, with zero cost when unused.

Part of  WOOA7S-462 ARC-925

https://github.com/user-attachments/assets/bcada8b5-4a88-4735-b7d3-519962a59efb

### What’s included

* **New public hook:** `useGridItemSize()` → returns `{ widthPx, heightPx, cols, rows }` for the current tile.
* **GridItem refactor into three pieces:**

  * New prop `exposeItemSize?: boolean` (default `false`).
  * Chooses `GridItemMeasured` **only** when `exposeItemSize` is `true`; otherwise uses `GridItemBasic`.
  * Wraps content with `GridMetricsProvider` only when exposing size.

### Size computation / measurement

* `widthPx`: **derived** from spans and grid metrics (no measuring).
* `heightPx`:

  * **derived** when `rowHeight` is numeric,
  * **measured** via `useResizeObserver` only when `rowHeight === 'auto'` (once per tile).

### Technical notes

* Single file `grid-item.tsx` now contains `GridItemBase`, `GridItemBasic`, `GridItemMeasured`.
* Internal contexts:

  * `GridMetricsProvider` + `useGridMetrics` provide `{ columns, columnWidth, gapPx, rowHeight }` and converters `spanToPxX/Y`.
  * `GridItemSizeProvider` provides the per-tile size object.
* `index.ts` re-exports `useGridItemSize`.
* Storybook: `EditableGridWithSizes` shows an overlay badge (`W×H px · cols×rows`) for visual validation.

### Performance

* Basic path: no extra contexts or measurement.
* Measured path: attaches `ResizeObserver` only when `rowHeight === 'auto'`; span↔px conversions are pure.

### Test plan

1. `EditableGrid` without `exposeItemSize`: drag/resize/overlay unchanged.
2. `EditableGridWithSizes` with `exposeItemSize`: badge reflects `widthPx/heightPx` and updates on resize.
3. Verify both `rowHeight="auto"` and numeric values: height measurement triggers only in the `auto` case.
4. Change `minColumnWidth`/`spacing` and confirm `widthPx`/`cols` update correctly.