### PR TITLE
Domains: Show the proper columns in domains list

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,0 +1,39 @@
+import { DomainTypes } from '@automattic/api-core';
+import { Badge } from '@automattic/ui';
+import { Link } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { domainOverviewRoute } from '../../app/router/domains';
+import { textOverflowStyles } from './utils';
+import type { DomainSummary, Site } from '@automattic/api-core';
+
+export const DomainNameField = ( {
+	domain,
+	site,
+	value,
+	showPrimaryDomainBadge,
+}: {
+	domain: DomainSummary;
+	site?: Site;
+	value: string;
+	showPrimaryDomainBadge?: boolean;
+} ) => {
+	const siteSlug = site?.slug ?? domain.site_slug;
+
+	return (
+		<Link
+			to={ domainOverviewRoute.fullPath }
+			params={ { siteSlug, domainName: domain.domain } }
+			disabled={ domain.type === DomainTypes.WPCOM }
+		>
+			<HStack spacing={ 1 }>
+				<span style={ textOverflowStyles }>{ value }</span>
+				{ showPrimaryDomainBadge && domain.primary_domain && (
+					<span style={ { flexShrink: 0 } }>
+						<Badge>{ __( 'Primary' ) }</Badge>
+					</span>
+				) }
+			</HStack>
+		</Link>
+	);
+};

--- a/client/dashboard/domains/dataviews/field-domain-site.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-site.tsx
@@ -1,0 +1,25 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { siteRoute } from '../../app/router/sites';
+import { Text } from '../../components/text';
+import SiteIcon from '../../sites/site-icon';
+import type { DomainSummary } from '@automattic/api-core';
+
+export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
+	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
+
+	return (
+		<HStack spacing={ 2 } alignment="left">
+			{ site && <SiteIcon size={ 16 } site={ site } /> }
+			<Link
+				to={ siteRoute.fullPath }
+				params={ { siteSlug: domain?.site_slug } }
+				style={ { textDecoration: 'none' } }
+			>
+				<Text>{ value }</Text>
+			</Link>
+		</HStack>
+	);
+};

--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -1,0 +1,66 @@
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { caution, reusableBlock } from '@wordpress/icons';
+import type { DomainSummary } from '@automattic/api-core';
+
+export const DomainExpiryField = ( {
+	domain,
+	value,
+	isCompact = false,
+}: {
+	domain: DomainSummary;
+	value: string;
+	isCompact?: boolean;
+} ) => {
+	if ( ! domain.expiry ) {
+		return __( 'Free forever' );
+	}
+
+	const isAutoRenewing = Boolean( domain.auto_renewing );
+	const isExpired = new Date( domain.expiry ) < new Date();
+	const isHundredYearDomain = Boolean( domain.is_hundred_year_domain );
+	const renderExpiry = () => {
+		if ( isHundredYearDomain ) {
+			return sprintf(
+				/* translators: %s - The date until which a domain was paid for */
+				__( 'Paid until %s' ),
+				value
+			);
+		}
+
+		if ( isExpired ) {
+			return sprintf(
+				/* translators: %s - The date on which a domain has expired */
+				__( 'Expired on %s' ),
+				value
+			);
+		}
+
+		if ( ! isAutoRenewing ) {
+			return sprintf(
+				/* translators: %s - The date on which a domain expires */
+				__( 'Expires on %s' ),
+				value
+			);
+		}
+
+		return sprintf(
+			/* translators: %s - The future date on which a domain renews */
+			__( 'Renews on %s' ),
+			value
+		);
+	};
+
+	return (
+		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
+			{ ! isCompact && (
+				<Icon
+					icon={ isExpired || isHundredYearDomain ? caution : reusableBlock }
+					size={ 16 }
+					style={ { fill: 'currentColor' } }
+				/>
+			) }
+			<span>{ renderExpiry() }</span>
+		</HStack>
+	);
+};

--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -1,0 +1,15 @@
+import { DomainSummary } from '@automattic/api-core';
+import { sslDetailsQuery } from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+
+export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
+	const { data: sslDetails } = useQuery( sslDetailsQuery( domain.domain ) );
+
+	if ( sslDetails?.certificate_provisioned ) {
+		return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
+	}
+
+	return <Badge intent="warning">{ __( 'SSL pending' ) }</Badge>;
+};

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -3,16 +3,16 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { sprintf, __ } from '@wordpress/i18n';
-import { caution, reusableBlock } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { domainOverviewRoute } from '../../app/router/domains';
 import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
 import SiteIcon from '../../sites/site-icon';
 import { isRecentlyRegistered } from '../../utils/domain';
