### PR TITLE
Domains: Replace the inaccurate "type" with a new "subtype"

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,4 +1,4 @@
-import { DomainTypes, DomainTransferStatus } from '@automattic/api-core';
+import { DomainTypes, DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
@@ -77,13 +77,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					window.location.href = domainMappingSetup( siteSlug, domain.domain );
 				},
 				isEligible: ( item: DomainSummary ) =>
-					item.type === DomainTypes.MAPPED && ! item.points_to_wpcom,
+					item.subtype.id === DomainSubtype.DOMAIN_CONNECTION && ! item.points_to_wpcom,
 			},
 			{
 				id: 'manage-domain',
 				label: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					return domain.type === DomainTypes.TRANSFER
+					return domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER
 						? __( 'View transfer' )
 						: __( 'View settings' );
 				},
@@ -94,6 +94,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					window.location.pathname = domainManagementLink( domain, siteSlug, false );
 				},
 				isEligible: ( item: DomainSummary ) => {
+					// What is equivalent to DomainTypes.WPCOM?
 					return item.type !== DomainTypes.WPCOM;
 				},
 			},
@@ -110,7 +111,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					return (
 						item.can_manage_dns_records &&
 						item.transfer_status !== DomainTransferStatus.PENDING_ASYNC &&
-						item.type !== DomainTypes.SITE_REDIRECT
+						item.subtype.id !== DomainSubtype.SITE_REDIRECT
 					);
 				},
 			},

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,4 +1,4 @@
-import { DomainTypes, DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
+import { DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
@@ -94,8 +94,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					window.location.pathname = domainManagementLink( domain, siteSlug, false );
 				},
 				isEligible: ( item: DomainSummary ) => {
-					// What is DomainSubtype equivalent to DomainTypes.WPCOM?
-					return item.type !== DomainTypes.WPCOM;
+					return item.subtype.id !== DomainSubtype.DEFAULT_ADDRESS;
 				},
 			},
 			{

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -94,7 +94,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					window.location.pathname = domainManagementLink( domain, siteSlug, false );
 				},
 				isEligible: ( item: DomainSummary ) => {
-					// What is equivalent to DomainTypes.WPCOM?
+					// What is DomainSubtype equivalent to DomainTypes.WPCOM?
 					return item.type !== DomainTypes.WPCOM;
 				},
 			},

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,4 +1,4 @@
-import { DomainTypes } from '@automattic/api-core';
+import { DomainSubtype } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import { Link } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -24,7 +24,7 @@ export const DomainNameField = ( {
 		<Link
 			to={ domainOverviewRoute.fullPath }
 			params={ { siteSlug, domainName: domain.domain } }
-			disabled={ domain.type === DomainTypes.WPCOM }
+			disabled={ domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS }
 		>
 			<HStack spacing={ 1 }>
 				<span style={ textOverflowStyles }>{ value }</span>

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,4 +1,4 @@
-import { DomainTypes } from '@automattic/api-core';
+import { DomainTypes, DomainSubtype } from '@automattic/api-core';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -90,7 +90,7 @@ export const useFields = ( {
 					// Site Overview does not show the Status column, so we use this column for error messages.
 					if (
 						site &&
-						item.type === DomainTypes.MAPPED &&
+						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
 						! item.points_to_wpcom &&
 						! isRecentlyRegistered( item.registration_date, THREE_DAYS_IN_MINUTES )
 					) {

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -52,6 +52,7 @@ export const useFields = ( {
 				label: __( 'Type' ),
 				enableHiding: false,
 				enableSorting: false,
+				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.label ?? '',
 			},
 			// {
 			// 	id: 'owner',

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,4 +1,4 @@
-import { DomainTypes, DomainSubtype } from '@automattic/api-core';
+import { DomainSubtype } from '@automattic/api-core';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -1,6 +1,6 @@
 import {
 	Domain,
-	DomainTypes,
+	DomainSubtype,
 	DomainSubtype,
 	DomainTransferStatus,
 	Purchase,
@@ -69,8 +69,8 @@ export const shouldShowDeleteAction = ( domain: Domain, purchase?: Purchase, sit
 
 // Delete action utils
 export const getDeleteTitle = ( domain: Domain ) => {
-	switch ( domain.type ) {
-		case DomainTypes.TRANSFER:
+	switch ( domain.subtype.id ) {
+		case DomainSubtype.DOMAIN_TRANSFER:
 			return __( 'Cancel transfer' );
 		default:
 			return __( 'Delete' );
@@ -78,8 +78,8 @@ export const getDeleteTitle = ( domain: Domain ) => {
 };
 
 export const getDeleteLabel = ( domain: Domain ) => {
-	switch ( domain.type ) {
-		case DomainTypes.TRANSFER:
+	switch ( domain.subtype.id ) {
+		case DomainSubtype.DOMAIN_TRANSFER:
 			return __( 'Cancel' );
 		default:
 			return __( 'Delete' );
@@ -87,12 +87,12 @@ export const getDeleteLabel = ( domain: Domain ) => {
 };
 
 export const getDeleteDescription = ( domain: Domain ) => {
-	switch ( domain.type ) {
-		case DomainTypes.SITE_REDIRECT:
+	switch ( domain.subtype.id ) {
+		case DomainSubtype.SITE_REDIRECT:
 			return __( 'Remove this site redirect permanently.' );
-		case DomainTypes.MAPPED:
+		case DomainSubtype.DOMAIN_CONNECTION:
 			return __( 'Remove this domain connection permanently.' );
-		case DomainTypes.TRANSFER:
+		case DomainSubtype.DOMAIN_TRANSFER:
 			return __( 'Cancel this domain transfer.' );
 		default:
 			return __( 'Remove this domain permanently.' );

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -1,11 +1,4 @@
-import {
-	Domain,
-	DomainSubtype,
-	DomainSubtype,
-	DomainTransferStatus,
-	Purchase,
-	Site,
-} from '@automattic/api-core';
+import { Domain, DomainSubtype, DomainTransferStatus, Purchase, Site } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { isAkismetProduct } from '../../utils/purchase';
 

--- a/client/dashboard/utils/domain-types.ts
+++ b/client/dashboard/utils/domain-types.ts
@@ -1,6 +1,8 @@
-import { DomainTypes } from '@automattic/api-core';
+import { DomainSubtype } from '@automattic/api-core';
 import type { SiteDomain } from '@automattic/api-core';
 
 export function isTransferrableToWpcom( domain: SiteDomain ) {
-	return domain.type === DomainTypes.MAPPED && domain.is_eligible_for_inbound_transfer;
+	return (
+		domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION && domain.is_eligible_for_inbound_transfer
+	);
 }

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -1,4 +1,4 @@
-import { DotcomFeatures, WhoisType, DomainTypes } from '@automattic/api-core';
+import { DotcomFeatures, WhoisType, DomainSubtype } from '@automattic/api-core';
 import { addQueryArgs } from '@wordpress/url';
 import { isAfter, subMinutes, subDays } from 'date-fns';
 import { getRenewalUrlFromPurchase } from './purchase';
@@ -98,7 +98,7 @@ const shouldUpgradeToMakeDomainPrimary = ( {
 	user: User;
 } ) => {
 	return (
-		( isRegisteredDomain( domain ) || domain.type === DomainTypes.MAPPED ) &&
+		domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
 		! domain.current_user_can_create_site_from_domain_only &&
 		! domain.primary_domain &&
 		! domain.wpcom_domain &&

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -27,7 +27,7 @@ export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase )
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {
-	return ! domain.wpcom_domain && domain.has_registration;
+	return domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION;
 }
 
 export function isRecentlyRegistered( registrationDate: string, numberOfMinutes = 30 ) {
@@ -98,7 +98,9 @@ const shouldUpgradeToMakeDomainPrimary = ( {
 	user: User;
 } ) => {
 	return (
-		domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
+		[ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
+			domain.subtype.id
+		) &&
 		! domain.current_user_can_create_site_from_domain_only &&
 		! domain.primary_domain &&
 		! domain.wpcom_domain &&


### PR DESCRIPTION
Part of DOTDASH-339

## Proposed Changes

* Replaced domain type with subtype

## Why are these changes being made?

* DOTDASH-339

## Testing Instructions

* Go to `/v2/domains`
* Check the "Type" field; it renders `subtype.label` provided from the BE

<img width="829" height="400" alt="Screenshot 2025-09-04 at 17 40 42" src="https://github.com/user-attachments/assets/a8f3f1be-49b8-4cde-9ec3-0eb444f18bd4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
