### PR TITLE
Scan Dashboard: add Scan scaffolding (feature, routes, menu, page)

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -15,6 +15,7 @@ boot( {
 			monitoring: true,
 			logs: true,
 			backups: true,
+			scan: true,
 			domains: false,
 			emails: false,
 		},

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -14,6 +14,7 @@ boot( {
 			monitoring: true,
 			logs: true,
 			backups: true,
+			scan: true,
 			domains: true,
 			emails: true,
 		},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -6,6 +6,7 @@ export type SiteFeatureSupports = {
 	monitoring: boolean;
 	logs: boolean;
 	backups: boolean;
+	scan: boolean;
 	domains: boolean;
 	emails: boolean;
 };

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -1,0 +1,144 @@
+import { HostingFeatures } from '@automattic/api-core';
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	Button,
+	TabPanel,
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { shield } from '@wordpress/icons';
+import { siteRoute } from '../../app/router/sites';
+import { ButtonStack } from '../../components/button-stack';
+import { Callout } from '../../components/callout';
+import { CalloutOverlay } from '../../components/callout-overlay';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import UpsellCTAButton from '../../components/upsell-cta-button';
+import { hasHostingFeature } from '../../utils/site-features';
+// @TODO: replace with Scan callout illustration
+import illustrationUrl from '../backups/backups-callout-illustration.svg';
+
+export function SiteScanCallout( {
+	siteSlug,
+	titleAs = 'h1',
+}: {
+	siteSlug: string;
+	titleAs?: React.ElementType | keyof JSX.IntrinsicElements;
+} ) {
+	return (
+		<Callout
+			icon={ shield }
+			title={ __( 'Scan for security threats' ) }
+			titleAs={ titleAs }
+			image={ illustrationUrl }
+			description={
+				<>
+					<Text as="p" variant="muted">
+						{ __(
+							'Automated daily scans check for malware and security vulnerabilities, with automated fixes for many issues.'
+						) }
+					</Text>
+					<Text as="p" variant="muted">
+						{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }
+					</Text>
+				</>
+			}
+			actions={
+				<UpsellCTAButton
+					text={ __( 'Upgrade plan' ) }
+					tracksId="scan"
+					variant="primary"
+					href={ `/checkout/${ siteSlug }/business` }
+				/>
+			}
+		/>
+	);
+}
+
+const SCAN_TABS = [
+	{ name: 'active', title: __( 'Active threats' ) },
+	{ name: 'history', title: __( 'History' ) },
+];
+
+function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
+	const { siteSlug } = siteRoute.useParams();
+	const router = useRouter();
+
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	const handleTabChange = ( tab: 'active' | 'history' ) => {
+		if ( tab === 'active' ) {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/active` } );
+		} else {
+			router.navigate( { to: `/sites/${ siteSlug }/scan/history` } );
+		}
+	};
+
+	return (
+		<PageLayout
+			header={
+				// @TODO: Add translation and relative time
+				<PageHeader
+					title={ __( 'Scan' ) }
+					description="Latest automated scan run X hours ago"
+					actions={
+						<ButtonStack>
+							<Button variant="secondary">{ __( 'Scan now' ) }</Button>
+							<Button variant="primary">
+								{ sprintf(
+									/* translators: %d: number of threats */
+									__( 'Auto-fix %(threatsCount)d threats' ),
+									{
+										// @TODO: replace with the actual number of active fixable threats
+										threatsCount: 4,
+									}
+								) }
+							</Button>
+						</ButtonStack>
+					}
+				/>
+			}
+		>
+			<CalloutOverlay
+				showCallout={ ! hasHostingFeature( site, HostingFeatures.SCAN ) }
+				callout={ <SiteScanCallout siteSlug={ site.slug } /> }
+				main={
+					<Card>
+						<CardHeader style={ { paddingBottom: '0' } }>
+							<TabPanel
+								activeClass="is-active"
+								tabs={ SCAN_TABS }
+								onSelect={ ( tabName ) => {
+									if ( tabName === 'active' || tabName === 'history' ) {
+										handleTabChange( tabName );
+									}
+								} }
+								initialTabName={ scanTab }
+							>
+								{ () => null }
+							</TabPanel>
+						</CardHeader>
+						<CardBody>
+							{ scanTab === 'active' ? (
+								<Text as="p" variant="muted">
+									{ __( 'No active threats found. Your site is secure.' ) }
+								</Text>
+							) : (
+								<Text as="p" variant="muted">
+									{ __( 'So far, there are no archived threats on your site.' ) }
+								</Text>
+							) }
+						</CardBody>
+					</Card>
+				}
+			/>
+		</PageLayout>
+	);
+}
+
+export default SiteScan;

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -39,9 +39,9 @@ export function SiteScanCallout( {
 			description={
 				<>
 					<Text as="p" variant="muted">
-						{ __(
-							'Automated daily scans check for malware and security vulnerabilities, with automated fixes for many issues.'
-						) }
+						{ /* @TODO: update copy when the design is ready and add translation */ }
+						Automated daily scans check for malware and security vulnerabilities, with automated
+						fixes for many issues.
 					</Text>
 					<Text as="p" variant="muted">
 						{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -69,6 +69,11 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 					{ __( 'Logs' ) }
 				</ResponsiveMenu.Item>
 			) }
+			{ hasAppSupport( supports, 'scan' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
+					{ __( 'Scan' ) }
+				</ResponsiveMenu.Item>
+			) }
 			{ hasAppSupport( supports, 'backups' ) && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
 					{ __( 'Backups' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-411

## Proposed Changes

* Enable scan feature in dotcom dashboard config
* Add site scan routes to dashboard, enabling scan feature navigation
* Added Scan menu item to sites dashboard navigation
* Add Scan page scaffolding with navigation, tab structure and action button placement
* Added SiteScanCallout component with plan upgrade CTA
  * For now we are using the same illustration as the Backup page, with a unconfirmed copy. We will follow it up after DOTDASH-437 is completed.

| Upgrade prompt | Active threats | History |
|---|---|---|
| <img width="2284" height="1410" alt="CleanShot 2025-09-12 at 00 08 28@2x" src="https://github.com/user-attachments/assets/445c7096-8652-4920-884d-91f4c6fb4c50" /> | <img width="2284" height="1410" alt="CleanShot 2025-09-12 at 00 07 51@2x" src="https://github.com/user-attachments/assets/d7a23dc6-d881-47eb-931e-241b154f1bb2" /> | <img width="2284" height="1410" alt="CleanShot 2025-09-12 at 00 08 13@2x" src="https://github.com/user-attachments/assets/4f394320-05cc-4a71-80f5-815d82b5cf0a" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR establishes the foundational scaffolding for the Scan feature in the Hosting Dashboard.

The changes specifically:
- **Add navigation structure**: Users can access scan features via `/v2/sites/[site]/scan` from the site menu
- **Implement feature gating**: Users without scan access see an upgrade prompt, following existing patterns
- **Create tab-based interface**: Active threats and History tabs provide logical organization
- **Enable future development**: Clean scaffolding allows for easy addition of DataViews, threat management, and scan controls
- **Follow dashboard patterns**: Uses same architectural patterns as Logs and Backup pages for consistency

The scaffolding follows the established Dashboard design system and provides the foundation for implementing actual scan functionality like threat detection, auto-fix features, and scan history management.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch
* Basic navigation & routing
  * Navigate to `/v2/sites/[site]`
  * Verify "Scan" appears in the site navigation menu
  * Click "Scan" menu item to navigate to scan page
  * Test direct navigation to both `/scan/active` and `/scan/history` tabs
  * Verify tab switching works between "Active threats" and "History"
* Test with a site that has scan access (Business/Commerce plan):
   * Verify scan tabs display properly
   * Verify no upsell overlay appears
   *  Check placeholder content shows in each tab
* Test with a site without scan access (like a simple site):
   * Verify upsell callout displays over content
   * Verify "Upgrade plan" button links to `/checkout/[site]/business`
   * Verify scan feature description displays correctly 

### Basic Navigation & Routing:
1. Navigate to `/v2/sites/[site-slug]/scan` - should redirect to `/v2/sites/[site-slug]/scan/active`
2. Verify "Scan" appears in the site navigation menu
3. Click "Scan" menu item to navigate to scan page
4. Test direct navigation to both `/scan/active` and `/scan/history` tabs
5. Verify tab switching works between "Active threats" and "History"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
