### PR TITLE
Plugins: Treat PayPal Payment Buttons as preinstalled to remove upgrade prompts

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -13,6 +13,7 @@ export const PREINSTALLED_PLUGINS = [
 	'full-site-editing',
 	'layout-grid',
 	'page-optimize',
+	'paypal-payment-buttons',
 ]; // These plugins auto update but shouldn't be deactivated.
 
 export const PREINSTALLED_PREMIUM_PLUGINS = {


### PR DESCRIPTION
## Proposed Changes

- Add `paypal-payment-buttons` to the `PREINSTALLED_PLUGINS` list in `/client/my-sites/plugins/constants.js`

## Why

The PayPal Payment Buttons plugin is bundled with Jetpack, which is installed on all WordPress.com sites. However, free users were seeing upgrade prompts when trying to use this plugin, which was confusing since the functionality is already available to them through Jetpack.

By adding it to the `PREINSTALLED_PLUGINS` list:
- Free users will no longer see upgrade prompts
- The plugin will show as "automatically managed for you" 
- Users can still activate/deactivate the plugin as needed

<img width="2892" height="2070" alt="CleanShot 2025-09-06 at 11 00 58@2x" src="https://github.com/user-attachments/assets/edbb9847-8f17-4853-a463-b578b004ef8d" />


<img width="1445" height="1035" alt="Screenshot 2025-09-06 at 11 02 07 AM" src="https://github.com/user-attachments/assets/69f7721f-37f1-4207-9418-0e17f4065daf" />


## Testing Instructions

1. As a free user on WordPress.com, navigate to the plugins page
2. Search for "PayPal Payment Buttons" or visit the plugin details page directly
3. Verify that:
   - The plugin shows as "Free" in price
   - It displays "PayPal Payment Buttons is automatically managed for you" instead of upgrade prompts
   - No "Upgrade my plan" button appears
   - The plugin can still be activated/deactivated if already installed

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (docs/CONTRIBUTING.md)
- [ ] Have you written new tests for your changes?
  - No new tests needed - this is a configuration change to an existing list
- [ ] Have you tested the feature in Simple sites, Atomic sites, and self-hosted Jetpack sites?
  - This change specifically affects Simple (WordPress.com) sites where Jetpack is preinstalled