### PR TITLE
Do not add Personal plan in onboarding

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -928,15 +928,15 @@ export function getDomainPriceRule(
 	}
 
 	if ( flowName === 'onboarding' ) {
-		// If there are no domains in the cart, the suggestions should show the "Free domain with a plan" discount
+		// If the user already selected a domain in onboarding, the suggestions should show their normal price
 		if ( isThereAtLeastOneDomainRegistrationInCart( cart ) ) {
 			return DOMAIN_PRICE_RULE.PRICE;
 		}
-		// Otherwise, the suggestions should show their normal price
-		return DOMAIN_PRICE_RULE.PRICE;
+		// Otherwise, the suggestions should show the "Free for the first year" discount
+		return DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN;
 	}
 
-	// The domain-only flow should not show the "Free domain with a plan" discount
+	// The domain-only flow should not show the "Free for the first year" discount
 	if (
 		flowName !== 'domain' &&
 		shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestion )

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -927,7 +927,20 @@ export function getDomainPriceRule(
 		return DOMAIN_PRICE_RULE.FREE_WITH_PLAN;
 	}
 
-	if ( shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestion ) ) {
+	if ( flowName === 'onboarding' ) {
+		// If there are no domains in the cart, the suggestions should show the "Free domain with a plan" discount
+		if ( isThereAtLeastOneDomainRegistrationInCart( cart ) ) {
+			return DOMAIN_PRICE_RULE.PRICE;
+		}
+		// Otherwise, the suggestions should show their normal price
+		return DOMAIN_PRICE_RULE.PRICE;
+	}
+
+	// The domain-only flow should not show the "Free domain with a plan" discount
+	if (
+		flowName !== 'domain' &&
+		shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestion )
+	) {
 		return DOMAIN_PRICE_RULE.INCLUDED_IN_HIGHER_PLAN;
 	}
 
@@ -936,6 +949,16 @@ export function getDomainPriceRule(
 	}
 
 	return DOMAIN_PRICE_RULE.PRICE;
+}
+
+function isThereAtLeastOneDomainRegistrationInCart( cart: ResponseCart ): boolean {
+	let numberOfDomainRegistrations = 0;
+	cart.products.forEach( ( product ) => {
+		if ( isDomainRegistration( product ) ) {
+			numberOfDomainRegistrations++;
+		}
+	} );
+	return numberOfDomainRegistrations >= 1;
 }
 
 export function getPlanCartItem( cartItems?: MinimalRequestCartProduct[] | null ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -50,10 +50,7 @@ import {
 	domainTransfer,
 	updatePrivacyForDomain,
 	planItem,
-	hasPlan,
-	hasDomainRegistration,
 	getDomainsInCart,
-	hasPersonalPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainProductSlug,
@@ -222,30 +219,6 @@ class RenderDomainsStepComponent extends Component {
 	componentDidMount() {
 		if ( isTailoredSignupFlow( this.props.flowName ) ) {
 			triggerGuidesForStep( this.props.flowName, 'domains' );
-		}
-
-		// We add a plan to cart on Multi Domains to show the proper discount on the mini-cart.
-		if (
-			shouldUseMultipleDomainsInCart( this.props.flowName ) &&
-			hasDomainRegistration( this.props.cart ) &&
-			this.props.multiDomainDefaultPlan
-		) {
-			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
-			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps?.cart?.products?.length !== this.props?.cart?.products?.length ) {
-			if (
-				shouldUseMultipleDomainsInCart( this.props.flowName ) &&
-				hasDomainRegistration( this.props.cart ) &&
-				! hasPersonalPlan( this.props.cart ) &&
-				this.props.multiDomainDefaultPlan
-			) {
-				// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
-				this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
-			}
 		}
 	}
 
@@ -762,10 +735,7 @@ class RenderDomainsStepComponent extends Component {
 
 			// We add a plan to cart on Multi Domains to show the proper discount on the mini-cart.
 			// TODO: remove productsToAdd
-			const productsToAdd =
-				! hasPlan( this.props.cart ) && this.props.multiDomainDefaultPlan
-					? [ registration, this.props.multiDomainDefaultPlan ]
-					: [ registration ];
+			const productsToAdd = [ registration ];
 
 			// Replace the products in the cart with the freshly sorted products.
 			clearTimeout( this.state.addDomainTimeout );


### PR DESCRIPTION
Part of [DOMAINS-1603](https://linear.app/a8c/issue/DOMAINS-1603)

## Proposed Changes

This PR removes the code that added a Personal plan to the cart during onboarding.

That was originally introduced in #82830 when multi-domain selection was added to onboarding. It's purpose was to apply the "Free for the first year" promotion correctly to a domain in the cart.

## Why are these changes being made?

Together with the changes proposed in 192214-ghe-Automattic/wpcom, this PR eliminates the need to add a Personal plan to the cart during onboarding.

## Testing Instructions

This depends on 192214-ghe-Automattic/wpcom

- Open the live Calypso link or build this branch locally
- Go to onboarding (`/setup/onboarding/`)
- Select some domains and ensure the most expensive one is always selected for domain credit
- Ensure the suggestion prices are shown correctly

During testing, ensure that your cart does *not* contain a Personal plan (you can check the `products` property in the response of the network call to `/me/shopping-cart/no-site`)

### Screenshots

| Description |  |
| --- | --- |
|  When there's no domain in the cart, suggestions should show "Free for the first year" | <img width="1171" height="802" alt="Screenshot 2025-09-12 at 00 17 52" src="https://github.com/user-attachments/assets/11165ecb-f565-49bf-963e-280f1b3d4a65" /> |
| After one domain is in the cart, suggestions should show their normal price | <img width="1174" height="809" alt="Screenshot 2025-09-12 at 00 18 40" src="https://github.com/user-attachments/assets/32e81745-4a99-4170-852b-ba3754480f66" /> |
| With multiple domains in the cart, ensure the most expensive one gets the free domain credit | <img width="1160" height="650" alt="Screenshot 2025-09-12 at 00 21 55" src="https://github.com/user-attachments/assets/59fc86d7-781d-4c46-9456-bb8016dbe526" /> |

## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?