### PR TITLE
Dashboard Retrofit: Fix the blog_id is not injected into track events

### DIFF
--- a/client/components/domain-search-v2/register-domain-step/index.jsx
+++ b/client/components/domain-search-v2/register-domain-step/index.jsx
@@ -447,7 +447,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	focusSearchCard = () => {
-		this.searchCard.focus();
+		this.searchCard?.focus();
 	};
 
 	bindSearchCardReference = ( searchCard ) => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -428,7 +428,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	focusSearchCard = () => {
-		this.searchCard.focus();
+		this.searchCard?.focus();
 	};
 
 	bindSearchCardReference = ( searchCard ) => {

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -147,6 +147,7 @@ export function LaunchForm( {
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',
+			back_to: window.location.href.replace( window.location.origin, '' ),
 		} );
 	};
 

--- a/client/lib/analytics/utils/should-report-omit-blog-id.js
+++ b/client/lib/analytics/utils/should-report-omit-blog-id.js
@@ -1,6 +1,7 @@
 import { getSiteFragment } from 'calypso/lib/route';
 
-const SITE_FRAGMENT_REGEX = /\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslug)(\/|$|\?)/i;
+const SITE_FRAGMENT_REGEX =
+	/\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslug|\$siteSlug)(\/|$|\?)/i;
 
 /**
  * Check if a path should report the currently selected site ID.

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -17,7 +17,7 @@ import {
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, getProtocol } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -1646,6 +1646,12 @@ class RenderDomainsStepComponent extends Component {
 			} else if ( backUrl === this.removeQueryParam( this.props.path ) ) {
 				backUrl = defaultBackUrl;
 				backLabelText = sitesBackLabelText;
+			}
+
+			const backTo = getQueryArg( window.location.href, 'back_to' );
+			if ( backTo && ! backTo.startsWith( '//' ) && ! getProtocol( backTo ) ) {
+				backUrl = backTo;
+				backLabelText = translate( 'Back' );
 			}
 
 			const externalBackUrl = getExternalBackUrl( source, stepSectionName );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -107,6 +107,8 @@ import {
 } from './utils';
 import './style.scss';
 
+const isRelativeUrl = ( url ) => ! url.startsWith( '//' ) && ! getProtocol( url );
+
 class RenderDomainsStepComponent extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
@@ -1649,7 +1651,7 @@ class RenderDomainsStepComponent extends Component {
 			}
 
 			const backTo = getQueryArg( window.location.href, 'back_to' );
-			if ( backTo && ! backTo.startsWith( '//' ) && ! getProtocol( backTo ) ) {
+			if ( backTo && isRelativeUrl( backTo ) ) {
 				backUrl = backTo;
 				backLabelText = translate( 'Back' );
 			}

--- a/client/sites/v2/hooks/use-analytics-client.ts
+++ b/client/sites/v2/hooks/use-analytics-client.ts
@@ -1,21 +1,28 @@
 import { useMemo } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actions';
+import type { AnyRouter } from '@tanstack/react-router';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 
-export const useAnalyticsClient = () => {
+export const useAnalyticsClient = ( router: AnyRouter ) => {
 	const dispatch = useDispatch();
 
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				dispatch( recordTracksEvent( eventName, properties ) );
+				const path = router.state.matches.at( -1 )?.fullPath;
+				dispatch(
+					recordTracksEvent( eventName, {
+						path,
+						...properties,
+					} )
+				);
 			},
 			recordPageView( url, title ) {
 				dispatch( recordPageView( url, title ) );
 			},
 		} ),
-		[ dispatch ]
+		[ router, dispatch ]
 	);
 
 	return analyticsClient;

--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -15,7 +15,7 @@ export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?
 	const containerRef = useRef< HTMLDivElement >( null );
 	const user = useSelector( ( state ) => getCurrentUser( state ) );
 	const site = useSelector( ( state ) => getSite( state, siteSlug ) );
-	const analyticsClient = useAnalyticsClient();
+	const analyticsClient = useAnalyticsClient( router );
 
 	// Initialize the root instance.
 	useEffect( () => {

--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -31,7 +31,7 @@ export default function DashboardBackportSiteSettingsRenderer( {
 	const user = useSelector( ( state ) => getCurrentUser( state ) );
 	const site = useSelector( ( state ) => getSite( state, siteSlug ) );
 	const siteSettings = useSelector( ( state ) => site?.ID && getSiteSettings( state, site.ID ) );
-	const analyticsClient = useAnalyticsClient();
+	const analyticsClient = useAnalyticsClient( router );
 
 	// Initialize the root instance.
 	useEffect( () => {

--- a/client/sites/v2/sites-list/index.tsx
+++ b/client/sites/v2/sites-list/index.tsx
@@ -13,7 +13,7 @@ export default function DashboardBackportSitesList() {
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const user = useSelector( ( state ) => getCurrentUser( state ) );
-	const analyticsClient = useAnalyticsClient();
+	const analyticsClient = useAnalyticsClient( router );
 
 	// Initialize the root instance.
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1757573365675079-slack-C08JZTRS6NA

## Proposed Changes

* Fix the `blog_id` wasn't not injected into track events because the `SITE_FRAGMENT_REGEX` didn't consider the path of retrofit

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to site settings on your un-launched site
* Click the Launch button
* Ensure the `calypso_dashboard_site_settings_launch_site_click` is sent with the correct `blog_id`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?