### PR TITLE
Notifications v2: implement note list and note details shortcuts

### DIFF
--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -10,6 +10,7 @@ import { SET_IS_SHOWING } from '../panel/state/action-types';
 import actions from '../panel/state/actions';
 import { addListeners, removeListeners } from '../panel/state/create-listener-middleware';
 import getIsPanelOpen from '../panel/state/selectors/get-is-panel-open';
+import getKeyboardShortcutsEnabled from '../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { AppProvider } from './context';
 import Note from './note';
 import NotePanel from './note-panel';
@@ -107,12 +108,19 @@ const NotificationApp = ( {
 	}, [ actionHandlers ] );
 
 	useEffect( () => {
+		store.dispatch( actions.ui.enableKeyboardShortcuts() );
+	}, [] );
+
+	useEffect( () => {
 		const stopEvent = ( event: KeyboardEvent ) => {
 			event.stopPropagation();
 			event.preventDefault();
 		};
 
 		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( ! getKeyboardShortcutsEnabled( store.getState() ) ) {
+				return;
+			}
 			if ( modifierKeyIsActive( event ) ) {
 				return;
 			}

--- a/apps/notifications/src/app/note-list/hooks.ts
+++ b/apps/notifications/src/app/note-list/hooks.ts
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { modifierKeyIsActive } from '../../panel/helpers/input';
+import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
+import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
+import getLastSelectedNoteId from '../../panel/state/selectors/get-last-selected-note-id';
+import type { Note } from '../types';
+
+import './style.scss';
+
+function focusToNote( noteListRef: React.RefObject< HTMLObjectElement >, note: Note ) {
+	const noteEl = noteListRef.current?.querySelector(
+		`.dataviews-view-list__item[id$="-${ note.id }-item-wrapper"]`
+	) as HTMLElement;
+
+	noteEl?.focus();
+}
+
+// Set the focus in the note list to the last selected note,
+// or to the nearest one when the last selected note is no longer visible.
+export function useNoteListFocusToLastSelectedNote( {
+	noteListRef,
+	notes,
+}: {
+	noteListRef: React.RefObject< HTMLObjectElement >;
+	notes: Note[];
+} ) {
+	const isNoteHidden = useSelector(
+		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
+	);
+
+	const lastSelectedNoteId = useSelector( getLastSelectedNoteId );
+
+	useEffect(
+		() => {
+			let noteToFocus: Note | undefined = undefined;
+
+			if ( lastSelectedNoteId ) {
+				const noteIndex = notes.findIndex( ( note ) => note.id === lastSelectedNoteId );
+				if ( noteIndex < 0 ) {
+					return;
+				}
+
+				if ( isNoteHidden( notes[ noteIndex ].id ) ) {
+					// The last selected note is no longer visible.
+
+					// Find the nearest visible note forwards.
+					for ( let i = noteIndex + 1; i < notes.length; i++ ) {
+						if ( ! isNoteHidden( notes[ i ].id ) ) {
+							noteToFocus = notes[ i ];
+							break;
+						}
+					}
+
+					if ( ! noteToFocus ) {
+						// Find the nearest visible note backwards.
+						for ( let i = noteIndex - 1; i >= 0; i-- ) {
+							if ( ! isNoteHidden( notes[ i ].id ) ) {
+								noteToFocus = notes[ i ];
+								break;
+							}
+						}
+					}
+				} else {
+					noteToFocus = notes[ noteIndex ];
+				}
+			}
+
+			if ( noteToFocus ) {
+				focusToNote( noteListRef, noteToFocus );
+			}
+		},
+
+		// Run only once on mount
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+}
+
+export function useNoteListNavigationKeyboardShortcuts( {
+	noteListRef,
+	visibleNotes,
+}: {
+	noteListRef: React.RefObject< HTMLObjectElement >;
+	visibleNotes: Note[];
+} ) {
+	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );
+
+	useEffect( () => {
+		const stopEvent = ( event: KeyboardEvent ) => {
+			event.stopPropagation();
+			event.preventDefault();
+		};
+
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( ! areKeyboardShortcutsEnabled ) {
+				return;
+			}
+			if ( modifierKeyIsActive( event ) ) {
+				return;
+			}
+
+			if ( event.key === 'ArrowDown' ) {
+				const hasFocus = noteListRef.current?.contains( document.activeElement );
+				if ( ! hasFocus ) {
+					stopEvent( event );
+					focusToNote( noteListRef, visibleNotes[ 0 ] );
+				}
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, false );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown, false );
+		};
+	}, [ areKeyboardShortcutsEnabled, visibleNotes ] ); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -86,7 +86,6 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	return (
 		<div ref={ noteListRef } className="wpnc__note-list">
 			<DataViews< Note >
-				key={ filterName }
 				data={ filteredData }
 				fields={ fields }
 				actions={ actions }

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -5,7 +5,7 @@ import {
 	useNavigator,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
@@ -13,6 +13,10 @@ import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
 import { getFields, getActions } from './dataviews';
+import {
+	useNoteListFocusToLastSelectedNote,
+	useNoteListNavigationKeyboardShortcuts,
+} from './hooks';
 import type { Note } from '../types';
 import type { View } from '@wordpress/dataviews';
 
@@ -21,23 +25,24 @@ import './style.scss';
 const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
 	const { goTo } = useNavigator();
 	const filter = getFilters()[ filterName ];
+
 	const isNoteHidden = useSelector(
 		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
 	);
+
 	const notes = useSelector( ( state ) =>
-		( ( getAllNotes( state ) || [] ) as Note[] ).filter(
-			( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
-		)
+		( ( getAllNotes( state ) || [] ) as Note[] ).filter( ( note ) => filter.filter( note ) )
 	);
+
+	// Filter out hidden notes, i.e. notes that have been just marked as spam or moved to the trash.
+	const visibleNotes = notes.filter( ( note ) => ! isNoteHidden( note.id ) );
 
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const { client } = useAppContext();
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const noteId = selection[ 0 ];
-		goTo( `/${ filterName }/notes/${ noteId }`, {
-			focusTargetSelector: `.dataviews-view-list__item[id$="-${ noteId }-item-wrapper"]`,
-		} );
+		goTo( `/${ filterName }/notes/${ noteId }` );
 	};
 
 	const [ initialView, setView ] = useState< View >( {
@@ -49,13 +54,17 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 		infiniteScrollEnabled: true,
 	} );
 
-	const view = { ...initialView, perPage: notes.length };
+	const view = { ...initialView, perPage: visibleNotes.length };
 
 	const fields = getFields();
 
 	const actions = getActions( { onSelect: onChangeSelection } );
 
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( notes, view, fields );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+		visibleNotes,
+		view,
+		fields
+	);
 
 	const infiniteScrollHandler = useCallback( () => {
 		if ( ! isLoading ) {
@@ -64,14 +73,20 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	}, [ client, isLoading ] );
 
 	useEffect( () => {
-		if ( notes.length <= 10 && ! isLoading ) {
+		if ( visibleNotes.length <= 10 && ! isLoading ) {
 			infiniteScrollHandler();
 		}
-	}, [ notes.length, isLoading, infiniteScrollHandler ] );
+	}, [ visibleNotes.length, isLoading, infiniteScrollHandler ] );
+
+	const noteListRef = useRef< HTMLObjectElement >( null );
+
+	useNoteListFocusToLastSelectedNote( { noteListRef, notes } );
+	useNoteListNavigationKeyboardShortcuts( { noteListRef, visibleNotes } );
 
 	return (
-		<div className="wpnc__note-list">
+		<div ref={ noteListRef } className="wpnc__note-list">
 			<DataViews< Note >
+				key={ filterName }
 				data={ filteredData }
 				fields={ fields }
 				actions={ actions }

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -1,0 +1,81 @@
+import { useNavigator } from '@wordpress/components';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { modifierKeyIsActive } from '../../panel/helpers/input';
+import getIsLoading from '../../panel/state/selectors/get-is-loading';
+import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
+import { useAppContext } from '../context';
+import './style.scss';
+import type { Note } from '../types';
+
+export function useNoteNavigationViaKeyboardShortcuts( {
+	visibleNotes,
+	note,
+}: {
+	visibleNotes: Note[];
+	note?: Note;
+} ) {
+	const { params, goTo } = useNavigator();
+	const { filterName } = params;
+
+	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );
+
+	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
+	const { client } = useAppContext();
+
+	useEffect( () => {
+		if ( ! isLoading && visibleNotes[ visibleNotes.length - 1 ].id === note?.id ) {
+			client?.loadMore();
+		}
+	}, [ isLoading, visibleNotes, note, client ] );
+
+	const goToNoteById = ( noteId: number ) => {
+		goTo( `/${ filterName }/notes/${ noteId }`, {
+			replace: true,
+		} );
+	};
+
+	const goToNoteByDirection = ( direction: number ) => {
+		const isValidIndex = ( index: number ) => index >= 0 && index < visibleNotes.length;
+
+		const noteIndex = visibleNotes.findIndex( ( currentNote ) => currentNote.id === note?.id );
+		const newIndex = noteIndex + direction;
+
+		if ( isValidIndex( newIndex ) ) {
+			goToNoteById( visibleNotes[ newIndex ].id );
+		}
+	};
+
+	useEffect( () => {
+		const stopEvent = ( event: KeyboardEvent ) => {
+			event.stopPropagation();
+			event.preventDefault();
+		};
+
+		const handleKeyDown = ( event: KeyboardEvent ) => {
+			if ( ! areKeyboardShortcutsEnabled ) {
+				return;
+			}
+			if ( modifierKeyIsActive( event ) ) {
+				return;
+			}
+			switch ( event.key ) {
+				case 'j':
+				case 'ArrowDown':
+					stopEvent( event );
+					goToNoteByDirection( 1 );
+					break;
+				case 'k':
+				case 'ArrowUp':
+					stopEvent( event );
+					goToNoteByDirection( -1 );
+					break;
+			}
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown, false );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown, false );
+		};
+	}, [ areKeyboardShortcutsEnabled, visibleNotes, note ] ); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -5,7 +5,6 @@ import { modifierKeyIsActive } from '../../panel/helpers/input';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { useAppContext } from '../context';
-import './style.scss';
 import type { Note } from '../types';
 
 export function useNoteNavigationViaKeyboardShortcuts( {

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -77,5 +77,5 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [ areKeyboardShortcutsEnabled, visibleNotes, note ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ areKeyboardShortcutsEnabled, note ] ); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -81,24 +81,23 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
 	);
 
-	const visibleNotes = useSelector( ( state ) =>
-		( ( getAllNotes( state ) || [] ) as NoteObject[] ).filter(
-			( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
-		)
-	);
+	const notes = useSelector( ( state ) => ( getAllNotes( state ) || [] ) as NoteObject[] );
+	const note = notes.find( ( note ) => String( note.id ) === noteId );
 
-	const note = visibleNotes.find( ( note ) => String( note.id ) === noteId );
+	const visibleNotes = notes.filter(
+		( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
+	);
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
+
+	useNoteNavigationViaKeyboardShortcuts( { visibleNotes, note } );
 
 	useEffect( () => {
 		if ( note?.id ) {
 			dispatch( actions.ui.selectNote( note.id ) );
 		}
 	}, [ note?.id, dispatch ] );
-
-	useNoteNavigationViaKeyboardShortcuts( { visibleNotes, note } );
 
 	if ( ! note ) {
 		return null;

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -17,11 +17,14 @@ import { getActions } from '../../panel/helpers/notes';
 import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
+import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
+import { getFilters } from '../../panel/templates/filters';
 import ActionDropdown from '../templates/action-dropdown';
 import { NoteBody, ActionBlock } from '../templates/body';
 import CloseButton from '../templates/close-button';
 import NoteSummary from '../templates/note-summary';
+import { useNoteNavigationViaKeyboardShortcuts } from './hooks';
 import './style.scss';
 import type { Note as NoteObject, Block } from '../types';
 
@@ -70,10 +73,21 @@ const getClasses = ( {
 const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const dispatch = useDispatch();
 	const { params, goBack } = useNavigator();
-	const { noteId } = params;
-	const note = useSelector( ( state ) =>
-		( getAllNotes( state ) as NoteObject[] ).find( ( note ) => String( note.id ) === noteId )
+	const { filterName, noteId } = params;
+
+	const filter = getFilters()[ filterName as keyof ReturnType< typeof getFilters > ];
+
+	const isNoteHidden = useSelector(
+		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
 	);
+
+	const visibleNotes = useSelector( ( state ) =>
+		( ( getAllNotes( state ) || [] ) as NoteObject[] ).filter(
+			( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
+		)
+	);
+
+	const note = visibleNotes.find( ( note ) => String( note.id ) === noteId );
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
@@ -83,6 +97,8 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			dispatch( actions.ui.selectNote( note.id ) );
 		}
 	}, [ note?.id, dispatch ] );
+
+	useNoteNavigationViaKeyboardShortcuts( { visibleNotes, note } );
 
 	if ( ! note ) {
 		return null;

--- a/apps/notifications/src/app/templates/action-button.jsx
+++ b/apps/notifications/src/app/templates/action-button.jsx
@@ -29,7 +29,7 @@ const ActionButton = ( { isActive, isBusy, hotkey, icon, onToggle, text, title }
 
 ActionButton.propTypes = {
 	isActive: PropTypes.bool.isRequired,
-	hotkey: PropTypes.number,
+	hotkey: PropTypes.string,
 	icon: PropTypes.object,
 	onToggle: PropTypes.func.isRequired,
 	text: PropTypes.string.isRequired,

--- a/apps/notifications/src/app/templates/action-dropdown.tsx
+++ b/apps/notifications/src/app/templates/action-dropdown.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
 import { trashNote } from '../../panel/state/notes/thunks';
 import { Note } from '../types';
-import { HotkeyContainer } from './container-hotkey';
+import HotkeyContainer from './container-hotkey';
 
 export default function ActionDropdown( { note, goBack }: { note: Note; goBack: () => void } ) {
 	const dispatch = useDispatch();

--- a/apps/notifications/src/app/templates/action-dropdown.tsx
+++ b/apps/notifications/src/app/templates/action-dropdown.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
 import { trashNote } from '../../panel/state/notes/thunks';
 import { Note } from '../types';
+import { HotkeyContainer } from './container-hotkey';
 
 export default function ActionDropdown( { note, goBack }: { note: Note; goBack: () => void } ) {
 	const dispatch = useDispatch();
@@ -26,21 +27,27 @@ export default function ActionDropdown( { note, goBack }: { note: Note; goBack: 
 	};
 
 	return (
-		<DropdownMenu icon={ moreVertical } label={ __( 'Actions' ) }>
-			{ ( { onClose } ) => {
-				return (
-					<MenuGroup>
-						<MenuItem
-							onClick={ async () => {
-								await handleDelete();
-								onClose();
-							} }
-						>
-							{ isDeleting ? __( 'Moving to the Trash…' ) : __( 'Trash' ) }
-						</MenuItem>
-					</MenuGroup>
-				);
-			} }
-		</DropdownMenu>
+		<HotkeyContainer shortcuts={ [ { hotkey: 't', action: handleDelete } ] }>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'Actions' ) }
+				toggleProps={ { size: 'small' } }
+			>
+				{ ( { onClose } ) => {
+					return (
+						<MenuGroup>
+							<MenuItem
+								onClick={ async () => {
+									await handleDelete();
+									onClose();
+								} }
+							>
+								{ isDeleting ? __( 'Moving to the Trash…' ) : __( 'Trash' ) }
+							</MenuItem>
+						</MenuGroup>
+					);
+				} }
+			</DropdownMenu>
+		</HotkeyContainer>
 	);
 }

--- a/apps/notifications/src/app/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/app/templates/button-answer-prompt.jsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { keys } from '../../panel/helpers/input';
 import { getNewPostLink } from '../../panel/helpers/notes';
 import { answerPrompt } from '../../panel/state/ui/actions';
 import ActionButton from './action-button';
@@ -18,7 +17,7 @@ const AnswerPromptButton = ( { answerPrompt, note } ) => {
 		<ActionButton
 			icon={ pin }
 			isActive={ false }
-			hotkey={ keys.KEY_E }
+			hotkey="e"
 			onToggle={ () => answerPrompt( siteId, newPostLink ) }
 			text={ __( 'Post Answer' ) }
 			title={ __( 'Post Answer' ) }

--- a/apps/notifications/src/app/templates/button-approve.jsx
+++ b/apps/notifications/src/app/templates/button-approve.jsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { keys } from '../../panel/helpers/input';
 import { getReferenceId } from '../../panel/helpers/notes';
 import { setApproveStatus as setApproveStatusAction } from '../../panel/state/notes/thunks';
 import { useAppContext } from '../context';
@@ -15,7 +14,7 @@ const ApproveButton = ( { isApproved, note, setApproveStatus } ) => {
 		<ActionButton
 			icon={ check }
 			isActive={ isApproved }
-			hotkey={ keys.KEY_A }
+			hotkey="a"
 			onToggle={ () =>
 				setApproveStatus(
 					note.id,

--- a/apps/notifications/src/app/templates/button-edit.jsx
+++ b/apps/notifications/src/app/templates/button-edit.jsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { edit } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { keys } from '../../panel/helpers/input';
 import { getEditCommentLink } from '../../panel/helpers/notes';
 import { editComment } from '../../panel/state/ui/actions';
 import ActionButton from './action-button';
@@ -14,7 +13,7 @@ const EditButton = ( { editComment, note } ) => {
 		<ActionButton
 			icon={ edit }
 			isActive={ false }
-			hotkey={ keys.KEY_E }
+			hotkey="e"
 			onToggle={ () => editComment( siteId, postId, commentId, getEditCommentLink( note ) ) }
 			text={ __( 'Edit' ) }
 			title={ __( 'Edit comment' ) }

--- a/apps/notifications/src/app/templates/button-like.jsx
+++ b/apps/notifications/src/app/templates/button-like.jsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { thumbsUp } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { keys } from '../../panel/helpers/input';
 import { getReferenceId } from '../../panel/helpers/notes';
 import { setLikeStatus } from '../../panel/state/notes/thunks/index';
 import { useAppContext } from '../context';
@@ -30,7 +29,7 @@ const LikeButton = ( { commentId, isLiked, note, setLikeStatus } ) => {
 		<ActionButton
 			icon={ thumbsUp }
 			isActive={ isLiked }
-			hotkey={ keys.KEY_L }
+			hotkey="l"
 			onToggle={ () =>
 				setLikeStatus(
 					note.id,

--- a/apps/notifications/src/app/templates/button-spam.jsx
+++ b/apps/notifications/src/app/templates/button-spam.jsx
@@ -3,7 +3,6 @@ import { removeBug } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { connect } from 'react-redux';
-import { keys } from '../../panel/helpers/input';
 import { spamNote } from '../../panel/state/notes/thunks';
 import ActionButton from './action-button';
 
@@ -22,7 +21,7 @@ const SpamButton = ( { note, spamNote, goBack } ) => {
 			icon={ removeBug }
 			isActive={ false }
 			isBusy={ isBusy }
-			hotkey={ keys.KEY_S }
+			hotkey="s"
 			onToggle={ handleSpam }
 			text={ __( 'Spam' ) }
 			title={ __( 'Mark comment as spam' ) }

--- a/apps/notifications/src/app/templates/container-hotkey.jsx
+++ b/apps/notifications/src/app/templates/container-hotkey.jsx
@@ -16,7 +16,7 @@ export class HotkeyContainer extends Component {
 		shortcuts: PropTypes.arrayOf(
 			PropTypes.shape( {
 				action: PropTypes.func.isRequired,
-				hotkey: PropTypes.number.isRequired,
+				hotkey: PropTypes.string.isRequired,
 				withModifiers: PropTypes.bool,
 			} )
 		),
@@ -36,7 +36,7 @@ export class HotkeyContainer extends Component {
 		}
 
 		this.props.shortcuts
-			.filter( ( shortcut ) => shortcut.hotkey === event.keyCode )
+			.filter( ( shortcut ) => shortcut.hotkey === event.key )
 			.filter(
 				( shortcut ) => ( shortcut.withModifiers || false ) === modifierKeyIsActive( event )
 			)

--- a/apps/notifications/src/app/templates/container-hotkey.jsx
+++ b/apps/notifications/src/app/templates/container-hotkey.jsx
@@ -20,6 +20,7 @@ export class HotkeyContainer extends Component {
 				withModifiers: PropTypes.bool,
 			} )
 		),
+		children: PropTypes.node,
 	};
 
 	componentDidMount() {

--- a/apps/notifications/src/panel/state/notes/thunks/spam-note.js
+++ b/apps/notifications/src/panel/state/notes/thunks/spam-note.js
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '../../../helpers/stats';
 import { wpcom } from '../../../rest-client/wpcom';
-import { removeNotes as removeNotesAction, spamNote as spamNoteAction } from '../actions';
+import { spamNote as spamNoteAction } from '../actions';
 import bumpStat from '../utils/bump-stat';
 
 const spamNote = ( note, immediately, restClient ) => async ( dispatch ) => {
@@ -9,8 +9,6 @@ const spamNote = ( note, immediately, restClient ) => async ( dispatch ) => {
 		note_type: note.type,
 	} );
 
-	dispatch( spamNoteAction( note.id ) );
-
 	if ( immediately ) {
 		const comment = wpcom().site( note.meta.ids.site ).comment( note.meta.ids.comment );
 
@@ -18,10 +16,11 @@ const spamNote = ( note, immediately, restClient ) => async ( dispatch ) => {
 		commentData.status = 'spam';
 
 		await comment.update( commentData );
-		dispatch( removeNotesAction( [ note.id ], true ) );
 	} else {
 		restClient.global.updateUndoBar( 'spam', note );
 	}
+
+	dispatch( spamNoteAction( note.id ) );
 };
 
 export default spamNote;

--- a/apps/notifications/src/panel/state/notes/thunks/trash-note.js
+++ b/apps/notifications/src/panel/state/notes/thunks/trash-note.js
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '../../../helpers/stats';
 import { wpcom } from '../../../rest-client/wpcom';
-import { removeNotes as removeNotesAction, trashNote as trashNoteAction } from '../actions';
+import { trashNote as trashNoteAction } from '../actions';
 import bumpStat from '../utils/bump-stat';
 
 const trashNote = ( note, immediately, restClient ) => async ( dispatch ) => {
@@ -9,14 +9,13 @@ const trashNote = ( note, immediately, restClient ) => async ( dispatch ) => {
 		note_type: note.type,
 	} );
 
-	dispatch( trashNoteAction( note.id ) );
-
 	if ( immediately ) {
 		await wpcom().site( note.meta.ids.site ).comment( note.meta.ids.comment ).del();
-		dispatch( removeNotesAction( [ note.id ], true ) );
 	} else {
 		restClient.global.updateUndoBar( 'trash', note );
 	}
+
+	dispatch( trashNoteAction( note.id ) );
 };
 
 export default trashNote;

--- a/apps/notifications/src/panel/state/selectors/get-last-selected-note-id.js
+++ b/apps/notifications/src/panel/state/selectors/get-last-selected-note-id.js
@@ -1,0 +1,5 @@
+import getUI from './get-ui';
+
+export const getLastSelectedNoteId = ( uiState ) => uiState.lastSelectedNoteId;
+
+export default ( state ) => getLastSelectedNoteId( getUI( state ) );

--- a/apps/notifications/src/panel/state/ui/reducer.js
+++ b/apps/notifications/src/panel/state/ui/reducer.js
@@ -36,6 +36,14 @@ export const selectedNoteId = ( state = null, { type, noteId } ) => {
 	return state;
 };
 
+export const lastSelectedNoteId = ( state = null, { type, noteId } ) => {
+	if ( SELECT_NOTE === type && noteId ) {
+		return noteId;
+	}
+
+	return state;
+};
+
 export const keyboardShortcutsAreEnabled = ( state = false, action ) => {
 	switch ( action.type ) {
 		case ENABLE_KEYBOARD_SHORTCUTS: {
@@ -67,6 +75,7 @@ export default combineReducers( {
 	isLoading,
 	isPanelOpen,
 	selectedNoteId,
+	lastSelectedNoteId,
 	filterName,
 	keyboardShortcutsAreEnabled,
 	shortcutsPopoverIsOpen,


### PR DESCRIPTION
Fixes DOTCOM-14291

## Proposed Changes

Implement the following shortcuts in notifications v2:

### From note list

- (arrow down):
   - if we're just going back to the note from details: it will navigate from that note
   - otherwise, it will go to the first note in the list
- (arrows up/down): after the list has focus, arrows will behave as expected to navigate the note list

### From note details

- `a`: approve
- `s`: mark as spam
- `t`: move to the trash
- `l`: like
- `e`: edit
- (arrows up/down): go to prev/next note in the current filter

After `s` and `t`, we will go back to the note list, and focus will be set to the next note.


## Testing Instructions

1. Go to /v2
2. Click notification bells
3. Use your keyboard and try the above shortcuts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
