### PR TITLE
Hosting Dashboard > Security: Implement Disable Two-step Authentication & rename queries and mutators

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -8,7 +8,7 @@ import {
 	queryClient,
 	accountRecoveryQuery,
 	smsCountryCodesQuery,
-	appAuthSetupQuery,
+	twoStepAuthAppSetupQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { rootRoute } from './root';
@@ -203,7 +203,7 @@ export const securityTwoStepAuthAppRoute = createRoute( {
 	loader: async () => {
 		await Promise.all( [
 			queryClient.ensureQueryData( userSettingsQuery() ),
-			queryClient.ensureQueryData( appAuthSetupQuery() ),
+			queryClient.ensureQueryData( twoStepAuthAppSetupQuery() ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/me/security-two-step-auth-app/scan-qr-code.tsx
+++ b/client/dashboard/me/security-two-step-auth-app/scan-qr-code.tsx
@@ -1,4 +1,4 @@
-import { appAuthSetupQuery } from '@automattic/api-queries';
+import { twoStepAuthAppSetupQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
@@ -17,7 +17,7 @@ import VerifyCodeForm from '../security-two-step-auth/common/verify-code-form';
 export default function ScanQRCode() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const { data: appAuthSetup } = useSuspenseQuery( appAuthSetupQuery() );
+	const { data: appAuthSetup } = useSuspenseQuery( twoStepAuthAppSetupQuery() );
 
 	const handleCopy = () => {
 		createSuccessNotice( __( 'Setup key copied to clipboard.' ), {

--- a/client/dashboard/me/security-two-step-auth/common/print-backup-codes.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/print-backup-codes.tsx
@@ -1,4 +1,4 @@
-import { generateBackupCodesMutation } from '@automattic/api-queries';
+import { generateTwoStepAuthBackupCodesMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -31,7 +31,7 @@ export default function PrintBackupCodes( {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const { mutate: generateBackupCodes, data: backupCodes } = useMutation(
-		generateBackupCodesMutation()
+		generateTwoStepAuthBackupCodesMutation()
 	);
 
 	const [ isBackupCodesPrinted, setIsBackupCodesPrinted ] = useState( false );

--- a/client/dashboard/me/security-two-step-auth/common/verify-code-form.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/verify-code-form.tsx
@@ -1,4 +1,4 @@
-import { validateTwoStepCodeMutation } from '@automattic/api-queries';
+import { validateTwoStepAuthCodeMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -49,7 +49,7 @@ export default function VerifyCodeForm( {
 	} );
 
 	const { mutate: validateTwoStepCode, isPending: isValidateTwoStepCodePending } = useMutation(
-		validateTwoStepCodeMutation()
+		validateTwoStepAuthCodeMutation()
 	);
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
@@ -102,9 +102,13 @@ export default function DisableTwoStepDialog( { onClose }: { onClose: () => void
 					onClose();
 				},
 				onError: ( e: Error ) => {
+					const errorMessage =
+						e.cause === 'invalid_code'
+							? __( 'You entered an invalid code. Please try again.' )
+							: e.message;
 					setError( {
 						title: __( 'Unable to disable two-step authentication' ),
-						message: e.message,
+						message: errorMessage,
 					} );
 				},
 			}

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
@@ -1,0 +1,208 @@
+import {
+	userSettingsQuery,
+	validateTwoStepAuthCodeMutation,
+	resendTwoStepAuthSMSCodeMutation,
+} from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Modal,
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState, useEffect, useCallback } from 'react';
+import { ButtonStack } from '../../../../components/button-stack';
+import { Notice } from '../../../../components/notice';
+import type { Field } from '@wordpress/dataviews';
+
+type TwoStepAuthAppFormData = {
+	code: string;
+};
+
+export default function DisableTwoStepDialog( { onClose }: { onClose: () => void } ) {
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	const username = userSettings.user_login;
+	const isTwoStepSMSEnabled = userSettings.two_step_sms_enabled;
+
+	const [ formData, setFormData ] = useState< TwoStepAuthAppFormData >( {
+		code: '',
+	} );
+	const [ isSMSResendThrottled, setIsSMSResendThrottled ] = useState( false );
+	const [ error, setError ] = useState< {
+		title: string;
+		message: string;
+	} | null >( null );
+
+	const { mutate: validateTwoStepCode, isPending: isValidateTwoStepCodePending } = useMutation(
+		validateTwoStepAuthCodeMutation()
+	);
+	const { mutate: resendSMSCode } = useMutation( resendTwoStepAuthSMSCodeMutation() );
+
+	// Allow SMS requests after 60 seconds
+	const handleThrottleSMSRequests = () => {
+		setTimeout( () => {
+			setIsSMSResendThrottled( false );
+		}, 60000 );
+	};
+
+	const handleResendSMSCode = useCallback( () => {
+		setIsSMSResendThrottled( true );
+		setError( null );
+		resendSMSCode( undefined, {
+			onSuccess: () => {
+				setError( null );
+				handleThrottleSMSRequests();
+			},
+			onError: ( e: { error?: string; message?: string } ) => {
+				const error = e?.error;
+				if ( error === 'rate_limited' ) {
+					setError( {
+						title: __( 'Unable to request a code via SMS right now' ),
+						message: __( 'Please try again after one minute.' ),
+					} );
+				} else {
+					setError( {
+						title: __( 'Failed to send verification code' ),
+						message: e.message || __( 'Please try again.' ),
+					} );
+				}
+				handleThrottleSMSRequests();
+			},
+		} );
+	}, [ resendSMSCode ] );
+
+	useEffect( () => {
+		if ( isTwoStepSMSEnabled ) {
+			handleResendSMSCode();
+		}
+	}, [ isTwoStepSMSEnabled, handleResendSMSCode ] );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		setError( null );
+		validateTwoStepCode(
+			{
+				code: formData.code,
+				action: 'disable-two-step',
+			},
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Two-step authentication disabled.' ), {
+						type: 'snackbar',
+					} );
+					onClose();
+				},
+				onError: ( e: Error ) => {
+					setError( {
+						title: __( 'Unable to disable two-step authentication' ),
+						message: e.message,
+					} );
+				},
+			}
+		);
+	};
+
+	const field: Field< TwoStepAuthAppFormData > = useMemo(
+		() => ( {
+			id: 'code',
+			type: 'text',
+			label: __( 'Verification code' ),
+			placeholder: '123456',
+			Edit: ( { field, data, onChange } ) => {
+				const { id, getValue } = field;
+				return (
+					<InputControl
+						__next40pxDefaultSize
+						type="text"
+						label={ field.label }
+						placeholder={ field.placeholder }
+						value={ getValue( { item: data } ) }
+						onChange={ ( value ) => {
+							return onChange( { [ id ]: value ?? '' } );
+						} }
+						disabled={ isValidateTwoStepCodePending }
+					/>
+				);
+			},
+		} ),
+		[ isValidateTwoStepCodePending ]
+	);
+
+	return (
+		<Modal onRequestClose={ onClose } title={ __( 'Disable two-step authentication' ) }>
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 } style={ { maxWidth: '450px' } }>
+					<Text as="p">
+						{ createInterpolateElement(
+							/* translators: username is the username of the account */
+							__(
+								'You are about to disable two-step authentication. This means we will no longer ask for your authentication code when you sign into your <username/> account.'
+							),
+							{
+								username: <strong>{ username }</strong>,
+							}
+						) }
+					</Text>
+					<Text as="p">
+						{ __(
+							'This will also disable your application passwords, though you can access them again if you ever re-enable two-step authentication. If you decide to re-enable two-step authentication, keep in mind you’ll need to generate new backup codes.'
+						) }
+					</Text>
+					<Text as="p">
+						{ __(
+							'To verify that you wish to disable two-step authentication, enter the verification code from your device or a backup code.'
+						) }
+					</Text>
+
+					{ error && (
+						<Notice variant="error" title={ error.title }>
+							{ error.message }
+						</Notice>
+					) }
+
+					<DataForm< TwoStepAuthAppFormData >
+						data={ formData }
+						fields={ [ field ] }
+						form={ { layout: { type: 'regular' as const }, fields: [ field ] } }
+						onChange={ ( edits: Partial< TwoStepAuthAppFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+
+					{ isTwoStepSMSEnabled && (
+						<Button
+							variant="link"
+							onClick={ handleResendSMSCode }
+							disabled={ isSMSResendThrottled }
+						>
+							{ __( 'Request a new code via SMS' ) }
+						</Button>
+					) }
+
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ handleSubmit }
+							isBusy={ isValidateTwoStepCodePending }
+							disabled={ isValidateTwoStepCodePending || ! formData.code }
+						>
+							{ __( 'Disable' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			</form>
+		</Modal>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
@@ -197,6 +197,7 @@ export default function DisableTwoStepDialog( { onClose }: { onClose: () => void
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							isDestructive
 							variant="primary"
 							onClick={ handleSubmit }
 							isBusy={ isValidateTwoStepCodePending }

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
@@ -1,24 +1,47 @@
 import { useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 import { ActionList } from '../../../../components/action-list';
+import DisableTwoStepDialog from './disable-two-step-dialog';
 
 export default function TwoStepAuthActions() {
 	const router = useRouter();
+
+	const [ showDisableDialog, setShowDisableDialog ] = useState( false );
+
 	return (
-		<ActionList>
-			<ActionList.ActionItem
-				title={ __( 'Generate new backup codes' ) }
-				actions={
-					<Button
-						onClick={ () => router.navigate( { to: '/me/security/two-step-auth/backup-codes' } ) }
-						variant="secondary"
-						size="compact"
-					>
-						{ __( 'Generate backup codes' ) }
-					</Button>
-				}
-			/>
-		</ActionList>
+		<>
+			<ActionList>
+				<ActionList.ActionItem
+					title={ __( 'Generate new backup codes' ) }
+					actions={
+						<Button
+							onClick={ () => router.navigate( { to: '/me/security/two-step-auth/backup-codes' } ) }
+							variant="secondary"
+							size="compact"
+						>
+							{ __( 'Generate backup codes' ) }
+						</Button>
+					}
+				/>
+				<ActionList.ActionItem
+					title={ __( 'Disable two-step authentication' ) }
+					actions={
+						<Button
+							isDestructive
+							onClick={ () => setShowDisableDialog( true ) }
+							variant="secondary"
+							size="compact"
+						>
+							{ __( 'Disable' ) }
+						</Button>
+					}
+				/>
+			</ActionList>
+			{ showDisableDialog && (
+				<DisableTwoStepDialog onClose={ () => setShowDisableDialog( false ) } />
+			) }
+		</>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -1,6 +1,6 @@
 import {
-	applicationPasswordsQuery,
-	deleteApplicationPasswordMutation,
+	twoStepAuthApplicationPasswordsQuery,
+	deleteTwoStepAuthApplicationPasswordMutation,
 } from '@automattic/api-queries';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -22,13 +22,13 @@ import { useState } from 'react';
 import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
 import RegisterApplicationPassword from './register-application-password';
-import type { ApplicationPassword } from '@automattic/api-core';
+import type { TwoStepAuthApplicationPassword } from '@automattic/api-core';
 
 const fields = [
 	{
 		id: 'name',
 		label: __( 'Name' ),
-		getValue: ( { item }: { item: ApplicationPassword } ) => item.name,
+		getValue: ( { item }: { item: TwoStepAuthApplicationPassword } ) => item.name,
 	},
 ];
 
@@ -42,16 +42,17 @@ const ApplicationPasswordsList = ( {
 	data,
 	isLoading,
 }: {
-	data: ApplicationPassword[];
+	data: TwoStepAuthApplicationPassword[];
 	isLoading: boolean;
 } ) => {
-	const { mutate: deleteApplicationPassword } = useMutation( deleteApplicationPasswordMutation() );
+	const { mutate: deleteApplicationPassword } = useMutation(
+		deleteTwoStepAuthApplicationPasswordMutation()
+	);
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const [ selectedKeyToRemove, setSelectedKeyToRemove ] = useState< ApplicationPassword | null >(
-		null
-	);
+	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
+		useState< TwoStepAuthApplicationPassword | null >( null );
 
 	const handleRemove = () => {
 		const selectedApplicationPassword = selectedKeyToRemove;
@@ -79,7 +80,7 @@ const ApplicationPasswordsList = ( {
 
 	return (
 		<>
-			<DataViews< ApplicationPassword >
+			<DataViews< TwoStepAuthApplicationPassword >
 				data={ data }
 				fields={ fields }
 				view={ view }
@@ -95,7 +96,7 @@ const ApplicationPasswordsList = ( {
 						label: __( 'Remove' ),
 						icon: <Icon icon={ closeSmall } />,
 						isPrimary: true,
-						callback: ( items: ApplicationPassword[] ) => {
+						callback: ( items: TwoStepAuthApplicationPassword[] ) => {
 							const item = items[ 0 ];
 							setSelectedKeyToRemove( item );
 						},
@@ -120,7 +121,9 @@ export default function ApplicationPasswords() {
 	const [ isAddApplicationPasswordModalOpen, setIsAddApplicationPasswordModalOpen ] =
 		useState( false );
 
-	const { data: applicationPasswords, isLoading } = useQuery( applicationPasswordsQuery() );
+	const { data: applicationPasswords, isLoading } = useQuery(
+		twoStepAuthApplicationPasswordsQuery()
+	);
 
 	return (
 		<>

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/register-application-password.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/register-application-password.tsx
@@ -1,4 +1,4 @@
-import { createApplicationPasswordMutation } from '@automattic/api-queries';
+import { createTwoStepAuthApplicationPasswordMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
 	Modal,
@@ -30,7 +30,7 @@ export default function RegisterApplicationPassword( { onClose }: { onClose: () 
 	const [ applicationPassword, setApplicationPassword ] = useState< string | null >( '' );
 
 	const { mutate: registerApplicationPassword, isPending: isRegisteringApplicationPassword } =
-		useMutation( createApplicationPasswordMutation() );
+		useMutation( createTwoStepAuthApplicationPasswordMutation() );
 
 	const handleSubmit = async ( e: React.FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -1,4 +1,7 @@
-import { securityKeysQuery, deleteSecurityKeyMutation } from '@automattic/api-queries';
+import {
+	twoStepAuthSecurityKeysQuery,
+	deleteTwoStepAuthSecurityKeyMutation,
+} from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -19,9 +22,9 @@ import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
 import { isWebAuthnSupported } from '../../utils';
 import RegisterKey from './register-key';
-import type { UserSecurityKeys } from '@automattic/api-core';
+import type { UserTwoStepAuthSecurityKeys } from '@automattic/api-core';
 
-type SecurityKeyRegistration = UserSecurityKeys[ 'registrations' ][ number ];
+type SecurityKeyRegistration = UserTwoStepAuthSecurityKeys[ 'registrations' ][ number ];
 
 const fields = [
 	{
@@ -44,7 +47,7 @@ const SecurityKeysList = ( {
 	data: SecurityKeyRegistration[];
 	isLoading: boolean;
 } ) => {
-	const { mutate: deleteSecurityKey } = useMutation( deleteSecurityKeyMutation() );
+	const { mutate: deleteSecurityKey } = useMutation( deleteTwoStepAuthSecurityKeyMutation() );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
@@ -114,7 +117,7 @@ const SecurityKeysList = ( {
 export default function SecurityKeys() {
 	const [ isAddKeyModalOpen, setIsAddKeyModalOpen ] = useState( false );
 
-	const { data: securityKeys, isLoading } = useQuery( securityKeysQuery() );
+	const { data: securityKeys, isLoading } = useQuery( twoStepAuthSecurityKeysQuery() );
 
 	const registrations = securityKeys?.registrations ?? [];
 

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -1,4 +1,4 @@
-import { registerSecurityKeyMutation } from '@automattic/api-queries';
+import { registerTwoStepAuthSecurityKeyMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
 	Modal,
@@ -26,7 +26,7 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutateAsync: registerSecurityKey, isPending: isRegisteringSecurityKey } = useMutation(
-		registerSecurityKeyMutation()
+		registerTwoStepAuthSecurityKeyMutation()
 	);
 
 	const handleSubmit = async ( e: React.FormEvent< HTMLFormElement > ) => {

--- a/packages/api-core/src/me-two-step/fetchers.ts
+++ b/packages/api-core/src/me-two-step/fetchers.ts
@@ -1,22 +1,22 @@
 import { wpcom } from '../wpcom-fetcher';
 import type {
-	UserSecurityKeys,
-	SecurityKeyRegistrationChallenge,
-	SecurityKeyRegistrationChallengeArgs,
-	AppAuthSetup,
-	ApplicationPassword,
+	UserTwoStepAuthSecurityKeys,
+	TwoStepAuthSecurityKeyRegistrationChallenge,
+	TwoStepAuthSecurityKeyRegistrationChallengeArgs,
+	TwoStepAuthAppAuthSetup,
+	TwoStepAuthApplicationPassword,
 } from './types';
 
-export async function fetchSecurityKeys(): Promise< UserSecurityKeys > {
+export async function fetchTwoStepAuthSecurityKeys(): Promise< UserTwoStepAuthSecurityKeys > {
 	return wpcom.req.get( {
 		path: '/me/two-step/security-key/get',
 		apiVersion: '1.1',
 	} );
 }
 
-export async function fetchSecurityKeyRegistrationChallenge(
-	data: SecurityKeyRegistrationChallengeArgs
-): Promise< SecurityKeyRegistrationChallenge > {
+export async function fetchTwoStepAuthSecurityKeyRegistrationChallenge(
+	data: TwoStepAuthSecurityKeyRegistrationChallengeArgs
+): Promise< TwoStepAuthSecurityKeyRegistrationChallenge > {
 	return wpcom.req.get(
 		{
 			path: '/me/two-step/security-key/registration_challenge',
@@ -28,14 +28,16 @@ export async function fetchSecurityKeyRegistrationChallenge(
 	);
 }
 
-export async function fetchAppAuthSetup(): Promise< AppAuthSetup > {
+export async function fetchTwoStepAuthAppSetup(): Promise< TwoStepAuthAppAuthSetup > {
 	return wpcom.req.get( {
 		path: '/me/two-step/app-auth-setup',
 		apiVersion: '1.1',
 	} );
 }
 
-export async function fetchApplicationPasswords(): Promise< ApplicationPassword[] > {
+export async function fetchTwoStepAuthApplicationPasswords(): Promise<
+	TwoStepAuthApplicationPassword[]
+> {
 	const { application_passwords } = await wpcom.req.get( {
 		path: '/me/two-step/application-passwords',
 		apiVersion: '1.1',

--- a/packages/api-core/src/me-two-step/mutators.ts
+++ b/packages/api-core/src/me-two-step/mutators.ts
@@ -1,15 +1,15 @@
 import { wpcom } from '../wpcom-fetcher';
 import type {
-	DeleteSecurityKeyArgs,
-	ValidateSecurityKeyRegistrationArgs,
-	CreateApplicationPasswordArgs,
-	CreateApplicationPasswordResponse,
-	ValidateTwoStepCodeArgs,
-	GenerateBackupCodesResponse,
+	DeleteTwoStepAuthSecurityKeyArgs,
+	ValidateTwoStepAuthSecurityKeyRegistrationArgs,
+	CreateTwoStepAuthApplicationPasswordArgs,
+	CreateTwoStepAuthApplicationPasswordResponse,
+	ValidateTwoStepAuthCodeArgs,
+	GenerateTwoStepAuthBackupCodesResponse,
 } from './types';
 
-export async function validateSecurityKeyRegistration(
-	data: ValidateSecurityKeyRegistrationArgs
+export async function validateTwoStepAuthSecurityKeyRegistration(
+	data: ValidateTwoStepAuthSecurityKeyRegistrationArgs
 ): Promise< Record< string, unknown > > {
 	return wpcom.req.post( {
 		path: '/me/two-step/security-key/registration_validate',
@@ -18,8 +18,8 @@ export async function validateSecurityKeyRegistration(
 	} );
 }
 
-export async function deleteSecurityKey(
-	data: DeleteSecurityKeyArgs
+export async function deleteTwoStepAuthSecurityKey(
+	data: DeleteTwoStepAuthSecurityKeyArgs
 ): Promise< Record< string, unknown > > {
 	return wpcom.req.get(
 		{
@@ -32,8 +32,8 @@ export async function deleteSecurityKey(
 	);
 }
 
-export async function validateTwoStepCode(
-	data: ValidateTwoStepCodeArgs
+export async function validateTwoStepAuthCode(
+	data: ValidateTwoStepAuthCodeArgs
 ): Promise< Record< string, unknown > > {
 	return wpcom.req.post( {
 		path: '/me/two-step/validate',
@@ -42,9 +42,9 @@ export async function validateTwoStepCode(
 	} );
 }
 
-export async function createApplicationPassword(
-	data: CreateApplicationPasswordArgs
-): Promise< CreateApplicationPasswordResponse > {
+export async function createTwoStepAuthApplicationPassword(
+	data: CreateTwoStepAuthApplicationPasswordArgs
+): Promise< CreateTwoStepAuthApplicationPasswordResponse > {
 	return wpcom.req.post( {
 		path: '/me/two-step/application-passwords/new',
 		apiVersion: '1.1',
@@ -52,14 +52,14 @@ export async function createApplicationPassword(
 	} );
 }
 
-export async function generateBackupCodes(): Promise< GenerateBackupCodesResponse > {
+export async function generateTwoStepAuthBackupCodes(): Promise< GenerateTwoStepAuthBackupCodesResponse > {
 	return wpcom.req.post( {
 		path: '/me/two-step/backup-codes/new',
 		apiVersion: '1.1',
 	} );
 }
 
-export async function deleteApplicationPassword(
+export async function deleteTwoStepAuthApplicationPassword(
 	applicationPasswordId: string
 ): Promise< Record< string, unknown > > {
 	return wpcom.req.post( {

--- a/packages/api-core/src/me-two-step/types.ts
+++ b/packages/api-core/src/me-two-step/types.ts
@@ -1,4 +1,4 @@
-export interface UserSecurityKeys {
+export interface UserTwoStepAuthSecurityKeys {
 	registrations: {
 		id: string;
 		name: string;
@@ -6,7 +6,7 @@ export interface UserSecurityKeys {
 	}[];
 }
 
-export interface SecurityKeyRegistrationChallenge {
+export interface TwoStepAuthSecurityKeyRegistrationChallenge {
 	rp: {
 		id: string;
 		name: string;
@@ -24,42 +24,42 @@ export interface SecurityKeyRegistrationChallenge {
 	timeout: number;
 }
 
-export interface DeleteSecurityKeyArgs {
+export interface DeleteTwoStepAuthSecurityKeyArgs {
 	credential_id: string;
 }
 
-export interface SecurityKeyRegistrationChallengeArgs {
+export interface TwoStepAuthSecurityKeyRegistrationChallengeArgs {
 	hostname?: string;
 }
 
-export interface ValidateSecurityKeyRegistrationArgs {
+export interface ValidateTwoStepAuthSecurityKeyRegistrationArgs {
 	data: string;
 	name: string;
 	hostname?: string;
 }
-export interface ApplicationPassword {
+export interface TwoStepAuthApplicationPassword {
 	ID: string;
 	name: string;
 	generated: string;
 }
 
-export interface CreateApplicationPasswordArgs {
+export interface CreateTwoStepAuthApplicationPasswordArgs {
 	application_name: string;
 }
 
-export interface CreateApplicationPasswordResponse {
+export interface CreateTwoStepAuthApplicationPasswordResponse {
 	application_password: string;
 }
-export interface AppAuthSetup {
+export interface TwoStepAuthAppAuthSetup {
 	otpauth_uri: string;
 	time_code: string;
 }
 
-export interface ValidateTwoStepCodeArgs {
+export interface ValidateTwoStepAuthCodeArgs {
 	code: string;
 	action: string;
 }
 
-export interface GenerateBackupCodesResponse {
+export interface GenerateTwoStepAuthBackupCodesResponse {
 	codes: string[];
 }

--- a/packages/api-queries/src/me-two-step.ts
+++ b/packages/api-queries/src/me-two-step.ts
@@ -1,14 +1,14 @@
 import {
-	fetchSecurityKeys,
-	fetchSecurityKeyRegistrationChallenge,
-	validateSecurityKeyRegistration,
-	deleteSecurityKey,
-	fetchApplicationPasswords,
-	createApplicationPassword,
-	deleteApplicationPassword,
-	fetchAppAuthSetup,
-	validateTwoStepCode,
-	generateBackupCodes,
+	fetchTwoStepAuthSecurityKeys,
+	fetchTwoStepAuthSecurityKeyRegistrationChallenge,
+	validateTwoStepAuthSecurityKeyRegistration,
+	deleteTwoStepAuthSecurityKey,
+	fetchTwoStepAuthApplicationPasswords,
+	createTwoStepAuthApplicationPassword,
+	deleteTwoStepAuthApplicationPassword,
+	fetchTwoStepAuthAppSetup,
+	validateTwoStepAuthCode,
+	generateTwoStepAuthBackupCodes,
 	updateUserSettings,
 	sendTwoStepAuthSMSCode,
 } from '@automattic/api-core';
@@ -19,20 +19,20 @@ import { userSettingsQuery } from './me-settings';
 import { queryClient } from './query-client';
 import type { UserSettings } from '@automattic/api-core';
 
-export const securityKeysQuery = () =>
+export const twoStepAuthSecurityKeysQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'security-keys' ],
-		queryFn: fetchSecurityKeys,
+		queryFn: fetchTwoStepAuthSecurityKeys,
 	} );
 
-export const registerSecurityKeyMutation = () =>
+export const registerTwoStepAuthSecurityKeyMutation = () =>
 	mutationOptions( {
 		mutationFn: async ( keyName: string ) => {
 			// Get hostname for non-production environments
 			const hostname = 'production' !== config( 'env_id' ) ? window.location.hostname : undefined;
 
 			// First, fetch the registration challenge
-			const options = await fetchSecurityKeyRegistrationChallenge( { hostname } );
+			const options = await fetchTwoStepAuthSecurityKeyRegistrationChallenge( { hostname } );
 
 			// Create the WebAuthn credential
 			const credential = await create( { publicKey: options } );
@@ -44,52 +44,52 @@ export const registerSecurityKeyMutation = () =>
 				hostname,
 			};
 
-			return await validateSecurityKeyRegistration( validationData );
+			return await validateTwoStepAuthSecurityKeyRegistration( validationData );
 		},
 		onSuccess: () => {
-			queryClient.invalidateQueries( securityKeysQuery() );
+			queryClient.invalidateQueries( twoStepAuthSecurityKeysQuery() );
 		},
 	} );
 
-export const deleteSecurityKeyMutation = () =>
+export const deleteTwoStepAuthSecurityKeyMutation = () =>
 	mutationOptions( {
-		mutationFn: deleteSecurityKey,
+		mutationFn: deleteTwoStepAuthSecurityKey,
 		onSuccess: () => {
-			queryClient.invalidateQueries( securityKeysQuery() );
+			queryClient.invalidateQueries( twoStepAuthSecurityKeysQuery() );
 		},
 	} );
 
-export const applicationPasswordsQuery = () =>
+export const twoStepAuthApplicationPasswordsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'application-passwords' ],
-		queryFn: fetchApplicationPasswords,
+		queryFn: fetchTwoStepAuthApplicationPasswords,
 	} );
 
-export const createApplicationPasswordMutation = () =>
+export const createTwoStepAuthApplicationPasswordMutation = () =>
 	mutationOptions( {
-		mutationFn: createApplicationPassword,
+		mutationFn: createTwoStepAuthApplicationPassword,
 		onSuccess: () => {
-			queryClient.invalidateQueries( applicationPasswordsQuery() );
+			queryClient.invalidateQueries( twoStepAuthApplicationPasswordsQuery() );
 		},
 	} );
 
-export const deleteApplicationPasswordMutation = () =>
+export const deleteTwoStepAuthApplicationPasswordMutation = () =>
 	mutationOptions( {
-		mutationFn: deleteApplicationPassword,
+		mutationFn: deleteTwoStepAuthApplicationPassword,
 		onSuccess: () => {
-			queryClient.invalidateQueries( applicationPasswordsQuery() );
+			queryClient.invalidateQueries( twoStepAuthApplicationPasswordsQuery() );
 		},
 	} );
 
-export const appAuthSetupQuery = () =>
+export const twoStepAuthAppSetupQuery = () =>
 	queryOptions( {
 		queryKey: [ 'me', 'app-auth-setup' ],
-		queryFn: fetchAppAuthSetup,
+		queryFn: fetchTwoStepAuthAppSetup,
 	} );
 
-export const validateTwoStepCodeMutation = () =>
+export const validateTwoStepAuthCodeMutation = () =>
 	mutationOptions( {
-		mutationFn: validateTwoStepCode,
+		mutationFn: validateTwoStepAuthCode,
 		onSuccess: ( data ) => {
 			// This is a workaround to handle the error/success response
 			// from the API as it always returns 200 status code.
@@ -102,9 +102,9 @@ export const validateTwoStepCodeMutation = () =>
 		},
 	} );
 
-export const generateBackupCodesMutation = () =>
+export const generateTwoStepAuthBackupCodesMutation = () =>
 	mutationOptions( {
-		mutationFn: generateBackupCodes,
+		mutationFn: generateTwoStepAuthBackupCodes,
 	} );
 
 export const setupTwoStepAuthSMSMutation = () =>


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTDASH-169/implement-account-security-two-step-authentication-to-the-hosting

Closes https://linear.app/a8c/issue/DOTDASH-428/implement-disable-two-step-authentication

## Proposed Changes

This PR:

- Implements disabling two-step authentication on the hosting dashboard: https://github.com/Automattic/wp-calypso/pull/105705/commits/21b810dfc5eb7cbc148faaa00081b9675a6b8d3f
- Renames all queries and mutators to ensure we follow a standard naming convention: https://github.com/Automattic/wp-calypso/pull/105705/commits/ba92be6dd4a0860070195b42625d8cce11cf800e

Note: We should handle the case where Two-step is enforced. I have asked the design team for the design. 

## Why are these changes being made?

* To allow users to disable two-step authentication

## Testing Instructions

* Enable [Two-step using an app](https://github.com/Automattic/wp-calypso/pull/105617) > Verify you can see a button to disable Two-step on the main auth screen as shown below

<img width="709" height="171" alt="Screenshot 2025-09-12 at 11 15 35 AM" src="https://github.com/user-attachments/assets/ea83f7b9-1099-47fc-baf5-156d76107882" />

* Click the "Disable" button > Verify a modal is displayed as shown below > Go ahead and enter a wrong code > Verify an error message is shown > Enter the correct code and click the "Disable" button > Verify two-step auth is disabled

**[Updated screenshot]** 

<img width="755" height="490" alt="Screenshot 2025-09-12 at 1 14 42 PM" src="https://github.com/user-attachments/assets/c51f9427-a50a-4bed-a580-785c96b37198" />

<img width="558" height="599" alt="Screenshot 2025-09-12 at 11 34 33 AM" src="https://github.com/user-attachments/assets/3f270976-4753-4cbd-a472-08ffcab6716d" />

<img width="285" height="80" alt="Screenshot 2025-09-12 at 11 35 39 AM" src="https://github.com/user-attachments/assets/6c61988b-a6ae-4b9f-b719-d035aef058ae" />

* Enable [Two-step using SMS](https://github.com/Automattic/wp-calypso/pull/105683) >  Click the "Disable" button > Verify a modal is displayed as shown below. 

<img width="1920" height="968" alt="Screenshot 2025-09-11 at 3 11 43 PM" src="https://github.com/user-attachments/assets/772e6d20-61df-4c7f-a33f-bb03b8fc514c" />

* Verify the resend button is disabled for a minute. Once, it is enabled, click the resend button > Verify the error notice is displayed as shown above. Looks like it requires more than a min, but I think it's ok. Enter a wrong code and verify the error notice changes > Enter the correct code and click the "Disable" button > Verify two-step auth is disabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
