### PR TITLE
Reader comments: Hide comment button in full post view engagement bar when comments disabled

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -11,6 +11,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getPostIcon } from 'calypso/reader/get-helpers';
 import FollowingEmptyContent from 'calypso/reader/stream/empty';
+import { isCommentsApiDisabled } from 'calypso/state/comments/selectors/get-comments-api-disabled';
 import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
@@ -109,6 +110,15 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 		},
 		[ posts ]
 	);
+
+	// Get comments API disabled status for the selected post
+	const commentsApiDisabled = useSelector( ( state: AppState ) => {
+		if ( ! selectedItem ) {
+			return false;
+		}
+		const post = getPostFromItem( selectedItem );
+		return post?.site_ID ? isCommentsApiDisabled( state, post.site_ID ) : false;
+	} );
 
 	const fields = useMemo(
 		() => [
@@ -294,7 +304,11 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 							setSelectedItem={ setSelectedItem }
 							layout="recent"
 						/>
-						<EngagementBar feedId={ selectedItem?.feedId } postId={ selectedItem?.postId } />
+						<EngagementBar
+							feedId={ selectedItem?.feedId }
+							postId={ selectedItem?.postId }
+							commentsApiDisabled={ commentsApiDisabled }
+						/>
 					</>
 				) }
 			</section>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CML-545/cannot-comment-on-jeremy-herves-blog-from-jetpack-mobile-reader-ios

## Proposed Changes

* Follow-up to https://github.com/Automattic/wp-calypso/pull/104377
* Removes the comment button in the full post view engagement bar when comments are disabled.

Before | After
---- | ----
<img width="883" height="175" alt="Screenshot 2025-09-12 at 3 14 51 PM" src="https://github.com/user-attachments/assets/1acd2f68-3372-49e5-acdd-f349fd4dc3d1" /> | <img width="1054" height="149" alt="Screenshot 2025-09-12 at 3 30 48 PM" src="https://github.com/user-attachments/assets/1d8cae39-b895-44c2-8b54-135aa4e3c331" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Follow-up fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Reader on Calypso live or localhost.
* Change to the "full post" view using the icons next to the Recent header.
* Check Jeremy's feed: http://calypso.localhost:3000/reader/recent/166150816 There should be no comment button visible in the engagement bar.
* Smoke test other feeds where you can currently comment and check that you still see the comment button in the engagement bar.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
