### PR TITLE
Show the correct status in the site/domains dataview

### DIFF
--- a/packages/api-core/src/site-domains/fetchers.ts
+++ b/packages/api-core/src/site-domains/fetchers.ts
@@ -2,10 +2,15 @@ import { wpcom } from '../wpcom-fetcher';
 import type { SiteDomain } from './types';
 
 export async function fetchSiteDomains( siteId: number ): Promise< SiteDomain[] > {
-	const { domains } = await wpcom.req.get( {
-		path: `/sites/${ siteId }/domains`,
-		apiVersion: '1.2',
-	} );
+	const { domains } = await wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/domains`,
+			apiVersion: '1.2',
+		},
+		{
+			resolve_status: true,
+		}
+	);
 
 	return domains;
 }

--- a/packages/api-core/src/site-domains/types.ts
+++ b/packages/api-core/src/site-domains/types.ts
@@ -8,7 +8,7 @@ export interface GoogleEmailSubscription extends EmailSubscription {}
 
 export interface TitanEmailSubscription extends EmailSubscription {}
 
-export type SiteDomain = Omit< DomainSummary, 'domain_status' > & {
+export type SiteDomain = DomainSummary & {
 	google_apps_subscription?: GoogleEmailSubscription | null;
 	titan_mail_subscription?: TitanEmailSubscription | null;
 };


### PR DESCRIPTION
Closes [DOTDASH-430](https://linear.app/a8c/issue/DOTDASH-430/show-correct-status-in-domain-site-list)

## Proposed Changes
This PR shows the correct status in the site domain DataView. The status is now returned be the site/domains endpoint.

## Why are these changes being made?
We need to show the status column in the site domains list.

## Testing Instructions
Before testing this PR, apply this backend patch:
192184-ghe-Automattic/wpcom

Ensure that the site/domains list show the status column properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?