### PR TITLE
Domains: Actions: Add missing domain subtype checks

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -9,6 +9,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { isAkismetProduct } from '../../utils/purchase';
 
+export const transferableTypes: DomainSubtype[] = [
+	DomainSubtype.DEFAULT_ADDRESS,
+	DomainSubtype.DOMAIN_CONNECTION,
+	DomainSubtype.DOMAIN_REGISTRATION,
+];
 export const disconnectableTypes: DomainSubtype[] = [ DomainSubtype.DOMAIN_REGISTRATION ];
 
 export const shouldShowTransferAction = ( domain: Domain ) => {
@@ -18,7 +23,8 @@ export const shouldShowTransferAction = ( domain: Domain ) => {
 		domain.pending_registration ||
 		domain.pending_registration_at_registry ||
 		domain.move_to_new_site_pending ||
-		domain.aftermarket_auction
+		domain.aftermarket_auction ||
+		! transferableTypes.includes( domain.subtype.id )
 	) {
 		return false;
 	}

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -1,6 +1,15 @@
-import { Domain, DomainTypes, DomainTransferStatus, Purchase, Site } from '@automattic/api-core';
+import {
+	Domain,
+	DomainTypes,
+	DomainSubtype,
+	DomainTransferStatus,
+	Purchase,
+	Site,
+} from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { isAkismetProduct } from '../../utils/purchase';
+
+export const disconnectableTypes: DomainSubtype[] = [ DomainSubtype.DOMAIN_REGISTRATION ];
 
 export const shouldShowTransferAction = ( domain: Domain ) => {
 	if (
@@ -21,7 +30,8 @@ export const shouldShowDisconnectAction = ( domain: Domain ) => {
 	if (
 		domain.is_domain_only_site ||
 		domain.move_to_new_site_pending ||
-		! domain.current_user_is_owner
+		! domain.current_user_is_owner ||
+		! disconnectableTypes.includes( domain.subtype.id )
 	) {
 		return false;
 	}


### PR DESCRIPTION
Part of DOTDASH-311

## Proposed Changes

* Add missing domain subtype checks for `shouldShowDisconnectAction` and `shouldShowTransferAction` functions

## Why are these changes being made?

* DOTDASH-311

## Testing Instructions

Existing checks:
- https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/transfer/index.tsx#L10
- https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx#L20

* Go to `/v2/domains`
* Select a domain
* Check the actions section; it should hide the action based on the subtype value

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
