### PR TITLE
A4A: Add Timeframe column with per site estimated commissions

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-payout-data.ts
@@ -24,6 +24,10 @@ const mockGetCurrentCycleActivityWindow =
 	getNextPayoutDate.getCurrentCycleActivityWindow as jest.MockedFunction<
 		typeof getNextPayoutDate.getCurrentCycleActivityWindow
 	>;
+const mockAreNextAndCurrentPayoutDatesEqual =
+	getNextPayoutDate.areNextAndCurrentPayoutDatesEqual as jest.MockedFunction<
+		typeof getNextPayoutDate.areNextAndCurrentPayoutDatesEqual
+	>;
 
 // Mock Date.prototype.toLocaleString to ensure consistent formatting across environments
 const originalToLocaleString = Date.prototype.toLocaleString;
@@ -59,6 +63,7 @@ describe( 'useGetPayoutData', () => {
 		mockGetCurrentCyclePayoutDate.mockReturnValue( mockCurrentCyclePayoutDate );
 		mockGetNextPayoutDateActivityWindow.mockReturnValue( mockNextPayoutWindow );
 		mockGetCurrentCycleActivityWindow.mockReturnValue( mockCurrentCycleWindow );
+		mockAreNextAndCurrentPayoutDatesEqual.mockReturnValue( false );
 	} );
 
 	it( 'should format next payout activity window with year', () => {
@@ -95,6 +100,7 @@ describe( 'useGetPayoutData', () => {
 		const sameDateValue = new Date( '2024-06-01' );
 		mockGetNextPayoutDate.mockReturnValue( sameDateValue );
 		mockGetCurrentCyclePayoutDate.mockReturnValue( sameDateValue );
+		mockAreNextAndCurrentPayoutDatesEqual.mockReturnValue( true );
 
 		const { result } = renderHook( () => useGetPayoutData() );
 

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-payout-data.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentCycleActivityWindow,
 	getNextPayoutDate,
 	getNextPayoutDateActivityWindow,
+	areNextAndCurrentPayoutDatesEqual,
 } from '../lib/get-next-payout-date';
 
 const formatDateWithYear = ( date: Date ) =>
@@ -37,8 +38,7 @@ export default function useGetPayoutData() {
 				currentCycleWindow.start,
 				currentCycleWindow.finish
 			),
-			areNextAndCurrentPayoutDatesEqual:
-				nextPayoutDateRaw.getTime() === currentCyclePayoutDateRaw.getTime(),
+			areNextAndCurrentPayoutDatesEqual: areNextAndCurrentPayoutDatesEqual( now ),
 			isFullQuarter:
 				new Date().toLocaleDateString() === currentCycleWindow.finish.toLocaleDateString(),
 		};

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -88,3 +88,9 @@ export const getCurrentCycleActivityWindow = ( currentDate: Date ) => {
 		finish: new Date( currentYear, activityEnd.month - 1, activityEnd.day ),
 	};
 };
+
+export const areNextAndCurrentPayoutDatesEqual = ( currentDate: Date ): boolean => {
+	const nextPayoutDate = getNextPayoutDate( currentDate );
+	const currentCyclePayoutDate = getCurrentCyclePayoutDate( currentDate );
+	return nextPayoutDate.getTime() === currentCyclePayoutDate.getTime();
+};

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -9,7 +9,12 @@ import {
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { useWooPaymentsContext } from '../context';
 import { getSiteData } from '../lib/site-data';
-import { SiteColumn, WooPaymentsStatusColumn, CommissionsPaidColumn } from './site-columns';
+import {
+	SiteColumn,
+	WooPaymentsStatusColumn,
+	CommissionsPaidColumn,
+	TimeframeCommissionsColumn,
+} from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPaymentsMobileView( {
@@ -40,6 +45,17 @@ export default function SitesWithWooPaymentsMobileView( {
 								) : (
 									<CommissionsPaidColumn
 										payout={ getSiteData( woopaymentsData, item.blogId ).payout }
+									/>
+								) }
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Timeframe Commissions' ) }>
+							<div className="sites-with-woopayments-list-mobile-view__column">
+								{ isLoadingWooPaymentsData ? (
+									<TextPlaceholder />
+								) : (
+									<TimeframeCommissionsColumn
+										estimatedPayout={ getSiteData( woopaymentsData, item.blogId ).estimatedPayout }
 									/>
 								) }
 							</div>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -16,6 +16,18 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 export const CommissionsPaidColumn = memo( ( { payout }: { payout: number | null } ) => {
 	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
 } );
+CommissionsPaidColumn.displayName = 'CommissionsPaidColumn';
+
+export const TimeframeCommissionsColumn = memo(
+	( { estimatedPayout }: { estimatedPayout: number | null } ) => {
+		return estimatedPayout ? (
+			formatCurrency( estimatedPayout, 'USD', { stripZeros: true } )
+		) : (
+			<Gridicon icon="minus" />
+		);
+	}
+);
+TimeframeCommissionsColumn.displayName = 'TimeframeCommissionsColumn';
 
 CommissionsPaidColumn.displayName = 'CommissionsPaidColumn';
 

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -14,7 +14,12 @@ import { useWooPaymentsContext } from '../context';
 import { useDownloadCommissionsReport } from '../hooks/use-download-commissions-report';
 import { getSiteData } from '../lib/site-data';
 import SitesWithWooPaymentsMobileView from './mobile-view';
-import { SiteColumn, CommissionsPaidColumn, WooPaymentsStatusColumn } from './site-columns';
+import {
+	SiteColumn,
+	CommissionsPaidColumn,
+	TimeframeCommissionsColumn,
+	WooPaymentsStatusColumn,
+} from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPayments() {
@@ -41,7 +46,7 @@ export default function SitesWithWooPayments() {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'site', 'commissionsPaid', 'woopaymentsStatus' ],
+		fields: [ 'site', 'commissionsPaid', 'timeframeCommissions', 'woopaymentsStatus' ],
 	} );
 
 	const fields = useMemo(
@@ -66,6 +71,20 @@ export default function SitesWithWooPayments() {
 					}
 					const { payout } = getSiteData( woopaymentsData, item.blogId );
 					return <CommissionsPaidColumn payout={ payout } />;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'timeframeCommissions',
+				label: translate( 'Timeframe Commissions' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ) => {
+					if ( isLoadingWooPaymentsData ) {
+						return <TextPlaceholder />;
+					}
+					const { estimatedPayout } = getSiteData( woopaymentsData, item.blogId );
+					return <TimeframeCommissionsColumn estimatedPayout={ estimatedPayout } />;
 				},
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
@@ -3,12 +3,24 @@ import { WooPaymentsData } from '../types';
 interface WooPaymentsSiteData {
 	transactions: number | null;
 	payout: number | null;
+	estimatedPayout: number | null;
 }
 
 export const getSiteData = (
 	woopaymentsData: WooPaymentsData,
 	siteId: number
-): WooPaymentsSiteData => ( {
-	transactions: woopaymentsData?.data?.total?.sites?.[ siteId ]?.transactions ?? 0,
-	payout: woopaymentsData?.data?.total?.sites?.[ siteId ]?.payout ?? 0,
-} );
+): WooPaymentsSiteData => {
+	const siteData = woopaymentsData?.data?.total?.sites?.[ siteId ];
+	const sitePayout = siteData?.payout ?? 0;
+	const siteTransactions = siteData?.transactions ?? 0;
+
+	// Get estimated payout directly from current quarter site data
+	const estimatedPayout =
+		woopaymentsData?.data?.estimated?.current_quarter?.sites?.[ siteId ]?.payout ?? 0;
+
+	return {
+		transactions: siteTransactions,
+		payout: sitePayout,
+		estimatedPayout,
+	};
+};

--- a/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
@@ -1,3 +1,4 @@
+import { areNextAndCurrentPayoutDatesEqual } from '../../referrals/lib/get-next-payout-date';
 import { WooPaymentsData } from '../types';
 
 interface WooPaymentsSiteData {
@@ -14,9 +15,19 @@ export const getSiteData = (
 	const sitePayout = siteData?.payout ?? 0;
 	const siteTransactions = siteData?.transactions ?? 0;
 
-	// Get estimated payout directly from current quarter site data
-	const estimatedPayout =
+	// Get estimated payout from current quarter
+	const currentQuarterEstimate =
 		woopaymentsData?.data?.estimated?.current_quarter?.sites?.[ siteId ]?.payout ?? 0;
+
+	// Get estimated payout from previous quarter
+	const previousQuarterEstimate =
+		woopaymentsData?.data?.estimated?.previous_quarter?.sites?.[ siteId ]?.payout ?? 0;
+
+	// If next and current payout dates are not equal, add previous quarter estimate
+	const now = new Date();
+	const estimatedPayout = areNextAndCurrentPayoutDatesEqual( now )
+		? currentQuarterEstimate
+		: currentQuarterEstimate + previousQuarterEstimate;
 
 	return {
 		transactions: siteTransactions,

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -35,8 +35,31 @@ export interface WooPaymentsData {
 			};
 		};
 		estimated?: WooPaymentsDataObject & {
-			current_quarter: WooPaymentsDataObject;
-			previous_quarter: WooPaymentsDataObject;
+			sites?: {
+				[ key: number ]: {
+					tpv?: number;
+					payout?: number;
+					transactions?: number;
+				};
+			};
+			current_quarter: WooPaymentsDataObject & {
+				sites?: {
+					[ key: number ]: {
+						tpv?: number;
+						payout?: number;
+						transactions?: number;
+					};
+				};
+			};
+			previous_quarter: WooPaymentsDataObject & {
+				sites?: {
+					[ key: number ]: {
+						tpv?: number;
+						payout?: number;
+						transactions?: number;
+					};
+				};
+			};
 		};
 	};
 	status: string;

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -36,11 +36,7 @@ export interface WooPaymentsData {
 		};
 		estimated?: WooPaymentsDataObject & {
 			sites?: {
-				[ key: number ]: {
-					tpv?: number;
-					payout?: number;
-					transactions?: number;
-				};
+				[ key: number ]: WooPaymentsDataObject;
 			};
 			current_quarter: WooPaymentsDataObject & {
 				sites?: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1525/frontend-add-timeframe-commissions-column

## Proposed Changes

* Adds a new column to the WooPayments dashboard table with the amount of estimated commissions for the specific site.

<img width="496" height="694" alt="Screenshot 2025-09-04 at 09 39 32" src="https://github.com/user-attachments/assets/74e08ea0-2285-49da-a488-c9068942e42e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 191763-ghe-Automattic/wpcom to your sandbox if not merged yet.
* Sandbox public-api.wordpress.com
* Go to the Referrals dashboard and find an agency with sites that are not eligible for incentives (sort by Total Referred Amount).
* Go to the agency owner profile, click the Switch to A4A button
* Open the live link on the window impersonating the agency owner
* Go to WooPayments > Dashboard 
* Confirm the total sum of the amounts shown on the Timeframe column matches the total in the "Estimated current quarter earnings to date" card at the top.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?