### PR TITLE
Hosting Dashboard: Scaffolding for the migration in progress UI

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -1,5 +1,6 @@
 import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
 import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
+import { isSiteMigrationInProgress } from '../utils/site-status';
 import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';
 import type { Site, User } from '@automattic/api-core';
 
@@ -62,10 +63,18 @@ export function canResetSite( site: Site ) {
 }
 
 export function canSwitchEnvironment( site: Site ) {
+	if ( isSiteMigrationInProgress( site ) ) {
+		return false;
+	}
+
 	return hasHostingFeature( site, HostingFeatures.STAGING_SITE );
 }
 
 export function canCreateStagingSite( site: Site ) {
+	if ( isSiteMigrationInProgress( site ) ) {
+		return false;
+	}
+
 	return (
 		hasHostingFeature( site, HostingFeatures.STAGING_SITE ) &&
 		! site.is_wpcom_staging_site &&

--- a/client/dashboard/sites/migration-in-progress/index.tsx
+++ b/client/dashboard/sites/migration-in-progress/index.tsx
@@ -1,0 +1,15 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import PageLayout from '../../components/page-layout';
+import { getSiteMigrationState } from '../../utils/site-status';
+
+export default function SiteMigrationInProgress( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const migrationState = getSiteMigrationState( site );
+
+	return (
+		<PageLayout size="small">
+			<h1>{ migrationState?.status }</h1>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -2,7 +2,6 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import ResponsiveMenu from '../../components/responsive-menu';
-import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import type { AppConfig, SiteFeatureSupports } from '../../app/context';
 import type { Site } from '@automattic/api-core';
@@ -20,16 +19,6 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			<ResponsiveMenu label={ __( 'Site Menu' ) }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
 					{ __( 'Trial ended' ) }
-				</ResponsiveMenu.Item>
-			</ResponsiveMenu>
-		);
-	}
-
-	if ( isSiteMigrationInProgress( site ) ) {
-		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-migration-in-progress` }>
-					{ __( 'Migration in progress' ) }
 				</ResponsiveMenu.Item>
 			</ResponsiveMenu>
 		);

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -2,6 +2,7 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import ResponsiveMenu from '../../components/responsive-menu';
+import { isSiteMigrationInProgress } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import type { AppConfig, SiteFeatureSupports } from '../../app/context';
 import type { Site } from '@automattic/api-core';
@@ -19,6 +20,16 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			<ResponsiveMenu label={ __( 'Site Menu' ) }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
 					{ __( 'Trial ended' ) }
+				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
+		);
+	}
+
+	if ( isSiteMigrationInProgress( site ) ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-migration-in-progress` }>
+					{ __( 'Migration in progress' ) }
 				</ResponsiveMenu.Item>
 			</ResponsiveMenu>
 		);

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -19,6 +19,7 @@ import MenuDivider from '../../components/menu-divider';
 import Switcher from '../../components/switcher';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { hasStagingSite } from '../../utils/site-staging-site';
+import { isSiteMigrationInProgress } from '../../utils/site-status';
 import AddNewSite from '../add-new-site';
 import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteIcon from '../site-icon';
@@ -80,8 +81,12 @@ function Site() {
 							<EnvironmentSwitcher site={ site } />
 						</>
 					) }
-					{ isDesktop && <MenuDivider /> }
-					<SiteMenu site={ site } />
+					{ ! isSiteMigrationInProgress( site ) && (
+						<>
+							{ isDesktop && <MenuDivider /> }
+							<SiteMenu site={ site } />
+						</>
+					) }
 				</HStack>
 			</HeaderBar>
 			<Outlet />

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -42,6 +42,37 @@ export function getSiteStatus( item: Site ) {
 	return 'public';
 }
 
+export function getSiteMigrationState( item: Site ) {
+	const { migration_status } = item.site_migration;
+	if ( migration_status === 'migration-in-progress' ) {
+		return { status: 'started', type: 'difm' };
+	}
+
+	const [ , status, type ] = migration_status?.split( '-' ) ?? [];
+	if ( ! [ 'pending', 'started', 'completed' ].includes( status ) ) {
+		return null;
+	}
+
+	if ( ! [ 'difm', 'diy' ].includes( type ) ) {
+		return null;
+	}
+
+	if ( ! status || ! type ) {
+		return null;
+	}
+
+	return { status, type };
+}
+
+export function isSiteMigrationInProgress( item: Site ) {
+	const { status } = getSiteMigrationState( item ) ?? {};
+	if ( ! status ) {
+		return false;
+	}
+
+	return [ 'pending', 'started' ].includes( status );
+}
+
 export function getSiteStatusLabel( item: Site ) {
 	return STATUS_LABELS[ getSiteStatus( item ) ];
 }


### PR DESCRIPTION
## Proposed Changes

Implement routing and page for the migration in progress screen. Site-level navigation items are not available.

<img width="1421" height="615" alt="SCR-20250908-pned" src="https://github.com/user-attachments/assets/bf413b5f-2354-4ba4-b447-475da709ba2b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a migration in progress site, head to /v2
* Click on the site 
* Ensure you see the blocking UI instead of the Site Overview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
