### PR TITLE
Domains: Update domain action routes

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -217,7 +217,16 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				id: 'connect-to-site',
 				label: __( 'Attach to an existing site' ),
 				supportsBulk: false,
-				callback: () => {},
+				callback: ( items: DomainSummary[] ) => {
+					const domain = items[ 0 ];
+
+					router.navigate( {
+						to: domainTransferToOtherSiteRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
+				},
 				isEligible: () => false,
 			},
 			{

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -4,7 +4,6 @@ import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/consta
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import {
 	domainManagementEditContactInfo,
-	domainManagementLink,
 	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -15,7 +14,11 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, Suspense, lazy } from 'react';
-import { domainDnsRoute, domainConnectionSetupRoute } from '../../app/router/domains';
+import {
+	domainOverviewRoute,
+	domainDnsRoute,
+	domainConnectionSetupRoute,
+} from '../../app/router/domains';
 import {
 	isRecentlyRegistered,
 	isDomainRenewable,
@@ -94,8 +97,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
-					window.location.pathname = domainManagementLink( domain, siteSlug, false );
+
+					router.navigate( {
+						to: domainOverviewRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return item.subtype.id !== DomainSubtype.DEFAULT_ADDRESS;

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -3,19 +3,20 @@ import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/ap
 import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import {
-	domainManagementDNS,
 	domainManagementEditContactInfo,
 	domainManagementLink,
 	domainMappingSetup,
 	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, Suspense, lazy } from 'react';
+import { domainDnsRoute } from '../../app/router/domains';
 import {
 	isRecentlyRegistered,
 	isDomainRenewable,
@@ -39,6 +40,7 @@ const SiteChangeAddressContent = lazy(
 const noop = () => {};
 
 export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
+	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
@@ -103,8 +105,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
-					window.location.pathname = domainManagementDNS( siteSlug, domain.domain, context );
+
+					router.navigate( {
+						to: domainDnsRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return (

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,8 +1,6 @@
 import { DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
-import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
-import { domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
@@ -16,6 +14,7 @@ import {
 	domainDnsRoute,
 	domainContactInfoRoute,
 	domainConnectionSetupRoute,
+	domainTransferToOtherSiteRoute,
 } from '../../app/router/domains';
 import {
 	isRecentlyRegistered,
@@ -23,7 +22,6 @@ import {
 	isDomainUpdatable,
 	isDomainInGracePeriod,
 	canSetAsPrimary,
-	getDomainSiteSlug,
 	getDomainRenewalUrl,
 } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
@@ -203,12 +201,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
-					window.location.pathname = domainUseMyDomain(
-						siteSlug,
-						domain.domain,
-						useMyDomainInputMode.transferDomain
-					);
+
+					router.navigate( {
+						to: domainTransferToOtherSiteRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return isTransferrableToWpcom( item );

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -2,10 +2,7 @@ import { DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { useMyDomainInputMode } from '@automattic/domains-table/src/utils/constants';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
-import {
-	domainManagementEditContactInfo,
-	domainUseMyDomain,
-} from '@automattic/domains-table/src/utils/paths';
+import { domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
@@ -17,6 +14,7 @@ import { useMemo, Suspense, lazy } from 'react';
 import {
 	domainOverviewRoute,
 	domainDnsRoute,
+	domainContactInfoRoute,
 	domainConnectionSetupRoute,
 } from '../../app/router/domains';
 import {
@@ -46,7 +44,6 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
-	const context = site ? 'site' : 'domains';
 	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{
@@ -137,13 +134,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
-					window.location.pathname = domainManagementEditContactInfo(
-						siteSlug,
-						domain.domain,
-						null,
-						context
-					);
+
+					router.navigate( {
+						to: domainContactInfoRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return (
@@ -254,7 +251,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 		[
 			user,
 			site,
-			context,
+			router,
 			purchases,
 			setPrimaryDomainMutation,
 			createSuccessNotice,

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -5,7 +5,6 @@ import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free
 import {
 	domainManagementEditContactInfo,
 	domainManagementLink,
-	domainMappingSetup,
 	domainUseMyDomain,
 } from '@automattic/domains-table/src/utils/paths';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -16,7 +15,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { payment, tool } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, Suspense, lazy } from 'react';
-import { domainDnsRoute } from '../../app/router/domains';
+import { domainDnsRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import {
 	isRecentlyRegistered,
 	isDomainRenewable,
@@ -73,10 +72,13 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				label: __( 'Set up connection' ),
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
-					const siteSlug = getDomainSiteSlug( domain );
 
-					// Use href instead of pathname to preserve query parameters.
-					window.location.href = domainMappingSetup( siteSlug, domain.domain );
+					router.navigate( {
+						to: domainConnectionSetupRoute.fullPath,
+						params: {
+							domainName: domain.domain,
+						},
+					} );
 				},
 				isEligible: ( item: DomainSummary ) =>
 					item.subtype.id === DomainSubtype.DOMAIN_CONNECTION && ! item.points_to_wpcom,

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -14,6 +14,7 @@ import {
 	domainDnsRoute,
 	domainContactInfoRoute,
 	domainConnectionSetupRoute,
+	domainTransferToAnyUserRoute,
 	domainTransferToOtherSiteRoute,
 } from '../../app/router/domains';
 import {
@@ -203,7 +204,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					const domain = items[ 0 ];
 
 					router.navigate( {
-						to: domainTransferToOtherSiteRoute.fullPath,
+						to: domainTransferToAnyUserRoute.fullPath,
 						params: {
 							domainName: domain.domain,
 						},


### PR DESCRIPTION
Part of DOTDASH-405

## Proposed Changes

* Replaces the old action destination within the domains table action list

## Why are these changes being made?

* Currently, it's redirection the old domain management screens

## Testing Instructions

* Go to `/v2/domains`
* Check the action list, each action should stay within dasboard v2
* **NOTE:** most of the actions are not visible since the eligibility check is falsy because of missing fields in the domain object that comes from the "all-domains" endpoint

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
