### PR TITLE
Hosting Dashboard: Update glue records delete modal to use the `ButtonStack` component

### DIFF
--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -1,7 +1,6 @@
 import { domainGlueRecordDeleteMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	Button,
@@ -10,6 +9,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
+import { ButtonStack } from '../../components/button-stack';
 import type { DomainGlueRecord } from '@automattic/api-core';
 
 interface DomainGlueRecordDeleteModalProps {
@@ -62,7 +62,7 @@ const DomainGlueRecordDeleteModal = ( {
 	return (
 		<VStack spacing={ 6 }>
 			<Text>{ __( 'Are you sure you want to delete this glue record?' ) }</Text>
-			<HStack justify="flex-end" spacing={ 2 }>
+			<ButtonStack justify="flex-end">
 				<Button onClick={ onClose } disabled={ deleteMutation.isPending }>
 					{ __( 'Cancel' ) }
 				</Button>
@@ -74,7 +74,7 @@ const DomainGlueRecordDeleteModal = ( {
 				>
 					{ __( 'Delete' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 		</VStack>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-271](https://linear.app/a8c/issue/DOTDASH-271)

## Proposed Changes

* Use the new `ButtonStack` component for the glue records delete modal.

<img width="731" height="426" alt="image" src="https://github.com/user-attachments/assets/58034f15-098f-40b5-8650-e72694bf7011" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/domains/[domain]/glue-records`
* Click on the "Delete" action from the item row menu.
* Make sure the confirmation dialog is shown and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
