### PR TITLE
Domain Search Rewrite: Add E2E tests to /setup/domain

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -10,6 +10,7 @@ export * from './site-select-component';
 export * from './cookie-banner-component';
 export * from './editor-settings-sidebar-component';
 export * from './domain-search-component';
+export * from './rewritten-domain-search-component';
 export * from './isolated-block-editor-component';
 export * from './block-widget-editor-component';
 export * from './notice-component';
@@ -35,6 +36,7 @@ export * from './full-side-editor-nav-sidebar-component';
 export * from './full-side-editor-data-views-component';
 export * from './editor-dimensions-component';
 export * from './jetpack-instant-search-modal-component';
+export * from './select-items-component';
 export * from './wp-admin-notice-component';
 export * from './wp-admin-sidebar-component';
 

--- a/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
@@ -80,9 +80,7 @@ export class RewrittenDomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectDomain( keyword: string ): Promise< string > {
-		const targetRow = this.page.locator( '[data-e2e-domain-suggestion]' ).filter( {
-			has: this.page.getByLabel( keyword ),
-		} );
+		const targetRow = this.page.getByTitle( keyword );
 		await targetRow.waitFor();
 
 		const target = targetRow.getByRole( 'button' );
@@ -90,7 +88,7 @@ export class RewrittenDomainSearchComponent {
 
 		await target.click();
 
-		const domainName = await targetRow.getAttribute( 'data-e2e-domain-suggestion' );
+		const domainName = await targetRow.getAttribute( 'title' );
 
 		if ( ! domainName ) {
 			throw new Error( `No domain found for keyword: ${ keyword }` );
@@ -105,14 +103,14 @@ export class RewrittenDomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectFirstSuggestion(): Promise< string > {
-		const targetItem = this.page.locator( '[data-e2e-domain-suggestion]' ).first();
-		const selectedDomain = await targetItem.getAttribute( 'data-e2e-domain-suggestion' );
+		const targetItem = this.page.getByRole( 'listitem' ).first();
+		await targetItem.waitFor();
+
+		const selectedDomain = await targetItem.getAttribute( 'title' );
 
 		if ( ! selectedDomain ) {
 			throw new Error( 'No domain found for first suggestion' );
 		}
-
-		await targetItem.waitFor();
 
 		const target = targetItem.getByRole( 'button', { name: 'Add to cart' } );
 		await target.waitFor();

--- a/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
@@ -1,0 +1,129 @@
+import { Page } from 'playwright';
+import { reloadAndRetry, waitForElementEnabled } from '../../element-helper';
+
+/**
+ * Component for the domain search feature.
+ *
+ * This class applies to multiple locations within WordPress.com that displays a domain search component.
+ * Examples:
+ * 	- Upgrades > Domains
+ * 	- Signup flow
+ */
+export class RewrittenDomainSearchComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Searches for a domain using the keyword.
+	 *
+	 * @param {string} keyword Keyword to use in domain search.
+	 */
+	async search( keyword: string ): Promise< void > {
+		/**
+		 *
+		 * Closure to pass into the retry method.
+		 *
+		 * @param {Page} page Page object.
+		 */
+		async function searchDomainClosure( page: Page ): Promise< void > {
+			const searchAndPressEnter = async () => {
+				await page.getByRole( 'searchbox' ).fill( keyword );
+				await page.getByRole( 'searchbox' ).press( 'Enter' );
+			};
+
+			const [ response ] = await Promise.all( [
+				page.waitForResponse( /suggestions\?/ ),
+				searchAndPressEnter(),
+			] );
+
+			if ( ! response ) {
+				const errorText = await page.getByRole( 'status', { name: 'Notice' } ).innerText();
+				throw new Error(
+					`Encountered error while searching for domain.\nOriginal error: ${ errorText }`
+				);
+			}
+		}
+
+		// Domain lookup service is external to Automattic and sometimes it returns an error.
+		// Retry a few times when this is encountered.
+		await reloadAndRetry( this.page, searchDomainClosure );
+	}
+
+	/**
+	 * Select a domain matching the keyword.
+	 *
+	 * The keyword can be anything that uniquely identifies the desired domain name
+	 * in the search results listing.
+	 *
+	 * Examples:
+	 * 	keyword = uniquewordpresscomsite.com
+	 * 	keyword = .com
+	 *
+	 * If multiple matches are found, the first match is attmpted.
+	 *
+	 * @param {string} keyword Unique keyword to select domains.
+	 * @returns {string} Domain that was selected.
+	 */
+	async selectDomain( keyword: string ): Promise< string > {
+		const targetRow = this.page.locator( '[data-e2e-domain-suggestion]' ).filter( {
+			has: this.page.getByLabel( keyword ),
+		} );
+		await targetRow.waitFor();
+
+		const target = targetRow.getByRole( 'button' );
+		await target.waitFor();
+
+		await target.click();
+
+		const domainName = await targetRow.getAttribute( 'data-e2e-domain-suggestion' );
+
+		if ( ! domainName ) {
+			throw new Error( `No domain found for keyword: ${ keyword }` );
+		}
+
+		return domainName;
+	}
+
+	/**
+	 * Select the first domain suggestion.
+	 *
+	 * @returns {string} Domain that was selected.
+	 */
+	async selectFirstSuggestion(): Promise< string > {
+		const targetItem = this.page.locator( '[data-e2e-domain-suggestion]' ).first();
+		const selectedDomain = await targetItem.getAttribute( 'data-e2e-domain-suggestion' );
+
+		if ( ! selectedDomain ) {
+			throw new Error( 'No domain found for first suggestion' );
+		}
+
+		await targetItem.waitFor();
+
+		const target = targetItem.getByRole( 'button', { name: 'Add to cart' } );
+		await target.waitFor();
+
+		await target.click();
+
+		return selectedDomain;
+	}
+
+	/**
+	 * Clicks the "Continue" button.
+	 */
+	async continue(): Promise< void > {
+		const continueButton = await waitForElementEnabled( this.page, 'button:text("Continue")', {
+			timeout: 30 * 1000,
+		} );
+
+		// Now click the enabled button using dispatchEvent to handle issues with the environment badge staying on top of the button.
+		await Promise.all( [ continueButton.dispatchEvent( 'click' ), this.page.waitForNavigation() ] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
@@ -58,6 +58,13 @@ export class RewrittenDomainSearchComponent {
 	}
 
 	/**
+	 * Clicks on the button to bring over an external domain to WordPress.com
+	 */
+	async clickBringItOver(): Promise< void > {
+		await this.page.getByRole( 'button', { name: 'Bring it over' } ).click();
+	}
+
+	/**
 	 * Select a domain matching the keyword.
 	 *
 	 * The keyword can be anything that uniquely identifies the desired domain name

--- a/packages/calypso-e2e/src/lib/components/select-items-component.ts
+++ b/packages/calypso-e2e/src/lib/components/select-items-component.ts
@@ -1,0 +1,29 @@
+import { Page } from 'playwright';
+
+/**
+ * Component representing the Select Items component.
+ */
+export class SelectItemsComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Clicks on a button matching the text.
+	 *
+	 * @param {string} title Title of the item.
+	 * @param {string} actionText Action text of the item.
+	 */
+	async clickButton( title: string, actionText: string ): Promise< void > {
+		await this.page
+			.getByRole( 'button', { name: `${ title }. ${ actionText }`, exact: true } )
+			.click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/site-select-component.ts
+++ b/packages/calypso-e2e/src/lib/components/site-select-component.ts
@@ -43,8 +43,8 @@ export class SiteSelectComponent {
 	 * @param {string} url URL of the desired site. Must not include the protocol (https).
 	 * @returns {Promise<void>} No return value.
 	 */
-	async selectSite( url: string ): Promise< void > {
-		await this.page.fill( selectors.searchInput, url );
+	async selectSite( url: string, navigatesHome = true ): Promise< void > {
+		await this.page.fill( selectors.searchInput, url, { timeout: 60 * 1000 } );
 		// For some accounts with many sites, the search process takes a looooong time.
 		await this.page.waitForSelector( '.is-loading', { state: 'hidden', timeout: 60 * 1000 } );
 
@@ -53,7 +53,9 @@ export class SiteSelectComponent {
 			this.page.click( `${ selectors.siteList } :text("${ url }")`, { timeout: 60 * 1000 } ),
 		] );
 
-		// Assert the resulting URL is in the form of <protocol><calypsoBaseURL>/home/<url>.
-		await this.page.waitForURL( `**/home/${ url }` );
+		if ( navigatesHome ) {
+			// Assert the resulting URL is in the form of <protocol><calypsoBaseURL>/home/<url>.
+			await this.page.waitForURL( `**/home/${ url }` );
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -113,9 +113,19 @@ export class CartCheckoutPage {
 	 * Validates that an item is in the cart with the expected text. Throws if it isn't.
 	 *
 	 * @param {string} expectedCartItemName Expected text for the name of the item in the cart.
+	 * @param {string} expectedDescription Expected text for the description of the item in the cart.
 	 * @throws If the expected cart item is not found in the timeout period.
 	 */
-	async validateCartItem( expectedCartItemName: string ): Promise< void > {
+	async validateCartItem(
+		expectedCartItemName: string,
+		expectedDescription?: string
+	): Promise< void > {
+		if ( expectedDescription ) {
+			return this.page
+				.locator( selectors.cartItem( expectedCartItemName ), { hasText: expectedDescription } )
+				.waitFor( { state: 'visible' } );
+		}
+
 		await this.page.waitForSelector( selectors.cartItem( expectedCartItemName ) );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -12,7 +12,7 @@ const selectors = {
 
 	// Cart item
 	cartItem: ( itemName: string ) =>
-		`[data-testid="review-order-step--visible"] .checkout-line-item >> text=${ itemName.trim() }`,
+		`[data-testid="review-order-step--visible"] .checkout-line-item:has-text("${ itemName.trim() }")`,
 	removeCartItemButton: ( itemName: string ) =>
 		`[data-testid="review-order-step--visible"] button[aria-label*="Remove ${ itemName.trim() } from cart"]`,
 	cartItems: '[data-testid="review-order-step--visible"] .checkout-line-item',

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -6,7 +6,7 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
  * The plans page URL regex.
  */
 export const plansPageUrl =
-	/.*setup\/onboarding\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
+	/.*setup\/onboarding\/plans|setup\/domain\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
-	nextButton: 'button:text("Next")',
+	continueButton: 'button:text("Continue")',
 	connectDomainButton: '.option-content:has-text("Connect your domain") button:text("Select")',
 	transferDomainButton: '.option-content:has-text("Transfer your domain") button:text("Select")',
 };
@@ -36,7 +36,7 @@ export class UseADomainIOwnPage {
 	 * Clicks on the button to continue
 	 */
 	async clickContinue(): Promise< void > {
-		await this.page.click( selectors.nextButton );
+		await this.page.click( selectors.continueButton );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -4,6 +4,7 @@ const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
 	nextButton: 'button:text("Next")',
 	connectDomainButton: '.option-content:has-text("Connect your domain") button:text("Select")',
+	transferDomainButton: '.option-content:has-text("Transfer your domain") button:text("Select")',
 };
 
 /**
@@ -51,5 +52,20 @@ export class UseADomainIOwnPage {
 	 */
 	async clickButtonToConnectDomain(): Promise< void > {
 		await this.page.click( selectors.connectDomainButton );
+	}
+
+	/**
+	 * Validates that the button to transfer your selected domain is present and enabled
+	 */
+	async validateButtonToTransferDomain(): Promise< void > {
+		const elementHandle = await this.page.waitForSelector( selectors.transferDomainButton );
+		await elementHandle.waitForElementState( 'enabled' );
+	}
+
+	/**
+	 * Clicks on the button to transfer your selected domain
+	 */
+	async clickButtonToTransferDomain(): Promise< void > {
+		await this.page.click( selectors.transferDomainButton );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -28,6 +28,13 @@ export class UseADomainIOwnPage {
 	 */
 	async search( domainName: string ): Promise< void > {
 		await this.page.fill( selectors.ownedDomainInput, domainName );
+		await this.clickContinue();
+	}
+
+	/**
+	 * Clicks on the button to continue
+	 */
+	async clickContinue(): Promise< void > {
 		await this.page.click( selectors.nextButton );
 	}
 
@@ -37,5 +44,12 @@ export class UseADomainIOwnPage {
 	async validateButtonToConnectDomain(): Promise< void > {
 		const elementHandle = await this.page.waitForSelector( selectors.connectDomainButton );
 		await elementHandle.waitForElementState( 'enabled' );
+	}
+
+	/**
+	 * Clicks on the button to connect/map your selected domain
+	 */
+	async clickButtonToConnectDomain(): Promise< void > {
+		await this.page.click( selectors.connectDomainButton );
 	}
 }

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -934,6 +934,41 @@ export class RestAPIClient {
 		return response;
 	}
 
+	/**
+	 * Clears the shopping cart.
+	 *
+	 * @param {string} siteId Site that has the shopping cart.
+	 * @throws {Error} If the user doesn't have access to the siteId.
+	 * @returns {{success:true}} If the request was successful.
+	 */
+	async clearMyShoppingCart( siteId: number | 'no-site' ): Promise< { success: true } > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( {
+				blog_id: siteId === 'no-site' ? 0 : siteId,
+				products: [],
+				temporary: false,
+			} ),
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', `/me/shopping-cart/${ siteId }` ),
+			params
+		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
 	/* Plugins */
 
 	/**

--- a/packages/domain-search/src/ui/domain-suggestion/featured.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.placeholder.tsx
@@ -1,4 +1,5 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { __ } from '@wordpress/i18n';
 import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
 import { FeaturedSkeleton } from './featured.skeleton';
 
@@ -7,10 +8,13 @@ export const FeaturedPlaceholder = () => {
 
 	return (
 		<FeaturedSkeleton
+			role="status"
+			aria-busy="true"
+			aria-label={ __( 'Loading domain suggestion' ) }
 			ref={ containerRef }
 			activeQuery={ activeQuery }
 			badges={ <LoadingPlaceholder width="6.3125rem" height="1.5rem" /> }
-			title={ <LoadingPlaceholder width="11.625rem" height="2.5rem" /> }
+			domainName={ <LoadingPlaceholder width="11.625rem" height="2.5rem" /> }
 			matchReasonsList={ <LoadingPlaceholder width="11.625rem" height="1.25rem" /> }
 			price={ null }
 			cta={

--- a/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
@@ -5,20 +5,19 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import clsx from 'clsx';
-import { forwardRef } from 'react';
+import { type ComponentProps, forwardRef } from 'react';
 
 import './featured.scss';
 
-interface SkeletonProps {
+interface SkeletonProps extends Omit< ComponentProps< typeof Card >, 'children' > {
 	activeQuery: 'small' | 'large';
 	className?: string;
 	badges?: React.ReactNode;
-	title: React.ReactNode;
+	domainName: React.ReactNode;
 	matchReasonsList?: React.ReactNode;
 	price: React.ReactNode;
 	cta: React.ReactNode;
 	isSingleFeaturedSuggestion?: boolean;
-	domainName?: string;
 }
 
 export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( props, ref ) => {
@@ -26,12 +25,12 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 		activeQuery,
 		className,
 		badges,
-		title,
+		domainName,
 		matchReasonsList,
 		price,
 		cta,
 		isSingleFeaturedSuggestion,
-		domainName,
+		...cardProps
 	} = props;
 
 	const getContent = () => {
@@ -46,7 +45,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 								alignment="left"
 								style={ { alignSelf: 'stretch', justifyContent: 'flex-start' } }
 							>
-								{ title }
+								{ domainName }
 								{ matchReasonsList }
 							</VStack>
 						</VStack>
@@ -67,7 +66,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 					<HStack spacing={ 6 } className="domain-suggestion-featured__content">
 						<VStack spacing={ 3 } style={ { justifyContent: 'center', height: '100%' } }>
 							{ badges }
-							{ title }
+							{ domainName }
 						</VStack>
 						<VStack
 							spacing={ 5 }
@@ -85,7 +84,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 				<VStack spacing={ 3 } className="domain-suggestion-featured__content">
 					<VStack spacing={ 3 } alignment="left">
 						{ badges }
-						{ title }
+						{ domainName }
 					</VStack>
 					<HStack>
 						{ price }
@@ -99,7 +98,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 			<VStack spacing={ 4 } className="domain-suggestion-featured__content--small">
 				<VStack spacing={ 3 }>
 					{ badges }
-					{ title }
+					{ domainName }
 					{ price }
 					{ matchReasonsList }
 				</VStack>
@@ -110,9 +109,9 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 
 	return (
 		<Card
+			{ ...cardProps }
 			ref={ ref }
 			className={ clsx( 'domain-suggestion-featured', className ) }
-			data-e2e-domain-suggestion={ domainName }
 		>
 			<CardBody
 				className="domain-suggestion-featured__body"

--- a/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
@@ -18,6 +18,7 @@ interface SkeletonProps {
 	price: React.ReactNode;
 	cta: React.ReactNode;
 	isSingleFeaturedSuggestion?: boolean;
+	domainName?: string;
 }
 
 export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( props, ref ) => {
@@ -30,6 +31,7 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 		price,
 		cta,
 		isSingleFeaturedSuggestion,
+		domainName,
 	} = props;
 
 	const getContent = () => {
@@ -107,7 +109,11 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 	};
 
 	return (
-		<Card ref={ ref } className={ clsx( 'domain-suggestion-featured', className ) }>
+		<Card
+			ref={ ref }
+			className={ clsx( 'domain-suggestion-featured', className ) }
+			data-e2e-domain-suggestion={ domainName }
+		>
 			<CardBody
 				className="domain-suggestion-featured__body"
 				style={ { padding: activeQuery === 'large' ? '1.5rem' : '1rem' } }

--- a/packages/domain-search/src/ui/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.tsx
@@ -71,6 +71,7 @@ const Featured = ( {
 		<DomainSuggestionContainerContext.Provider value={ contextValue }>
 			<FeaturedSkeleton
 				ref={ containerRef }
+				domainName={ `${ domain }.${ tld }` }
 				activeQuery={ activeQuery }
 				className={ clsx( 'domain-suggestion-featured', {
 					'domain-suggestion-featured--highlighted': isHighlighted,

--- a/packages/domain-search/src/ui/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.tsx
@@ -52,7 +52,7 @@ const Featured = ( {
 		[ activeQuery, matchReasons, isSingleFeaturedSuggestion, currentWidth ]
 	);
 
-	const title = (
+	const domainName = (
 		<Text size={ activeQuery === 'large' ? 32 : 24 } style={ { wordBreak: 'break-all' } }>
 			{ domain }
 			<span style={ { whiteSpace: 'nowrap' } }>.{ tld }</span>
@@ -70,14 +70,15 @@ const Featured = ( {
 	return (
 		<DomainSuggestionContainerContext.Provider value={ contextValue }>
 			<FeaturedSkeleton
+				role="listitem"
+				title={ `${ domain }.${ tld }` }
 				ref={ containerRef }
-				domainName={ `${ domain }.${ tld }` }
 				activeQuery={ activeQuery }
 				className={ clsx( 'domain-suggestion-featured', {
 					'domain-suggestion-featured--highlighted': isHighlighted,
 				} ) }
 				badges={ badgesElement }
-				title={ title }
+				domainName={ domainName }
 				matchReasonsList={ matchReasonsList }
 				price={ price }
 				cta={ cta }

--- a/packages/domain-search/src/ui/domain-suggestion/index.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.placeholder.tsx
@@ -1,8 +1,12 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { __ } from '@wordpress/i18n';
 import { SuggestionSkeleton } from './index.skeleton';
 
 export const SuggestionPlaceholder = () => (
 	<SuggestionSkeleton
+		role="status"
+		aria-busy="true"
+		aria-label={ __( 'Loading domain suggestion' ) }
 		domainName={ <LoadingPlaceholder width="11.625rem" height="1.5rem" /> }
 		price={ <LoadingPlaceholder width="6.5rem" height="1rem" /> }
 		cta={ <LoadingPlaceholder width="2.5rem" height="2.5rem" /> }

--- a/packages/domain-search/src/ui/domain-suggestion/index.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.skeleton.tsx
@@ -7,10 +7,12 @@ import {
 import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
 
 export const SuggestionSkeleton = ( {
+	originalDomainName,
 	domainName,
 	price,
 	cta,
 }: {
+	originalDomainName?: string;
 	domainName: React.ReactNode;
 	price: React.ReactNode;
 	cta: React.ReactNode;
@@ -49,7 +51,11 @@ export const SuggestionSkeleton = ( {
 	};
 
 	return (
-		<Card isBorderless size={ activeQuery === 'large' ? 'medium' : 'small' }>
+		<Card
+			isBorderless
+			size={ activeQuery === 'large' ? 'medium' : 'small' }
+			data-e2e-domain-suggestion={ originalDomainName }
+		>
 			<CardBody style={ { borderRadius: 0 } }>{ getContent() }</CardBody>
 		</Card>
 	);

--- a/packages/domain-search/src/ui/domain-suggestion/index.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.skeleton.tsx
@@ -5,18 +5,20 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';
+import type { ComponentProps } from 'react';
 
-export const SuggestionSkeleton = ( {
-	originalDomainName,
-	domainName,
-	price,
-	cta,
-}: {
-	originalDomainName?: string;
+interface SuggestionSkeletonProps extends Omit< ComponentProps< typeof Card >, 'children' > {
 	domainName: React.ReactNode;
 	price: React.ReactNode;
 	cta: React.ReactNode;
-} ) => {
+}
+
+export const SuggestionSkeleton = ( {
+	domainName,
+	price,
+	cta,
+	...cardProps
+}: SuggestionSkeletonProps ) => {
 	const listContext = useDomainSuggestionContainerContext();
 
 	if ( ! listContext ) {
@@ -51,11 +53,7 @@ export const SuggestionSkeleton = ( {
 	};
 
 	return (
-		<Card
-			isBorderless
-			size={ activeQuery === 'large' ? 'medium' : 'small' }
-			data-e2e-domain-suggestion={ originalDomainName }
-		>
+		<Card { ...cardProps } isBorderless size={ activeQuery === 'large' ? 'medium' : 'small' }>
 			<CardBody style={ { borderRadius: 0 } }>{ getContent() }</CardBody>
 		</Card>
 	);

--- a/packages/domain-search/src/ui/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.tsx
@@ -68,7 +68,14 @@ const DomainSuggestionComponent = ( {
 			domainName
 		);
 
-	return <SuggestionSkeleton domainName={ domainNameElement } price={ price } cta={ cta } />;
+	return (
+		<SuggestionSkeleton
+			originalDomainName={ `${ domain }.${ tld }` }
+			domainName={ domainNameElement }
+			price={ price }
+			cta={ cta }
+		/>
+	);
 };
 
 export const DomainSuggestion = ( props: DomainSuggestionProps ) => {

--- a/packages/domain-search/src/ui/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.tsx
@@ -70,7 +70,8 @@ const DomainSuggestionComponent = ( {
 
 	return (
 		<SuggestionSkeleton
-			originalDomainName={ `${ domain }.${ tld }` }
+			role="listitem"
+			title={ `${ domain }.${ tld }` }
 			domainName={ domainNameElement }
 			price={ price }
 			cta={ cta }

--- a/packages/domain-search/src/ui/domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/ui/domain-suggestions-list/index.tsx
@@ -39,7 +39,7 @@ export const DomainSuggestionsList = ( { children }: DomainSuggestionsListProps 
 	}, [ children ] );
 
 	return (
-		<Card ref={ containerRef }>
+		<Card ref={ containerRef } role="list">
 			<DomainSuggestionContainerContext.Provider value={ contextValue }>
 				{ childrenWithSeparators }
 			</DomainSuggestionContainerContext.Provider>

--- a/packages/domain-search/src/ui/featured-domain-suggestions-list/index.tsx
+++ b/packages/domain-search/src/ui/featured-domain-suggestions-list/index.tsx
@@ -19,7 +19,7 @@ export const FeaturedDomainSuggestionsList = ( {
 	const Element = activeQuery === 'large' ? HStack : VStack;
 
 	return (
-		<Element ref={ ref } spacing={ 4 }>
+		<Element ref={ ref } spacing={ 4 } role="list">
 			{ children }
 		</Element>
 	);

--- a/packages/onboarding/src/select-items/index.tsx
+++ b/packages/onboarding/src/select-items/index.tsx
@@ -68,11 +68,12 @@ function SelectItems< T >( { className, items, onSelect, preventWidows }: Props<
 							</div>
 							{ actionText && (
 								<Button
+									label={ `${ title }. ${ actionText }` }
 									variant="secondary"
 									className="select-items__item-button"
 									onClick={ () => onSelect( value ) }
-									aria-hidden="true"
-									tabIndex={ -1 }
+									aria-hidden={ allItemClickable ? 'true' : 'false' }
+									tabIndex={ allItemClickable ? -1 : 0 }
 								>
 									{ actionText }
 								</Button>

--- a/packages/onboarding/src/select-items/style.scss
+++ b/packages/onboarding/src/select-items/style.scss
@@ -65,7 +65,6 @@
 		font-weight: 400;
 		line-height: 1.2;
 		color: #101517;
-		cursor: pointer;
 	}
 
 	&-description {

--- a/packages/onboarding/src/select-items/style.scss
+++ b/packages/onboarding/src/select-items/style.scss
@@ -65,6 +65,7 @@
 		font-weight: 400;
 		line-height: 1.2;
 		color: #101517;
+		cursor: pointer;
 	}
 
 	&-description {

--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -20,8 +20,7 @@ import { apiDeleteSite } from '../shared/api-delete-site';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site' ), function () {
-	// TODO: Use a domain that we own. Which one though?
-	const targetDomain = 'zaguini.me';
+	const targetDomain = 'a8ctesting.com';
 
 	const planName = 'Personal';
 	let page: Page;

--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -20,7 +20,7 @@ import { apiDeleteSite } from '../shared/api-delete-site';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site' ), function () {
-	const targetDomain = 'a8ctesting.com';
+	const targetDomain = 'testwoo.com';
 
 	const planName = 'Personal';
 	let page: Page;
@@ -58,11 +58,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 		const useADomainIOwnPage = new UseADomainIOwnPage( page );
 		await useADomainIOwnPage.clickContinue();
 		await useADomainIOwnPage.clickButtonToConnectDomain();
-	} );
-
-	it( 'Continue to next step', async function () {
-		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-		await domainSearchComponent.continue();
 	} );
 
 	it( 'Select new site option', async function () {

--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -1,0 +1,100 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	SelectItemsComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	NewSiteResponse,
+	SignupPickPlanPage,
+	UseADomainIOwnPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiDeleteSite } from '../shared/api-delete-site';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site' ), function () {
+	const planName = 'Personal';
+	let page: Page;
+	// TODO: Use a domain that we own. Which one though?
+	const targetDomain = 'zaguini.me';
+	const testAccount = new TestAccount( 'defaultUser' );
+	let newSiteDetails: NewSiteResponse;
+	let restAPIClient: RestAPIClient;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+		await testAccount.authenticate( page );
+
+		restAPIClient = new RestAPIClient( testAccount.credentials );
+		await restAPIClient.clearMyShoppingCart( 'no-site' );
+	} );
+
+	it( 'Enter the flow', async function () {
+		const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+
+		await page.goto( flowUrl );
+	} );
+
+	it( 'Search for a domain', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.search( targetDomain );
+	} );
+
+	it( 'Click the bring it over button', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.clickBringItOver();
+	} );
+
+	it( 'Click the connect button', async function () {
+		const useADomainIOwnPage = new UseADomainIOwnPage( page );
+		await useADomainIOwnPage.clickContinue();
+		await useADomainIOwnPage.clickButtonToConnectDomain();
+	} );
+
+	it( 'Continue to next step', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.continue();
+	} );
+
+	it( 'Select new site option', async function () {
+		const domainSearchComponent = new SelectItemsComponent( page );
+		await domainSearchComponent.clickButton( 'New site', 'Create a new site' );
+	} );
+
+	it( `Select ${ planName } plan`, async function () {
+		const plansPage = new SignupPickPlanPage( page );
+
+		[ newSiteDetails ] = await Promise.all( [
+			plansPage.selectPlan( planName ),
+			page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
+		] );
+	} );
+
+	it( 'See plan and domain connection product at checkout', async function () {
+		const cartCheckoutPage = new CartCheckoutPage( page );
+
+		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+		await cartCheckoutPage.validateCartItem( targetDomain, 'Domain Connection' );
+	} );
+
+	afterAll( async function () {
+		if ( ! newSiteDetails ) {
+			return;
+		}
+
+		await apiDeleteSite( restAPIClient, {
+			url: newSiteDetails.blog_details.url,
+			id: newSiteDetails.blog_details.blogid,
+			name: newSiteDetails.blog_details.blogname,
+		} );
+	} );
+} );

--- a/test/e2e/specs/flows/setup-domain__domain-only.ts
+++ b/test/e2e/specs/flows/setup-domain__domain-only.ts
@@ -1,0 +1,64 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	SelectItemsComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Domain flow: Purchase only a domain' ), function () {
+	let page: Page;
+	let selectedDomain: string;
+	const testAccount = new TestAccount( 'defaultUser' );
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+		await testAccount.authenticate( page );
+
+		const restAPIClient = new RestAPIClient( testAccount.credentials );
+		await restAPIClient.clearMyShoppingCart( 'no-site' );
+	} );
+
+	it( 'Enter the flow', async function () {
+		const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+
+		await page.goto( flowUrl );
+	} );
+
+	it( 'Search for a domain', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.search( 'example' );
+	} );
+
+	it( 'Add the first suggestion to the cart', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+	} );
+
+	it( 'Continue to next step', async function () {
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.continue();
+	} );
+
+	it( 'Select domain only option', async function () {
+		const domainSearchComponent = new SelectItemsComponent( page );
+		await domainSearchComponent.clickButton( 'Just buy a domain', 'Continue' );
+	} );
+
+	it( 'See domain at checkout', async function () {
+		const cartCheckoutPage = new CartCheckoutPage( page );
+
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+} );

--- a/test/e2e/specs/flows/setup-domain__existing-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-free-site.ts
@@ -24,7 +24,7 @@ describe(
 		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'simpleSiteFreePlanUser';
+		const testAccountName = 'siteEditorSimpleSiteUser';
 		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
 		const testAccount = new TestAccount( testAccountName );
 		let restAPIClient: RestAPIClient;
@@ -66,8 +66,11 @@ describe(
 		} );
 
 		it( 'Select the site', async function () {
-			const domainSearchComponent = new SiteSelectComponent( page );
-			await domainSearchComponent.selectSite( testAccountUser.testSites?.primary?.url as string );
+			const siteSelectComponent = new SiteSelectComponent( page );
+			await siteSelectComponent.selectSite(
+				testAccountUser.testSites?.primary?.url as string,
+				false
+			);
 		} );
 
 		it( `Select ${ planName } plan`, async function () {
@@ -84,9 +87,6 @@ describe(
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
 			await cartCheckoutPage.validateCartItem( selectedDomain );
-
-			await cartCheckoutPage.removeCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.removeCartItem( selectedDomain );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__existing-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-free-site.ts
@@ -1,0 +1,92 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	SelectItemsComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	SignupPickPlanPage,
+	SiteSelectComponent,
+	SecretsManager,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for an existing free site' ),
+	function () {
+		const planName = 'Personal';
+		let page: Page;
+		let selectedDomain: string;
+		const testAccountName = 'simpleSiteFreePlanUser';
+		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
+		const testAccount = new TestAccount( testAccountName );
+		let restAPIClient: RestAPIClient;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+			await testAccount.authenticate( page );
+
+			restAPIClient = new RestAPIClient( testAccount.credentials );
+			await restAPIClient.clearMyShoppingCart( 'no-site' );
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Search for a domain', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( 'example' );
+		} );
+
+		it( 'Add the first suggestion to the cart', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		} );
+
+		it( 'Continue to next step', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.continue();
+		} );
+
+		it( 'Select existing site option', async function () {
+			const domainSearchComponent = new SelectItemsComponent( page );
+			await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
+		} );
+
+		it( 'Select the site', async function () {
+			const domainSearchComponent = new SiteSelectComponent( page );
+			await domainSearchComponent.selectSite( testAccountUser.testSites?.primary?.url as string );
+		} );
+
+		it( `Select ${ planName } plan`, async function () {
+			const plansPage = new SignupPickPlanPage( page );
+
+			await Promise.all( [
+				plansPage.selectPlan( planName ),
+				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
+			] );
+		} );
+
+		it( 'See plan and domain at checkout', async function () {
+			const cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+
+			await cartCheckoutPage.removeCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.removeCartItem( selectedDomain );
+		} );
+	}
+);

--- a/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
@@ -1,0 +1,78 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	SelectItemsComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	SiteSelectComponent,
+	SecretsManager,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for an existing paid site' ),
+	function () {
+		let page: Page;
+		let selectedDomain: string;
+		const testAccountName = 'atomicUser';
+		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
+		const testAccount = new TestAccount( testAccountName );
+		let restAPIClient: RestAPIClient;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+			await testAccount.authenticate( page );
+
+			restAPIClient = new RestAPIClient( testAccount.credentials );
+			await restAPIClient.clearMyShoppingCart( 'no-site' );
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Search for a domain', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( 'example' );
+		} );
+
+		it( 'Add the first suggestion to the cart', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		} );
+
+		it( 'Continue to next step', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.continue();
+		} );
+
+		it( 'Select existing site option', async function () {
+			const domainSearchComponent = new SelectItemsComponent( page );
+			await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
+		} );
+
+		it( 'Select the site', async function () {
+			const domainSearchComponent = new SiteSelectComponent( page );
+			await domainSearchComponent.selectSite( testAccountUser.testSites?.primary?.url as string );
+		} );
+
+		it( 'See domain at checkout', async function () {
+			const cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await cartCheckoutPage.removeCartItem( selectedDomain );
+		} );
+	}
+);

--- a/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
@@ -64,15 +64,17 @@ describe(
 		} );
 
 		it( 'Select the site', async function () {
-			const domainSearchComponent = new SiteSelectComponent( page );
-			await domainSearchComponent.selectSite( testAccountUser.testSites?.primary?.url as string );
+			const siteSelectComponent = new SiteSelectComponent( page );
+			await siteSelectComponent.selectSite(
+				testAccountUser.testSites?.primary?.url as string,
+				false
+			);
 		} );
 
 		it( 'See domain at checkout', async function () {
 			const cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( selectedDomain );
-			await cartCheckoutPage.removeCartItem( selectedDomain );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__new-site.ts
+++ b/test/e2e/specs/flows/setup-domain__new-site.ts
@@ -1,0 +1,95 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	SelectItemsComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	NewSiteResponse,
+	SignupPickPlanPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiDeleteSite } from '../shared/api-delete-site';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for a new site' ),
+	function () {
+		const planName = 'Personal';
+		let page: Page;
+		let selectedDomain: string;
+		const testAccount = new TestAccount( 'defaultUser' );
+		let newSiteDetails: NewSiteResponse;
+		let restAPIClient: RestAPIClient;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+			await testAccount.authenticate( page );
+
+			restAPIClient = new RestAPIClient( testAccount.credentials );
+			await restAPIClient.clearMyShoppingCart( 'no-site' );
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Search for a domain', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( 'example' );
+		} );
+
+		it( 'Add the first suggestion to the cart', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		} );
+
+		it( 'Continue to next step', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.continue();
+		} );
+
+		it( 'Select new site option', async function () {
+			const domainSearchComponent = new SelectItemsComponent( page );
+			await domainSearchComponent.clickButton( 'New site', 'Create a new site' );
+		} );
+
+		it( `Select ${ planName } plan`, async function () {
+			const plansPage = new SignupPickPlanPage( page );
+
+			[ newSiteDetails ] = await Promise.all( [
+				plansPage.selectPlan( planName ),
+				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
+			] );
+		} );
+
+		it( 'See plan and domain at checkout', async function () {
+			const cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+		} );
+
+		afterAll( async function () {
+			if ( ! newSiteDetails ) {
+				return;
+			}
+
+			await apiDeleteSite( restAPIClient, {
+				url: newSiteDetails.blog_details.url,
+				id: newSiteDetails.blog_details.blogid,
+				name: newSiteDetails.blog_details.blogname,
+			} );
+		} );
+	}
+);

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -1,0 +1,82 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	SignupPickPlanPage,
+	SecretsManager,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for a pre-selected free site' ),
+	function () {
+		const planName = 'Personal';
+		let page: Page;
+		let selectedDomain: string;
+		const testAccountName = 'simpleSiteFreePlanUser';
+		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
+		const testAccount = new TestAccount( testAccountName );
+		let restAPIClient: RestAPIClient;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+			await testAccount.authenticate( page );
+
+			restAPIClient = new RestAPIClient( testAccount.credentials );
+			await restAPIClient.clearMyShoppingCart( testAccountUser.testSites?.primary?.id as number );
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL(
+				`/setup/domain?siteSlug=${ testAccountUser.testSites?.primary?.url as string }`
+			);
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Search for a domain', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( 'example' );
+		} );
+
+		it( 'Add the first suggestion to the cart', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		} );
+
+		it( 'Continue to next step', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.continue();
+		} );
+
+		it( `Select ${ planName } plan`, async function () {
+			const plansPage = new SignupPickPlanPage( page );
+
+			await Promise.all( [
+				plansPage.selectPlan( planName ),
+				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
+			] );
+		} );
+
+		it( 'See plan and domain at checkout', async function () {
+			const cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+
+			await cartCheckoutPage.removeCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.removeCartItem( selectedDomain );
+		} );
+	}
+);

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -22,7 +22,7 @@ describe(
 		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'simpleSiteFreePlanUser';
+		const testAccountName = 'siteEditorSimpleSiteUser';
 		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
 		const testAccount = new TestAccount( testAccountName );
 		let restAPIClient: RestAPIClient;
@@ -74,9 +74,6 @@ describe(
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
 			await cartCheckoutPage.validateCartItem( selectedDomain );
-
-			await cartCheckoutPage.removeCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.removeCartItem( selectedDomain );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
@@ -62,7 +62,6 @@ describe(
 			const cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( selectedDomain );
-			await cartCheckoutPage.removeCartItem( selectedDomain );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
@@ -1,0 +1,68 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	BrowserManager,
+	RewrittenDomainSearchComponent,
+	CartCheckoutPage,
+	RestAPIClient,
+	TestAccount,
+	SecretsManager,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for a pre-selected paid site' ),
+	function () {
+		let page: Page;
+		let selectedDomain: string;
+		const testAccountName = 'atomicUser';
+		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
+		const testAccount = new TestAccount( testAccountName );
+		let restAPIClient: RestAPIClient;
+
+		beforeAll( async () => {
+			page = await browser.newPage();
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+
+			await testAccount.authenticate( page );
+
+			restAPIClient = new RestAPIClient( testAccount.credentials );
+			await restAPIClient.clearMyShoppingCart( testAccountUser.testSites?.primary?.id as number );
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL(
+				`/setup/domain?siteSlug=${ testAccountUser.testSites?.primary?.url as string }`
+			);
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Search for a domain', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( 'example' );
+		} );
+
+		it( 'Add the first suggestion to the cart', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		} );
+
+		it( 'Continue to next step', async function () {
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.continue();
+		} );
+
+		it( 'See domain at checkout', async function () {
+			const cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await cartCheckoutPage.removeCartItem( selectedDomain );
+		} );
+	}
+);

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -60,11 +60,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 		await useADomainIOwnPage.clickButtonToTransferDomain();
 	} );
 
-	it( 'Continue to next step', async function () {
-		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-		await domainSearchComponent.continue();
-	} );
-
 	it( 'Select new site option', async function () {
 		const domainSearchComponent = new SelectItemsComponent( page );
 		await domainSearchComponent.clickButton( 'New site', 'Create a new site' );

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -19,7 +19,7 @@ import { apiDeleteSite } from '../shared/api-delete-site';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site' ), function () {
+describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site' ), function () {
 	// TODO: Use a domain that we own. Which one though?
 	const targetDomain = 'zaguini.me';
 
@@ -55,10 +55,10 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 		await domainSearchComponent.clickBringItOver();
 	} );
 
-	it( 'Click the connect button', async function () {
+	it( 'Click the transfer button', async function () {
 		const useADomainIOwnPage = new UseADomainIOwnPage( page );
 		await useADomainIOwnPage.clickContinue();
-		await useADomainIOwnPage.clickButtonToConnectDomain();
+		await useADomainIOwnPage.clickButtonToTransferDomain();
 	} );
 
 	it( 'Continue to next step', async function () {
@@ -80,11 +80,11 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 		] );
 	} );
 
-	it( 'See plan and domain connection product at checkout', async function () {
+	it( 'See plan and domain transfer product at checkout', async function () {
 		const cartCheckoutPage = new CartCheckoutPage( page );
 
 		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-		await cartCheckoutPage.validateCartItem( targetDomain, 'Domain Connection' );
+		await cartCheckoutPage.validateCartItem( targetDomain, 'Domain Transfer' );
 	} );
 
 	afterAll( async function () {

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -20,8 +20,7 @@ import { apiDeleteSite } from '../shared/api-delete-site';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site' ), function () {
-	// TODO: Use a domain that we own. Which one though?
-	const targetDomain = 'zaguini.me';
+	const targetDomain = 'a8ctesting.com';
 
 	const planName = 'Personal';
 	let page: Page;


### PR DESCRIPTION
Closes DOMAINS-1645.

## Proposed Changes

Adds tests to `/setup/domain` and its variations:

- domain-only
- new site
- existing free site
- existing paid site
- pre-selected (i.e., `siteSlug` in query param) free site
- pre-selected (i.e., `siteSlug` in query param) paid site
- connect domain
- transfer domain

## Testing Instructions

Verify the [Pre-release E2E tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/15697352) are 🟢 
