### PR TITLE
Staging Sites in V2: Disable environment switching and staging creation for A4A dev sites

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -63,7 +63,7 @@ export function canResetSite( site: Site ) {
 }
 
 export function canSwitchEnvironment( site: Site ) {
-	if ( isSiteMigrationInProgress( site ) ) {
+	if ( isSiteMigrationInProgress( site ) || site.is_a4a_dev_site ) {
 		return false;
 	}
 
@@ -71,7 +71,7 @@ export function canSwitchEnvironment( site: Site ) {
 }
 
 export function canCreateStagingSite( site: Site ) {
-	if ( isSiteMigrationInProgress( site ) ) {
+	if ( isSiteMigrationInProgress( site ) || site.is_a4a_dev_site ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14504

## Proposed Changes

* disable environment switching and staging creation for A4A dev sites

<img width="2304" height="864" alt="Markup on 2025-09-10 at 15:54:11" src="https://github.com/user-attachments/assets/09eeceff-aa7a-4d56-a0ba-d299696ae36d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are matching the experience with the V1 dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If you don't have any A4A Development site, head over to https://agencies.automattic.com and create one:

<img width="4464" height="1680" alt="Markup on 2025-09-10 at 16:02:10" src="https://github.com/user-attachments/assets/84c34cde-06b5-4378-bdd0-b1092d5d318a" />

ℹ️ Please note that you may need to follow these steps if you haven't tested with A4A portal before: PCYsg-XAV-p2[

2. Check out this PR and build the app with `yarn start` (or use the Calypso Live link below).
3. Navigate to your A4A Development site in the new Hosting Dashboard.
4. Observe that there's no Environment Switcher present (as can be seen in the first screenshot of this PR).
5. Switch to some other normal WoA WordPress.com site. The Environment Switcher should be still there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?