### PR TITLE
Hosting Dashboard: `/` will redirect to v2 dashboard if that is the user's preference

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -47,6 +47,7 @@ import {
 	getSitePlan,
 	getSiteOption,
 } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from '../celebrate-launch-modal';
@@ -70,6 +71,7 @@ const HomeContent = ( {
 	fetchingJetpackModules,
 	handleVerifyIcannEmail,
 	isAdmin,
+	hostingDashboardOptIn,
 } ) => {
 	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
@@ -183,8 +185,13 @@ const HomeContent = ( {
 				{ translate( 'View site' ) }
 			</Button>
 			{ isAdmin && ! isP2 && (
-				<Button primary href={ `/overview/${ site.slug }` }>
-					{ translate( 'Hosting Overview' ) }
+				<Button
+					primary
+					href={ hostingDashboardOptIn ? `/v2/sites/${ site.slug }` : `/overview/${ site.slug }` }
+				>
+					{ hostingDashboardOptIn
+						? translate( 'Hosting Dashboard' )
+						: translate( 'Hosting Overview' ) }
 				</Button>
 			) }
 		</>
@@ -375,6 +382,7 @@ const mapStateToProps = ( state ) => {
 		fetchingJetpackModules: !! isFetchingJetpackModules( state, siteId ),
 		isSiteLaunching: getRequest( state, launchSite( siteId ) )?.isLoading ?? false,
 		isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
+		hostingDashboardOptIn: hasHostingDashboardOptIn( state ),
 	};
 };
 

--- a/client/root.js
+++ b/client/root.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from '@automattic/calypso-router';
+import { pathToUrl } from 'calypso/lib/url/path-to-url';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -13,6 +14,7 @@ import {
 	getSiteAdminUrl,
 	isAdminInterfaceWPAdmin,
 } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { hasReadersAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { getSelectedSiteId } from './state/ui/selectors';
@@ -89,8 +91,13 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 async function getLoggedInLandingPage( { dispatch, getState } ) {
 	await dispatch( waitForPrefs() );
 	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
+	const hostingDashboardOptIn = hasHostingDashboardOptIn( getState() );
 
 	if ( useSitesAsLandingPage ) {
+		if ( hostingDashboardOptIn ) {
+			// Use absolute URL to force a hard reload.
+			return pathToUrl( '/v2/sites' );
+		}
 		return '/sites';
 	}
 

--- a/client/state/sites/selectors/has-hosting-dashboard-opt-in.ts
+++ b/client/state/sites/selectors/has-hosting-dashboard-opt-in.ts
@@ -1,0 +1,15 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+
+export const hasHostingDashboardOptIn = ( state: AppState ): boolean => {
+	if ( ! isEnabled( 'dashboard/v2' ) ) {
+		return false;
+	}
+
+	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
+		| HostingDashboardOptIn
+		| undefined;
+	return preference?.value === 'opt-in';
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-401

## Proposed Changes

* The default landing page is set to `/v2/sites` if that is the user's preference
* The "Hosting Overview" button on My Home is switched to a v2 link too.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Making the user's preference take affect

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Must be tested in an environment where `dashboard/v2` flag is set.

Go to `http://calypso.localhost:3000`

You should be taken to the hosting dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
