### PR TITLE
Domain Search Rewrite: Make /setup/domain flow functional

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -12,9 +12,24 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 	};
 };
 
+const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
+
+const getInitialQuery = () => {
+	try {
+		return sessionStorage.getItem( SESSION_STORAGE_QUERY_KEY ) ?? '';
+	} catch {
+		return '';
+	}
+};
+
+const setInitialQuery = ( query: string ) => {
+	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
+};
+
 const DomainSearchWithCart = ( {
 	currentSiteId,
 	flowName,
+	initialQuery: externalInitialQuery,
 	config: externalConfig,
 	...props
 }: DomainSearchProps ) => {
@@ -24,6 +39,10 @@ const DomainSearchWithCart = ( {
 		cartKey,
 		flowName,
 	} );
+
+	const initialQuery = useMemo( () => {
+		return externalInitialQuery ?? getInitialQuery();
+	}, [ externalInitialQuery ] );
 
 	const config = useMemo( () => {
 		return {
@@ -38,13 +57,24 @@ const DomainSearchWithCart = ( {
 	const events = useMemo( () => {
 		return {
 			...props.events,
+			onQueryChange: ( query: string ) => {
+				setInitialQuery( query );
+			},
 			onContinue: () => {
 				props.events?.onContinue?.( items );
 			},
 		};
 	}, [ props.events, items ] );
 
-	return <DomainSearch { ...props } config={ config } cart={ cart } events={ events } />;
+	return (
+		<DomainSearch
+			{ ...props }
+			config={ config }
+			cart={ cart }
+			events={ events }
+			initialQuery={ initialQuery }
+		/>
+	);
 };
 
 export const WPCOMDomainSearch = ( props: DomainSearchProps ) => {

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -1,12 +1,15 @@
 import { DomainSearch } from '@automattic/domain-search';
-import { ShoppingCartProvider } from '@automattic/shopping-cart';
+import { ResponseCartProduct, ShoppingCartProvider } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps } from 'react';
 import { shoppingCartManagerClient } from 'calypso/dashboard/app/shopping-cart';
 import { useWPCOMShoppingCartForDomainSearch } from './use-wpcom-shopping-cart-for-domain-search';
 
-type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' > & {
+type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | 'events' > & {
 	currentSiteId?: number;
 	flowName: string;
+	events?: Omit< Required< ComponentProps< typeof DomainSearch > >[ 'events' ], 'onContinue' > & {
+		onContinue?: ( items: ResponseCartProduct[] ) => void;
+	};
 };
 
 const DomainSearchWithCart = ( {
@@ -17,7 +20,7 @@ const DomainSearchWithCart = ( {
 }: DomainSearchProps ) => {
 	const cartKey = currentSiteId ?? 'no-site';
 
-	const { cart, isNextDomainFree } = useWPCOMShoppingCartForDomainSearch( {
+	const { cart, isNextDomainFree, items } = useWPCOMShoppingCartForDomainSearch( {
 		cartKey,
 		flowName,
 	} );
@@ -32,7 +35,16 @@ const DomainSearchWithCart = ( {
 		};
 	}, [ externalConfig, isNextDomainFree ] );
 
-	return <DomainSearch { ...props } config={ config } cart={ cart } />;
+	const events = useMemo( () => {
+		return {
+			...props.events,
+			onContinue: () => {
+				props.events?.onContinue?.( items );
+			},
+		};
+	}, [ props.events, items ] );
+
+	return <DomainSearch { ...props } config={ config } cart={ cart } events={ events } />;
 };
 
 export const WPCOMDomainSearch = ( props: DomainSearchProps ) => {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -77,6 +77,10 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 			onRemoveItem: ( uuid ) => removeProductFromCart( uuid ),
 		};
 
-		return { cart, isNextDomainFree: responseCart.next_domain_is_free };
+		return {
+			cart,
+			isNextDomainFree: responseCart.next_domain_is_free,
+			items: domainItems,
+		};
 	}, [ responseCart, removeProductFromCart, addProductsToCart, flowName ] );
 };

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -19,7 +19,6 @@ import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
 import { type FlowV2, type SubmitHandler } from '../../internals/types';
-import type { DomainSuggestion } from '@automattic/api-core';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
 	const isDomainsStep = currentStepSlug === 'domains';
@@ -58,7 +57,7 @@ const domain: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	initialize,
 	useStepNavigation( currentStepSlug, navigate ) {
-		const { setDomain, setDomainCartItem, setDomainCartItems, setSiteUrl, setSignupDomainOrigin } =
+		const { setDomainCartItem, setDomainCartItems, setSiteUrl, setSignupDomainOrigin } =
 			useDispatch( ONBOARD_STORE ) as OnboardActions;
 
 		const { signupDomainOrigin } = useSelect(
@@ -75,7 +74,7 @@ const domain: FlowV2< typeof initialize > = {
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
-				case 'domains':
+				case STEPS.DOMAIN_SEARCH.slug:
 					if ( ! providedDependencies ) {
 						throw new Error( 'No provided dependencies found' );
 					}
@@ -102,13 +101,12 @@ const domain: FlowV2< typeof initialize > = {
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
-				case 'use-my-domain':
+				case STEPS.USE_MY_DOMAIN.slug:
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 					if ( providedDependencies?.mode && providedDependencies?.domain ) {
 						setUseMyDomainTracksEventProps( {

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -34,7 +34,15 @@ const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => 
 };
 
 function initialize() {
-	const steps = [ STEPS.DOMAIN_SEARCH, STEPS.USE_MY_DOMAIN ];
+	const steps = [
+		STEPS.DOMAIN_SEARCH,
+		STEPS.USE_MY_DOMAIN,
+		STEPS.NEW_OR_EXISTING_SITE,
+		STEPS.SITE_PICKER,
+		STEPS.PLANS,
+		STEPS.SITE_CREATION_STEP,
+		STEPS.PROCESSING,
+	];
 
 	return stepsWithRequiredLogin( steps );
 }
@@ -99,7 +107,7 @@ const domain: FlowV2< typeof initialize > = {
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
-					return;
+					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
 				case 'use-my-domain':
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 					if ( providedDependencies?.mode && providedDependencies?.domain ) {
@@ -127,6 +135,29 @@ const domain: FlowV2< typeof initialize > = {
 					} );
 
 					return;
+
+				case STEPS.NEW_OR_EXISTING_SITE.slug:
+					if ( providedDependencies.newExistingSiteChoice === 'domain' ) {
+						return window.location.assign(
+							addQueryArgs( '/checkout/no-site', {
+								redirect_to: '/domains/manage',
+								signup: 0,
+								isDomainOnly: 1,
+								checkoutBackUrl: addQueryArgs(
+									'/setup/domain/new-or-existing-site',
+									window.location.search
+								),
+							} )
+						);
+					}
+
+					if ( providedDependencies.newExistingSiteChoice === 'existing-site' ) {
+						return navigate( STEPS.SITE_PICKER.slug );
+					}
+
+					if ( providedDependencies.newExistingSiteChoice === 'new-site' ) {
+						return navigate( STEPS.PLANS.slug );
+					}
 				default:
 					return;
 			}

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -72,20 +72,13 @@ const domain: FlowV2< typeof initialize > = {
 						throw new Error( 'No provided dependencies found' );
 					}
 
-					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
-					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
-					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
-					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
-
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
 						currentQueryArgs.step = 'domain-input';
 
 						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
 
-						const lastQueryParam = ( providedDependencies?.domainForm as { lastQuery?: string } )
-							?.lastQuery;
+						const lastQueryParam = providedDependencies.lastQuery;
 
 						if ( lastQueryParam !== undefined ) {
 							currentQueryArgs.initialQuery = lastQueryParam;
@@ -99,6 +92,12 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
 					return;
 				case 'use-my-domain':

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -43,7 +43,7 @@ function initialize() {
 		STEPS.USE_MY_DOMAIN,
 		STEPS.NEW_OR_EXISTING_SITE,
 		STEPS.SITE_PICKER,
-		STEPS.PLANS,
+		STEPS.UNIFIED_PLANS,
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
 	];
@@ -207,7 +207,7 @@ const domain: FlowV2< typeof initialize > = {
 					}
 
 					if ( providedDependencies.newExistingSiteChoice === 'new-site' ) {
-						return navigate( STEPS.PLANS.slug );
+						return navigate( STEPS.UNIFIED_PLANS.slug );
 					}
 
 					return;
@@ -226,7 +226,7 @@ const domain: FlowV2< typeof initialize > = {
 					return navigate( STEPS.PROCESSING.slug );
 				}
 
-				case STEPS.PLANS.slug: {
+				case STEPS.UNIFIED_PLANS.slug: {
 					const cartItems = providedDependencies.cartItems;
 					const [ pickedPlan, ...products ] = cartItems ?? [];
 

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -130,7 +130,10 @@ const domain: FlowV2< typeof initialize > = {
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: `/domains/manage/${ siteSlug }`,
 								signup: 1,
-								checkoutBackUrl: new URL( `/domains/add/${ siteSlug }`, window.location.href ).href,
+								cancel_to: new URL(
+									addQueryArgs( '/setup/domain', { siteSlug } ),
+									window.location.href
+								).href,
 							} )
 						);
 					}
@@ -195,7 +198,7 @@ const domain: FlowV2< typeof initialize > = {
 								redirect_to: '/domains/manage',
 								signup: 0,
 								isDomainOnly: 1,
-								checkoutBackUrl: new URL(
+								cancel_to: new URL(
 									addQueryArgs( '/setup/domain/new-or-existing-site', window.location.search ),
 									window.location.href
 								).href,
@@ -273,8 +276,8 @@ const domain: FlowV2< typeof initialize > = {
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 									redirect_to: destination,
 									signup: 1,
-									checkoutBackUrl: new URL(
-										`/domains/add/${ providedDependencies.siteSlug }`,
+									cancel_to: new URL(
+										addQueryArgs( '/setup/domain', { siteSlug } ),
 										window.location.href
 									).href,
 								} )

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -1,5 +1,5 @@
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
-import { DOMAIN_FLOW, clearStepPersistedState } from '@automattic/onboarding';
+import { DOMAIN_FLOW, addProductsToCart, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -10,14 +10,19 @@ import {
 	clearSignupCompleteFlowName,
 	clearSignupDestinationCookie,
 	clearSignupCompleteSiteID,
+	setSignupCompleteFlowName,
+	persistSignupDestination,
+	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
+import { useSiteData } from '../../../hooks/use-site-data';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
+import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type SubmitHandler } from '../../internals/types';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
@@ -57,12 +62,22 @@ const domain: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	initialize,
 	useStepNavigation( currentStepSlug, navigate ) {
-		const { setDomainCartItem, setDomainCartItems, setSiteUrl, setSignupDomainOrigin } =
-			useDispatch( ONBOARD_STORE ) as OnboardActions;
+		const {
+			setDomainCartItem,
+			setDomainCartItems,
+			setSiteUrl,
+			setSignupDomainOrigin,
+			setPlanCartItem,
+			setProductCartItems,
+			setPendingAction,
+		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 
-		const { signupDomainOrigin } = useSelect(
+		const { siteSlug } = useSiteData();
+
+		const { signupDomainOrigin, productCartItems } = useSelect(
 			( select ) => ( {
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+				productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
 			} ),
 			[]
 		);
@@ -105,6 +120,20 @@ const domain: FlowV2< typeof initialize > = {
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
+					if ( siteSlug ) {
+						setSignupCompleteFlowName( this.name );
+						setSignupCompleteSlug( siteSlug );
+
+						// replace the location to delete processing step from history.
+						return window.location.assign(
+							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
+								redirect_to: `/domains/manage/${ siteSlug }`,
+								signup: 1,
+								checkoutBackUrl: new URL( `/domains/add/${ siteSlug }`, window.location.href ).href,
+							} )
+						);
+					}
+
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
 				case STEPS.USE_MY_DOMAIN.slug:
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
@@ -141,10 +170,10 @@ const domain: FlowV2< typeof initialize > = {
 								redirect_to: '/domains/manage',
 								signup: 0,
 								isDomainOnly: 1,
-								checkoutBackUrl: addQueryArgs(
-									'/setup/domain/new-or-existing-site',
-									window.location.search
-								),
+								checkoutBackUrl: new URL(
+									addQueryArgs( '/setup/domain/new-or-existing-site', window.location.search ),
+									window.location.href
+								).href,
 							} )
 						);
 					}
@@ -156,6 +185,81 @@ const domain: FlowV2< typeof initialize > = {
 					if ( providedDependencies.newExistingSiteChoice === 'new-site' ) {
 						return navigate( STEPS.PLANS.slug );
 					}
+
+					return;
+
+				case STEPS.SITE_PICKER.slug: {
+					setPendingAction( async () => {
+						await addProductsToCart( providedDependencies.siteSlug, this.name, productCartItems );
+
+						return {
+							siteSlug: providedDependencies.siteSlug,
+							goToCheckout: true,
+							siteCreated: false,
+						};
+					} );
+
+					return navigate( STEPS.PROCESSING.slug );
+				}
+
+				case STEPS.PLANS.slug: {
+					const cartItems = providedDependencies.cartItems;
+					const [ pickedPlan, ...products ] = cartItems ?? [];
+
+					setPlanCartItem( pickedPlan );
+
+					if ( ! pickedPlan ) {
+						// Since we're removing the paid domain, it means that the user chose to continue
+						// with a free domain. Because signupDomainOrigin should reflect the last domain
+						// selection status before they land on the checkout page, this value can be
+						// 'free' or 'choose-later'
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
+					}
+
+					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
+					setProductCartItems( products.filter( ( product ) => product !== null ) );
+
+					setSignupCompleteFlowName( this.name );
+					return navigate( STEPS.SITE_CREATION_STEP.slug, undefined, false );
+				}
+				case STEPS.SITE_CREATION_STEP.slug:
+					return navigate( STEPS.PROCESSING.slug, undefined, true );
+				case STEPS.PROCESSING.slug: {
+					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
+						const destination = `/domains/manage/${ providedDependencies.siteSlug }`;
+
+						persistSignupDestination( destination );
+						setSignupCompleteFlowName( this.name );
+						setSignupCompleteSlug( providedDependencies.siteSlug );
+
+						if ( providedDependencies.goToCheckout ) {
+							const siteSlug = providedDependencies.siteSlug as string;
+
+							// replace the location to delete processing step from history.
+							window.location.replace(
+								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
+									redirect_to: destination,
+									signup: 1,
+									checkoutBackUrl: new URL(
+										`/domains/add/${ providedDependencies.siteSlug }`,
+										window.location.href
+									).href,
+								} )
+							);
+						} else {
+							// replace the location to delete processing step from history.
+							window.location.replace( destination );
+						}
+					} else {
+						// TODO: Handle errors
+						// navigate( 'error' );
+					}
+					return;
+				}
 				default:
 					return;
 			}
@@ -165,7 +269,8 @@ const domain: FlowV2< typeof initialize > = {
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE ) as OnboardActions;
+		const { siteId } = useSiteData();
 
 		/**
 		 * Clears every state we're persisting during the flow
@@ -175,14 +280,14 @@ const domain: FlowV2< typeof initialize > = {
 		useEffect( () => {
 			if ( ! currentStepSlug ) {
 				resetOnboardStore();
-				reduxDispatch( setSelectedSiteId( null ) );
+				reduxDispatch( setSelectedSiteId( siteId ) );
 				clearStepPersistedState( this.name );
 				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
 				clearSignupCompleteSiteID();
 			}
-		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+		}, [ currentStepSlug, reduxDispatch, resetOnboardStore, siteId ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
+import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import {
 	clearSignupCompleteSlug,
 	clearSignupCompleteFlowName,
@@ -213,6 +214,10 @@ const domain: FlowV2< typeof initialize > = {
 					return;
 
 				case STEPS.SITE_PICKER.slug: {
+					if ( ! siteHasPaidPlan( providedDependencies.site ) ) {
+						return navigate( STEPS.UNIFIED_PLANS.slug );
+					}
+
 					setPendingAction( async () => {
 						await addProductsToCart( providedDependencies.siteSlug, this.name, productCartItems );
 

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -137,7 +137,12 @@ const domain: FlowV2< typeof initialize > = {
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
 				case STEPS.USE_MY_DOMAIN.slug:
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
-					if ( providedDependencies?.mode && providedDependencies?.domain ) {
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
 						setUseMyDomainTracksEventProps( {
 							...useMyDomainTracksEventProps,
 							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
@@ -161,7 +166,26 @@ const domain: FlowV2< typeof initialize > = {
 						providedDependencies: useMyDomainTracksEventProps,
 					} );
 
-					return;
+					if ( siteSlug && providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setSignupCompleteFlowName( this.name );
+						setSignupCompleteSlug( siteSlug );
+
+						setPendingAction( async () => {
+							await addProductsToCart( siteSlug, this.name, [
+								providedDependencies.domainCartItem,
+							] );
+
+							return {
+								siteSlug,
+								goToCheckout: true,
+								siteCreated: false,
+							};
+						} );
+
+						return navigate( STEPS.PROCESSING.slug );
+					}
+
+					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
 
 				case STEPS.NEW_OR_EXISTING_SITE.slug:
 					if ( providedDependencies.newExistingSiteChoice === 'domain' ) {

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -27,8 +27,6 @@ import type { DomainSuggestion } from '@automattic/api-core';
 import type { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import type { Store } from 'redux';
 
-const DOMAINS_STEP = STEPS.UNIFIED_DOMAINS;
-
 async function initialize( reduxStore: Store ) {
 	const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;
 
@@ -43,7 +41,7 @@ async function initialize( reduxStore: Store ) {
 	const steps = [];
 
 	if ( showDomainStep ) {
-		steps.push( DOMAINS_STEP );
+		steps.push( STEPS.UNIFIED_DOMAINS );
 	}
 
 	const utmSource = queryParams.get( 'utm_source' );
@@ -115,7 +113,7 @@ const hosting: FlowV2< typeof initialize > = {
 
 		const getGoBack = () => {
 			if ( _currentStepSlug === STEPS.UNIFIED_PLANS.slug && showDomainStep ) {
-				return () => navigate( DOMAINS_STEP.slug );
+				return () => navigate( STEPS.UNIFIED_DOMAINS.slug );
 			}
 
 			if ( _currentStepSlug === STEPS.TRIAL_ACKNOWLEDGE.slug ) {
@@ -127,7 +125,7 @@ const hosting: FlowV2< typeof initialize > = {
 			const { slug, providedDependencies } = submittedStep;
 
 			switch ( slug ) {
-				case DOMAINS_STEP.slug: {
+				case STEPS.UNIFIED_DOMAINS.slug: {
 					if ( ! providedDependencies ) {
 						throw new Error( 'No provided dependencies found' );
 					}

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -7,7 +7,6 @@ import { useEffect } from 'react';
 import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -28,9 +27,7 @@ import type { DomainSuggestion } from '@automattic/api-core';
 import type { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import type { Store } from 'redux';
 
-const DOMAINS_STEP = shouldRenderRewrittenDomainSearch()
-	? STEPS.DOMAIN_SEARCH
-	: STEPS.UNIFIED_DOMAINS;
+const DOMAINS_STEP = STEPS.UNIFIED_DOMAINS;
 
 async function initialize( reduxStore: Store ) {
 	const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -161,6 +161,12 @@ const onboarding: FlowV2< typeof initialize > = {
 						throw new Error( 'No provided dependencies found' );
 					}
 
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
 						currentQueryArgs.step = 'domain-input';
@@ -182,12 +188,6 @@ const onboarding: FlowV2< typeof initialize > = {
 						} );
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}
-
-					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
-					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
-					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
-					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
 					return navigate( 'plans' );
 				case 'use-my-domain':

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -192,7 +192,12 @@ const onboarding: FlowV2< typeof initialize > = {
 					return navigate( 'plans' );
 				case 'use-my-domain':
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
-					if ( providedDependencies?.mode && providedDependencies?.domain ) {
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
 						setUseMyDomainTracksEventProps( {
 							...useMyDomainTracksEventProps,
 							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -162,12 +162,6 @@ const onboarding: FlowV2< typeof initialize > = {
 						throw new Error( 'No provided dependencies found' );
 					}
 
-					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
-					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
-					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
-					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
-
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
 						currentQueryArgs.step = 'domain-input';
@@ -189,6 +183,12 @@ const onboarding: FlowV2< typeof initialize > = {
 						} );
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
 					return navigate( 'plans' );
 				case 'use-my-domain':

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -8,7 +8,6 @@ import { useState, useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { pathToUrl } from 'calypso/lib/url';
@@ -58,7 +57,7 @@ const withLocale = ( url: string, locale: string ) => {
 
 function initialize() {
 	const steps = [
-		shouldRenderRewrittenDomainSearch() ? STEPS.DOMAIN_SEARCH : STEPS.UNIFIED_DOMAINS,
+		STEPS.UNIFIED_DOMAINS,
 		STEPS.USE_MY_DOMAIN,
 		STEPS.UNIFIED_PLANS,
 		STEPS.SITE_CREATION_STEP,

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -5,6 +5,7 @@ import {
 	NEW_HOSTED_SITE_FLOW,
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	DOMAIN_FLOW,
 } from '@automattic/onboarding';
 
 const FLOWS_USING_STEP_CONTAINER_V2 = [
@@ -14,6 +15,7 @@ const FLOWS_USING_STEP_CONTAINER_V2 = [
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	SITE_MIGRATION_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	DOMAIN_FLOW,
 ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -13,10 +13,30 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useQuery } from '../../../../hooks/use-query';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
+import type { DomainSuggestion } from '@automattic/api-core';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 import './style.scss';
 
-const DomainSearchStep: StepType = function DomainSearchStep( { flow } ) {
+type UseMyDomain = {
+	navigateToUseMyDomain: true;
+	siteUrl?: string;
+	domainItem?: MinimalRequestCartProduct;
+	lastQuery?: string;
+};
+
+type StepSubmission = {
+	navigateToUseMyDomain?: never;
+	siteUrl?: string;
+	suggestion: DomainSuggestion;
+	domainItem: MinimalRequestCartProduct;
+	domainCart: MinimalRequestCartProduct[];
+	signupDomainOrigin?: string;
+};
+
+const DomainSearchStep: StepType< {
+	submits: UseMyDomain | StepSubmission;
+} > = function DomainSearchStep( { navigation, flow } ) {
 	const initialQuery = useQuery().get( 'new' ) ?? '';
 
 	const config = {
@@ -49,6 +69,14 @@ const DomainSearchStep: StepType = function DomainSearchStep( { flow } ) {
 					flowName={ flow }
 					config={ config }
 					initialQuery={ initialQuery }
+					events={ {
+						onExternalDomainClick: ( domainName ) => {
+							navigation.submit( {
+								navigateToUseMyDomain: true,
+								lastQuery: domainName,
+							} );
+						},
+					} }
 				/>
 			</Step.CenteredColumnLayout>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -11,6 +11,7 @@ import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-searc
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useQuery } from '../../../../hooks/use-query';
+import { useSite } from '../../../../hooks/use-site';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -35,7 +36,8 @@ type StepSubmission = {
 const DomainSearchStep: StepType< {
 	submits: UseMyDomain | StepSubmission;
 } > = function DomainSearchStep( { navigation, flow } ) {
-	const initialQuery = useQuery().get( 'new' ) ?? '';
+	const site = useSite();
+	const initialQuery = useQuery().get( 'new' ) ?? site?.slug ?? '';
 
 	const config = {
 		vendor: getSuggestionsVendor( {
@@ -64,6 +66,7 @@ const DomainSearchStep: StepType< {
 			>
 				<WPCOMDomainSearch
 					className="step-container-v2-domain-search"
+					currentSiteId={ site?.ID }
 					flowName={ flow }
 					config={ config }
 					initialQuery={ initialQuery }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -13,7 +13,6 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useQuery } from '../../../../hooks/use-query';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import type { DomainSuggestion } from '@automattic/api-core';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 import './style.scss';
@@ -28,7 +27,6 @@ type UseMyDomain = {
 type StepSubmission = {
 	navigateToUseMyDomain?: never;
 	siteUrl?: string;
-	suggestion: DomainSuggestion;
 	domainItem: MinimalRequestCartProduct;
 	domainCart: MinimalRequestCartProduct[];
 	signupDomainOrigin?: string;
@@ -74,6 +72,12 @@ const DomainSearchStep: StepType< {
 							navigation.submit( {
 								navigateToUseMyDomain: true,
 								lastQuery: domainName,
+							} );
+						},
+						onContinue: ( items ) => {
+							navigation.submit( {
+								domainCart: items,
+								domainItem: items[ 0 ],
 							} );
 						},
 					} }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -37,7 +37,7 @@ const DomainSearchStep: StepType< {
 	submits: UseMyDomain | StepSubmission;
 } > = function DomainSearchStep( { navigation, flow } ) {
 	const site = useSite();
-	const initialQuery = useQuery().get( 'new' ) ?? site?.slug ?? '';
+	const initialQuery = useQuery().get( 'new' ) ?? site?.slug;
 
 	const config = {
 		vendor: getSuggestionsVendor( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -1,5 +1,4 @@
 import {
-	DOMAIN_FLOW,
 	isDomainFlow,
 	isHundredYearDomainFlow,
 	isHundredYearPlanFlow,
@@ -51,7 +50,7 @@ const DomainSearchStep: StepType< {
 		},
 	};
 
-	if ( shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW ) {
+	if ( shouldUseStepContainerV2( flow ) ) {
 		return (
 			<Step.CenteredColumnLayout
 				topBar={ <Step.TopBar /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -53,7 +53,13 @@ const DomainSearchStep: StepType< {
 	if ( shouldUseStepContainerV2( flow ) ) {
 		return (
 			<Step.CenteredColumnLayout
-				topBar={ <Step.TopBar /> }
+				topBar={
+					<Step.TopBar
+						leftElement={
+							navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
+						}
+					/>
+				}
 				columnWidth={ 10 }
 				className="step-container-v2--domain-search"
 				heading={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -7,3 +7,9 @@
 		--domain-search-full-cart-z-index: 3;
 	}
 }
+
+.step-container-v2--domain-search {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -107,20 +107,36 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 		case DOMAIN_FLOW: {
 			const options = [
 				{
-					key: 'existing-site',
-					title: translate( 'Existing WordPress.com site' ),
-					description: '',
-					icon: <WordPressLogo size={ 24 } />,
-					value: 'existing-site',
-					actionText: translate( 'Select a site' ),
-				},
-				{
 					key: 'new-site',
 					title: translate( 'New site' ),
-					description: '',
+					description: translate(
+						'Customize and launch your site.{{br/}}{{freeDomainPromo}}Free domain for the first year on annual plans.{{/freeDomainPromo}}',
+						{
+							components: {
+								freeDomainPromo: <span className="new-or-existing-site__free-domain-promo" />,
+								br: <br aria-hidden="true" />,
+							},
+						}
+					),
 					icon: <NewSiteIcon />,
 					value: 'new-site',
 					actionText: translate( 'Create a new site' ),
+				},
+				{
+					key: 'existing-site',
+					title: translate( 'Existing WordPress.com site' ),
+					description: translate(
+						'Use the domain with a site you already started.{{br/}}{{freeDomainPromo}}Free domain for the first year on annual plans.{{/freeDomainPromo}}',
+						{
+							components: {
+								freeDomainPromo: <span className="new-or-existing-site__free-domain-promo" />,
+								br: <br aria-hidden="true" />,
+							},
+						}
+					),
+					icon: <WordPressLogo size={ 24 } />,
+					value: 'existing-site',
+					actionText: translate( 'Select a site' ),
 				},
 			];
 
@@ -144,7 +160,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 
 const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: ChoiceType } } > =
 	function NewOrExistingSiteStep( { navigation, flow } ) {
-		const { submit } = navigation;
+		const { submit, goBack } = navigation;
 		const translate = useTranslate();
 
 		const intents = useIntentsForFlow( flow );
@@ -180,8 +196,11 @@ const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: Choic
 		if ( flow === DOMAIN_FLOW ) {
 			return (
 				<Step.CenteredColumnLayout
-					columnWidth={ 6 }
-					topBar={ <Step.TopBar /> }
+					columnWidth={ 5 }
+					className="step-container-v2--new-or-existing-site"
+					topBar={
+						<Step.TopBar leftElement={ goBack ? <Step.BackButton onClick={ goBack } /> : null } />
+					}
 					heading={ <Step.Heading text={ getHeaderText() } subText={ getSubHeaderText() } /> }
 				>
 					<IntentScreen

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -9,7 +9,11 @@ import {
 	isStartWritingFlow,
 	START_WRITING_FLOW,
 	READYMADE_TEMPLATE_FLOW,
+	DOMAIN_FLOW,
+	Step,
 } from '@automattic/onboarding';
+import { Icon } from '@wordpress/components';
+import { globe } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -17,7 +21,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import NewSiteIcon from './icons/new-site';
 import { ChoiceType } from './types';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 
 import './styles.scss';
 
@@ -80,19 +84,46 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 					actionText: translate( 'Start a new site' ),
 				},
 			];
+		case DOMAIN_FLOW:
+			return [
+				{
+					key: 'domain',
+					title: translate( 'Just buy a domain' ),
+					description: translate( 'Add a site later.' ),
+					icon: <Icon icon={ globe } />,
+					value: 'domain',
+					actionText: translate( 'Continue' ),
+				},
+				{
+					key: 'existing-site',
+					title: translate( 'Existing WordPress.com site' ),
+					description: '',
+					icon: <WordPressLogo size={ 24 } />,
+					value: 'existing-site',
+					actionText: translate( 'Select a site' ),
+				},
+				{
+					key: 'new-site',
+					title: translate( 'New site' ),
+					description: '',
+					icon: <NewSiteIcon />,
+					value: 'new-site',
+					actionText: translate( 'Create a new site' ),
+				},
+			];
 		default:
 			return [];
 	}
 };
 
-const NewOrExistingSiteStep: Step< { submits: { newExistingSiteChoice: ChoiceType } } > =
+const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: ChoiceType } } > =
 	function NewOrExistingSiteStep( { navigation, flow } ) {
 		const { submit } = navigation;
 		const translate = useTranslate();
 
 		const intents = useIntentsForFlow( flow );
 
-		const newOrExistingSiteSelected = ( value: ChoiceType ) => {
+		const onSelect = ( value: ChoiceType ) => {
 			submit?.( { newExistingSiteChoice: value } );
 		};
 
@@ -104,10 +135,38 @@ const NewOrExistingSiteStep: Step< { submits: { newExistingSiteChoice: ChoiceTyp
 				case HUNDRED_YEAR_PLAN_FLOW:
 				case HUNDRED_YEAR_DOMAIN_FLOW:
 					return translate( 'Start your legacy' );
+				case DOMAIN_FLOW:
+					return translate( 'Choose how to use your domain' );
 				default:
 					return null;
 			}
 		};
+
+		const getSubHeaderText = () => {
+			switch ( flow ) {
+				case DOMAIN_FLOW:
+					return translate( 'Don’t worry, you can easily change it later.' );
+				default:
+					return null;
+			}
+		};
+
+		if ( flow === DOMAIN_FLOW ) {
+			return (
+				<Step.CenteredColumnLayout
+					columnWidth={ 6 }
+					topBar={ <Step.TopBar /> }
+					heading={ <Step.Heading text={ getHeaderText() } subText={ getSubHeaderText() } /> }
+				>
+					<IntentScreen
+						intents={ intents }
+						onSelect={ onSelect }
+						preventWidows={ preventWidows }
+						intentsAlt={ [] }
+					/>
+				</Step.CenteredColumnLayout>
+			);
+		}
 
 		const Container = [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( flow )
 			? HundredYearPlanStepWrapper
@@ -118,12 +177,18 @@ const NewOrExistingSiteStep: Step< { submits: { newExistingSiteChoice: ChoiceTyp
 				stepContent={
 					<IntentScreen
 						intents={ intents }
-						onSelect={ newOrExistingSiteSelected }
+						onSelect={ onSelect }
 						preventWidows={ preventWidows }
 						intentsAlt={ [] }
 					/>
 				}
-				formattedHeader={ <FormattedHeader brandFont headerText={ getHeaderText() } /> }
+				formattedHeader={
+					<FormattedHeader
+						brandFont
+						headerText={ getHeaderText() }
+						subHeaderText={ getSubHeaderText() }
+					/>
+				}
 				justifyStepContent="center"
 				stepName="new-or-existing-site"
 				flowName={ flow }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { WordPressLogo } from '@automattic/components';
+import { type OnboardSelect } from '@automattic/data-stores';
 import {
 	type SelectItem,
 	IntentScreen,
@@ -13,11 +14,13 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { Icon } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { globe } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
+import { ONBOARD_STORE } from '../../../../stores';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import NewSiteIcon from './icons/new-site';
 import { ChoiceType } from './types';
@@ -28,6 +31,23 @@ import './styles.scss';
 type NewOrExistingSiteIntent = SelectItem< ChoiceType >;
 
 const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
+	const { productCartItems, domainCartItem } = useSelect(
+		( select ) => ( {
+			signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
+		} ),
+		[]
+	);
+
+	const mergedCartItems = [ domainCartItem, ...( productCartItems ?? [] ) ].filter(
+		( item ) => !! item
+	);
+
+	const hasDomainOperation = mergedCartItems.some( ( item ) =>
+		[ 'domain_transfer', 'domain_map' ].includes( item.product_slug )
+	);
+
 	const translate = useTranslate();
 	switch ( flowName ) {
 		case HUNDRED_YEAR_PLAN_FLOW:
@@ -84,16 +104,8 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 					actionText: translate( 'Start a new site' ),
 				},
 			];
-		case DOMAIN_FLOW:
-			return [
-				{
-					key: 'domain',
-					title: translate( 'Just buy a domain' ),
-					description: translate( 'Add a site later.' ),
-					icon: <Icon icon={ globe } />,
-					value: 'domain',
-					actionText: translate( 'Continue' ),
-				},
+		case DOMAIN_FLOW: {
+			const options = [
 				{
 					key: 'existing-site',
 					title: translate( 'Existing WordPress.com site' ),
@@ -111,6 +123,20 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 					actionText: translate( 'Create a new site' ),
 				},
 			];
+
+			if ( ! hasDomainOperation ) {
+				options.unshift( {
+					key: 'domain',
+					title: translate( 'Just buy a domain' ),
+					description: translate( 'Add a site later.' ),
+					icon: <Icon icon={ globe } />,
+					value: 'domain',
+					actionText: translate( 'Continue' ),
+				} );
+			}
+
+			return options as NewOrExistingSiteIntent[];
+		}
 		default:
 			return [];
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -21,6 +21,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import { ONBOARD_STORE } from '../../../../stores';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import NewSiteIcon from './icons/new-site';
 import { ChoiceType } from './types';
@@ -193,7 +194,7 @@ const NewOrExistingSiteStep: StepType< { submits: { newExistingSiteChoice: Choic
 			}
 		};
 
-		if ( flow === DOMAIN_FLOW ) {
+		if ( shouldUseStepContainerV2( flow ) ) {
 			return (
 				<Step.CenteredColumnLayout
 					columnWidth={ 5 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -1,6 +1,20 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
+.step-container-v2--new-or-existing-site {
+	.select-items__item {
+		width: auto;
+	}
+
+	.select-items__item-info-wrapper {
+		align-items: center;
+	}
+}
+
+.new-or-existing-site__free-domain-promo {
+	color: var(--studio-green-60);
+}
+
 .hundred-year-plan-step-wrapper.new-or-existing-site {
 	.formatted-header {
 		.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/types.ts
@@ -1,1 +1,1 @@
-export type ChoiceType = 'new-site' | 'existing-site';
+export type ChoiceType = 'new-site' | 'existing-site' | 'domain';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,16 +1,16 @@
-import { DOMAIN_FLOW, StepContainer } from '@automattic/onboarding';
+import { DOMAIN_FLOW, Step, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import SiteSelector from 'calypso/components/site-selector';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { SiteId } from 'calypso/types';
 
 import './styles.scss';
 
-const SitePicker: Step< {
+const SitePicker: StepType< {
 	submits: {
 		siteSlug: string;
 		siteId: SiteId;
@@ -36,16 +36,33 @@ const SitePicker: Step< {
 		);
 	};
 
+	const stepContent = (
+		<>
+			<QuerySites allSites />
+			<SiteSelector filter={ filter } onSiteSelect={ selectSite } />
+		</>
+	);
+
+	if ( flow === DOMAIN_FLOW ) {
+		return (
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				className="step-container-v2--site-picker"
+				topBar={
+					<Step.TopBar leftElement={ goBack ? <Step.BackButton onClick={ goBack } /> : null } />
+				}
+				heading={ <Step.Heading text={ translate( 'Select your site' ) } /> }
+			>
+				{ stepContent }
+			</Step.CenteredColumnLayout>
+		);
+	}
+
 	return (
 		<>
 			<StepContainer
-				stepName="site-picker"
-				stepContent={
-					<div className="site-picker__container">
-						<QuerySites allSites />
-						<SiteSelector filter={ filter } onSiteSelect={ selectSite } />
-					</div>
-				}
+				stepName="site-picker-step"
+				stepContent={ <div className="site-picker__container">{ stepContent }</div> }
 				formattedHeader={
 					<FormattedHeader align="center" headerText={ translate( 'Select your site' ) } />
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,8 +1,9 @@
-import { DOMAIN_FLOW, Step, StepContainer } from '@automattic/onboarding';
+import { isDomainFlow, Step, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import SiteSelector from 'calypso/components/site-selector';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step as StepType } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -26,7 +27,7 @@ const SitePicker: StepType< {
 	};
 
 	const filter = ( site: SiteDetails ) => {
-		const isSiteUnlaunched = flow !== DOMAIN_FLOW ? site.launch_status === 'unlaunched' : true;
+		const isSiteUnlaunched = isDomainFlow( flow ) ? true : site.launch_status === 'unlaunched';
 
 		return !! (
 			site.capabilities?.manage_options &&
@@ -44,7 +45,7 @@ const SitePicker: StepType< {
 		</>
 	);
 
-	if ( flow === DOMAIN_FLOW ) {
+	if ( shouldUseStepContainerV2( flow ) ) {
 		return (
 			<Step.CenteredColumnLayout
 				columnWidth={ 4 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { DOMAIN_FLOW, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -25,12 +25,14 @@ const SitePicker: Step< {
 	};
 
 	const filter = ( site: SiteDetails ) => {
+		const isSiteUnlaunched = flow !== DOMAIN_FLOW ? site.launch_status === 'unlaunched' : true;
+
 		return !! (
 			site.capabilities?.manage_options &&
 			( site.is_wpcom_atomic || ! site.jetpack ) &&
 			! site.options?.is_wpforteams_site &&
 			! site.is_wpcom_staging_site &&
-			site.launch_status === 'unlaunched'
+			isSiteUnlaunched
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -14,6 +14,7 @@ const SitePicker: StepType< {
 	submits: {
 		siteSlug: string;
 		siteId: SiteId;
+		site: SiteDetails;
 	};
 } > = function SitePicker( { navigation, flow } ) {
 	const translate = useTranslate();
@@ -21,7 +22,7 @@ const SitePicker: StepType< {
 
 	const selectSite = ( siteId: SiteId, site: SiteDetails ) => {
 		const siteSlug = site.URL ? new URL( site.URL ).host : '';
-		submit?.( { siteSlug, siteId } );
+		submit?.( { siteSlug, siteId, site } );
 	};
 
 	const filter = ( site: SiteDetails ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -2,7 +2,21 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "../hundred-year-plan-step-wrapper/mixins";
 
-.site-picker {
+.step-container-v2--site-picker {
+	.sites-list {
+		border: 1px solid var(--studio-gray-5);
+	}
+
+	.site {
+		cursor: pointer;
+
+		&:hover {
+			background-color: var(--studio-gray-0);
+		}
+	}
+}
+
+.site-picker-step {
 	.step-container__header {
 		margin: 44px 24px 24px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -1,6 +1,7 @@
 import { OnboardSelect } from '@automattic/data-stores';
 import {
 	AI_SITE_BUILDER_FLOW,
+	DOMAIN_FLOW,
 	EXAMPLE_FLOW,
 	NEW_HOSTED_SITE_FLOW,
 	NEWSLETTER_FLOW,
@@ -166,7 +167,8 @@ const PlansStepAdaptor: StepType< {
 		setPlanInterval( intervalType );
 	};
 
-	const isUsingStepContainerV2 = shouldUseStepContainerV2( props.flow );
+	const isUsingStepContainerV2 =
+		shouldUseStepContainerV2( props.flow ) || props.flow === DOMAIN_FLOW;
 
 	if ( isLoadingSelectedTheme ) {
 		return isUsingStepContainerV2 ? <Step.Loading /> : <Loading />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -4,6 +4,7 @@ import { UrlFriendlyTermType } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
+	DOMAIN_FLOW,
 	isNewHostedSiteCreationFlow,
 	isTailoredSignupFlow,
 	ONBOARDING_FLOW,
@@ -389,7 +390,8 @@ function UnifiedPlansStep( {
 	}
 
 	const deemphasizeFreePlan =
-		( ONBOARDING_FLOW === flowName && ( paidDomainName != null || isPaidTheme ) ) ||
+		( [ ONBOARDING_FLOW, DOMAIN_FLOW ].includes( flowName ) &&
+			( paidDomainName != null || isPaidTheme ) ) ||
 		deemphasizeFreePlanFromProps;
 
 	const getSubheaderText = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -5,6 +5,7 @@ import {
 	StepContainer,
 	isStartWritingFlow,
 	Step,
+	DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -108,7 +109,7 @@ const UseMyDomain: StepType< {
 					isStepper
 					stepLocation={ location }
 					registerNowAction={ handleGoBack }
-					hideHeader={ shouldUseStepContainerV2( flow ) }
+					hideHeader={ shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW }
 				/>
 			</CalypsoShoppingCartProvider>
 		);
@@ -118,6 +119,7 @@ const UseMyDomain: StepType< {
 		switch ( flow ) {
 			case START_WRITING_FLOW:
 			case ONBOARDING_FLOW:
+			case DOMAIN_FLOW:
 				return getBlogOnboardingFlowStepContent();
 			default:
 				return getDefaultStepContent();
@@ -126,7 +128,7 @@ const UseMyDomain: StepType< {
 
 	const shouldHideButtons = isStartWritingFlow( flow );
 
-	if ( shouldUseStepContainerV2( flow ) ) {
+	if ( shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW ) {
 		const [ columnWidth, headingText ] =
 			useMyDomainMode === 'domain-input'
 				? [ 4 as const, __( 'Use a domain I own' ) ]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -7,6 +7,7 @@ import {
 	Step,
 	DOMAIN_FLOW,
 } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -33,6 +34,7 @@ const UseMyDomain: StepType< {
 				mode: 'transfer' | 'connect';
 				domain: string;
 		  }
+		| { domainCartItem: MinimalRequestCartProduct }
 		| undefined;
 } > = function UseMyDomain( { navigation, flow } ) {
 	const { __ } = useI18n();
@@ -64,7 +66,7 @@ const UseMyDomain: StepType< {
 		setHideFreePlan( true );
 		setDomainCartItem( domainCartItem );
 
-		submit?.( undefined );
+		submit?.( { domainCartItem } );
 	};
 
 	const handleOnConnect = async ( domain: string ) => {
@@ -72,7 +74,7 @@ const UseMyDomain: StepType< {
 		setHideFreePlan( true );
 		setDomainCartItem( domainCartItem );
 
-		submit?.( undefined );
+		submit?.( { domainCartItem } );
 	};
 
 	const getInitialQuery = function () {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -111,7 +111,7 @@ const UseMyDomain: StepType< {
 					isStepper
 					stepLocation={ location }
 					registerNowAction={ handleGoBack }
-					hideHeader={ shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW }
+					hideHeader={ shouldUseStepContainerV2( flow ) }
 				/>
 			</CalypsoShoppingCartProvider>
 		);
@@ -130,7 +130,7 @@ const UseMyDomain: StepType< {
 
 	const shouldHideButtons = isStartWritingFlow( flow );
 
-	if ( shouldUseStepContainerV2( flow ) || flow === DOMAIN_FLOW ) {
+	if ( shouldUseStepContainerV2( flow ) ) {
 		const [ columnWidth, headingText ] =
 			useMyDomainMode === 'domain-input'
 				? [ 4 as const, __( 'Use a domain I own' ) ]

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -145,12 +145,13 @@ export const useCreateSite = () => {
 	/**
 	 * Support singular and multiple domain cart items.
 	 */
-	const mergedDomainCartItems = Array.isArray( domains?.domainCart )
-		? domains?.domainCart.slice( 0 )
-		: [];
+	const mergedDomainCartItems =
+		domains && 'domainCart' in domains && Array.isArray( domains.domainCart )
+			? domains.domainCart.slice( 0 )
+			: [];
 
 	if ( domains?.domainItem ) {
-		mergedDomainCartItems.push( domains?.domainItem );
+		mergedDomainCartItems.push( domains.domainItem );
 	}
 
 	return useMutation( {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -1,6 +1,6 @@
 import { isFreePlan, PLAN_FREE } from '@automattic/calypso-products';
 import { FREE_THEME } from '@automattic/design-picker';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { DOMAIN_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useCallback } from '@wordpress/element';
 import {
 	FREE_PLAN_FREE_DOMAIN_DIALOG,
@@ -51,7 +51,7 @@ export function useModalResolutionCallback( {
 			// TODO: look into decoupling the flowName from here as well.
 			if (
 				paidDomainName &&
-				( ( flowName && ONBOARDING_FLOW === flowName ) ||
+				( ( flowName && [ ONBOARDING_FLOW, DOMAIN_FLOW ].includes( flowName ) ) ||
 					[ 'plans-jetpack-app-site-creation', 'plans-site-selected-legacy' ].includes(
 						intent || ''
 					) )

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1240,7 +1240,11 @@ class RenderDomainsStepComponent extends Component {
 					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
 				}
 				isOnboarding
-				sideContent={ ! shouldUseStepContainerV2( this.props.flowName ) && this.getSideContent() }
+				sideContent={
+					! this.props.useStepperWrapper &&
+					! shouldUseStepContainerV2( this.props.flowName ) &&
+					this.getSideContent()
+				}
 				isInLaunchFlow={ 'launch-site' === this.props.flowName }
 				promptText={
 					isHostingSignupFlow( this.props.flowName )
@@ -1527,7 +1531,7 @@ class RenderDomainsStepComponent extends Component {
 			return null;
 		}
 
-		if ( shouldUseStepContainerV2( flowName ) ) {
+		if ( this.props.useStepperWrapper && shouldUseStepContainerV2( flowName ) ) {
 			return (
 				<Step.LinkButton onClick={ this.handleUseYourDomainClick }>
 					{ translate( 'Use a domain I already own' ) }
@@ -1672,7 +1676,7 @@ class RenderDomainsStepComponent extends Component {
 			} );
 		}
 
-		if ( shouldUseStepContainerV2( flowName ) ) {
+		if ( this.props.useStepperWrapper && shouldUseStepContainerV2( flowName ) ) {
 			const [ content, sideContent ] = this.getContentColumns();
 
 			const backButton = ( backUrl || goBack ) && (
@@ -1788,7 +1792,7 @@ const StyleWrappedDomainsStepComponent = ( props ) => {
 	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( props.flowName );
 
 	if ( isLoading ) {
-		if ( shouldUseStepContainerV2( props.flowName ) ) {
+		if ( props.useStepperWrapper && shouldUseStepContainerV2( props.flowName ) ) {
 			return <Step.Loading />;
 		}
 

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -20,6 +20,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onRegisterDomainClick: noop,
 		onCheckTransferStatusClick: noop,
 		onMapDomainClick: noop,
+		onQueryChange: noop,
 	},
 	queries: {
 		availableTlds: ( search?: string, vendor?: string ) => availableTldsQuery( vendor, search ),
@@ -137,7 +138,10 @@ export const useDomainSearchContextValue = (
 			closeFullCart,
 			openFullCart,
 			query,
-			setQuery,
+			setQuery: ( query ) => {
+				setQuery( query );
+				normalizedEvents.onQueryChange( query );
+			},
 			slots,
 			currentSiteUrl,
 			filter,

--- a/packages/domain-search/src/page/initial-state.tsx
+++ b/packages/domain-search/src/page/initial-state.tsx
@@ -1,9 +1,20 @@
 import { SearchForm } from '../components/search-form';
+import { DomainSearchAlreadyOwnDomainCTA } from '../ui';
+import { useDomainSearch } from './context';
 
 export const InitialState = () => {
+	const {
+		events: { onExternalDomainClick },
+	} = useDomainSearch();
+
 	return (
 		<div className="domain-search--initial-state">
 			<SearchForm />
+			{ onExternalDomainClick && (
+				<div className="domain-search--initial-state__already-own-domain-cta">
+					<DomainSearchAlreadyOwnDomainCTA onClick={ () => onExternalDomainClick() } />
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -27,11 +27,19 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+		flex: 1;
 	}
 
 	.domain-search--initial-state {
 		width: 100%;
 		max-width: var( --domain-search-initial-state-max-width );
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.domain-search--initial-state__already-own-domain-cta {
+		margin-top: auto !important;
 	}
 
 	.domain-search--results {

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -32,7 +32,7 @@ export interface DomainSearchCart {
 export interface DomainSearchEvents {
 	onContinue: () => void;
 	onSkip: ( suggestion?: FreeDomainSuggestion ) => void;
-	onExternalDomainClick?: ( domainName: string ) => void;
+	onExternalDomainClick?: ( domainName?: string ) => void;
 	onMakePrimaryAddressClick: ( domainName: string ) => void;
 	onMoveDomainToSiteClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onTransferDomainToWordPressComClick: ( domainName: string ) => void;

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -39,6 +39,7 @@ export interface DomainSearchEvents {
 	onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onCheckTransferStatusClick: ( domainName: string ) => void;
 	onMapDomainClick: ( currentSiteSlug: string, domainName: string ) => void;
+	onQueryChange: ( query: string ) => void;
 }
 
 export interface DomainSearchConfig {

--- a/packages/domain-search/src/ui/domain-search-already-own-domain-cta/style.scss
+++ b/packages/domain-search/src/ui/domain-search-already-own-domain-cta/style.scss
@@ -1,4 +1,9 @@
 .domain-search-already-own-domain-cta {
+	&.summary-button.components-button {
+		width: auto;
+		margin: 0 auto;
+	}
+
 	.summary-button-description {
 		text-align: left;
 	}


### PR DESCRIPTION
Closes DOMAINS-1617.

## Proposed Changes

Adds the flow to purchase a domain, be it for a site or domain-only. Allows starting with a pre-selected site through the `siteSlug` query parameter.

Soon I'll work on adding an E2E to it, so don't worry if there are bugs here and there, although I think I fixed all of them.

## Testing Instructions

### Domain only

1. Enter `/setup/domain`, search and domains to the cart.
2. Click "Continue" and you should see the "Choose how to use your domain" step.
3. Pick the "Just buy a domain" option.

Verify you end up at checkout with the domains in the cart.

### Domain to new site

1. Enter `/setup/domain`, search and domains to the cart.
2. Click "Continue" and you should see the "Choose how to use your domain" step.
3. Pick the "New site" option.
4. Pick a plan.

Verify you end up at checkout with the domains in the cart and the new site.

### Domain to existing free site

1. Enter `/setup/domain`, search and domains to the cart.
2. Click "Continue" and you should see the "Choose how to use your domain" step.
3. Pick the "Existing WordPress.com site" option.
4. Pick a site in the free plan and verify you see the plans step.
5. Add the personal plan to it.

Verify you end up at checkout with the domains in the cart to be added to the existing site (e.g., the URL is `/checkout/%s`).

### Domain to existing paid site

1. Enter `/setup/domain`, search and domains to the cart.
2. Click "Continue" and you should see the "Choose how to use your domain" step.
3. Pick the "Existing WordPress.com site" option.
4. Pick a site in any paid plan.

Verify you end up at checkout with the domains in the cart to be added to the existing site (e.g., the URL is `/checkout/%s`).

### Transfer a domain

1. Enter `/setup/domain` and either click the "Already own a domain?" CTA at the bottom, or search for some existing domain (e.g., `zaguini.me`) and click the "Already yours? Bring it over" button.
2. Verify you see the "use your domain" step with the domain suggestion preselected. Click continue.

Click "Transfer" and "Connect," then add a new site or pick an existing site.

Verify you DON'T see the "Domain only" option at the "Choose how to use your domain" step. 

Verify you end up with the domain transfer or connection item at checkout.

### Pre-selected site

Go through the test instructions again, but this time add `?siteSlug=%s` to the URL.

Apart from the scenario verifications, verify you never see the site picker, and the checkout reflects the site passed to the query parameter.