### PR TITLE
Summer Special: Remove Install plugins feature custom styling

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { MaterialIcon, ExternalLink, Gridicon } from '@automattic/components';
+import { MaterialIcon, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatNumber } from '@automattic/number-formatters';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from '@automattic/urls';
@@ -799,23 +799,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL ]: {
 		getSlug: () => FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL,
-		getTitle: () => {
-			return (
-				<span style={ { fontWeight: 500 } }>
-					{ i18n.translate( 'Install plugins' ) }
-					<Gridicon
-						icon="info-outline"
-						size={ 16 }
-						style={ {
-							fill: 'var(--studio-blue-50)',
-							verticalAlign: 'middle',
-							marginLeft: '2px',
-							marginTop: '-2px',
-						} }
-					/>
-				</span>
-			);
-		},
+		getTitle: () => i18n.translate( 'Install plugins' ),
 		getDescription: () =>
 			i18n.translate(
 				'Plugins extend the functionality of your site and ' +


### PR DESCRIPTION
## Proposed Changes

Remove the custom `Install plugins` styling for Personal and Premium.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Align the styling across all plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding/plans` and confirm the `Install plugins` feature does not have custom styling.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?