### PR TITLE
Hosting Dashboard: v2 user preferences allow opt-in/out

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -2,6 +2,7 @@ import { fetchTwoStep } from '@automattic/api-core';
 import {
 	userSettingsQuery,
 	userPurchasesQuery,
+	rawUserPreferencesQuery,
 	purchaseQuery,
 	sitesQuery,
 	queryClient,
@@ -48,6 +49,7 @@ export const profileRoute = createRoute( {
 const preferencesRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'preferences',
+	loader: () => queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 } ).lazy( () =>
 	import( '../../me/preferences' ).then( ( d ) =>
 		createLazyRoute( 'preferences' )( {

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -92,7 +92,7 @@ export default function PreferencesLanguageForm() {
 			{
 				onSuccess( _, { value } ) {
 					if ( value === 'opt-in' ) {
-						createSuccessNotice( __( 'Saved new Hosting Dashboard.' ), { type: 'snackbar' } );
+						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
 					} else {
 						setIsRedirecting( true );
 						window.location.href = '/me/account';
@@ -101,8 +101,8 @@ export default function PreferencesLanguageForm() {
 				onError( _, { value } ) {
 					createErrorNotice(
 						value === 'opt-in'
-							? __( 'Failed to choose new Hosting Dashboard.' )
-							: __( 'Failed to choose old dashboard.' ),
+							? __( 'Failed to enable new Hosting Dashboard.' )
+							: __( 'Failed to disable new Hosting Dashboard.' ),
 						{
 							type: 'snackbar',
 						}

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,0 +1,141 @@
+import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Button,
+	Card,
+	CardBody,
+	CheckboxControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { Text } from '../../components/text';
+import type { Field } from '@wordpress/dataviews';
+
+interface OptInFormData {
+	enabled: boolean;
+}
+
+const form = {
+	layout: {
+		type: 'regular' as const,
+		labelPosition: 'top' as const,
+	},
+	fields: [
+		{
+			id: 'optInForm',
+			label: (
+				<HStack spacing={ 1 }>
+					<span>{ __( 'Try the new Hosting Dashboard' ) }</span>
+					<Badge intent="info">{ __( 'New feature' ) }</Badge>
+				</HStack>
+			),
+			children: [ 'description', 'enabled' ],
+		},
+	],
+};
+
+const fields: Field< OptInFormData >[] = [
+	{
+		id: 'enabled',
+		label: __( 'I want to try the beta version.' ),
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+			return (
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ field.getValue( { item: data } ) }
+					label={ hideLabelFromVision ? '' : field.label }
+					onChange={ ( value ) => {
+						onChange( { [ field.id ]: value } );
+					} }
+				/>
+			);
+		},
+	},
+	{
+		id: 'description',
+		Edit: () => (
+			<Text as="p" variant="muted">
+				{ __(
+					'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
+				) }
+			</Text>
+		),
+	},
+];
+
+export default function PreferencesLanguageForm() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
+	const { mutate: saveOptInPreference, isPending } = useMutation(
+		userPreferenceMutation( 'hosting-dashboard-opt-in' )
+	);
+	const [ formData, setFormData ] = useState< OptInFormData >( {
+		enabled: optIn.value === 'opt-in',
+	} );
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
+	const isDirty = formData.enabled !== ( optIn.value === 'opt-in' );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		saveOptInPreference(
+			{
+				value: formData.enabled ? 'opt-in' : 'opt-out',
+				updated_at: new Date().toISOString(),
+			},
+			{
+				onSuccess( _, { value } ) {
+					if ( value === 'opt-in' ) {
+						createSuccessNotice( __( 'Saved new Hosting Dashboard.' ), { type: 'snackbar' } );
+					} else {
+						setIsRedirecting( true );
+						window.location.href = '/me/account';
+					}
+				},
+				onError( _, { value } ) {
+					createErrorNotice(
+						value === 'opt-in'
+							? __( 'Failed to choose new Hosting Dashboard.' )
+							: __( 'Failed to choose old dashboard.' ),
+						{
+							type: 'snackbar',
+						}
+					);
+				},
+			}
+		);
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack as="form" onSubmit={ handleSubmit } spacing={ 6 } alignment="flex-start">
+					<DataForm< OptInFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits ) => {
+							setFormData( ( current ) => ( { ...current, ...edits } ) );
+						} }
+					/>
+					<Button
+						variant="primary"
+						type="submit"
+						__next40pxDefaultSize
+						accessibleWhenDisabled
+						isBusy={ isPending || isRedirecting }
+						disabled={ isPending || isRedirecting || ! isDirty }
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -95,7 +95,7 @@ export default function PreferencesLanguageForm() {
 						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
 					} else {
 						setIsRedirecting( true );
-						window.location.href = '/me/account';
+						window.location.href = '/me/account?updated=dashboard';
 					}
 				},
 				onError( _, { value } ) {

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -2,10 +2,12 @@ import { __ } from '@wordpress/i18n';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import PreferencesLanguageForm from '../preferences-language';
+import PreferencesNewHostingDashboard from '../preferences-new-hosting-dashboard';
 
 export default function Preferences() {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Preferences' ) } /> }>
+			<PreferencesNewHostingDashboard />
 			<PreferencesLanguageForm />
 		</PageLayout>
 	);

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -15,6 +15,15 @@ export function account( context, next ) {
 		);
 		page.replace( context.pathname );
 	}
+	if ( context.query && context.query.updated === 'dashboard' ) {
+		context.store.dispatch(
+			successNotice( i18n.translate( 'New Hosting Dashboard disabled.' ), {
+				displayOnNextPage: true,
+				id: meSettingsNoticeId,
+			} )
+		);
+		page.replace( context.pathname );
+	}
 
 	const AccountTitle = () => {
 		const translate = useTranslate();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-361

## Proposed Changes

Provides a UI in the v2 dashboard for the `hosting-dashboard-opt-in` preference.

<img width="1488" height="862" alt="CleanShot 2025-09-10 at 17 09 06@2x" src="https://github.com/user-attachments/assets/09f92593-15a6-4ca6-89a6-a931c043d3c5" />

Snackbars:

<img height="295" alt="CleanShot 2025-09-11 at 17 08 40@2x" src="https://github.com/user-attachments/assets/8ea65acf-6ccc-43fd-82d3-726270cfc495" />


This doesn't include any opt-out survey since this can be done in a later PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We need to provide a mechanism to opt in and out.
Once a user opts _out_ we can automatically take them to the v1 dashboard. That's why we use a checkbox and explicit save button rather than the classic toggle control. Redirecting via an explicit button press feels more polite than redirecting after flipping a toggle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test at `/v2/me/preferences`

Figma is here 12LxFL9UjT15z2HNbOsaM8-fi-21_27220

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?