### PR TITLE
Plugins: remove Persistent Login from marketplace

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -84,8 +84,9 @@ export const ECOMMERCE_BUNDLED_PLUGINS = [
 
 export const UNLISTED_PLUGINS = [
 	'automated-db-schenker-shipping',
-	'wp-fusion-lite',
 	'social-blend',
+	'wp-fusion-lite',
+	'wp-persistent-login',
 ];
 
 export const WPBEGINNER_PLUGINS = [


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTPAR-3/marketplace-remove-persistent-login-from-dotcom

## Testing Instructions
* Check out this branch
* Visit the `/plugins/wp-persistent-login` page and make sure it says plugin not found
* Visit `/plugins` and search for `Persistent Login` or `persistent-login`
* Ensure the "Persistent Login" plugin doesn't appear in searches
