### PR TITLE
Notifications v2: render note back button separately from heading

### DIFF
--- a/apps/notifications/src/app/note-panel/actions.tsx
+++ b/apps/notifications/src/app/note-panel/actions.tsx
@@ -25,6 +25,9 @@ export default function NotePanelActions() {
 			label={ __( 'Actions' ) }
 			onToggle={ setIsOpen }
 			open={ isOpen || isShortcutsPopoverOpen }
+			toggleProps={ {
+				size: 'small',
+			} }
 			popoverProps={ {
 				focusOnMount: true,
 			} }

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -93,10 +93,7 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			<CardHeader size="small">
 				<HStack>
 					<HStack justify="flex-start">
-						<Navigator.BackButton
-							icon={ isRTL() ? chevronRight : chevronLeft }
-							style={ { flexShrink: 0, padding: 0 } }
-						/>
+						<Navigator.BackButton size="small" icon={ isRTL() ? chevronRight : chevronLeft } />
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ note.title }
 						</Heading>

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -92,14 +92,15 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 		<>
 			<CardHeader size="small">
 				<HStack>
-					<Navigator.BackButton
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						style={ { flexShrink: 0, padding: 0 } }
-					>
+					<HStack justify="flex-start">
+						<Navigator.BackButton
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							style={ { flexShrink: 0, padding: 0 } }
+						/>
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ note.title }
 						</Heading>
-					</Navigator.BackButton>
+					</HStack>
 					<HStack justify="flex-end">
 						<ActionDropdown note={ note } goBack={ goBack } />
 						{ isDismissible && <CloseButton /> }

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -98,7 +98,7 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 							{ note.title }
 						</Heading>
 					</HStack>
-					<HStack justify="flex-end">
+					<HStack justify="flex-end" style={ { width: 'auto' } }>
 						<ActionDropdown note={ note } goBack={ goBack } />
 						{ isDismissible && <CloseButton /> }
 					</HStack>


### PR DESCRIPTION
## Proposed Changes

Render the heading in notification details separately from the back button so that the focus state is only in the button. This is to be consistent with many other Gutenberg screens.

|Before|After|
|-|-|
|<img width="454" height="149" alt="image" src="https://github.com/user-attachments/assets/393b3fc9-15d2-488e-b7bb-1a1630af28ef" />|<img width="454" height="138" alt="image" src="https://github.com/user-attachments/assets/554acdc5-409d-4606-93d1-00cbe4ce1529" />|

## Why are these changes being made?

Polish

## Testing Instructions

1. Go to /v2
2. Click the notification bell
3. Click any notification
4. Verify the focus state as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
