### PR TITLE
Domain Search Rewrite: Add trademark claims modal

### DIFF
--- a/client/components/domain-search-v2/__legacy/domain-suggestion-cta/index.tsx
+++ b/client/components/domain-search-v2/__legacy/domain-suggestion-cta/index.tsx
@@ -1,7 +1,9 @@
+import { TrademarkClaimsNoticeInfo } from '@automattic/api-core';
 import {
 	DomainSuggestionContinueCTA,
 	DomainSuggestionErrorCTA,
 	DomainSuggestionPrimaryCTA,
+	DomainSearchTrademarkClaimsModal,
 } from '@automattic/domain-search';
 import { useDomainSearch } from '../domain-search';
 import { useFocusedCartAction } from '../use-focused-cart-action';
@@ -10,9 +12,22 @@ export interface DomainSuggestionCTAProps {
 	uuid: string;
 	onClick?( action: 'add-to-cart' | 'continue' ): void;
 	disabled?: boolean;
+	trademarkClaimsNoticeInfo?: {
+		domain: string;
+		trademarkClaimsNoticeInfo: TrademarkClaimsNoticeInfo;
+	};
+	onAcceptTrademarkClaim: () => void;
+	onRejectTrademarkClaim: () => void;
 }
 
-export const DomainSuggestionCTA = ( { uuid, onClick, disabled }: DomainSuggestionCTAProps ) => {
+export const DomainSuggestionCTA = ( {
+	uuid,
+	onClick,
+	disabled,
+	trademarkClaimsNoticeInfo,
+	onAcceptTrademarkClaim,
+	onRejectTrademarkClaim,
+}: DomainSuggestionCTAProps ) => {
 	const { cart, onContinue } = useDomainSearch();
 	const { isBusy, errorMessage, callback } = useFocusedCartAction( () => {
 		onClick?.( 'add-to-cart' );
@@ -40,10 +55,20 @@ export const DomainSuggestionCTA = ( { uuid, onClick, disabled }: DomainSuggesti
 	}
 
 	return (
-		<DomainSuggestionPrimaryCTA
-			onClick={ callback }
-			disabled={ disabled || cart.isBusy }
-			isBusy={ isBusy }
-		/>
+		<>
+			<DomainSuggestionPrimaryCTA
+				onClick={ callback }
+				disabled={ disabled || cart.isBusy }
+				isBusy={ isBusy }
+			/>
+			{ trademarkClaimsNoticeInfo?.domain === uuid && (
+				<DomainSearchTrademarkClaimsModal
+					domainName={ uuid }
+					trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo.trademarkClaimsNoticeInfo }
+					onAccept={ onAcceptTrademarkClaim }
+					onClose={ onRejectTrademarkClaim }
+				/>
+			) }
+		</>
 	);
 };

--- a/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
+++ b/client/components/domain-search-v2/domain-registration-suggestion/index.jsx
@@ -72,6 +72,9 @@ class DomainRegistrationSuggestion extends Component {
 		hideMatchReasons: PropTypes.bool,
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		products: PropTypes.object,
+		trademarkClaimsNoticeInfo: PropTypes.object,
+		onAcceptTrademarkClaim: PropTypes.func,
+		onRejectTrademarkClaim: PropTypes.func,
 	};
 
 	componentDidMount() {
@@ -444,7 +447,15 @@ class DomainRegistrationSuggestion extends Component {
 					renewPrice={ renewCost }
 				/>
 			);
-			cta = <DomainSuggestionCTA uuid={ fullDomain } onClick={ this.onButtonClick } />;
+			cta = (
+				<DomainSuggestionCTA
+					uuid={ fullDomain }
+					onClick={ this.onButtonClick }
+					trademarkClaimsNoticeInfo={ this.props.trademarkClaimsNoticeInfo }
+					onAcceptTrademarkClaim={ this.props.onAcceptTrademarkClaim }
+					onRejectTrademarkClaim={ this.props.onRejectTrademarkClaim }
+				/>
+			);
 		}
 
 		return (

--- a/client/components/domain-search-v2/domain-search-results/index.jsx
+++ b/client/components/domain-search-v2/domain-search-results/index.jsx
@@ -247,6 +247,9 @@ class DomainSearchResults extends Component {
 					isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 					temporaryCart={ this.props.temporaryCart }
 					domainRemovalQueue={ this.props.domainRemovalQueue }
+					trademarkClaimsNoticeInfo={ this.props.trademarkClaimsNoticeInfo }
+					onAcceptTrademarkClaim={ this.props.onAcceptTrademarkClaim }
+					onRejectTrademarkClaim={ this.props.onRejectTrademarkClaim }
 				/>
 			);
 
@@ -282,6 +285,9 @@ class DomainSearchResults extends Component {
 						isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 						temporaryCart={ this.props.temporaryCart }
 						domainRemovalQueue={ this.props.domainRemovalQueue }
+						trademarkClaimsNoticeInfo={ this.props.trademarkClaimsNoticeInfo }
+						onAcceptTrademarkClaim={ this.props.onAcceptTrademarkClaim }
+						onRejectTrademarkClaim={ this.props.onRejectTrademarkClaim }
 					/>
 				);
 			} );

--- a/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
+++ b/client/components/domain-search-v2/featured-domain-suggestions/index.jsx
@@ -39,6 +39,9 @@ export class FeaturedDomainSuggestions extends Component {
 			'domainAndPlanUpsellFlow',
 			'temporaryCart',
 			'domainRemovalQueue',
+			'trademarkClaimsNoticeInfo',
+			'onAcceptTrademarkClaim',
+			'onRejectTrademarkClaim',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -72,7 +72,6 @@ import {
 	isMissingVendor,
 	markFeaturedSuggestions,
 } from 'calypso/components/domains/register-domain-step/utility';
-import TrademarkClaimsNotice from 'calypso/components/domains/trademark-claims-notice';
 import { getDomainsInCart, hasDomainInCart } from 'calypso/lib/cart-values/cart-items';
 import {
 	checkDomainAvailability,
@@ -620,12 +619,6 @@ class RegisterDomainStep extends Component {
 	render() {
 		const { onContinue, isDomainAndPlanPackageFlow, translate } = this.props;
 
-		const { trademarkClaimsNoticeInfo } = this.state;
-
-		if ( trademarkClaimsNoticeInfo ) {
-			return this.renderTrademarkClaimsNotice();
-		}
-
 		const notices = this.renderGeneralNotices();
 
 		const showFreeDomainPromo =
@@ -869,25 +862,6 @@ class RegisterDomainStep extends Component {
 		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
 		this.clearTrademarkClaimState();
 	};
-
-	renderTrademarkClaimsNotice() {
-		const { isSignupStep } = this.props;
-		const { selectedSuggestion, trademarkClaimsNoticeInfo, isLoading } = this.state;
-		const domain = get( selectedSuggestion, 'domain_name' );
-
-		return (
-			<TrademarkClaimsNotice
-				domain={ domain }
-				isLoading={ isLoading }
-				isSignupStep={ isSignupStep }
-				onAccept={ this.acceptTrademarkClaim }
-				onGoBack={ this.clearTrademarkClaimState }
-				onReject={ this.clearTrademarkClaimState }
-				suggestion={ selectedSuggestion }
-				trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo }
-			/>
-		);
-	}
 
 	renderFilterResetNotice() {
 		const { exactSldMatchesOnly = false, tlds = [] } = this.state.lastFilters;
@@ -1235,9 +1209,14 @@ class RegisterDomainStep extends Component {
 					const isAvailable = domainAvailability.AVAILABLE === status;
 					const isAvailableSupportedPremiumDomain =
 						domainAvailability.AVAILABLE_PREMIUM === status && result?.is_supported_premium_domain;
+
+					const trademarkClaimsNoticeInfo = get( result, 'trademark_claims_notice_info', null );
+
 					resolve( {
 						status: ! isAvailable && ! isAvailableSupportedPremiumDomain ? status : null,
-						trademarkClaimsNoticeInfo: get( result, 'trademark_claims_notice_info', null ),
+						trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo
+							? { domain, trademarkClaimsNoticeInfo }
+							: null,
 					} );
 				}
 			);
@@ -1872,6 +1851,9 @@ class RegisterDomainStep extends Component {
 				temporaryCart={ this.props.temporaryCart }
 				domainRemovalQueue={ this.props.domainRemovalQueue }
 				flowName={ this.props.flowName }
+				trademarkClaimsNoticeInfo={ this.state.trademarkClaimsNoticeInfo }
+				onAcceptTrademarkClaim={ this.acceptTrademarkClaim }
+				onRejectTrademarkClaim={ this.clearTrademarkClaimState }
 			/>
 		);
 	}

--- a/client/components/domains/trademark-claims-notice/index.jsx
+++ b/client/components/domains/trademark-claims-notice/index.jsx
@@ -1,4 +1,5 @@
 import { Button, CompactCard } from '@automattic/components';
+import { TRADE_MARK_CLAIMS_MODAL_COPY } from '@automattic/domain-search';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -115,11 +116,7 @@ class TrademarkClaimsNotice extends Component {
 		return (
 			<CompactCard>
 				<h2>{ translate( '%(domain)s matches a trademark.', { args: { domain } } ) }</h2>
-				<p>
-					{ translate(
-						"To continue, you must agree not to infringe on the trademark holders' rights. Please review and acknowledge the following notice."
-					) }
-				</p>
+				<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.PREAMBLE }</p>
 			</CompactCard>
 		);
 	};

--- a/client/components/domains/trademark-claims-notice/trademark-constants.js
+++ b/client/components/domains/trademark-claims-notice/trademark-constants.js
@@ -1,46 +1,18 @@
+import { TRADE_MARK_CLAIMS_MODAL_COPY } from '@automattic/domain-search';
 import { Fragment } from 'react';
-
-// Note: Please don't change the text in this file as it is specified in the RPM-Requirements of the
-// ICANN TMCH functional specifications: https://tools.ietf.org/html/draft-ietf-eppext-tmch-func-spec-01#ref-RPM-Requirements
 
 export const trademarkNoticeText = (
 	<Fragment>
 		<h3>Trademark Notice</h3>
-		<p>
-			You have received this Trademark Notice because you have applied for a domain name which
-			matches at least one trademark record submitted to the Trademark Clearinghouse.
-		</p>
+		<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.REASON }</p>
 		<p>
 			<strong>
-				<em>
-					You may or may not be entitled to register the domain name depending on your intended use
-					and whether it is the same or significantly overlaps with the trademarks listed below.
-					Your rights to register this domain name may or may not be protected as noncommercial use
-					or “fair use” by the laws of your country.
-				</em>
+				<em>{ TRADE_MARK_CLAIMS_MODAL_COPY.ENTITLEMENT }</em>
 			</strong>
 		</p>
-		<p>
-			Please read the trademark information below carefully, including the trademarks,
-			jurisdictions, and goods and services for which the trademarks are registered. Please be aware
-			that not all jurisdictions review trademark applications closely, so some of the trademark
-			information below may exist in a national or regional registry which does not conduct a
-			thorough or substantive review of trademark rights prior to registration. If you have
-			questions, you may want to consult an attorney or legal expert on trademarks and intellectual
-			property for guidance.
-		</p>
-		<p>
-			If you continue with this registration, you represent that, you have received and you
-			understand this notice and to the best of your knowledge, your registration and use of the
-			requested domain name will not infringe on the trademark rights listed below. The following
-			marks are listed in the Trademark Clearinghouse:
-		</p>
+		<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.INSTRUCTIONS }</p>
+		<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.CONSENT }</p>
 	</Fragment>
 );
 
