### PR TITLE
Hosting Dashboard Retrofit: Ignore basePath if it's just a forward slash

### DIFF
--- a/client/dashboard/components/page-view-tracker/index.tsx
+++ b/client/dashboard/components/page-view-tracker/index.tsx
@@ -10,7 +10,8 @@ export function PageViewTracker() {
 	useEffect( () => {
 		return router.subscribe( 'onResolved', () => {
 			const leafMatch = router.state.matches.at( -1 );
-			const path = leafMatch?.context?.config?.basePath + leafMatch?.routeId;
+			const basePath = leafMatch?.context?.config?.basePath;
+			const path = ( basePath !== '/' ? basePath : '' ) + leafMatch?.routeId;
 
 			if ( path && ( ! lastPath.current || lastPath.current !== path ) ) {
 				recordPageView( path, document.title );


### PR DESCRIPTION
## Proposed Changes

The HD retrofit's basePath is "/". As a result, for page views Tracks event will record path `//sites` instead of `/sites`. This PR updates the logic to ignore prepending the basePath if it's "/".

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites
* Ensure that calypso_page_view has the path /sites instead of //sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
