### PR TITLE
Backups Dashboard: Hide `Back up now` button and notices on mobile details view

### DIFF
--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -107,16 +107,20 @@ export function BackupsListPage() {
 		);
 	};
 
+	const isMobileDetailsView = isSmallViewport && showDetails;
+	const shouldShowActions = hasBackups && ! isMobileDetailsView;
+	const shouldShowNotices = ! isMobileDetailsView;
+
 	return (
 		<PageLayout
 			header={
 				<PageHeader
-					title={ isSmallViewport && showDetails ? __( 'Backup details' ) : __( 'Backups' ) }
-					prefix={ isSmallViewport && showDetails ? backButton : undefined }
-					actions={ hasBackups && <BackupNowButton site={ site } /> }
+					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
+					prefix={ isMobileDetailsView ? backButton : undefined }
+					actions={ shouldShowActions ? <BackupNowButton site={ site } /> : undefined }
 				/>
 			}
-			notices={ <BackupNotices site={ site } /> }
+			notices={ shouldShowNotices ? <BackupNotices site={ site } /> : undefined }
 		>
 			{ hasBackups && (
 				<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the “fixes” keyword. Consider using “part of” instead.
-->

Fixes DOTDASH-398

## Proposed Changes

* Hide “Back up now” button when viewing individual backup details on mobile viewports
* Hide backup notices when showing backup details on small screens
* Extract semantic variables (`isMobileDetailsView`, `shouldShowActions`, `shouldShowNotices`) for better code readability
* Maintain existing functionality on desktop viewports (no changes to larger screen experience)

| Before | After |
|---|---|
| <img width="996" height="1436" alt="image" src="https://github.com/user-attachments/assets/de122508-52dc-40f8-ad86-7283c9e706ca" /> | <img width="996" height="1436" alt="image" src="https://github.com/user-attachments/assets/39d3dab0-8f23-4cb8-80cb-3dfb4ee26a68" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On mobile devices, when users drill down to view individual backup details, the screen real estate is limited and the focus should be on the specific backup content rather than global actions. The “Back up now” button and backup notices are contextually irrelevant when examining a single backup's details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
“Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Calypso Live branch and navigate to `/v2/sites/{site}/backups`
3. Resize browser window to mobile width
4. Click on any backup to view details
5. Verify “Back up now” button is hidden in the mobile details view
6. Verify backup notices are hidden in mobile details view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the“"[Status] String Freez”" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the“"[Status] Needs Privacy Update”" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
