### PR TITLE
Staging Sites: Add staging site deletion callout overlay to site dashboard

### DIFF
--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,4 +1,4 @@
-import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, sitesQuery, isDeletingStagingSiteQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, notFound } from '@tanstack/react-router';
 import {
@@ -14,6 +14,7 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
+import { CalloutOverlay } from '../../components/callout-overlay';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
 import Switcher from '../../components/switcher';
@@ -23,6 +24,7 @@ import AddNewSite from '../add-new-site';
 import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteIcon from '../site-icon';
 import SiteMenu from '../site-menu';
+import { StagingSiteDeletionCallout } from '../staging-site-deletion-callout';
 import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
@@ -32,11 +34,16 @@ function Site() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
+	const { data: isStagingSiteDeletionInProgress } = useQuery( {
+		...isDeletingStagingSiteQuery( site.ID ),
+		enabled: !! site.ID,
+	} );
+
 	if ( ! canManageSite( site ) ) {
 		throw notFound();
 	}
 
-	return (
+	const siteContent = (
 		<>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
 			<HeaderBar>
@@ -86,6 +93,16 @@ function Site() {
 			</HeaderBar>
 			<Outlet />
 		</>
+	);
+
+	//const isStagingSiteDeletionInProgressX = true;
+
+	return (
+		<CalloutOverlay
+			showCallout={ !! isStagingSiteDeletionInProgress && site.is_wpcom_staging_site }
+			callout={ <StagingSiteDeletionCallout site={ site } /> }
+			main={ siteContent }
+		/>
 	);
 }
 

--- a/client/dashboard/sites/staging-site-deletion-callout.tsx
+++ b/client/dashboard/sites/staging-site-deletion-callout.tsx
@@ -1,0 +1,54 @@
+import { siteByIdQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { __experimentalText as Text, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import deleteStagingSiteIllustration from '../../sites/staging-site/components/staging-site-transfer-banner/delete-staging-site-illustration.svg';
+import { Callout } from '../components/callout';
+import { getProductionSiteId } from '../utils/site-staging-site';
+import type { Site } from '@automattic/api-core';
+
+export function StagingSiteDeletionCallout( { site }: { site: Site } ) {
+	const navigate = useNavigate();
+	const productionSiteId = Number( getProductionSiteId( site ) );
+	const { data: productionSite } = useQuery( {
+		...siteByIdQuery( productionSiteId ?? 0 ),
+		enabled: !! productionSiteId,
+	} );
+
+	const handleViewProductionSite = () => {
+		if ( productionSite?.slug ) {
+			navigate( {
+				to: '/sites/$siteSlug',
+				params: { siteSlug: productionSite.slug },
+			} );
+		}
+	};
+
+	return (
+		<Callout
+			title={ __( 'Deleting staging site' ) }
+			image={ deleteStagingSiteIllustration }
+			imageAlt={ __( 'Deleting staging site illustration' ) }
+			description={
+				<>
+					<Text as="p" variant="muted">
+						{ __(
+							"We're permanently deleting your staging site. Your live site is safe and won't be affected."
+						) }
+					</Text>
+					<Text as="p" variant="muted">
+						{ __( 'Hang tight, this may take a few moments.' ) }
+					</Text>
+				</>
+			}
+			actions={
+				productionSite && (
+					<Button variant="primary" __next40pxDefaultSize onClick={ handleViewProductionSite }>
+						{ __( 'Go to production site' ) }
+					</Button>
+				)
+			}
+		/>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14366

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
