### PR TITLE
Domain Search Retrofit: Remove experiment code

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -8,7 +8,6 @@ import { useState, useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
-import { useIsDomainSearchV2Enabled } from 'calypso/lib/domains/use-domain-search-v2';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -31,12 +30,7 @@ import { recordStepNavigation } from '../../internals/analytics/record-step-navi
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
-import {
-	AssertConditionState,
-	type FlowV2,
-	type ProvidedDependencies,
-	type SubmitHandler,
-} from '../../internals/types';
+import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import type { DomainSuggestion } from '@automattic/api-core';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
@@ -307,13 +301,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 		};
 		return { submit };
-	},
-	useAssertConditions() {
-		const [ isLoading ] = useIsDomainSearchV2Enabled( this.name );
-
-		return {
-			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
-		};
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -63,7 +63,7 @@ export function DomainFormControl( {
 	isCartPendingUpdate,
 	isCartPendingUpdateDomain,
 }: DomainFormControlProps ) {
-	const [ , isDomainSearchV2Enabled ] = useIsDomainSearchV2Enabled( flow ?? '' );
+	const isDomainSearchV2Enabled = useIsDomainSearchV2Enabled();
 
 	const selectedSite = useSelector( getSelectedSite );
 	const productsList = useSelector( getAvailableProductsList );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -54,7 +54,7 @@ const DomainsStep: Step< {
 		  }
 		| undefined;
 } > = function DomainsStep( { navigation, flow } ) {
-	const [ , shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( flow );
+	const shouldUseDomainSearchV2 = useIsDomainSearchV2Enabled();
 	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );
 	const { __ } = useI18n();
 
@@ -369,12 +369,7 @@ const DomainsStep: Step< {
 };
 
 const StyleWrappedDomainsStep: typeof DomainsStep = ( props ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( props.flow );
-
-	if ( isLoading ) {
-		// TODO: Add a loading state to indicate that the experiment is loading.
-		return null;
-	}
+	const shouldUseDomainSearchV2 = useIsDomainSearchV2Enabled();
 
 	return (
 		<>

--- a/client/lib/domains/use-domain-search-v2.ts
+++ b/client/lib/domains/use-domain-search-v2.ts
@@ -1,36 +1,9 @@
 import config from '@automattic/calypso-config';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useExperiment } from 'calypso/lib/explat';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-const isDomainSearchV2Enabled = config.isEnabled( 'domains/ui-redesign' );
-
-const EXPERIMENT_NAME = 'calypso_signup_onboarding_domain_search_redesign_202508_v2';
 
 /**
  * This hook is used to determine if the domain search redesign is enabled for a given flow.
  * It should NOT be used within components, only at top level pages.
  */
-export const useIsDomainSearchV2Enabled = ( flowName: string ) => {
-	const isLoggedIn = useSelector( isUserLoggedIn );
-
-	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible: flowName === ONBOARDING_FLOW && isLoggedIn,
-	} );
-
-	if ( flowName === ONBOARDING_FLOW ) {
-		/**
-		 * If the user is not eligible, we'll treat them as if they were in the
-		 * holdout/control group so we can provide the existing experience.
-		 *
-		 * This fallback is necessary because experimentAssignment returns null when the user
-		 * is not eligible, and we're using this hook within steps that are used by other flows.
-		 */
-		const variationName = experimentAssignment?.variationName ?? 'control';
-
-		return [ isLoading, variationName === 'treatment' ];
-	}
-
-	return [ false, isDomainSearchV2Enabled ];
+export const useIsDomainSearchV2Enabled = () => {
+	return config.isEnabled( 'domains/ui-redesign' );
 };

--- a/client/my-sites/domains/domain-search/legacy.tsx
+++ b/client/my-sites/domains/domain-search/legacy.tsx
@@ -497,11 +497,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 }
 
 const StyleWrappedDomainSearch = ( props: DomainSearchProps ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( 'domains/add' );
-
-	if ( isLoading ) {
-		return null;
-	}
+	const shouldUseDomainSearchV2 = useIsDomainSearchV2Enabled();
 
 	return (
 		<>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -302,7 +302,7 @@ class RenderDomainsStepComponent extends Component {
 		}
 
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) && suggestion ) {
-			await this.handleDomainToDomainCart( previousState );
+			await this.handleDomainToDomainCart( previousState, suggestion );
 
 			// If we already have a free selection in place, let's enforce that as a free site suggestion
 			if ( this.state.wpcomSubdomainSelected ) {
@@ -425,9 +425,7 @@ class RenderDomainsStepComponent extends Component {
 		}
 	};
 
-	handleDomainToDomainCart = async ( previousState ) => {
-		const { suggestion } = this.props.step;
-
+	handleDomainToDomainCart = async ( previousState, suggestion ) => {
 		if ( previousState ) {
 			await this.removeDomain( suggestion );
 		} else {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1769,16 +1769,7 @@ class RenderDomainsStepComponent extends Component {
 }
 
 const StyleWrappedDomainsStepComponent = ( props ) => {
-	const [ isLoading, shouldUseDomainSearchV2 ] = useIsDomainSearchV2Enabled( props.flowName );
-
-	if ( isLoading ) {
-		if ( props.useStepperWrapper && shouldUseStepContainerV2( props.flowName ) ) {
-			return <Step.Loading />;
-		}
-
-		// TODO: Add a loading state to indicate that the experiment is loading.
-		return null;
-	}
+	const shouldUseDomainSearchV2 = useIsDomainSearchV2Enabled();
 
 	return (
 		<>

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/ui-redesign": false,
+		"domains/ui-redesign": true,
 		"domain-search-rewrite": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,

--- a/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/rewritten-domain-search-component.ts
@@ -144,4 +144,24 @@ export class RewrittenDomainSearchComponent {
 		// Now click the enabled button using dispatchEvent to handle issues with the environment badge staying on top of the button.
 		await Promise.all( [ continueButton.dispatchEvent( 'click' ), this.page.waitForNavigation() ] );
 	}
+
+	/**
+	 * Skips the domain search screen.
+	 */
+	async skipPurchase(): Promise< string > {
+		const button = this.page.getByRole( 'button', { name: 'Skip purchase' } );
+
+		await button.waitFor();
+
+		let domain = await button.getAttribute( 'aria-label' );
+		domain = domain?.replace( 'Skip purchase and continue with ', '' ) ?? null;
+
+		if ( ! domain ) {
+			throw new Error( 'No domain found for skip purchase button' );
+		}
+
+		await button.click();
+
+		return domain;
+	}
 }

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -70,6 +70,8 @@ const DomainSearchSkipSuggestion = ( {
 		return null;
 	}
 
+	const domain = existingSiteUrl ?? freeSuggestion;
+
 	return (
 		<DomainSearchSkipSuggestionSkeleton
 			title={
@@ -82,6 +84,8 @@ const DomainSearchSkipSuggestion = ( {
 				<Button
 					className="domain-search-skip-suggestion__btn"
 					variant="secondary"
+					// translators: %(domain)s is the domain name
+					label={ sprintf( __( 'Skip purchase and continue with %(domain)s' ), { domain } ) }
 					onClick={ onSkip }
 					disabled={ disabled }
 					isBusy={ isBusy }

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -13,7 +13,6 @@ import {
 	CartCheckoutPage,
 	StartSiteFlow,
 	SecretsManager,
-	SignupDomainPage,
 	MyHomePage,
 	ComingSoonPage,
 	NewSiteResponse,
@@ -23,6 +22,7 @@ import {
 	MeSidebarComponent,
 	NoticeComponent,
 	PurchasesPage,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -69,9 +69,9 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Skip domain selection', async function () {
-			const signupDomainPage = new SignupDomainPage( page );
-			await signupDomainPage.searchForFooDomains();
-			await signupDomainPage.skipDomainSelection();
+			const signupDomainPage = new RewrittenDomainSearchComponent( page );
+			await signupDomainPage.search( 'foo' );
+			await signupDomainPage.skipPurchase();
 		} );
 
 		it( `Select WordPress.com ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -5,7 +5,7 @@
 import {
 	DataHelper,
 	RestAPIClient,
-	DomainSearchComponent,
+	RewrittenDomainSearchComponent,
 	NewUserResponse,
 	UserSignupPage,
 	CartCheckoutPage,
@@ -26,7 +26,6 @@ describe(
 		let newUserDetails: NewUserResponse;
 		let plansPage: PlansPage;
 		let cartCheckoutPage: CartCheckoutPage;
-		let domainSearchComponent: DomainSearchComponent;
 		let page: Page;
 		let selectedDomain: string;
 
@@ -48,9 +47,10 @@ describe(
 		} );
 
 		it( 'Select a domain name', async function () {
-			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.blog' );
-			selectedDomain = await domainSearchComponent.selectDomain( '.blog' );
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( blogName );
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+			await domainSearchComponent.continue();
 		} );
 
 		it( `Pick the ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -5,10 +5,10 @@
 import {
 	DataHelper,
 	RestAPIClient,
-	DomainSearchComponent,
 	NewUserResponse,
 	UserSignupPage,
 	CartCheckoutPage,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -31,7 +31,6 @@ describe(
 
 		let newUserDetails: NewUserResponse;
 		let cartCheckoutPage: CartCheckoutPage;
-		let domainSearchComponent: DomainSearchComponent;
 		let page: Page;
 		let selectedDomain: string;
 
@@ -54,15 +53,15 @@ describe(
 		} );
 
 		it( 'Select a domain name', async function () {
-			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.blog' );
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+			await domainSearchComponent.search( blogName );
 
-			const promises = await Promise.all( [
-				domainSearchComponent.selectDomain( '.blog' ),
+			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+
+			await Promise.all( [
+				domainSearchComponent.continue(),
 				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
 			] );
-
-			selectedDomain = promises[ 0 ];
 		} );
 
 		it( 'See domain and plan at checkout', async function () {

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -6,13 +6,12 @@ import {
 	DataHelper,
 	StartSiteFlow,
 	RestAPIClient,
-	DomainSearchComponent,
-	envVariables,
 	SignupPickPlanPage,
 	NewUserResponse,
 	LoginPage,
 	UserSignupPage,
 	EditorPage,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount, fixme_retry } from '../shared';
@@ -51,12 +50,9 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		} );
 
 		it( 'Select a .wordpress.com domain name', async function () {
-			const domainSearchComponent = new DomainSearchComponent( page );
+			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
 			await domainSearchComponent.search( blogName );
-			selectedFreeDomain = await domainSearchComponent.selectDomain(
-				'.wordpress.com',
-				envVariables.VIEWPORT_NAME === 'mobile'
-			);
+			selectedFreeDomain = await domainSearchComponent.skipPurchase();
 		} );
 
 		it( 'Select WordPress.com Free plan', async function () {

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
@@ -8,8 +8,8 @@ import {
 	BrowserManager,
 	NewUserResponse,
 	RestAPIClient,
-	DomainSearchComponent,
 	EditorPage,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -59,17 +59,13 @@ describe( 'Signup: Tailored Start Writing Flow', () => {
 
 	it( 'Ensure domain search is working', async function () {
 		await page.getByRole( 'link', { name: 'Select to choose a domain' } ).click();
-		const domainSearchComponent = new DomainSearchComponent( page );
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
 		await domainSearchComponent.search( 'test' );
-		await page
-			.locator( '.domain-search-results' )
-			.getByRole( 'button', { name: 'Select' } )
-			.first()
-			.waitFor();
 	} );
 
 	it( 'Skip the domain selection step', async function () {
-		await page.getByText( 'Decide later' ).click();
+		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+		await domainSearchComponent.skipPurchase();
 	} );
 
 	it( 'Select WordPress.com Free plan', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -5,7 +5,6 @@
 import {
 	DataHelper,
 	BrowserManager,
-	DomainSearchComponent,
 	UserSignupPage,
 	SignupPickPlanPage,
 	CartCheckoutPage,
@@ -22,6 +21,7 @@ import {
 	LoggedOutThemesPage,
 	ThemesDetailPage,
 	cancelAtomicPurchaseFlow,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -86,10 +86,10 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 		} );
 
 		it( 'Skip domain selection', async function () {
-			const domainSearch = new DomainSearchComponent( page );
+			const domainSearch = new RewrittenDomainSearchComponent( page );
 
 			await domainSearch.search( testUser.siteName );
-			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com`, false );
+			await domainSearch.skipPurchase();
 		} );
 
 		it( `Select WordPress.com ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -5,7 +5,6 @@
 import {
 	DataHelper,
 	BrowserManager,
-	DomainSearchComponent,
 	UserSignupPage,
 	SignupPickPlanPage,
 	CartCheckoutPage,
@@ -20,6 +19,7 @@ import {
 	ThemesDetailPage,
 	ThemesPage,
 	cancelAtomicPurchaseFlow,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -80,10 +80,10 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 		} );
 
 		it( 'Skip domain selection', async function () {
-			const domainSearch = new DomainSearchComponent( page );
+			const domainSearch = new RewrittenDomainSearchComponent( page );
 
 			await domainSearch.search( testUser.siteName );
-			await domainSearch.selectDomain( `${ testUser.siteName }.wordpress.com`, false );
+			await domainSearch.skipPurchase();
 		} );
 
 		it( `Select WordPress.com ${ planName } plan`, async function () {

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -10,8 +10,8 @@ import {
 	RestAPIClient,
 	CartCheckoutPage,
 	TestAccount,
-	SignupDomainPage,
 	NewSiteResponse,
+	RewrittenDomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiDeleteSite } from '../shared';
@@ -47,9 +47,9 @@ describe(
 			} );
 
 			it( 'Skip domain selection', async function () {
-				const signupDomainPage = new SignupDomainPage( page );
-				await signupDomainPage.searchForFooDomains();
-				await signupDomainPage.skipDomainSelection();
+				const signupDomainPage = new RewrittenDomainSearchComponent( page );
+				await signupDomainPage.search( 'foo' );
+				await signupDomainPage.skipPurchase();
 			} );
 
 			it( `Select WordPress.com ${ planName } plan`, async function () {


### PR DESCRIPTION
Part of DOMAINS-1648.

## Proposed Changes

Removes the experiment code. Let's rely solely on the feature flag, which is already on, to determine whether to display the retrofitted or the legacy domain search UI.

This is an intermediary PR to make the retrofitted experience the default as quickly as possible. A follow up PR will be created as soon as possible to clean up the feature flag and the dead code.

## Testing Instructions

- Enter `/setup` and verify you see the retrofitted domain search experience.
- Enter `/start/domain` and verify you see the retrofitted domain search experience.
- Enter `/domains/add/%s` and verify you see the retrofitted domain search experience.

Verify [Pre-Release E2E tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/15707397) are passing.