### PR TITLE
Remove the `sortProductsByPriceDescending` function

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -100,11 +100,7 @@ import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import DomainsMiniCart from './domains-mini-cart';
-import {
-	getExternalBackUrl,
-	shouldUseMultipleDomainsInCart,
-	sortProductsByPriceDescending,
-} from './utils';
+import { getExternalBackUrl, shouldUseMultipleDomainsInCart } from './utils';
 import './style.scss';
 
 class RenderDomainsStepComponent extends Component {
@@ -799,17 +795,15 @@ class RenderDomainsStepComponent extends Component {
 					productsInCart = productsInCart.filter( ( product ) => {
 						return ! this.state.domainsWithMappingError.includes( product.meta );
 					} );
-					// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
-					const sortedProducts = sortProductsByPriceDescending( productsInCart );
 					this.props.shoppingCartManager
-						.replaceProductsInCart( sortedProducts )
+						.replaceProductsInCart( productsInCart )
 						.then( () => {
 							this.setState( { replaceDomainFailedMessage: null } );
 							if ( this.state.domainAddingQueue?.length > 0 ) {
 								this.setState( ( state ) => ( {
 									domainAddingQueue: state.domainAddingQueue.filter(
 										( domainInQueue ) =>
-											! sortedProducts.find( ( item ) => item.meta === domainInQueue.meta )
+											! productsInCart.find( ( item ) => item.meta === domainInQueue.meta )
 									),
 								} ) );
 							}
@@ -817,7 +811,7 @@ class RenderDomainsStepComponent extends Component {
 								this.setState( ( state ) => ( {
 									temporaryCart: state.temporaryCart.filter(
 										( temporaryCart ) =>
-											! sortedProducts.find( ( item ) => item.meta === temporaryCart.meta )
+											! productsInCart.find( ( item ) => item.meta === temporaryCart.meta )
 									),
 								} ) );
 							}
@@ -966,7 +960,7 @@ class RenderDomainsStepComponent extends Component {
 		const { step, cart, multiDomainDefaultPlan, shoppingCartManager, goToNextStep } = this.props;
 		const { lastDomainSearched } = step.domainForm ?? {};
 
-		const domainCart = sortProductsByPriceDescending( getDomainsInCart( this.props.cart ) );
+		const domainCart = getDomainsInCart( this.props.cart );
 		const { suggestion } = step;
 		const isPurchasingItem =
 			( suggestion && Boolean( suggestion.product_slug ) ) || domainCart?.length > 0;

--- a/client/signup/steps/domains/test/utils.js
+++ b/client/signup/steps/domains/test/utils.js
@@ -6,7 +6,6 @@ import {
 	getExternalBackUrl,
 	backUrlExternalSourceStepsOverrides,
 	backUrlSourceOverrides,
-	sortProductsByPriceDescending,
 } from '../utils';
 
 const backUrlSourceOverrideKeys = Object.keys( backUrlSourceOverrides );
@@ -44,113 +43,5 @@ describe( 'getExternalBackUrl', () => {
 		);
 		expect( result ).toBe( 'https://wordpress.com' );
 		expect( result ).toBeTruthy();
-	} );
-} );
-
-describe( 'sortProductsByPriceDescending', () => {
-	test( 'should sort products by item_subtotal_integer', async () => {
-		const products = [
-			{
-				meta: 'domain.com',
-				item_subtotal_integer: 200, // The price we consider when sorting.
-				cost_overrides: [],
-				item_original_cost_integer: 200,
-			},
-			{
-				meta: 'domain.net',
-				item_subtotal_integer: 100, // The price we consider when sorting.
-				cost_overrides: [],
-				item_original_cost_integer: 100,
-			},
-		];
-
-		const sortedProducts = sortProductsByPriceDescending( products );
-		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.com' );
-		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.net' );
-	} );
-
-	test( 'should sort products by item_original_cost_integer', async () => {
-		const products = [
-			{
-				meta: 'domain.com',
-				item_subtotal_integer: 2000, // The price we consider when sorting.
-				cost_overrides: [],
-				item_original_cost_integer: 2000,
-			},
-			{
-				meta: 'domain.kitchen',
-				item_subtotal_integer: 0,
-				cost_overrides: [
-					{
-						old_price: 40,
-						new_price: 0,
-						reason: 'bundled domain credit for 1st year',
-					},
-				],
-				item_original_cost_integer: 4000, // The price we consider when sorting.
-			},
-		];
-
-		const sortedProducts = sortProductsByPriceDescending( products );
-		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.kitchen' );
-		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.com' );
-	} );
-
-	test( 'should sort products considering cost_overrides', async () => {
-		const products = [
-			{
-				meta: 'domain.store',
-				item_subtotal_integer: 96,
-				cost_overrides: [
-					{
-						old_price: 48,
-						new_price: 0.96, // The price we consider when sorting.
-						reason: 'Sale_Coupon->apply_sale_discount',
-					},
-				],
-				item_original_cost_integer: 4800,
-			},
-			{
-				meta: 'domain.blog',
-				item_subtotal_integer: 484,
-				cost_overrides: [
-					{
-						old_price: 22,
-						new_price: 4.84, // The price we consider when sorting.
-						reason: 'Sale_Coupon->apply_sale_discount',
-					},
-				],
-				item_original_cost_integer: 2200,
-			},
-			{
-				meta: 'domain.fish',
-				item_subtotal_integer: 3000, // The price we consider when sorting.
-				cost_overrides: [],
-				item_original_cost_integer: 3000,
-			},
-			{
-				meta: 'domain.kitchen',
-				item_subtotal_integer: 0,
-				cost_overrides: [
-					{
-						old_price: 40,
-						new_price: 19.6, // The price we consider when sorting.
-						reason: 'Sale_Coupon->apply_sale_discount',
-					},
-					{
-						old_price: 19.6,
-						new_price: 0,
-						reason: 'bundled domain credit for 1st year',
-					},
-				],
-				item_original_cost_integer: 4000,
-			},
-		];
-
-		const sortedProducts = sortProductsByPriceDescending( products );
-		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.fish' );
-		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.kitchen' );
-		expect( sortedProducts[ 2 ].meta ).toBe( 'domain.blog' );
-		expect( sortedProducts[ 3 ].meta ).toBe( 'domain.store' );
 	} );
 } );

--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -45,24 +45,3 @@ export function shouldUseMultipleDomainsInCart( flowName ) {
 
 	return enabledFlows.includes( flowName );
 }
-
-export function sortProductsByPriceDescending( productsInCart ) {
-	// Sort products by price descending, considering promotions.
-	const getSortingValue = ( product ) => {
-		if ( product.item_subtotal_integer !== 0 ) {
-			return product.item_subtotal_integer;
-		}
-
-		// Use the lowest non-zero new_price or fallback to item_original_cost_integer.
-		const nonZeroPrices =
-			product.cost_overrides
-				?.map( ( override ) => override.new_price * 100 )
-				.filter( ( price ) => price > 0 ) || [];
-
-		return nonZeroPrices.length ? Math.min( ...nonZeroPrices ) : product.item_original_cost_integer;
-	};
-
-	return productsInCart.sort( ( a, b ) => {
-		return getSortingValue( b ) - getSortingValue( a );
-	} );
-}


### PR DESCRIPTION
Part of [DOMAINS-1616](https://linear.app/a8c/issue/DOMAINS-1616)

## Proposed Changes

This PR removes the `sortProductsByPriceDescending` function, which was introduced in #83016.

## Why are these changes being made?

The domain ordering by price in the cart is now being done in the backend, so this function isn't needed anymore. The function was written when the mini-cart feature was introduced, allowing multiple domains to be added to the cart.

## Testing Instructions

This depends on 192014-ghe-Automattic/wpcom

- Open the live Calypso link or build this branch locally
- Go to `/setup/onboarding` and add multiple domains to your cart, mixing domains on sale and not on sale
- Ensure the domain with the highest price (considering sale discounts) is the one that gets domain credit

Some expensive TLDs are `.io`, `.creditcard` and `. accountants`

For example, in this scenario:

<img width="1181" height="662" alt="Screenshot 2025-09-08 at 20 23 28" src="https://github.com/user-attachments/assets/6009d5f5-19dc-48dd-90d0-b9021f9ac9f3" />

The `.io` domain is the most expensive at R$262, so it gets the domain credit. If that domain is removed, the domain credit is now applied to the `.com` domain, which would be R$71:

<img width="1170" height="580" alt="Screenshot 2025-09-08 at 20 24 55" src="https://github.com/user-attachments/assets/15737da3-2ba6-425a-a7cb-49e4f4bbb774" />

The `.blog` domain's regular price is R$109, but due to a sale discount, it's currently R$10.90.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?