### PR TITLE
Help Center: don't block sending a message after connection recovery

### DIFF
--- a/packages/odie-client/src/components/notices/use-connection-status-notice.tsx
+++ b/packages/odie-client/src/components/notices/use-connection-status-notice.tsx
@@ -23,6 +23,11 @@ export default function useConnectionStatusNotice( isLiveChat: boolean = false )
 		if ( connectionStatus === 'disconnected' ) {
 			setShouldWarn( true );
 		}
+
+		if ( connectionStatus === 'connected' ) {
+			const timeout = setTimeout( setShouldWarn, 2000, false );
+			return () => clearTimeout( timeout );
+		}
 	}, [ connectionStatus, isLiveChat ] );
 
 	if ( ! shouldWarn ) {

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -125,7 +125,7 @@ export const OdieSendMessageButton = () => {
 		[ sendMessageHandler, handleImagePaste ]
 	);
 
-	const isDisabled = !! notice || ( isLiveChat && connectionStatus !== 'connected' );
+	const isDisabled = !! messageSizeNotice || ( isLiveChat && connectionStatus !== 'connected' );
 	// When there is a reason to disable the input, we should not convey a processing state.
 	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
 

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -38,10 +38,6 @@ $blueberry-blue: #3858e9;
 	gap: 28px;
 	box-sizing: border-box;
 
-	&:has( .odie-notice ) {
-		margin-bottom: 135px;
-	}
-
 	.chatbox-loading-chat__spinner {
 		display: flex;
 		width: 100%;


### PR DESCRIPTION
Fixes DOTCOM-14570

## Proposed Changes

This fixes the `isDisabled` condition to not check the existence of the connection status notice, since the `isLiveChat && connectionStatus !== 'connected'` part of the check takes care of that. It also auto-dismisses the "Connected" notice after 2 seconds.

## Why are these changes being made?
Bug fix and better UX.

## Testing Instructions

1. Start a chat convo.
2. Simulate being offline.
3. You should get a notice.
4. Disable the simulation.
5. Connection should recover.
6. You should get a connected notice.
7. The notice should disappear automatically.
8. The button should be re-enabled even before the success notices disappears.
