### PR TITLE
Backup FileBrowser: extract queries to @automattic/api-queries package

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -1,11 +1,10 @@
-import { fetchBackupFileUrl } from '@automattic/api-core';
+import { fetchBackupExtensionUrl, fetchBackupFileUrl } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { useCallback, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useEffect } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { hasJetpackCredentials } from 'calypso/state/jetpack/credentials/selectors';
@@ -123,7 +122,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 					return;
 				} );
 		} else {
-			if ( fileInfo === undefined || parentItem === undefined ) {
+			if ( ! fileInfo || ! parentItem || ! parentItem.extensionVersion ) {
 				handleDownloadError();
 				return;
 			}
@@ -135,19 +134,13 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 				archiveType = 'theme';
 			}
 
-			const period = Math.round( rewindId );
-
-			wp.req
-				.post(
-					{
-						path: `/sites/${ siteId }/rewind/backup/${ period }/extension/${ archiveType }/url`,
-						apiNamespace: 'wpcom/v2',
-					},
-					{
-						extension_slug: parentItem.name,
-						extension_version: parentItem.extensionVersion,
-					}
-				)
+			fetchBackupExtensionUrl(
+				siteId,
+				Math.round( rewindId ).toString(),
+				archiveType,
+				parentItem.name,
+				parentItem.extensionVersion
+			)
 				.then( ( response: { url: string } ) => {
 					if ( ! response.url ) {
 						handleDownloadError();

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
@@ -9,7 +9,8 @@ export const useBackupContentsQuery = (
 	shouldFetch = true
 ) => {
 	return useQuery( {
-		...siteBackupContentsQuery( siteId, rewindId, path, shouldFetch ),
+		...siteBackupContentsQuery( siteId, rewindId, path ),
+		enabled: !! siteId && !! rewindId && !! path && shouldFetch,
 		select: parseBackupContentsData,
 	} );
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-contents-query.ts
@@ -1,4 +1,4 @@
-import { fetchBackupContents } from '@automattic/api-core';
+import { siteBackupContentsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { parseBackupContentsData } from './util';
 
@@ -9,11 +9,7 @@ export const useBackupContentsQuery = (
 	shouldFetch = true
 ) => {
 	return useQuery( {
-		queryKey: [ 'jetpack-backup-contents-ls', siteId, rewindId, path ],
-		queryFn: () => fetchBackupContents( siteId, rewindId, path ),
-		enabled: !! siteId && !! rewindId && !! path && shouldFetch,
-		meta: { persist: false },
+		...siteBackupContentsQuery( siteId, rewindId, path, shouldFetch ),
 		select: parseBackupContentsData,
-		staleTime: Infinity,
 	} );
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
@@ -1,4 +1,4 @@
-import { siteBackupFileQuery } from '@automattic/api-queries';
+import { siteBackupFileUrlQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { encodeToBase64 } from './util';
 
@@ -10,12 +10,8 @@ export const useBackupFileQuery = (
 ) => {
 	const encodedManifestPath = encodeToBase64( ( manifestPath as string ) ?? '' );
 
-	return useQuery(
-		siteBackupFileQuery(
-			siteId,
-			rewindId!,
-			encodedManifestPath,
-			!! siteId && !! rewindId && !! manifestPath && shouldFetch
-		)
-	);
+	return useQuery( {
+		...siteBackupFileUrlQuery( siteId, rewindId!, encodedManifestPath ),
+		enabled: !! siteId && !! rewindId && !! manifestPath && shouldFetch,
+	} );
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
@@ -1,4 +1,4 @@
-import { fetchBackupFileUrl } from '@automattic/api-core';
+import { siteBackupFileQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { encodeToBase64 } from './util';
 
@@ -10,12 +10,12 @@ export const useBackupFileQuery = (
 ) => {
 	const encodedManifestPath = encodeToBase64( ( manifestPath as string ) ?? '' );
 
-	return useQuery( {
-		queryKey: [ 'jetpack-backup-file-url', siteId, rewindId, encodedManifestPath ],
-		queryFn: () => fetchBackupFileUrl( siteId, rewindId!, encodedManifestPath ),
-		enabled: !! siteId && !! rewindId && !! manifestPath && shouldFetch,
-		meta: { persist: false },
-		staleTime: Infinity,
-		retry: 2,
-	} );
+	return useQuery(
+		siteBackupFileQuery(
+			siteId,
+			rewindId!,
+			encodedManifestPath,
+			!! siteId && !! rewindId && !! manifestPath && shouldFetch
+		)
+	);
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
@@ -1,4 +1,4 @@
-import { fetchBackupPathInfo } from '@automattic/api-core';
+import { siteBackupPathInfoQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { parseBackupPathInfo } from './util';
 
@@ -9,12 +9,7 @@ export const useBackupPathInfoQuery = (
 	extensionType = ''
 ) => {
 	return useQuery( {
-		queryKey: [ 'jetpack-backup-path-info', siteId, rewindId, manifestPath, extensionType ],
-		queryFn: () => fetchBackupPathInfo( siteId, rewindId, manifestPath, extensionType ),
-		enabled: !! siteId,
-		meta: { persist: false },
+		...siteBackupPathInfoQuery( siteId, rewindId, manifestPath, extensionType ),
 		select: parseBackupPathInfo,
-		staleTime: Infinity,
-		retry: 2,
 	} );
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-path-info-query.ts
@@ -10,6 +10,7 @@ export const useBackupPathInfoQuery = (
 ) => {
 	return useQuery( {
 		...siteBackupPathInfoQuery( siteId, rewindId, manifestPath, extensionType ),
+		enabled: !! siteId,
 		select: parseBackupPathInfo,
 	} );
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
@@ -22,7 +22,6 @@ export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 		...siteBackupFilteredDownloadStatusQuery( siteId, buildKey, dataType ),
 		enabled: !! buildKey && status === PREPARE_DOWNLOAD_STATUS.PREPARING,
 		refetchInterval: 5000,
-		retry: false,
 	} );
 
 	useEffect( () => {
@@ -35,23 +34,23 @@ export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 		}
 	}, [ isSuccess, isError, handleError, data?.status ] );
 
-	const mutation = useMutation( {
-		...siteBackupFilteredDownloadPrepareMutation(),
-		onSuccess: ( data ) => {
-			setBuildKey( data.key );
-		},
-		onError: handleError,
-	} );
-
-	const { mutate } = mutation;
+	const { mutate } = useMutation( siteBackupFilteredDownloadPrepareMutation() );
 
 	const prepareDownload = useCallback(
 		( siteId: number, rewindId: string, manifestFilter: string, dataType: number ) => {
 			setStatus( PREPARE_DOWNLOAD_STATUS.PREPARING );
 			setDataType( dataType );
-			return mutate( { siteId, rewindId, manifestFilter, dataType } );
+			return mutate(
+				{ siteId, rewindId, manifestFilter, dataType },
+				{
+					onSuccess: ( data ) => {
+						setBuildKey( data.key );
+					},
+					onError: handleError,
+				}
+			);
 		},
-		[ mutate ]
+		[ mutate, handleError ]
 	);
 
 	return {

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
@@ -1,20 +1,10 @@
-import { prepareBackupDownload } from '@automattic/api-core';
-import { siteBackupFilteredDownloadStatusQuery } from '@automattic/api-queries';
+import {
+	siteBackupFilteredDownloadStatusQuery,
+	siteBackupFilteredDownloadPrepareMutation,
+} from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { PREPARE_DOWNLOAD_STATUS } from './constants';
-
-interface PrepareDownloadArgs {
-	siteId: number;
-	rewindId: string;
-	manifestFilter: string;
-	dataType: number;
-}
-
-interface FilteredPrepareResponse {
-	ok: boolean;
-	key: string;
-}
 
 export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 	const [ status, setStatus ] = useState( PREPARE_DOWNLOAD_STATUS.NOT_STARTED );
@@ -46,9 +36,8 @@ export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 	}, [ isSuccess, isError, handleError, data?.status ] );
 
 	const mutation = useMutation( {
-		mutationFn: ( { siteId, rewindId, manifestFilter, dataType }: PrepareDownloadArgs ) =>
-			prepareBackupDownload( siteId, rewindId, manifestFilter, dataType ),
-		onSuccess: ( data: FilteredPrepareResponse ) => {
+		...siteBackupFilteredDownloadPrepareMutation(),
+		onSuccess: ( data ) => {
 			setBuildKey( data.key );
 		},
 		onError: handleError,

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
@@ -1,4 +1,5 @@
-import { prepareBackupDownload, getBackupDownloadStatus } from '@automattic/api-core';
+import { prepareBackupDownload } from '@automattic/api-core';
+import { siteBackupFilteredDownloadStatusQuery } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { PREPARE_DOWNLOAD_STATUS } from './constants';
@@ -13,14 +14,6 @@ interface PrepareDownloadArgs {
 interface FilteredPrepareResponse {
 	ok: boolean;
 	key: string;
-}
-
-interface FilteredStatusResponse {
-	ok: boolean;
-	status: string;
-	download_id: string;
-	token: string;
-	url: string;
 }
 
 export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
@@ -39,12 +32,13 @@ export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 		data,
 		isSuccess: isQuerySuccess,
 		isError: isQueryError,
-	} = useQuery< FilteredStatusResponse >( {
-		queryKey: [ 'jetpack-backup-filtered-status', buildKey, siteId, dataType ],
-		queryFn: () => getBackupDownloadStatus( siteId, buildKey, dataType ),
-		enabled: buildKey !== '' && status === PREPARE_DOWNLOAD_STATUS.PREPARING,
-		refetchInterval: 5000, // 5 seconds
-		retry: false,
+	} = useQuery( {
+		...siteBackupFilteredDownloadStatusQuery(
+			siteId,
+			buildKey,
+			dataType,
+			buildKey !== '' && status === PREPARE_DOWNLOAD_STATUS.PREPARING
+		),
 	} );
 
 	useEffect( () => {

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-prepare-download.ts
@@ -28,28 +28,22 @@ export const usePrepareDownload = ( siteId: number, onError: () => void ) => {
 		onError();
 	}, [ onError ] );
 
-	const {
-		data,
-		isSuccess: isQuerySuccess,
-		isError: isQueryError,
-	} = useQuery( {
-		...siteBackupFilteredDownloadStatusQuery(
-			siteId,
-			buildKey,
-			dataType,
-			buildKey !== '' && status === PREPARE_DOWNLOAD_STATUS.PREPARING
-		),
+	const { data, isSuccess, isError } = useQuery( {
+		...siteBackupFilteredDownloadStatusQuery( siteId, buildKey, dataType ),
+		enabled: !! buildKey && status === PREPARE_DOWNLOAD_STATUS.PREPARING,
+		refetchInterval: 5000,
+		retry: false,
 	} );
 
 	useEffect( () => {
-		if ( isQuerySuccess && data?.status === 'ready' ) {
+		if ( isSuccess && data?.status === 'ready' ) {
 			setStatus( PREPARE_DOWNLOAD_STATUS.READY );
 		}
 
-		if ( isQueryError ) {
+		if ( isError ) {
 			handleError();
 		}
-	}, [ isQuerySuccess, isQueryError, handleError, data?.status ] );
+	}, [ isSuccess, isError, handleError, data?.status ] );
 
 	const mutation = useMutation( {
 		mutationFn: ( { siteId, rewindId, manifestFilter, dataType }: PrepareDownloadArgs ) =>

--- a/packages/api-core/src/site-backups/fetchers.ts
+++ b/packages/api-core/src/site-backups/fetchers.ts
@@ -3,7 +3,7 @@ import type {
 	BackupEntry,
 	BackupContentsResponse,
 	BackupPathInfoResponse,
-	BackupFileUrl,
+	BackupItemUrl,
 } from './types';
 
 /**
@@ -79,9 +79,28 @@ export function fetchBackupFileUrl(
 	siteId: number,
 	rewindId: string,
 	encodedManifestPath: string
-): Promise< BackupFileUrl > {
+): Promise< BackupItemUrl > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/rewind/backup/${ rewindId }/file/${ encodedManifestPath }/url`,
 		apiNamespace: 'wpcom/v2',
 	} );
+}
+
+export function fetchBackupExtensionUrl(
+	siteId: number,
+	period: string,
+	archiveType: string,
+	extensionSlug: string,
+	extensionVersion: string
+): Promise< BackupItemUrl > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/rewind/backup/${ period }/extension/${ archiveType }/url`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			extension_slug: extensionSlug,
+			extension_version: extensionVersion,
+		}
+	);
 }

--- a/packages/api-core/src/site-backups/types.ts
+++ b/packages/api-core/src/site-backups/types.ts
@@ -57,6 +57,6 @@ export interface BackupPathInfoResponse {
 	error?: string;
 }
 
-export interface BackupFileUrl {
+export interface BackupItemUrl {
 	url: string;
 }

--- a/packages/api-queries/src/site-backup-download.ts
+++ b/packages/api-queries/src/site-backup-download.ts
@@ -41,13 +41,6 @@ export const siteBackupDownloadInitiateMutation = ( siteId: number ) =>
 		},
 	} );
 
-/**
- * Fetch the status of a filtered backup download preparation.
- * @param siteId - The ID of the site to fetch the status for.
- * @param buildKey - The build key to fetch the status for.
- * @param dataType - The data type to fetch the status for.
- * @returns A promise that resolves to the download status.
- */
 export const siteBackupFilteredDownloadStatusQuery = (
 	siteId: number,
 	buildKey: string,
@@ -58,10 +51,6 @@ export const siteBackupFilteredDownloadStatusQuery = (
 		queryFn: () => getBackupDownloadStatus( siteId, buildKey, dataType ),
 	} );
 
-/**
- * Prepare a filtered backup download.
- * @returns A promise that resolves to the prepare download response.
- */
 export const siteBackupFilteredDownloadPrepareMutation = () =>
 	mutationOptions( {
 		mutationFn: ( {

--- a/packages/api-queries/src/site-backup-download.ts
+++ b/packages/api-queries/src/site-backup-download.ts
@@ -1,6 +1,8 @@
 import {
 	fetchSiteBackupDownloadProgress,
 	initiateSiteBackupDownload,
+	prepareBackupDownload,
+	getBackupDownloadStatus,
 	type DownloadConfig,
 } from '@automattic/api-core';
 import configApi from '@automattic/calypso-config';
@@ -37,4 +39,47 @@ export const siteBackupDownloadInitiateMutation = ( siteId: number ) =>
 			// Start polling download progress
 			queryClient.prefetchQuery( siteBackupDownloadProgressQuery( siteId, downloadId ) );
 		},
+	} );
+
+/**
+ * Fetch the status of a filtered backup download preparation.
+ * @param siteId - The ID of the site to fetch the status for.
+ * @param buildKey - The build key to fetch the status for.
+ * @param dataType - The data type to fetch the status for.
+ * @param enabled - Whether the query is enabled.
+ * @returns A promise that resolves to the download status.
+ */
+export const siteBackupFilteredDownloadStatusQuery = (
+	siteId: number,
+	buildKey: string,
+	dataType: number,
+	enabled = false
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', 'download', 'status', buildKey, dataType ],
+		queryFn: () => getBackupDownloadStatus( siteId, buildKey, dataType ),
+
+		// These should be handled by the consumer
+		enabled: !! buildKey && enabled,
+		refetchInterval: 5000,
+		retry: false,
+	} );
+
+/**
+ * Prepare a filtered backup download.
+ * @returns A promise that resolves to the prepare download response.
+ */
+export const siteBackupFilteredDownloadPrepareMutation = () =>
+	mutationOptions( {
+		mutationFn: ( {
+			siteId,
+			rewindId,
+			manifestFilter,
+			dataType,
+		}: {
+			siteId: number;
+			rewindId: string;
+			manifestFilter: string;
+			dataType: number;
+		} ) => prepareBackupDownload( siteId, rewindId, manifestFilter, dataType ),
 	} );

--- a/packages/api-queries/src/site-backup-download.ts
+++ b/packages/api-queries/src/site-backup-download.ts
@@ -46,23 +46,16 @@ export const siteBackupDownloadInitiateMutation = ( siteId: number ) =>
  * @param siteId - The ID of the site to fetch the status for.
  * @param buildKey - The build key to fetch the status for.
  * @param dataType - The data type to fetch the status for.
- * @param enabled - Whether the query is enabled.
  * @returns A promise that resolves to the download status.
  */
 export const siteBackupFilteredDownloadStatusQuery = (
 	siteId: number,
 	buildKey: string,
-	dataType: number,
-	enabled = false
+	dataType: number
 ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', 'download', 'status', buildKey, dataType ],
 		queryFn: () => getBackupDownloadStatus( siteId, buildKey, dataType ),
-
-		// These should be handled by the consumer
-		enabled: !! buildKey && enabled,
-		refetchInterval: 5000,
-		retry: false,
 	} );
 
 /**

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -30,17 +30,10 @@ export const siteBackupEnqueueMutation = ( siteId: number ) =>
 		},
 	} );
 
-export const siteBackupContentsQuery = (
-	siteId: number,
-	rewindId: number,
-	path: string,
-	enabled = true
-) =>
+export const siteBackupContentsQuery = ( siteId: number, rewindId: number, path: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', rewindId, 'contents', path ],
 		queryFn: () => fetchBackupContents( siteId, rewindId, path ),
-		enabled: !! siteId && !! rewindId && !! path && enabled,
-		meta: { persist: false },
 		staleTime: Infinity,
 	} );
 
@@ -53,23 +46,16 @@ export const siteBackupPathInfoQuery = (
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', rewindId, 'path-info', manifestPath, extensionType ],
 		queryFn: () => fetchBackupPathInfo( siteId, rewindId, manifestPath, extensionType ),
-		enabled: !! siteId,
-		meta: { persist: false },
 		staleTime: Infinity,
-		retry: 2,
 	} );
 
-export const siteBackupFileQuery = (
+export const siteBackupFileUrlQuery = (
 	siteId: number,
 	rewindId: string,
-	encodedManifestPath: string,
-	enabled = true
+	encodedManifestPath: string
 ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backup', rewindId, 'file', encodedManifestPath ],
 		queryFn: () => fetchBackupFileUrl( siteId, rewindId, encodedManifestPath ),
-		enabled: !! siteId && !! rewindId && !! encodedManifestPath && enabled,
 		meta: { persist: false },
-		staleTime: Infinity,
-		retry: 2,
 	} );

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -2,6 +2,9 @@ import {
 	fetchSiteRewindableActivityLog,
 	enqueueSiteBackup,
 	fetchSiteBackups,
+	fetchBackupContents,
+	fetchBackupPathInfo,
+	fetchBackupFileUrl,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -25,4 +28,48 @@ export const siteBackupEnqueueMutation = ( siteId: number ) =>
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteBackupsQuery( siteId ) );
 		},
+	} );
+
+export const siteBackupContentsQuery = (
+	siteId: number,
+	rewindId: number,
+	path: string,
+	enabled = true
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', rewindId, 'contents', path ],
+		queryFn: () => fetchBackupContents( siteId, rewindId, path ),
+		enabled: !! siteId && !! rewindId && !! path && enabled,
+		meta: { persist: false },
+		staleTime: Infinity,
+	} );
+
+export const siteBackupPathInfoQuery = (
+	siteId: number,
+	rewindId: string,
+	manifestPath: string,
+	extensionType = ''
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', rewindId, 'path-info', manifestPath, extensionType ],
+		queryFn: () => fetchBackupPathInfo( siteId, rewindId, manifestPath, extensionType ),
+		enabled: !! siteId,
+		meta: { persist: false },
+		staleTime: Infinity,
+		retry: 2,
+	} );
+
+export const siteBackupFileQuery = (
+	siteId: number,
+	rewindId: string,
+	encodedManifestPath: string,
+	enabled = true
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'backup', rewindId, 'file', encodedManifestPath ],
+		queryFn: () => fetchBackupFileUrl( siteId, rewindId, encodedManifestPath ),
+		enabled: !! siteId && !! rewindId && !! encodedManifestPath && enabled,
+		meta: { persist: false },
+		staleTime: Infinity,
+		retry: 2,
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-382
Follow-up of #105557

## Proposed Changes
- Extract FileBrowser queries to `@automattic/api-queries` package
  - Move query factories from component-level to standardized package architecture
  - Create `siteBackupContentsQuery`, `siteBackupPathInfoQuery`, `siteBackupFileUrlQuery` in api-queries
  - Add `siteBackupFilteredDownloadPrepareMutation` for download preparation
- Clean up query implementations
  - Remove unnecessary configuration from query factories (retry, refetchInterval, enabled)
  - Streamline query factories to focus purely on data fetching
- Leftover from #105557:
  - Add and replace wp.req extension download with `fetchBackupExtensionUrl` from api-core

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of rewriting the FileBrowser component to make it work in the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Pick a site with Jetpack VaultPress Backup
* Click on `View files` on any full backup to navigate to the file browser
* Try navigating through the file browser (opening directories, clicking files, download/preview files).
* Ensure the file browser continues to work as expected either on Jetpack Cloud and Staging Site Sync implementation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
