### PR TITLE
Fix typo in PaymentMethodDeleteDialog

### DIFF
--- a/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
@@ -87,7 +87,7 @@ export const PaymentMethodDeleteDialog = ( {
 									<Text>
 										{ sprintf(
 											// translators: date is a formatted renewal date
-											__( 'Renews on on %(date)s' ),
+											__( 'Renews on %(date)s' ),
 											{
 												date: formatDate( new Date( purchase.renew_date ), locale, {
 													dateStyle: 'long',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This fixes a small typo in the payment method deletion dialog added to the Hosting Dashboard (not yet live) added by https://github.com/Automattic/wp-calypso/pull/105388

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/v2/me/billing/payment-methods for an account with multiple payment methods (ideally including active credit cards, expired credit cards, and PayPal payment agreements). Try deleting a payment method for a credit card and verify that the text reads "Renews on X" instead of "Renews on on X".


