### PR TITLE
e2e tests: Configure Team City builds for Playwright Test: part 5 - conditional run

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1011,7 +1011,7 @@ object PlaywrightTestPRMatrix : BuildType({
 
 				cd test/e2e
 				echo "Running Playwright tests for project: %playwrightProject%"
-				yarn test:pw:%playwrightProject% --grep=@calypso-pr --reporter=blob
+				yarn test:pw:%playwrightProject% --grep=@calypso-pr
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1009,9 +1009,19 @@ object PlaywrightTestPRMatrix : BuildType({
 					exit 1
 				fi
 
+				# Check if test/e2e or packages/calypso-e2e files have been changed
+				CHANGED_FILES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
+				if echo "${'$'}CHANGED_FILES" | grep -q -E "^(test/e2e/|packages/calypso-e2e/)"; then
+					echo "Changes detected in test/e2e/ or packages/calypso-e2e/, running all tests"
+					GREP_FLAG=""
+				else
+					echo "No changes in test/e2e/ or packages/calypso-e2e/, running @calypso-pr tests only"
+					GREP_FLAG="--grep=@calypso-pr"
+				fi
+
 				cd test/e2e
 				echo "Running Playwright tests for project: %playwrightProject%"
-				yarn test:pw:%playwrightProject% --grep=@calypso-pr
+				yarn test:pw:%playwrightProject% ${'$'}GREP_FLAG
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1011,7 +1011,7 @@ object PlaywrightTestPRMatrix : BuildType({
 
 				cd test/e2e
 				echo "Running Playwright tests for project: %playwrightProject%"
-				yarn test:pw:%playwrightProject% --grep=@calypso-pr
+				yarn test:pw:%playwrightProject% --grep=@calypso-pr --reporter=blob
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -1019,6 +1019,7 @@ object PlaywrightTestPRMatrix : BuildType({
 
 	artifactRules = """
 		test/e2e/output => %playwrightProject%/output
+		test/e2e/blob-report => blob-report
 	""".trimIndent()
 })
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -946,7 +946,7 @@ object PlaywrightTestPRMatrix : BuildType({
 		}
 		xmlReport {
         	reportType = XmlReport.XmlReportType.JUNIT
-        	rules = "+:test/e2e/output/results.xml"
+        	rules = "+:**/output/results.xml"
 			verbose = true
         }
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -946,7 +946,7 @@ object PlaywrightTestPRMatrix : BuildType({
 		}
 		xmlReport {
         	reportType = XmlReport.XmlReportType.JUNIT
-        	rules = "+:**/output/results.xml"
+        	rules = "+:test/e2e/output/results.xml"
 			verbose = true
         }
 	}

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -10,8 +10,8 @@ const reporter: ReporterDescription[] = [
 ];
 
 if ( process.env.CI ) {
-	console.log( 'Running in CI, adding list reporter.' );
 	reporter.push( [ 'list' ] );
+	reporter.push( [ 'blob' ] );
 }
 
 /**


### PR DESCRIPTION
Part of #105466 DOTCOM-14356

## Proposed Changes

Conditionally run all e2e tests is the e2e files are changed. This is to prevent breaking e2e tests and no knowing because those tests are not running in PR checks.

## Testing Instructions

Check the TeamCity builds for this branch. Trigger new manual runs and include a different changes set with no changes to the affected paths.
- All e2e tests should run if there are changes in either `test/e2e` or `packages/calypso-e2e` paths
- Only `calypso-pr` tests should run if there are no changes in the above paths
