### PR TITLE
Jest Package: consolidate transformIgnorePatterns

### DIFF
--- a/packages/api-core/jest.config.js
+++ b/packages/api-core/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/api-queries/jest.config.js
+++ b/packages/api-queries/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/block-renderer/jest.config.js
+++ b/packages/block-renderer/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/calypso-jest/jest-preset.js
+++ b/packages/calypso-jest/jest-preset.js
@@ -15,6 +15,9 @@ module.exports = {
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': require.resolve( './src/asset-transform.js' ),
 	},
 	testPathIgnorePatterns: [ ...defaults.testPathIgnorePatterns, '/dist/' ],
+	transformIgnorePatterns: [
+		'node_modules/(?!gridicons|components|swiper|@fnando)(?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css)$)',
+	],
 	verbose: false,
 	snapshotFormat: {
 		escapeString: true,

--- a/packages/calypso-package-generator/templates/shared/jest.config.js
+++ b/packages/calypso-package-generator/templates/shared/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/calypso-products/jest.config.js
+++ b/packages/calypso-products/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
 	globals: {
 		configData: {},
 	},
-	transformIgnorePatterns: [ 'node_modules/(?!components)(?!.*\\.svg)' ],
 };

--- a/packages/calypso-sentry/jest.config.js
+++ b/packages/calypso-sentry/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/calypso-support-session/jest.config.js
+++ b/packages/calypso-support-session/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/command-palette/jest.config.js
+++ b/packages/command-palette/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
 	testMatch: [ '<rootDir>/test/**/*.{ts,tsx}' ],
 	testEnvironment: 'jsdom',
 	globals: { window: { navigator: { userAgent: 'jest' } } },
-	transformIgnorePatterns: [
-		'node_modules[\\/\\\\](?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css)$)',
-	],
 	// This includes a lot of globals that don't exist, like fetch, matchMedia, etc.
 	setupFilesAfterEnv: [ require.resolve( '../../test/client/setup-test-framework.js' ) ],
 };

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/data-stores/jest.config.js
+++ b/packages/data-stores/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
-	transformIgnorePatterns: [ 'node_modules/(?!components)(?!.*\\.svg)' ],
 };

--- a/packages/design-picker/jest.config.js
+++ b/packages/design-picker/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/design-preview/jest.config.js
+++ b/packages/design-preview/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/domain-search/jest.config.js
+++ b/packages/domain-search/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/domains-table/jest.config.js
+++ b/packages/domains-table/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/global-styles/jest.config.js
+++ b/packages/global-styles/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/help-center/jest.config.js
+++ b/packages/help-center/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
 	setupFiles: [ '<rootDir>/jestSetup.ts' ],
 	testEnvironment: 'jsdom',
 	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'json' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/jetpack-ai-calypso/jest.config.js
+++ b/packages/jetpack-ai-calypso/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/launchpad/jest.config.js
+++ b/packages/launchpad/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/odie-client/jest.config.js
+++ b/packages/odie-client/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/onboarding/jest.config.js
+++ b/packages/onboarding/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/plans-grid-next/jest.config.js
+++ b/packages/plans-grid-next/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/privacy-toolset/jest.config.js
+++ b/packages/privacy-toolset/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/verbum-block-editor/jest.config.js
+++ b/packages/verbum-block-editor/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	setupFilesAfterEnv: [ '@automattic/calypso-build/jest/mocks/match-media' ],
-	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/wpcom-checkout/jest.config.js
+++ b/packages/wpcom-checkout/jest.config.js
@@ -4,7 +4,4 @@ module.exports = {
 	globals: {
 		configData: {},
 	},
-	transformIgnorePatterns: [
-		'node_modules[\\/\\\\](?!@fnando[\\/\\\\]|.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css)$)',
-	],
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-862/reader-gallery-not-working

## Proposed Changes

* Move all `transformIgnorePatterns` in different jest configs around packages to the main template
* Add swiper pattern to the ignored patterns

## Why are these changes being made?

While wrestling with Jest test issue in a separate PR I realized that setting the transformIgnorePatterns in a config upstream is overwriting the value. This leads to whatever being set getting overwritten and requires going through and adding it to each child config.

Rather than doing this for my desired pattern for swiper I consolidated everything into a singular point to manage.

## Testing Instructions

Make sure tests pass 👍 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
