### PR TITLE
Removes the "new feature" badge from hosting dashboard opt-ins

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,12 +1,10 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
 	Card,
 	CardBody,
 	CheckboxControl,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -30,12 +28,7 @@ const form = {
 	fields: [
 		{
 			id: 'optInForm',
-			label: (
-				<HStack spacing={ 1 }>
-					<span>{ __( 'Try the new Hosting Dashboard' ) }</span>
-					<Badge intent="info">{ __( 'New feature' ) }</Badge>
-				</HStack>
-			),
+			label: __( 'Try the new Hosting Dashboard' ),
 			children: [ 'description', 'enabled' ],
 		},
 	],

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -1,6 +1,4 @@
 import { Card, FormLabel } from '@automattic/components';
-import { Badge } from '@automattic/ui';
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
@@ -77,14 +75,7 @@ export default function HostingDashboardOptInForm() {
 
 	return (
 		<>
-			<SectionHeader
-				label={
-					<HStack justify="flex-start">
-						<div>{ translate( 'Try the new Hosting Dashboard' ) }</div>
-						<Badge intent="info">{ translate( 'New feature' ) }</Badge>
-					</HStack>
-				}
-			/>
+			<SectionHeader label={ translate( 'Try the new Hosting Dashboard' ) } />
 			<Card className="account__settings">
 				<form onSubmit={ handleSubmit }>
 					<p className="account__hosting-dashboard-description">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

We're removing the "New feature" badge from the opt-in https://github.com/Automattic/wp-calypso/pull/105662#issuecomment-3286586066

**Before**

<img width="1360" height="460" alt="CleanShot 2025-09-15 at 11 29 16@2x" src="https://github.com/user-attachments/assets/3310a1b6-4e3d-4e5a-976e-552fcc0c091f" />

<img width="1376" height="524" alt="CleanShot 2025-09-15 at 11 29 46@2x" src="https://github.com/user-attachments/assets/86092340-b655-43cb-a1d3-3efa3ebcceb8" />


**After**

<img width="1422" height="554" alt="CleanShot 2025-09-15 at 11 27 00@2x" src="https://github.com/user-attachments/assets/388a1e1e-997c-473d-90dd-90b88a87674c" />

<img width="1386" height="602" alt="CleanShot 2025-09-15 at 11 26 45@2x" src="https://github.com/user-attachments/assets/24abfabd-9355-46e9-970c-a0a6671404c5" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't need to promote the feature so heavily

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/v2/me/preferences`
* `/me/account`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
