### PR TITLE
Summer Special: Remove time limit in tooltip

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -816,38 +816,11 @@ const FEATURES_LIST: FeatureList = {
 				</span>
 			);
 		},
-		getDescription: () => {
-			const result = i18n.fixMe( {
-				text: 'Until %(date)s: Unlock plugin access on new Personal and Premium plans.',
-				newCopy: i18n.translate(
-					// translators: %(date)s is a date string in the format of "August 25, 2025"
-					'Until %(date)s: Unlock plugin access on new Personal and Premium plans.',
-					{
-						args: {
-							date: new Intl.DateTimeFormat( i18n.getLocaleSlug() || 'en-US', {
-								month: 'long',
-								day: 'numeric',
-								year: 'numeric',
-							} ).format( new Date( '2025-08-31' ) ),
-						},
-					}
-				),
-				oldCopy: i18n.translate(
-					// translators: %(date)s is a date string in the format of "August 25, 2025"
-					'One-time offer: Install plugins available in all paid plans. Valid until %(date)s!',
-					{
-						args: {
-							date: new Intl.DateTimeFormat( i18n.getLocaleSlug() || 'en-US', {
-								month: 'long',
-								day: 'numeric',
-								year: 'numeric',
-							} ).format( new Date( '2025-08-31' ) ),
-						},
-					}
-				),
-			} );
-			return result || '';
-		},
+		getDescription: () =>
+			i18n.translate(
+				'Plugins extend the functionality of your site and ' +
+					'open up endless possibilities for presenting your content and interacting with visitors.'
+			),
 	},
 
 	[ FEATURE_INSTALL_PLUGINS ]: {


### PR DESCRIPTION
## Proposed Changes

Update the copy to no longer mention a time-limited offer. Use the same tooltip used on Business plans.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable the Summer Special behavior without a time limit.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the development.json config file, set summer-special-2025 to true and visit `setup/onboarding/plans`. Confirm the tooltip you see for `Install Plugins` matches: 

<img width="464" height="225" alt="image" src="https://github.com/user-attachments/assets/3aa45b1d-714c-44b7-a30b-5901257eb715" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
