### PR TITLE
Domains: Fix the width of domain search when adding a domain to existing site

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -636,7 +636,7 @@ class RegisterDomainStep extends Component {
 					cart={ this.getCart() }
 					className="wpcom-domain-search-v2 initial-state"
 				>
-					<VStack spacing={ 8 }>
+					<VStack spacing={ 8 } style={ { width: '100%' } }>
 						<VStack spacing={ 2 }>
 							<HStack spacing={ 4 } className="wpcom-domain-search-v2__empty-state-search-controls">
 								{ this.renderSearchBar() }
@@ -689,7 +689,7 @@ class RegisterDomainStep extends Component {
 				cart={ this.getCart() }
 				className="wpcom-domain-search-v2"
 			>
-				<VStack spacing={ 8 }>
+				<VStack spacing={ 8 } style={ { width: '100%' } }>
 					<VStack spacing={ 4 }>
 						{ this.renderSearchControls() }
 						{ isDomainAndPlanPackageFlow && this.renderQuickFilters() }


### PR DESCRIPTION
Part of [DOMAINS-1647](https://linear.app/a8c/issue/DOMAINS-1647)

## Proposed Changes

This PR fixes the width of domain search when adding a domain to an existing site.

## Why are these changes being made?

The domain search area was too narrow after #105625

### Screenshots

| Before | After |
| --- | --- |
| <img width="963" height="930" alt="Screenshot 2025-09-08 at 16 14 11" src="https://github.com/user-attachments/assets/6ca18701-2556-406b-a421-ff005d2431ce" /> | <img width="1072" height="695" alt="Screenshot 2025-09-08 at 16 10 37" src="https://github.com/user-attachments/assets/95d5d5a0-dea3-4117-bf20-dc5ce7692be4" /> |

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to a test site
- Go to the domains section and click the "Add new domain" button
- Ensure the domain search component covers the whole width of the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
