### PR TITLE
Hosting Dashboard: Avoid showing Unavailable to security settings on Simple sites

### DIFF
--- a/client/dashboard/sites/settings-web-application-firewall/summary.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/summary.tsx
@@ -30,7 +30,9 @@ export default function WebApplicationFirewallSettingsSummary( {
 		isJetpackModuleAvailable( jetpackModules, jetpackConnection, JetpackModules.WAF ) &&
 		isJetpackModuleAvailable( jetpackModules, jetpackConnection, JetpackModules.PROTECT );
 
-	const badges = modulesAvailable ? undefined : [ { text: __( 'Unavailable' ) } ];
+	// Don't show any badge for Simple sites.
+	const badges =
+		isSimple( site ) || modulesAvailable ? undefined : [ { text: __( 'Unavailable' ) } ];
 
 	return (
 		<RouterLinkSummaryButton

--- a/client/dashboard/sites/settings-wpcom-login/summary.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/summary.tsx
@@ -39,9 +39,10 @@ export default function WpcomLoginSettingsSummary( {
 	const ssoEnabled = isJetpackModuleActivated( jetpackModules, JetpackModules.SSO );
 
 	let badges;
-	if ( ! ssoAvailable ) {
+	// Don't show any badge for Simple sites.
+	if ( ! isSimple( site ) && ! ssoAvailable ) {
 		badges = [ { text: __( 'Unavailable' ) } ];
-	} else if ( hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
+	} else if ( ! isSimple( site ) && hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
 		badges = ssoEnabled
 			? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
 			: [ { text: __( 'Disabled' ) } ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14490

## Proposed Changes

* Stop showing the "Unavailable" badge on security settings on Simple sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On Simple, we don't need to show the badge, but leave it to the upsell inside each section to fully inform users on how to access granular security controls.

On self-hosted, instead, the Unavailable badge indicates that the site is in offline mode.

| Before | After |
|--------|--------|
| <img width="1372" height="462" alt="Screenshot 2025-09-09 at 19 21 59" src="https://github.com/user-attachments/assets/a76b92a1-46a1-47a9-802c-c7b4dfcb2b49" /> | <img width="1384" height="472" alt="Screenshot 2025-09-09 at 19 42 59" src="https://github.com/user-attachments/assets/c74cde0a-acb3-4608-a972-0cbda26db2a5" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick a Simple, Atomic, and self-hosted test sites.
* Enter `/v2/sites/:SITE/settings` with each site.
* On Simple, confirm there are no "Unavailable" badges on security settings.
* On Atomic, confirm that there is a "Enabled/Disabled" badge for WordPress.com login, depending on the setting state.
* On self-hosted, confirm that the "Unavailable" badges are only displayed if the site is in offline mode.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
