### PR TITLE
"Still need help start a new chat" button does not work

### DIFF
--- a/packages/odie-client/src/components/closed-conversation-footer/index.tsx
+++ b/packages/odie-client/src/components/closed-conversation-footer/index.tsx
@@ -1,21 +1,17 @@
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
-import { useManageSupportInteraction } from '../../data';
 import './style.scss';
 
 export const ClosedConversationFooter = () => {
 	const { __ } = useI18n();
 	const { trackEvent } = useOdieAssistantContext();
-
-	const { startNewInteraction } = useManageSupportInteraction();
+	const navigate = useNavigate();
 
 	const handleOnClick = async () => {
 		trackEvent( 'chat_new_from_closed_conversation' );
-		await startNewInteraction( {
-			event_source: 'help-center',
-			event_external_id: crypto.randomUUID(),
-		} );
+		navigate( '/odie' );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14576/still-need-help-start-a-new-chat-button-does-not-work

## Proposed Changes

Fixed the button.

<img width="455" height="371" alt="image" src="https://github.com/user-attachments/assets/1f1d327f-584d-4f9c-af86-1fe8e1388ec3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

After a chat ends, the “Still need help? Start a new chat” button/link does not work 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Solve a conversation
* Click on the button
* A new chat should start
