### PR TITLE
launchpad: Fix translators comment position for sprintf

### DIFF
--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/launchpad",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Launchpad components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -60,23 +60,38 @@ const ChecklistItem: FC< Props > = ( {
 		const taskTitle = typeof title === 'string' ? title : String( title );
 
 		if ( completed ) {
-			/* translators: %s: Task title */
-			return sprintf( __( 'Completed: %s', 'launchpad' ), taskTitle );
+			return sprintf(
+				/* translators: %s: Task title */
+				__( 'Completed: %s', 'launchpad' ),
+				taskTitle
+			);
 		}
 		if ( disabled ) {
-			/* translators: %s: Task title */
-			return sprintf( __( 'Not available yet: %s', 'launchpad' ), taskTitle );
+			return sprintf(
+				/* translators: %s: Task title */
+				__( 'Not available yet: %s', 'launchpad' ),
+				taskTitle
+			);
 		}
 		if ( isClickable ) {
 			if ( isPrimaryAction ) {
-				/* translators: %s: Task title */
-				return sprintf( __( 'Start task: %s', 'launchpad' ), taskTitle );
+				return sprintf(
+					/* translators: %s: Task title */
+					__( 'Start task: %s', 'launchpad' ),
+					taskTitle
+				);
 			}
-			/* translators: %s: Task title in lowercase */
-			return sprintf( __( 'Select to %s', 'launchpad' ), taskTitle.toLowerCase() );
+			return sprintf(
+				/* translators: %s: Task title in lowercase */
+				__( 'Select to %s', 'launchpad' ),
+				taskTitle.toLowerCase()
+			);
 		}
-		/* translators: %s: Task title */
-		return sprintf( __( 'To do: %s', 'launchpad' ), taskTitle );
+		return sprintf(
+			/* translators: %s: Task title */
+			__( 'To do: %s', 'launchpad' ),
+			taskTitle
+		);
 	};
 
 	return (


### PR DESCRIPTION
Currently, the translators' comments for some components in the launchpad package are placed outside of sprintf, which end up getting stripped out in consumer components, resulting in a [build error for Jetpack](https://github.com/Automattic/jetpack/actions/runs/17544198235/job/49821765795?pr=45096#step:9:16919).

## Proposed Changes

* Move the translators comment inside `sprintf`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
