### PR TITLE
A4A: Remove Transactions column from WooPayments dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -9,12 +9,7 @@ import {
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { useWooPaymentsContext } from '../context';
 import { getSiteData } from '../lib/site-data';
-import {
-	SiteColumn,
-	WooPaymentsStatusColumn,
-	TransactionsColumn,
-	CommissionsPaidColumn,
-} from './site-columns';
+import { SiteColumn, WooPaymentsStatusColumn, CommissionsPaidColumn } from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPaymentsMobileView( {
@@ -36,17 +31,6 @@ export default function SitesWithWooPaymentsMobileView( {
 						<ListItemCardContent title={ translate( 'Site' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								<SiteColumn site={ item.siteUrl } />
-							</div>
-						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Transactions' ) }>
-							<div className="sites-with-woopayments-list-mobile-view__column">
-								{ isLoadingWooPaymentsData ? (
-									<TextPlaceholder />
-								) : (
-									<TransactionsColumn
-										transactions={ getSiteData( woopaymentsData, item.blogId ).transactions }
-									/>
-								) }
 							</div>
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Commissions Paid' ) }>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -13,13 +13,11 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
 };
 
-export const TransactionsColumn = memo( ( { transactions }: { transactions: number | null } ) => {
-	return transactions ?? <Gridicon icon="minus" />;
-} );
-
 export const CommissionsPaidColumn = memo( ( { payout }: { payout: number | null } ) => {
 	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
 } );
+
+CommissionsPaidColumn.displayName = 'CommissionsPaidColumn';
 
 export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; siteId: number } ) => {
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -14,12 +14,7 @@ import { useWooPaymentsContext } from '../context';
 import { useDownloadCommissionsReport } from '../hooks/use-download-commissions-report';
 import { getSiteData } from '../lib/site-data';
 import SitesWithWooPaymentsMobileView from './mobile-view';
-import {
-	SiteColumn,
-	TransactionsColumn,
-	CommissionsPaidColumn,
-	WooPaymentsStatusColumn,
-} from './site-columns';
+import { SiteColumn, CommissionsPaidColumn, WooPaymentsStatusColumn } from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPayments() {
@@ -46,7 +41,7 @@ export default function SitesWithWooPayments() {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'site', 'transactions', 'commissionsPaid', 'woopaymentsStatus' ],
+		fields: [ 'site', 'commissionsPaid', 'woopaymentsStatus' ],
 	} );
 
 	const fields = useMemo(
@@ -58,20 +53,6 @@ export default function SitesWithWooPayments() {
 				render: ( { item }: { item: SitesWithWooPaymentsState } ) => (
 					<SiteColumn site={ item.siteUrl } />
 				),
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'transactions',
-				label: translate( 'Transactions' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item } ) => {
-					if ( isLoadingWooPaymentsData ) {
-						return <TextPlaceholder />;
-					}
-					const { transactions } = getSiteData( woopaymentsData, item.blogId );
-					return <TransactionsColumn transactions={ transactions } />;
-				},
 				enableHiding: false,
 				enableSorting: false,
 			},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1527/frontend-remove-transactions-column

## Proposed Changes

* Removes the transactions column since the new database table that powers this dashboard doesn't have the number of transactions.

| Before  | After |
| ------------- | ------------- |
|  <img width="1066" height="218" alt="Screenshot 2025-09-04 at 13 23 22" src="https://github.com/user-attachments/assets/b2fe258e-bafc-49e4-91f6-b526d73f4d15" /> |  <img width="1080" height="230" alt="Screenshot 2025-09-04 at 13 22 57" src="https://github.com/user-attachments/assets/c1122e16-f0de-4232-a207-3ba95da2a94a" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Go to `/woopayments/dashboard` and confirm that the Transactions column is not there anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
