### PR TITLE
Backup FileBrowser: extract API calls to @automattic/api-core package

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -1,3 +1,4 @@
+import { fetchBackupFileUrl } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { useCallback, useState } from '@wordpress/element';
@@ -102,13 +103,9 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const downloadFile = useCallback( () => {
 		setIsProcessingDownload( true );
 
-		if ( item.type !== 'archive' ) {
+		if ( item.type !== 'archive' && item.period && item.manifestPath ) {
 			const manifestPath = encodeToBase64( ( item.manifestPath as string ) ?? '' );
-			wp.req
-				.get( {
-					path: `/sites/${ siteId }/rewind/backup/${ item.period }/file/${ manifestPath }/url`,
-					apiNamespace: 'wpcom/v2',
-				} )
+			fetchBackupFileUrl( siteId, item.period, manifestPath )
 				.then( ( response: { url: string } ) => {
 					if ( ! response.url ) {
 						handleDownloadError();

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-preview.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-preview.tsx
@@ -78,14 +78,14 @@ const FilePreview: FunctionComponent< FilePreviewProps > = ( { item, siteId } ) 
 				content = <pre>{ fileContent }</pre>;
 				break;
 			case 'image':
-				content = <img src={ data.url } alt="file-preview" />;
+				content = <img src={ data?.url } alt="file-preview" />;
 				break;
 			case 'audio':
 				content = (
 					// We don't have captions for backed up audio files
 					// eslint-disable-next-line jsx-a11y/media-has-caption
 					<audio controls>
-						<source src={ data.url } type="audio/mpeg" />
+						<source src={ data?.url } type="audio/mpeg" />
 					</audio>
 				);
 				break;
@@ -94,7 +94,7 @@ const FilePreview: FunctionComponent< FilePreviewProps > = ( { item, siteId } ) 
 					// We don't have captions for backed up video files
 					// eslint-disable-next-line jsx-a11y/media-has-caption
 					<video controls>
-						<source src={ data.url } type="video/mp4" />
+						<source src={ data?.url } type="video/mp4" />
 					</video>
 				);
 				break;

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
@@ -1,5 +1,5 @@
+import { fetchBackupContents } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
-import wp from 'calypso/lib/wp';
 import { parseBackupContentsData } from './util';
 
 export const useBackupContentsQuery = (
@@ -10,18 +10,7 @@ export const useBackupContentsQuery = (
 ) => {
 	return useQuery( {
 		queryKey: [ 'jetpack-backup-contents-ls', siteId, rewindId, path ],
-		queryFn: async () => {
-			return wp.req.post(
-				{
-					path: `/sites/${ siteId }/rewind/backup/ls`,
-					apiNamespace: 'wpcom/v2',
-				},
-				{
-					backup_id: rewindId,
-					path: path,
-				}
-			);
-		},
+		queryFn: () => fetchBackupContents( siteId, rewindId, path ),
 		enabled: !! siteId && !! rewindId && !! path && shouldFetch,
 		meta: { persist: false },
 		select: parseBackupContentsData,

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
@@ -1,5 +1,5 @@
+import { fetchBackupFile } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
-import wp from 'calypso/lib/wp';
 import { encodeToBase64 } from './util';
 
 export const useBackupFileQuery = (
@@ -12,12 +12,7 @@ export const useBackupFileQuery = (
 
 	return useQuery( {
 		queryKey: [ 'jetpack-backup-file-url', siteId, rewindId, encodedManifestPath ],
-		queryFn: async () => {
-			return wp.req.get( {
-				path: `/sites/${ siteId }/rewind/backup/${ rewindId }/file/${ encodedManifestPath }/url`,
-				apiNamespace: 'wpcom/v2',
-			} );
-		},
+		queryFn: () => fetchBackupFile( siteId, rewindId!, encodedManifestPath ),
 		enabled: !! siteId && !! rewindId && !! manifestPath && shouldFetch,
 		meta: { persist: false },
 		staleTime: Infinity,

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
@@ -1,4 +1,4 @@
-import { fetchBackupFile } from '@automattic/api-core';
+import { fetchBackupFileUrl } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
 import { encodeToBase64 } from './util';
 
@@ -12,7 +12,7 @@ export const useBackupFileQuery = (
 
 	return useQuery( {
 		queryKey: [ 'jetpack-backup-file-url', siteId, rewindId, encodedManifestPath ],
-		queryFn: () => fetchBackupFile( siteId, rewindId!, encodedManifestPath ),
+		queryFn: () => fetchBackupFileUrl( siteId, rewindId!, encodedManifestPath ),
 		enabled: !! siteId && !! rewindId && !! manifestPath && shouldFetch,
 		meta: { persist: false },
 		staleTime: Infinity,

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
@@ -1,5 +1,5 @@
+import { fetchBackupPathInfo } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
-import wp from 'calypso/lib/wp';
 import { parseBackupPathInfo } from './util';
 
 export const useBackupPathInfoQuery = (
@@ -10,19 +10,7 @@ export const useBackupPathInfoQuery = (
 ) => {
 	return useQuery( {
 		queryKey: [ 'jetpack-backup-path-info', siteId, rewindId, manifestPath, extensionType ],
-		queryFn: async () => {
-			return wp.req.post(
-				{
-					path: `/sites/${ siteId }/rewind/backup/path-info`,
-					apiNamespace: 'wpcom/v2',
-				},
-				{
-					backup_id: rewindId,
-					manifest_path: manifestPath,
-					extension_type: extensionType,
-				}
-			);
-		},
+		queryFn: () => fetchBackupPathInfo( siteId, rewindId, manifestPath, extensionType ),
 		enabled: !! siteId,
 		meta: { persist: false },
 		select: parseBackupPathInfo,

--- a/packages/api-core/src/site-backup-download/fetchers.ts
+++ b/packages/api-core/src/site-backup-download/fetchers.ts
@@ -1,5 +1,9 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DownloadProgress, DownloadStatusResponse } from './types';
+import type {
+	DownloadProgress,
+	DownloadStatusResponse,
+	BackupDownloadStatusResponse,
+} from './types';
 
 /**
  * Fetch the progress of a download operation.
@@ -57,7 +61,7 @@ export function getBackupDownloadStatus(
 	siteId: number,
 	buildKey: string,
 	dataType: number
-): Promise< any > {
+): Promise< BackupDownloadStatusResponse > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/rewind/backup/filtered/status`,

--- a/packages/api-core/src/site-backup-download/fetchers.ts
+++ b/packages/api-core/src/site-backup-download/fetchers.ts
@@ -45,3 +45,27 @@ export async function fetchSiteBackupDownloadProgress(
 		error: code ? { code, message } : undefined,
 	};
 }
+
+/**
+ * Get status of a filtered backup download preparation.
+ * @param siteId - The ID of the site to check download status for.
+ * @param buildKey - The build key from prepare download response.
+ * @param dataType - The data type for the download.
+ * @returns A promise that resolves to the download status.
+ */
+export function getBackupDownloadStatus(
+	siteId: number,
+	buildKey: string,
+	dataType: number
+): Promise< any > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backup/filtered/status`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			data_type: dataType,
+			key: buildKey,
+		}
+	);
+}

--- a/packages/api-core/src/site-backup-download/mutators.ts
+++ b/packages/api-core/src/site-backup-download/mutators.ts
@@ -27,3 +27,30 @@ export async function initiateSiteBackupDownload(
 
 	return data.downloadId;
 }
+
+/**
+ * Prepare a filtered backup download.
+ * @param siteId - The ID of the site to prepare download for.
+ * @param rewindId - The backup/rewind ID to download from.
+ * @param manifestFilter - The manifest filter specifying what to include.
+ * @param dataType - The data type for the download.
+ * @returns A promise that resolves to the prepare download response.
+ */
+export function prepareBackupDownload(
+	siteId: number,
+	rewindId: string,
+	manifestFilter: string,
+	dataType: number
+): Promise< any > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backup/filtered/prepare`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			backup_id: rewindId,
+			manifest_filter: manifestFilter,
+			data_type: dataType,
+		}
+	);
+}

--- a/packages/api-core/src/site-backup-download/mutators.ts
+++ b/packages/api-core/src/site-backup-download/mutators.ts
@@ -1,5 +1,9 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DownloadConfig, DownloadStatusResponse } from './types';
+import type {
+	DownloadConfig,
+	DownloadStatusResponse,
+	PrepareBackupDownloadResponse,
+} from './types';
 
 /**
  * Initiate a download operation for a site backup at a specific timestamp.
@@ -41,7 +45,7 @@ export function prepareBackupDownload(
 	rewindId: string,
 	manifestFilter: string,
 	dataType: number
-): Promise< any > {
+): Promise< PrepareBackupDownloadResponse > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/rewind/backup/filtered/prepare`,

--- a/packages/api-core/src/site-backup-download/types.ts
+++ b/packages/api-core/src/site-backup-download/types.ts
@@ -53,3 +53,16 @@ export interface DownloadStatusResponse {
 	code: string;
 	message: string;
 }
+
+export interface PrepareBackupDownloadResponse {
+	ok: boolean;
+	key: string;
+}
+
+export interface BackupDownloadStatusResponse {
+	ok: boolean;
+	status: string;
+	download_id: string;
+	token: string;
+	url: string;
+}

--- a/packages/api-core/src/site-backups/fetchers.ts
+++ b/packages/api-core/src/site-backups/fetchers.ts
@@ -3,7 +3,7 @@ import type {
 	BackupEntry,
 	BackupContentsResponse,
 	BackupPathInfoResponse,
-	BackupFileResponse,
+	BackupFileUrl,
 } from './types';
 
 /**
@@ -75,11 +75,11 @@ export function fetchBackupPathInfo(
  * @param encodedManifestPath - The base64 encoded manifest path.
  * @returns A promise that resolves to the backup file URL data.
  */
-export function fetchBackupFile(
+export function fetchBackupFileUrl(
 	siteId: number,
 	rewindId: string,
 	encodedManifestPath: string
-): Promise< BackupFileResponse > {
+): Promise< BackupFileUrl > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/rewind/backup/${ rewindId }/file/${ encodedManifestPath }/url`,
 		apiNamespace: 'wpcom/v2',

--- a/packages/api-core/src/site-backups/fetchers.ts
+++ b/packages/api-core/src/site-backups/fetchers.ts
@@ -11,3 +11,72 @@ export function fetchSiteBackups( siteId: number ): Promise< BackupEntry[] > {
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+/**
+ * Fetch backup contents (file/directory listing) for a site backup.
+ * @param siteId - The ID of the site to fetch backup contents for.
+ * @param rewindId - The backup/rewind ID to fetch contents from.
+ * @param path - The path within the backup to list contents for.
+ * @returns A promise that resolves to the backup contents data.
+ */
+export function fetchBackupContents(
+	siteId: number,
+	rewindId: number,
+	path: string
+): Promise< any > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backup/ls`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			backup_id: rewindId,
+			path: path,
+		}
+	);
+}
+
+/**
+ * Fetch backup path info (file metadata) for a specific path in a backup.
+ * @param siteId - The ID of the site to fetch backup path info for.
+ * @param rewindId - The backup/rewind ID to fetch path info from.
+ * @param manifestPath - The manifest path to get info for.
+ * @param extensionType - Optional extension type filter.
+ * @returns A promise that resolves to the backup path info data.
+ */
+export function fetchBackupPathInfo(
+	siteId: number,
+	rewindId: string,
+	manifestPath: string,
+	extensionType = ''
+): Promise< any > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backup/path-info`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			backup_id: rewindId,
+			manifest_path: manifestPath,
+			extension_type: extensionType,
+		}
+	);
+}
+
+/**
+ * Fetch backup file URL for a specific file in a backup.
+ * @param siteId - The ID of the site to fetch backup file for.
+ * @param rewindId - The backup/rewind ID to fetch file from.
+ * @param encodedManifestPath - The base64 encoded manifest path.
+ * @returns A promise that resolves to the backup file URL data.
+ */
+export function fetchBackupFile(
+	siteId: number,
+	rewindId: string,
+	encodedManifestPath: string
+): Promise< any > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/rewind/backup/${ rewindId }/file/${ encodedManifestPath }/url`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/site-backups/fetchers.ts
+++ b/packages/api-core/src/site-backups/fetchers.ts
@@ -1,5 +1,10 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { BackupEntry } from './types';
+import type {
+	BackupEntry,
+	BackupContentsResponse,
+	BackupPathInfoResponse,
+	BackupFileResponse,
+} from './types';
 
 /**
  * Fetch the list of backups for a site.
@@ -23,7 +28,7 @@ export function fetchBackupContents(
 	siteId: number,
 	rewindId: number,
 	path: string
-): Promise< any > {
+): Promise< BackupContentsResponse > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/rewind/backup/ls`,
@@ -49,7 +54,7 @@ export function fetchBackupPathInfo(
 	rewindId: string,
 	manifestPath: string,
 	extensionType = ''
-): Promise< any > {
+): Promise< BackupPathInfoResponse > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/rewind/backup/path-info`,
@@ -74,7 +79,7 @@ export function fetchBackupFile(
 	siteId: number,
 	rewindId: string,
 	encodedManifestPath: string
-): Promise< any > {
+): Promise< BackupFileResponse > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/rewind/backup/${ rewindId }/file/${ encodedManifestPath }/url`,
 		apiNamespace: 'wpcom/v2',

--- a/packages/api-core/src/site-backups/types.ts
+++ b/packages/api-core/src/site-backups/types.ts
@@ -57,7 +57,6 @@ export interface BackupPathInfoResponse {
 	error?: string;
 }
 
-export interface BackupFileResponse {
+export interface BackupFileUrl {
 	url: string;
-	filename?: string;
 }

--- a/packages/api-core/src/site-backups/types.ts
+++ b/packages/api-core/src/site-backups/types.ts
@@ -27,3 +27,37 @@ export interface BackupEntry {
 	is_backup: string;
 	is_scan: string;
 }
+
+export interface BackupContentsResponse {
+	ok: boolean;
+	error: string;
+	contents: {
+		[ key: string ]: {
+			id?: string;
+			type: 'file' | 'dir' | 'wordpress' | 'table' | 'theme' | 'plugin' | 'archive';
+			has_children: boolean;
+			period?: string;
+			sort?: number;
+			manifest_path?: string;
+			label?: string;
+			row_count?: number;
+			extension_version?: string;
+			total_items?: number;
+		};
+	};
+}
+
+export interface BackupPathInfoResponse {
+	download_url?: string;
+	mtime?: number;
+	size?: number;
+	hash?: string;
+	data_type?: number;
+	manifest_filter?: string;
+	error?: string;
+}
+
+export interface BackupFileResponse {
+	url: string;
+	filename?: string;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-382

## Proposed Changes

- Extract API calls to @automattic/api-core package
  - Add fetchBackupContents, fetchBackupPathInfo, fetchBackupFile to `site-backups/fetchers.ts`
  - Add prepareBackupDownload to `site-backup-download/mutators.ts`
  - Add getBackupDownloadStatus to `site-backup-download/fetchers.ts`
  - Update FileBrowser query hooks to use new API functions instead of direct wp.req calls

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of rewriting the FileBrowser component to make it work in the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Pick a site with Jetpack VaultPress Backup
* Click on `View files` on any full backup to navigate to the file browser
* Try navigating through the file browser (opening directories, clicking files, download/preview files).
* Ensure the file browser continues to work as expected either on Jetpack Cloud and Staging Site Sync implementation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
