### PR TITLE
Enable scan and backup functionality for summer special sites

### DIFF
--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -1,4 +1,5 @@
 import { getPlan } from '@automattic/calypso-products';
+import { useSummerSpecialStatus } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
 import {
 	ReactElement,
@@ -71,6 +72,9 @@ function UpsellSwitch( props: Props ) {
 	} = props;
 	const { state, reason } = siteState || {};
 
+	// Check if site has summer special enabled
+	const hasSummerSpecialSticker = useSummerSpecialStatus( { siteId } );
+
 	const [ uiState, setUiState ] = useState< UiState >( null );
 	const [ showUpsell, setUpsell ] = useState( false );
 
@@ -87,12 +91,12 @@ function UpsellSwitch( props: Props ) {
 			const sitePlanDetails = getPlan( sitePlan.product_slug );
 			productsList = [
 				...productsList,
-				...( sitePlanDetails?.getIncludedFeatures?.() ?? [] ),
+				...( sitePlanDetails?.getIncludedFeatures?.( hasSummerSpecialSticker ) ?? [] ),
 				...( sitePlanDetails?.getInferiorFeatures?.() ?? [] ),
 			];
 		}
 		return !! productsList.find( productSlugTest );
-	}, [ siteProducts, productSlugTest, sitePlan ] ) as boolean;
+	}, [ siteProducts, productSlugTest, sitePlan, hasSummerSpecialSticker ] ) as boolean;
 
 	// Reset states when site or section changes
 	useEffect( () => {

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -46,6 +46,8 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
+import type { AppState } from 'calypso/types';
 
 import './style.scss';
 import 'calypso/blocks/eligibility-warnings/style.scss';
@@ -151,7 +153,9 @@ export default function WPCOMBusinessAT( {
 }: { content?: AtomicContentSwitch } = {} ) {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
-	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) );
+	const rewindState = useSelector( ( state: AppState ) =>
+		getRewindState( state, siteId )
+	) as RewindState;
 
 	// Gets the site eligibility data.
 	const isEligible = useSelector( ( state ) => isEligibleForAutomatedTransfer( state, siteId ) );
@@ -185,19 +189,19 @@ export default function WPCOMBusinessAT( {
 	}, [ dispatch, siteId ] );
 	const trackInitiateAT = useTrackCallback( initiateAT, 'calypso_jetpack_backup_business_at' );
 
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const isJetpack = useSelector( ( state: AppState ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state: AppState ) => isSiteWpcomAtomic( state, siteId ) );
 
-	const rewindAtomicDeactivated =
-		isAtomic && ( rewindState as { state?: string } | undefined )?.state === 'unavailable';
+	const rewindAtomicDeactivated = isAtomic && rewindState?.state === 'unavailable';
 
+	const onActivationResolved = content.onActivationResolved;
 	useEffect( () => {
 		if ( isRewindActivating && ! rewindAtomicDeactivated ) {
 			setIsRewindActivating( false );
 			// Notify product-specific callback when activation settles
-			content.onActivationResolved?.();
+			onActivationResolved?.();
 		}
-	}, [ isRewindActivating, rewindAtomicDeactivated, content ] );
+	}, [ isRewindActivating, rewindAtomicDeactivated, onActivationResolved ] );
 
 	// Check if features are loaded
 	const featuresNotLoaded = useSelector(

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -194,14 +194,13 @@ export default function WPCOMBusinessAT( {
 
 	const rewindAtomicDeactivated = isAtomic && rewindState?.state === 'unavailable';
 
-	const onActivationResolved = content.onActivationResolved;
 	useEffect( () => {
 		if ( isRewindActivating && ! rewindAtomicDeactivated ) {
 			setIsRewindActivating( false );
 			// Notify product-specific callback when activation settles
-			onActivationResolved?.();
+			content.onActivationResolved?.();
 		}
-	}, [ isRewindActivating, rewindAtomicDeactivated, onActivationResolved ] );
+	}, [ isRewindActivating, rewindAtomicDeactivated, content.onActivationResolved ] );
 
 	// Check if features are loaded
 	const featuresNotLoaded = useSelector(

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -74,6 +74,8 @@ export interface AtomicContentSwitch {
 		content: string;
 	};
 	getProductUrl: ( siteSlug: string ) => string;
+	/** Optional hook for product-specific activation handling */
+	onActivationResolved?: () => void;
 }
 
 const vaultpressContent: AtomicContentSwitch = {
@@ -100,7 +102,7 @@ function BlockingHoldNotice( {
 	suppressInstallNotice = false,
 }: BlockingHoldNoticeProps ) {
 	const { eligibilityHolds: holds } = useSelector( ( state ) => getEligibility( state, siteId ) );
-	if ( ! holds ) {
+	if ( ! holds || suppressInstallNotice ) {
 		return null;
 	}
 
@@ -113,18 +115,10 @@ function BlockingHoldNotice( {
 		)
 	);
 
-	// Minimal change: always suppress the transient "Installation in progress" notice
-	// by filtering out TRANSFER_ALREADY_EXISTS from the holds passed to the notice.
-	const filteredHolds = holds.filter( ( h: string ) => h !== 'TRANSFER_ALREADY_EXISTS' );
-
-	const holdsForNotice = suppressInstallNotice
-		? filteredHolds.filter( ( h: string ) => h !== 'TRANSFER_ALREADY_EXISTS' )
-		: filteredHolds;
-
 	return (
 		<HardBlockingNotice
 			translate={ translate }
-			holds={ holdsForNotice }
+			holds={ holds }
 			blockingMessages={ blockingMessages }
 		/>
 	);
@@ -196,6 +190,14 @@ export default function WPCOMBusinessAT( {
 
 	const rewindAtomicDeactivated =
 		isAtomic && ( rewindState as { state?: string } | undefined )?.state === 'unavailable';
+
+	useEffect( () => {
+		if ( isRewindActivating && ! rewindAtomicDeactivated ) {
+			setIsRewindActivating( false );
+			// Notify product-specific callback when activation settles
+			content.onActivationResolved?.();
+		}
+	}, [ isRewindActivating, rewindAtomicDeactivated, content ] );
 
 	// Check if features are loaded
 	const featuresNotLoaded = useSelector(
@@ -311,11 +313,7 @@ export default function WPCOMBusinessAT( {
 					<SpinnerButton
 						text={ content.primaryPromo.promoCTA.text }
 						loadingText={ content.primaryPromo.promoCTA.loadingText }
-						loading={
-							automatedTransferStatus === START ||
-							( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
-							isRewindActivating
-						}
+						loading={ automatedTransferStatus === START || isRewindActivating }
 						onClick={ () => {
 							if ( rewindAtomicDeactivated ) {
 								setIsRewindActivating( true );

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -36,9 +36,12 @@ import {
 	getEligibility,
 	EligibilityData,
 } from 'calypso/state/automated-transfer/selectors';
+import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { successNotice } from 'calypso/state/notices/actions';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
@@ -50,6 +53,7 @@ import 'calypso/blocks/eligibility-warnings/style.scss';
 interface BlockingHoldNoticeProps {
 	siteId: number;
 	productName: string;
+	suppressInstallNotice?: boolean;
 }
 
 // This gets the values of the object transferStates.
@@ -90,7 +94,11 @@ const vaultpressContent: AtomicContentSwitch = {
 	getProductUrl: ( siteSlug: string ) => `/backup/${ siteSlug }`,
 };
 
-function BlockingHoldNotice( { siteId, productName }: BlockingHoldNoticeProps ) {
+function BlockingHoldNotice( {
+	siteId,
+	productName,
+	suppressInstallNotice = false,
+}: BlockingHoldNoticeProps ) {
 	const { eligibilityHolds: holds } = useSelector( ( state ) => getEligibility( state, siteId ) );
 	if ( ! holds ) {
 		return null;
@@ -105,10 +113,18 @@ function BlockingHoldNotice( { siteId, productName }: BlockingHoldNoticeProps ) 
 		)
 	);
 
+	// Minimal change: always suppress the transient "Installation in progress" notice
+	// by filtering out TRANSFER_ALREADY_EXISTS from the holds passed to the notice.
+	const filteredHolds = holds.filter( ( h: string ) => h !== 'TRANSFER_ALREADY_EXISTS' );
+
+	const holdsForNotice = suppressInstallNotice
+		? filteredHolds.filter( ( h: string ) => h !== 'TRANSFER_ALREADY_EXISTS' )
+		: filteredHolds;
+
 	return (
 		<HardBlockingNotice
 			translate={ translate }
-			holds={ holds }
+			holds={ holdsForNotice }
 			blockingMessages={ blockingMessages }
 		/>
 	);
@@ -141,6 +157,7 @@ export default function WPCOMBusinessAT( {
 }: { content?: AtomicContentSwitch } = {} ) {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
+	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) );
 
 	// Gets the site eligibility data.
 	const isEligible = useSelector( ( state ) => isEligibleForAutomatedTransfer( state, siteId ) );
@@ -164,6 +181,7 @@ export default function WPCOMBusinessAT( {
 	// Gets state to control dialog and continue button.
 	const [ showDialog, setShowDialog ] = useState( false );
 	const onClose = () => setShowDialog( false );
+	const [ isRewindActivating, setIsRewindActivating ] = useState( false );
 
 	// Handles dispatching automated transfer.
 	const dispatch = useDispatch();
@@ -174,6 +192,10 @@ export default function WPCOMBusinessAT( {
 	const trackInitiateAT = useTrackCallback( initiateAT, 'calypso_jetpack_backup_business_at' );
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+
+	const rewindAtomicDeactivated =
+		isAtomic && ( rewindState as { state?: string } | undefined )?.state === 'unavailable';
 
 	// Check if features are loaded
 	const featuresNotLoaded = useSelector(
@@ -270,7 +292,11 @@ export default function WPCOMBusinessAT( {
 				align="left"
 				brandFont
 			/>
-			<BlockingHoldNotice siteId={ siteId } productName={ content.header } />
+			<BlockingHoldNotice
+				siteId={ siteId }
+				productName={ content.header }
+				suppressInstallNotice={ rewindAtomicDeactivated }
+			/>
 			<TransferFailureNotice
 				transferStatus={ automatedTransferStatus as TransferStatus }
 				productName={ content.header }
@@ -287,10 +313,21 @@ export default function WPCOMBusinessAT( {
 						loadingText={ content.primaryPromo.promoCTA.loadingText }
 						loading={
 							automatedTransferStatus === START ||
-							( automatedTransferStatus === COMPLETE && ! isJetpack )
+							( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
+							isRewindActivating
 						}
-						onClick={ initiateATOrShowWarnings }
-						disabled={ cannotInitiateTransfer }
+						onClick={ () => {
+							if ( rewindAtomicDeactivated ) {
+								setIsRewindActivating( true );
+								dispatch( autoConfigCredentials( siteId ) );
+								page( content.getProductUrl( siteSlug ) );
+								return;
+							}
+							initiateATOrShowWarnings();
+						} }
+						disabled={
+							( cannotInitiateTransfer && ! rewindAtomicDeactivated ) || isRewindActivating
+						}
 					/>
 				</div>
 			</PromoCard>

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -245,9 +245,8 @@ export default function WPCOMBusinessAT( {
 				}
 			)
 		);
-		// Reload the page, whatever siteSlug is
-		page( content.getProductUrl( siteSlug ) );
-	}, [ automatedTransferStatus, isJetpack ] );
+		content.onActivationResolved?.();
+	}, [ automatedTransferStatus, isJetpack, content.onActivationResolved ] );
 
 	// If there are any issues, show a dialog.
 	// Otherwise, kick off the transfer!
@@ -316,7 +315,11 @@ export default function WPCOMBusinessAT( {
 					<SpinnerButton
 						text={ content.primaryPromo.promoCTA.text }
 						loadingText={ content.primaryPromo.promoCTA.loadingText }
-						loading={ automatedTransferStatus === START || isRewindActivating }
+						loading={
+							automatedTransferStatus === START ||
+							( automatedTransferStatus === COMPLETE && ! isJetpack ) ||
+							isRewindActivating
+						}
 						onClick={ () => {
 							if ( rewindAtomicDeactivated ) {
 								setIsRewindActivating( true );

--- a/client/lib/jetpack/wpcom-atomic-transfer.tsx
+++ b/client/lib/jetpack/wpcom-atomic-transfer.tsx
@@ -1,10 +1,31 @@
 import { isEnabled } from '@automattic/calypso-config';
 import BusinessATSwitch from 'calypso/components/jetpack/business-at-switch';
 import { AtomicContentSwitch } from 'calypso/components/jetpack/wpcom-business-at';
+import { useSelector } from 'calypso/state';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { Context } from './types';
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
+
+type GateProps = {
+	UpsellComponent: ComponentType;
+	content?: AtomicContentSwitch;
+	children?: ReactNode;
+};
+
+const AtomicATGate = ( { UpsellComponent, content, children }: GateProps ) => {
+	const siteId = useSelector( getSelectedSiteId ) as number | undefined;
+	const rewind = useSelector( ( state ) => getRewindState( state, siteId ) );
+	const isUnavailable = ( rewind as { state?: string } | undefined )?.state === 'unavailable';
+
+	if ( isUnavailable ) {
+		return <BusinessATSwitch UpsellComponent={ UpsellComponent } content={ content } />;
+	}
+
+	return children as ReactNode;
+};
 
 export default function wpcomAtomicTransfer(
 	UpsellComponent: ComponentType,
@@ -14,11 +35,21 @@ export default function wpcomAtomicTransfer(
 		const getState = context.store.getState;
 		const siteId = getSelectedSiteId( getState() );
 		const isJetpack = isJetpackSite( getState(), siteId );
+		const isAtomic = isSiteWpcomAtomic( getState(), siteId );
 
-		if ( ! isJetpack && ! isEnabled( 'jetpack-cloud' ) && context.primary ) {
-			context.primary = (
-				<BusinessATSwitch UpsellComponent={ UpsellComponent } content={ content } />
-			);
+		if ( ! isEnabled( 'jetpack-cloud' ) && context.primary ) {
+			const originalPrimary = context.primary;
+			if ( ! isJetpack ) {
+				context.primary = (
+					<BusinessATSwitch UpsellComponent={ UpsellComponent } content={ content } />
+				);
+			} else if ( isAtomic ) {
+				context.primary = (
+					<AtomicATGate UpsellComponent={ UpsellComponent } content={ content }>
+						{ originalPrimary }
+					</AtomicATGate>
+				);
+			}
 		}
 
 		next();

--- a/client/lib/jetpack/wpcom-atomic-transfer.tsx
+++ b/client/lib/jetpack/wpcom-atomic-transfer.tsx
@@ -7,6 +7,8 @@ import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { Context } from './types';
+import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
+import type { AppState } from 'calypso/types';
 import type { ComponentType, ReactNode } from 'react';
 
 type GateProps = {
@@ -17,8 +19,10 @@ type GateProps = {
 
 const AtomicATGate = ( { UpsellComponent, content, children }: GateProps ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number | undefined;
-	const rewind = useSelector( ( state ) => getRewindState( state, siteId ) );
-	const isUnavailable = ( rewind as { state?: string } | undefined )?.state === 'unavailable';
+	const rewind = useSelector( ( state: AppState ) =>
+		getRewindState( state, siteId )
+	) as RewindState;
+	const isUnavailable = rewind?.state === 'unavailable';
 
 	if ( isUnavailable ) {
 		return <BusinessATSwitch UpsellComponent={ UpsellComponent } content={ content } />;

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -1,4 +1,4 @@
-import { isJetpackBackupSlug } from '@automattic/calypso-products';
+import { isJetpackBackupSlug, WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products';
 import Debug from 'debug';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
@@ -49,7 +49,9 @@ export function showUpsellIfNoBackup( context, next ) {
 					'uninitialized' === getRewindState( state, siteId )?.state
 				}
 				display={ context.primary }
-				productSlugTest={ isJetpackBackupSlug }
+				productSlugTest={ ( slug ) =>
+					isJetpackBackupSlug( slug ) || slug === WPCOM_FEATURES_BACKUPS
+				}
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }
 				<UpsellPlaceholder />

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -1,4 +1,4 @@
-import { isJetpackScanSlug } from '@automattic/calypso-products';
+import { isJetpackScanSlug, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
@@ -114,7 +114,7 @@ function scanUpsellSwitcher( placeholder, primary ) {
 				'pending' === getSiteScanRequestStatus( state, siteId )
 			}
 			display={ primary }
-			productSlugTest={ isJetpackScanSlug }
+			productSlugTest={ ( slug ) => isJetpackScanSlug( slug ) || slug === WPCOM_FEATURES_SCAN }
 		>
 			{ placeholder }
 		</UpsellSwitch>

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -11,6 +11,8 @@ import Main from 'calypso/components/main';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import WPCOMScanUpsellPage from 'calypso/my-sites/scan/wpcom-upsell';
+import { useDispatch } from 'calypso/state';
+import { requestScanStatus } from 'calypso/state/jetpack-scan/actions';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import getSiteScanRequestStatus from 'calypso/state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'calypso/state/selectors/get-site-scan-state';
@@ -42,6 +44,7 @@ const ScanLoadingPlaceholder = () => {
 // Wrapper component that handles the feature loading logic
 const ScanAtomicTransferWrapper = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const dispatch = useDispatch();
 
 	const featuresNotLoaded: boolean = useSelector(
 		( state: AppState ) =>
@@ -97,6 +100,9 @@ const ScanAtomicTransferWrapper = () => {
 		},
 
 		getProductUrl: ( siteSlug: string ) => `/scan/${ siteSlug }`,
+		onActivationResolved: () => {
+			dispatch( requestScanStatus( siteId ) );
+		},
 	};
 
 	// Render the atomic transfer UI with the scan-specific content

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -68,6 +68,13 @@ const ScanAtomicTransferWrapper = () => {
 		return <ScanLoadingPlaceholder />;
 	}
 
+	// If the site already has the Scan feature, skip the AT flow entirely
+	// and let the normal Scan page render (even if scanState is 'unavailable').
+	// The Scan page will query status and progress from the API directly.
+	if ( hasScanFeature ) {
+		return null;
+	}
+
 	// If site doesn't have scan feature, show Business plan upsell instead of activation
 	if ( ! hasScanFeature ) {
 		return <WPCOMScanUpsellPage />;

--- a/client/my-sites/scan/wpcom-atomic-transfer.tsx
+++ b/client/my-sites/scan/wpcom-atomic-transfer.tsx
@@ -68,13 +68,6 @@ const ScanAtomicTransferWrapper = () => {
 		return <ScanLoadingPlaceholder />;
 	}
 
-	// If the site already has the Scan feature, skip the AT flow entirely
-	// and let the normal Scan page render (even if scanState is 'unavailable').
-	// The Scan page will query status and progress from the API directly.
-	if ( hasScanFeature ) {
-		return null;
-	}
-
 	// If site doesn't have scan feature, show Business plan upsell instead of activation
 	if ( ! hasScanFeature ) {
 		return <WPCOMScanUpsellPage />;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -922,7 +922,12 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			: baseFeatures;
 	},
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
+	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
+		FEATURE_AUDIO_UPLOADS,
+		...( hasSummerSpecialSticker
+			? [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_BACKUP_T1_BI_YEARLY ]
+			: [] ),
+	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
@@ -1529,11 +1534,14 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		];
 	},
 	// Features not displayed but used for checking plan abilities
-	getIncludedFeatures: () => [
+	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
 		FEATURE_AUDIO_UPLOADS,
 		WPCOM_FEATURES_SCAN,
 		WPCOM_FEATURES_ANTISPAM,
 		WPCOM_FEATURES_BACKUPS,
+		...( hasSummerSpecialSticker
+			? [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_BACKUP_T1_BI_YEARLY ]
+			: [] ),
 	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -924,9 +924,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
 		FEATURE_AUDIO_UPLOADS,
-		...( hasSummerSpecialSticker
-			? [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_BACKUP_T1_BI_YEARLY ]
-			: [] ),
+		...( hasSummerSpecialSticker ? [ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_BACKUPS ] : [] ),
 	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [
@@ -1536,12 +1534,8 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
 		FEATURE_AUDIO_UPLOADS,
-		WPCOM_FEATURES_SCAN,
 		WPCOM_FEATURES_ANTISPAM,
-		WPCOM_FEATURES_BACKUPS,
-		...( hasSummerSpecialSticker
-			? [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_BACKUP_T1_BI_YEARLY ]
-			: [] ),
+		...( hasSummerSpecialSticker ? [ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_BACKUPS ] : [] ),
 	],
 	getInferiorFeatures: () => [],
 	getCancellationFeatures: () => [

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -373,7 +373,7 @@ export type Plan = BillingTerm & {
 	 * to determine what a given plan *may* be capable of doing
 	 * before verifying with an API.
 	 */
-	getIncludedFeatures?: () => Feature[];
+	getIncludedFeatures?: ( hasSummerSpecialSticker?: boolean ) => Feature[];
 
 	/**
 	 * Features that are superseded by another feature included in this plan.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTOBRD-318](https://linear.app/a8c/issue/DOTOBRD-318/enable-scan-and-backup-functionality-for-summer-special-sites)

## Proposed Changes

* adds the Scans and Backups features to the Summer Special
* shows the activate features screens for atomic sites which don't have Rewind activated (needed for Scans and Backups)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Create a new Summer Special Personal/Premium site 
* While the site is simple, you should see the activation screen on Jetpack Scans and Backups
* After activation, you should be able to use the Scan and Backups features on a Personal or Premium Summer special plans

<img width="623" height="408" alt="Screenshot 2025-09-04 at 17 43 00" src="https://github.com/user-attachments/assets/c8244b5c-bee5-4bbb-8d70-c186079bde5a" />
<img width="630" height="458" alt="Screenshot 2025-09-04 at 17 42 55" src="https://github.com/user-attachments/assets/c984dedc-9149-4b3f-b2d2-9aa0e78a8a60" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?