### PR TITLE
Notifications v2: implement note list and note details shortcuts (fix crash)

### DIFF
--- a/apps/notifications/src/app/note-list/hooks.ts
+++ b/apps/notifications/src/app/note-list/hooks.ts
@@ -8,9 +8,9 @@ import type { Note } from '../types';
 
 import './style.scss';
 
-function focusToNote( noteListRef: React.RefObject< HTMLObjectElement >, note: Note ) {
+function focusToNote( noteListRef: React.RefObject< HTMLObjectElement >, note?: Note ) {
 	const noteEl = noteListRef.current?.querySelector(
-		`.dataviews-view-list__item[id$="-${ note.id }-item-wrapper"]`
+		`.dataviews-view-list__item[id$="-${ note?.id }-item-wrapper"]`
 	) as HTMLElement;
 
 	noteEl?.focus();


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/105578


## Proposed Changes

Fix crash after reading all Unread notifications

## Testing Instructions

1. Go to /v2
2. Click notification bell
3. Go to Unread
4. Read until the last notifications
5. Verify you can be redirected to the list again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
