### PR TITLE
e2e tests: Add missing tags to use in Playwright Test

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -187,9 +187,14 @@ export const tags = {
 	AUTHENTICATION: '@authentication',
 	CALYPSO_PR: '@calypso-pr',
 	CALYPSO_RELEASE: '@calypso-release',
+	EXAMPLE_BLOCKS: '@example-blocks',
 	GUTENBERG: '@gutenberg',
 	I18N: '@i18n',
 	JETPACK_REMOTE_SITE: '@jetpack-remote-site',
+	JETPACK_WPCOM_INTEGRATION: '@jetpack-wpcom-integration',
+	LEGAL: '@legal',
+	P2: '@p2',
+	SETTINGS: '@settings',
 };
 
 export { expect };


### PR DESCRIPTION
## Proposed Changes

Added all the tags used by Jest tests.

## Testing Instructions

Not much to test here. Maybe list the tests running with Playwright Test using `--grep=@some-tag`. Make sure they're matching the tags they have applied.

