### PR TITLE
Restart the Visual Split experiment

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -339,7 +339,7 @@ const onboarding: FlowV2< typeof initialize > = {
 
 		// Preload the visual split experiment
 		useEffect( () => {
-			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_2' );
+			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
 		}, [] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -339,7 +339,7 @@ const onboarding: FlowV2< typeof initialize > = {
 
 		// Preload the visual split experiment
 		useEffect( () => {
-			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09' );
+			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_2' );
 		}, [] );
 	},
 };

--- a/client/lib/plans/use-visual-split-experiment.ts
+++ b/client/lib/plans/use-visual-split-experiment.ts
@@ -3,7 +3,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-const EXPERIMENT_NAME = 'calypso_plans_page_visual_separation_2025_09';
+const EXPERIMENT_NAME = 'calypso_plans_page_visual_separation_2025_09_2';
 
 /**
  * This hook is used to determine if the visual split feature is enabled for a given flow.

--- a/client/lib/plans/use-visual-split-experiment.ts
+++ b/client/lib/plans/use-visual-split-experiment.ts
@@ -3,7 +3,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-const EXPERIMENT_NAME = 'calypso_plans_page_visual_separation_2025_09_2';
+const EXPERIMENT_NAME = 'calypso_plans_page_visual_separation_2025_09_v2';
 
 /**
  * This hook is used to determine if the visual split feature is enabled for a given flow.


### PR DESCRIPTION
The previous experiment was completed due to product changes

Part of #

## Proposed Changes

* Restart the experiment introduced with https://github.com/Automattic/wp-calypso/pull/105390 under the name calypso_plans_page_visual_separation_2025_09_2

## Why are these changes being made?

* A recent product change required this experiment to end

Screenshots from the experiment:
<img width="1443" height="823" alt="Screenshot 2025-08-28 at 15 48 08" src="https://github.com/user-attachments/assets/bec07013-ed35-48ea-8197-239e0938b109" />
<img width="1443" height="823" alt="Screenshot 2025-08-28 at 15 48 17" src="https://github.com/user-attachments/assets/b0a7239d-4eb8-44f3-8627-5b2f08183659" />
<img width="1443" height="823" alt="Screenshot 2025-08-28 at 15 48 25" src="https://github.com/user-attachments/assets/de383ec8-7881-41c0-bcef-b899a88e9d68" />
<img width="1443" height="823" alt="Screenshot 2025-08-28 at 15 49 16" src="https://github.com/user-attachments/assets/d7310f9e-87c7-4ab8-9ddd-5b7cf89aa09c" />

And also the product change is visible here
<img width="1310" height="758" alt="Screenshot 2025-09-09 at 17 54 32" src="https://github.com/user-attachments/assets/e58173dd-039d-4627-8eaa-5dd237154378" />


## Testing Instructions


* Find the calypso_plans_page_visual_separation_2025_09_2 in Abacus (22334-explat-experiment)
* Create 3 bookmarklets with control, hosting, and builder variations
* Create a test user and assign it to one of them (you'll need to test all 3)
* Start the signup onboarding or reload the domains step, and then move on to plans

Notes:
* There are two general cases, when a free domain is selected or not
* When a domain is selected, there's no Free plan in the builder tab, and there's a link above, which is not bold
* When a domain is not selected, there is a Free plan in the builder tab but there is no link above the hosting tab (this might be a design flaw, we may need to reconsider)

Control should remain unchanged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
