### PR TITLE
Validate the Survicate user object and add a unit test

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -1,4 +1,4 @@
-import { getCurrentUser } from '@automattic/calypso-analytics';
+import { getCurrentUser, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import debug from 'debug';
@@ -6,6 +6,36 @@ import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 const survicateDebug = debug( 'calypso:analytics:survicate' );
 
 let survicateScriptLoaded = false;
+
+/**
+ * Sets Survicate visitor traits with current user data
+ */
+const setSurvicateVisitorTraits = () => {
+	const user = getCurrentUser();
+
+	if ( ! user || ! user.email ) {
+		survicateDebug( 'Not setting Survicate visitor traits because user is not logged in' );
+
+		// Log error to backend for monitoring
+		recordTracksEvent( 'calypso_survicate_user_not_available_error', {
+			user_exists: !! user,
+			user_has_email: !! ( user && user.email ),
+		} );
+
+		return;
+	}
+
+	// eslint-disable-next-line no-undef
+	if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {
+		// eslint-disable-next-line no-undef
+		_sva.setVisitorTraits( {
+			email: user.email,
+		} );
+		survicateDebug( 'Survicate visitor traits set with email: ' + user.email );
+	} else {
+		survicateDebug( 'Survicate _sva object not available' );
+	}
+};
 
 export function mayWeLoadSurvicateScript() {
 	return config( 'survicate_enabled' );
@@ -38,26 +68,7 @@ export function addSurvicate() {
 		// Wait for the script to load before setting visitor traits
 		s.onload = function () {
 			survicateDebug( 'Survicate script loaded' );
-
-			const user = getCurrentUser();
-
-			if ( ! user || ! user.email ) {
-				survicateDebug( 'Not setting Survicate visitor traits because user is not logged in' );
-				return;
-			}
-
-			setTimeout( () => {
-				// eslint-disable-next-line no-undef
-				if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {
-					// eslint-disable-next-line no-undef
-					_sva.setVisitorTraits( {
-						email: user.email,
-					} );
-					survicateDebug( 'Survicate visitor traits set with email: ' + user.email );
-				} else {
-					survicateDebug( 'Survicate _sva object not available' );
-				}
-			}, 1000 );
+			setTimeout( setSurvicateVisitorTraits, 1000 );
 		};
 
 		s.onerror = function () {

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -41,6 +41,11 @@ export function addSurvicate() {
 
 			const user = getCurrentUser();
 
+			if ( ! user || ! user.email ) {
+				survicateDebug( 'Not setting Survicate visitor traits because user is not logged in' );
+				return;
+			}
+
 			setTimeout( () => {
 				// eslint-disable-next-line no-undef
 				if ( typeof _sva !== 'undefined' && _sva.setVisitorTraits ) {

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -5,6 +5,7 @@
 // Mock dependencies before importing the module
 jest.mock( '@automattic/calypso-analytics', () => ( {
 	getCurrentUser: jest.fn(),
+	recordTracksEvent: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => jest.fn() );
@@ -19,7 +20,7 @@ jest.mock( 'calypso/lib/i18n-utils', () => ( {
 
 jest.mock( 'debug', () => () => jest.fn() );
 
-import { getCurrentUser } from '@automattic/calypso-analytics';
+import { getCurrentUser, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
@@ -191,6 +192,7 @@ describe( 'survicate', () => {
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
 				email: 'test@example.com',
 			} );
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not set visitor traits when user is not logged in', () => {
@@ -206,6 +208,27 @@ describe( 'survicate', () => {
 			mockScript.onload();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should log error when user is not logged in', () => {
+			getCurrentUser.mockReturnValue( null );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_survicate_user_not_available_error',
+				{
+					user_exists: false,
+					user_has_email: false,
+				}
+			);
 		} );
 
 		test( 'should not set visitor traits when user has no email', () => {
@@ -224,6 +247,30 @@ describe( 'survicate', () => {
 			mockScript.onload();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should log error when user has no email', () => {
+			const mockUser = {
+				id: 123,
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_survicate_user_not_available_error',
+				{
+					user_exists: true,
+					user_has_email: false,
+				}
+			);
 		} );
 
 		test( 'should handle case when _sva object is not available', () => {

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -1,0 +1,298 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Mock dependencies before importing the module
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getCurrentUser: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => jest.fn() );
+
+jest.mock( '@automattic/viewport', () => ( {
+	isMobile: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/i18n-utils', () => ( {
+	getLocaleSlug: jest.fn(),
+} ) );
+
+jest.mock( 'debug', () => () => jest.fn() );
+
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { isMobile } from '@automattic/viewport';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+
+describe( 'survicate', () => {
+	let mockScript;
+	let mockScriptElement;
+	let originalCreateElement;
+	let originalGetElementsByTagName;
+	let mayWeLoadSurvicateScript;
+	let addSurvicate;
+
+	beforeAll( () => {
+		// Set up DOM mocks
+		originalCreateElement = document.createElement;
+		originalGetElementsByTagName = document.getElementsByTagName;
+	} );
+
+	beforeEach( () => {
+		// Reset all mocks
+		jest.clearAllMocks();
+
+		// Set up fresh module imports
+		jest.isolateModules( () => {
+			const survicateModule = require( 'calypso/lib/analytics/survicate' );
+			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
+			addSurvicate = survicateModule.addSurvicate;
+		} );
+
+		// Mock DOM methods
+		mockScript = {
+			src: '',
+			async: false,
+			onload: null,
+			onerror: null,
+		};
+
+		mockScriptElement = {
+			parentNode: {
+				insertBefore: jest.fn(),
+			},
+		};
+
+		document.createElement = jest.fn( ( tagName ) => {
+			if ( tagName === 'script' ) {
+				return mockScript;
+			}
+			return originalCreateElement.call( document, tagName );
+		} );
+
+		document.getElementsByTagName = jest.fn( ( tagName ) => {
+			if ( tagName === 'script' ) {
+				return [ mockScriptElement ];
+			}
+			return originalGetElementsByTagName.call( document, tagName );
+		} );
+
+		// Reset global survicate object
+		global._sva = undefined;
+
+		// Mock setTimeout to be synchronous for testing
+		jest.spyOn( global, 'setTimeout' ).mockImplementation( ( fn ) => fn() );
+	} );
+
+	afterEach( () => {
+		// Restore setTimeout
+		jest.restoreAllMocks();
+	} );
+
+	afterAll( () => {
+		// Restore original DOM methods
+		document.createElement = originalCreateElement;
+		document.getElementsByTagName = originalGetElementsByTagName;
+	} );
+
+	describe( 'mayWeLoadSurvicateScript', () => {
+		test( 'should return true when survicate is enabled in config', () => {
+			config.mockReturnValue( true );
+
+			expect( mayWeLoadSurvicateScript() ).toBe( true );
+			expect( config ).toHaveBeenCalledWith( 'survicate_enabled' );
+		} );
+
+		test( 'should return false when survicate is disabled in config', () => {
+			config.mockReturnValue( false );
+
+			expect( mayWeLoadSurvicateScript() ).toBe( false );
+			expect( config ).toHaveBeenCalledWith( 'survicate_enabled' );
+		} );
+	} );
+
+	describe( 'addSurvicate', () => {
+		beforeEach( () => {
+			// Set default mocks for successful loading
+			getLocaleSlug.mockReturnValue( 'en' );
+			isMobile.mockReturnValue( false );
+			config.mockReturnValue( true );
+		} );
+
+		test( 'should not load script for non-English languages', () => {
+			getLocaleSlug.mockReturnValue( 'fr' );
+
+			addSurvicate();
+
+			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should not load script for non-English languages starting with different prefix', () => {
+			getLocaleSlug.mockReturnValue( 'es-ES' );
+
+			addSurvicate();
+
+			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should load script for English language variants', () => {
+			getLocaleSlug.mockReturnValue( 'en-US' );
+
+			addSurvicate();
+
+			expect( document.createElement ).toHaveBeenCalledWith( 'script' );
+		} );
+
+		test( 'should not load script on mobile devices', () => {
+			isMobile.mockReturnValue( true );
+
+			addSurvicate();
+
+			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should not load script when survicate is disabled', () => {
+			config.mockReturnValue( false );
+
+			addSurvicate();
+
+			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should create script element with correct properties', () => {
+			addSurvicate();
+
+			expect( document.createElement ).toHaveBeenCalledWith( 'script' );
+			expect( mockScript.src ).toBe(
+				'https://survey.survicate.com/workspaces/e4794374cce15378101b63de24117572/web_surveys.js'
+			);
+			expect( mockScript.async ).toBe( true );
+			expect( mockScriptElement.parentNode.insertBefore ).toHaveBeenCalledWith(
+				mockScript,
+				mockScriptElement
+			);
+		} );
+
+		test( 'should set visitor traits when script loads successfully with logged-in user', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
+				email: 'test@example.com',
+			} );
+		} );
+
+		test( 'should not set visitor traits when user is not logged in', () => {
+			getCurrentUser.mockReturnValue( null );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should not set visitor traits when user has no email', () => {
+			const mockUser = {
+				id: 123,
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should handle case when _sva object is not available', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			// _sva is undefined
+			global._sva = undefined;
+
+			addSurvicate();
+
+			// Simulate script load - should not throw error
+			expect( () => mockScript.onload() ).not.toThrow();
+		} );
+
+		test( 'should handle case when _sva exists but setVisitorTraits is not available', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			global._sva = {}; // No setVisitorTraits method
+
+			addSurvicate();
+
+			// Simulate script load - should not throw error
+			expect( () => mockScript.onload() ).not.toThrow();
+		} );
+
+		test( 'should handle script load error', () => {
+			addSurvicate();
+
+			// Simulate script error - should not throw
+			expect( () => mockScript.onerror() ).not.toThrow();
+		} );
+
+		test( 'should use setTimeout for setting visitor traits', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			// Restore real setTimeout for this test
+			jest.restoreAllMocks();
+			jest.spyOn( global, 'setTimeout' );
+
+			addSurvicate();
+			mockScript.onload();
+
+			expect( setTimeout ).toHaveBeenCalledWith( expect.any( Function ), 1000 );
+		} );
+
+		test( 'should not load script twice when called multiple times', () => {
+			// First call should create script
+			addSurvicate();
+			expect( document.createElement ).toHaveBeenCalledTimes( 1 );
+
+			// Reset the mock to track subsequent calls
+			document.createElement.mockClear();
+
+			// Second call should not create another script
+			addSurvicate();
+			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Slack thread: p1757862761540939-slack-C04H4NY6STW
Follow-up of: https://github.com/Automattic/wp-calypso/pull/105641


## Proposed Changes

* We're validating user's object to ensure we only start Survate if the user and its email is defined

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid console errors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the code won't throw arrors anymore when the user is not defined
* Run the test and ensure it covers it: `yarn jest -c=test/client/jest.config.js  client/lib/analytics/test/survicate.js`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?