### PR TITLE
Backups: add uploaded image preview

### DIFF
--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -17,11 +17,13 @@ import { ButtonStack } from '../../components/button-stack';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
+import { ImagePreview } from './image-preview';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
 
 export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; site: Site } ) {
 	const router = useRouter();
-	const formattedTime = useFormattedTime( backup.published, {
+	const publishedTimestamp = backup.published || backup.last_published;
+	const formattedTime = useFormattedTime( publishedTimestamp, {
 		dateStyle: 'medium',
 		timeStyle: 'short',
 	} );
@@ -90,6 +92,15 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 									sprintf( __( 'By %s' ), backup.actor.name )
 								}
 							</Text>
+						) }
+					</HStack>
+					<HStack justify="flex-start" style={ { flexWrap: 'wrap' } }>
+						{ backup.streams ? (
+							backup.streams.map( ( item, index ) => (
+								<ImagePreview key={ index } item={ item } multipleImages />
+							) )
+						) : (
+							<ImagePreview item={ backup } />
 						) }
 					</HStack>
 				</VStack>

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from '@tanstack/react-router';
 import {
+	__experimentalGrid as Grid,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -94,7 +95,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 							</Text>
 						) }
 					</HStack>
-					<HStack justify="flex-start" style={ { flexWrap: 'wrap' } }>
+					<Grid templateColumns="repeat(auto-fit, minmax(200px, 1fr))">
 						{ backup.streams ? (
 							backup.streams.map( ( item, index ) => (
 								<ImagePreview key={ index } item={ item } multipleImages />
@@ -102,7 +103,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 						) : (
 							<ImagePreview item={ backup } />
 						) }
-					</HStack>
+					</Grid>
 				</VStack>
 			</CardBody>
 		</Card>

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -31,7 +31,7 @@ export function BackupsList( {
 	const { backup, hasRecentlyCompleted } = useBackupState( site.ID );
 
 	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery( {
-		...siteRewindableActivityLogEntriesQuery( site.ID ),
+		...siteRewindableActivityLogEntriesQuery( site.ID, undefined, true ),
 		// Refetch the activity log every 3 seconds when a recent backup completed until the backup is found in the Activity Log
 		refetchInterval: ( query ) => {
 			if ( ! backup || ! hasRecentlyCompleted ) {

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -14,6 +14,8 @@ const FormattedTime = ( { timestamp }: { timestamp: string } ) => {
 	return <>{ formattedTime }</>;
 };
 
+const getPublishedTimestamp = ( item: ActivityLogEntry ) => item.published || item.last_published;
+
 export function getFields(): Field< ActivityLogEntry >[] {
 	return [
 		{
@@ -44,10 +46,10 @@ export function getFields(): Field< ActivityLogEntry >[] {
 				operators: [ 'on' ],
 			},
 			getValue: ( { item } ) => {
-				const date = new Date( item.published );
+				const date = new Date( getPublishedTimestamp( item ) );
 				return formatYmd( date );
 			},
-			render: ( { item } ) => <FormattedTime timestamp={ item.published } />,
+			render: ( { item } ) => <FormattedTime timestamp={ getPublishedTimestamp( item ) } />,
 		},
 		{
 			id: 'content_text',

--- a/client/dashboard/sites/backups/image-preview.tsx
+++ b/client/dashboard/sites/backups/image-preview.tsx
@@ -1,0 +1,28 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import type { ActivityLogEntry } from '@automattic/api-core';
+
+interface ImagePreviewProps {
+	item: ActivityLogEntry;
+	multipleImages?: boolean;
+}
+
+export function ImagePreview( { item, multipleImages = false }: ImagePreviewProps ) {
+	if ( ! item.image?.available ) {
+		return null;
+	}
+
+	const { image } = item;
+
+	return (
+		<VStack>
+			<a href={ image.url } target="_blank" rel="noopener noreferrer">
+				<img
+					src={ image.medium_url }
+					alt={ image.name }
+					style={ { maxWidth: '256px', maxHeight: '256px' } }
+				/>
+			</a>
+			{ multipleImages && <Text weight={ 500 }>{ image.name }</Text> }
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/backups/image-preview.tsx
+++ b/client/dashboard/sites/backups/image-preview.tsx
@@ -19,7 +19,7 @@ export function ImagePreview( { item, multipleImages = false }: ImagePreviewProp
 				<img
 					src={ image.medium_url }
 					alt={ image.name }
-					style={ { maxWidth: '256px', maxHeight: '256px' } }
+					style={ { width: '100%', aspectRatio: '1 / 1', objectFit: 'cover' } }
 				/>
 			</a>
 			{ multipleImages && <Text weight={ 500 }>{ image.name }</Text> }

--- a/packages/api-core/src/site-activity-log/fetchers.ts
+++ b/packages/api-core/src/site-activity-log/fetchers.ts
@@ -18,7 +18,7 @@ export async function fetchSiteActivityLog(
 
 export async function fetchSiteRewindableActivityLog(
 	siteId: number,
-	{ number }: { number: number }
+	{ number, aggregate }: { number: number; aggregate: boolean }
 ): Promise< ActivityLog > {
 	return wpcom.req.get(
 		{
@@ -27,6 +27,7 @@ export async function fetchSiteRewindableActivityLog(
 		},
 		{
 			number,
+			aggregate,
 		}
 	);
 }

--- a/packages/api-core/src/site-activity-log/fetchers.ts
+++ b/packages/api-core/src/site-activity-log/fetchers.ts
@@ -18,7 +18,7 @@ export async function fetchSiteActivityLog(
 
 export async function fetchSiteRewindableActivityLog(
 	siteId: number,
-	{ number, aggregate }: { number: number; aggregate: boolean }
+	{ number, aggregate = false }: { number: number; aggregate?: boolean }
 ): Promise< ActivityLog > {
 	return wpcom.req.get(
 		{

--- a/packages/api-core/src/site-activity-log/types.ts
+++ b/packages/api-core/src/site-activity-log/types.ts
@@ -7,6 +7,13 @@ export interface ActivityLogEntry {
 		text: string;
 	};
 	gridicon: string;
+	image?: {
+		available: boolean;
+		medium_url: string;
+		name: string;
+		url: string;
+	};
+	last_published: string;
 	name: string;
 	object?: {
 		backup_type?: string;
@@ -20,6 +27,7 @@ export interface ActivityLogEntry {
 	published: string;
 	rewind_id: string;
 	summary: string;
+	streams: ActivityLogEntry[];
 }
 
 export interface ActivityLog {

--- a/packages/api-queries/src/site-activity-log.ts
+++ b/packages/api-queries/src/site-activity-log.ts
@@ -10,10 +10,11 @@ export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
 
 export const siteRewindableActivityLogEntriesQuery = (
 	siteId: number,
-	number: number = 1000 // 1000 is the maximum number of entries that can be fetched.
+	number: number = 1000, // 1000 is the maximum number of entries that can be fetched.
+	aggregate: boolean = false
 ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'activity-log', 'rewindable', number ],
-		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number } ),
+		queryKey: [ 'site', siteId, 'activity-log', 'rewindable', number, aggregate ],
+		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number, aggregate } ),
 		select: ( data ) => data.current?.orderedItems?.slice( 0, number ) ?? [],
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-354][1].

## Proposed Changes

This PR adds the uploaded image preview for backup entries.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, only the image name is being shown.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`.
- Check different `Image uploaded` entries:

### Single image uploaded individually

<img width="1252" height="841" alt="image" src="https://github.com/user-attachments/assets/4a8c2bf6-9258-4e2b-a7bd-51ea756cc155" />

### Single image uploaded to a post

<img width="1251" height="830" alt="image" src="https://github.com/user-attachments/assets/6d827927-0311-40cb-956f-c3a9e997d942" />

### Multiple images uploaded together

<img width="1251" height="536" alt="image" src="https://github.com/user-attachments/assets/e912dc3b-4f8c-4cd1-9891-3fc4ca102310" />
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-354