### PR TITLE
Hosting Navigation: Improve slow page navigation experience

### DIFF
--- a/client/dashboard/components/loading-line/index.tsx
+++ b/client/dashboard/components/loading-line/index.tsx
@@ -1,9 +1,15 @@
 import './style.scss';
 
-export function LoadingLine() {
+interface LoadingLineProps {
+	variant: 'progress' | 'spinner';
+	progressDuration: string;
+}
+
+export function LoadingLine( { variant, progressDuration }: LoadingLineProps ) {
+	const durationStyle = variant === 'progress' ? { animationDuration: progressDuration } : {};
 	return (
-		<div className="loading-line-wrapper">
-			<div className="loading-line-bar" />
+		<div className={ `loading-line-wrapper is-${ variant }` }>
+			<div className="loading-line-bar" style={ durationStyle } />
 		</div>
 	);
 }

--- a/client/dashboard/components/loading-line/style.scss
+++ b/client/dashboard/components/loading-line/style.scss
@@ -1,4 +1,4 @@
-@keyframes loading {
+@keyframes spinning {
 	from {
 		transform: translateX(-50vw);
 	}
@@ -7,20 +7,49 @@
 	}
 }
 
+@keyframes progress {
+	0% {
+		width: 0;
+	}
+	30% {
+		width: 70vw;
+	}
+	100% {
+		width: 95vw;
+	}
+}
+
 .loading-line-wrapper {
 	position: fixed;
 	top: 0;
 	inset-inline-start: 0;
 	width: 100%;
-	height: 2px;
 	background-color: transparent;
 	z-index: 1000;
+
+	&.is-spinner {
+		height: 2px;
+	}
+
+	&.is-progress {
+		height: 4px;
+	}
 }
 
 .loading-line-bar {
-	width: 50vw;
 	height: 100%;
 	position: absolute;
-	background: linear-gradient( to right, transparent 0%, var(--wp-admin-theme-color) 50%, transparent 100% );
-	animation: loading 2s infinite linear;
+
+	.is-spinner & {
+		width: 50vw;
+		background: linear-gradient( to right, transparent 0%, var(--wp-admin-theme-color) 50%, transparent 100% );
+		animation: spinning 2s infinite linear;
+	}
+
+	.is-progress & {
+		background: var(--wp-admin-theme-color);
+        animation-name: progress;
+        animation-timing-function: ease;
+        // animation-duration is set dynamically
+	}
 }

--- a/client/dashboard/components/loading-line/style.scss
+++ b/client/dashboard/components/loading-line/style.scss
@@ -48,8 +48,8 @@
 
 	.is-progress & {
 		background: var(--wp-admin-theme-color);
-        animation-name: progress;
-        animation-timing-function: ease;
-        // animation-duration is set dynamically
+		animation-name: progress;
+		animation-timing-function: ease;
+		// animation-duration is set dynamically
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This is a prototype for how we could improve the experience for slow page navigations.

When a page navigation takes less than 300ms we don't show any loading state. It should be fast enough to not feel _too_ janky.

After 300ms is passed we show a progress bar at the top of the page. YouTube, GitHub are examples that do this.

After 6000ms we show a full page loader. For now it's just the (w) logo, but it could be a spinner.

In this video the network has been throttled to Slow 4G/3G

https://github.com/user-attachments/assets/03dc62d8-4c9c-49a6-a988-69d18aedfdde


In this video the "very long" timer has been changed to 2s so you can see what it looks like.

https://github.com/user-attachments/assets/ca5c975c-cc0f-4f92-af7c-9918adf669e0



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The loading indicator is currently very subtle, which is fine for in-progress ajax requests. But it too subtle for very slow navigations. It makes the user wonder whether anything is happening.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

`/v2` and click around. See how it feels. The domains screens can take some time to load since they often have to make requests to 3rd party services. So they can be good views to test.

If you want a fresh cache you can try logging in with an incognito window.

You can throttle the network in the browser network tools.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
