### PR TITLE
Domain Search Rewrite: Add TLD restriction

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -39,6 +39,7 @@ const DomainSearchStep: StepType< {
 } > = function DomainSearchStep( { navigation, flow } ) {
 	const site = useSite();
 	const initialQuery = useQuery().get( 'new' ) ?? site?.slug;
+	const allowedTlds = useQuery().get( 'tld' )?.split( ',' ) ?? [];
 
 	const config = {
 		vendor: getSuggestionsVendor( {
@@ -52,6 +53,7 @@ const DomainSearchStep: StepType< {
 		},
 		includeDotBlogSubdomain: isNewsletterFlow( flow ),
 		skippable: isNewsletterFlow( flow ),
+		allowedTlds,
 	};
 
 	const text = __( 'Claim your space on the web' );

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -1,7 +1,15 @@
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { useSelector } from '../../../state';
+import getCurrentQueryArguments from '../../../state/selectors/get-current-query-arguments';
 
 export default function DomainSearch() {
+	const queryArguments = useSelector( getCurrentQueryArguments );
+
+	const allowedTlds = Array.isArray( queryArguments?.tld )
+		? queryArguments.tld
+		: queryArguments?.tld?.split( ',' ) ?? [];
+
 	return (
 		<WPCOMDomainSearch
 			flowName="domains"
@@ -11,6 +19,7 @@ export default function DomainSearch() {
 					isDomainOnly: false,
 					flowName: 'domains',
 				} ),
+				allowedTlds,
 			} }
 		/>
 	);

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -10,9 +10,12 @@ export type StepProps = {
 	goToStep: () => void;
 	goToNextStep: () => void;
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
+	queryObject: Record< string, string | undefined >;
 };
 
 export default function DomainSearchStep( props: StepProps ) {
+	const allowedTlds = props.queryObject.tld?.split( ',' ) ?? [];
+
 	const getContent = () => {
 		return (
 			<WPCOMDomainSearch
@@ -26,6 +29,7 @@ export default function DomainSearchStep( props: StepProps ) {
 					priceRules: {
 						forceRegularPrice: isMonthlyOrFreeFlow( props.flowName ),
 					},
+					allowedTlds,
 				} }
 			/>
 		);

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -13,13 +13,13 @@ interface PartitionedSuggestions {
 interface PartitionSuggestionsParams {
 	suggestions: string[];
 	query: string;
-	deemphasiseTlds: string[];
+	deemphasizedTlds: string[];
 }
 
 export const partitionSuggestions = ( {
 	suggestions,
 	query,
-	deemphasiseTlds,
+	deemphasizedTlds,
 }: PartitionSuggestionsParams ): PartitionedSuggestions => {
 	const exactMatch = suggestions.find( ( suggestion ) => suggestion === query );
 
@@ -39,7 +39,7 @@ export const partitionSuggestions = ( {
 	const regularSuggestions: string[] = [];
 
 	for ( const suggestion of suggestions ) {
-		if ( deemphasiseTlds.some( ( tld ) => suggestion.endsWith( `.${ tld }` ) ) ) {
+		if ( deemphasizedTlds.some( ( tld ) => suggestion.endsWith( `.${ tld }` ) ) ) {
 			regularSuggestions.push( suggestion );
 			continue;
 		}

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -49,13 +49,10 @@ const getPriceRuleForSuggestion = ( {
 };
 
 export const useSuggestion = ( domainName: string ) => {
-	const { query, queries, filter, config } = useDomainSearch();
+	const { query, queries, config } = useDomainSearch();
 
 	const { data: suggestion } = useQuery( {
-		...queries.domainSuggestions( query, {
-			tlds: filter.tlds,
-			exact_sld_matches_only: filter.exactSldMatchesOnly,
-		} ),
+		...queries.domainSuggestions( query ),
 		select: ( data ) => {
 			const suggestion = data.find( ( suggestion ) => suggestion.domain_name === domainName );
 

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -6,13 +6,10 @@ import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from '../page/context';
 
 export const useSuggestionsList = () => {
-	const { query, queries, config, filter } = useDomainSearch();
+	const { query, queries, config } = useDomainSearch();
 
 	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery( {
-		...queries.domainSuggestions( query, {
-			tlds: filter.tlds,
-			exact_sld_matches_only: filter.exactSldMatchesOnly,
-		} ),
+		...queries.domainSuggestions( query ),
 		enabled: true,
 	} );
 

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -73,7 +73,7 @@ export const useSuggestionsList = () => {
 				.map( ( suggestion ) => suggestion.domain_name )
 				.filter( ( suggestion ) => ! unavailablePremiumDomains.includes( suggestion ) ),
 			query,
-			deemphasiseTlds: config.deemphasizedTlds,
+			deemphasizedTlds: config.deemphasizedTlds,
 		} );
 	}, [ suggestions, query, config.deemphasizedTlds, unavailablePremiumDomains ] );
 

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -135,6 +135,15 @@ export const useDomainSearchContextValue = (
 				} ),
 				availableTlds: ( vendor, search ) => ( {
 					...availableTldsQuery( vendor, search ),
+					select: ( data ) => {
+						const { allowedTlds = [] } = normalizedConfig;
+
+						if ( allowedTlds.length > 0 ) {
+							return data.filter( ( tld ) => allowedTlds.includes( tld ) );
+						}
+
+						return data;
+					},
 					enabled: false,
 				} ),
 			},

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -108,16 +108,21 @@ export const useDomainSearchContextValue = (
 	}, [ config ] );
 
 	return useMemo( () => {
+		const allowedTlds = normalizedConfig.allowedTlds?.length
+			? normalizedConfig.allowedTlds
+			: undefined;
+
 		return {
 			...DEFAULT_CONTEXT_VALUE,
 			events: normalizedEvents,
 			config: normalizedConfig,
 			queries: {
-				domainSuggestions: ( query, params = {} ) => ( {
+				domainSuggestions: ( query ) => ( {
 					...domainSuggestionsQuery( query, {
-						...params,
 						quantity: 30,
 						vendor: normalizedConfig.vendor,
+						tlds: filter.tlds.length > 0 ? filter.tlds : allowedTlds,
+						exact_sld_matches_only: filter.exactSldMatchesOnly,
 					} ),
 					enabled: false,
 				} ),
@@ -136,9 +141,7 @@ export const useDomainSearchContextValue = (
 				availableTlds: ( vendor, search ) => ( {
 					...availableTldsQuery( vendor, search ),
 					select: ( data ) => {
-						const { allowedTlds = [] } = normalizedConfig;
-
-						if ( allowedTlds.length > 0 ) {
+						if ( allowedTlds ) {
 							return data.filter( ( tld ) => allowedTlds.includes( tld ) );
 						}
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -48,6 +48,7 @@ export interface DomainSearchConfig {
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;
+	allowedTlds?: string[];
 }
 
 export interface DomainSearchProps {

--- a/packages/domain-search/src/ui/domain-search-controls/filter-popover.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-popover.tsx
@@ -92,13 +92,19 @@ export const DomainSearchControlsFilterPopover = ( {
 
 	// Show list of available TLDs that weren't selected
 	const renderAvailableTldsList = () => {
+		const tldList = generateAvailableTldsList();
+
+		if ( tldList.length === 0 ) {
+			return null;
+		}
+
 		return (
 			<Card
 				className="domain-search-controls__filters-popover-available-tlds-container"
 				isRounded={ false }
 			>
 				<Scrollable scrollDirection="y" style={ { maxHeight: '18.5rem' } }>
-					{ generateAvailableTldsList().map( ( tld ) => {
+					{ tldList.map( ( tld ) => {
 						return tld.isLabel ? (
 							<FilterPopoverLabel key={ tld.text } text={ tld.text } />
 						) : (


### PR DESCRIPTION
Closes DOMAINS-1632.

## Proposed Changes

Allows restricting possible TLDs by passing a `tld` query parameter.

## Why are these changes being made?

Feature parity with the retrofitted domain search component.

## Testing Instructions

With the `domain-search-rewrite` feature flag turned on...

- Enter `/setup/domain?tld=com` and verify you only see `.com` domains, as well as being possible to filter only by that TLD;
- Enter `/start/domain?tld=com` and verify you only see `.com` domains, as well as being possible to filter only by that TLD;
- Enter `/domains/add/%s?tld=com` and verify you only see `.com` domains, as well as being possible to filter only by that TLD.

Remove the `tld` query parameter and verify you don't see the restriction anymore.