### PR TITLE
Domain Search Rewrite: Add blog subdomain fetching

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useQuery } from '../../../../hooks/use-query';
@@ -53,6 +54,9 @@ const DomainSearchStep: StepType< {
 		skippable: isNewsletterFlow( flow ),
 	};
 
+	const text = __( 'Claim your space on the web' );
+	const subText = __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
+
 	if ( shouldUseStepContainerV2( flow ) ) {
 		return (
 			<Step.CenteredColumnLayout
@@ -65,12 +69,7 @@ const DomainSearchStep: StepType< {
 				}
 				columnWidth={ 10 }
 				className="step-container-v2--domain-search"
-				heading={
-					<Step.Heading
-						text={ __( 'Claim your space on the web' ) }
-						subText={ __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' ) }
-					/>
-				}
+				heading={ <Step.Heading text={ text } subText={ subText } /> }
 			>
 				<WPCOMDomainSearch
 					className="step-container-v2-domain-search"
@@ -104,6 +103,7 @@ const DomainSearchStep: StepType< {
 			flowName={ flow }
 			goBack={ () => {} }
 			goNext={ () => {} }
+			formattedHeader={ <FormattedHeader headerText={ text } subHeaderText={ subText } /> }
 			stepContent={
 				<WPCOMDomainSearch flowName={ flow } config={ config } initialQuery={ initialQuery } />
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -2,6 +2,7 @@ import {
 	isDomainFlow,
 	isHundredYearDomainFlow,
 	isHundredYearPlanFlow,
+	isNewsletterFlow,
 	Step,
 	StepContainer,
 } from '@automattic/onboarding';
@@ -48,6 +49,8 @@ const DomainSearchStep: StepType< {
 			hidePrice: isHundredYearPlanFlow( flow ),
 			oneTimePrice: isHundredYearDomainFlow( flow ),
 		},
+		includeDotBlogSubdomain: isNewsletterFlow( flow ),
+		skippable: isNewsletterFlow( flow ),
 	};
 
 	if ( shouldUseStepContainerV2( flow ) ) {
@@ -97,6 +100,7 @@ const DomainSearchStep: StepType< {
 	return (
 		<StepContainer
 			stepName="domain-search"
+			isWideLayout
 			flowName={ flow }
 			goBack={ () => {} }
 			goNext={ () => {} }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -13,3 +13,9 @@
 	display: flex;
 	flex-direction: column;
 }
+
+.step-container.domain-search {
+	.step-container__content {
+		width: 100%;
+	}
+}

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -23,7 +23,10 @@ export async function fetchDomainSuggestions(
 	return suggestions;
 }
 
-export async function fetchFreeDomainSuggestion( search: string ): Promise< FreeDomainSuggestion > {
+export async function fetchFreeDomainSuggestion(
+	search: string,
+	params: Partial< DomainSuggestionQuery > = {}
+): Promise< FreeDomainSuggestion > {
 	const [ suggestion ] = await wpcom.req.get(
 		{
 			apiVersion: '1.1',
@@ -36,6 +39,7 @@ export async function fetchFreeDomainSuggestion( search: string ): Promise< Free
 			only_wordpressdotcom: false,
 			vendor: 'dot',
 			query: search.trim().toLocaleLowerCase(),
+			...params,
 		}
 	);
 

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -23,10 +23,13 @@ export const domainSuggestionsQuery = (
 		meta: { persist: false },
 	} );
 
-export const freeSuggestionQuery = ( query: string ) =>
+export const freeSuggestionQuery = (
+	query: string,
+	params: Partial< DomainSuggestionQuery > = {}
+) =>
 	queryOptions( {
-		queryKey: [ 'free-suggestion', query ],
-		queryFn: () => fetchFreeDomainSuggestion( query ),
+		queryKey: [ 'free-suggestion', query, params ],
+		queryFn: () => fetchFreeDomainSuggestion( query, params ),
 	} );
 
 export const availableTldsQuery = ( query?: string, vendor?: string ) =>

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -45,6 +45,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		vendor: 'variation2_front',
 		skippable: false,
 		deemphasizedTlds: [],
+		includeDotBlogSubdomain: false,
 		priceRules: {
 			hidePrice: false,
 			oneTimePrice: false,
@@ -121,7 +122,11 @@ export const useDomainSearchContextValue = (
 					enabled: false,
 				} ),
 				freeSuggestion: ( query ) => ( {
-					...freeSuggestionQuery( query ),
+					...freeSuggestionQuery( query, {
+						include_dotblogsubdomain: normalizedConfig.includeDotBlogSubdomain
+							? query.includes( '.blog' )
+							: false,
+					} ),
 					enabled: normalizedConfig.skippable,
 				} ),
 				domainAvailability: ( domainName ) => ( {

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -47,6 +47,7 @@ export interface DomainSearchConfig {
 	skippable: boolean;
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
+	includeDotBlogSubdomain: boolean;
 }
 
 export interface DomainSearchProps {


### PR DESCRIPTION
Closes DOMAINS-1631.

## Proposed Changes

Fetches .blog subdomains if flow allows and query contains `.blog`.

<img width="1176" height="688" alt="image" src="https://github.com/user-attachments/assets/4de9478d-34fe-4dc3-b0ae-7e6fe26e4ee4" />

## Testing Instructions

Enter `/setup/newsletter`, which is a flow that shows blog subdomains, and search for something that includes `.blog`. You should see the blog subdomain as the free, skippable option.