### PR TITLE
Hosting Dashboard > Security: Implement Two-step Authentication setup using SMS

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -181,7 +181,12 @@ export const securityAccountRecoveryRoute = createRoute( {
 export const securityTwoStepAuthRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'security/two-step-auth',
-	loader: () => queryClient.ensureQueryData( userSettingsQuery() ),
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( smsCountryCodesQuery() ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../../me/security-two-step-auth' ).then( ( d ) =>
 		createLazyRoute( 'security-two-step-auth' )( {
@@ -202,6 +207,23 @@ export const securityTwoStepAuthAppRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../me/security-two-step-auth-app' ).then( ( d ) =>
 		createLazyRoute( 'security-two-step-auth-app' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const securityTwoStepAuthSMSRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'security/two-step-auth/sms',
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( smsCountryCodesQuery() ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../me/security-two-step-auth-sms' ).then( ( d ) =>
+		createLazyRoute( 'security-two-step-auth-sms' )( {
 			component: d.default,
 		} )
 	)
@@ -359,6 +381,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		securityAccountRecoveryRoute,
 		securityTwoStepAuthRoute,
 		securityTwoStepAuthAppRoute,
+		securityTwoStepAuthSMSRoute,
 		securityTwoStepAuthBackupCodesRoute,
 		securitySshKeyRoute,
 		securityConnectedAppsRoute,

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -6,11 +6,15 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import type { SecuritySMSNumber } from './types';
 
 import './style.scss';
 
-// TODO: We could potentially move this component to a shared place
+export type SecuritySMSNumber = {
+	phoneNumber: string;
+	countryCode: string;
+	countryNumericCode: string;
+};
+
 export default function PhoneNumberInput( {
 	data,
 	onChange,

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -1,0 +1,3 @@
+.phone-number-input__number-input {
+	width: 100%;
+}

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -21,9 +21,9 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
+import PhoneNumberInput from '../../components/phone-number-input';
 import { SectionHeader } from '../../components/section-header';
 import { validatePhone } from '../../utils/phone-number';
-import PhoneNumberInput from './phone-number-input';
 import type { SecuritySMSFormData } from './types';
 import type { Field } from '@wordpress/dataviews';
 

--- a/client/dashboard/me/security-two-step-auth-app/index.tsx
+++ b/client/dashboard/me/security-two-step-auth-app/index.tsx
@@ -3,8 +3,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
+import SecurityTwoStepAuthPageLayout from '../security-two-step-auth/common/page-layout';
 import PrintBackupCodes from '../security-two-step-auth/common/print-backup-codes';
-import SecurityTwoStepAuthAppPageLayout from './page-layout';
 import ScanQRCode from './scan-qr-code';
 
 export default function SecurityTwoStepAuthApp() {
@@ -17,7 +17,7 @@ export default function SecurityTwoStepAuthApp() {
 	const showPrintBackupCodes = isTwoStepAppEnabled && ! isBackupCodesPrinted;
 
 	return (
-		<SecurityTwoStepAuthAppPageLayout>
+		<SecurityTwoStepAuthPageLayout>
 			<VStack spacing={ 8 }>
 				{ ! isTwoStepAppEnabled && (
 					<Notice variant="info" title={ __( 'Before you continue' ) }>
@@ -32,6 +32,6 @@ export default function SecurityTwoStepAuthApp() {
 
 				{ showPrintBackupCodes ? <PrintBackupCodes username={ username } /> : <ScanQRCode /> }
 			</VStack>
-		</SecurityTwoStepAuthAppPageLayout>
+		</SecurityTwoStepAuthPageLayout>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth-sms/index.tsx
+++ b/client/dashboard/me/security-two-step-auth-sms/index.tsx
@@ -1,0 +1,25 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import SecurityTwoStepAuthPageLayout from '../security-two-step-auth/common/page-layout';
+import PrintBackupCodes from '../security-two-step-auth/common/print-backup-codes';
+import SetupPhoneNumber from './setup-phone-number';
+
+export default function SecurityTwoStepAuthSMS() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	const isTwoStepSMSEnabled = userSettings.two_step_sms_enabled;
+	const isBackupCodesPrinted = userSettings.two_step_backup_codes_printed;
+	const showPrintBackupCodes = isTwoStepSMSEnabled && ! isBackupCodesPrinted;
+
+	const username = userSettings.user_login;
+
+	return (
+		<SecurityTwoStepAuthPageLayout>
+			{ showPrintBackupCodes ? (
+				<PrintBackupCodes username={ username } />
+			) : (
+				<SetupPhoneNumber userSettings={ userSettings } />
+			) }
+		</SecurityTwoStepAuthPageLayout>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
+++ b/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
@@ -1,7 +1,7 @@
 import {
 	smsCountryCodesQuery,
-	setupSMSMutation,
-	resendSMSCodeMutation,
+	setupTwoStepAuthSMSMutation,
+	resendTwoStepAuthSMSCodeMutation,
 } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -30,8 +30,12 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 
 	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
 
-	const { mutate: setupSMS, isPending: isSetupSMSPending } = useMutation( setupSMSMutation() );
-	const { mutate: resendSMSCode, isPending: isResending } = useMutation( resendSMSCodeMutation() );
+	const { mutate: setupTwoStepAuthSMS, isPending: isSetupSMSPending } = useMutation(
+		setupTwoStepAuthSMSMutation()
+	);
+	const { mutate: resendTwoStepAuthSMSCode, isPending: isResending } = useMutation(
+		resendTwoStepAuthSMSCodeMutation()
+	);
 
 	const initialCountryCode = userSettings.two_step_sms_country;
 	const initialPhoneNumber = userSettings.two_step_sms_phone_number || '';
@@ -71,7 +75,7 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 
 		setIsSMSResendThrottled( true );
 
-		setupSMS(
+		setupTwoStepAuthSMS(
 			{
 				two_step_sms_country: formData.phoneNumber.countryCode,
 				two_step_sms_phone_number: formData.phoneNumber.phoneNumber,
@@ -81,8 +85,16 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 					setShowVerifyCode( true );
 					handleThrottleSMSRequests();
 				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to save phone number. Please try again.' ), {
+				onError: ( e: Error ) => {
+					const cause = e?.cause as { error?: string; message?: string };
+					const error = cause?.error;
+					const errorMessage =
+						error === 'rate_limited'
+							? __(
+									'Unable to request a code via SMS right now. Please try again after one minute.'
+							  )
+							: cause?.message || __( 'Failed to save phone number. Please try again.' );
+					createErrorNotice( errorMessage, {
 						type: 'snackbar',
 					} );
 					setIsSMSResendThrottled( false );
@@ -93,7 +105,7 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 
 	const handleResend = () => {
 		setIsSMSResendThrottled( true );
-		resendSMSCode( undefined, {
+		resendTwoStepAuthSMSCode( undefined, {
 			onSuccess: () => {
 				createSuccessNotice( __( 'Verification code sent to your phone.' ), {
 					type: 'snackbar',

--- a/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
+++ b/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
@@ -1,0 +1,219 @@
+import {
+	smsCountryCodesQuery,
+	setupSMSMutation,
+	resendSMSCodeMutation,
+} from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { __experimentalVStack as VStack, Button, Card, CardBody } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+import PhoneNumberInput, { type SecuritySMSNumber } from '../../components/phone-number-input';
+import { SectionHeader } from '../../components/section-header';
+import { validatePhone } from '../../utils/phone-number';
+import VerifyCodeForm from '../security-two-step-auth/common/verify-code-form';
+import type { UserSettings } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
+
+type SMSSetupFormData = {
+	phoneNumber: SecuritySMSNumber;
+};
+
+export default function SetupPhoneNumber( { userSettings }: { userSettings: UserSettings } ) {
+	const router = useRouter();
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
+
+	const { mutate: setupSMS, isPending: isSetupSMSPending } = useMutation( setupSMSMutation() );
+	const { mutate: resendSMSCode, isPending: isResending } = useMutation( resendSMSCodeMutation() );
+
+	const initialCountryCode = userSettings.two_step_sms_country;
+	const initialPhoneNumber = userSettings.two_step_sms_phone_number || '';
+
+	const countryCode =
+		smsCountryCodes.find( ( countryCode ) => countryCode.code === initialCountryCode ) ||
+		smsCountryCodes[ 0 ];
+
+	const [ formData, setFormData ] = useState< SMSSetupFormData >( {
+		phoneNumber: {
+			phoneNumber: initialPhoneNumber,
+			countryCode: countryCode.code,
+			countryNumericCode: countryCode.numeric_code,
+		},
+	} );
+	const [ showVerifyCode, setShowVerifyCode ] = useState( false );
+	const [ isSMSResendThrottled, setIsSMSResendThrottled ] = useState( false );
+
+	// Allow SMS requests after 60 seconds
+	const handleThrottleSMSRequests = () => {
+		setTimeout( () => {
+			setIsSMSResendThrottled( false );
+		}, 60000 );
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+
+		const fullPhoneNumber = `${ formData.phoneNumber.countryNumericCode }${ formData.phoneNumber.phoneNumber }`;
+		const validation = validatePhone( fullPhoneNumber );
+		if ( validation.error ) {
+			createErrorNotice( validation.message, {
+				type: 'snackbar',
+			} );
+			return;
+		}
+
+		setIsSMSResendThrottled( true );
+
+		setupSMS(
+			{
+				two_step_sms_country: formData.phoneNumber.countryCode,
+				two_step_sms_phone_number: formData.phoneNumber.phoneNumber,
+			},
+			{
+				onSuccess: () => {
+					setShowVerifyCode( true );
+					handleThrottleSMSRequests();
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save phone number. Please try again.' ), {
+						type: 'snackbar',
+					} );
+					setIsSMSResendThrottled( false );
+				},
+			}
+		);
+	};
+
+	const handleResend = () => {
+		setIsSMSResendThrottled( true );
+		resendSMSCode( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Verification code sent to your phone.' ), {
+					type: 'snackbar',
+				} );
+				handleThrottleSMSRequests();
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to send verification code. Please try again.' ), {
+					type: 'snackbar',
+				} );
+				setIsSMSResendThrottled( false );
+			},
+		} );
+	};
+
+	const field: Field< SMSSetupFormData > = useMemo(
+		() => ( {
+			id: 'phoneNumber',
+			type: 'text',
+			label: __( 'Phone number' ),
+			Edit: ( { data, onChange } ) => {
+				return (
+					<PhoneNumberInput
+						data={ data.phoneNumber }
+						onChange={ ( phoneNumber ) => onChange( { phoneNumber } ) }
+						isDisabled={ isSetupSMSPending }
+					/>
+				);
+			},
+			// TODO: Add validation via isValid.custom.
+			// There is currently a bug that prevents it from working.
+			// For now, we're using the handleSubmit to validate the phone number.
+		} ),
+		[ isSetupSMSPending ]
+	);
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					{ showVerifyCode ? (
+						<>
+							<SectionHeader
+								title={ __( 'Verify code' ) }
+								level={ 3 }
+								description={ __(
+									'A code has been sent to your device via SMS. You may request another code after one minute.'
+								) }
+							/>
+							<VerifyCodeForm
+								actionType="enable-two-step"
+								primaryButtonText={ __( 'Continue' ) }
+								resendButtonProps={ {
+									onClick: handleResend,
+									isBusy: isResending,
+									disabled: isResending || isSMSResendThrottled,
+								} }
+								customField={ {
+									hideLabelFromVision: true,
+									placeholder: '12345678',
+								} }
+								onSuccess={ () => {
+									createSuccessNotice( __( 'Two-step authentication enabled.' ), {
+										type: 'snackbar',
+									} );
+								} }
+								onError={ () => {
+									createErrorNotice( __( 'Failed to enable two-step authentication.' ), {
+										type: 'snackbar',
+									} );
+								} }
+							/>
+						</>
+					) : (
+						<>
+							<SectionHeader
+								title={ __( 'Enter phone number' ) }
+								level={ 3 }
+								description={ __(
+									'We need your phone number to send you two-step authentication codes when you log in.'
+								) }
+							/>
+							<form onSubmit={ handleSubmit }>
+								<VStack spacing={ 4 }>
+									<DataForm< SMSSetupFormData >
+										data={ formData }
+										fields={ [ field ] }
+										form={ { layout: { type: 'regular' as const }, fields: [ field ] } }
+										onChange={ ( edits: Partial< SMSSetupFormData > ) => {
+											setFormData( ( data ) => ( { ...data, ...edits } ) );
+										} }
+									/>
+
+									<ButtonStack justify="flex-start">
+										<Button
+											variant="primary"
+											type="submit"
+											isBusy={ isSetupSMSPending }
+											disabled={
+												! formData.phoneNumber.phoneNumber ||
+												! formData.phoneNumber.countryCode ||
+												isSetupSMSPending
+											}
+										>
+											{ __( 'Continue' ) }
+										</Button>
+
+										<Button
+											variant="tertiary"
+											onClick={ () => router.navigate( { to: '/me/security/two-step-auth' } ) }
+										>
+											{ __( 'Cancel' ) }
+										</Button>
+									</ButtonStack>
+								</VStack>
+							</form>
+						</>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth/common/page-layout.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/page-layout.tsx
@@ -2,10 +2,10 @@ import { useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
 
-export default function SecurityTwoStepAuthAppPageLayout( {
+export default function SecurityTwoStepAuthPageLayout( {
 	children,
 }: {
 	children: React.ReactNode;

--- a/client/dashboard/me/security-two-step-auth/common/verify-code-form.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/verify-code-form.tsx
@@ -21,6 +21,11 @@ interface VerifyCodeFormProps {
 	primaryButtonText?: string;
 	showCancelButton?: boolean;
 	infoNoticeText?: string;
+	resendButtonProps?: {
+		onClick: () => void;
+		isBusy: boolean;
+		disabled: boolean;
+	};
 }
 
 type TwoStepAuthAppFormData = {
@@ -35,6 +40,7 @@ export default function VerifyCodeForm( {
 	primaryButtonText,
 	showCancelButton = true,
 	infoNoticeText,
+	resendButtonProps,
 }: VerifyCodeFormProps ) {
 	const router = useRouter();
 
@@ -113,6 +119,17 @@ export default function VerifyCodeForm( {
 						>
 							{ primaryButtonText ?? __( 'Enable' ) }
 						</Button>
+
+						{ resendButtonProps && (
+							<Button
+								variant="secondary"
+								onClick={ resendButtonProps.onClick }
+								isBusy={ resendButtonProps.isBusy }
+								disabled={ resendButtonProps.disabled || isValidateTwoStepCodePending }
+							>
+								{ __( 'Resend code' ) }
+							</Button>
+						) }
 
 						{ showCancelButton && (
 							<Button

--- a/client/dashboard/me/security-two-step-auth/empty-state.tsx
+++ b/client/dashboard/me/security-two-step-auth/empty-state.tsx
@@ -1,14 +1,34 @@
 import { __ } from '@wordpress/i18n';
-import { Icon, mobile } from '@wordpress/icons';
+import { Icon, mobile, comment } from '@wordpress/icons';
+import { Notice } from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
-export default function SecurityTwoStepAuthEmptyState() {
+export default function SecurityTwoStepAuthEmptyState( {
+	isEnforcedByOrganization,
+}: {
+	isEnforcedByOrganization: boolean;
+} ) {
 	return (
-		<RouterLinkSummaryButton
-			to="/me/security/two-step-auth/app"
-			title={ __( 'Set up using an app' ) }
-			description={ __( 'Use an app to generate two-step authentication codes.' ) }
-			decoration={ <Icon icon={ mobile } /> }
-		/>
+		<>
+			{ isEnforcedByOrganization && (
+				<Notice variant="info" title={ __( 'Enforced by your organization' ) }>
+					{ __(
+						'Two-step authentication is required by your organization to keep your account secure.'
+					) }
+				</Notice>
+			) }
+			<RouterLinkSummaryButton
+				to="/me/security/two-step-auth/app"
+				title={ __( 'Set up using an app' ) }
+				description={ __( 'Use an app to generate two-step authentication codes.' ) }
+				decoration={ <Icon icon={ mobile } /> }
+			/>
+			<RouterLinkSummaryButton
+				to="/me/security/two-step-auth/sms"
+				title={ __( 'Set up using SMS' ) }
+				description={ __( 'Receive two-step authentication codes by text message.' ) }
+				decoration={ <Icon icon={ comment } /> }
+			/>
+		</>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/index.tsx
@@ -1,5 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import PageLayout from '../../components/page-layout';
 import SecurityPageHeader from '../security-page-header';
@@ -7,9 +7,10 @@ import SecurityTwoStepAuthEmptyState from './empty-state';
 import SecurityTwoStepAuthMainPage from './main-page';
 
 export default function SecurityTwoStepAuth() {
-	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	const isTwoStepEnabled = userSettings?.two_step_enabled;
+	const isEnforcedByOrganization = !! userSettings?.two_step_enhanced_security_forced;
 
 	return (
 		<PageLayout
@@ -32,7 +33,7 @@ export default function SecurityTwoStepAuth() {
 			{ isTwoStepEnabled ? (
 				<SecurityTwoStepAuthMainPage userSettings={ userSettings } />
 			) : (
-				<SecurityTwoStepAuthEmptyState />
+				<SecurityTwoStepAuthEmptyState isEnforcedByOrganization={ isEnforcedByOrganization } />
 			) }
 		</PageLayout>
 	);

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -20,6 +20,8 @@ export async function updateUserSettings(
 		'i18n_empathy_mode',
 		'use_fallback_for_incomplete_languages',
 		'enable_translator',
+		'two_step_sms_country',
+		'two_step_sms_phone_number',
 	];
 	const payload = Object.fromEntries(
 		saveableKeys.filter( ( key ) => key in data ).map( ( key ) => [ key, data[ key ] ] )

--- a/packages/api-core/src/me-two-step/mutators.ts
+++ b/packages/api-core/src/me-two-step/mutators.ts
@@ -6,7 +6,6 @@ import type {
 	CreateApplicationPasswordResponse,
 	ValidateTwoStepCodeArgs,
 	GenerateBackupCodesResponse,
-	SetupSMSArgs,
 } from './types';
 
 export async function validateSecurityKeyRegistration(
@@ -69,15 +68,7 @@ export async function deleteApplicationPassword(
 	} );
 }
 
-export async function setupSMS( data: SetupSMSArgs ): Promise< Record< string, unknown > > {
-	return wpcom.req.post( {
-		path: '/me/settings',
-		apiVersion: '1.1',
-		body: data,
-	} );
-}
-
-export async function sendSMSCode(): Promise< Record< string, unknown > > {
+export async function sendTwoStepAuthSMSCode(): Promise< Record< string, unknown > > {
 	return wpcom.req.post( {
 		path: '/me/two-step/sms/new',
 		apiVersion: '1.1',

--- a/packages/api-core/src/me-two-step/mutators.ts
+++ b/packages/api-core/src/me-two-step/mutators.ts
@@ -6,6 +6,7 @@ import type {
 	CreateApplicationPasswordResponse,
 	ValidateTwoStepCodeArgs,
 	GenerateBackupCodesResponse,
+	SetupSMSArgs,
 } from './types';
 
 export async function validateSecurityKeyRegistration(
@@ -64,6 +65,21 @@ export async function deleteApplicationPassword(
 ): Promise< Record< string, unknown > > {
 	return wpcom.req.post( {
 		path: `/me/two-step/application-passwords/${ applicationPasswordId }/delete`,
+		apiVersion: '1.1',
+	} );
+}
+
+export async function setupSMS( data: SetupSMSArgs ): Promise< Record< string, unknown > > {
+	return wpcom.req.post( {
+		path: '/me/settings',
+		apiVersion: '1.1',
+		body: data,
+	} );
+}
+
+export async function sendSMSCode(): Promise< Record< string, unknown > > {
+	return wpcom.req.post( {
+		path: '/me/two-step/sms/new',
 		apiVersion: '1.1',
 	} );
 }

--- a/packages/api-core/src/me-two-step/types.ts
+++ b/packages/api-core/src/me-two-step/types.ts
@@ -63,3 +63,8 @@ export interface ValidateTwoStepCodeArgs {
 export interface GenerateBackupCodesResponse {
 	codes: string[];
 }
+
+export interface SetupSMSArgs {
+	two_step_sms_country: string;
+	two_step_sms_phone_number: string;
+}

--- a/packages/api-core/src/me-two-step/types.ts
+++ b/packages/api-core/src/me-two-step/types.ts
@@ -63,8 +63,3 @@ export interface ValidateTwoStepCodeArgs {
 export interface GenerateBackupCodesResponse {
 	codes: string[];
 }
-
-export interface SetupSMSArgs {
-	two_step_sms_country: string;
-	two_step_sms_phone_number: string;
-}

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -9,12 +9,15 @@ import {
 	fetchAppAuthSetup,
 	validateTwoStepCode,
 	generateBackupCodes,
+	setupSMS,
+	sendSMSCode,
 } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { create } from '@github/webauthn-json';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userSettingsQuery } from './me-settings';
 import { queryClient } from './query-client';
+import type { SetupSMSArgs } from '@automattic/api-core';
 
 export const securityKeysQuery = () =>
 	queryOptions( {
@@ -102,4 +105,17 @@ export const validateTwoStepCodeMutation = () =>
 export const generateBackupCodesMutation = () =>
 	mutationOptions( {
 		mutationFn: generateBackupCodes,
+	} );
+
+export const setupSMSMutation = () =>
+	mutationOptions( {
+		mutationFn: async ( data: SetupSMSArgs ) => {
+			await setupSMS( data );
+			return await sendSMSCode();
+		},
+	} );
+
+export const resendSMSCodeMutation = () =>
+	mutationOptions( {
+		mutationFn: sendSMSCode,
 	} );

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -9,15 +9,15 @@ import {
 	fetchAppAuthSetup,
 	validateTwoStepCode,
 	generateBackupCodes,
-	setupSMS,
-	sendSMSCode,
+	updateUserSettings,
+	sendTwoStepAuthSMSCode,
 } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { create } from '@github/webauthn-json';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userSettingsQuery } from './me-settings';
 import { queryClient } from './query-client';
-import type { SetupSMSArgs } from '@automattic/api-core';
+import type { UserSettings } from '@automattic/api-core';
 
 export const securityKeysQuery = () =>
 	queryOptions( {
@@ -107,15 +107,19 @@ export const generateBackupCodesMutation = () =>
 		mutationFn: generateBackupCodes,
 	} );
 
-export const setupSMSMutation = () =>
+export const setupTwoStepAuthSMSMutation = () =>
 	mutationOptions( {
-		mutationFn: async ( data: SetupSMSArgs ) => {
-			await setupSMS( data );
-			return await sendSMSCode();
+		mutationFn: async ( data: Partial< UserSettings > ) => {
+			try {
+				await updateUserSettings( data );
+				return await sendTwoStepAuthSMSCode();
+			} catch ( error ) {
+				throw new Error( 'SMS setup failed.', { cause: error } );
+			}
 		},
 	} );
 
-export const resendSMSCodeMutation = () =>
+export const resendTwoStepAuthSMSCodeMutation = () =>
 	mutationOptions( {
-		mutationFn: sendSMSCode,
+		mutationFn: sendTwoStepAuthSMSCode,
 	} );


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/105666

Part of https://linear.app/a8c/issue/DOTDASH-169/implement-account-security-two-step-authentication-to-the-hosting

Closes https://linear.app/a8c/issue/DOTDASH-391/implement-set-up-using-sms-for-two-step-authentication

## Proposed Changes

This PR:
 
* Implements Two-step Authentication set up using an app on the Hosting Dashboard
* Moves the "PhoneNumberInput" component to the components directory as this is now being reused and could potentially be reused somewhere else
* Refactors the "SecurityTwoStepAuthAppPageLayout" component for reusability & moves to a common directory

## Why are these changes being made?

* To allow users to set up Two-step Authentication using SMS on the Hosting Dashboard.

## Testing Instructions

* Please make sure you use an account without Two-Step Authentication enabled.
* Go to /v2/me/security/two-step-auth > Verify you can see the below screen to set up Two-Step Authentication using SMS.

<img width="1920" height="626" alt="Screenshot 2025-09-11 at 12 26 54 PM" src="https://github.com/user-attachments/assets/6373fb74-7ffb-49bc-a3dc-fc79b3f2fd03" />

When enforced:

<img width="1920" height="717" alt="Screenshot 2025-09-11 at 12 27 27 PM" src="https://github.com/user-attachments/assets/cc79beec-b762-49a2-adac-e6250367e775" />

* Select the SMS option > Verify you can see a screen to set up Two-Step Authentication using a phone number

<img width="1920" height="626" alt="Screenshot 2025-09-11 at 11 31 27 AM" src="https://github.com/user-attachments/assets/fd688ed9-56f2-4475-9674-bef0cee4037b" />

Error message:

<img width="542" height="89" alt="Screenshot 2025-09-11 at 7 52 45 PM" src="https://github.com/user-attachments/assets/ef25edac-2e92-47d8-952a-d9cf8797008f" />


* Click "Cancel" > Verify you are taken back to the main auth screen > Repeat the previous step > Enter the phone number > Click "Continue" > Verify you can see a screen to enter the code > Wait for a 1 min to test the "Resend code" option > Click the "Resend code" button > Verify the button is disabled for a min > Enter the code recieved on your phone > Click "Continue" 

<img width="1920" height="626" alt="Screenshot 2025-09-11 at 11 32 26 AM" src="https://github.com/user-attachments/assets/ca45fe80-d241-449a-9e27-6c105f7a8cce" />

<img width="284" height="68" alt="Screenshot 2025-09-11 at 12 33 13 PM" src="https://github.com/user-attachments/assets/e8c63dea-2c4a-4566-bcf1-8cd26475c648" />

* Verify you can backup codes > Continue

<img width="1870" height="932" alt="Screenshot 2025-09-10 at 1 43 11 PM" src="https://github.com/user-attachments/assets/ca33b234-589b-4a65-af10-4d6ba1895da9" />

* Verify the backup code

<img width="1920" height="966" alt="Screenshot 2025-09-10 at 1 43 32 PM" src="https://github.com/user-attachments/assets/87a12434-260a-4473-86c0-8438e30c5a8c" />

* Verify you can see the auth screen as below

<img width="743" height="315" alt="Screenshot 2025-09-11 at 10 57 50 AM" src="https://github.com/user-attachments/assets/cd52f051-9a24-435d-8000-65ef693afc6c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
