### PR TITLE
WIP: Add new Breadcrumbs component for the Hosting Dashboard

### DIFF
--- a/client/dashboard/components/breadcrumbs/index.tsx
+++ b/client/dashboard/components/breadcrumbs/index.tsx
@@ -1,0 +1,51 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import RouterLinkButton from '../router-link-button';
+import type { BreadcrumbsProps } from './types';
+import './style.scss';
+
+export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
+	if ( items.length === 0 ) {
+		return null;
+	}
+
+	// Single item - render as back button with chevron
+	if ( items.length === 1 ) {
+		const item = items[ 0 ];
+
+		return (
+			<RouterLinkButton
+				className="dashboard-breadcrumbs__button"
+				icon={ isRTL() ? chevronRight : chevronLeft }
+				to={ item.to }
+				params={ item.params }
+			>
+				{ item.label }
+			</RouterLinkButton>
+		);
+	}
+
+	// Multiple items - render as breadcrumb trail
+	return (
+		<HStack spacing={ 0 } className="dashboard-breadcrumbs" alignment="center" justify="flex-start">
+			{ items.map( ( item, index ) => {
+				return (
+					<span key={ index }>
+						<RouterLinkButton
+							className="dashboard-breadcrumbs__button"
+							to={ item.to }
+							params={ item.params }
+						>
+							{ item.label }
+						</RouterLinkButton>
+
+						<span className="dashboard-breadcrumbs__separator">/</span>
+					</span>
+				);
+			} ) }
+		</HStack>
+	);
+};
+
+export default Breadcrumbs;

--- a/client/dashboard/components/breadcrumbs/style.scss
+++ b/client/dashboard/components/breadcrumbs/style.scss
@@ -1,0 +1,13 @@
+@import '@wordpress/base-styles/colors';
+
+.dashboard-breadcrumbs {
+	&__button, &__button.components-button.has-icon.has-text {
+		padding-inline: 0;
+		color: $gray-700;
+	}
+
+	&__separator {
+		margin: 0 10px;
+		color: $gray-300;
+	}
+}

--- a/client/dashboard/components/breadcrumbs/types.ts
+++ b/client/dashboard/components/breadcrumbs/types.ts
@@ -1,0 +1,9 @@
+export interface BreadcrumbItem {
+	label: string;
+	to: string;
+	params: Record< string, string >;
+}
+
+export interface BreadcrumbsProps {
+	items: BreadcrumbItem[];
+}

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -4,7 +4,8 @@ import { useNavigate } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { domainRoute } from '../../app/router/domains';
+import { domainRoute, domainOverviewRoute, domainDnsRoute } from '../../app/router/domains';
+import { Breadcrumbs } from '../../components/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DNSRecordForm from './form';
@@ -49,7 +50,30 @@ export default function DomainAddDNS() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Add a new DNS record' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={
+						<Breadcrumbs
+							items={ [
+								{
+									label: __( 'Overview' ),
+									to: domainOverviewRoute.fullPath,
+									params: { domainName },
+								},
+								{
+									label: __( 'DNS records' ),
+									to: domainDnsRoute.fullPath,
+									params: { domainName },
+								},
+							] }
+						/>
+					}
+					title={ __( 'Add a new DNS record' ) }
+				/>
+			}
+		>
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -14,7 +14,8 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
+import { domainDnsAddRoute, domainRoute, domainOverviewRoute } from '../../app/router/domains';
+import { Breadcrumbs } from '../../components/breadcrumbs';
 import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -285,6 +286,17 @@ export default function DomainDns() {
 				<VStack>
 					<PageHeader
 						title={ __( 'DNS records' ) }
+						prefix={
+							<Breadcrumbs
+								items={ [
+									{
+										label: __( 'Overview' ),
+										to: domainOverviewRoute.fullPath,
+										params: { domainName },
+									},
+								] }
+							/>
+						}
 						actions={
 							<>
 								<ImportBindFileButton

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -11,7 +11,8 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useCallback } from 'react';
 import { useAuth } from '../../app/auth';
-import { domainRoute } from '../../app/router/domains';
+import { domainRoute, domainOverviewRoute } from '../../app/router/domains';
+import { Breadcrumbs } from '../../components/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getDomainSiteSlug } from '../../utils/domain';
@@ -53,7 +54,25 @@ export default function NameServers() {
 	);
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Name servers' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={
+						<Breadcrumbs
+							items={ [
+								{
+									label: __( 'Overview' ),
+									to: domainOverviewRoute.fullPath,
+									params: { domainName },
+								},
+							] }
+						/>
+					}
+					title={ __( 'Name servers' ) }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<NameServersForm


### PR DESCRIPTION
This is more of a WIP for now but I want to clarify if this is how the breadcrumbs/back buttons should work before replacing all the instances everywhere.

So for example - if from the Domain Name Overview screen you click on "DNS records" and you'll get this in the header:

<img width="719" height="282" alt="Screenshot 2025-09-12 at 18 28 19" src="https://github.com/user-attachments/assets/5a73ea3f-5469-42a7-b07d-fd5f4e83a78b" />

but then if you click on Add DNS record you'll see this:

<img width="689" height="270" alt="Screenshot 2025-09-12 at 18 28 26" src="https://github.com/user-attachments/assets/222c8301-4986-4800-85da-d474a9f16d66" />

@ollierozdarz Is this how you imagine things to look and work? I think you can test how it feels in the calypso.live link



Part of #

## Proposed Changes

* Add new Breadcrumbs component that would 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
