### PR TITLE
Hosting Dashboard: Add domain contact details policy protection

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -193,8 +193,12 @@ export const domainForwardingEditRoute = createRoute( {
 export const domainContactInfoRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: 'contact-info',
-	loader: ( { params: { domainName } } ) =>
-		queryClient.ensureQueryData( domainWhoisQuery( domainName ) ),
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainWhoisQuery( domainName ) ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../../domains/domain-contact-details' ).then( ( d ) =>
 		createLazyRoute( 'domain-contact-info' )( {

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -1,4 +1,10 @@
 import {
+	domainPrivacyDisableMutation,
+	domainPrivacyEnableMutation,
+	domainQuery,
+} from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ToggleControl,
@@ -7,13 +13,30 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
-import type { Domain } from '@automattic/api-core';
 
 interface ContactFormPrivacyProps {
-	domain: Domain;
+	domainName: string;
 }
 
-export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps ) {
+export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyProps ) {
+	const { data: domain, isFetching: domainQueryIsFetching } = useSuspenseQuery(
+		domainQuery( domainName )
+	);
+	const enablePrivacyMutation = useMutation( domainPrivacyEnableMutation( domainName ) );
+	const disablePrivacyMutation = useMutation( domainPrivacyDisableMutation( domainName ) );
+	const isUpdatingPrivacy =
+		enablePrivacyMutation.isPending || disablePrivacyMutation.isPending || domainQueryIsFetching;
+
+	const togglePrivacy = () => {
+		if ( domain.private_domain ) {
+			disablePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {},
+			} );
+		} else {
+			enablePrivacyMutation.mutate();
+		}
+	};
+
 	const renderPrivacyProtection = () => {
 		let note;
 
@@ -44,8 +67,8 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.private_domain }
-					disabled={ ! domain.privacy_available }
-					onChange={ () => {} }
+					disabled={ isUpdatingPrivacy || ! domain.privacy_available }
+					onChange={ togglePrivacy }
 					label={ __( 'Privacy protection' ) }
 				/>
 
@@ -74,7 +97,7 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 					__nextHasNoMarginBottom
 					checked={ domain.contact_info_disclosed }
 					onChange={ () => {} }
-					disabled={ domain.is_pending_icann_verification }
+					disabled={ isUpdatingPrivacy || domain.is_pending_icann_verification }
 					label={ __( 'Display my contact information in public WHOIS' ) }
 				/>
 

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -1,0 +1,69 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	ToggleControl,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../components/inline-support-link';
+import { SectionHeader } from '../../components/section-header';
+import type { Domain } from '@automattic/api-core';
+
+interface ContactFormPrivacyProps {
+	domain: Domain;
+}
+
+export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps ) {
+	const renderPrivacyProtection = () => {
+		return (
+			<ToggleControl
+				checked={ domain.private_domain }
+				disabled={ ! domain.privacy_available }
+				onChange={ () => {} }
+				label={ __( 'Privacy protection' ) }
+			/>
+		);
+	};
+
+	const renderPrivacyDisclosure = () => {
+		if (
+			! domain.privacy_available ||
+			! domain.contact_info_disclosure_available ||
+			domain.private_domain ||
+			domain.is_hundred_year_domain
+		) {
+			return false;
+		}
+
+		return (
+			<ToggleControl
+				checked={ domain.contact_info_disclosed }
+				onChange={ () => {} }
+				disabled={ domain.is_pending_icann_verification }
+				label={ __( 'Display my contact information in public WHOIS' ) }
+			/>
+		);
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<SectionHeader title={ __( 'Privacy protection' ) } level={ 3 } />
+
+			<VStack spacing={ 2 }>
+				{ renderPrivacyProtection() }
+				{ renderPrivacyDisclosure() }
+			</VStack>
+
+			{ domain.privacy_available && (
+				<Text as="p" variant="muted">
+					{ createInterpolateElement(
+						__( 'We recommend keeping privacy protection on. <link>Learn more</link>' ),
+						{
+							link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+						}
+					) }
+				</Text>
+			) }
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -15,14 +15,46 @@ interface ContactFormPrivacyProps {
 
 export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps ) {
 	const renderPrivacyProtection = () => {
+		let note;
+
+		if ( ! domain.privacy_available ) {
+			note = createInterpolateElement(
+				__(
+					'Privacy protection is not available due to the registry’s policies. <link>Learn more</link>'
+				),
+				{
+					link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+				}
+			);
+
+			if ( domain.private_domain ) {
+				note = createInterpolateElement(
+					__(
+						'Privacy protection must be enabled due to the registry’s policies. <link>Learn more</link>'
+					),
+					{
+						link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+					}
+				);
+			}
+		}
+
 		return (
-			<ToggleControl
-				__nextHasNoMarginBottom
-				checked={ domain.private_domain }
-				disabled={ ! domain.privacy_available }
-				onChange={ () => {} }
-				label={ __( 'Privacy protection' ) }
-			/>
+			<>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					checked={ domain.private_domain }
+					disabled={ ! domain.privacy_available }
+					onChange={ () => {} }
+					label={ __( 'Privacy protection' ) }
+				/>
+
+				{ note && (
+					<Text as="p" variant="muted">
+						{ note }
+					</Text>
+				) }
+			</>
 		);
 	};
 
@@ -37,7 +69,7 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 		}
 
 		return (
-			<VStack spacing={ 2 }>
+			<>
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.contact_info_disclosed }
@@ -53,7 +85,7 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 						) }
 					</Text>
 				) }
