### PR TITLE
Billing history: Do not display volume for domain mapping receipts

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -582,7 +582,11 @@ function ReceiptLineItem( {
 					{ isTransactionJetpackSearch10kTier( item ) && (
 						<em>{ renderJetpackSearch10kTierBreakdown( item, subtotal_integer, translate ) }</em>
 					) }
-					{ item.volume && <em>{ renderDomainTransactionVolumeSummary( item, translate ) }</em> }
+					{ item.volume &&
+						item.product_slug === 'wp-domains' &&
+						item.variation_slug !== 'wp-domain-mapping' && (
+							<em>{ renderDomainTransactionVolumeSummary( item, translate ) }</em>
+						) }
 				</td>
 				<td className="billing-history__receipt-amount">
 					{ doesIntroductoryOfferHaveDifferentTermLengthThanProduct(

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -41,7 +41,7 @@ import {
 	getTransactionTermLabel,
 	groupDomainProducts,
 	renderTransactionQuantitySummary,
-	renderDomainTransactionVolumeSummary,
+	DomainTransactionVolumeSummary,
 	transactionIncludesTax,
 	isTransactionJetpackSearch10kTier,
 	renderJetpackSearch10kTierBreakdown,
@@ -582,11 +582,7 @@ function ReceiptLineItem( {
 					{ isTransactionJetpackSearch10kTier( item ) && (
 						<em>{ renderJetpackSearch10kTierBreakdown( item, subtotal_integer, translate ) }</em>
 					) }
-					{ item.volume &&
-						item.product_slug === 'wp-domains' &&
-						item.variation_slug !== 'wp-domain-mapping' && (
-							<em>{ renderDomainTransactionVolumeSummary( item, translate ) }</em>
-						) }
+					<DomainTransactionVolumeSummary item={ item } />
 				</td>
 				<td className="billing-history__receipt-amount">
 					{ doesIntroductoryOfferHaveDifferentTermLengthThanProduct(

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -248,7 +248,7 @@ function renderSpaceAddOnquantitySummary(
 	} );
 }
 
-export function DomainTransactionVolumeSummary( item: BillingTransactionItem ) {
+export function DomainTransactionVolumeSummary( { item }: { item: BillingTransactionItem } ) {
 	const translate = useTranslate();
 	if ( ! item.volume ) {
 		return null;

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -258,7 +258,7 @@ export function DomainTransactionVolumeSummary( { item }: { item: BillingTransac
 
 	const volume = parseInt( String( item.volume ) );
 
-	if ( 'wp-domains' !== item.product_slug ) {
+	if ( 'wp-domains' !== item.product_slug || item.variation_slug === 'wp-domain-mapping' ) {
 		return null;
 	}
 

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -248,42 +248,48 @@ function renderSpaceAddOnquantitySummary(
 	} );
 }
 
-export function renderDomainTransactionVolumeSummary(
-	{ volume, product_slug, variation_slug, type }: BillingTransactionItem,
-	translate: LocalizeProps[ 'translate' ]
-) {
-	if ( ! volume ) {
+export function DomainTransactionVolumeSummary( item: BillingTransactionItem ) {
+	const translate = useTranslate();
+	if ( ! item.volume ) {
 		return null;
 	}
 
-	const isRenewal = 'recurring' === type;
+	const isRenewal = 'recurring' === item.type;
 
-	volume = parseInt( String( volume ) );
+	const volume = parseInt( String( item.volume ) );
 
-	if ( 'wp-domains' !== product_slug || 'wp-domain-mapping' === variation_slug ) {
+	if ( 'wp-domains' !== item.product_slug ) {
 		return null;
 	}
 
 	if ( isRenewal ) {
-		return translate(
-			'Domain renewed for %(quantity)d year',
-			'Domain renewed for %(quantity)d years',
-			{
-				args: { quantity: volume },
-				count: volume,
-				comment: '%(quantity)d is the number of years the domain has been renewed for',
-			}
+		return (
+			<em>
+				{ translate(
+					'Domain renewed for %(quantity)d year',
+					'Domain renewed for %(quantity)d years',
+					{
+						args: { quantity: volume },
+						count: volume,
+						comment: '%(quantity)d is the number of years the domain has been renewed for',
+					}
+				) }
+			</em>
 		);
 	}
 
-	return translate(
-		'Domain registered for %(quantity)d year',
-		'Domain registered for %(quantity)d years',
-		{
-			args: { quantity: volume },
-			count: volume,
-			comment: '%(quantity)d is number of years the domain has been registered for',
-		}
+	return (
+		<em>
+			{ translate(
+				'Domain registered for %(quantity)d year',
+				'Domain registered for %(quantity)d years',
+				{
+					args: { quantity: volume },
+					count: volume,
+					comment: '%(quantity)d is number of years the domain has been registered for',
+				}
+			) }
+		</em>
 	);
 }
 

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -249,7 +249,7 @@ function renderSpaceAddOnquantitySummary(
 }
 
 export function renderDomainTransactionVolumeSummary(
-	{ volume, product_slug, type }: BillingTransactionItem,
+	{ volume, product_slug, variation_slug, type }: BillingTransactionItem,
 	translate: LocalizeProps[ 'translate' ]
 ) {
 	if ( ! volume ) {
@@ -260,7 +260,7 @@ export function renderDomainTransactionVolumeSummary(
 
 	volume = parseInt( String( volume ) );
 
-	if ( 'wp-domains' !== product_slug ) {
+	if ( 'wp-domains' !== product_slug || 'wp-domain-mapping' === variation_slug ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-978/misleading-label-domain-registered-for-1-year-shown-for-connected

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/91554, text was added to the single receipt view in calypso which displayed something like "Domain registered for 1 year" for any product with `volume` which was a domain product. However, domain mapping (AKA domain connection) products are also domain products and they are not domain registrations, so this text is misleading.

In this PR we modify the receipt logic so that it does not render the "Domain registered for X years" text if the product is a domain mapping. I also refactored the render function into a component for clarity and to avoid needing to duplicate logic.

Before             |  After
:-------------------------:|:-------------------------:
<img width="606" height="213" alt="Screenshot 2025-09-04 at 6 22 37 PM" src="https://github.com/user-attachments/assets/cf354886-a38d-4449-83e9-e44f48f70f6e" /> | <img width="614" height="217" alt="Screenshot 2025-09-04 at 6 20 31 PM" src="https://github.com/user-attachments/assets/3324a0d9-8542-4544-b54a-8620c412b6f8" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Buy a domain connection product and then view the receipt in calypso. Verify that it does not read "Domain registered for 1 year". Then verify that a domain _registration_ product _does_ include that text.

Note that `volume` on receipt items was only added in D130395-code (Nov 29 2023) so any purchases before that point will not have `volume` on the receipt item and will not display this information.