### PR TITLE
Dashboard v2 Plugins: Scheduled Updates - add per-site Tracking and post-success navigation

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -14,7 +14,10 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
-import { pluginsScheduledUpdatesRoute } from '../../../app/router/plugins';
+import {
+	pluginsScheduledUpdatesNewRoute,
+	pluginsScheduledUpdatesRoute,
+} from '../../../app/router/plugins';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { SectionHeader } from '../../../components/section-header';
@@ -36,7 +39,7 @@ function ScheduledUpdatesNew() {
 	const [ time, setTime ] = useState( DEFAULT_TIME );
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
 
-	const navigate = useNavigate( { from: pluginsScheduledUpdatesRoute.fullPath } );
+	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
 	const { data: eligibleSites = [] } = useEligibleSites();
 	const siteIdsAsNumbers = useMemo(
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -64,12 +64,10 @@ function ScheduledUpdatesNew() {
 		};
 
 		createBatch.mutate( body, {
-			onSuccess: async (
-				results: Array< { siteId: number; response?: unknown; error?: unknown } >
-			) => {
+			onSuccess: async ( results ) => {
 				const successfulSiteIds = ( results || [] )
-					.filter( ( r ) => ! r.error )
-					.map( ( r ) => r.siteId );
+					.filter( ( result ) => ! result.error )
+					.map( ( result ) => result.siteId );
 
 				// Precompute values reused per site for Tracks
 				const eventDate = new Date( timestamp * 1000 );

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -42,7 +42,7 @@ function ScheduledUpdatesNew() {
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),
 		[ selectedSiteIds ]
 	);
-	const createMutation = useMutation( updateSchedulesBatchCreateMutation( siteIdsAsNumbers ) );
+	const createBatch = useMutation( updateSchedulesBatchCreateMutation( siteIdsAsNumbers ) );
 	const { mutateAsync: createMonitorForSite } = useMutation(
 		siteJetpackMonitorSettingsCreateMutation()
 	);
@@ -61,13 +61,16 @@ function ScheduledUpdatesNew() {
 			},
 			health_check_paths: [],
 		};
-		createMutation.mutate( body, {
-			onSuccess: async ( results ) => {
-				const successfulSiteIds = ( results || [] )
-					.filter( ( result ) => ! result.error )
-					.map( ( result ) => result.siteId );
 
-				// Compute hours and weekday from the scheduled timestamp (parity with legacy)
+		createBatch.mutate( body, {
+			onSuccess: async (
+				results: Array< { siteId: number; response?: unknown; error?: unknown } >
+			) => {
+				const successfulSiteIds = ( results || [] )
+					.filter( ( r ) => ! r.error )
+					.map( ( r ) => r.siteId );
+
+				// Precompute values reused per site for Tracks
 				const eventDate = new Date( timestamp * 1000 );
 				const hours = eventDate.getHours();
 				const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
@@ -110,10 +113,10 @@ function ScheduledUpdatesNew() {
 		weekday,
 		time,
 		selectedPluginSlugs,
-		createMutation,
+		createBatch,
 		eligibleSites,
-		navigate,
 		createMonitorForSite,
+		navigate,
 	] );
 
 	return (

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -2,7 +2,6 @@ import {
 	updateSchedulesBatchCreateMutation,
 	siteJetpackMonitorSettingsCreateMutation,
 } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -14,6 +13,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
 import {
 	pluginsScheduledUpdatesNewRoute,
 	pluginsScheduledUpdatesRoute,
@@ -38,7 +38,7 @@ function ScheduledUpdatesNew() {
 	const [ weekday, setWeekday ] = useState< Weekday >( DEFAULT_WEEKDAY );
 	const [ time, setTime ] = useState( DEFAULT_TIME );
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
-
+	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
 	const { data: eligibleSites = [] } = useEligibleSites();
 	const siteIdsAsNumbers = useMemo(
@@ -119,6 +119,7 @@ function ScheduledUpdatesNew() {
 		eligibleSites,
 		createMonitorForSite,
 		navigate,
+		recordTracksEvent,
 	] );
 
 	return (

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -51,6 +51,7 @@ function ScheduledUpdatesNew() {
 		if ( ! isValid ) {
 			return;
 		}
+
 		const timestamp = prepareTimestamp( frequency, weekday, time );
 		const body = {
 			plugins: selectedPluginSlugs,

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -2,7 +2,9 @@ import {
 	updateSchedulesBatchCreateMutation,
 	siteJetpackMonitorSettingsCreateMutation,
 } from '@automattic/api-queries';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	Button,
 	Card,
@@ -12,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
+import { pluginsScheduledUpdatesRoute } from '../../../app/router/plugins';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { SectionHeader } from '../../../components/section-header';
@@ -33,6 +36,7 @@ function ScheduledUpdatesNew() {
 	const [ time, setTime ] = useState( DEFAULT_TIME );
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
 
+	const navigate = useNavigate( { from: pluginsScheduledUpdatesRoute.fullPath } );
 	const { data: eligibleSites = [] } = useEligibleSites();
 	const siteIdsAsNumbers = useMemo(
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),
@@ -63,12 +67,25 @@ function ScheduledUpdatesNew() {
 					.filter( ( result ) => ! result.error )
 					.map( ( result ) => result.siteId );
 
+				// Compute hours and weekday from the scheduled timestamp (parity with legacy)
+				const eventDate = new Date( timestamp * 1000 );
+				const hours = eventDate.getHours();
+				const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
+
 				// Create monitor settings for each successful site using per-site mutation (with retry)
 				const siteMap = new Map( eligibleSites.map( ( site ) => [ site.ID, site ] ) );
 				const monitorTasks = successfulSiteIds
 					.map( ( siteId ) => siteMap.get( siteId ) )
 					.filter( ( site ): site is Site => Boolean( site ) )
 					.map( ( site ) => {
+						recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
+							site_slug: site.slug,
+							frequency,
+							plugins_number: selectedPluginSlugs.length,
+							hours,
+							weekday: weekdayIndex,
+						} );
+
 						return async () => {
 							await createMonitorForSite( {
 								siteId: site.ID,
@@ -81,7 +98,10 @@ function ScheduledUpdatesNew() {
 							} );
 						};
 					} );
+
 				await runWithConcurrency( monitorTasks, 4 );
+				// Navigate back to the schedules list
+				navigate( { to: pluginsScheduledUpdatesRoute.to } );
 			},
 		} );
 	}, [
@@ -92,6 +112,7 @@ function ScheduledUpdatesNew() {
 		selectedPluginSlugs,
 		createMutation,
 		eligibleSites,
+		navigate,
 		createMonitorForSite,
 	] );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Proposed Changes

* Adds `calypso_scheduled_updates_create_schedule` per-site tracking when a new Schedule is created
* Adds back-navigation when the operation is successful end-to-end 

> [!NOTE]
> V2 page aggregates the multi-site creation into one batch mutation. My original attempt would emit one event centrally, which made sense, but it wouldn't match the original (which emits per-site events with a single site-slug). This final form matches the original.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/plugins/scheduled-updates/new`
  - Select a site (must have an atomic site) - ideally multiple sites for testing this
  - Select a plugin (must have a non-managed plugins installed from marketplace)
  - Select a frequency
- Ensure `calypso_scheduled_updates_create_schedule` is tracked per-site being included in the new schedule 
  - Ensure the following props are properly passed to Tracks: `site_slug, frequency, plugins_number, hours, weekday`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