-			</VStack>
+			</>
 		);
 	};
 

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -1,6 +1,8 @@
 import {
 	domainPrivacyDisableMutation,
+	domainPrivacyDiscloseMutation,
 	domainPrivacyEnableMutation,
+	domainPrivacyRedactMutation,
 	domainQuery,
 } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
@@ -9,8 +11,10 @@ import {
 	__experimentalText as Text,
 	ToggleControl,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 
@@ -19,69 +23,113 @@ interface ContactFormPrivacyProps {
 }
 
 export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyProps ) {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain, isFetching: domainQueryIsFetching } = useSuspenseQuery(
 		domainQuery( domainName )
 	);
 	const enablePrivacyMutation = useMutation( domainPrivacyEnableMutation( domainName ) );
 	const disablePrivacyMutation = useMutation( domainPrivacyDisableMutation( domainName ) );
+	const disclosePrivacyMutation = useMutation( domainPrivacyDiscloseMutation( domainName ) );
+	const redactPrivacyMutation = useMutation( domainPrivacyRedactMutation( domainName ) );
 	const isUpdatingPrivacy =
-		enablePrivacyMutation.isPending || disablePrivacyMutation.isPending || domainQueryIsFetching;
+		enablePrivacyMutation.isPending ||
+		disablePrivacyMutation.isPending ||
+		disclosePrivacyMutation.isPending ||
+		redactPrivacyMutation.isPending ||
+		domainQueryIsFetching;
 
