### PR TITLE
Untangling: Replace links to Marketing Connections with Jetpack Social URL

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/use-celebration-data.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/test/use-celebration-data.test.tsx
@@ -36,7 +36,7 @@ describe( 'The useCelebrationData hook', () => {
 				subTitle: 'Now it’s time to connect your social accounts.',
 				primaryCtaName: 'Connect to social',
 				primaryCtaText: 'Connect to social',
-				primaryCtaLink: `/marketing/connections/${ siteSlug }`,
+				primaryCtaLink: `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-social`,
 				secondaryCtaName: 'Visit your blog',
 				secondaryCtaText: 'Visit your blog',
 				secondaryCtaLink: `https://${ siteSlug }`,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/use-celebration-data.tsx
@@ -29,7 +29,7 @@ const useCelebrationData = ( { flow, siteSlug = '', isFirstPostPublished = false
 			? translate( 'Connect to social' )
 			: translate( 'Write your first post' ),
 		primaryCtaLink: isStartWritingFlowOrFirstPostPublished
-			? `/marketing/connections/${ siteSlug }`
+			? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-social`
 			: `/post/${ siteSlug }`,
 		secondaryCtaName: 'Visit your blog',
 		secondaryCtaText: translate( 'Visit your blog' ),

--- a/client/my-sites/marketing/paths.ts
+++ b/client/my-sites/marketing/paths.ts
@@ -2,10 +2,6 @@ export const marketingConnections = ( siteSlug?: string | null ): string => {
 	return siteSlug ? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-social` : '';
 };
 
-export const marketingFediverse = ( siteSlug?: string | null ): string => {
-	return `/marketing/connections/${ siteSlug || '' }`;
-};
-
 export const marketingTraffic = ( siteSlug?: string | null ): string => {
 	return `/marketing/traffic/${ siteSlug || '' }`;
 };

--- a/client/my-sites/marketing/paths.ts
+++ b/client/my-sites/marketing/paths.ts
@@ -1,4 +1,8 @@
 export const marketingConnections = ( siteSlug?: string | null ): string => {
+	return siteSlug ? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack-social` : '';
+};
+
+export const marketingFediverse = ( siteSlug?: string | null ): string => {
 	return `/marketing/connections/${ siteSlug || '' }`;
 };
 

--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -13,6 +13,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { pluginsPath } from 'calypso/my-sites/marketing/paths';
 import { useSelector } from 'calypso/state';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
@@ -30,6 +31,7 @@ export default function MarketingTools() {
 	const searchRef = useRef< ImperativeHandle >( null );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
+	const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
 	const items = [
 		{ key: '', text: translate( 'All' ) },
 		{ key: 'new', text: translate( 'New tools' ) },
@@ -49,7 +51,8 @@ export default function MarketingTools() {
 		selectedSiteSlug,
 		translate,
 		localizeUrl,
-		activityPubStatus
+		activityPubStatus,
+		isPrivate
 	);
 
 	const marketingFeaturesFiltered = useMemo( () => {

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -17,7 +17,8 @@ export const getMarketingFeaturesData = (
 	selectedSiteSlug: T.SiteSlug | null,
 	translate: ( text: string, options?: any ) => string,
 	localizeUrl: ( url: string ) => string,
-	activityPubStatus: any
+	activityPubStatus: any,
+	isPrivate: boolean | null
 ): MarketingToolsFeatureData[] => {
 	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
 	const currentDate = new Date();
@@ -86,7 +87,10 @@ export const getMarketingFeaturesData = (
 				recordTracksEvent( 'calypso_marketing_tools_hire_an_seo_expert_button_click' );
 			},
 		},
-		{
+	];
+
+	if ( ! isPrivate ) {
+		result.push( {
 			title: translate( 'Get social, and share your blog posts where the people are' ),
 			description: translate(
 				"Use your site's Jetpack Social tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Facebook, LinkedIn, and more."
@@ -100,8 +104,8 @@ export const getMarketingFeaturesData = (
 
 				page( marketingConnections( selectedSiteSlug ) );
 			},
-		},
-	];
+		} );
+	}
 
 	if ( ! activityPubStatus?.isEnabled ) {
 		result.splice( 3, 0, {


### PR DESCRIPTION
Part of DOTCOM-14515

## Proposed Changes

Replaces a couple of links pointing to `/marketing/connections/:site` with the Jetpack Social URL. 

Celebration step | Marketing tools
--- | ---
<img width="1278" height="1126" alt="Screenshot 2025-09-11 at 12 55 06" src="https://github.com/user-attachments/assets/aa3981ea-1504-42a5-af25-0d55a5c32f80" /> | <img width="1280" height="816" alt="Screenshot 2025-09-11 at 17 03 33" src="https://github.com/user-attachments/assets/da95c45c-fb5f-4549-b4d8-12e7e72c8475" />


Note that Calypso has a few more instances of links to the `/marketing/connections/:site` path, but AFAICS they are no longer used, so I refrained from changing them.

## Why are these changes being made?

Because we're deprecating the Marketing Connections page in favor of Jetpack Social

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/start-writing` and create a new site with this flow
- After the site is created, you'll land in the post editor
- Get out of it by clicking on the W button in the top-left button
- Go to My Home
- You'll be redirected to the onboarding launchpad
- Complete all steps and launch the site
- After launching the site, the celebration step will show up
- Click on the "Connect to social" button
- Make sure you are redirected to Jetpack Social
- Go to Tools > Marketing
- Check the "Get social" card
- Click on the "Start sharing" link
- Make sure you are redirected to Jetpack Social
- Go to Settings > Reading
- Mark your site as private
- Go back to Tools > Marketing
- Make sure the "Get social" card is not visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
