### PR TITLE
Backups Dashboard: add option to dismiss backup notices

### DIFF
--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -1,6 +1,6 @@
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { Button, ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useBackupState } from '../../app/hooks/site-backup-state';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -15,6 +15,18 @@ export function BackupNotices( { site }: { site: Site } ) {
 	const backupDate = useFormattedTime( backup?.started ?? '', {
 		timeStyle: 'short',
 	} );
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const handleDismiss = () => {
+		setIsDismissed( true );
+	};
+
+	useEffect( () => {
+		// Reset dismissal when a new backup starts
+		if ( status === 'running' ) {
+			setIsDismissed( false );
+		}
+	}, [ status ] );
 
 	if ( status === 'running' ) {
 		return (
@@ -35,19 +47,20 @@ export function BackupNotices( { site }: { site: Site } ) {
 		);
 	}
 
-	if ( status === 'success' ) {
+	if ( status === 'success' && ! isDismissed ) {
 		return (
-			<Notice variant="success" title={ __( 'Backup completed' ) }>
+			<Notice variant="success" title={ __( 'Backup completed' ) } onClose={ handleDismiss }>
 				{ __( 'You’ll be able to access your new backup in just a few minutes.' ) }
 			</Notice>
 		);
 	}
 
-	if ( status === 'error' ) {
+	if ( status === 'error' && ! isDismissed ) {
 		return (
 			<Notice
 				variant="error"
 				title={ __( 'Latest backup couldn’t be completed' ) }
+				onClose={ handleDismiss }
 				actions={
 					<Button variant="primary" href={ JETPACK_CONTACT_SUPPORT } target="_blank">
 						{ __( 'Contact support' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-288

## Proposed Changes

* Add option to dismiss success and error backup notices 

<img width="2666" height="400" alt="CleanShot 2025-09-03 at 22 15 20@2x" src="https://github.com/user-attachments/assets/03cd035a-0166-4c09-a99c-049234944eb4" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up to address [this comment](https://github.com/Automattic/wp-calypso/pull/105437/files#r2310091476).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /v2/sites/`SITE_SLUG`/backups using a site with the backup feature
* Click on "Back up now" button and wait for a backup to complete
* When the success notice appears, ensure the x button is visible. After clicking it, confirm that the notice is dismissed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