-	const togglePrivacy = () => {
+	const togglePrivacyProtection = () => {
 		if ( domain.private_domain ) {
 			disablePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {},
+				onSuccess: () => {
+					createSuccessNotice( __( 'Privacy has been successfully disabled!' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message, {
+						type: 'snackbar',
+					} );
+				},
 			} );
 		} else {
-			enablePrivacyMutation.mutate();
+			enablePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Yay, privacy has been successfully enabled!' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message, {
+						type: 'snackbar',
+					} );
+				},
+			} );
 		}
 	};
 
 	const renderPrivacyProtection = () => {
-		let note;
-
-		if ( ! domain.privacy_available ) {
-			note = createInterpolateElement(
-				__(
-					'Privacy protection is not available due to the registry’s policies. <link>Learn more</link>'
-				),
-				{
-					link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
-				}
-			);
-
-			if ( domain.private_domain ) {
-				note = createInterpolateElement(
-					__(
-						'Privacy protection must be enabled due to the registry’s policies. <link>Learn more</link>'
-					),
-					{
-						link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
-					}
-				);
-			}
-		}
-
 		return (
 			<>
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.private_domain }
 					disabled={ isUpdatingPrivacy || ! domain.privacy_available }
-					onChange={ togglePrivacy }
+					onChange={ togglePrivacyProtection }
 					label={ __( 'Privacy protection' ) }
 				/>
 
-				{ note && (
+				{ ! domain.privacy_available && (
 					<Text as="p" variant="muted">
-						{ note }
+						{ createInterpolateElement(
+							domain.private_domain
+								? __(
+										'Privacy protection must be enabled due to the registry’s policies. <link>Learn more</link>'
+								  )
+								: __(
+										'Privacy protection is not available due to the registry’s policies. <link>Learn more</link>'
+								  ),
+							{
+								link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+							}
+						) }
 					</Text>
 				) }
 			</>
 		);
 	};
 
-	const renderContactDisclosure = () => {
+	const togglePrivacyDisclosure = () => {
+		if ( domain.contact_info_disclosed ) {
+			redactPrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Your contact information is now redacted!' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message, {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		} else {
+			disclosePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Your contact information is now publicly visible!' ), {
+						type: 'snackbar',
+					} );
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message, {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		}
+	};
+
+	const renderPrivacyDisclosure = () => {
 		if (
 			! domain.privacy_available ||
 			! domain.contact_info_disclosure_available ||
@@ -96,7 +144,7 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.contact_info_disclosed }
-					onChange={ () => {} }
+					onChange={ togglePrivacyDisclosure }
 					disabled={ isUpdatingPrivacy || domain.is_pending_icann_verification }
 					label={ __( 'Display my contact information in public WHOIS' ) }
 				/>
@@ -117,7 +165,7 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 			<SectionHeader title={ __( 'Privacy protection' ) } level={ 3 } />
 
 			{ renderPrivacyProtection() }
-			{ renderContactDisclosure() }
+			{ renderPrivacyDisclosure() }
 
 			{ domain.privacy_available && (
 				<Text as="p" variant="muted">

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -55,7 +55,7 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 		} else {
 			enablePrivacyMutation.mutate( undefined, {
 				onSuccess: () => {
-					createSuccessNotice( __( 'Yay, privacy has been successfully enabled!' ), {
+					createSuccessNotice( __( 'Privacy has been successfully enabled!' ), {
 						type: 'snackbar',
 					} );
 				},

--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -17,6 +17,7 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 	const renderPrivacyProtection = () => {
 		return (
 			<ToggleControl
+				__nextHasNoMarginBottom
 				checked={ domain.private_domain }
 				disabled={ ! domain.privacy_available }
 				onChange={ () => {} }
@@ -25,7 +26,7 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 		);
 	};
 
-	const renderPrivacyDisclosure = () => {
+	const renderContactDisclosure = () => {
 		if (
 			! domain.privacy_available ||
 			! domain.contact_info_disclosure_available ||
@@ -36,12 +37,23 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 		}
 
 		return (
-			<ToggleControl
-				checked={ domain.contact_info_disclosed }
-				onChange={ () => {} }
-				disabled={ domain.is_pending_icann_verification }
-				label={ __( 'Display my contact information in public WHOIS' ) }
-			/>
+			<VStack spacing={ 2 }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					checked={ domain.contact_info_disclosed }
+					onChange={ () => {} }
+					disabled={ domain.is_pending_icann_verification }
+					label={ __( 'Display my contact information in public WHOIS' ) }
+				/>
+
+				{ domain.is_pending_icann_verification && (
+					<Text as="p" variant="muted">
+						{ __(
+							'You need to verify the contact information for the domain before you can disclose it publicly.'
+						) }
+					</Text>
+				) }
+			</VStack>
 		);
 	};
 
@@ -49,10 +61,8 @@ export default function ContactFormPrivacy( { domain }: ContactFormPrivacyProps 
 		<VStack spacing={ 4 }>
 			<SectionHeader title={ __( 'Privacy protection' ) } level={ 3 } />
 
-			<VStack spacing={ 2 }>
-				{ renderPrivacyProtection() }
-				{ renderPrivacyDisclosure() }
-			</VStack>
+			{ renderPrivacyProtection() }
+			{ renderContactDisclosure() }
 
 			{ domain.privacy_available && (
 				<Text as="p" variant="muted">

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -4,8 +4,9 @@ import {
 	statesListQuery,
 	domainWhoisMutation,
 	domainWhoisValidateMutation,
+	domainQuery,
 } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	ExternalLink,
 	__experimentalVStack as VStack,
@@ -24,6 +25,7 @@ import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { getContactFormFields } from './contact-form-fields';
+import ContactFormPrivacy from './contact-form-privacy';
 
 interface ContactFormProps {
 	domainName: string;
@@ -31,6 +33,7 @@ interface ContactFormProps {
 }
 
 export default function ContactForm( { domainName, initialData }: ContactFormProps ) {
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: countryList } = useQuery( countryListQuery() );
 	const [ formData, setFormData ] = useState< DomainContactDetails >(
@@ -144,6 +147,14 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 					</Text>
 				</VStack>
 			</Notice>
+
+			{ ! domain.is_hundred_year_domain && (
+				<Card>
+					<CardBody>
+						<ContactFormPrivacy domain={ domain } />
+					</CardBody>
+				</Card>
+			) }
 
 			<Card>
 				<CardBody>

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -151,7 +151,7 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 			{ ! domain.is_hundred_year_domain && (
 				<Card>
 					<CardBody>
-						<ContactFormPrivacy domain={ domain } />
+						<ContactFormPrivacy domainName={ domainName } />
 					</CardBody>
 				</Card>
 			) }

--- a/packages/api-core/src/domain-privacy/index.ts
+++ b/packages/api-core/src/domain-privacy/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/domain-privacy/mutators.ts
+++ b/packages/api-core/src/domain-privacy/mutators.ts
@@ -1,0 +1,16 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { DomainPrivacyResponse } from './types';
+
+export function enableDomainPrivacy( domainName: string ): Promise< DomainPrivacyResponse > {
+	return wpcom.req.post( {
+		path: `/domains/${ domainName }/privacy/enable`,
+		apiVersion: '1.1',
+	} );
+}
+
+export function disableDomainPrivacy( domainName: string ): Promise< DomainPrivacyResponse > {
+	return wpcom.req.post( {
+		path: `/domains/${ domainName }/privacy/disable`,
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-core/src/domain-privacy/mutators.ts
+++ b/packages/api-core/src/domain-privacy/mutators.ts
@@ -14,3 +14,17 @@ export function disableDomainPrivacy( domainName: string ): Promise< DomainPriva
 		apiVersion: '1.1',
 	} );
 }
+
+export function discloseDomainPrivacy( domainName: string ): Promise< DomainPrivacyResponse > {
+	return wpcom.req.post( {
+		path: `/domains/${ domainName }/privacy/disclose`,
+		apiVersion: '1.1',
+	} );
+}
+
+export function redactDomainPrivacy( domainName: string ): Promise< DomainPrivacyResponse > {
+	return wpcom.req.post( {
+		path: `/domains/${ domainName }/privacy/redact`,
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-core/src/domain-privacy/types.ts
+++ b/packages/api-core/src/domain-privacy/types.ts
@@ -1,0 +1,1 @@
+export type DomainPrivacyResponse = { success: boolean };

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -22,6 +22,8 @@ export interface Domain extends DomainSummary {
 	can_transfer_to_any_user: boolean;
 	can_transfer_to_other_site: boolean;
 	cannot_manage_name_servers_reason: null | string;
+	contact_info_disclosure_available: boolean;
+	contact_info_disclosed: boolean;
 	dnssec_records?: {
 		dnskey: string[];
 		ds_data: string[];
@@ -36,6 +38,7 @@ export interface Domain extends DomainSummary {
 	is_locked: boolean;
 	is_root_domain_registered_with_automattic: boolean;
 	is_subdomain: boolean;
+	is_pending_icann_verification: boolean;
 	move_to_new_site_pending: boolean;
 	private_domain: boolean;
 	privacy_available: boolean;

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -11,6 +11,7 @@ export * from './domain-dnssec';
 export * from './domain-forwarding';
 export * from './domain-glue-records';
 export * from './domain-name-servers';
+export * from './domain-privacy';
 export * from './domain-ssl';
 export * from './domain-suggestions';
 export * from './domain-supported-countries';

--- a/packages/api-queries/src/domain-privacy.ts
+++ b/packages/api-queries/src/domain-privacy.ts
@@ -1,4 +1,9 @@
-import { disableDomainPrivacy, enableDomainPrivacy } from '@automattic/api-core';
+import {
+	disableDomainPrivacy,
+	discloseDomainPrivacy,
+	enableDomainPrivacy,
+	redactDomainPrivacy,
+} from '@automattic/api-core';
 import { mutationOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
 import { queryClient } from './query-client';
@@ -14,6 +19,22 @@ export const domainPrivacyEnableMutation = ( domainName: string ) =>
 export const domainPrivacyDisableMutation = ( domainName: string ) =>
 	mutationOptions( {
 		mutationFn: () => disableDomainPrivacy( domainName ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainQuery( domainName ) );
+		},
+	} );
+
+export const domainPrivacyDiscloseMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: () => discloseDomainPrivacy( domainName ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainQuery( domainName ) );
+		},
+	} );
+
+export const domainPrivacyRedactMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: () => redactDomainPrivacy( domainName ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},

--- a/packages/api-queries/src/domain-privacy.ts
+++ b/packages/api-queries/src/domain-privacy.ts
@@ -1,0 +1,20 @@
+import { disableDomainPrivacy, enableDomainPrivacy } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { domainQuery } from './domain';
+import { queryClient } from './query-client';
+
+export const domainPrivacyEnableMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: () => enableDomainPrivacy( domainName ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainQuery( domainName ) );
+		},
+	} );
+
+export const domainPrivacyDisableMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: () => disableDomainPrivacy( domainName ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainQuery( domainName ) );
+		},
+	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -7,6 +7,7 @@ export * from './domain-dnssec';
 export * from './domain-forwarding';
 export * from './domain-glue-records';
 export * from './domain-name-servers';
+export * from './domain-privacy';
 export * from './domain-ssl';
 export * from './domain-supported-contries';
 export * from './domain-transfer';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves https://linear.app/a8c/issue/DOTDASH-325/add-privacy-protection-whois-inside-contact-details-screen

## Proposed Changes

* This PR adds the privacy protection section to the contact details screen. The logic is based on the [`ContactsPrivacyCard`](https://github.com/Automattic/wp-calypso/blob/3af5bdbbb2a1bd740d63040ae73ada63b8cd49e4/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx) component.

<img width="1402" height="890" alt="image" src="https://github.com/user-attachments/assets/636a8c99-70e2-4cdd-a524-4bb0fb096dec" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to be able to edit the privacy settings in the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/domains/[domain]/contact-info`
* Make sure both privacy toggles work the same as the ones on `/domains/manage/all/overview/[domain]/[site]` -> Contact information.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
