### PR TITLE
Add a badge showing the domain subtype below the domain name

### DIFF
--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,7 +1,8 @@
 import { domainQuery, sitePurchaseQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
+import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useLocale } from '../../app/locale';
@@ -40,10 +41,21 @@ export default function DomainOverview() {
 			header={
 				<PageHeader
 					title={ wrappableDomainName }
-					// translators: date is the date the domain was registered.
-					description={ sprintf( __( 'Registered on %(date)s' ), {
-						date: formatDate( new Date( domain.registration_date ), locale, { dateStyle: 'long' } ),
-					} ) }
+					description={
+						<HStack spacing={ 2 } alignment="center" justify="flex-start">
+							{ domain.subtype?.label && <Badge>{ domain.subtype.label }</Badge> }
+							<span>
+								{
+									// translators: date is the date the domain was registered.
+									sprintf( __( 'Registered on %(date)s' ), {
+										date: formatDate( new Date( domain.registration_date ), locale, {
+											dateStyle: 'long',
+										} ),
+									} )
+								}
+							</span>
+						</HStack>
+					}
 					actions={
 						purchase?.can_explicit_renew && (
 							<Button


### PR DESCRIPTION
It's not clear if a domain is a connected domain name or registered domain name once you click on it, so why not add a badge to show that:

Here's how it looks:
<img width="706" height="185" alt="Screenshot 2025-09-10 at 18 34 47" src="https://github.com/user-attachments/assets/20217fa0-b88a-418a-970a-9963d4ac1e66" />
<img width="704" height="190" alt="Screenshot 2025-09-10 at 18 34 28" src="https://github.com/user-attachments/assets/45321867-ef2c-4d51-b67b-a4004009424c" />


Part of [DOTDASH-424: Add a badge with the domain subtype label so that it's clear if you're looking at domain name connection or registration or transfer](https://linear.app/a8c/issue/DOTDASH-424/add-a-badge-with-the-domain-subtype-label-so-that-its-clear-if-youre)

## Proposed Changes

* Add a badge in the PageHeader description that shows the domain type

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make it clear if a domain is registration, connection or transfer (or site redirect)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you see the badge when you go to the overview section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
