### PR TITLE
Backups Dashboard: enhance backup listing mobile view

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -27,7 +27,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 	} );
 
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
-	const direction = isSmallViewport ? 'column' : 'row';
+	const direction = isSmallViewport ? 'column-reverse' : 'row';
 
 	const handleRestoreClick = () => {
 		router.navigate( {
@@ -43,35 +43,38 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 		} );
 	};
 
+	const actions = backup.rewind_id ? (
+		<ButtonStack alignment="stretch" justify="center" direction={ direction }>
+			<Button
+				variant="tertiary"
+				size={ isSmallViewport ? 'default' : 'compact' }
+				icon={ download }
+				onClick={ handleDownloadClick }
+				style={ { justifyContent: 'center' } }
+			>
+				{ __( 'Download backup' ) }
+			</Button>
+			<Button
+				variant="primary"
+				size={ isSmallViewport ? 'default' : 'compact' }
+				icon={ rotateLeft }
+				onClick={ handleRestoreClick }
+				style={ { justifyContent: 'center' } }
+			>
+				{ __( 'Restore to this point' ) }
+			</Button>
+		</ButtonStack>
+	) : null;
+
 	return (
 		<Card>
 			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
 				<SectionHeader
 					title={ backup.summary }
 					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
-					actions={
-						backup.rewind_id && (
-							<ButtonStack alignment="stretch" direction={ direction }>
-								<Button
-									variant="secondary"
-									size="compact"
-									icon={ download }
-									onClick={ handleDownloadClick }
-								>
-									{ __( 'Download backup' ) }
-								</Button>
-								<Button
-									variant="primary"
-									size="compact"
-									icon={ rotateLeft }
-									onClick={ handleRestoreClick }
-								>
-									{ __( 'Restore to this point' ) }
-								</Button>
-							</ButtonStack>
-						)
-					}
+					actions={ ! isSmallViewport ? actions : null }
 				/>
+				{ isSmallViewport ? actions : null }
 			</CardHeader>
 			<CardBody>
 				<VStack>

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -13,10 +13,12 @@ export function BackupsList( {
 	site,
 	selectedBackup,
 	setSelectedBackup,
+	autoSelect = true,
 }: {
 	site: Site;
 	selectedBackup: ActivityLogEntry | null;
 	setSelectedBackup: ( backup: ActivityLogEntry | null ) => void;
+	autoSelect?: boolean;
 } ) {
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
@@ -53,11 +55,11 @@ export function BackupsList( {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
 
 	useEffect( () => {
-		if ( ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
+		if ( autoSelect && ! isLoadingActivityLog && activityLog.length > 0 && ! selectedBackup ) {
 			const firstBackup = activityLog[ 0 ];
 			setSelectedBackup( firstBackup );
 		}
-	}, [ isLoadingActivityLog, activityLog, selectedBackup, setSelectedBackup ] );
+	}, [ autoSelect, isLoadingActivityLog, activityLog, selectedBackup, setSelectedBackup ] );
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const backup =

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -88,7 +88,7 @@ export function BackupsListPage() {
 				setShowDetails( false );
 			} }
 		>
-			{ __( 'All backups' ) }
+			{ __( 'Backups' ) }
 		</Button>
 	);
 
@@ -111,7 +111,7 @@ export function BackupsListPage() {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ __( 'Backups' ) }
+					title={ isSmallViewport && showDetails ? __( 'Backup details' ) : __( 'Backups' ) }
 					prefix={ isSmallViewport && showDetails ? backButton : undefined }
 					actions={ hasBackups && <BackupNowButton site={ site } /> }
 				/>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
-import { chartBar, arrowLeft, chevronLeft, chevronRight } from '@wordpress/icons';
+import { chartBar, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -92,6 +92,21 @@ export function BackupsListPage() {
 		</Button>
 	);
 
+	const renderMobileView = () => {
+		if ( showDetails && selectedBackup ) {
+			return <BackupDetails backup={ selectedBackup } site={ site } />;
+		}
+
+		return (
+			<BackupsList
+				site={ site }
+				selectedBackup={ selectedBackup }
+				setSelectedBackup={ handleBackupSelection }
+				autoSelect={ false }
+			/>
+		);
+	};
+
 	return (
 		<PageLayout
 			header={
@@ -105,22 +120,19 @@ export function BackupsListPage() {
 		>
 			{ hasBackups && (
 				<>
-					{ isSmallViewport && showDetails && selectedBackup && (
-						<BackupDetails backup={ selectedBackup } site={ site } />
-					) }
-					{ ! isSmallViewport || ! showDetails ? (
-						<Grid columns={ columns } templateColumns={ ! isSmallViewport ? '40% 1fr' : undefined }>
+					{ isSmallViewport ? (
+						renderMobileView()
+					) : (
+						<Grid columns={ columns } templateColumns="40% 1fr">
 							<BackupsList
 								site={ site }
 								selectedBackup={ selectedBackup }
 								setSelectedBackup={ handleBackupSelection }
-								autoSelect={ ! isSmallViewport }
 							/>
-							{ ! isSmallViewport && selectedBackup && (
-								<BackupDetails backup={ selectedBackup } site={ site } />
-							) }
+
+							{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
 						</Grid>
-					) : null }
+					) }
 				</>
 			) }
 		</PageLayout>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -8,8 +8,8 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
-import { chartBar, arrowLeft } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import { chartBar, arrowLeft, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
@@ -80,15 +80,24 @@ export function BackupsListPage() {
 		}
 	};
 
-	const handleBackToList = () => {
-		setShowDetails( false );
-	};
+	const backButton = (
+		<Button
+			className="dashboard-page-header__back-button"
+			icon={ isRTL() ? chevronRight : chevronLeft }
+			onClick={ () => {
+				setShowDetails( false );
+			} }
+		>
+			{ __( 'All backups' ) }
+		</Button>
+	);
 
 	return (
 		<PageLayout
 			header={
 				<PageHeader
 					title={ __( 'Backups' ) }
+					prefix={ isSmallViewport && showDetails ? backButton : undefined }
 					actions={ hasBackups && <BackupNowButton site={ site } /> }
 				/>
 			}
@@ -97,12 +106,7 @@ export function BackupsListPage() {
 			{ hasBackups && (
 				<>
 					{ isSmallViewport && showDetails && selectedBackup && (
-						<>
-							<Button variant="tertiary" icon={ arrowLeft } onClick={ handleBackToList }>
-								{ __( 'All backups' ) }
-							</Button>
-							<BackupDetails backup={ selectedBackup } site={ site } />
-						</>
+						<BackupDetails backup={ selectedBackup } site={ site } />
 					) }
 					{ ! isSmallViewport || ! showDetails ? (
 						<Grid columns={ columns } templateColumns={ ! isSmallViewport ? '40% 1fr' : undefined }>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -2,10 +2,14 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
-import { __experimentalGrid as Grid, __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalGrid as Grid,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { chartBar } from '@wordpress/icons';
+import { chartBar, arrowLeft } from '@wordpress/icons';
 import { useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
 import { Callout } from '../../components/callout';
@@ -63,10 +67,22 @@ export function BackupsListPage() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const [ selectedBackup, setSelectedBackup ] = useState< ActivityLogEntry | null >( null );
+	const [ showDetails, setShowDetails ] = useState( false );
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
 
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
+
+	const handleBackupSelection = ( backup: ActivityLogEntry | null ) => {
+		setSelectedBackup( backup );
+		if ( isSmallViewport && backup ) {
+			setShowDetails( true );
+		}
+	};
+
+	const handleBackToList = () => {
+		setShowDetails( false );
+	};
 
 	return (
 		<PageLayout
@@ -79,14 +95,29 @@ export function BackupsListPage() {
 			notices={ <BackupNotices site={ site } /> }
 		>
 			{ hasBackups && (
-				<Grid className="dashboard-backups__list-grid" columns={ columns }>
-					<BackupsList
-						site={ site }
-						selectedBackup={ selectedBackup }
-						setSelectedBackup={ setSelectedBackup }
-					/>
-					{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
-				</Grid>
+				<>
+					{ isSmallViewport && showDetails && selectedBackup && (
+						<>
+							<Button variant="tertiary" icon={ arrowLeft } onClick={ handleBackToList }>
+								{ __( 'All backups' ) }
+							</Button>
+							<BackupDetails backup={ selectedBackup } site={ site } />
+						</>
+					) }
+					{ ! isSmallViewport || ! showDetails ? (
+						<Grid columns={ columns } templateColumns={ ! isSmallViewport ? '40% 1fr' : undefined }>
+							<BackupsList
+								site={ site }
+								selectedBackup={ selectedBackup }
+								setSelectedBackup={ handleBackupSelection }
+								autoSelect={ ! isSmallViewport }
+							/>
+							{ ! isSmallViewport && selectedBackup && (
+								<BackupDetails backup={ selectedBackup } site={ site } />
+							) }
+						</Grid>
+					) : null }
+				</>
 			) }
 		</PageLayout>
 	);

--- a/client/dashboard/sites/backups/style.scss
+++ b/client/dashboard/sites/backups/style.scss
@@ -1,11 +1,3 @@
-.dashboard-backups__list-grid {
-	@media ( max-width: 782px ) {
-		> *:last-child {
-			order: -1;
-		}
-	}
-}
-
 .dashboard-backups__list-icon {
 	position: relative;
 	top: 50%;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of BACKUP-264

## Proposed Changes
* Improved mobile view for backup listing with improved navigation

| <img width="1102" height="1410" alt="CleanShot 2025-09-04 at 21 25 30@2x" src="https://github.com/user-attachments/assets/0ff666de-21c8-48b8-9378-a31f321b67c9" /> | <img width="1102" height="1410" alt="CleanShot 2025-09-04 at 21 25 47@2x" src="https://github.com/user-attachments/assets/c7a8f883-a232-4c06-8f40-82f2efe25df3" /> |
|---|---|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

BACKUP-264

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a Calypso Live branch
- Navigate to `/v2/sites/{site}/backups`
- On mobile, validate the layout looks as shared above. Try selecting a backup on the list and then clicking the `< All backups` link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
