### PR TITLE
Added the plugin slug from the api response to the PluginListRow mapping

### DIFF
--- a/client/dashboard/plugins/manage/fields/name.tsx
+++ b/client/dashboard/plugins/manage/fields/name.tsx
@@ -11,7 +11,7 @@ export const nameField: Field< PluginListRow > = {
 	enableSorting: true,
 	getValue: ( { item } ) => item.name,
 	render: ( { item, field } ) => (
-		<Link to={ pluginRoute.to } params={ { pluginId: item.id } }>
+		<Link to={ pluginRoute.to } params={ { pluginId: item.slug } }>
 			{ field.getValue( { item } ) }
 		</Link>
 	),

--- a/client/dashboard/plugins/manage/types.ts
+++ b/client/dashboard/plugins/manage/types.ts
@@ -1,7 +1,8 @@
 // Centralized types for the dashboard plugins package
 
 export type PluginListRow = {
-	id: string; // plugin slug
+	id: string;
+	slug: string;
 	name: string;
 	sitesCount: number;
 	isActive: 'all' | 'some' | 'none';

--- a/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
+++ b/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
@@ -3,6 +3,7 @@ import type { PluginItem, PluginsResponse } from '@automattic/api-core';
 
 type Aggregated = {
 	name: string;
+	slug: string;
 	count: number;
 	activeCount: number;
 	updateCount: number;
@@ -34,7 +35,8 @@ export function mapApiPluginsToDataViewPlugins( response?: PluginsResponse ): Pl
 			}
 
 			const entry: Aggregated = map.get( p.id ) || {
-				name: p.name || p.slug,
+				name: p.name,
+				slug: p.slug,
 				count: 0,
 				activeCount: 0,
 				updateCount: 0,
@@ -42,7 +44,6 @@ export function mapApiPluginsToDataViewPlugins( response?: PluginsResponse ): Pl
 				siteIds: [],
 			};
 			entry.count += 1;
-			entry.name = p.name || entry.name;
 			entry.siteIds.push( siteId );
 			if ( p.active ) {
 				entry.activeCount += 1;
@@ -58,9 +59,10 @@ export function mapApiPluginsToDataViewPlugins( response?: PluginsResponse ): Pl
 	} );
 
 	return Array.from( map.entries() ).map(
-		( [ id, { name, count, activeCount, updateCount, autoupdateCount, siteIds } ] ) => ( {
+		( [ id, { name, slug, count, activeCount, updateCount, autoupdateCount, siteIds } ] ) => ( {
 			id,
 			name,
+			slug,
 			sitesCount: count,
 			hasUpdate: mapCountToQuantifier( updateCount, count ),
 			isActive: mapCountToQuantifier( activeCount, count ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DSGCOM-240/hosting-dashboard-plugins-add-slug-field-to-pluginlistrow

## Proposed Changes

* Updated the mapping from the API to PluginListRow to include the plugin slug.

| Before | After |
|--------|--------|
| <img width="1528" height="1294" alt="Screenshot 2025-09-11 at 15 15 37" src="https://github.com/user-attachments/assets/a47c24b9-0ef1-4358-a093-647ab930025e" />| <img width="1530" height="1296" alt="Screenshot 2025-09-11 at 15 16 15" src="https://github.com/user-attachments/assets/454118b4-f90b-4161-adae-3d67d0a61609" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we don't provide the plugin slug the plugin item view doesn't build/re-create the slug and fails.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/v2/plugins/manage`
* click on any plugin
* it should display the plugin's details data view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
