### PR TITLE
Two Factor Authentication: Add email based second factor

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-content.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-content.jsx
@@ -30,7 +30,7 @@ function TwoFactorContent( {
 		poller = <PushNotificationApprovalPoller onSuccess={ rebootAfterLogin } />;
 	}
 
-	if ( [ 'authenticator', 'sms', 'backup' ].includes( twoFactorAuthType ) ) {
+	if ( [ 'authenticator', 'email', 'sms', 'backup' ].includes( twoFactorAuthType ) ) {
 		let verificationCodeInputPlaceholder = '';
 
 		if ( isGravPoweredClient ) {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -68,8 +68,9 @@ class VerificationCodeForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		const { onSuccess, twoFactorAuthType } = this.props;
+		const { onSuccess, twoFactorAuthType: _twoFactorAuthType, twoFactorEmailNonce } = this.props;
 		const { twoStepCode } = this.state;
+		const twoFactorAuthType = twoFactorEmailNonce ? 'email' : _twoFactorAuthType;
 
 		this.props.recordTracksEvent( 'calypso_login_two_factor_verification_code_submit' );
 

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -15,7 +15,7 @@ import {
 	loginUserWithTwoFactorVerificationCode,
 	sendSmsCode,
 } from 'calypso/state/login/actions';
-import { getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
+import { getTwoFactorAuthNonce, getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
 import TwoFactorActions from './two-factor-actions';
 
 import './verification-code-form.scss';
@@ -102,12 +102,18 @@ class VerificationCodeForm extends Component {
 			twoFactorAuthRequestError: requestError,
 			twoFactorAuthType,
 			switchTwoFactorAuthType,
+			twoFactorEmailNonce,
 		} = this.props;
 
 		let buttonText = translate( 'Continue' );
 		let helpText = translate( 'Enter the code from your authenticator app.' );
 		let labelText = translate( '6-Digit code' );
 		let smallPrint;
+
+		if ( twoFactorEmailNonce ) {
+			helpText = translate( 'Enter the code from the email we sent you.' );
+			labelText = translate( '9-Digit code' );
+		}
 
 		if ( twoFactorAuthType === 'sms' ) {
 			helpText = translate( 'Enter the code from the text message we sent you.' );
@@ -187,6 +193,7 @@ class VerificationCodeForm extends Component {
 export default connect(
 	( state ) => ( {
 		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
+		twoFactorEmailNonce: getTwoFactorAuthNonce( state, 'email' ),
 	} ),
 	{
 		formUpdate,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -120,15 +120,15 @@ export default ( router ) => {
 
 	router(
 		[
-			`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:twoFactorAuthType(authenticator|backup|email|sms|push|webauthn)/${ lang }`,
 			`/log-in/:flow(social-connect)/${ lang }`,
 			`/log-in/:socialService(google|apple|github)/callback/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:socialService(google|apple|github)/${ lang }`,
-			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|email|sms|push|webauthn)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:action(lostpassword)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/${ lang }`,
-			`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+			`/log-in/:isGutenboarding(new)/:twoFactorAuthType(authenticator|backup|email|sms|push|webauthn)/${ lang }`,
 			`/log-in/:action(lostpassword)/${ lang }`,
 			`/log-in/${ lang }`,
 		],

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -127,7 +127,7 @@ export function getHeaderText( {
 			: translate( 'Log in to WordPress.com' );
 	}
 
-	if ( twoFactorAuthType === 'authenticator' ) {
+	if ( twoFactorAuthType === 'authenticator' || twoFactorAuthType === 'email' ) {
 		headerText = translate( 'Continue with an authentication code' );
 	}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -245,6 +245,7 @@ export class Login extends Component {
 			isGravPoweredClient &&
 			! currentRoute.startsWith( '/log-in/push' ) &&
 			! currentRoute.startsWith( '/log-in/authenticator' ) &&
+			! currentRoute.startsWith( '/log-in/email' ) &&
 			! currentRoute.startsWith( '/log-in/sms' ) &&
 			! currentRoute.startsWith( '/log-in/webauthn' ) &&
 			! currentRoute.startsWith( '/log-in/backup' );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -263,6 +263,7 @@ const twoFactorProperties = [
 	'two_step_nonce',
 	'two_step_supported_auth_types',
 	'two_step_notification_sent',
+	'two_step_nonce_email',
 	'two_step_nonce_backup',
 	'two_step_nonce_sms',
 	'two_step_nonce_authenticator',


### PR DESCRIPTION
Add the ability to provide a login code received by email.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
