### PR TITLE
Summer Special: Update config to enable Summer Special without enabling the banner.

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -983,14 +983,15 @@ const PlansFeaturesMain = ( {
 					</>
 				) }
 			</div>
-			{ config.isEnabled( 'summer-special-2025' ) && (
-				<AsyncLoad
-					require="calypso/blocks/summer-special-banner"
-					placeholder={ null }
-					visiblePlans={ gridPlansForFeaturesGrid }
-					isFixed
-				/>
-			) }
+			{ config.isEnabled( 'summer-special-2025' ) &&
+				config.isEnabled( 'summer-special-2025-banner' ) && (
+					<AsyncLoad
+						require="calypso/blocks/summer-special-banner"
+						placeholder={ null }
+						visiblePlans={ gridPlansForFeaturesGrid }
+						isFixed
+					/>
+				) }
 			{ isPlansGridReady && renderSiblingWhenLoaded?.() }
 		</>
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -34,6 +34,7 @@
 		"100-year-plan/vip": true,
 		"a4a-dev-sites": true,
 		"summer-special-2025": false,
+		"summer-special-2025-banner": false,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -40,6 +40,7 @@
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
 		"summer-special-2025": false,
+		"summer-special-2025-banner": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/production.json
+++ b/config/production.json
@@ -50,6 +50,7 @@
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
 		"summer-special-2025": false,
+		"summer-special-2025-banner": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -50,6 +50,7 @@
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
 		"summer-special-2025": false,
+		"summer-special-2025-banner": false,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,6 +57,7 @@
 		"hosting/datacenter-picker": true,
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
+		"summer-special-2025": false,
 		"summer-special-2025-banner": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,7 +57,7 @@
 		"hosting/datacenter-picker": true,
 		"hosting/hosting-features-callout": true,
 		"hosting-server-settings-enhancements": true,
-		"summer-special-2025": false,
+		"summer-special-2025-banner": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
## Proposed Changes

* Add a separate `summer-special-2025-banner` feature that controls enabling the banner. `summer-special-2025` must be `true` for this setting to do anything.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We'd like to enable Summer Special without also enabling the banner.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the development.json config file, set `summer-special-2025`  to `true` and `summer-special-2025-banner` to `true`  and visit `setup/onboarding/plans`. Confirm the banner is shown when a Personal or Premium plan is visible in the grid. 

* Update the development.json config file, set `summer-special-2025`  to `true` and `summer-special-2025-banner` to `false`  and visit `setup/onboarding/plans`. Confirm the banner is not shown when a Personal or Premium plan is visible in the grid. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
