### PR TITLE
Split Backup operations from Activity Log package

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -3,7 +3,7 @@ import {
 	isAutomatticianQuery,
 	rawUserPreferencesQuery,
 	siteLastFiveActivityLogEntriesQuery,
-	siteRewindableActivityLogEntriesQuery,
+	siteBackupActivityLogEntriesQuery,
 	siteAgencyBlogQuery,
 	siteLastBackupQuery,
 	siteEdgeCacheStatusQuery,
@@ -238,7 +238,7 @@ export const siteBackupsIndexRoute = createRoute( {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		// Preload activity log backup-related entries.
 		if ( hasHostingFeature( site, HostingFeatures.BACKUPS ) ) {
-			queryClient.ensureQueryData( siteRewindableActivityLogEntriesQuery( site.ID ) );
+			queryClient.ensureQueryData( siteBackupActivityLogEntriesQuery( site.ID ) );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -1,4 +1,4 @@
-import { siteRewindableActivityLogEntriesQuery } from '@automattic/api-queries';
+import { siteBackupActivityLogEntriesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -31,7 +31,7 @@ export function BackupsList( {
 	const { backup, hasRecentlyCompleted } = useBackupState( site.ID );
 
 	const { data: activityLog = [], isLoading: isLoadingActivityLog } = useQuery( {
-		...siteRewindableActivityLogEntriesQuery( site.ID, undefined, true ),
+		...siteBackupActivityLogEntriesQuery( site.ID, undefined, true ),
 		// Refetch the activity log every 3 seconds when a recent backup completed until the backup is found in the Activity Log
 		refetchInterval: ( query ) => {
 			if ( ! backup || ! hasRecentlyCompleted ) {

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -43,6 +43,7 @@ export * from './purchase';
 export * from './read-teams';
 export * from './site';
 export * from './site-activity-log';
+export * from './site-activity-log-backup';
 export * from './site-address-change';
 export * from './site-atomic-transfers';
 export * from './site-automated-transfers-eligibility';

--- a/packages/api-core/src/site-activity-log-backup/fetchers.ts
+++ b/packages/api-core/src/site-activity-log-backup/fetchers.ts
@@ -1,0 +1,18 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ActivityLog } from '../site-activity-log/types';
+
+export async function fetchSiteRewindableActivityLog(
+	siteId: number,
+	{ number, aggregate = false }: { number: number; aggregate?: boolean }
+): Promise< ActivityLog > {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/activity/rewindable`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{
+			number,
+			aggregate,
+		}
+	);
+}

--- a/packages/api-core/src/site-activity-log-backup/fetchers.ts
+++ b/packages/api-core/src/site-activity-log-backup/fetchers.ts
@@ -1,7 +1,7 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { ActivityLog } from '../site-activity-log/types';
 
-export async function fetchSiteRewindableActivityLog(
+export async function fetchSiteBackupActivityLog(
 	siteId: number,
 	{ number, aggregate = false }: { number: number; aggregate?: boolean }
 ): Promise< ActivityLog > {

--- a/packages/api-core/src/site-activity-log-backup/index.ts
+++ b/packages/api-core/src/site-activity-log-backup/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchers';

--- a/packages/api-core/src/site-activity-log/fetchers.ts
+++ b/packages/api-core/src/site-activity-log/fetchers.ts
@@ -15,19 +15,3 @@ export async function fetchSiteActivityLog(
 		}
 	);
 }
-
-export async function fetchSiteRewindableActivityLog(
-	siteId: number,
-	{ number, aggregate = false }: { number: number; aggregate?: boolean }
-): Promise< ActivityLog > {
-	return wpcom.req.get(
-		{
-			path: `/sites/${ siteId }/activity/rewindable`,
-			apiNamespace: 'wpcom/v2',
-		},
-		{
-			number,
-			aggregate,
-		}
-	);
-}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -33,6 +33,7 @@ export * from './performance';
 export * from './plugin';
 export * from './purchase';
 export * from './site-activity-log';
+export * from './site-activity-log-backup';
 export * from './site-address-change';
 export * from './site-agency';
 export * from './site-atomic-transfers';

--- a/packages/api-queries/src/site-activity-log-backup.ts
+++ b/packages/api-queries/src/site-activity-log-backup.ts
@@ -1,13 +1,13 @@
-import { fetchSiteRewindableActivityLog } from '@automattic/api-core';
+import { fetchSiteBackupActivityLog } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const siteRewindableActivityLogEntriesQuery = (
+export const siteBackupActivityLogEntriesQuery = (
 	siteId: number,
 	number: number = 1000, // 1000 is the maximum number of entries that can be fetched.
 	aggregate: boolean = false
 ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'activity-log', 'rewindable', number, aggregate ],
-		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number, aggregate } ),
+		queryKey: [ 'site', siteId, 'backup-activity-log', number, aggregate ],
+		queryFn: () => fetchSiteBackupActivityLog( siteId, { number, aggregate } ),
 		select: ( data ) => data.current?.orderedItems?.slice( 0, number ) ?? [],
 	} );

--- a/packages/api-queries/src/site-activity-log-backup.ts
+++ b/packages/api-queries/src/site-activity-log-backup.ts
@@ -1,0 +1,13 @@
+import { fetchSiteRewindableActivityLog } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const siteRewindableActivityLogEntriesQuery = (
+	siteId: number,
+	number: number = 1000, // 1000 is the maximum number of entries that can be fetched.
+	aggregate: boolean = false
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'activity-log', 'rewindable', number, aggregate ],
+		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number, aggregate } ),
+		select: ( data ) => data.current?.orderedItems?.slice( 0, number ) ?? [],
+	} );

--- a/packages/api-queries/src/site-activity-log.ts
+++ b/packages/api-queries/src/site-activity-log.ts
@@ -1,4 +1,4 @@
-import { fetchSiteActivityLog, fetchSiteRewindableActivityLog } from '@automattic/api-core';
+import { fetchSiteActivityLog } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
 export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
@@ -6,15 +6,4 @@ export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
 		queryKey: [ 'site', siteId, 'activity-log', 'last-five' ],
 		queryFn: () => fetchSiteActivityLog( siteId, { number: 5 } ),
 		select: ( data ) => data.current?.orderedItems?.slice( 0, 5 ) ?? [],
-	} );
-
-export const siteRewindableActivityLogEntriesQuery = (
-	siteId: number,
-	number: number = 1000, // 1000 is the maximum number of entries that can be fetched.
-	aggregate: boolean = false
-) =>
-	queryOptions( {
-		queryKey: [ 'site', siteId, 'activity-log', 'rewindable', number, aggregate ],
-		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number, aggregate } ),
-		select: ( data ) => data.current?.orderedItems?.slice( 0, number ) ?? [],
 	} );

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -1,5 +1,5 @@
 import {
-	fetchSiteRewindableActivityLog,
+	fetchSiteBackupActivityLog,
 	enqueueSiteBackup,
 	fetchSiteBackups,
 	fetchBackupContents,
@@ -12,7 +12,7 @@ import { queryClient } from './query-client';
 export const siteLastBackupQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'backups', 'last' ],
-		queryFn: () => fetchSiteRewindableActivityLog( siteId, { number: 1 } ),
+		queryFn: () => fetchSiteBackupActivityLog( siteId, { number: 1 } ),
 		select: ( data ) => data.current?.orderedItems[ 0 ] ?? null,
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-429][1].

## Proposed Changes

Split backup-related operations from general Activity Log functionality.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The original Activity Log package was handling both general activity logs (`/sites/:id/activity`) and backup-specific activity logs (`/sites/:id/activity/rewindable`). This could create confusion and make it difficult for developers to understand which functionality was backup-related or just part of the regular activity logs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/{site}/backups`.
- Ensure backups listing works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-429