### PR TITLE
Don't wrap user-sent links with CustomALink

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -84,11 +84,19 @@ export const UserMessage = ( {
 			<div className="odie-chatbox-message__content">
 				<MarkdownOrChildren
 					messageContent={ messageContent }
-					components={ {
-						a: ( props: React.ComponentProps< 'a' > ) => (
-							<CustomALink { ...props } target="_blank" />
-						),
-					} }
+					components={
+						message.role === 'user'
+							? {
+									a: ( props: React.ComponentProps< 'a' > ) => (
+										<a rel="noopener noreferrer" target="_blank" { ...props } />
+									),
+							  }
+							: {
+									a: ( props: React.ComponentProps< 'a' > ) => (
+										<CustomALink { ...props } target="_blank" />
+									),
+							  }
+					}
 				/>
 			</div>
 			{ isMessageWithEscalationOption && (


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14575/chat-sent-links-are-hard-to-read by not wrapping user-sent messages with Odie resources styling.