### PR TITLE
Notifications v2: Fix more styles

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -64,7 +64,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 	}, [ client, isLoading ] );
 
 	useEffect( () => {
-		if ( notes.length < 10 && ! isLoading ) {
+		if ( notes.length <= 10 && ! isLoading ) {
 			infiniteScrollHandler();
 		}
 	}, [ notes.length, isLoading, infiniteScrollHandler ] );

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -1,4 +1,5 @@
 .wpnc__note-list {
+	flex: 1;
 	overflow: hidden;
 
 	.wpnc__note-list-item {

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -82,7 +82,6 @@
 		display: block;
 		max-width: 100%;
 		height: auto;
-		padding: $grid-unit-20;
 		margin: auto;
 	}
 
@@ -98,6 +97,44 @@
 		&:first-child {
 			padding-top: 0;
 		}
+
+		&:has(.wpnc__button) {
+			margin: 0 -#{$grid-unit-20};
+			padding: 16px;
+			border-top: 1px solid $gray-300;
+		}
+	}
+
+	.wpnc__button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 36px;
+		padding: 6px 12px;
+		margin: 0;
+		border: 0;
+		border-radius: 2px;
+		box-sizing: border-box;
+		font-family: inherit;
+		font-size: 13px;
+		color: var(--wp-components-color-accent-inverted, #fff);
+		background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9 ));
+		white-space: nowrap;
+		text-decoration: none;
+		text-shadow: none;
+		outline: 1px solid transparent;
+		cursor: pointer;
+
+		&:hover:not(:disabled) {
+			color: var(--wp-components-color-accent-inverted, #fff);
+			background: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #2145e6));
+		}
+	}
+
+	.wpnc__hr-separator {
+		border: none;
+		border-top: 1px solid $gray-300;
 	}
 
 	// Links
@@ -129,7 +166,7 @@
 	blockquote {
 		padding: 0 $grid-unit-20;
 		margin: 0 0 $grid-unit-20 0;
-		box-shadow: inset 4px 0 0 #f6f7f7;
+		box-shadow: inset 3px 0 0 #f0f0f0;
 		font-weight: 400;
 		font-style: italic;
 		color: #646970;
@@ -208,7 +245,7 @@
  */
 .wpnc__note.wpnc__comment .wpnc__body .wpnc__body-content {
 	padding: 0 0 0 $grid-unit-20;
-	box-shadow: inset 4px 0 0 #f6f7f7;
+	box-shadow: inset 3px 0 0 #f0f0f0;
 
 	.wpnc__user {
 		padding: 0 0 $grid-unit-20 0;

--- a/apps/notifications/src/app/templates/action-button.jsx
+++ b/apps/notifications/src/app/templates/action-button.jsx
@@ -30,7 +30,7 @@ const ActionButton = ( { isActive, isBusy, hotkey, icon, onToggle, text, title }
 ActionButton.propTypes = {
 	isActive: PropTypes.bool.isRequired,
 	hotkey: PropTypes.number,
-	icon: PropTypes.string,
+	icon: PropTypes.object,
 	onToggle: PropTypes.func.isRequired,
 	text: PropTypes.string.isRequired,
 	title: PropTypes.string.isRequired,

--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -15,7 +15,7 @@ import NotePreface from './preface';
 import type { Note, Block, BlockWithSignature } from '../types';
 
 const isReplyBlock = ( note: Note, block: Block ) =>
-	block.ranges && block.ranges.length > 1 && block.ranges[ 1 ].id === note.meta?.ids.reply_comment;
+	block.ranges && block.ranges.length > 1 && block.ranges[ 1 ].id === note.meta?.ids?.reply_comment;
 
 const ReplyBlock = ( { note }: { note: Note } ) => {
 	const [ replyURL, setReplyURL ] = useState< string >( '' );
@@ -34,7 +34,7 @@ const ReplyBlock = ( { note }: { note: Note } ) => {
 			return;
 		}
 
-		const { site: siteId, reply_comment: replyCommentId } = note.meta.ids;
+		const { site: siteId, reply_comment: replyCommentId } = note.meta?.ids || {};
 		if ( ! siteId || ! replyCommentId ) {
 			return;
 		}
@@ -55,7 +55,7 @@ const ReplyBlock = ( { note }: { note: Note } ) => {
 
 	if ( replyURL ) {
 		const replyMessage = createInterpolateElement(
-			note.meta.ids.comment
+			note.meta?.ids?.comment
 				? __( 'You <a>replied</a> to this comment.' )
 				: __( 'You <a>replied</a> to this post.' ),
 			{

--- a/apps/notifications/src/app/templates/comment-reply-input.tsx
+++ b/apps/notifications/src/app/templates/comment-reply-input.tsx
@@ -92,12 +92,14 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 
 			let wpObject;
 			let submitComment;
-			if ( note.meta.ids.comment ) {
+			if ( note.meta?.ids?.site && note.meta?.ids?.comment ) {
 				wpObject = wpcom().site( note.meta.ids.site ).comment( note.meta.ids.comment );
 				submitComment = wpObject.reply;
-			} else {
+			} else if ( note.meta?.ids?.site && note.meta?.ids?.post ) {
 				wpObject = wpcom().site( note.meta.ids.site ).post( note.meta.ids.post ).comment();
 				submitComment = wpObject.add;
+			} else {
+				return;
 			}
 
 			submitComment.call( wpObject, replyInputRef.current.value, ( error: Error | null ) => {
@@ -114,7 +116,7 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 					return;
 				}
 
-				if ( note.meta.ids.comment ) {
+				if ( note.meta?.ids?.comment ) {
 					// pre-emptively approve the comment if it wasn't already
 					dispatch( actions.notes.approveNote( note.id, true ) );
 					client?.getNote( note.id );
@@ -239,7 +241,7 @@ const CommentReplyInput = ( { note, defaultValue }: { note: Note; defaultValue: 
 				</HStack>
 			</form>
 			<Suggestions
-				site={ note.meta.ids.site }
+				site={ note.meta?.ids?.site }
 				onInsertSuggestion={ insertSuggestion }
 				getContextEl={ () => replyInputRef.current }
 			/>

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -90,15 +90,15 @@ export type Note = {
 	timestamp: string;
 	icon: string;
 	url: string;
-	meta: {
-		ids: {
+	meta?: {
+		ids?: {
 			site?: number;
 			post?: number;
 			comment?: number;
 			reply_comment?: number;
 			user?: number;
 		};
-		links: {
+		links?: {
 			site?: string;
 			post?: string;
 			comment?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix more styles, especially for the `wpnc__button`
  <img width="447" height="109" alt="image" src="https://github.com/user-attachments/assets/04212016-d9b3-4ea6-aa7a-8f12390b12a9" />
* Fix the error that the `note.meta.ids` may be undefined
* Fix the infinite scroll on the all tab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Open notifications
* Select note like `Happy Anniversary with WordPress.com!` or `You accepted ...`
* Ensure it works correctly and styles look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
