### PR TITLE
Add display rules for the Settings in the Domain Overview section in the Hosting Dashboard

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -1,11 +1,10 @@
-import { DomainSubtype } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { domainConnectionSetupRoute } from '../../app/router/domains';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '@automattic/api-core';
 
 export default function DomainConnectionSetupSummary( { domain }: { domain: Domain } ) {
-	if ( domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION || domain.points_to_wpcom ) {
+	if ( domain.points_to_wpcom ) {
 		return null;
 	}
 

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -81,7 +81,7 @@ export default function DomainOverview() {
 			}
 		>
 			<FeaturedCards />
-			<DomainOverviewSettings />
+			<DomainOverviewSettings domain={ domain } />
 			<Actions />
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -13,8 +13,10 @@ import DomainGlueRecordsSettingsSummary from '../overview-glue-records/summary';
 export default function DomainOverviewSettings( { domain }: { domain: Domain } ) {
 	const buttonListItems = [];
 
-	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
-		buttonListItems.push( <DomainConnectionSetupSummary domain={ domain } /> );
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION && ! domain.points_to_wpcom ) {
+		buttonListItems.push(
+			<DomainConnectionSetupSummary key="connection-setup" domain={ domain } />
+		);
 	}
 
 	if (

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -1,8 +1,6 @@
-import { domainQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { DomainSubtype, DomainTransferStatus, type Domain } from '@automattic/api-core';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { domainRoute } from '../../app/router/domains';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
 import DomainConnectionSetupSummary from '../domain-connection-setup/summary';
@@ -12,22 +10,76 @@ import DomainForwardingsSettingsSummary from '../domain-forwardings/summary';
 import DomainSecuritySettingsSummary from '../domain-security/summary';
 import NameServersSettingsSummary from '../name-servers/summary';
 import DomainGlueRecordsSettingsSummary from '../overview-glue-records/summary';
+export default function DomainOverviewSettings( { domain }: { domain: Domain } ) {
+	const buttonListItems = [];
 
-export default function DomainOverviewSettings() {
-	const { domainName } = domainRoute.useParams();
-	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+		buttonListItems.push( <DomainConnectionSetupSummary domain={ domain } /> );
+	}
+
+	if (
+		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
+		! domain.is_gravatar_restricted_domain // TODO: should we show some notice for gravatar domains instead of just hiding the button?
+	) {
+		buttonListItems.push( <NameServersSettingsSummary domain={ domain } /> );
+	}
+
+	if (
+		[
+			DomainSubtype.DOMAIN_REGISTRATION,
+			DomainSubtype.DOMAIN_CONNECTION,
+			DomainSubtype.DOMAIN_TRANSFER,
+		].includes( domain.subtype.id ) &&
+		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC &&
+		domain.can_manage_dns_records
+	) {
+		buttonListItems.push( <DnsSettingsSummary domain={ domain } /> );
+		buttonListItems.push( <DomainForwardingsSettingsSummary domain={ domain } /> );
+	}
+
+	/**
+	 * I simplified the condition heere because the original code seemed to have a logical redundancy.
+	 * see: https://github.com/Automattic/wp-calypso/blob/b1c63880294fcf63f95518a3c42779236f56f5b2/client/my-sites/domains/domain-management/settings/index.tsx#L515
+	 */
+	if (
+		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
+		domain.current_user_can_manage &&
+		! domain.pending_transfer &&
+		! domain.expired
+	) {
+		buttonListItems.push( <DomainContactDetailsSettingsSummary domain={ domain } /> );
+	}
+
+	/**
+	 * TODO: review this one - we need to show the security for transfers but only if there is
+	 * mapping. Right now I copied the code from the original code but it seems wrong
+	 */
+	if (
+		[
+			DomainSubtype.DOMAIN_REGISTRATION,
+			DomainSubtype.DOMAIN_CONNECTION,
+			DomainSubtype.DOMAIN_TRANSFER,
+		].includes( domain.subtype.id ) &&
+		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC
+	) {
+		buttonListItems.push( <DomainSecuritySettingsSummary domain={ domain } /> );
+	}
+
+	if (
+		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
+		domain.current_user_can_manage &&
+		domain.can_manage_dns_records
+		// TODO: Add property that shows or hides this option depending on the availability of the feature
+	) {
+		buttonListItems.push( <DomainGlueRecordsSettingsSummary domain={ domain } /> );
+	}
+
 	return (
-		<VStack spacing={ 3 }>
-			<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
-			<SummaryButtonList>
-				<DomainConnectionSetupSummary domain={ domain } />
-				<NameServersSettingsSummary domain={ domain } />
-				<DnsSettingsSummary domain={ domain } />
-				<DomainForwardingsSettingsSummary domain={ domain } />
-				<DomainContactDetailsSettingsSummary domain={ domain } />
-				<DomainSecuritySettingsSummary domain={ domain } />
-				<DomainGlueRecordsSettingsSummary domain={ domain } />
-			</SummaryButtonList>
-		</VStack>
+		buttonListItems.length > 0 && (
+			<VStack spacing={ 3 }>
+				<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
+				<SummaryButtonList>{ buttonListItems }</SummaryButtonList>
+			</VStack>
+		)
 	);
 }

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -21,7 +21,7 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
 		! domain.is_gravatar_restricted_domain // TODO: should we show some notice for gravatar domains instead of just hiding the button?
 	) {
-		buttonListItems.push( <NameServersSettingsSummary domain={ domain } /> );
+		buttonListItems.push( <NameServersSettingsSummary key="name-servers" domain={ domain } /> );
 	}
 
 	if (
@@ -33,8 +33,10 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC &&
 		domain.can_manage_dns_records
 	) {
-		buttonListItems.push( <DnsSettingsSummary domain={ domain } /> );
-		buttonListItems.push( <DomainForwardingsSettingsSummary domain={ domain } /> );
+		buttonListItems.push( <DnsSettingsSummary key="dns" domain={ domain } /> );
+		buttonListItems.push(
+			<DomainForwardingsSettingsSummary key="forwardings" domain={ domain } />
+		);
 	}
 
 	/**
@@ -47,7 +49,9 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		! domain.pending_transfer &&
 		! domain.expired
 	) {
-		buttonListItems.push( <DomainContactDetailsSettingsSummary domain={ domain } /> );
+		buttonListItems.push(
+			<DomainContactDetailsSettingsSummary key="contact-details" domain={ domain } />
+		);
 	}
 
 	/**
@@ -62,7 +66,7 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		].includes( domain.subtype.id ) &&
 		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC
 	) {
-		buttonListItems.push( <DomainSecuritySettingsSummary domain={ domain } /> );
+		buttonListItems.push( <DomainSecuritySettingsSummary key="security" domain={ domain } /> );
 	}
 
 	if (
@@ -71,7 +75,9 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		domain.can_manage_dns_records
 		// TODO: Add property that shows or hides this option depending on the availability of the feature
 	) {
-		buttonListItems.push( <DomainGlueRecordsSettingsSummary domain={ domain } /> );
+		buttonListItems.push(
+			<DomainGlueRecordsSettingsSummary key="glue-records" domain={ domain } />
+		);
 	}
 
 	return (

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainSubtype, DomainTransferStatus, type Domain } from '@automattic/api-core';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import DomainOverviewSettings from '../settings';
+
+const domainName = 'example.com';
+
+const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
+	return {
+		domain: domainName,
+		aftermarket_auction: false,
+		auto_renewing: false,
+		blog_id: 123,
+		blog_name: 'Test Blog',
+		can_manage_dns_records: true,
+		can_update_contact_info: true,
+		can_set_as_primary: true,
+		current_user_can_create_site_from_domain_only: false,
+		current_user_can_manage: true,
+		current_user_is_owner: true,
+		domain_status: { status: 'active' },
+		expired: false,
+		expiry: false,
+		has_registration: true,
+		is_dnssec_enabled: false,
+		is_dnssec_supported: true,
+		is_eligible_for_inbound_transfer: false,
+		is_hundred_year_domain: false,
+		is_gravatar_domain: false,
+		is_gravatar_restricted_domain: false,
+		move_to_new_site_pending: false,
+		can_manage_name_servers: true,
+		cannot_manage_name_servers_reason: null,
+		is_redeemable: false,
+		is_renewable: true,
+		is_wpcom_staging_domain: false,
+		pending_registration: false,
+		pending_registration_at_registry: false,
+		pending_renewal: false,
+		pending_transfer: false,
+		points_to_wpcom: false,
+		registration_date: '2023-01-01',
+		subscription_id: 'sub123',
+		transfer_status: null,
+		type: 'wpcom',
+		wpcom_domain: true,
+		subtype: {
+			id: DomainSubtype.DOMAIN_REGISTRATION,
+			label: 'Domain Registration',
+		},
+		ssl_status: 'disabled',
+		private_domain: false,
+		...customProps,
+	} as Domain;
+};
+
+function renderDomainSettings( domainProps: Partial< Domain > = {} ) {
+	const mockDomain = getMockedDomainData( domainProps );
+	return render( <DomainOverviewSettings domain={ mockDomain } /> );
+}
+
+describe( 'DomainOverviewSettings', () => {
+	describe( 'Registered Domain Tests', () => {
+		test( 'shows all settings for fully manageable registered domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				current_user_can_manage: true,
+				can_manage_dns_records: true,
+				expired: false,
+				pending_transfer: false,
+				is_gravatar_restricted_domain: false,
+				transfer_status: null,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show all 5 settings buttons
+			expect( screen.getByText( 'Name servers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Contact details & privacy' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Glue records' ) ).toBeInTheDocument();
+		} );
+
+		test( 'hides name servers setting for gravatar restricted domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				is_gravatar_restricted_domain: true,
+				current_user_can_manage: true,
+				can_manage_dns_records: true,
+				expired: false,
+				pending_transfer: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should not show name servers
+			expect( screen.queryByText( 'Name servers' ) ).not.toBeInTheDocument();
+
+			// Should show other settings
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Contact details & privacy' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Glue records' ) ).toBeInTheDocument();
+		} );
+
+		test( 'hides DNS-related settings when cannot manage DNS records', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				can_manage_dns_records: false,
+				current_user_can_manage: true,
+				expired: false,
+				pending_transfer: false,
+				is_gravatar_restricted_domain: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show name servers (not affected by can_manage_dns_records)
+			expect( screen.getByText( 'Name servers' ) ).toBeInTheDocument();
+
+			// Should not show DNS records, email forwarding, or glue records
+			expect( screen.queryByText( 'DNS records' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Domain forwarding' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
+
+			// Should show contact information and security
+			expect( screen.getByText( 'Contact details & privacy' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+		} );
+
+		test( 'hides contact details when user cannot manage', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				current_user_can_manage: false,
+				can_manage_dns_records: true,
+				expired: false,
+				pending_transfer: false,
+				is_gravatar_restricted_domain: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show DNS-related settings
+			expect( screen.getByText( 'Name servers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+
+			// Should not show contact details or glue records
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides contact details for expired domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				current_user_can_manage: true,
+				can_manage_dns_records: true,
+				expired: true,
+				pending_transfer: false,
+				is_gravatar_restricted_domain: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show other settings
+			expect( screen.getByText( 'Name servers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Glue records' ) ).toBeInTheDocument();
+
+			// Should not show contact details for expired domain
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides contact details for pending transfer domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				current_user_can_manage: true,
+				can_manage_dns_records: true,
+				expired: false,
+				pending_transfer: true,
+				is_gravatar_restricted_domain: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show other settings
+			expect( screen.getByText( 'Name servers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Glue records' ) ).toBeInTheDocument();
+
+			// Should not show contact details for pending transfer
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Connected Domain Tests', () => {
+		test( 'shows limited settings for basic connected domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
+				current_user_can_manage: true,
+				can_manage_dns_records: true,
+				transfer_status: null,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show DNS records, email forwarding, and security
+			expect( screen.getByText( 'DNS records' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain forwarding' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+
+			// Should not show name servers, contact details, or glue records
+			expect( screen.queryByText( 'Name servers' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides DNS settings when connected domain cannot manage DNS', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
+				can_manage_dns_records: false,
+				transfer_status: null,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should show only security
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+
+			// Should not show DNS records or email forwarding
+			expect( screen.queryByText( 'DNS records' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Domain forwarding' ) ).not.toBeInTheDocument();
+
+			// Should not show registration-only settings
+			expect( screen.queryByText( 'Name servers' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'hides settings when transfer is pending async', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
+				can_manage_dns_records: true,
+				transfer_status: DomainTransferStatus.PENDING_ASYNC,
+			} );
+
+			// Should render nothing or empty state when transfer is pending async
+			const { container } = render(
+				<DomainOverviewSettings
+					domain={ getMockedDomainData( {
+						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
+						can_manage_dns_records: true,
+						transfer_status: DomainTransferStatus.PENDING_ASYNC,
+					} ) }
+				/>
+			);
+
+			// Should not show any settings
+			expect( screen.queryByText( 'Settings' ) ).not.toBeInTheDocument();
+			expect( container.firstChild ).toBeNull();
+		} );
+	} );
+
+	describe( 'Edge Cases', () => {
+		test( 'renders nothing when no settings should be shown', async () => {
+			// Domain with no permissions or capabilities
+			const { container } = render(
+				<DomainOverviewSettings
+					domain={ getMockedDomainData( {
+						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
+						can_manage_dns_records: false,
+						transfer_status: DomainTransferStatus.PENDING_ASYNC,
+					} ) }
+				/>
+			);
+
+			// Component should return null and render nothing
+			expect( container.firstChild ).toBeNull();
+			expect( screen.queryByText( 'Settings' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'shows correct number of settings for partially restricted registered domain', async () => {
+			renderDomainSettings( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+				current_user_can_manage: false, // Restricts contact details and glue records
+				can_manage_dns_records: false, // Restricts DNS records, email forwarding, and glue records
+				is_gravatar_restricted_domain: true, // Restricts name servers
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Settings' ) ).toBeInTheDocument();
+			} );
+
+			// Should only show security setting
+			expect( screen.getByText( 'Domain security' ) ).toBeInTheDocument();
+
+			// Should not show any other settings
+			expect( screen.queryByText( 'Name servers' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'DNS records' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Domain forwarding' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
+
+			// Verify only 1 setting button exists
+			const settingsButtons = screen.getAllByRole( 'link' );
+			expect( settingsButtons ).toHaveLength( 1 );
+		} );
+	} );
+} );

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -265,22 +265,12 @@ describe( 'DomainOverviewSettings', () => {
 		} );
 
 		test( 'hides settings when transfer is pending async', async () => {
-			renderDomainSettings( {
+			const { container } = renderDomainSettings( {
 				subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
 				can_manage_dns_records: true,
 				transfer_status: DomainTransferStatus.PENDING_ASYNC,
+				points_to_wpcom: true, // This makes DomainConnectionSetupSummary return null
 			} );
-
-			// Should render nothing or empty state when transfer is pending async
-			const { container } = render(
-				<DomainOverviewSettings
-					domain={ getMockedDomainData( {
-						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
-						can_manage_dns_records: true,
-						transfer_status: DomainTransferStatus.PENDING_ASYNC,
-					} ) }
-				/>
-			);
 
 			// Should not show any settings
 			expect( screen.queryByText( 'Settings' ) ).not.toBeInTheDocument();
@@ -297,6 +287,7 @@ describe( 'DomainOverviewSettings', () => {
 						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
 						can_manage_dns_records: false,
 						transfer_status: DomainTransferStatus.PENDING_ASYNC,
+						points_to_wpcom: true, // This makes DomainConnectionSetupSummary return null
 					} ) }
 				/>
 			);


### PR DESCRIPTION
It should look like this:

Domain Name Connection:
<img width="710" height="232" alt="Screenshot 2025-09-10 at 17 30 55" src="https://github.com/user-attachments/assets/b07160b5-8d75-427d-8af5-6174d2959e36" />

Domain Name Registration:
<img width="738" height="419" alt="Screenshot 2025-09-10 at 17 31 35" src="https://github.com/user-attachments/assets/6e5cff94-2f30-4830-839d-c162ebbb56da" />

Part of [DOTDASH-422: Show/hide the Settings in the Domain Overview section depending on the domain state](https://linear.app/a8c/issue/DOTDASH-422/showhide-the-settings-in-the-domain-overview-section-depending-on-the)

## Proposed Changes

* I replicated the existing logic in showing/hiding the Setting for a domain from the old domain management screen

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because depending on the domain type and status we should show or hide certain Settings

## Testing Instructions

* Click on a connected domain and make sure that you can't see the nameservers Setting

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