+import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -71,68 +71,6 @@ const DomainSite = ( { domain, value }: { domain: DomainSummary; value: string }
 			>
 				<Text>{ value }</Text>
 			</Link>
-		</HStack>
-	);
-};
-
-const DomainExpiry = ( {
-	domain,
-	value,
-	isCompact = false,
-}: {
-	domain: DomainSummary;
-	value: string;
-	isCompact?: boolean;
-} ) => {
-	if ( ! domain.expiry ) {
-		return __( 'Free forever' );
-	}
-
-	const isAutoRenewing = Boolean( domain.auto_renewing );
-	const isExpired = new Date( domain.expiry ) < new Date();
-	const isHundredYearDomain = Boolean( domain.is_hundred_year_domain );
-	const renderExpiry = () => {
-		if ( isHundredYearDomain ) {
-			return sprintf(
-				/* translators: %s - The date until which a domain was paid for */
-				__( 'Paid until %s' ),
-				value
-			);
-		}
-
-		if ( isExpired ) {
-			return sprintf(
-				/* translators: %s - The date on which a domain has expired */
-				__( 'Expired on %s' ),
-				value
-			);
-		}
-
-		if ( ! isAutoRenewing ) {
-			return sprintf(
-				/* translators: %s - The date on which a domain expires */
-				__( 'Expires on %s' ),
-				value
-			);
-		}
-
-		return sprintf(
-			/* translators: %s - The future date on which a domain renews */
-			__( 'Renews on %s' ),
-			value
-		);
-	};
-
-	return (
-		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
-			{ ! isCompact && (
-				<Icon
-					icon={ isExpired || isHundredYearDomain ? caution : reusableBlock }
-					size={ 16 }
-					style={ { fill: 'currentColor' } }
-				/>
-			) }
-			<span>{ renderExpiry() }</span>
 		</HStack>
 	);
 };
@@ -219,7 +157,7 @@ export const useFields = ( {
 					}
 
 					return (
-						<DomainExpiry
+						<DomainExpiryField
 							domain={ item }
 							value={ field.getValue( { item } ) }
 							isCompact={ !! site }

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,5 +1,7 @@
 import { DomainTypes } from '@automattic/api-core';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
@@ -7,7 +9,9 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { caution, reusableBlock } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { domainOverviewRoute } from '../../app/router/domains';
+import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
+import SiteIcon from '../../sites/site-icon';
 import { isRecentlyRegistered } from '../../utils/domain';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -50,6 +54,23 @@ const DomainName = ( {
 				) }
 			</HStack>
 		</Link>
+	);
+};
+
+const DomainSite = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
+	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
+
+	return (
+		<HStack spacing={ 2 } alignment="left">
+			{ site && <SiteIcon size={ 16 } site={ site } /> }
+			<Link
+				to={ siteRoute.fullPath }
+				params={ { siteSlug: domain?.site_slug } }
+				style={ { textDecoration: 'none' } }
+			>
+				<Text>{ value }</Text>
+			</Link>
+		</HStack>
 	);
 };
 
@@ -164,7 +185,12 @@ export const useFields = ( {
 				label: __( 'Site' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainSummary } ) => item.blog_name ?? '',
+				getValue: ( { item }: { item: DomainSummary } ) => {
+					return item.blog_name ?? '';
+				},
+				render: ( { field, item } ) => (
+					<DomainSite domain={ item } value={ field.getValue( { item } ) } />
+				),
 			},
 			// {
 			// 	id: 'ssl_status',

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,17 +1,16 @@
 import { DomainTypes } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { domainOverviewRoute } from '../../app/router/domains';
 import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
 import SiteIcon from '../../sites/site-icon';
 import { isRecentlyRegistered } from '../../utils/domain';
+import { DomainNameField } from './field-domain-name';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import type { DomainSummary, Site } from '@automattic/api-core';
@@ -19,44 +18,7 @@ import type { Field } from '@wordpress/dataviews';
 
 const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
