### PR TITLE
Help Center: fix escalation by url not working

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -84,8 +84,10 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 							</>
 						),
 						action: async () => {
+							const params = new URLSearchParams( search );
+							params.set( 'id', supportInteraction.uuid );
 							trackEvent( 'chat_open_previous_conversation' );
-							navigate( '/odie?id=' + supportInteraction.uuid );
+							navigate( '/odie?' + params.toString() );
 						},
 					} );
 				}
@@ -94,8 +96,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					buttons.push( {
 						text: __( 'Get support', __i18n_text_domain__ ),
 						action: async () => {
+							const params = new URLSearchParams( search );
 							onClickAdditionalEvent?.( 'chat-ai' );
-							navigate( '/odie' );
+							navigate( '/odie?' + params.toString() );
 						},
 					} );
 				} else if ( canConnectToZendesk || contextCanConnectToZendesk ) {

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -29,8 +29,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const createZendeskConversation = useCreateZendeskConversation();
 	const { resetSupportInteraction } = useResetSupportInteraction();
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const isForwardingToZendesk =
-		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
+
+	const [ isForwardingToZendesk, setIsForwardingToZendesk ] = useState(
+		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk'
+	);
 	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
 	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
 	const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
@@ -67,6 +69,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	useEffect( () => {
 		if ( isForwardingToZendesk && ! isUserEligibleForPaidSupport ) {
 			searchParams.delete( 'provider' );
+			setIsForwardingToZendesk( false );
 			setChatMessagesLoaded( true );
 		}
 	}, [ isForwardingToZendesk, isUserEligibleForPaidSupport, setChatMessagesLoaded, searchParams ] );
@@ -90,6 +93,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 			isChatLoaded &&
 			! forceEmailSupport
 		) {
+			setIsForwardingToZendesk( false );
 			searchParams.delete( 'provider' );
 			searchParams.set( 'direct-zd-chat', '1' );
 			setSearchParams( searchParams );

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -29,10 +29,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const createZendeskConversation = useCreateZendeskConversation();
 	const { resetSupportInteraction } = useResetSupportInteraction();
 	const [ searchParams, setSearchParams ] = useSearchParams();
-
-	const [ isForwardingToZendesk, setIsForwardingToZendesk ] = useState(
-		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk'
-	);
+	const isForwardingToZendesk =
+		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
 	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
 	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
 	const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
@@ -69,7 +67,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	useEffect( () => {
 		if ( isForwardingToZendesk && ! isUserEligibleForPaidSupport ) {
 			searchParams.delete( 'provider' );
-			setIsForwardingToZendesk( false );
 			setChatMessagesLoaded( true );
 		}
 	}, [ isForwardingToZendesk, isUserEligibleForPaidSupport, setChatMessagesLoaded, searchParams ] );
@@ -93,7 +90,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 			isChatLoaded &&
 			! forceEmailSupport
 		) {
-			setIsForwardingToZendesk( false );
 			searchParams.delete( 'provider' );
 			searchParams.set( 'direct-zd-chat', '1' );
 			setSearchParams( searchParams );

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -31,13 +31,16 @@ export const OdieAssistant: React.FC = () => {
 				event_source: 'help-center',
 				event_external_id: newID,
 			} ).then( ( interaction ) => {
-				navigate( `/odie?id=${ interaction.uuid }`, { replace: true } );
+				const params = new URLSearchParams( search );
+				params.set( 'id', interaction.uuid );
+				navigate( `/odie?${ params.toString() }`, { replace: true } );
 			} );
 		}
 	}, [
 		interactionId,
 		startNewInteraction,
 		navigate,
+		search,
 		queryClient,
 		currentInteractionQuery,
 		isStartingNewInteraction,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14554/fix-escalation-by-url-not-working

## Proposed Changes

When Odie detects that the user has landed at /odie without an interaction ID, it creates an interaction and redirects the user there. But this redirect has a bug; it drops the preexisting query params besides the interaction ID. So the `provider` parameter (`provider=zendesk`), which was added when we wanted to directly escalate to Happiness Engineers, was being erased before creating during this redirect. This PR makes sure all query params are maintained across redirects.

## Why are these changes being made?
To fix the direct escalation link.

## Testing Instructions

* Go to `/sites?help-center=happiness-engineer`
* You should see a live chat.