-export const trademarkDecisionText = (
-	<p>
-		This domain name label has previously been found to be used or registered abusively against the
-		following trademarks according to the referenced decisions:
-	</p>
-);
+export const trademarkDecisionText = <p>{ TRADE_MARK_CLAIMS_MODAL_COPY.COURT_CASES }</p>;

--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -113,7 +113,6 @@ export interface DomainAvailability {
 
 	/**
 	 * Trademark claims notice info
-	 * @example { "domain_name": "example.com", "trademark_claims_notice_info": "Trademark claims notice info" }
 	 */
 	trademark_claims_notice_info?: TrademarkClaimsNoticeInfo;
 }

--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -115,7 +115,7 @@ export interface DomainAvailability {
 	 * Trademark claims notice info
 	 * @example { "domain_name": "example.com", "trademark_claims_notice_info": "Trademark claims notice info" }
 	 */
-	trademark_claims_notice_info?: string;
+	trademark_claims_notice_info?: TrademarkClaimsNoticeInfo;
 }
 
 export enum DomainAvailabilityStatus {
@@ -166,4 +166,47 @@ export enum DomainAvailabilityStatus {
 	UNKNOWN = 'unknown',
 	UNKOWN_ACTIVE = 'unknown_active_domain_with_wpcom',
 	WPCOM_STAGING_DOMAIN = 'wpcom_staging_domain',
+}
+
+export interface TrademarkClaimsNoticeInfo {
+	claim: TrademarkClaim | TrademarkClaim[];
+}
+
+export interface TrademarkClaimContact {
+	name?: string;
+	org?: string;
+	voice?: string;
+	fax?: string;
+	email?: string;
+	addr?: {
+		street?: string[];
+		city?: string;
+		sp?: string;
+		pc?: string;
+		cc?: string;
+	};
+}
+
+export interface TrademarkClaimCourtCase {
+	refNum: string;
+	cc: string;
+	courtName: string;
+}
+
+export interface TrademarkClaimUdrpCase {
+	caseNo: string;
+	udrpProvider: string;
+}
+
+export interface TrademarkClaim {
+	markName?: string;
+	jurDesc?: string;
+	goodsAndServices?: string[];
+	classDesc?: string[];
+	holder?: TrademarkClaimContact;
+	contact?: TrademarkClaimContact;
+	notExactMatch?: {
+		court?: TrademarkClaimCourtCase[];
+		udrp?: TrademarkClaimUdrpCase[];
+	};
 }

--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -110,6 +110,12 @@ export interface DomainAvailability {
 	 * @example true
 	 */
 	cannot_transfer_due_to_unsupported_premium_tld?: boolean;
+
+	/**
+	 * Trademark claims notice info
+	 * @example { "domain_name": "example.com", "trademark_claims_notice_info": "Trademark claims notice info" }
+	 */
+	trademark_claims_notice_info?: string;
 }
 
 export enum DomainAvailabilityStatus {

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -49,6 +49,7 @@
 		"@automattic/urls": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^29.9.0",
+		"@wordpress/compose": "7.23.0",
 		"@wordpress/icons": "^10.23.0",
 		"@wordpress/react-i18n": "^4.23.0",
 		"clsx": "^2.1.1",

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -90,14 +90,17 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 				isBusy={ isPending }
 				onClick={ () => addToCart( { acceptedTrademarkClaim: false } ) }
 			/>
-			<DomainSearchTrademarkClaimsModal
-				isOpen={ trademarkClaimModalOpen }
-				onAccept={ () => {
-					setTrademarkClaimModalOpen( false );
-					addToCart( { acceptedTrademarkClaim: true } );
-				} }
-				onClose={ () => setTrademarkClaimModalOpen( false ) }
-			/>
+			{ availability?.trademark_claims_notice_info && trademarkClaimModalOpen && (
+				<DomainSearchTrademarkClaimsModal
+					domainName={ domainName }
+					trademarkClaimsNoticeInfo={ availability.trademark_claims_notice_info }
+					onAccept={ () => {
+						setTrademarkClaimModalOpen( false );
+						addToCart( { acceptedTrademarkClaim: true } );
+					} }
+					onClose={ () => setTrademarkClaimModalOpen( false ) }
+				/>
+			) }
 		</>
 	);
 };

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -1,10 +1,12 @@
-import { useIsMutating, useMutation, useQuery } from '@tanstack/react-query';
+import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
+import { useState } from 'react';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
 import { useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSearch } from '../../page/context';
 import {
+	DomainSearchTrademarkClaimsModal,
 	DomainSuggestionContinueCTA,
 	DomainSuggestionErrorCTA,
 	DomainSuggestionPrimaryCTA,
@@ -16,8 +18,13 @@ export interface DomainSuggestionCTAProps {
 
 export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) => {
 	const { cart, events, queries } = useDomainSearch();
-
 	const suggestion = useSuggestion( domainName );
+
+	const queryClient = useQueryClient();
+
+	const { data: availability } = useQuery( queries.domainAvailability( domainName ) );
+
+	const [ trademarkClaimModalOpen, setTrademarkClaimModalOpen ] = useState( false );
 
 	const {
 		mutate: addToCart,
@@ -25,15 +32,27 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 		error,
 		submittedAt,
 	} = useMutation( {
-		mutationFn: () => cart.onAddItem( suggestion ),
+		mutationFn: async ( { acceptedTrademarkClaim }: { acceptedTrademarkClaim: boolean } ) => {
+			if ( acceptedTrademarkClaim ) {
+				return cart.onAddItem( suggestion );
+			}
+
+			const availability = await queryClient.ensureQueryData(
+				queries.domainAvailability( domainName )
+			);
+
+			if ( ! availability?.trademark_claims_notice_info ) {
+				return cart.onAddItem( suggestion );
+			}
+
+			setTrademarkClaimModalOpen( true );
+		},
 		networkMode: 'always',
 		retry: false,
 	} );
 
 	const isMutating = !! useIsMutating();
 	const isCurrentMutation = useIsCurrentMutation( submittedAt );
-
-	const { data: availability } = useQuery( queries.domainAvailability( domainName ) );
 
 	if ( availability?.is_price_limit_exceeded ) {
 		return (
@@ -56,14 +75,29 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 	const errorMessage = isCurrentMutation && error?.message;
 
 	if ( errorMessage ) {
-		return <DomainSuggestionErrorCTA errorMessage={ errorMessage } callback={ addToCart } />;
+		return (
+			<DomainSuggestionErrorCTA
+				errorMessage={ errorMessage }
+				callback={ () => addToCart( { acceptedTrademarkClaim: false } ) }
+			/>
+		);
 	}
 
 	return (
-		<DomainSuggestionPrimaryCTA
-			disabled={ isMutating }
-			isBusy={ isPending }
-			onClick={ addToCart }
-		/>
+		<>
+			<DomainSuggestionPrimaryCTA
+				disabled={ isMutating }
+				isBusy={ isPending }
+				onClick={ () => addToCart( { acceptedTrademarkClaim: false } ) }
+			/>
+			<DomainSearchTrademarkClaimsModal
+				isOpen={ trademarkClaimModalOpen }
+				onAccept={ () => {
+					setTrademarkClaimModalOpen( false );
+					addToCart( { acceptedTrademarkClaim: true } );
+				} }
+				onClose={ () => setTrademarkClaimModalOpen( false ) }
+			/>
+		</>
 	);
 };

--- a/packages/domain-search/src/hooks/use-container-query.ts
+++ b/packages/domain-search/src/hooks/use-container-query.ts
@@ -6,8 +6,10 @@ export const useContainerQuery = < T extends string >(
 ): {
 	ref: ( element: Element | null | undefined ) => void;
 	activeQuery: T;
+	currentWidth: number | null;
 } => {
 	const [ activeQuery, setActiveQuery ] = useState< T >( Object.keys( queries )[ 0 ] as T );
+	const [ currentWidth, setCurrentWidth ] = useState< number | null >( null );
 
 	const initialMountRef = useRef< Element | null | undefined >( null );
 
@@ -16,6 +18,7 @@ export const useContainerQuery = < T extends string >(
 		if ( query ) {
 			setActiveQuery( query[ 0 ] as T );
 		}
+		setCurrentWidth( width );
 	} );
 
 	useLayoutEffect( () => {
@@ -36,5 +39,6 @@ export const useContainerQuery = < T extends string >(
 			resizableContainerRef( element );
 		},
 		activeQuery,
+		currentWidth,
 	};
 };

--- a/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
+++ b/packages/domain-search/src/hooks/use-domain-suggestion-container.ts
@@ -2,16 +2,21 @@ import { createContext, useContext } from 'react';
 import { useContainerQuery } from '../hooks/use-container-query';
 
 export const useDomainSuggestionContainer = () => {
-	const { ref: containerRef, activeQuery } = useContainerQuery( {
+	const {
+		ref: containerRef,
+		activeQuery,
+		currentWidth,
+	} = useContainerQuery( {
 		small: 0,
 		large: 480,
 	} );
 
-	return { containerRef, activeQuery };
+	return { containerRef, activeQuery, currentWidth };
 };
 
 interface DomainSuggestionContainerContextValue {
 	activeQuery: 'small' | 'large';
+	currentWidth: number | null;
 	priceAlignment?: 'left' | 'right';
 	priceSize?: number;
 	isFeatured?: boolean;

--- a/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
+++ b/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
@@ -1,0 +1,31 @@
+import { RefObject, useEffect, useState } from 'react';
+
+export const useHasScrolledToEnd = ( contentRef: RefObject< HTMLElement > ) => {
+	const [ hasScrolledToEnd, setHasScrolledToEnd ] = useState( false );
+
+	useEffect( () => {
+		const contentElement = contentRef.current;
+
+		if ( ! contentElement ) {
+			return;
+		}
+
+		const checkIfScrollHasReachedBottom = () => {
+			const { scrollHeight, scrollTop, clientHeight } = contentElement;
+
+			if ( scrollHeight - scrollTop === clientHeight ) {
+				setHasScrolledToEnd( true );
+			}
+		};
+
+		checkIfScrollHasReachedBottom();
+
+		contentElement.addEventListener( 'scroll', checkIfScrollHasReachedBottom );
+
+		return () => {
+			contentElement.removeEventListener( 'scroll', checkIfScrollHasReachedBottom );
+		};
+	}, [ contentRef ] );
+
+	return hasScrolledToEnd;
+};

--- a/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
+++ b/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
@@ -13,7 +13,11 @@ export const useHasScrolledToEnd = ( contentRef: RefObject< HTMLElement > ) => {
 		const checkIfScrollHasReachedBottom = () => {
 			const { scrollHeight, scrollTop, clientHeight } = contentElement;
 
-			if ( scrollHeight - scrollTop === clientHeight ) {
+			// NOTE: scrollTop is fractional, while scrollHeight and clientHeight are
+			// not, so without this Math.abs() trick then sometimes the result won't
+			// work because scrollTop may not be exactly equal to el.scrollHeight -
+			// el.clientHeight when scrolled to the bottom.
+			if ( Math.abs( scrollHeight - clientHeight - scrollTop ) < 1 ) {
 				setHasScrolledToEnd( true );
 			}
 		};

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/constants.ts
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/constants.ts
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+
+// Note: Please don't change the text in this file as it is specified in the RPM-Requirements of the
+// ICANN TMCH functional specifications: https://tools.ietf.org/html/draft-ietf-eppext-tmch-func-spec-01#ref-RPM-Requirements
+export const TRADE_MARK_CLAIMS_MODAL_COPY = {
+	PREAMBLE: __(
+		"To continue, you must agree not to infringe on the trademark holders' rights. Please review and acknowledge the following notice."
+	),
+	REASON: __(
+		'You have received this Trademark Notice because you have applied for a domain name which matches at least one trademark record submitted to the Trademark Clearinghouse.'
+	),
+	ENTITLEMENT: __(
+		'You may or may not be entitled to register the domain name depending on your intended use and whether it is the same or significantly overlaps with the trademarks listed below. Your rights to register this domain name may or may not be protected as noncommercial use or “fair use” by the laws of your country.'
+	),
+	INSTRUCTIONS: __(
+		'Please read the trademark information below carefully, including the trademarks, jurisdictions, and goods and services for which the trademarks are registered. Please be aware that not all jurisdictions review trademark applications closely, so some of the trademark information below may exist in a national or regional registry which does not conduct a thorough or substantive review of trademark rights prior to registration. If you have questions, you may want to consult an attorney or legal expert on trademarks and intellectual property for guidance.'
+	),
+	CONSENT: __(
+		'If you continue with this registration, you represent that, you have received and you understand this notice and to the best of your knowledge, your registration and use of the requested domain name will not infringe on the trademark rights listed below. The following marks are listed in the Trademark Clearinghouse:'
+	),
+	COURT_CASES: __(
+		'This domain name label has previously been found to be used or registered abusively against the following trademarks according to the referenced decisions:'
+	),
+};

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/content.tsx
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/content.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { ReactNode } from 'react';
+import { TRADE_MARK_CLAIMS_MODAL_COPY } from './constants';
 import type {
 	TrademarkClaim,
 	TrademarkClaimContact,
@@ -125,11 +126,7 @@ const renderCases = ( { notExactMatch }: TrademarkClaim ) => {
 
 	return (
 		<div key="claim-cases">
-			<p>
-				{ __(
-					'This domain name label has previously been found to be used or registered abusively against the following trademarks according to the referenced decisions:'
-				) }
-			</p>
+			<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.COURT_CASES }</p>
 
 			{ courtCases && renderCourtCases( courtCases ) }
 			{ udrpCases && renderUdrpCases( udrpCases ) }

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/content.tsx
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/content.tsx
@@ -1,0 +1,166 @@
+import { __ } from '@wordpress/i18n';
+import { ReactNode } from 'react';
+import type {
+	TrademarkClaim,
+	TrademarkClaimContact,
+	TrademarkClaimCourtCase,
+	TrademarkClaimsNoticeInfo,
+	TrademarkClaimUdrpCase,
+} from '@automattic/api-core';
+
+const renderItemLabel = ( label: string ) => (
+	<span className="domain-search-trademark-claims-modal__content-claim-item-label">
+		{ label + ': ' }
+	</span>
+);
+
+const renderItem = ( key: string | number, label: string | null, data: ReactNode ) => (
+	<div key={ key }>
+		{ label && renderItemLabel( label ) }
+		{ data }
+	</div>
+);
+
+const renderListItem = ( key: string | number, data: ReactNode ) => <li key={ key }>{ data }</li>;
+
+const renderList = ( list: ReactNode[] ) => (
+	<ul>{ list.map( ( item, index ) => item && renderListItem( index, item ) ) }</ul>
+);
+
+const renderMark = ( { markName }: TrademarkClaim ) => {
+	return markName && renderItem( 'mark-name', __( 'Mark' ), markName );
+};
+
+const renderJurisdiction = ( { jurDesc }: TrademarkClaim ) => {
+	return jurDesc && renderItem( 'jurisdiction', __( 'Jurisdiction' ), jurDesc );
+};
+
+const renderGoodsAndServices = ( { goodsAndServices }: TrademarkClaim ) => {
+	return (
+		goodsAndServices &&
+		renderItem( 'goods-and-services', __( 'Goods and Services' ), renderList( goodsAndServices ) )
+	);
+};
+
+const renderInternationalClassification = ( { classDesc }: TrademarkClaim ) => {
+	return (
+		classDesc &&
+		renderItem(
+			'international-classification',
+			__( 'International Class of Goods and Services or Equivalent if applicable' ),
+			renderList( classDesc )
+		)
+	);
+};
+
+const renderContactInfo = ( contact: TrademarkClaimContact ) => {
+	if ( ! contact ) {
+		return;
+	}
+
+	const addr = contact.addr;
+
+	const contactData: ReactNode[] = [];
+	contact.name && contactData.push( renderItem( 'name', __( 'Name' ), contact.name ) );
+	contact.org && contactData.push( renderItem( 'org', __( 'Organization' ), contact.org ) );
+	addr?.street?.forEach(
+		( street, index ) =>
+			street && contactData.push( renderItem( 'street' + index, __( 'Address' ), street ) )
+	);
+	addr?.city && contactData.push( renderItem( 'city', __( 'City' ), addr.city ) );
+	addr?.sp && contactData.push( renderItem( 'sp', __( 'State' ), addr.sp ) );
+	addr?.pc && contactData.push( renderItem( 'pc', __( 'Postal Code' ), addr.pc ) );
+	addr?.cc && contactData.push( renderItem( 'cc', __( 'Country' ), addr.cc ) );
+	contact.voice && contactData.push( renderItem( 'voice', __( 'Phone' ), contact.voice ) );
+	contact.fax && contactData.push( renderItem( 'fax', __( 'Fax' ), contact.fax ) );
+	contact.email && contactData.push( renderItem( 'email', __( 'Email' ), contact.email ) );
+
+	return renderList( contactData );
+};
+
+const renderRegistrant = ( { holder }: TrademarkClaim ) => {
+	return (
+		holder && renderItem( 'holder', __( 'Trademark Registrant' ), renderContactInfo( holder ) )
+	);
+};
+
+const renderContact = ( { contact }: TrademarkClaim ) => {
+	return contact && renderItem( 'contact', __( 'Contact' ), renderContactInfo( contact ) );
+};
+
+const renderCourtCases = ( courtCases: TrademarkClaimCourtCase[] ) => {
+	return courtCases.map( ( courtCase, index ) =>
+		renderItem(
+			index,
+			null,
+			renderList( [
+				renderItem( 'ref-num', __( 'Reference Number' ), courtCase.refNum ),
+				renderItem( 'cc', __( 'Jurisdiction' ), courtCase.cc ),
+				renderItem( 'court-name', __( 'Court Name' ), courtCase.courtName ),
+			] )
+		)
+	);
+};
+
+const renderUdrpCases = ( udrpCases: TrademarkClaimUdrpCase[] ) => {
+	return udrpCases.map( ( udrpCase, index ) =>
+		renderItem(
+			index,
+			null,
+			renderList( [
+				renderItem( 'case-no', __( 'Case Number' ), udrpCase.caseNo ),
+				renderItem( 'udrp-provider', __( 'UDRP Provider' ), udrpCase.udrpProvider ),
+			] )
+		)
+	);
+};
+
+const renderCases = ( { notExactMatch }: TrademarkClaim ) => {
+	if ( ! notExactMatch ) {
+		return;
+	}
+
+	const courtCases = notExactMatch?.court;
+	const udrpCases = notExactMatch?.udrp;
+
+	return (
+		<div key="claim-cases">
+			<p>
+				{ __(
+					'This domain name label has previously been found to be used or registered abusively against the following trademarks according to the referenced decisions:'
+				) }
+			</p>
+
+			{ courtCases && renderCourtCases( courtCases ) }
+			{ udrpCases && renderUdrpCases( udrpCases ) }
+		</div>
+	);
+};
+
+export const TrademarkClaimsModalContent = ( {
+	trademarkClaimsNoticeInfo,
+}: {
+	trademarkClaimsNoticeInfo: TrademarkClaimsNoticeInfo;
+} ) => {
+	const claims = Array.isArray( trademarkClaimsNoticeInfo.claim )
+		? trademarkClaimsNoticeInfo.claim
+		: [ trademarkClaimsNoticeInfo.claim ];
+
+	return (
+		<ol>
+			{ claims.map( ( claim, index ) => (
+				<li key={ index }>
+					<div className="domain-search-trademark-claims-modal__content-claim-item">
+						{ renderMark( claim ) }
+						{ renderJurisdiction( claim ) }
+						{ renderGoodsAndServices( claim ) }
+						{ renderInternationalClassification( claim ) }
+						{ renderRegistrant( claim ) }
+						{ renderContact( claim ) }
+						{ renderCases( claim ) }
+					</div>
+				</li>
+			) ) }
+		</ol>
+	);
+};

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
@@ -1,26 +1,90 @@
-import { Button, Modal } from '@wordpress/components';
+import { type TrademarkClaimsNoticeInfo } from '@automattic/api-core';
+import { Button, ScrollLock, Modal } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import { useRef } from 'react';
+import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
+import { useHasScrolledToEnd } from '../../hooks/use-has-scrolled-to-end';
+import { TrademarkClaimsModalContent } from './content';
+
+import './style.scss';
 
 export const DomainSearchTrademarkClaimsModal = ( {
-	isOpen,
+	domainName,
 	onAccept,
 	onClose,
+	trademarkClaimsNoticeInfo,
 }: {
-	isOpen: boolean;
+	domainName: string;
 	onAccept: () => void;
 	onClose: () => void;
+	trademarkClaimsNoticeInfo: TrademarkClaimsNoticeInfo;
 } ) => {
-	if ( ! isOpen ) {
-		return null;
-	}
+	const contentRef = useRef< HTMLDivElement >( null );
+	const hasScrolledToEnd = useHasScrolledToEnd( contentRef );
+
+	const listContext = useDomainSuggestionContainerContext();
+	const isSmallOrBigger = useViewportMatch( 'small', '>=' );
+
+	const getMaxWidth = () => {
+		if ( isSmallOrBigger ) {
+			return listContext?.currentWidth ?? undefined;
+		}
+
+		return undefined;
+	};
 
 	return (
-		<Modal title="This is my modal" onRequestClose={ onClose }>
-			<Button variant="secondary" onClick={ onClose }>
-				Reject
-			</Button>
-			<Button variant="primary" onClick={ onAccept }>
-				Accept
-			</Button>
+		<Modal
+			style={ { maxWidth: getMaxWidth() } }
+			overlayClassName="domain-search-trademark-claims-modal"
+			title={
+				// translators: %s is the domain name
+				sprintf( __( '%s matches a trademark.' ), domainName )
+			}
+			onRequestClose={ onClose }
+		>
+			<div className="domain-search-trademark-claims-modal__body">
+				<div className="domain-search-trademark-claims-modal__content" ref={ contentRef }>
+					<p>
+						{ __(
+							"To continue, you must agree not to infringe on the trademark holders' rights. Please review and acknowledge the following notice."
+						) }
+					</p>
+					<p>
+						{ __(
+							'You have received this Trademark Notice because you have applied for a domain name which matches at least one trademark record submitted to the Trademark Clearinghouse.'
+						) }
+					</p>
+					<p style={ { fontStyle: 'italic', fontWeight: 'bold' } }>
+						{ __(
+							'You may or may not be entitled to register the domain name depending on your intended use and whether it is the same or significantly overlaps with the trademarks listed below. Your rights to register this domain name may or may not be protected as noncommercial use or “fair use” by the laws of your country.'
+						) }
+					</p>
+					<p>
+						{ __(
+							'Please read the trademark information below carefully, including the trademarks, jurisdictions, and goods and services for which the trademarks are registered. Please be aware that not all jurisdictions review trademark applications closely, so some of the trademark information below may exist in a national or regional registry which does not conduct a thorough or substantive review of trademark rights prior to registration. If you have questions, you may want to consult an attorney or legal expert on trademarks and intellectual property for guidance.'
+						) }
+					</p>
+					<p>
+						{ __(
+							'If you continue with this registration, you represent that, you have received and you understand this notice and to the best of your knowledge, your registration and use of the requested domain name will not infringe on the trademark rights listed below. The following marks are listed in the Trademark Clearinghouse:'
+						) }
+					</p>
+					<TrademarkClaimsModalContent trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo } />
+				</div>
+				<div className="domain-search-trademark-claims-modal__actions">
+					<Button
+						variant="primary"
+						onClick={ onAccept }
+						disabled={ ! hasScrolledToEnd }
+						__next40pxDefaultSize
+					>
+						{ __( 'Acknowledge trademark' ) }
+					</Button>
+				</div>
+			</div>
+			<ScrollLock />
 		</Modal>
 	);
 };

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from 'react';
 import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
 import { useHasScrolledToEnd } from '../../hooks/use-has-scrolled-to-end';
+import { TRADE_MARK_CLAIMS_MODAL_COPY } from './constants';
 import { TrademarkClaimsModalContent } from './content';
 
 import './style.scss';
@@ -46,31 +47,13 @@ export const DomainSearchTrademarkClaimsModal = ( {
 		>
 			<div className="domain-search-trademark-claims-modal__body">
 				<div className="domain-search-trademark-claims-modal__content" ref={ contentRef }>
-					<p>
-						{ __(
-							"To continue, you must agree not to infringe on the trademark holders' rights. Please review and acknowledge the following notice."
-						) }
-					</p>
-					<p>
-						{ __(
-							'You have received this Trademark Notice because you have applied for a domain name which matches at least one trademark record submitted to the Trademark Clearinghouse.'
-						) }
-					</p>
+					<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.PREAMBLE }</p>
+					<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.REASON }</p>
 					<p style={ { fontStyle: 'italic', fontWeight: 'bold' } }>
-						{ __(
-							'You may or may not be entitled to register the domain name depending on your intended use and whether it is the same or significantly overlaps with the trademarks listed below. Your rights to register this domain name may or may not be protected as noncommercial use or “fair use” by the laws of your country.'
-						) }
+						{ TRADE_MARK_CLAIMS_MODAL_COPY.ENTITLEMENT }
 					</p>
-					<p>
-						{ __(
-							'Please read the trademark information below carefully, including the trademarks, jurisdictions, and goods and services for which the trademarks are registered. Please be aware that not all jurisdictions review trademark applications closely, so some of the trademark information below may exist in a national or regional registry which does not conduct a thorough or substantive review of trademark rights prior to registration. If you have questions, you may want to consult an attorney or legal expert on trademarks and intellectual property for guidance.'
-						) }
-					</p>
-					<p>
-						{ __(
-							'If you continue with this registration, you represent that, you have received and you understand this notice and to the best of your knowledge, your registration and use of the requested domain name will not infringe on the trademark rights listed below. The following marks are listed in the Trademark Clearinghouse:'
-						) }
-					</p>
+					<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.INSTRUCTIONS }</p>
+					<p>{ TRADE_MARK_CLAIMS_MODAL_COPY.CONSENT }</p>
 					<TrademarkClaimsModalContent trademarkClaimsNoticeInfo={ trademarkClaimsNoticeInfo } />
 				</div>
 				<div className="domain-search-trademark-claims-modal__actions">
@@ -88,3 +71,5 @@ export const DomainSearchTrademarkClaimsModal = ( {
 		</Modal>
 	);
 };
+
+export { TRADE_MARK_CLAIMS_MODAL_COPY };

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/index.tsx
@@ -1,0 +1,26 @@
+import { Button, Modal } from '@wordpress/components';
+
+export const DomainSearchTrademarkClaimsModal = ( {
+	isOpen,
+	onAccept,
+	onClose,
+}: {
+	isOpen: boolean;
+	onAccept: () => void;
+	onClose: () => void;
+} ) => {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal title="This is my modal" onRequestClose={ onClose }>
+			<Button variant="secondary" onClick={ onClose }>
+				Reject
+			</Button>
+			<Button variant="primary" onClick={ onAccept }>
+				Accept
+			</Button>
+		</Modal>
+	);
+};

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/style.scss
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/style.scss
@@ -1,0 +1,38 @@
+@import '@wordpress/base-styles/variables';
+
+.domain-search-trademark-claims-modal {
+	.components-modal__content {
+		display: flex;
+	}
+}
+
+.domain-search-trademark-claims-modal__body {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	gap: $grid-unit-20;
+}
+
+.domain-search-trademark-claims-modal__content {
+	flex: 1;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+	font-size: $font-size-large;
+}
+
+.domain-search-trademark-claims-modal__content-claim-item {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+}
+
+.domain-search-trademark-claims-modal__content-claim-item-label {
+	font-weight: 600;
+}
+
+.domain-search-trademark-claims-modal__actions {
+	display: flex;
+	justify-content: flex-end;
+}

--- a/packages/domain-search/src/ui/domain-search-trademark-claims-modal/style.scss
+++ b/packages/domain-search/src/ui/domain-search-trademark-claims-modal/style.scss
@@ -20,6 +20,10 @@
 	flex-direction: column;
 	gap: $grid-unit-20;
 	font-size: $font-size-large;
+
+	p {
+		margin-bottom: 0;
+	}
 }
 
 .domain-search-trademark-claims-modal__content-claim-item {

--- a/packages/domain-search/src/ui/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.tsx
@@ -32,7 +32,7 @@ const Featured = ( {
 	cta,
 	isSingleFeaturedSuggestion,
 }: DomainSuggestionFeaturedProps ) => {
-	const { containerRef, activeQuery } = useDomainSuggestionContainer();
+	const { containerRef, activeQuery, currentWidth } = useDomainSuggestionContainer();
 
 	const contextValue = useMemo(
 		() =>
@@ -47,8 +47,9 @@ const Featured = ( {
 						: undefined,
 				priceSize: activeQuery === 'large' ? 20 : 18,
 				isFeatured: true,
+				currentWidth: currentWidth,
 			} ) as const,
-		[ activeQuery, matchReasons, isSingleFeaturedSuggestion ]
+		[ activeQuery, matchReasons, isSingleFeaturedSuggestion, currentWidth ]
 	);
 
 	const title = (

--- a/packages/domain-search/src/ui/domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/ui/domain-suggestions-list/index.tsx
@@ -10,9 +10,12 @@ interface DomainSuggestionsListProps {
 }
 
 export const DomainSuggestionsList = ( { children }: DomainSuggestionsListProps ) => {
-	const { containerRef, activeQuery } = useDomainSuggestionContainer();
+	const { containerRef, activeQuery, currentWidth } = useDomainSuggestionContainer();
 
-	const contextValue = useMemo( () => ( { activeQuery } ), [ activeQuery ] );
+	const contextValue = useMemo(
+		() => ( { activeQuery, currentWidth } ),
+		[ activeQuery, currentWidth ]
+	);
 
 	const childrenWithSeparators = useMemo( () => {
 		const totalChildren = Children.count( children );

--- a/packages/domain-search/src/ui/index.ts
+++ b/packages/domain-search/src/ui/index.ts
@@ -1,5 +1,6 @@
 export { DomainSearchAlreadyOwnDomainCTA } from './domain-search-already-own-domain-cta';
 export { DomainSearchNotice } from './domain-search-notice';
+export { DomainSearchTrademarkClaimsModal } from './domain-search-trademark-claims-modal';
 export { DomainsMiniCart } from './domains-mini-cart';
 export { DomainsFullCart } from './domains-full-cart';
 export { DomainsFullCartItems } from './domains-full-cart-items';

--- a/packages/domain-search/src/ui/index.ts
+++ b/packages/domain-search/src/ui/index.ts
@@ -1,6 +1,6 @@
 export { DomainSearchAlreadyOwnDomainCTA } from './domain-search-already-own-domain-cta';
 export { DomainSearchNotice } from './domain-search-notice';
-export { DomainSearchTrademarkClaimsModal } from './domain-search-trademark-claims-modal';
+export * from './domain-search-trademark-claims-modal';
 export { DomainsMiniCart } from './domains-mini-cart';
 export { DomainsFullCart } from './domains-full-cart';
 export { DomainsFullCartItems } from './domains-full-cart-items';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,6 +1169,7 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@wordpress/base-styles": "npm:^5.23.0"
     "@wordpress/components": "npm:^29.9.0"
+    "@wordpress/compose": "npm:7.23.0"
     "@wordpress/icons": "npm:^10.23.0"
     "@wordpress/react-i18n": "npm:^4.23.0"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
Closes DOMAINS-1621.

## Proposed Changes

Adds the trademark modal to the retrofitted and rewritten versions. The design has already been approved by @ollierozdarz.

<img width="1107" height="821" alt="image" src="https://github.com/user-attachments/assets/753ded26-3ebf-4cec-b13a-7dfa334594ce" />

## Testing Instructions

With the `domains/ui-redesign` feature flag turned ON, enter `/start/domain` (retrofitted version) and search for `parmalat.dev`:
- Click the exact match and verify you see the trademark modal.
- Clicking X or outside the modal should close it, without adding the domain to the cart.
- Verify the "Acknowledge trademark" button closes the modal and adds the domain to the cart.

With the `domains/ui-redesign` feature flag turned OFF, enter `/start/domain` (retrofitted version) and search for `parmalat.dev`. The behavior should match production: a notice instead of a modal, but you should still be able to perform the primary action.

Enter `/setup/domain`, which uses the rewritten version, and perform the same steps as the retrofitted version. You should see the same outcomes.