### PR TITLE
Backup FileBrowser: replace moment.js and add locale context

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-context.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-context.tsx
@@ -4,6 +4,7 @@ import { useFileBrowserState } from './use-file-browser-state';
 
 interface FileBrowserContextValue {
 	fileBrowserState: FileBrowserStateActions;
+	locale: string;
 }
 
 const FileBrowserContext = createContext< FileBrowserContextValue | null >( null );
@@ -18,16 +19,17 @@ export const useFileBrowserContext = () => {
 
 interface FileBrowserProviderProps {
 	children: React.ReactNode;
+	locale: string;
 }
 
 /**
  * Provider that wraps backup pages with FileBrowser context
  */
-export function FileBrowserProvider( { children }: FileBrowserProviderProps ) {
+export function FileBrowserProvider( { children, locale }: FileBrowserProviderProps ) {
 	const fileBrowserState = useFileBrowserState();
 
 	return (
-		<FileBrowserContext.Provider value={ { fileBrowserState } }>
+		<FileBrowserContext.Provider value={ { fileBrowserState, locale } }>
 			{ children }
 		</FileBrowserContext.Provider>
 	);

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -3,7 +3,6 @@ import { Button } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDispatch } from 'calypso/state';
 import { PREPARE_DOWNLOAD_STATUS } from './constants';
 import { useFileBrowserContext } from './file-browser-context';
@@ -43,9 +42,8 @@ function FileInfoCard( {
 	onTrackEvent,
 	onRequestGranularRestore,
 }: FileInfoCardProps ) {
-	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
-	const { fileBrowserState } = useFileBrowserContext();
+	const { fileBrowserState, locale } = useFileBrowserContext();
 	const { setNodeCheckState } = fileBrowserState;
 
 	const {
@@ -70,7 +68,12 @@ function FileInfoCard( {
 		handlePrepareDownloadError
 	);
 
-	const modifiedTime = fileInfo?.mtime ? moment.unix( fileInfo.mtime ).format( 'lll' ) : null;
+	const modifiedTime = fileInfo?.mtime
+		? new Intl.DateTimeFormat( locale, {
+				dateStyle: 'medium',
+				timeStyle: 'short',
+		  } ).format( new Date( fileInfo.mtime * 1000 ) )
+		: null;
 	const size = fileInfo?.size !== undefined ? convertBytes( fileInfo.size ) : null;
 
 	const [ isProcessingDownload, setIsProcessingDownload ] = useState< boolean >( false );

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -5,8 +5,6 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
-import { useFirstMatchingBackupAttempt } from 'calypso/my-sites/backup/hooks';
 import FileBrowserHeader from './file-browser-header';
 import FileBrowserNode from './file-browser-node';
 import { FileBrowserItem } from './types';
@@ -33,6 +31,7 @@ interface FileBrowserProps {
 	// Optional site data props
 	hasCredentials?: boolean;
 	isRestoreEnabled?: boolean;
+	displayBackupDate?: string;
 
 	// Tracks analytics callback
 	onTrackEvent?: ( eventName: string, properties?: Record< string, unknown > ) => void;
@@ -56,22 +55,13 @@ function FileBrowser( {
 	siteSlug,
 	hasCredentials,
 	isRestoreEnabled,
+	displayBackupDate,
 	onTrackEvent,
 	onRequestGranularDownload,
 	onRequestGranularRestore = () => {},
 }: FileBrowserProps ) {
 	// This is the path of the node that is clicked
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
-	const getDisplayDate = useGetDisplayDate( siteId );
-
-	const { backupAttempt: lastKnownBackupAttempt } = useFirstMatchingBackupAttempt( siteId, {
-		sortOrder: 'desc',
-		successOnly: true,
-	} );
-
-	const displayBackupDate = lastKnownBackupAttempt
-		? getDisplayDate( lastKnownBackupAttempt.activityTs, false )
-		: null;
 
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
@@ -96,7 +86,7 @@ function FileBrowser( {
 				onRequestGranularDownload={ onRequestGranularDownload }
 				onRequestGranularRestore={ onRequestGranularRestore }
 			/>
-			{ fileBrowserConfig?.showBackupTime && (
+			{ fileBrowserConfig?.showBackupTime && displayBackupDate && (
 				<HStack alignment="left" spacing={ 1 }>
 					<Text
 						color="var(--studio-gray-40)"

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -10,6 +10,7 @@ import UpsellSwitch from 'calypso/components/jetpack/upsell-switch';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { setFilter } from 'calypso/state/activity-log/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import BackupContentsPage from './backup-contents-page';
@@ -155,10 +156,9 @@ export function backupRestore( context, next ) {
 export function backupGranularRestore( context, next ) {
 	debug( 'controller: backupGranularRestore', context.params );
 	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
 
 	context.primary = (
-		<FileBrowserProvider siteId={ siteId } rewindId={ Number( context.params.rewindId ) }>
+		<FileBrowserProvider locale={ getCurrentUserLocale( state ) || 'en' }>
 			<BackupRewindFlow
 				rewindId={ context.params.rewindId }
 				purpose={ RewindFlowPurpose.GRANULAR_RESTORE }
@@ -185,7 +185,7 @@ export function backupContents( context, next ) {
 	const siteId = getSelectedSiteId( state );
 
 	context.primary = (
-		<FileBrowserProvider siteId={ siteId } rewindId={ Number( context.params.rewindId ) }>
+		<FileBrowserProvider locale={ getCurrentUserLocale( state ) || 'en' }>
 			<BackupContentsPage siteId={ siteId } rewindId={ context.params.rewindId } />
 		</FileBrowserProvider>
 	);

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -30,6 +30,7 @@ import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import SiteEnvironmentBadge, {
 	EnvironmentType,
 } from 'calypso/dashboard/components/site-environment-badge';
+import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import FileBrowser from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 import {
 	FileBrowserProvider,
@@ -214,6 +215,7 @@ function SyncModal( {
 		targetEnvironment === 'production' ? productionSiteTitle : stagingSiteTitle;
 
 	const querySiteId = sourceEnvironment === 'staging' ? stagingSiteId : productionSiteId;
+	const getDisplayDate = useGetDisplayDate( querySiteId );
 
 	const browserCheckList = fileBrowserState.getCheckList();
 
@@ -263,6 +265,10 @@ function SyncModal( {
 			successOnly: true,
 		} );
 	const rewindId = lastKnownBackupAttempt?.rewindId;
+
+	const displayBackupDate = lastKnownBackupAttempt
+		? getDisplayDate( lastKnownBackupAttempt.activityTs, false )
+		: null;
 
 	const shouldDisableGranularSync = ! lastKnownBackupAttempt && ! isLoadingBackupAttempt;
 
@@ -494,6 +500,7 @@ function SyncModal( {
 									siteId={ querySiteId }
 									siteSlug={ querySiteSlug }
 									fileBrowserConfig={ fileBrowserConfig }
+									displayBackupDate={ displayBackupDate }
 								/>
 							</div>
 							<HStack

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -1,4 +1,5 @@
 import { pushToStagingMutation, pullFromStagingMutation } from '@automattic/api-queries';
+import { useLocale } from '@automattic/i18n-utils';
 import { useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -25,12 +26,12 @@ import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import clsx from 'clsx';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import SiteEnvironmentBadge, {
 	EnvironmentType,
 } from 'calypso/dashboard/components/site-environment-badge';
-import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import FileBrowser from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 import {
 	FileBrowserProvider,
@@ -614,8 +615,10 @@ function SyncModal( {
 
 // Wrapper component to provide FileBrowser context
 export default function SyncModalWrapper( props: SyncModalProps ) {
+	const locale = useLocale();
+
 	return (
-		<FileBrowserProvider>
+		<FileBrowserProvider locale={ locale }>
 			<SyncModal { ...props } />
 		</FileBrowserProvider>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14400

## Proposed Changes

* Replace moment.js with native `Intl.DateTimeFormat` for date formatting in FileBrowser components
* Add locale support
* Remove `useLocalizedMoment` dependency from `file-info-card.tsx` component
* Update backup controller to pass locale from `getCurrentUserLocale` Redux selector
* Update staging sync modal to pass locale from `@automattic/i18n-utils`
* Move backup date display responsibility from FileBrowser to staging sync modal
  * Add `displayBackupDate` prop to FileBrowser for explicit backup time display
* Prepare FileBrowser for future Hosting Dashboard integration with flexible locale handling

### Locale Context Architecture

| **Component Type** | **Locale Source** | **Usage Pattern** |
|---|---|---|
| Router Controllers | `getCurrentUserLocale(state) \|\| 'en'` | Redux state with fallback |
| React Components | `useLocale()` from `@automattic/i18n-utils` | Hook in component |
| Context Provider | Explicit `locale` prop (required) | No defaults, must be passed |
| Hosting Dashboard | `useLocale()` from `client/dashboard/app/locale` | HD-specific hook |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

FileBrowser needs to work in the Hosting Dashboard environment, which doesn't work with Redux. This is another attempt to remove all Calypso-specific dependencies and make external requirements explicit through context and/or props, enabling Dashboard integration while maintaining backward compatibility for existing consumers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Pick a site with Jetpack VaultPress Backup
* Click on `View files` on any full backup to navigate to the file browser
* Try navigating through the file browser:
  * Open directories
  * Click on files, try to download, preview them
  * Ensure the date on the file details still looks good
* Ensure the file browser continues to work as expected either on Jetpack Cloud and Staging Site Sync implementation.
  * On staging site sync implementation, ensure the date of the latest backup is still working as expected:
    <img width="1332" height="1174" alt="CleanShot 2025-09-12 at 07 47 48@2x" src="https://github.com/user-attachments/assets/04c418a4-8845-430b-b69f-e6c218979fd4" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
