### PR TITLE
Legacy Domain Search: Fix add to cart handler

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -75,6 +75,7 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
@@ -1583,6 +1584,11 @@ class RegisterDomainStep extends Component {
 
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
+			// For Multi-domain flows, add the domain first, than check availability
+			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+				this.props.onAddDomain( suggestion, position, previousState );
+			}
+
 			this.setState( { pendingCheckSuggestion: suggestion } );
 			const promise = this.preCheckDomainAvailability( domain )
 				.catch( () => [] )
@@ -1614,7 +1620,7 @@ class RegisterDomainStep extends Component {
 							selectedSuggestion: suggestion,
 							selectedSuggestionPosition: position,
 						} );
-					} else {
+					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 						this.props.onAddDomain( suggestion, position, previousState );
 					}
 				} );


### PR DESCRIPTION
Puts back some code introduced by https://github.com/Automattic/wp-calypso/pull/105551.

## Proposed Changes

In the legacy domain search component, we need to add the domain to the cart before the availability check to make the transaction effective. However, I understand the code wrong and deleted that bit. This affected only the legacy domain search, not the retrofitted one.

## Testing Instructions

Enter `/setup?flags=-domains/ui-redesign` in production and verify you see the legacy domain search. Click "Select" and verify it doesn't add the domain to the cart unless you click twice.

Do the same process on this branch, but this time verify it adds the domain to the cart immediately.