### PR TITLE
Add email visitor information for survicate script

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -1,8 +1,8 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import debug from 'debug';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-
 const survicateDebug = debug( 'calypso:analytics:survicate' );
 
 let survicateScriptLoaded = false;
@@ -34,10 +34,31 @@ export function addSurvicate() {
 		const s = document.createElement( 'script' );
 		s.src = `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`;
 		s.async = true;
+
+		// Wait for the script to load before setting visitor traits
+		s.onload = function () {
+			survicateDebug( 'Survicate script loaded' );
+
+			const user = getCurrentUser();
+
+			// Ensure _sva is available before calling it
+			// eslint-disable-next-line no-undef
+			if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {
+				// eslint-disable-next-line no-undef
+				_sva.setVisitorTraits( {
+					email: user.email,
+				} );
+			} else {
+				survicateDebug( 'Survicate _sva object not available' );
+			}
+		};
+
+		s.onerror = function () {
+			survicateDebug( 'Failed to load Survicate script' );
+		};
+
 		const e = document.getElementsByTagName( 'script' )[ 0 ];
 		e.parentNode.insertBefore( s, e );
-
-		survicateDebug( 'Survicate script loaded' );
 	} )();
 
 	survicateScriptLoaded = true;

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -41,16 +41,18 @@ export function addSurvicate() {
 
 			const user = getCurrentUser();
 
-			// Ensure _sva is available before calling it
-			// eslint-disable-next-line no-undef
-			if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {
+			setTimeout( () => {
 				// eslint-disable-next-line no-undef
-				_sva.setVisitorTraits( {
-					email: user.email,
-				} );
-			} else {
-				survicateDebug( 'Survicate _sva object not available' );
-			}
+				if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {
+					// eslint-disable-next-line no-undef
+					_sva.setVisitorTraits( {
+						email: user.email,
+					} );
+					survicateDebug( 'Survicate visitor traits set with email: ' + user.email );
+				} else {
+					survicateDebug( 'Survicate _sva object not available' );
+				}
+			}, 1000 );
 		};
 
 		s.onerror = function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Task related: pgpvpK-5E-p2#comment-209

## Proposed Changes

* We're connecting logged user email to survicate survey so users don't need to fill them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to make the user experience better

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add this parameter to the URL to see the test survey: `?test_survey=true`
* Test on local/staging and make sure we're storing the email automatically:

<img width="1222" height="962" alt="image" src="https://github.com/user-attachments/assets/a3f4df66-08a3-4aad-ba8e-ea713a5c06db" />



This will be logged at Survicate:

<img width="1125" height="462" alt="image" src="https://github.com/user-attachments/assets/1e4cfcf2-65e8-4300-8b3c-078d213c01c0" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?