### PR TITLE
Hosting Dashboard: Adds centralised handling of mutation snackbar messages

### DIFF
--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -36,19 +36,21 @@ export default function Snackbars() {
 	// the `useMutation` hook.
 	useEffect( () => {
 		const cleanupSuccess = registerMutationSuccessCallback(
-			( data, variables, context, mutation ) => {
+			( _data, _variables, _context, mutation ) => {
 				const message = mutation.meta?.snackbar?.success;
 				if ( message ) {
 					createSuccessNotice( message, { type: 'snackbar' } );
 				}
 			}
 		);
-		const cleanupError = registerMutationErrorCallback( ( error, variables, context, mutation ) => {
-			const message = mutation.meta?.snackbar?.error;
-			if ( message ) {
-				createErrorNotice( message, { type: 'snackbar' } );
+		const cleanupError = registerMutationErrorCallback(
+			( _error, _variables, _context, mutation ) => {
+				const message = mutation.meta?.snackbar?.error;
+				if ( message ) {
+					createErrorNotice( message, { type: 'snackbar' } );
+				}
 			}
-		} );
+		);
 		return () => {
 			cleanupSuccess();
 			cleanupError();

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -1,8 +1,12 @@
+import {
+	registerMutationSuccessCallback,
+	registerMutationErrorCallback,
+} from '@automattic/api-queries';
 import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon, published, error } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import React from 'react';
+import { useEffect } from 'react';
 import './style.scss';
 
 // Last three notices. Slices from the tail end of the list.
@@ -13,9 +17,44 @@ const statusIcon: Record< string, React.JSX.Element > = {
 	error,
 };
 
+declare module '@tanstack/react-query' {
+	interface Register {
+		mutationMeta: {
+			snackbar?: {
+				success?: string;
+				error?: string;
+			};
+		};
+	}
+}
+
 export default function Snackbars() {
 	const notices = useSelect( ( select ) => select( noticesStore ).getNotices(), [] );
-	const { removeNotice } = useDispatch( noticesStore );
+	const { removeNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	// Displays snackbars which have been requested through the `meta` option of
+	// the `useMutation` hook.
+	useEffect( () => {
+		const cleanupSuccess = registerMutationSuccessCallback(
+			( data, variables, context, mutation ) => {
+				const message = mutation.meta?.snackbar?.success;
+				if ( message ) {
+					createSuccessNotice( message, { type: 'snackbar' } );
+				}
+			}
+		);
+		const cleanupError = registerMutationErrorCallback( ( error, variables, context, mutation ) => {
+			const message = mutation.meta?.snackbar?.error;
+			if ( message ) {
+				createErrorNotice( message, { type: 'snackbar' } );
+			}
+		} );
+		return () => {
+			cleanupSuccess();
+			cleanupError();
+		};
+	}, [ createSuccessNotice, createErrorNotice ] );
+
 	const snackbarNotices = notices
 		.filter( ( { type } ) => type === 'snackbar' )
 		.map( ( { status, ...notice } ) => ( {

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -1,7 +1,4 @@
-import {
-	registerMutationSuccessCallback,
-	registerMutationErrorCallback,
-} from '@automattic/api-queries';
+import { useQueryClient } from '@tanstack/react-query';
 import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon, published, error } from '@wordpress/icons';
@@ -31,31 +28,28 @@ declare module '@tanstack/react-query' {
 export default function Snackbars() {
 	const notices = useSelect( ( select ) => select( noticesStore ).getNotices(), [] );
 	const { removeNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const queryClient = useQueryClient();
 
 	// Displays snackbars which have been requested through the `meta` option of
 	// the `useMutation` hook.
 	useEffect( () => {
-		const cleanupSuccess = registerMutationSuccessCallback(
-			( _data, _variables, _context, mutation ) => {
-				const message = mutation.meta?.snackbar?.success;
-				if ( message ) {
-					createSuccessNotice( message, { type: 'snackbar' } );
+		return queryClient.getMutationCache().subscribe( ( event ) => {
+			const { type, mutation } = event;
+			if ( type === 'updated' ) {
+				if ( event.action.type === 'success' ) {
+					const message = mutation.meta?.snackbar?.success;
+					if ( message ) {
+						createSuccessNotice( message, { type: 'snackbar' } );
+					}
+				} else if ( event.action.type === 'error' ) {
+					const message = mutation.meta?.snackbar?.error;
+					if ( message ) {
+						createErrorNotice( message, { type: 'snackbar' } );
+					}
 				}
 			}
-		);
-		const cleanupError = registerMutationErrorCallback(
-			( _error, _variables, _context, mutation ) => {
-				const message = mutation.meta?.snackbar?.error;
-				if ( message ) {
-					createErrorNotice( message, { type: 'snackbar' } );
-				}
-			}
-		);
-		return () => {
-			cleanupSuccess();
-			cleanupError();
-		};
-	}, [ createSuccessNotice, createErrorNotice ] );
+		} );
+	}, [ queryClient, createSuccessNotice, createErrorNotice ] );
 
 	const snackbarNotices = notices
 		.filter( ( { type } ) => type === 'snackbar' )

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -1,34 +1,7 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
-import { MutationCache, QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
+import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
-
-type MutationCacheConfig = MutationCache[ 'config' ];
-type MutationSuccessCallback = NonNullable< MutationCacheConfig[ 'onSuccess' ] >;
-type MutationErrorCallback = NonNullable< MutationCacheConfig[ 'onError' ] >;
-
-const mutationSuccessCallback: MutationSuccessCallback[] = [];
-const mutationErrorCallback: MutationErrorCallback[] = [];
-
-function registerMutationSuccessCallback( callback: MutationSuccessCallback ) {
-	mutationSuccessCallback.push( callback );
-	return () => {
-		const index = mutationSuccessCallback.indexOf( callback );
-		if ( index > -1 ) {
-			mutationSuccessCallback.splice( index, 1 );
-		}
-	};
-}
-
-function registerMutationErrorCallback( callback: MutationErrorCallback ) {
-	mutationErrorCallback.push( callback );
-	return () => {
-		const index = mutationErrorCallback.indexOf( callback );
-		if ( index > -1 ) {
-			mutationErrorCallback.splice( index, 1 );
-		}
-	};
-}
 
 const queryClient = new QueryClient( {
 	defaultOptions: {
@@ -46,18 +19,6 @@ const queryClient = new QueryClient( {
 			},
 		},
 	},
-	mutationCache: new MutationCache( {
-		onSuccess: ( data, variables, context, mutation ) => {
-			mutationSuccessCallback.forEach( ( callback ) => {
-				callback( data, variables, context, mutation );
-			} );
-		},
-		onError: ( error, variables, context, mutation ) => {
-			mutationErrorCallback.forEach( ( callback ) => {
-				callback( error, variables, context, mutation );
-			} );
-		},
-	} ),
 } );
 
 const persister = createSyncStoragePersister( {
@@ -82,9 +43,4 @@ const [ , persistQueryClientPromise ] = persistQueryClient( {
 	},
 } );
 
-export {
-	queryClient,
-	persistQueryClientPromise,
-	registerMutationSuccessCallback,
-	registerMutationErrorCallback,
-};
+export { queryClient, persistQueryClientPromise };

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -1,7 +1,34 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
-import { QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
+import { MutationCache, QueryClient, defaultShouldDehydrateQuery } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
+
+type MutationCacheConfig = MutationCache[ 'config' ];
+type MutationSuccessCallback = NonNullable< MutationCacheConfig[ 'onSuccess' ] >;
+type MutationErrorCallback = NonNullable< MutationCacheConfig[ 'onError' ] >;
+
+const mutationSuccessCallback: MutationSuccessCallback[] = [];
+const mutationErrorCallback: MutationErrorCallback[] = [];
+
+function registerMutationSuccessCallback( callback: MutationSuccessCallback ) {
+	mutationSuccessCallback.push( callback );
+	return () => {
+		const index = mutationSuccessCallback.indexOf( callback );
+		if ( index > -1 ) {
+			mutationSuccessCallback.splice( index, 1 );
+		}
+	};
+}
+
+function registerMutationErrorCallback( callback: MutationErrorCallback ) {
+	mutationErrorCallback.push( callback );
+	return () => {
+		const index = mutationErrorCallback.indexOf( callback );
+		if ( index > -1 ) {
+			mutationErrorCallback.splice( index, 1 );
+		}
+	};
+}
 
 const queryClient = new QueryClient( {
 	defaultOptions: {
@@ -19,6 +46,18 @@ const queryClient = new QueryClient( {
 			},
 		},
 	},
+	mutationCache: new MutationCache( {
+		onSuccess: ( data, variables, context, mutation ) => {
+			mutationSuccessCallback.forEach( ( callback ) => {
+				callback( data, variables, context, mutation );
+			} );
+		},
+		onError: ( error, variables, context, mutation ) => {
+			mutationErrorCallback.forEach( ( callback ) => {
+				callback( error, variables, context, mutation );
+			} );
+		},
+	} ),
 } );
 
 const persister = createSyncStoragePersister( {
@@ -43,4 +82,9 @@ const [ , persistQueryClientPromise ] = persistQueryClient( {
 	},
 } );
 
-export { queryClient, persistQueryClientPromise };
+export {
+	queryClient,
+	persistQueryClientPromise,
+	registerMutationSuccessCallback,
+	registerMutationErrorCallback,
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

So many hosting dashboard views include the line

```ts
const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );

// ...

mutation( newValue, {
  onSuccess: () => {
    createSuccessNotice( __( 'My setting enabled.' ) );
  },
  onSuccess: () => {
    createErrorNotice( __( 'Failed to enable setting.' ) );
  },
} );
```

This is such a common pattern. It feels like something the hosting dashboard should do for us.

The other downside is that it spreads usage of the `@wordpress/data` store throughout our codebase. This central handling of snackbars doesn't remove the need for the store. But it will allow the dependency to be removed from most of our components.

This PR only migrates the cache settings view to the new method. But it should illustrate how it is done. In short, if you create your mutations like this:

```tsx
const { mutate } = useMutation( {
  ...siteSettingMutation( site.ID ),
  meta: {
    snackbar: {
      success: __( 'My setting enabled.' ),
      error: __( 'Failed to enable setting.' ),
    }
  }
} );
```

then the usual success/error snackbars will appear at the usual time.

If you have more advanced needs the old mechanism will work. But the `snackbar` object also gives us room to add new advanced features in the future. E.g. we could add a `flashMessage` property if we want the page to refresh and then show a message (see https://github.com/Automattic/wp-calypso/pull/105703)

If this PR merges I will follow up with another PR which migrates other basic snackbars to this mechanism.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit cache settings with an atomic site: `/v2/sites/{{ site slug }}/settings/caching`
* Change settings and watch the snackbar notifications
* Change pages while the mutation is still in progress and confirm the snackbar appears when complete
  * This worked before the PR too, but its worth pointing out

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
