### PR TITLE
Re-enable tests for form validation of the Hosting Dashboard Domain Forwarding form

### DIFF
--- a/client/dashboard/domains/domain-forwardings/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwardings/test/add.test.tsx
@@ -33,7 +33,7 @@ function renderForm( props: TestFormProps = {} ) {
 
 afterEach( () => nock.cleanAll() );
 
-test.skip( 'renders domain forwarding form with correct fields', async () => {
+test( 'renders domain forwarding form with correct fields', async () => {
 	renderForm();
 
 	await waitFor( () => {
@@ -45,7 +45,7 @@ test.skip( 'renders domain forwarding form with correct fields', async () => {
 	expect( screen.getByRole( 'button', { name: 'Add' } ) ).toBeInTheDocument();
 } );
 
-test.skip( 'hides source URL selector when forceSubdomain is true', async () => {
+test( 'hides source URL selector when forceSubdomain is true', async () => {
 	renderForm( { forceSubdomain: true } );
 
 	await waitFor( () => {
@@ -57,7 +57,7 @@ test.skip( 'hides source URL selector when forceSubdomain is true', async () => 
 	expect( screen.getByText( 'Subdomain' ) ).toBeInTheDocument();
 } );
 
-test.skip( 'shows both root domain and subdomain options when forceSubdomain is false', async () => {
+test( 'shows both root domain and subdomain options when forceSubdomain is false', async () => {
 	renderForm( { forceSubdomain: false } );
 
 	await waitFor( () => {
@@ -68,7 +68,7 @@ test.skip( 'shows both root domain and subdomain options when forceSubdomain is 
 	expect( screen.getByText( 'Source URL' ) ).toBeInTheDocument();
 } );
 
-test.skip( 'calls onSubmit with correct data when form is submitted', async () => {
+test( 'calls onSubmit with correct data when form is submitted', async () => {
 	const user = userEvent.setup();
 	const mockOnSubmit = jest.fn();
 
@@ -100,7 +100,7 @@ test.skip( 'calls onSubmit with correct data when form is submitted', async () =
 	} );
 } );
 
-test.skip( 'disables submit button when isSubmitting is true', async () => {
+test( 'disables submit button when isSubmitting is true', async () => {
 	renderForm( { isSubmitting: true } );
 
 	await waitFor( () => {
@@ -111,7 +111,7 @@ test.skip( 'disables submit button when isSubmitting is true', async () => {
 	expect( submitButton ).toBeDisabled();
 } );
 
-test.skip( 'shows advanced settings panel', async () => {
+test( 'shows advanced settings panel', async () => {
 	const user = userEvent.setup();
 	renderForm();
 
@@ -132,7 +132,7 @@ test.skip( 'shows advanced settings panel', async () => {
 	} );
 } );
 
-test.skip( 'shows validation error when subdomain starts with dash and is blurred', async () => {
+test( 'shows validation error when subdomain starts with dash and is blurred', async () => {
 	const user = userEvent.setup();
 
 	renderForm();
@@ -152,7 +152,7 @@ test.skip( 'shows validation error when subdomain starts with dash and is blurre
 	} );
 } );
 
-test.skip( 'shows validation error when target URL is empty and blurred', async () => {
+test( 'shows validation error when target URL is empty and blurred', async () => {
 	const user = userEvent.setup();
 
 	renderForm();
@@ -176,7 +176,7 @@ test.skip( 'shows validation error when target URL is empty and blurred', async 
 	} );
 } );
 
-test.skip( 'shows validation error when target URL is invalid and blurred', async () => {
+test( 'shows validation error when target URL is invalid and blurred', async () => {
 	const user = userEvent.setup();
 
 	renderForm();
@@ -200,7 +200,7 @@ test.skip( 'shows validation error when target URL is invalid and blurred', asyn
 	} );
 } );
 
-test.skip( 'shows validation error when target URL redirects to same domain without path', async () => {
+test( 'shows validation error when target URL redirects to same domain without path', async () => {
 	const user = userEvent.setup();
 
 	renderForm();
@@ -224,7 +224,7 @@ test.skip( 'shows validation error when target URL redirects to same domain with
 	} );
 } );
 
-test.skip( 'allows target URL that redirects to same domain with path', async () => {
+test( 'allows target URL that redirects to same domain with path', async () => {
 	const user = userEvent.setup();
 	const mockOnSubmit = jest.fn();
 
@@ -258,7 +258,7 @@ test.skip( 'allows target URL that redirects to same domain with path', async ()
 	} );
 } );
 
-test.skip( 'allows target URL without protocol (normalizes input)', async () => {
+test( 'allows target URL without protocol (normalizes input)', async () => {
 	const user = userEvent.setup();
 	const mockOnSubmit = jest.fn();
 
@@ -294,7 +294,7 @@ test.skip( 'allows target URL without protocol (normalizes input)', async () => 
 	} );
 } );
 
-test.skip( 'pre-fills form with initial data when provided', async () => {
+test( 'pre-fills form with initial data when provided', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',

--- a/client/dashboard/domains/domain-forwardings/test/edit.test.tsx
+++ b/client/dashboard/domains/domain-forwardings/test/edit.test.tsx
@@ -32,7 +32,7 @@ function renderEditForm( props: TestFormProps = {} ) {
 
 afterEach( () => nock.cleanAll() );
 
-test.skip( 'renders edit form with pre-filled subdomain forwarding data', async () => {
+test( 'renders edit form with pre-filled subdomain forwarding data', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',
@@ -53,7 +53,7 @@ test.skip( 'renders edit form with pre-filled subdomain forwarding data', async 
 	expect( screen.getByRole( 'button', { name: 'Update' } ) ).toBeInTheDocument();
 } );
 
-test.skip( 'renders edit form with pre-filled root domain forwarding data', async () => {
+test( 'renders edit form with pre-filled root domain forwarding data', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		target_host: 'newsite.com',
@@ -72,7 +72,7 @@ test.skip( 'renders edit form with pre-filled root domain forwarding data', asyn
 	expect( screen.getByText( 'Source URL' ) ).toBeInTheDocument();
 } );
 
-test.skip( 'forces subdomain mode when forceSubdomain is true for existing subdomain forwarding', async () => {
+test( 'forces subdomain mode when forceSubdomain is true for existing subdomain forwarding', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',
@@ -96,7 +96,7 @@ test.skip( 'forces subdomain mode when forceSubdomain is true for existing subdo
 	expect( screen.getByText( 'Subdomain' ) ).toBeInTheDocument();
 } );
 
-test.skip( 'calls onSubmit with updated data when form is submitted', async () => {
+test( 'calls onSubmit with updated data when form is submitted', async () => {
 	const user = userEvent.setup();
 	const mockOnSubmit = jest.fn();
 
@@ -142,7 +142,7 @@ test.skip( 'calls onSubmit with updated data when form is submitted', async () =
 	} );
 } );
 
-test.skip( 'shows advanced settings panel expanded when initial data has non-default values', async () => {
+test( 'shows advanced settings panel expanded when initial data has non-default values', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',
@@ -166,7 +166,7 @@ test.skip( 'shows advanced settings panel expanded when initial data has non-def
 	} );
 } );
 
-test.skip( 'disables submit button when isSubmitting is true', async () => {
+test( 'disables submit button when isSubmitting is true', async () => {
 	const initialData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',
@@ -189,7 +189,7 @@ test.skip( 'disables submit button when isSubmitting is true', async () => {
 	expect( submitButton ).toBeDisabled();
 } );
 
-test.skip( 'handles HTTP vs HTTPS protocol correctly in pre-filled data', async () => {
+test( 'handles HTTP vs HTTPS protocol correctly in pre-filled data', async () => {
 	const httpData = {
 		domain_redirect_id: 123,
 		subdomain: 'blog',
@@ -207,7 +207,7 @@ test.skip( 'handles HTTP vs HTTPS protocol correctly in pre-filled data', async 
 	} );
 } );
 
-test.skip( 'handles advanced settings correctly when updating', async () => {
+test( 'handles advanced settings correctly when updating', async () => {
 	const user = userEvent.setup();
 	const mockOnSubmit = jest.fn();
 


### PR DESCRIPTION
Now that https://github.com/Automattic/wp-calypso/pull/105582 is merged the form validation works again so I can re-enable my tests for that and hopefully it won't break again

## Proposed Changes

* Re-enable the tests for the the domain forwarding form

## Why are these changes being made?

* We don't have any tests for Domains in the Hosting Dashboard - hopefully this is a good pattern and we can add more tests for all components in the future. Also this would prevent breaking changes being deployed without anyone noticing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that unit tests work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
