### PR TITLE
Marketing Tools: Update ActivityPub card to link to wp-admin settings

### DIFF
--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -12,6 +12,8 @@ import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { pluginsPath } from 'calypso/my-sites/marketing/paths';
 import { useSelector } from 'calypso/state';
+import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
 import MarketingToolsFeature from './feature';
@@ -34,7 +36,21 @@ export default function MarketingTools() {
 		{ key: 'favourite', text: translate( 'User favorites' ) },
 	];
 
-	const marketingFeatures = getMarketingFeaturesData( selectedSiteSlug, translate, localizeUrl );
+	const activityPubSettingsUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'options-general.php?page=activitypub' )
+	);
+	const activityPubStatus = useActivityPubStatus( siteId, () => {
+		if ( activityPubSettingsUrl ) {
+			window.location.href = activityPubSettingsUrl;
+		}
+	} );
+
+	const marketingFeatures = getMarketingFeaturesData(
+		selectedSiteSlug,
+		translate,
+		localizeUrl,
+		activityPubStatus
+	);
 
 	const marketingFeaturesFiltered = useMemo( () => {
 		let filteredFeatures = marketingFeatures.filter( ( feature ) =>

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -16,7 +16,8 @@ import { MarketingToolsFeatureData } from './types';
 export const getMarketingFeaturesData = (
 	selectedSiteSlug: T.SiteSlug | null,
 	translate: ( text: string, options?: any ) => string,
-	localizeUrl: ( url: string ) => string
+	localizeUrl: ( url: string ) => string,
+	activityPubStatus: any
 ): MarketingToolsFeatureData[] => {
 	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
 	const currentDate = new Date();
@@ -71,21 +72,6 @@ export const getMarketingFeaturesData = (
 			},
 		},
 		{
-			title: translate( 'Share your blog with a new audience' ),
-			description: translate(
-				'Connect your WordPress.com site to the social web. Let people follow your posts from platforms like Mastodon, Threads, and more—no extra work needed.'
-			),
-			categories: [ 'share', 'new' ],
-			imagePath: activityPubLogo,
-			imageAlt: translate( 'Activitypub logo' ),
-			buttonText: translate( 'Enter the fediverse' ),
-			onClick: () => {
-				recordTracksEvent( 'calypso_marketing_tools_activitypub_button_click' );
-
-				page( marketingConnections( selectedSiteSlug ) );
-			},
-		},
-		{
 			title: translate( 'Hire an SEO expert' ),
 			description: translate(
 				'In today‘s digital age, visibility is key. Hire an SEO expert to boost your online presence and capture valuable opportunities.'
@@ -116,6 +102,27 @@ export const getMarketingFeaturesData = (
 			},
 		},
 	];
+
+	if ( ! activityPubStatus?.isEnabled ) {
+		result.splice( 3, 0, {
+			title: translate( 'Share your blog with a new audience' ),
+			description: translate(
+				'Connect your WordPress.com site to the social web. Let people follow your posts from platforms like Mastodon, Threads, and more—no extra work needed.'
+			),
+			categories: [ 'share', 'new' ],
+			imagePath: activityPubLogo,
+			imageAlt: translate( 'Activitypub logo' ),
+			buttonText: activityPubStatus.isLoading
+				? translate( 'Joining…' )
+				: translate( 'Join the open social web' ),
+			onClick: () => {
+				recordTracksEvent( 'calypso_marketing_tools_activitypub_button_click' );
+
+				// @ts-ignore There are no type definitions in useActivityPubStatus
+				activityPubStatus.setEnabled( true );
+			},
+		} );
+	}
 
 	// Add Facebook feature conditionally as 3rd item
 	if ( shouldShowFacebook ) {

--- a/client/state/activitypub/use-activitypub-status.js
+++ b/client/state/activitypub/use-activitypub-status.js
@@ -6,14 +6,14 @@ export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
 	const apiNamespace = 'wpcom/v2';
 	const queryKey = [ path, apiNamespace ];
 
-	const { data, isInitialLoading, isError } = useQuery( {
+	const { data, isLoading, isError } = useQuery( {
 		queryKey,
 		staleTime: 0, // refetches are important here, lots of stuff in play while doing upgrades, activation, etc
 		gcTime: 5 * 60 * 1000, // 5 mins
 		queryFn: () => wpcom.req.get( { path, apiNamespace } ),
 	} );
 	const queryClient = useQueryClient();
-	const { mutate, isLoading } = useMutation( {
+	const { mutate, isPending } = useMutation( {
 		mutationFn: ( enabled ) => wpcom.req.post( { path, apiNamespace }, { enabled } ),
 		onSuccess: ( responseData ) => {
 			queryClient.setQueryData( queryKey, responseData );
@@ -24,7 +24,7 @@ export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
 	return {
 		isEnabled: !! data?.enabled,
 		setEnabled: mutate,
-		isLoading: isInitialLoading || isLoading,
+		isLoading: isLoading || isPending,
 		isError,
 		data,
 	};


### PR DESCRIPTION
### After

<img width="1091" height="606" alt="Screenshot 2025-09-11 at 2 31 58 PM" src="https://github.com/user-attachments/assets/34e9d6c5-c2db-45d9-877d-b2695e23874e" />
<img width="1075" height="601" alt="Screenshot 2025-09-11 at 2 32 24 PM" src="https://github.com/user-attachments/assets/60c112ab-a242-4d23-8615-70c4dcf7eff1" />


## Proposed Changes

* Update ActivityPub marketing card to only shows when ActivityPub is not enabled.
* Card links directly to wp-admin ActivityPub settings page.
* Automatically enables ActivityPub when card is clicked.
* Shows loading state ("Joining…") during API call.
* Redirects to ActivityPub settings page after successful enablement.
* Fixes useActivityPubStatus hook to use correct TanStack Query properties.

## Why are these changes being made?

The Marketing > Connections screen is about to go away, so the Activitypub marketing card needs to point to the new location in Settings > Activitypub.

## Testing Instructions

* Navigate to Tools > MArketing on a site where ActivityPub is not enabled.
* Verify the "Share your blog with a new audience" ActivityPub card appears.
* Click the "Join the open social web" button.
* Verify button text changes to "Joining…" during API call.
* Verify you are redirected to wp-admin ActivityPub settings page after completion.
* Test on a site where ActivityPub is already enabled and verify the card does not appear.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?