-const textOverflowStyles = {
-	overflowX: 'hidden',
-	textOverflow: 'ellipsis',
-	whiteSpace: 'nowrap',
-} as const;
-
 const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
-
-const DomainName = ( {
-	domain,
-	site,
-	value,
-	showPrimaryDomainBadge,
-}: {
-	domain: DomainSummary;
-	site?: Site;
-	value: string;
-	showPrimaryDomainBadge?: boolean;
-} ) => {
-	const siteSlug = site?.slug ?? domain.site_slug;
-
-	return (
-		<Link
-			to={ domainOverviewRoute.fullPath }
-			params={ { siteSlug, domainName: domain.domain } }
-			disabled={ domain.type === DomainTypes.WPCOM }
-		>
-			<HStack spacing={ 1 }>
-				<span style={ textOverflowStyles }>{ value }</span>
-				{ showPrimaryDomainBadge && domain.primary_domain && (
-					<span style={ { flexShrink: 0 } }>
-						<Badge>{ __( 'Primary' ) }</Badge>
-					</span>
-				) }
-			</HStack>
-		</Link>
-	);
-};
 
 const DomainSite = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
 	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
@@ -92,7 +54,7 @@ export const useFields = ( {
 				enableGlobalSearch: true,
 				getValue: ( { item }: { item: DomainSummary } ) => item.domain,
 				render: ( { field, item } ) => (
-					<DomainName
+					<DomainNameField
 						domain={ item }
 						site={ site }
 						value={ field.getValue( { item } ) }

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,16 +1,11 @@
 import { DomainTypes } from '@automattic/api-core';
-import { siteBySlugQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
-import SiteIcon from '../../sites/site-icon';
 import { isRecentlyRegistered } from '../../utils/domain';
 import { DomainNameField } from './field-domain-name';
+import { DomainSiteField } from './field-domain-site';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import type { DomainSummary, Site } from '@automattic/api-core';
@@ -19,23 +14,6 @@ import type { Field } from '@wordpress/dataviews';
 const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
 const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
-
-const DomainSite = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
-	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
-
-	return (
-		<HStack spacing={ 2 } alignment="left">
-			{ site && <SiteIcon size={ 16 } site={ site } /> }
-			<Link
-				to={ siteRoute.fullPath }
-				params={ { siteSlug: domain?.site_slug } }
-				style={ { textDecoration: 'none' } }
-			>
-				<Text>{ value }</Text>
-			</Link>
-		</HStack>
-	);
-};
 
 export const useFields = ( {
 	site,
@@ -90,7 +68,7 @@ export const useFields = ( {
 					return item.blog_name ?? '';
 				},
 				render: ( { field, item } ) => (
-					<DomainSite domain={ item } value={ field.getValue( { item } ) } />
+					<DomainSiteField domain={ item } value={ field.getValue( { item } ) } />
 				),
 			},
 			{

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -13,6 +13,7 @@ import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
 import SiteIcon from '../../sites/site-icon';
 import { isRecentlyRegistered } from '../../utils/domain';
+import { DomainSslField } from './field-ssl';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
@@ -192,12 +193,13 @@ export const useFields = ( {
 					<DomainSite domain={ item } value={ field.getValue( { item } ) } />
 				),
 			},
-			// {
-			// 	id: 'ssl_status',
-			// 	label: __( 'SSL' ),
-			// 	enableHiding: false,
-			// 	enableSorting: true,
-			// },
+			{
+				id: 'ssl_status',
+				label: __( 'SSL' ),
+				enableHiding: true,
+				enableSorting: false,
+				render: ( { item } ) => <DomainSslField domain={ item } />,
+			},
 			{
 				id: 'expiry',
 				label: __( 'Expires/Renews on' ),

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -142,9 +142,14 @@ export const useFields = ( {
 			},
 			{
 				id: 'is_primary_domain',
+				label: __( 'Primary' ),
 				getValue: ( { item }: { item: DomainSummary } ) => item.primary_domain,
 				render: ( { field, item } ) =>
-					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : null,
+					field.getValue( { item } ) ? (
+						<Text>{ __( 'Primary' ) }</Text>
+					) : (
+						<Text variant="muted">—</Text>
+					),
 			},
 			{
 				id: 'type',

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -145,11 +145,7 @@ export const useFields = ( {
 				label: __( 'Primary' ),
 				getValue: ( { item }: { item: DomainSummary } ) => item.primary_domain,
 				render: ( { field, item } ) =>
-					field.getValue( { item } ) ? (
-						<Text>{ __( 'Primary' ) }</Text>
-					) : (
-						<Text variant="muted">—</Text>
-					),
+					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : <IneligibleIndicator />,
 			},
 			{
 				id: 'type',

--- a/client/dashboard/domains/dataviews/utils.ts
+++ b/client/dashboard/domains/dataviews/utils.ts
@@ -1,0 +1,5 @@
+export const textOverflowStyles = {
+	overflowX: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+} as const;

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -18,7 +18,7 @@ export const DEFAULT_VIEW: Partial< DomainsView > = {
 		'type',
 		// 'owner',
 		'blog_name',
-		// 'ssl_status',
+		'ssl_status',
 		'expiry',
 		'domain_status',
 	],

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -15,7 +15,6 @@ export const DEFAULT_VIEW: Partial< DomainsView > = {
 	titleField: 'domain',
 	// descriptionField: 'domain_type',
 	fields: [
-		'type',
 		// 'owner',
 		'blog_name',
 		'ssl_status',

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -24,6 +24,11 @@ export const DEFAULT_VIEW: Partial< DomainsView > = {
 	],
 };
 
+export const SITE_CONTEXT_VIEW: Partial< DomainsView > = {
+	...DEFAULT_VIEW,
+	fields: [ 'type', 'ssl_status', 'expiry', 'domain_status' ],
+};
+
 // Default layouts
 export const DEFAULT_LAYOUTS = {
 	table: {},

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -11,7 +11,7 @@ import { siteRoute } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
+import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
 import type { DomainsView } from '../../domains/dataviews';
 import type { SiteDomain } from '@automattic/api-core';
 
@@ -31,7 +31,7 @@ function SiteDomains() {
 	const actions = useActions( { user, site } );
 
 	const [ view, setView ] = useState< DomainsView >( () => ( {
-		...DEFAULT_VIEW,
+		...SITE_CONTEXT_VIEW,
 		type: 'table',
 	} ) );
 

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -8,7 +8,7 @@ import { useState, useMemo } from 'react';
 import { useAuth } from '../../app/auth';
 import { CalloutSkeleton } from '../../components/callout-skeleton';
 import { SectionHeader } from '../../components/section-header';
-import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
+import { useActions, useFields, SITE_CONTEXT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
@@ -38,7 +38,7 @@ const SiteDomainDataViews = ( {
 	const actions = useActions( { user, site } );
 
 	const [ initialView, setView ] = useState< DomainsView >( {
-		...DEFAULT_VIEW,
+		...SITE_CONTEXT_VIEW,
 		type,
 	} );
 

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -8,7 +8,7 @@ import { useState, useMemo } from 'react';
 import { useAuth } from '../../app/auth';
 import { CalloutSkeleton } from '../../components/callout-skeleton';
 import { SectionHeader } from '../../components/section-header';
-import { useActions, useFields, SITE_CONTEXT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
+import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
@@ -38,7 +38,7 @@ const SiteDomainDataViews = ( {
 	const actions = useActions( { user, site } );
 
 	const [ initialView, setView ] = useState< DomainsView >( {
-		...SITE_CONTEXT_VIEW,
+		...DEFAULT_VIEW,
 		type,
 	} );
 


### PR DESCRIPTION
Part of DOTDASH-190

## Proposed Changes

* Matches the domains table configuration with the Figma design
* Removes the Site column from the site context domains table
* Shows SSL column
* Creates dedicated field template files for easier maintenance

## Why are these changes being made?

* DOTDASH-190

## Testing Instructions

* Go to `/v2/domains`
* Check the domains table
* Select a site and go to the domains card
* The domains table should not have Site column

<img width="1248" height="638" alt="Screenshot 2025-09-08 at 13 09 14" src="https://github.com/user-attachments/assets/cd5ed048-9503-4bce-9c67-4ddbb8e593bf" />

<img width="1613" height="702" alt="Screenshot 2025-09-08 at 13 29 32" src="https://github.com/user-attachments/assets/9392c6bb-1d99-4c2b-b354-992fa1692f96" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
