### PR TITLE
Notifications v2: Improve styles based on the feedback (pt1)

### DIFF
--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -9,8 +9,10 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 
-		.wpnc__gridicon {
-			vertical-align: top;
+		.wpnc__gridicon svg {
+			display: inline-block;
+			transform: translateY(2px);
+			fill: #8c8f94;
 		}
 	}
 }

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -90,7 +90,10 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 
 	return (
 		<>
-			<CardHeader size="small">
+			<CardHeader
+				size="small"
+				style={ { position: 'sticky', top: 0, background: '#fff', zIndex: 1 } }
+			>
 				<HStack>
 					<HStack justify="flex-start">
 						<Navigator.BackButton size="small" icon={ isRTL() ? chevronRight : chevronLeft } />

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -85,7 +85,10 @@ export const ActionBlock = ( { note, goBack }: { note: Note; goBack: () => void 
 	}
 
 	return (
-		<CardFooter size="small">
+		<CardFooter
+			size="small"
+			style={ { position: 'sticky', bottom: 0, background: '#fff', zIndex: 1 } }
+		>
 			<NoteActions note={ note } goBack={ goBack } />
 		</CardFooter>
 	);

--- a/apps/notifications/src/app/templates/comment-reply-input.tsx
+++ b/apps/notifications/src/app/templates/comment-reply-input.tsx
@@ -5,6 +5,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { send } from '@wordpress/icons';
 import debugModule from 'debug';
 import { useRef, useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -212,7 +213,7 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 	return (
 		<VStack>
 			<form onSubmit={ handleSubmit }>
-				<HStack spacing={ 4 } alignment="flex-start">
+				<HStack spacing={ 2 } alignment="flex-start">
 					<TextareaControl
 						className="comment-reply-input__textarea"
 						ref={ replyInputRef }
@@ -230,12 +231,11 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 						title={
 							value.length ? __( 'Submit reply' ) : __( 'Write your response in order to submit' )
 						}
+						icon={ send }
 						isBusy={ isSubmitting }
 						disabled={ ! value.length }
 						__next40pxDefaultSize
-					>
-						{ __( 'Send' ) }
-					</Button>
+					/>
 				</HStack>
 			</form>
 			<Suggestions


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1757014356409749/1756991779.442799-slack-C08JZTRS6NA

## Proposed Changes

* [Adjust the color of the reply icon in list](https://github.com/Automattic/wp-calypso/commit/53079e3c31d29ade16032d8e7fa584f8de60f925)
* [Use send icon for the reply button](https://github.com/Automattic/wp-calypso/commit/757a07597080ecbc1cce7b083fb707abb8b9db62)
* [Make note header and footer sticky](https://github.com/Automattic/wp-calypso/commit/192c4cd802261a5d967b31a68a341d3da372b0ab)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open the notifications
* Switch to the Comment tab
* Ensure the color of the reply icon is correct
* Select any notifications
* Ensure the header & footer are sticky
* Ensure the reply button changes to the send icon

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?