### PR TITLE
Help Center: Implement own ChatFooter to support mutli attachment upload

### DIFF
--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.11",
+		"@automattic/agenttic-ui": "^0.1.12",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.10",
+		"@automattic/agenttic-ui": "^0.1.11",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",
@@ -54,6 +54,7 @@
 		"autosize": "^6.0.1",
 		"clsx": "^2.1.1",
 		"dompurify": "^3.2.6",
+		"framer-motion": "^12.23.12",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-intersection-observer": "^9.4.3",

--- a/packages/odie-client/src/components/attachment-preview/index.tsx
+++ b/packages/odie-client/src/components/attachment-preview/index.tsx
@@ -8,7 +8,7 @@ import './style.scss';
 export const AttachmentPreview = ( {
 	attachmentPreview,
 	onCancel,
-	isAttachingFile,
+	isAttachingFile = true,
 }: {
 	attachmentPreview: File;
 	onCancel: () => void;

--- a/packages/odie-client/src/components/attachment-preview/index.tsx
+++ b/packages/odie-client/src/components/attachment-preview/index.tsx
@@ -1,0 +1,43 @@
+import { ArrowUpIcon } from '@automattic/agenttic-ui';
+import { Button } from '@wordpress/components';
+import { cancelCircleFilled } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+import './style.scss';
+
+export const AttachmentPreview = ( {
+	attachmentPreview,
+	onSend,
+	onCancel,
+	isAttachingFile,
+}: {
+	attachmentPreview: File;
+	onSend: () => void;
+	onCancel: () => void;
+	isAttachingFile: boolean;
+} ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className={ clsx( 'odie-attachment-preview', { 'is-attaching-file': isAttachingFile } ) }>
+			<img src={ URL.createObjectURL( attachmentPreview ) } alt={ attachmentPreview.name } />
+			<Button
+				className="odie-attachment-send-button"
+				icon={ ArrowUpIcon }
+				variant="primary"
+				aria-label={ __( 'Send attachment', __i18n_text_domain__ ) }
+				onClick={ onSend }
+				isBusy={ isAttachingFile }
+				disabled={ isAttachingFile }
+			/>
+			<Button
+				icon={ cancelCircleFilled }
+				variant="tertiary"
+				isDestructive
+				aria-label={ __( 'Cancel attachment', __i18n_text_domain__ ) }
+				disabled={ isAttachingFile }
+				onClick={ onCancel }
+			/>
+		</div>
+	);
+};

--- a/packages/odie-client/src/components/attachment-preview/index.tsx
+++ b/packages/odie-client/src/components/attachment-preview/index.tsx
@@ -1,43 +1,61 @@
-import { ArrowUpIcon } from '@automattic/agenttic-ui';
+import { animations } from '@automattic/agenttic-ui';
 import { Button } from '@wordpress/components';
-import { cancelCircleFilled } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
+import { cancelCircleFilled, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { motion, Transition } from 'framer-motion';
 import './style.scss';
 
 export const AttachmentPreview = ( {
 	attachmentPreview,
-	onSend,
 	onCancel,
 	isAttachingFile,
 }: {
 	attachmentPreview: File;
-	onSend: () => void;
 	onCancel: () => void;
 	isAttachingFile: boolean;
 } ) => {
-	const { __ } = useI18n();
+	const fileType = attachmentPreview.type.split( '/' ).pop();
 
 	return (
-		<div className={ clsx( 'odie-attachment-preview', { 'is-attaching-file': isAttachingFile } ) }>
+		<motion.div
+			initial={ { opacity: 0, scale: 1 } }
+			animate={ { opacity: 1, scale: 1 } }
+			transition={ { ...animations.fastSpring } as Transition }
+			className={ clsx( 'odie-attachment-preview', { 'is-attaching-file': isAttachingFile } ) }
+		>
 			<img src={ URL.createObjectURL( attachmentPreview ) } alt={ attachmentPreview.name } />
-			<Button
-				className="odie-attachment-send-button"
-				icon={ ArrowUpIcon }
-				variant="primary"
-				aria-label={ __( 'Send attachment', __i18n_text_domain__ ) }
-				onClick={ onSend }
-				isBusy={ isAttachingFile }
-				disabled={ isAttachingFile }
-			/>
-			<Button
-				icon={ cancelCircleFilled }
-				variant="tertiary"
-				isDestructive
-				aria-label={ __( 'Cancel attachment', __i18n_text_domain__ ) }
-				disabled={ isAttachingFile }
-				onClick={ onCancel }
-			/>
+			<div>
+				<p className="odie-attachment-preview-name">{ attachmentPreview.name }</p>
+				{ fileType && (
+					<p className="odie-attachment-preview-file-type">{ fileType.toUpperCase() }</p>
+				) }
+			</div>
+			<Button className="odie-attachment-preview-cancel" onClick={ onCancel }>
+				<Icon icon={ cancelCircleFilled } />
+			</Button>
+		</motion.div>
+	);
+};
+
+export const AttachmentPreviews = ( {
+	attachmentPreviews,
+	onCancel,
+	isAttachingFile,
+}: {
+	attachmentPreviews: File[];
+	onCancel: ( index: number ) => void;
+	isAttachingFile: boolean;
+} ) => {
+	return (
+		<div className="odie-attachment-previews">
+			{ attachmentPreviews.map( ( preview, index ) => (
+				<AttachmentPreview
+					key={ preview.name + preview.lastModified }
+					attachmentPreview={ preview }
+					isAttachingFile={ isAttachingFile }
+					onCancel={ () => onCancel( index ) }
+				/>
+			) ) }
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -12,6 +12,29 @@
 	border-radius: 4px;
 	flex-shrink: 0;
 
+	&.is-attaching-file {
+		background: linear-gradient(
+			90deg,
+			color-mix( in srgb, $gray-100 20%, $gray-400 ),
+			$gray-100,
+			color-mix( in srgb, $gray-100 20%, $gray-400 )
+		);
+		background-size: 200% 100%;
+		animation: shimmer 2000ms infinite linear 0ms;
+	}
+
+	@keyframes shimmer {
+		0% {
+			background-position: 0 0;
+		}
+		50% {
+			opacity: 0.5;
+		}
+		100% {
+			background-position: 200% 0;
+		}
+	}
+
 	.odie-attachment-preview-cancel {
 		$width: 18px;
 		$height: 10px;

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -1,22 +1,84 @@
+@import '@wordpress/base-styles/variables';
+
+.Suggestions-module_container {
+	height: unset;
+	.button-module_button.button-module_outline {
+		height: unset;
+		padding: 0;
+	}
+}
+
 .odie-attachment-preview {
 	display: flex;
-	gap: 10px;
-	padding: 20px;
+	gap: 6px;
 	position: relative;
-	z-index: 6;
-	border: 1px solid #e0e0e0;
 	box-sizing: border-box;
-	border-radius: 16px;
+	width: 128px;
+	padding: 6px;
+	background-color: $gray-100;
+	align-items: center;
+	border-radius: 4px;
+	flex-shrink: 0;
+
+	.odie-attachment-preview-cancel {
+		$width: 18px;
+		$height: 10px;
+		position: absolute;
+		height: $height;
+		width: $width;
+		top: -$height / 2;
+		right: -$width / 2;
+		margin: 0;
+		padding: 0;
+
+
+		svg {
+			fill: $gray-700;
+		}
+	}
+
+	.odie-attachment-preview-name,
+	.odie-attachment-preview-file-type {
+		margin: 2px;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+		max-width: 68px;
+	}
+
+	.odie-attachment-preview-name {
+		font-size: 12px;
+		line-height: 16px;
+		font-weight: 500;
+		color: $gray-900;
+		text-align: left;
+	}
+
+	.odie-attachment-preview-file-type {
+		font-size: 12px;
+		line-height: 16px;
+		font-weight: 400;
+		color: $gray-700;
+		text-align: left;
+	}
 
 	img {
-		max-height: 250px;
-		max-width: 250px;
-		border-radius: 8px;
-		flex: 1;
+		width: 40px;
+		height: 40px;
+		object-fit: cover;
+		border-radius: 4px;
 	}
 
 	.odie-attachment-send-button {
 		border-radius: 50%;
 		box-sizing: border-box;
 	}
+}
+
+.odie-attachment-previews {
+	display: flex;
+	overflow-x: auto;
+	padding: 8px;
+	gap: 6px;
+	box-sizing: content-box;
 }

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -31,9 +31,10 @@
 		margin: 0;
 		padding: 0;
 
-
-		svg {
-			fill: $gray-700;
+		&:not( :hover ) {
+			svg {
+				fill: $gray-700;
+			}
 		}
 	}
 

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -1,13 +1,5 @@
 @import '@wordpress/base-styles/variables';
 
-.Suggestions-module_container {
-	height: unset;
-	.button-module_button.button-module_outline {
-		height: unset;
-		padding: 0;
-	}
-}
-
 .odie-attachment-preview {
 	display: flex;
 	gap: 6px;

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -19,11 +19,5 @@
 	.odie-attachment-send-button {
 		border-radius: 50%;
 		box-sizing: border-box;
-		background-color: var( --color-primary );
-        --wp-admin-border-width-focus: var( --color-primary );
-
-		&:hover:not( :disabled ) {
-			background-color: color-mix( in srgb, var( --color-primary ) 85%, #000 );
-		}
 	}
 }

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -9,9 +9,8 @@
 	border-radius: 16px;
 
 	img {
-		max-height: 100%;
 		max-height: 250px;
-		align-self: top;
+		max-width: 250px;
 		border-radius: 8px;
 		flex: 1;
 	}

--- a/packages/odie-client/src/components/attachment-preview/style.scss
+++ b/packages/odie-client/src/components/attachment-preview/style.scss
@@ -1,0 +1,29 @@
+.odie-attachment-preview {
+	display: flex;
+	gap: 10px;
+	padding: 20px;
+	position: relative;
+	z-index: 6;
+	border: 1px solid #e0e0e0;
+	box-sizing: border-box;
+	border-radius: 16px;
+
+	img {
+		max-height: 100%;
+		max-height: 250px;
+		align-self: top;
+		border-radius: 8px;
+		flex: 1;
+	}
+
+	.odie-attachment-send-button {
+		border-radius: 50%;
+		box-sizing: border-box;
+		background-color: var( --color-primary );
+        --wp-admin-border-width-focus: var( --color-primary );
+
+		&:hover:not( :disabled ) {
+			background-color: color-mix( in srgb, var( --color-primary ) 85%, #000 );
+		}
+	}
+}

--- a/packages/odie-client/src/components/chat-footer/index.tsx
+++ b/packages/odie-client/src/components/chat-footer/index.tsx
@@ -1,0 +1,29 @@
+import { Notice, animations, ChatInput, AgentUIProvider } from '@automattic/agenttic-ui';
+import { motion } from 'framer-motion';
+import './style.scss';
+import type { Transition } from 'framer-motion';
+import type { ComponentProps } from 'react';
+
+type AgentUIFooterProps = ComponentProps< typeof ChatInput > & {
+	attachmentPreviews?: React.ReactNode;
+	setInputValue?: ( value: string ) => void;
+	notice?: ComponentProps< typeof Notice >;
+};
+
+export function AgentUIFooter( props: AgentUIFooterProps ) {
+	return (
+		<AgentUIProvider value={ {} as any }>
+			<motion.div
+				data-slot="chat-footer"
+				className="agenttic--chat-footer-container"
+				initial={ { opacity: 0, scale: 1 } }
+				animate={ { opacity: 1, scale: 1 } }
+				transition={ { ...animations.fastSpring } as Transition }
+			>
+				{ props.attachmentPreviews }
+				{ props.notice ? <Notice { ...props.notice } /> : null }
+				<ChatInput { ...props } />
+			</motion.div>
+		</AgentUIProvider>
+	);
+}

--- a/packages/odie-client/src/components/chat-footer/style.scss
+++ b/packages/odie-client/src/components/chat-footer/style.scss
@@ -1,0 +1,13 @@
+.agenttic--chat-footer-container {
+    background-color: var(--color-background);
+    /* stylelint-disable-next-line */
+    border-radius: calc( var(--radius-lg) + 1px); /* Accounts for the 1px shadow */
+    box-shadow: var(--shadow-sm);
+    color: var(--color-foreground);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2);
+    position: relative;
+    z-index: 10;
+}

--- a/packages/odie-client/src/components/message/messages-cluster/style.scss
+++ b/packages/odie-client/src/components/message/messages-cluster/style.scss
@@ -2,7 +2,7 @@
 
 .odie-chatbox-messages-cluster {
 	width: 100%;
-    padding: 0;
+	padding: 0;
 	box-sizing: border-box;
 
 	&.role-attachment {
@@ -17,6 +17,19 @@
 			border-radius: 0;
 			padding: 0;
 		}
+
+		animation: fadeIn 0.5s ease-in-out forwards;
+		transform-origin: center bottom;
+
+		@keyframes fadeIn {
+			from {
+				opacity: 0;
+				transform: scaleX( 0 );
+			}
+			to {
+				opacity: 1;
+			}
+		}
 	}
 
 	&.role-bot {
@@ -28,7 +41,7 @@
 			margin-bottom: 16px;
 		}
 	}
-	
+
 	&.role-business {
 		flex-direction: column;
 		align-self: flex-start;
@@ -39,10 +52,10 @@
 		border: 1px solid $gray-200;
 		max-width: calc( 100% - 32px );
 
-        .message-header {
-            font-weight: $font-weight-medium;
-            margin-right: 16px;
-        }
+		.message-header {
+			font-weight: $font-weight-medium;
+			margin-right: 16px;
+		}
 	}
 
 	&.role-user {

--- a/packages/odie-client/src/components/message/messages-cluster/style.scss
+++ b/packages/odie-client/src/components/message/messages-cluster/style.scss
@@ -1,6 +1,6 @@
 @import '@wordpress/base-styles/variables';
 
-.odie-chatbox-messages-cluster {
+.odie-chatbox-messages-cluster { 
 	width: 100%;
 	padding: 0;
 	box-sizing: border-box;
@@ -18,13 +18,12 @@
 			padding: 0;
 		}
 
-		animation: fadeIn 0.5s ease-in-out forwards;
-		transform-origin: center bottom;
+		animation: fadeInAttachment 0.2s ease-in-out forwards;
+		transform-origin: center top;
 
-		@keyframes fadeIn {
+		@keyframes fadeInAttachment {
 			from {
 				opacity: 0;
-				transform: scaleX( 0 );
 			}
 			to {
 				opacity: 1;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -41,9 +41,6 @@ export const OdieSendMessageButton = () => {
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 
-	// Prioritize connection status notice over message size notice
-	const notice = connectionNotice || messageSizeNotice;
-
 	const { connectionStatus } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -69,7 +66,11 @@ export const OdieSendMessageButton = () => {
 		isAttachingFile,
 		showAttachmentButton,
 		AttachmentDropZone,
+		badFormatNotice,
 	} = useAttachmentHandler();
+
+	// Prioritize connection status notice over message size notice
+	const notice = connectionNotice || messageSizeNotice || badFormatNotice;
 
 	useEffect( () => {
 		function handleBlur() {

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -102,7 +102,7 @@ export const OdieSendMessageButton = () => {
 			setInputValue( '' );
 		} else if ( chat.conversationId ) {
 			Smooch.stopTyping();
-			await sendAttachments();
+			sendAttachments();
 		}
 
 		try {
@@ -168,14 +168,6 @@ export const OdieSendMessageButton = () => {
 	const isDisabled = !! messageSizeNotice || ( isLiveChat && connectionStatus !== 'connected' );
 	// When there is a reason to disable the input, we should not convey a processing state.
 	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
-
-	// if ( attachmentPreview ) {
-	// 	return (
-	// 		<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
-	// 			{ attachmentPreview }
-	// 		</div>
-	// 	);
-	// }
 
 	return (
 		<>

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,4 +1,3 @@
-import { ChatFooter } from '@automattic/agenttic-ui';
 import '@automattic/agenttic-ui/index.css';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
@@ -10,6 +9,7 @@ import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { Message } from '../../types';
+import { AgentUIFooter } from '../chat-footer';
 import { useConnectionStatusNotice, useMessageSizeErrorNotice } from '../notices';
 import { useAttachmentHandler } from './use-attachment-handler';
 
@@ -62,7 +62,8 @@ export const OdieSendMessageButton = () => {
 	}, [ inputValue, isLiveChat ] );
 
 	const {
-		attachmentPreview,
+		attachmentPreviews,
+		sendAttachments,
 		handleImagePaste,
 		attachmentAction,
 		isAttachingFile,
@@ -101,6 +102,7 @@ export const OdieSendMessageButton = () => {
 			setInputValue( '' );
 		} else if ( chat.conversationId ) {
 			Smooch.stopTyping();
+			await sendAttachments();
 		}
 
 		try {
@@ -139,7 +141,15 @@ export const OdieSendMessageButton = () => {
 		} finally {
 			textareaRef.current?.focus();
 		}
-	}, [ inputValue, isChatBusy, chat?.provider, sendMessage, trackEvent, chat.conversationId ] );
+	}, [
+		inputValue,
+		isChatBusy,
+		chat?.provider,
+		sendMessage,
+		trackEvent,
+		chat.conversationId,
+		sendAttachments,
+	] );
 
 	const isEmailFallback = chat?.provider === 'zendesk' && forceEmailSupport;
 
@@ -159,13 +169,13 @@ export const OdieSendMessageButton = () => {
 	// When there is a reason to disable the input, we should not convey a processing state.
 	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
 
-	if ( attachmentPreview ) {
-		return (
-			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
-				{ attachmentPreview }
-			</div>
-		);
-	}
+	// if ( attachmentPreview ) {
+	// 	return (
+	// 		<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
+	// 			{ attachmentPreview }
+	// 		</div>
+	// 	);
+	// }
 
 	return (
 		<>
@@ -173,10 +183,11 @@ export const OdieSendMessageButton = () => {
 				{ isEmailFallback ? (
 					<EmailFallbackNotice />
 				) : (
-					<ChatFooter
-						inputValue={ inputValue }
-						onInputChange={ setInputValue }
+					<AgentUIFooter
+						value={ inputValue }
+						onChange={ setInputValue }
 						onSubmit={ sendMessageHandler }
+						attachmentPreviews={ attachmentPreviews }
 						onKeyDown={ handleKeyDown }
 						textareaRef={ textareaRef }
 						disabled={ isDisabled }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -51,6 +51,7 @@ export const OdieSendMessageButton = () => {
 	}, [] );
 
 	const {
+		attachmentPreview,
 		handleImagePaste,
 		attachmentAction,
 		isAttachingFile,
@@ -128,6 +129,14 @@ export const OdieSendMessageButton = () => {
 	const isDisabled = !! messageSizeNotice || ( isLiveChat && connectionStatus !== 'connected' );
 	// When there is a reason to disable the input, we should not convey a processing state.
 	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
+
+	if ( attachmentPreview ) {
+		return (
+			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
+				{ attachmentPreview }
+			</div>
+		);
+	}
 
 	return (
 		<>

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -17,6 +17,7 @@ const NOTICE_BAD_FORMAT = {
 	icon: <Icon size={ 24 } icon={ error } />,
 	message: __( 'Only .jpg, .png, or .gif files are supported.', __i18n_text_domain__ ),
 	dismissible: true,
+	onDismiss: () => {},
 };
 
 const SUPPORTED_IMAGE_TYPES = [ 'image/png', 'image/jpg', 'image/jpeg', 'image/gif' ];
@@ -87,7 +88,10 @@ export const useAttachmentHandler = () => {
 			}
 			setAttachmentPreviewFiles( newAttachmentPreviewFiles );
 			if ( anyUnsupportedFormats ) {
-				setBadFormatNotice( NOTICE_BAD_FORMAT );
+				setBadFormatNotice( {
+					...NOTICE_BAD_FORMAT,
+					onDismiss: () => setBadFormatNotice( undefined ),
+				} );
 			}
 		},
 

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -15,6 +15,7 @@ import { zendeskMessageConverter } from '../../utils';
 import { AttachmentPreviews } from '../attachment-preview';
 
 const SUPPORTED_IMAGE_TYPES = [ 'image/png', 'image/jpg', 'image/jpeg', 'image/gif' ];
+const MAX_ATTACHMENTS = 5;
 
 function isSupportedImageType( type: string ) {
 	return SUPPORTED_IMAGE_TYPES.includes( type );
@@ -64,8 +65,9 @@ export const useAttachmentHandler = () => {
 
 	const handleFileUpload = useCallback(
 		async ( files: File[] ) => {
+			const limitedFiles = files.slice( 0, MAX_ATTACHMENTS );
 			const newAttachmentPreviewFiles = [ ...attachmentPreviewFiles ];
-			for ( const file of files ) {
+			for ( const file of limitedFiles ) {
 				if ( isSupportedImageType( file.type ) ) {
 					// Avoid duplicates.
 					if ( ! newAttachmentPreviewFiles.some( ( f ) => f.name === file.name ) ) {

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -67,6 +67,7 @@ export const useAttachmentHandler = () => {
 		async ( files: File[] ) => {
 			const limitedFiles = files.slice( 0, MAX_ATTACHMENTS );
 			const newAttachmentPreviewFiles = [ ...attachmentPreviewFiles ];
+			const unsupportedFormats = new Set< string >();
 			for ( const file of limitedFiles ) {
 				if ( isSupportedImageType( file.type ) ) {
 					// Avoid duplicates.
@@ -74,10 +75,15 @@ export const useAttachmentHandler = () => {
 						newAttachmentPreviewFiles.push( file );
 					}
 				} else {
-					addMessage( getOdieWrongFileTypeMessage( file.name ) );
+					unsupportedFormats.add(
+						file.name.split( '.' ).pop() || __( 'unknown', __i18n_text_domain__ )
+					);
 				}
 			}
 			setAttachmentPreviewFiles( newAttachmentPreviewFiles );
+			if ( unsupportedFormats.size > 0 ) {
+				addMessage( getOdieWrongFileTypeMessage( Array.from( unsupportedFormats ).join( ', ' ) ) );
+			}
 		},
 
 		[ addMessage, setAttachmentPreviewFiles, attachmentPreviewFiles ]

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -15,7 +15,7 @@ import { AttachmentPreviews } from '../attachment-preview';
 
 const NOTICE_BAD_FORMAT = {
 	icon: <Icon size={ 24 } icon={ error } />,
-	message: __( 'Only .jpg, .png, .gif files are supported.', __i18n_text_domain__ ),
+	message: __( 'Only .jpg, .png, or .gif files are supported.', __i18n_text_domain__ ),
 	dismissible: true,
 };
 

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -6,12 +6,13 @@ import {
 } from '@automattic/zendesk-client';
 import { DropZone, Icon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image } from '@wordpress/icons';
 import { getOdieWrongFileTypeMessage } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { zendeskMessageConverter } from '../../utils';
+import { AttachmentPreview } from '../attachment-preview';
 
 const getFileType = ( file: File ) => {
 	if ( file.type.startsWith( 'image/' ) ) {
@@ -34,6 +35,7 @@ const getPlaceholderAttachmentMessage = ( file: File ) => {
 
 export const useAttachmentHandler = () => {
 	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport } = useOdieAssistantContext();
+	const [ attachmentPreviewFile, setAttachmentPreviewFile ] = useState< File | null >( null );
 
 	const { data: authData } = useAuthenticateZendeskMessaging(
 		isUserEligibleForPaidSupport,
@@ -57,30 +59,38 @@ export const useAttachmentHandler = () => {
 	const handleFileUpload = useCallback(
 		async ( file: File ) => {
 			if ( file.type.startsWith( 'image/' ) ) {
-				if ( authData && chat.conversationId && inferredClientId && file ) {
-					attachFileToConversation( {
-						authData,
-						file,
-						conversationId: chat.conversationId,
-						clientId: inferredClientId,
-					} ).then( () => {
-						addMessage( getPlaceholderAttachmentMessage( file ) );
-						trackEvent( 'send_message_attachment', { type: file.type } );
-					} );
-				}
+				setAttachmentPreviewFile( file );
 			} else {
 				addMessage( getOdieWrongFileTypeMessage() );
 			}
 		},
-		[
-			authData,
-			chat.conversationId,
-			inferredClientId,
-			attachFileToConversation,
-			addMessage,
-			trackEvent,
-		]
+		[ addMessage, setAttachmentPreviewFile ]
 	);
+
+	const sendAttachment = useCallback( async () => {
+		if ( attachmentPreviewFile ) {
+			if ( authData && chat.conversationId && inferredClientId ) {
+				attachFileToConversation( {
+					authData,
+					file: attachmentPreviewFile,
+					conversationId: chat.conversationId,
+					clientId: inferredClientId,
+				} ).then( () => {
+					setAttachmentPreviewFile( null );
+					addMessage( getPlaceholderAttachmentMessage( attachmentPreviewFile ) );
+					trackEvent( 'send_message_attachment', { type: attachmentPreviewFile.type } );
+				} );
+			}
+		}
+	}, [
+		attachmentPreviewFile,
+		attachFileToConversation,
+		authData,
+		chat.conversationId,
+		inferredClientId,
+		addMessage,
+		trackEvent,
+	] );
 
 	const onFilesDrop = ( files: File[] ) => {
 		const file = files?.[ 0 ];
@@ -156,6 +166,15 @@ export const useAttachmentHandler = () => {
 
 	return {
 		handleFileUpload,
+		sendAttachment,
+		attachmentPreview: attachmentPreviewFile ? (
+			<AttachmentPreview
+				attachmentPreview={ attachmentPreviewFile }
+				onSend={ sendAttachment }
+				isAttachingFile={ isAttachingFile }
+				onCancel={ () => setAttachmentPreviewFile( null ) }
+			/>
+		) : null,
 		handleImagePaste,
 		attachmentAction,
 		isAttachingFile,

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -12,7 +12,13 @@ import { image } from '@wordpress/icons';
 import { getOdieWrongFileTypeMessage } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { zendeskMessageConverter } from '../../utils';
-import { AttachmentPreview } from '../attachment-preview';
+import { AttachmentPreviews } from '../attachment-preview';
+
+const SUPPORTED_IMAGE_TYPES = [ 'image/png', 'image/jpg', 'image/jpeg', 'image/gif' ];
+
+function isSupportedImageType( type: string ) {
+	return SUPPORTED_IMAGE_TYPES.includes( type );
+}
 
 const getFileType = ( file: File ) => {
 	if ( file.type.startsWith( 'image/' ) ) {
@@ -35,7 +41,7 @@ const getPlaceholderAttachmentMessage = ( file: File ) => {
 
 export const useAttachmentHandler = () => {
 	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport } = useOdieAssistantContext();
-	const [ attachmentPreviewFile, setAttachmentPreviewFile ] = useState< File | null >( null );
+	const [ attachmentPreviewFiles, setAttachmentPreviewFiles ] = useState< File[] >( [] );
 
 	const { data: authData } = useAuthenticateZendeskMessaging(
 		isUserEligibleForPaidSupport,
@@ -57,33 +63,46 @@ export const useAttachmentHandler = () => {
 		useAttachFileToConversation();
 
 	const handleFileUpload = useCallback(
-		async ( file: File ) => {
-			if ( file.type.startsWith( 'image/' ) ) {
-				setAttachmentPreviewFile( file );
-			} else {
-				addMessage( getOdieWrongFileTypeMessage() );
+		async ( files: File[] ) => {
+			const newAttachmentPreviewFiles = [ ...attachmentPreviewFiles ];
+			for ( const file of files ) {
+				if ( isSupportedImageType( file.type ) ) {
+					// Avoid duplicates.
+					if ( ! newAttachmentPreviewFiles.some( ( f ) => f.name === file.name ) ) {
+						newAttachmentPreviewFiles.push( file );
+					}
+				} else {
+					addMessage( getOdieWrongFileTypeMessage( file.name ) );
+				}
 			}
+			setAttachmentPreviewFiles( newAttachmentPreviewFiles );
 		},
-		[ addMessage, setAttachmentPreviewFile ]
+
+		[ addMessage, setAttachmentPreviewFiles, attachmentPreviewFiles ]
 	);
 
-	const sendAttachment = useCallback( async () => {
-		if ( attachmentPreviewFile ) {
+	const sendAttachments = useCallback( async () => {
+		if ( attachmentPreviewFiles.length > 0 ) {
 			if ( authData && chat.conversationId && inferredClientId ) {
-				attachFileToConversation( {
-					authData,
-					file: attachmentPreviewFile,
-					conversationId: chat.conversationId,
-					clientId: inferredClientId,
-				} ).then( () => {
-					setAttachmentPreviewFile( null );
-					addMessage( getPlaceholderAttachmentMessage( attachmentPreviewFile ) );
-					trackEvent( 'send_message_attachment', { type: attachmentPreviewFile.type } );
+				Promise.all(
+					attachmentPreviewFiles.map( ( file ) =>
+						attachFileToConversation( {
+							authData,
+							file,
+							conversationId: chat.conversationId as string,
+							clientId: inferredClientId,
+						} ).then( () => {
+							addMessage( getPlaceholderAttachmentMessage( file ) );
+							trackEvent( 'send_message_attachment', { type: file.type } );
+						} )
+					)
+				).then( () => {
+					setAttachmentPreviewFiles( [] );
 				} );
 			}
 		}
 	}, [
-		attachmentPreviewFile,
+		attachmentPreviewFiles,
 		attachFileToConversation,
 		authData,
 		chat.conversationId,
@@ -93,9 +112,8 @@ export const useAttachmentHandler = () => {
 	] );
 
 	const onFilesDrop = ( files: File[] ) => {
-		const file = files?.[ 0 ];
-		if ( file ) {
-			handleFileUpload( file );
+		if ( files.length > 0 ) {
+			handleFileUpload( files );
 		}
 	};
 
@@ -112,10 +130,10 @@ export const useAttachmentHandler = () => {
 						.then( ( items ) => {
 							for ( const item of items ) {
 								for ( const type of item.types ) {
-									if ( type.startsWith( 'image/' ) ) {
+									if ( isSupportedImageType( type ) ) {
 										item.getType( type ).then( ( blob ) => {
 											const file = new File( [ blob ], 'pasted-image.png', { type } );
-											handleFileUpload( file );
+											handleFileUpload( [ file ] );
 										} );
 										break;
 									}
@@ -150,11 +168,12 @@ export const useAttachmentHandler = () => {
 		onClick: () => {
 			const input = document.createElement( 'input' );
 			input.type = 'file';
-			input.accept = 'image/*';
+			input.multiple = true;
+			input.accept = 'image/png, image/jpg, image/jpeg, image/gif';
 			input.onchange = ( e ) => {
-				const file = ( e.target as HTMLInputElement ).files?.[ 0 ];
-				if ( file ) {
-					handleFileUpload( file );
+				const files = ( e.target as HTMLInputElement ).files;
+				if ( files?.length ) {
+					handleFileUpload( Array.from( files ) );
 				}
 			};
 			input.click();
@@ -166,13 +185,14 @@ export const useAttachmentHandler = () => {
 
 	return {
 		handleFileUpload,
-		sendAttachment,
-		attachmentPreview: attachmentPreviewFile ? (
-			<AttachmentPreview
-				attachmentPreview={ attachmentPreviewFile }
-				onSend={ sendAttachment }
+		sendAttachments,
+		attachmentPreviews: attachmentPreviewFiles.length ? (
+			<AttachmentPreviews
+				attachmentPreviews={ attachmentPreviewFiles }
 				isAttachingFile={ isAttachingFile }
-				onCancel={ () => setAttachmentPreviewFile( null ) }
+				onCancel={ ( index ) =>
+					setAttachmentPreviewFiles( attachmentPreviewFiles.filter( ( _, i ) => i !== index ) )
+				}
 			/>
 		) : null,
 		handleImagePaste,

--- a/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
+++ b/packages/odie-client/src/components/send-message-input/use-attachment-handler.tsx
@@ -4,15 +4,20 @@ import {
 	useAttachFileToConversation,
 	useAuthenticateZendeskMessaging,
 } from '@automattic/zendesk-client';
-import { DropZone, Icon } from '@wordpress/components';
+import { DropZone } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { image } from '@wordpress/icons';
-import { getOdieWrongFileTypeMessage } from '../../constants';
+import { error, image, Icon } from '@wordpress/icons';
 import { useOdieAssistantContext } from '../../context';
 import { zendeskMessageConverter } from '../../utils';
 import { AttachmentPreviews } from '../attachment-preview';
+
+const NOTICE_BAD_FORMAT = {
+	icon: <Icon size={ 24 } icon={ error } />,
+	message: __( 'Only .jpg, .png, .gif files are supported.', __i18n_text_domain__ ),
+	dismissible: true,
+};
 
 const SUPPORTED_IMAGE_TYPES = [ 'image/png', 'image/jpg', 'image/jpeg', 'image/gif' ];
 const MAX_ATTACHMENTS = 5;
@@ -43,6 +48,7 @@ const getPlaceholderAttachmentMessage = ( file: File ) => {
 export const useAttachmentHandler = () => {
 	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport } = useOdieAssistantContext();
 	const [ attachmentPreviewFiles, setAttachmentPreviewFiles ] = useState< File[] >( [] );
+	const [ badFormatNotice, setBadFormatNotice ] = useState< typeof NOTICE_BAD_FORMAT >();
 
 	const { data: authData } = useAuthenticateZendeskMessaging(
 		isUserEligibleForPaidSupport,
@@ -65,9 +71,10 @@ export const useAttachmentHandler = () => {
 
 	const handleFileUpload = useCallback(
 		async ( files: File[] ) => {
+			setBadFormatNotice( undefined );
 			const limitedFiles = files.slice( 0, MAX_ATTACHMENTS );
 			const newAttachmentPreviewFiles = [ ...attachmentPreviewFiles ];
-			const unsupportedFormats = new Set< string >();
+			let anyUnsupportedFormats = false;
 			for ( const file of limitedFiles ) {
 				if ( isSupportedImageType( file.type ) ) {
 					// Avoid duplicates.
@@ -75,21 +82,20 @@ export const useAttachmentHandler = () => {
 						newAttachmentPreviewFiles.push( file );
 					}
 				} else {
-					unsupportedFormats.add(
-						file.name.split( '.' ).pop() || __( 'unknown', __i18n_text_domain__ )
-					);
+					anyUnsupportedFormats = true;
 				}
 			}
 			setAttachmentPreviewFiles( newAttachmentPreviewFiles );
-			if ( unsupportedFormats.size > 0 ) {
-				addMessage( getOdieWrongFileTypeMessage( Array.from( unsupportedFormats ).join( ', ' ) ) );
+			if ( anyUnsupportedFormats ) {
+				setBadFormatNotice( NOTICE_BAD_FORMAT );
 			}
 		},
 
-		[ addMessage, setAttachmentPreviewFiles, attachmentPreviewFiles ]
+		[ setAttachmentPreviewFiles, attachmentPreviewFiles, setBadFormatNotice ]
 	);
 
 	const sendAttachments = useCallback( async () => {
+		setBadFormatNotice( undefined );
 		if ( attachmentPreviewFiles.length > 0 ) {
 			if ( authData && chat.conversationId && inferredClientId ) {
 				Promise.all(
@@ -117,6 +123,7 @@ export const useAttachmentHandler = () => {
 		inferredClientId,
 		addMessage,
 		trackEvent,
+		setBadFormatNotice,
 	] );
 
 	const onFilesDrop = ( files: File[] ) => {
@@ -203,6 +210,7 @@ export const useAttachmentHandler = () => {
 				}
 			/>
 		) : null,
+		badFormatNotice,
 		handleImagePaste,
 		attachmentAction,
 		isAttachingFile,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots } from './types';
 declare const __i18n_text_domain__: string;
 
@@ -78,26 +78,6 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',
 		__i18n_text_domain__
 	) }`;
-
-export const getOdieWrongFileTypeMessage = ( formats: string ): Message => ( {
-	content: sprintf(
-		/* translators: %s is the name of the file that is not supported */
-		__(
-			"We don't support %s files at this time. Please upload a .jpg, .png, or .gif.",
-			__i18n_text_domain__
-		),
-		formats
-	),
-	role: 'bot',
-	type: 'message',
-	context: {
-		flags: {
-			hide_disclaimer_content: true,
-			show_contact_support_msg: false,
-		},
-		site_id: null,
-	},
-} );
 
 export const getOdieEmailFallbackMessageContent = (): string =>
 	__(

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -79,14 +79,14 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		__i18n_text_domain__
 	) }`;
 
-export const getOdieWrongFileTypeMessage = ( name: string ): Message => ( {
+export const getOdieWrongFileTypeMessage = ( formats: string ): Message => ( {
 	content: sprintf(
 		/* translators: %s is the name of the file that is not supported */
 		__(
-			'Sorry! The file (%s) you are trying to upload is not supported. Please upload a .jpg, .png, or .gif file.',
+			"We don't support %s files at this time. Please upload a .jpg, .png, or .gif.",
 			__i18n_text_domain__
 		),
-		name
+		formats
 	),
 	role: 'bot',
 	type: 'message',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots } from './types';
 declare const __i18n_text_domain__: string;
 
@@ -79,10 +79,14 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		__i18n_text_domain__
 	) }`;
 
-export const getOdieWrongFileTypeMessage = (): Message => ( {
-	content: __(
-		'Sorry! The file you are trying to upload is not supported. Please upload a .jpg, .png, or .gif file.',
-		__i18n_text_domain__
+export const getOdieWrongFileTypeMessage = ( name: string ): Message => ( {
+	content: sprintf(
+		/* translators: %s is the name of the file that is not supported */
+		__(
+			'Sorry! The file (%s) you are trying to upload is not supported. Please upload a .jpg, .png, or .gif file.',
+			__i18n_text_domain__
+		),
+		name
 	),
 	role: 'bot',
 	type: 'message',

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@antfu/install-pkg@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@antfu/install-pkg@npm:1.1.0"
+  dependencies:
+    package-manager-detector: "npm:^1.3.0"
+    tinyexec: "npm:^1.0.1"
+  checksum: 140d5994c76fd3d0e824c88f1ce91b3370e8066a8bc2f5729ae133bf768caa239f7915e29c78f239b7ead253113ace51293e95127fafe2b786b88eb615b3be47
+  languageName: node
+  linkType: hard
+
+"@antfu/utils@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@antfu/utils@npm:9.2.0"
+  checksum: c622bd64985abee4324ddc80e11312b6e8154d648f7e80b2e0010276ca527b723ab25df4013cba344b2cd606960e42e05186013c6af79ef724ccb59acba9b893
+  languageName: node
+  linkType: hard
+
 "@ariakit/core@npm:0.4.14":
   version: 0.4.14
   resolution: "@ariakit/core@npm:0.4.14"
@@ -313,6 +330,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@automattic/agenttic-client@npm:0.1.11":
+  version: 0.1.11
+  resolution: "@automattic/agenttic-client@npm:0.1.11"
+  dependencies:
+    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
+    "@types/react": "npm:^18.0.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/element": "npm:^6.2.0"
+    "@wordpress/i18n": "npm:^6.1.0"
+    react: "npm:^18.0.0"
+    react-markdown: "npm:^10.1.0"
+    remark-gfm: "npm:^4.0.1"
+    streamdown: "npm:1.1.1"
+  peerDependencies:
+    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
+    react: ^18.0.0
+  peerDependenciesMeta:
+    "@wordpress/api-fetch":
+      optional: true
+  checksum: f5f5e9b72b72227df46e96b7f9e94c0e8e1e8f3c6b8ae093fd07b8b08b3040b715a236adf3ed74f1e3e6c8ba302d509e8531745cfa01d78de283cb34e95d24e5
+  languageName: node
+  linkType: hard
+
 "@automattic/agenttic-ui@npm:^0.1.10, @automattic/agenttic-ui@npm:^0.1.9":
   version: 0.1.10
   resolution: "@automattic/agenttic-ui@npm:0.1.10"
@@ -337,6 +377,33 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: c07a10f3d7fefa32d1aefcf21776fa315ba5f7608195c3704e0142a8da8c5a50ac6a474ccf24d032a03f3d1bee5807e34d3efe51446f60b6c628e21a9e492f5f
+  languageName: node
+  linkType: hard
+
+"@automattic/agenttic-ui@npm:^0.1.11":
+  version: 0.1.11
+  resolution: "@automattic/agenttic-ui@npm:0.1.11"
+  dependencies:
+    "@automattic/agenttic-client": "npm:0.1.11"
+    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
+    "@radix-ui/react-scroll-area": "npm:^1.2.9"
+    "@radix-ui/react-slot": "npm:^1.2.3"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/data": "npm:^10.0.0"
+    "@wordpress/element": "npm:^6.24.0"
+    "@wordpress/i18n": "npm:^6.1.0"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    framer-motion: "npm:^12.23.0"
+    lucide-react: "npm:^0.525.0"
+    react: "npm:^18.0.0"
+    react-dom: "npm:^18.0.0"
+    react-textarea-autosize: "npm:^8.5.9"
+    streamdown: "npm:1.1.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: f723d08fc10c14509d61add089b8ba770cbb8438f0ab1e7cf1725f1d8ec3e2a8b93d3dc45c461d0312fdd7ad38d798fdba217018dde92f9ef0d7d083903dc84a
   languageName: node
   linkType: hard
 
@@ -1847,7 +1914,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.10"
+    "@automattic/agenttic-ui": "npm:^0.1.11"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -1866,6 +1933,7 @@ __metadata:
     autosize: "npm:^6.0.1"
     clsx: "npm:^2.1.1"
     dompurify: "npm:^3.2.6"
+    framer-motion: "npm:^12.23.12"
     jest: "npm:^29.7.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -4292,6 +4360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:^7.0.4":
+  version: 7.1.1
+  resolution: "@braintree/sanitize-url@npm:7.1.1"
+  checksum: fdfc1759c4244e287693ce1e9d42d649423e7c203fdccf27a571f8951ddfe34baa5273b7e6a8dd3007d7676859c7a0a9819be0ab42a3505f8505ad0eefecf7c1
+  languageName: node
+  linkType: hard
+
 "@bufbuild/protobuf@npm:^2.0.0":
   version: 2.5.0
   resolution: "@bufbuild/protobuf@npm:2.5.0"
@@ -4314,6 +4389,48 @@ __metadata:
   dependencies:
     statuses: "npm:^2.0.1"
   checksum: c1a8ede3efa8da61ccda4b98e773582a9733edfbeeee569d4630785f8e018766202edb190a754a3ec7a7f6bd738e857829affc2fdb676b6dab4db1bb44e62785
+  languageName: node
+  linkType: hard
+
+"@chevrotain/cst-dts-gen@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/cst-dts-gen@npm:11.0.3"
+  dependencies:
+    "@chevrotain/gast": "npm:11.0.3"
+    "@chevrotain/types": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: 9e945a0611386e4e08af34c2d0b3af36c1af08f726b58145f11310f2aeafcb2d65264c06ec65a32df6b6a65771e6a55be70580c853afe3ceb51487e506967104
+  languageName: node
+  linkType: hard
+
+"@chevrotain/gast@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/gast@npm:11.0.3"
+  dependencies:
+    "@chevrotain/types": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: 54fc44d7b4a7b0323f49d957dd88ad44504922d30cb226d93b430b0e09925efe44e0726068581d777f423fabfb878a2238ed2c87b690c0c0014ebd12b6968354
+  languageName: node
+  linkType: hard
+
+"@chevrotain/regexp-to-ast@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/regexp-to-ast@npm:11.0.3"
+  checksum: 6939c5c94fbfb8c559a4a37a283af5ded8e6147b184a7d7bcf5ad1404d9d663c78d81602bd8ea8458ec497358a9e1671541099c511835d0be2cad46f00c62b3f
+  languageName: node
+  linkType: hard
+
+"@chevrotain/types@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/types@npm:11.0.3"
+  checksum: 72fe8f0010ebef848e47faea14a88c6fdc3cdbafaef6b13df4a18c7d33249b1b675e37b05cb90a421700c7016dae7cd4187ab6b549e176a81cea434f69cd2503
+  languageName: node
+  linkType: hard
+
+"@chevrotain/utils@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/utils@npm:11.0.3"
+  checksum: b31972d1b2d444eef1499cf9b7576fc1793e8544910de33a3c18e07c270cfad88067f175d0ee63e7bc604713ebed647f8190db45cc8311852cd2d4fe2ef14068
   languageName: node
   linkType: hard
 
@@ -6118,6 +6235,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@iconify/types@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@iconify/types@npm:2.0.0"
+  checksum: 65a3be43500c7ccacf360e136d00e1717f050b7b91da644e94370256ac66f582d59212bdb30d00788aab4fc078262e91c95b805d1808d654b72f6d2072a7e4b2
+  languageName: node
+  linkType: hard
+
+"@iconify/utils@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "@iconify/utils@npm:3.0.2"
+  dependencies:
+    "@antfu/install-pkg": "npm:^1.1.0"
+    "@antfu/utils": "npm:^9.2.0"
+    "@iconify/types": "npm:^2.0.0"
+    debug: "npm:^4.4.1"
+    globals: "npm:^15.15.0"
+    kolorist: "npm:^1.8.0"
+    local-pkg: "npm:^1.1.1"
+    mlly: "npm:^1.7.4"
+  checksum: ac9f9362b0d0143dd9861bcc64a0699f607f4f9df902aab3875b06832a89dd6a0e8ba2e1c43e927073a84661bf2882f1c79b5a3159a3cee53570d080b535c12c
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^3.0.0":
   version: 3.1.6
   resolution: "@inquirer/confirm@npm:3.1.6"
@@ -6556,6 +6696,15 @@ __metadata:
     "@types/react": ">=16"
     react: ">=16"
   checksum: 381ed1211ba2b8491bf0ad9ef0d8d1badcdd114e1931d55d44019d4b827cc2752586708f9c7d2f9c3244150ed81f1f671a6ca95fae0edd5797fb47a22e06ceca
+  languageName: node
+  linkType: hard
+
+"@mermaid-js/parser@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@mermaid-js/parser@npm:0.6.2"
+  dependencies:
+    langium: "npm:3.3.1"
+  checksum: 6059341a5dc3fdf56dd75c858843154e18c582e5cc41c3e73e9a076e218116c6bdbdba729d27154cef61430c900d87342423bbb81e37d8a9968c6c2fdd99e87a
   languageName: node
   linkType: hard
 
@@ -8628,6 +8777,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/core@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/core@npm:3.12.2"
+  dependencies:
+    "@shikijs/types": "npm:3.12.2"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+    hast-util-to-html: "npm:^9.0.5"
+  checksum: 3a05bc0a316a8a0170996ffe5dfc76021d20a459ed2c1aa5e659468a1a65af1cf0f69415535ecbd54387f4c61caf5d4b4e88b8fde21caf6af649d4178da52092
+  languageName: node
+  linkType: hard
+
+"@shikijs/engine-javascript@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/engine-javascript@npm:3.12.2"
+  dependencies:
+    "@shikijs/types": "npm:3.12.2"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    oniguruma-to-es: "npm:^4.3.3"
+  checksum: 421a3c20ab9841ffcefd776ac8c4ad7394458fa7919113b4ee5a0d97c2093dcc2299c886ea37216356972108024b5ac6b787dae26c25b42c54ae358f9feec3f0
+  languageName: node
+  linkType: hard
+
+"@shikijs/engine-oniguruma@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/engine-oniguruma@npm:3.12.2"
+  dependencies:
+    "@shikijs/types": "npm:3.12.2"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 89887dda52949f82537388000b13f9060ae1fcdd87f4b305282b97bdbb1afde0bc4abb8f4f046896164fd8b9c251923f2a4d780fac933fa214ba90fb957a9873
+  languageName: node
+  linkType: hard
+
+"@shikijs/langs@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/langs@npm:3.12.2"
+  dependencies:
+    "@shikijs/types": "npm:3.12.2"
+  checksum: 1e72b8efedb5d3959ac4d4fea5a2d5eb7855eea5cddc35e21b5090bf903d40c058214be8c1d63355ad2cffc022be8ec0297bdc6695eddc91c02324dcc417814d
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/themes@npm:3.12.2"
+  dependencies:
+    "@shikijs/types": "npm:3.12.2"
+  checksum: 728b89554a166dca87aa3a4b53d0aa2c0b2c560252036275b3e8d3b4c790cf8fc980b5e06574e4fbad223627149eff150af12db5acd599fffd71e6ff6391af18
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.12.2":
+  version: 3.12.2
+  resolution: "@shikijs/types@npm:3.12.2"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 74622ac69a84f0d7b66f6f9253bdaa0fee69b7bc97d5f85e12b2a70a9d77d2b04fdbccf65fcd9460449340a214594cb945fee8b3d2c091175e58e8cdf2cb2920
+  languageName: node
+  linkType: hard
+
+"@shikijs/vscode-textmate@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@shikijs/vscode-textmate@npm:10.0.2"
+  checksum: 36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -9941,10 +10158,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-array@npm:*":
+  version: 3.2.2
+  resolution: "@types/d3-array@npm:3.2.2"
+  checksum: 6137cb97302f8a4f18ca22c0560c585cfcb823f276b23d89f2c0c005d72697ec13bca671c08e68b4b0cabd622e3f0e91782ee221580d6774074050be96dd7028
+  languageName: node
+  linkType: hard
+
 "@types/d3-array@npm:3.0.3":
   version: 3.0.3
   resolution: "@types/d3-array@npm:3.0.3"
   checksum: 4dddae293e6e16764f8e465539548454b202a0f325f7d1cd0777690c4598bd593b1fb952501421d771204988b1a10393cf062775d2fc23851b0dec96c92eb3a4
+  languageName: node
+  linkType: hard
+
+"@types/d3-axis@npm:*":
+  version: 3.0.6
+  resolution: "@types/d3-axis@npm:3.0.6"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: d756d42360261f44d8eefd0950c5bb0a4f67a46dd92069da3f723ac36a1e8cb2b9ce6347d836ef19d5b8aef725dbcf8fdbbd6cfbff676ca4b0642df2f78b599a
+  languageName: node
+  linkType: hard
+
+"@types/d3-brush@npm:*":
+  version: 3.0.6
+  resolution: "@types/d3-brush@npm:3.0.6"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: fd6e2ac7657a354f269f6b9c58451ffae9d01b89ccb1eb6367fd36d635d2f1990967215ab498e0c0679ff269429c57fad6a2958b68f4d45bc9f81d81672edc01
+  languageName: node
+  linkType: hard
+
+"@types/d3-chord@npm:*":
+  version: 3.0.6
+  resolution: "@types/d3-chord@npm:3.0.6"
+  checksum: c5a25eb5389db01e63faec0c5c2ec7cc41c494e9b3201630b494c4e862a60f1aa83fabbc33a829e7e1403941e3c30d206c741559b14406ac2a4239cfdf4b4c17
   languageName: node
   linkType: hard
 
@@ -9962,10 +10211,80 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-contour@npm:*":
+  version: 3.0.6
+  resolution: "@types/d3-contour@npm:3.0.6"
+  dependencies:
+    "@types/d3-array": "npm:*"
+    "@types/geojson": "npm:*"
+  checksum: e7d83e94719af4576ceb5ac7f277c5806f83ba6c3631744ae391cffc3641f09dfa279470b83053cd0b2acd6784e8749c71141d05bdffa63ca58ffb5b31a0f27c
+  languageName: node
+  linkType: hard
+
+"@types/d3-delaunay@npm:*":
+  version: 6.0.4
+  resolution: "@types/d3-delaunay@npm:6.0.4"
+  checksum: d154a8864f08c4ea23ecb9bdabcef1c406a25baa8895f0cb08a0ed2799de0d360e597552532ce7086ff0cdffa8f3563f9109d18f0191459d32bb620a36939123
+  languageName: node
+  linkType: hard
+
 "@types/d3-delaunay@npm:6.0.1":
   version: 6.0.1
   resolution: "@types/d3-delaunay@npm:6.0.1"
   checksum: b03f84560a98e0d08b96095759484de6ebccc4fc137a9114795ece15898ccb67c5b0897ffe1e939658224fe387dd58090b951a2c3ff31c70ec9fe2dddc0df1f9
+  languageName: node
+  linkType: hard
+
+"@types/d3-dispatch@npm:*":
+  version: 3.0.7
+  resolution: "@types/d3-dispatch@npm:3.0.7"
+  checksum: 38c6605ebf0bf0099dfb70eafe0dd4ae8213368b40b8f930b72a909ff2e7259d2bd8a54d100bb5a44eb4b36f4f2a62dcb37f8be59613ca6b507c7a2f910b3145
+  languageName: node
+  linkType: hard
+
+"@types/d3-drag@npm:*":
+  version: 3.0.7
+  resolution: "@types/d3-drag@npm:3.0.7"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 65e29fa32a87c72d26c44b5e2df3bf15af21cd128386bcc05bcacca255927c0397d0cd7e6062aed5f0abd623490544a9d061c195f5ed9f018fe0b698d99c079d
+  languageName: node
+  linkType: hard
+
+"@types/d3-dsv@npm:*":
+  version: 3.0.7
+  resolution: "@types/d3-dsv@npm:3.0.7"
+  checksum: c0f01da862465594c8a28278b51c850af3b4239cc22b14fd1a19d7a98f93d94efa477bf59d8071beb285dca45bf614630811451e18e7c52add3a0abfee0a1871
+  languageName: node
+  linkType: hard
+
+"@types/d3-ease@npm:*":
+  version: 3.0.2
+  resolution: "@types/d3-ease@npm:3.0.2"
+  checksum: aff5a1e572a937ee9bff6465225d7ba27d5e0c976bd9eacdac2e6f10700a7cb0c9ea2597aff6b43a6ed850a3210030870238894a77ec73e309b4a9d0333f099c
+  languageName: node
+  linkType: hard
+
+"@types/d3-fetch@npm:*":
+  version: 3.0.7
+  resolution: "@types/d3-fetch@npm:3.0.7"
+  dependencies:
+    "@types/d3-dsv": "npm:*"
+  checksum: 3d147efa52a26da1a5d40d4d73e6cebaaa964463c378068062999b93ea3731b27cc429104c21ecbba98c6090e58ef13429db6399238c5e3500162fb3015697a0
+  languageName: node
+  linkType: hard
+
+"@types/d3-force@npm:*":
+  version: 3.0.10
+  resolution: "@types/d3-force@npm:3.0.10"
+  checksum: c82b459079a106b50e346c9b79b141f599f2fc4f598985a5211e72c7a2e20d35bd5dc6e91f306b323c8bfa325c02c629b1645f5243f1c6a55bd51bc85cccfa92
+  languageName: node
+  linkType: hard
+
+"@types/d3-format@npm:*":
+  version: 3.0.4
+  resolution: "@types/d3-format@npm:3.0.4"
+  checksum: 3ac1600bf9061a59a228998f7cd3f29e85cbf522997671ba18d4d84d10a2a1aff4f95aceb143fa9960501c3ec351e113fc75884e6a504ace44dc1744083035ee
   languageName: node
   linkType: hard
 
@@ -9976,12 +10295,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-geo@npm:3.1.0":
+"@types/d3-geo@npm:*, @types/d3-geo@npm:3.1.0":
   version: 3.1.0
   resolution: "@types/d3-geo@npm:3.1.0"
   dependencies:
     "@types/geojson": "npm:*"
   checksum: 3745a93439038bb5b0b38facf435f7079812921d46406f5d38deaee59e90084ff742443c7ea0a8446df81a0d81eaf622fe7068cf4117a544bd4aa3b2dc182f88
+  languageName: node
+  linkType: hard
+
+"@types/d3-hierarchy@npm:*":
+  version: 3.1.7
+  resolution: "@types/d3-hierarchy@npm:3.1.7"
+  checksum: 873711737d6b8e7b6f1dda0bcd21294a48f75024909ae510c5d2c21fad2e72032e0958def4d9f68319d3aaac298ad09c49807f8bfc87a145a82693b5208613c7
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:*":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "npm:*"
+  checksum: 066ebb8da570b518dd332df6b12ae3b1eaa0a7f4f0c702e3c57f812cf529cc3500ec2aac8dc094f31897790346c6b1ebd8cd7a077176727f4860c2b181a65ca4
   languageName: node
   linkType: hard
 
@@ -9994,10 +10329,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-path@npm:*":
+  version: 3.1.1
+  resolution: "@types/d3-path@npm:3.1.1"
+  checksum: 2c36eb31ebaf2ce4712e793fd88087117976f7c4ed69cc2431825f999c8c77cca5cea286f3326432b770739ac6ccd5d04d851eb65e7a4dbcc10c982b49ad2c02
+  languageName: node
+  linkType: hard
+
 "@types/d3-path@npm:^1, @types/d3-path@npm:^1.0.8":
   version: 1.0.11
   resolution: "@types/d3-path@npm:1.0.11"
   checksum: 3353fe6c009b1d9e32aa5442787c0a1816120f83c73d6b4ba24d5d7c51472561e664e8541ac672cdca598f8c91879be14d5f7b66fba16f7c06afa45d992c4660
+  languageName: node
+  linkType: hard
+
+"@types/d3-polygon@npm:*":
+  version: 3.0.2
+  resolution: "@types/d3-polygon@npm:3.0.2"
+  checksum: f46307bb32b6c2aef8c7624500e0f9b518de8f227ccc10170b869dc43e4c542560f6c8d62e9f087fac45e198d6e4b623e579c0422e34c85baf56717456d3f439
+  languageName: node
+  linkType: hard
+
+"@types/d3-quadtree@npm:*":
+  version: 3.0.6
+  resolution: "@types/d3-quadtree@npm:3.0.6"
+  checksum: 7eaa0a4d404adc856971c9285e1c4ab17e9135ea669d847d6db7e0066126a28ac751864e7ce99c65d526e130f56754a2e437a1617877098b3bdcc3ef23a23616
+  languageName: node
+  linkType: hard
+
+"@types/d3-random@npm:*":
+  version: 3.0.3
+  resolution: "@types/d3-random@npm:3.0.3"
+  checksum: 5f4fea40080cd6d4adfee05183d00374e73a10c530276a6455348983dda341003a251def28565a27c25d9cf5296a33e870e397c9d91ff83fb7495a21c96b6882
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale-chromatic@npm:*":
+  version: 3.1.0
+  resolution: "@types/d3-scale-chromatic@npm:3.1.0"
+  checksum: 93c564e02d2e97a048e18fe8054e4a935335da6ab75a56c3df197beaa87e69122eef0dfbeb7794d4a444a00e52e3123514ee27cec084bd21f6425b7037828cc2
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale@npm:*":
+  version: 4.0.9
+  resolution: "@types/d3-scale@npm:4.0.9"
+  dependencies:
+    "@types/d3-time": "npm:*"
+  checksum: 4ac44233c05cd50b65b33ecb35d99fdf07566bcdbc55bc1306b2f27d1c5134d8c560d356f2c8e76b096e9125ffb8d26d95f78d56e210d1c542cb255bdf31d6c8
   languageName: node
   linkType: hard
 
@@ -10010,12 +10389,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-selection@npm:*":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 0c512956c7503ff5def4bb32e0c568cc757b9a2cc400a104fc0f4cfe5e56d83ebde2a97821b6f2cb26a7148079d3b86a2f28e11d68324ed311cf35c2ed980d1d
+  languageName: node
+  linkType: hard
+
+"@types/d3-shape@npm:*":
+  version: 3.1.7
+  resolution: "@types/d3-shape@npm:3.1.7"
+  dependencies:
+    "@types/d3-path": "npm:*"
+  checksum: 38e59771c1c4c83b67aa1f941ce350410522a149d2175832fdc06396b2bb3b2c1a2dd549e0f8230f9f24296ee5641a515eaf10f55ee1ef6c4f83749e2dd7dcfd
+  languageName: node
+  linkType: hard
+
 "@types/d3-shape@npm:^1.3.1":
   version: 1.3.12
   resolution: "@types/d3-shape@npm:1.3.12"
   dependencies:
     "@types/d3-path": "npm:^1"
   checksum: e4aa0a0bc200d5a50d7f699da0e848a01b37447e92ecc3484eefbed7fcd2bd90dc0adc7e2b7e437f484f69ee91f3ff57c6f97a9853c5467ac53d3c37e78fbac7
+  languageName: node
+  linkType: hard
+
+"@types/d3-time-format@npm:*":
+  version: 4.0.3
+  resolution: "@types/d3-time-format@npm:4.0.3"
+  checksum: 9ef5e8e2b96b94799b821eed5d61a3d432c7903247966d8ad951b8ce5797fe46554b425cb7888fa5bf604b4663c369d7628c0328ffe80892156671c58d1a7f90
   languageName: node
   linkType: hard
 
@@ -10040,10 +10442,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-timer@npm:*":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: c644dd9571fcc62b1aa12c03bcad40571553020feeb5811f1d8a937ac1e65b8a04b759b4873aef610e28b8714ac71c9885a4d6c127a048d95118f7e5b506d9e1
+  languageName: node
+  linkType: hard
+
+"@types/d3-transition@npm:*":
+  version: 3.0.9
+  resolution: "@types/d3-transition@npm:3.0.9"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 4f68b9df7ac745b3491216c54203cbbfa0f117ae4c60e2609cdef2db963582152035407fdff995b10ee383bae2f05b7743493f48e1b8e46df54faa836a8fb7b5
+  languageName: node
+  linkType: hard
+
 "@types/d3-voronoi@npm:^1.1.9":
   version: 1.1.12
   resolution: "@types/d3-voronoi@npm:1.1.12"
   checksum: 9cb1d88400ba442edd27b93a0e80bf6c4e88ab1e6ced4a9761b232e26f565c42753f4aa25ca0f9f773f1d13dae1ed10b3282b48b3fe078f3a7a25706f3a482e1
+  languageName: node
+  linkType: hard
+
+"@types/d3-zoom@npm:*":
+  version: 3.0.8
+  resolution: "@types/d3-zoom@npm:3.0.8"
+  dependencies:
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-selection": "npm:*"
+  checksum: 1dbdbcafddcae12efb5beb6948546963f29599e18bc7f2a91fb69cc617c2299a65354f2d47e282dfb86fec0968406cd4fb7f76ba2d2fb67baa8e8d146eb4a547
+  languageName: node
+  linkType: hard
+
+"@types/d3@npm:^7.4.3":
+  version: 7.4.3
+  resolution: "@types/d3@npm:7.4.3"
+  dependencies:
+    "@types/d3-array": "npm:*"
+    "@types/d3-axis": "npm:*"
+    "@types/d3-brush": "npm:*"
+    "@types/d3-chord": "npm:*"
+    "@types/d3-color": "npm:*"
+    "@types/d3-contour": "npm:*"
+    "@types/d3-delaunay": "npm:*"
+    "@types/d3-dispatch": "npm:*"
+    "@types/d3-drag": "npm:*"
+    "@types/d3-dsv": "npm:*"
+    "@types/d3-ease": "npm:*"
+    "@types/d3-fetch": "npm:*"
+    "@types/d3-force": "npm:*"
+    "@types/d3-format": "npm:*"
+    "@types/d3-geo": "npm:*"
+    "@types/d3-hierarchy": "npm:*"
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-path": "npm:*"
+    "@types/d3-polygon": "npm:*"
+    "@types/d3-quadtree": "npm:*"
+    "@types/d3-random": "npm:*"
+    "@types/d3-scale": "npm:*"
+    "@types/d3-scale-chromatic": "npm:*"
+    "@types/d3-selection": "npm:*"
+    "@types/d3-shape": "npm:*"
+    "@types/d3-time": "npm:*"
+    "@types/d3-time-format": "npm:*"
+    "@types/d3-timer": "npm:*"
+    "@types/d3-transition": "npm:*"
+    "@types/d3-zoom": "npm:*"
+  checksum: a9c6d65b13ef3b42c87f2a89ea63a6d5640221869f97d0657b0cb2f1dac96a0f164bf5605643c0794e0de3aa2bf05df198519aaf15d24ca135eb0e8bd8a9d879
   languageName: node
   linkType: hard
 
@@ -10244,7 +10710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hast@npm:^3.0.0":
+"@types/hast@npm:^3.0.0, @types/hast@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/hast@npm:3.0.4"
   dependencies:
@@ -10382,6 +10848,13 @@ __metadata:
     "@types/ms": "npm:*"
     "@types/node": "npm:*"
   checksum: d754a7b65fc021b298fc94e8d7a7d71f35dedf24296ac89286f80290abc5dbb0c7830a21440ee9ecbb340efc1b0a21f5609ea298a35b874cae5ad29a65440741
+  languageName: node
+  linkType: hard
+
+"@types/katex@npm:^0.16.0":
+  version: 0.16.7
+  resolution: "@types/katex@npm:0.16.7"
+  checksum: 68dcb9f68a90513ec78ca0196a142e15c2a2c270b1520d752bafd47a99207115085a64087b50140359017d7e9c870b3c68e7e4d36668c9e348a9ef0c48919b5a
   languageName: node
   linkType: hard
 
@@ -15780,6 +16253,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chevrotain-allstar@npm:~0.3.0":
+  version: 0.3.1
+  resolution: "chevrotain-allstar@npm:0.3.1"
+  dependencies:
+    lodash-es: "npm:^4.17.21"
+  peerDependencies:
+    chevrotain: ^11.0.0
+  checksum: 5cadedffd3114eb06b15fd3939bb1aa6c75412dbd737fe302b52c5c24334f9cb01cee8edc1d1067d98ba80dddf971f1d0e94b387de51423fc6cf3c5d8b7ef27a
+  languageName: node
+  linkType: hard
+
+"chevrotain@npm:~11.0.3":
+  version: 11.0.3
+  resolution: "chevrotain@npm:11.0.3"
+  dependencies:
+    "@chevrotain/cst-dts-gen": "npm:11.0.3"
+    "@chevrotain/gast": "npm:11.0.3"
+    "@chevrotain/regexp-to-ast": "npm:11.0.3"
+    "@chevrotain/types": "npm:11.0.3"
+    "@chevrotain/utils": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: ffd425fa321e3f17e9833d7f44cd39f2743f066e92ca74b226176080ca5d455f853fe9091cdfd86354bd899d85c08b3bdc3f55b267e7d07124b048a88349765f
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.3.0, chokidar@npm:^3.3.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
@@ -16320,6 +16818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:7, commander@npm:^7.0.0, commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: 8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+  languageName: node
+  linkType: hard
+
 "commander@npm:^10.0.0":
   version: 10.0.1
   resolution: "commander@npm:10.0.1"
@@ -16352,13 +16857,6 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
-  languageName: node
-  linkType: hard
-
-"commander@npm:^7.0.0, commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
   languageName: node
   linkType: hard
 
@@ -16535,6 +17033,13 @@ __metadata:
   version: 0.1.8
   resolution: "confbox@npm:0.1.8"
   checksum: fc2c68d97cb54d885b10b63e45bd8da83a8a71459d3ecf1825143dd4c7f9f1b696b3283e07d9d12a144c1301c2ebc7842380bdf0014e55acc4ae1c9550102418
+  languageName: node
+  linkType: hard
+
+"confbox@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "confbox@npm:0.2.2"
+  checksum: 7c246588d533d31e8cdf66cb4701dff6de60f9be77ab54c0d0338e7988750ac56863cc0aca1b3f2046f45ff223a765d3e5d4977a7674485afcd37b6edf3fd129
   languageName: node
   linkType: hard
 
@@ -16794,6 +17299,24 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 980a37a93956d0de8a828ce508f9b9e3317039d68922ca79995421944146700e4aaf490a6dbfebcb1c5292a7184600c7710b957d724be1e37b8254c6bc0fe246
+  languageName: node
+  linkType: hard
+
+"cose-base@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "cose-base@npm:1.0.3"
+  dependencies:
+    layout-base: "npm:^1.0.0"
+  checksum: a6e400b1d101393d6af0967c1353355777c1106c40417c5acaef6ca8bdda41e2fc9398f466d6c85be30290943ad631f2590569f67b3fd5368a0d8318946bd24f
+  languageName: node
+  linkType: hard
+
+"cose-base@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "cose-base@npm:2.2.0"
+  dependencies:
+    layout-base: "npm:^2.0.0"
+  checksum: 14b9f8100ac322a00777ffb1daeb3321af368bbc9cabe3103943361273baee2003202ffe38e4ab770960b600214224e9c196195a78d589521540aa694df7cdec
   languageName: node
   linkType: hard
 
@@ -17560,6 +18083,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cytoscape-cose-bilkent@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cytoscape-cose-bilkent@npm:4.1.0"
+  dependencies:
+    cose-base: "npm:^1.0.0"
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: 5e2480ddba9da1a68e700ed2c674cbfd51e9efdbd55788f1971a68de4eb30708e3b3a5e808bf5628f7a258680406bbe6586d87a9133e02a9bdc1ab1a92f512f2
+  languageName: node
+  linkType: hard
+
+"cytoscape-fcose@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "cytoscape-fcose@npm:2.2.0"
+  dependencies:
+    cose-base: "npm:^2.2.0"
+  peerDependencies:
+    cytoscape: ^3.2.0
+  checksum: ce472c9f85b9057e75c5685396f8e1f2468895e71b184913e05ad56dcf3092618fe59a1054f29cb0995051ba8ebe566ad0dd49a58d62845145624bd60cd44917
+  languageName: node
+  linkType: hard
+
+"cytoscape@npm:^3.29.3":
+  version: 3.33.1
+  resolution: "cytoscape@npm:3.33.1"
+  checksum: dffcf5f74df4d91517c4faf394df880d8283ce76edef19edba0c762941cf4f18daf7c4c955ec50c794f476ace39ad4394f8c98483222bd2682e1fd206e976411
+  languageName: node
+  linkType: hard
+
+"d3-array@npm:1 - 2":
+  version: 2.12.1
+  resolution: "d3-array@npm:2.12.1"
+  dependencies:
+    internmap: "npm:^1.0.0"
+  checksum: 7eca10427a9f113a4ca6a0f7301127cab26043fd5e362631ef5a0edd1c4b2dd70c56ed317566700c31e4a6d88b55f3951aaba192291817f243b730cb2352882e
+  languageName: node
+  linkType: hard
+
 "d3-array@npm:1.2.0 - 2, d3-array@npm:^2.4.0":
   version: 2.4.0
   resolution: "d3-array@npm:2.4.0"
@@ -17567,7 +18128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.2.0":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
   dependencies:
@@ -17585,10 +18146,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-axis@npm:3":
+  version: 3.0.0
+  resolution: "d3-axis@npm:3.0.0"
+  checksum: a271e70ba1966daa5aaf6a7f959ceca3e12997b43297e757c7b945db2e1ead3c6ee226f2abcfa22abbd4e2e28bd2b71a0911794c4e5b911bbba271328a582c78
+  languageName: node
+  linkType: hard
+
 "d3-axis@npm:^1.0.12":
   version: 1.0.12
   resolution: "d3-axis@npm:1.0.12"
   checksum: e42d089bd5707f8384acbdfa47246630885d2d02ac5650f5570881c50a0f2983aef4105e2e4063b960939ad61af389c3f84cbf9140c97b3beabae1d193ccfa2a
+  languageName: node
+  linkType: hard
+
+"d3-brush@npm:3":
+  version: 3.0.0
+  resolution: "d3-brush@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-drag: "npm:2 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-selection: "npm:3"
+    d3-transition: "npm:3"
+  checksum: 07baf00334c576da2f68a91fc0da5732c3a5fa19bd3d7aed7fd24d1d674a773f71a93e9687c154176f7246946194d77c48c2d8fed757f5dcb1a4740067ec50a8
+  languageName: node
+  linkType: hard
+
+"d3-chord@npm:3":
+  version: 3.0.1
+  resolution: "d3-chord@npm:3.0.1"
+  dependencies:
+    d3-path: "npm:1 - 3"
+  checksum: baa6013914af3f4fe1521f0d16de31a38eb8a71d08ff1dec4741f6f45a828661e5cd3935e39bd14e3032bdc78206c283ca37411da21d46ec3cfc520be6e7a7ce
   languageName: node
   linkType: hard
 
@@ -17599,10 +18189,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-color@npm:1 - 3, d3-color@npm:3.1.0":
+"d3-color@npm:1 - 3, d3-color@npm:3, d3-color@npm:3.1.0":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
   checksum: a4e20e1115fa696fce041fbe13fbc80dc4c19150fa72027a7c128ade980bc0eeeba4bcf28c9e21f0bce0e0dbfe7ca5869ef67746541dcfda053e4802ad19783c
+  languageName: node
+  linkType: hard
+
+"d3-contour@npm:4":
+  version: 4.0.2
+  resolution: "d3-contour@npm:4.0.2"
+  dependencies:
+    d3-array: "npm:^3.2.0"
+  checksum: 98bc5fbed6009e08707434a952076f39f1cd6ed8b9288253cc3e6a3286e4e80c63c62d84954b20e64bf6e4ededcc69add54d3db25e990784a59c04edd3449032
+  languageName: node
+  linkType: hard
+
+"d3-delaunay@npm:6":
+  version: 6.0.4
+  resolution: "d3-delaunay@npm:6.0.4"
+  dependencies:
+    delaunator: "npm:5"
+  checksum: 57c3aecd2525664b07c4c292aa11cf49b2752c0cf3f5257f752999399fe3c592de2d418644d79df1f255471eec8057a9cc0c3062ed7128cb3348c45f69597754
   languageName: node
   linkType: hard
 
@@ -17615,6 +18223,71 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-dispatch@npm:1 - 3, d3-dispatch@npm:3":
+  version: 3.0.1
+  resolution: "d3-dispatch@npm:3.0.1"
+  checksum: 6eca77008ce2dc33380e45d4410c67d150941df7ab45b91d116dbe6d0a3092c0f6ac184dd4602c796dc9e790222bad3ff7142025f5fd22694efe088d1d941753
+  languageName: node
+  linkType: hard
+
+"d3-drag@npm:2 - 3, d3-drag@npm:3":
+  version: 3.0.0
+  resolution: "d3-drag@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-selection: "npm:3"
+  checksum: d2556e8dc720741a443b595a30af403dd60642dfd938d44d6e9bfc4c71a962142f9a028c56b61f8b4790b65a34acad177d1263d66f103c3c527767b0926ef5aa
+  languageName: node
+  linkType: hard
+
+"d3-dsv@npm:1 - 3, d3-dsv@npm:3":
+  version: 3.0.1
+  resolution: "d3-dsv@npm:3.0.1"
+  dependencies:
+    commander: "npm:7"
+    iconv-lite: "npm:0.6"
+    rw: "npm:1"
+  bin:
+    csv2json: bin/dsv2json.js
+    csv2tsv: bin/dsv2dsv.js
+    dsv2dsv: bin/dsv2dsv.js
+    dsv2json: bin/dsv2json.js
+    json2csv: bin/json2dsv.js
+    json2dsv: bin/json2dsv.js
+    json2tsv: bin/json2dsv.js
+    tsv2csv: bin/dsv2dsv.js
+    tsv2json: bin/dsv2json.js
+  checksum: 10e6af9e331950ed258f34ab49ac1b7060128ef81dcf32afc790bd1f7e8c3cc2aac7f5f875250a83f21f39bb5925fbd0872bb209f8aca32b3b77d32bab8a65ab
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:1 - 3, d3-ease@npm:3":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: fec8ef826c0cc35cda3092c6841e07672868b1839fcaf556e19266a3a37e6bc7977d8298c0fcb9885e7799bfdcef7db1baaba9cd4dcf4bc5e952cf78574a88b0
+  languageName: node
+  linkType: hard
+
+"d3-fetch@npm:3":
+  version: 3.0.1
+  resolution: "d3-fetch@npm:3.0.1"
+  dependencies:
+    d3-dsv: "npm:1 - 3"
+  checksum: 4f467a79bf290395ac0cbb5f7562483f6a18668adc4c8eb84c9d3eff048b6f6d3b6f55079ba1ebf1908dabe000c941d46be447f8d78453b2dad5fb59fb6aa93b
+  languageName: node
+  linkType: hard
+
+"d3-force@npm:3":
+  version: 3.0.0
+  resolution: "d3-force@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-quadtree: "npm:1 - 3"
+    d3-timer: "npm:1 - 3"
+  checksum: 220a16a1a1ac62ba56df61028896e4b52be89c81040d20229c876efc8852191482c233f8a52bb5a4e0875c321b8e5cb6413ef3dfa4d8fe79eeb7d52c587f52cf
+  languageName: node
+  linkType: hard
+
 "d3-format@npm:1":
   version: 1.4.3
   resolution: "d3-format@npm:1.4.3"
@@ -17622,10 +18295,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-format@npm:1 - 3, d3-format@npm:3.1.0":
+"d3-format@npm:1 - 3, d3-format@npm:3, d3-format@npm:3.1.0":
   version: 3.1.0
   resolution: "d3-format@npm:3.1.0"
   checksum: 049f5c0871ebce9859fc5e2f07f336b3c5bfff52a2540e0bac7e703fce567cd9346f4ad1079dd18d6f1e0eaa0599941c1810898926f10ac21a31fd0a34b4aa75
+  languageName: node
+  linkType: hard
+
+"d3-geo@npm:3":
+  version: 3.1.1
+  resolution: "d3-geo@npm:3.1.1"
+  dependencies:
+    d3-array: "npm:2.5.0 - 3"
+  checksum: d32270dd2dc8ac3ea63e8805d63239c4c8ec6c0d339d73b5e5a30a87f8f54db22a78fb434369799465eae169503b25f9a107c642c8a16c32a3285bc0e6d8e8c1
   languageName: node
   linkType: hard
 
@@ -17638,6 +18320,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-hierarchy@npm:3":
+  version: 3.1.2
+  resolution: "d3-hierarchy@npm:3.1.2"
+  checksum: 6dcdb480539644aa7fc0d72dfc7b03f99dfbcdf02714044e8c708577e0d5981deb9d3e99bbbb2d26422b55bcc342ac89a0fa2ea6c9d7302e2fc0951dd96f89cf
+  languageName: node
+  linkType: hard
+
 "d3-interpolate-path@npm:2.2.1":
   version: 2.2.1
   resolution: "d3-interpolate-path@npm:2.2.1"
@@ -17645,7 +18334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3.0.1":
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3, d3-interpolate@npm:3.0.1":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:
@@ -17670,6 +18359,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-path@npm:1 - 3, d3-path@npm:3, d3-path@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-path@npm:3.1.0"
+  checksum: dc1d58ec87fa8319bd240cf7689995111a124b141428354e9637aa83059eb12e681f77187e0ada5dedfce346f7e3d1f903467ceb41b379bfd01cd8e31721f5da
+  languageName: node
+  linkType: hard
+
 "d3-path@npm:1, d3-path@npm:^1.0.5":
   version: 1.0.9
   resolution: "d3-path@npm:1.0.9"
@@ -17677,7 +18373,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-scale@npm:4.0.2":
+"d3-polygon@npm:3":
+  version: 3.0.1
+  resolution: "d3-polygon@npm:3.0.1"
+  checksum: e236aa7f33efa9a4072907af7dc119f85b150a0716759d4fe5f12f62573018264a6cbde8617fbfa6944a7ae48c1c0c8d3f39ae72e11f66dd471e9b5e668385df
+  languageName: node
+  linkType: hard
+
+"d3-quadtree@npm:1 - 3, d3-quadtree@npm:3":
+  version: 3.0.1
+  resolution: "d3-quadtree@npm:3.0.1"
+  checksum: 18302d2548bfecaef788152397edec95a76400fd97d9d7f42a089ceb68d910f685c96579d74e3712d57477ed042b056881b47cd836a521de683c66f47ce89090
+  languageName: node
+  linkType: hard
+
+"d3-random@npm:3":
+  version: 3.0.1
+  resolution: "d3-random@npm:3.0.1"
+  checksum: 987a1a1bcbf26e6cf01fd89d5a265b463b2cea93560fc17d9b1c45e8ed6ff2db5924601bcceb808de24c94133f000039eb7fa1c469a7a844ccbf1170cbb25b41
+  languageName: node
+  linkType: hard
+
+"d3-sankey@npm:^0.12.3":
+  version: 0.12.3
+  resolution: "d3-sankey@npm:0.12.3"
+  dependencies:
+    d3-array: "npm:1 - 2"
+    d3-shape: "npm:^1.2.0"
+  checksum: 261debb01a13269f6fc53b9ebaef174a015d5ad646242c23995bf514498829ab8b8f920a7873724a7494288b46bea3ce7ebc5a920b745bc8ae4caa5885cf5204
+  languageName: node
+  linkType: hard
+
+"d3-scale-chromatic@npm:3":
+  version: 3.1.0
+  resolution: "d3-scale-chromatic@npm:3.1.0"
+  dependencies:
+    d3-color: "npm:1 - 3"
+    d3-interpolate: "npm:1 - 3"
+  checksum: 9a3f4671ab0b971f4a411b42180d7cf92bfe8e8584e637ce7e698d705e18d6d38efbd20ec64f60cc0dfe966c20d40fc172565bc28aaa2990c0a006360eed91af
+  languageName: node
+  linkType: hard
+
+"d3-scale@npm:4, d3-scale@npm:4.0.2":
   version: 4.0.2
   resolution: "d3-scale@npm:4.0.2"
   dependencies:
@@ -17703,10 +18440,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-selection@npm:2 - 3, d3-selection@npm:3":
+  version: 3.0.0
+  resolution: "d3-selection@npm:3.0.0"
+  checksum: e59096bbe8f0cb0daa1001d9bdd6dbc93a688019abc97d1d8b37f85cd3c286a6875b22adea0931b0c88410d025563e1643019161a883c516acf50c190a11b56b
+  languageName: node
+  linkType: hard
+
 "d3-selection@npm:^1.4.2":
   version: 1.4.2
   resolution: "d3-selection@npm:1.4.2"
   checksum: e755b6b62d794d0b968cc6264f37109e425de0d9fd306ce94414b07e46a2c6830d21c1fe0821a660d07e82069b6fe3b67da1b3b909e8f6af8f16f020cd25cae0
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:3":
+  version: 3.2.0
+  resolution: "d3-shape@npm:3.2.0"
+  dependencies:
+    d3-path: "npm:^3.1.0"
+  checksum: f1c9d1f09926daaf6f6193ae3b4c4b5521e81da7d8902d24b38694517c7f527ce3c9a77a9d3a5722ad1e3ff355860b014557b450023d66a944eabf8cfde37132
   languageName: node
   linkType: hard
 
@@ -17737,7 +18490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time-format@npm:2 - 4, d3-time-format@npm:4.1.0, d3-time-format@npm:^4.1.0":
+"d3-time-format@npm:2 - 4, d3-time-format@npm:4, d3-time-format@npm:4.1.0, d3-time-format@npm:^4.1.0":
   version: 4.1.0
   resolution: "d3-time-format@npm:4.1.0"
   dependencies:
@@ -17753,7 +18506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3.1.0":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3, d3-time@npm:3.1.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -17762,10 +18515,93 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-timer@npm:1 - 3, d3-timer@npm:3":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: d4c63cb4bb5461d7038aac561b097cd1c5673969b27cbdd0e87fa48d9300a538b9e6f39b4a7f0e3592ef4f963d858c8a9f0e92754db73116770856f2fc04561a
+  languageName: node
+  linkType: hard
+
+"d3-transition@npm:2 - 3, d3-transition@npm:3":
+  version: 3.0.1
+  resolution: "d3-transition@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+    d3-dispatch: "npm:1 - 3"
+    d3-ease: "npm:1 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-timer: "npm:1 - 3"
+  peerDependencies:
+    d3-selection: 2 - 3
+  checksum: 4e74535dda7024aa43e141635b7522bb70cf9d3dfefed975eb643b36b864762eca67f88fafc2ca798174f83ca7c8a65e892624f824b3f65b8145c6a1a88dbbad
+  languageName: node
+  linkType: hard
+
 "d3-voronoi@npm:^1.1.2":
   version: 1.1.4
   resolution: "d3-voronoi@npm:1.1.4"
   checksum: 9fd4689323a8eed547dde44e9cae0b3e6a7333447cf37b069e278b8e899fc16e0251d099fe22d751c900a3a0b7a610a16e747224219538758afaf4561749047a
+  languageName: node
+  linkType: hard
+
+"d3-zoom@npm:3":
+  version: 3.0.0
+  resolution: "d3-zoom@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-drag: "npm:2 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-selection: "npm:2 - 3"
+    d3-transition: "npm:2 - 3"
+  checksum: ee2036479049e70d8c783d594c444fe00e398246048e3f11a59755cd0e21de62ece3126181b0d7a31bf37bcf32fd726f83ae7dea4495ff86ec7736ce5ad36fd3
+  languageName: node
+  linkType: hard
+
+"d3@npm:^7.9.0":
+  version: 7.9.0
+  resolution: "d3@npm:7.9.0"
+  dependencies:
+    d3-array: "npm:3"
+    d3-axis: "npm:3"
+    d3-brush: "npm:3"
+    d3-chord: "npm:3"
+    d3-color: "npm:3"
+    d3-contour: "npm:4"
+    d3-delaunay: "npm:6"
+    d3-dispatch: "npm:3"
+    d3-drag: "npm:3"
+    d3-dsv: "npm:3"
+    d3-ease: "npm:3"
+    d3-fetch: "npm:3"
+    d3-force: "npm:3"
+    d3-format: "npm:3"
+    d3-geo: "npm:3"
+    d3-hierarchy: "npm:3"
+    d3-interpolate: "npm:3"
+    d3-path: "npm:3"
+    d3-polygon: "npm:3"
+    d3-quadtree: "npm:3"
+    d3-random: "npm:3"
+    d3-scale: "npm:4"
+    d3-scale-chromatic: "npm:3"
+    d3-selection: "npm:3"
+    d3-shape: "npm:3"
+    d3-time: "npm:3"
+    d3-time-format: "npm:4"
+    d3-timer: "npm:3"
+    d3-transition: "npm:3"
+    d3-zoom: "npm:3"
+  checksum: 3dd9c08c73cfaa69c70c49e603c85e049c3904664d9c79a1a52a0f52795828a1ff23592dc9a7b2257e711d68a615472a13103c212032f38e016d609796e087e8
+  languageName: node
+  linkType: hard
+
+"dagre-d3-es@npm:7.0.11":
+  version: 7.0.11
+  resolution: "dagre-d3-es@npm:7.0.11"
+  dependencies:
+    d3: "npm:^7.9.0"
+    lodash-es: "npm:^4.17.21"
+  checksum: 52f88bdfeca0d8554bee0c1419377585355b4ef179e5fedd3bac75f772745ecb789f6d7ea377a17566506bc8f151bc0dfe02a5175207a547975f335cd88c726c
   languageName: node
   linkType: hard
 
@@ -17854,6 +18690,13 @@ __metadata:
   version: 1.10.7
   resolution: "dayjs@npm:1.10.7"
   checksum: 2ce908776ea5b383dba2c01c72290ff12ad97cafa81b9c72a9cc4f801d736d592f20bd992ea1dff083ab80e807080b5af21f634bb09e67f89f66582a9059053a
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.13":
+  version: 1.11.18
+  resolution: "dayjs@npm:1.11.18"
+  checksum: 83b67f5d977e2634edf4f5abdd91d9041a696943143638063016915d2cd8c7e57e0751e40379a07ebca8be7a48dd380bef8752d22a63670f2d15970e34f96d7a
   languageName: node
   linkType: hard
 
@@ -18515,7 +19358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.6":
+"dompurify@npm:^3.2.5, dompurify@npm:^3.2.6":
   version: 3.2.6
   resolution: "dompurify@npm:3.2.6"
   dependencies:
@@ -20271,6 +21114,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exsolve@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "exsolve@npm:1.0.7"
+  checksum: 4479369d0bd84bb7e0b4f5d9bc18d26a89b6dbbbccd73f9d383d14892ef78ddbe159e01781055342f83dc00ebe90044036daf17ddf55cc21e2cac6609aa15631
+  languageName: node
+  linkType: hard
+
 "extend-shallow@npm:^2.0.1":
   version: 2.0.1
   resolution: "extend-shallow@npm:2.0.1"
@@ -21035,7 +21885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^12.23.0":
+"framer-motion@npm:^12.23.0, framer-motion@npm:^12.23.12":
   version: 12.23.12
   resolution: "framer-motion@npm:12.23.12"
   dependencies:
@@ -21615,6 +22465,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globals@npm:^15.15.0":
+  version: 15.15.0
+  resolution: "globals@npm:15.15.0"
+  checksum: f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
+  languageName: node
+  linkType: hard
+
 "globalthis@npm:^1.0.1, globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
@@ -21849,6 +22706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hachure-fill@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "hachure-fill@npm:0.5.2"
+  checksum: 307e3b6f9f2d3c11a82099c3f71eecbb9c440c00c1f896ac1732c23e6dbff16a92bb893d222b8b721b89cf11e58649ca60b4c24e5663f705f877cefd40153429
+  languageName: node
+  linkType: hard
+
 "handle-thing@npm:^2.0.0":
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
@@ -21933,6 +22797,16 @@ __metadata:
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
   checksum: febc3343a1ad575aedcc112580835b44a89a89e01f400b4eda6e8110869edfdab0b00cd1bd4c3bfec9475a57e79e0b355aecd5be46454b6a62b9a359af60e564
+  languageName: node
+  linkType: hard
+
+"harden-react-markdown@npm:^1.0.4":
+  version: 1.0.5
+  resolution: "harden-react-markdown@npm:1.0.5"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-markdown: ">=9.0.0"
+  checksum: c47035dcb4f80950cc7b7b2e8d4f161ae871a2d2c5b2a7f469179620d8b806476370dc68ddb2cfaa5612663c07d05b2577fc692493e5571d2a2d6835fa2c1198
   languageName: node
   linkType: hard
 
@@ -22031,6 +22905,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-dom@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "hast-util-from-dom@npm:5.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hastscript: "npm:^9.0.0"
+    web-namespaces: "npm:^2.0.0"
+  checksum: 9a90381e048107a093a3da758bb17b67aaf5322e222f02497f841c4990abf94aa177d38d5b9bf61ad07b3601d0409f34f5b556d89578cc189230c6b994d2af77
+  languageName: node
+  linkType: hard
+
+"hast-util-from-html-isomorphic@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "hast-util-from-html-isomorphic@npm:2.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-from-dom: "npm:^5.0.0"
+    hast-util-from-html: "npm:^2.0.0"
+    unist-util-remove-position: "npm:^5.0.0"
+  checksum: fc68d9245e794483a802d5c85a9f6c25959e00db78cc796411efc965134f3206f9cc9fa38134572ea781ad74663e801f1f83202007b208e27a770855566a62b6
+  languageName: node
+  linkType: hard
+
+"hast-util-from-html@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "hast-util-from-html@npm:2.0.3"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    devlop: "npm:^1.1.0"
+    hast-util-from-parse5: "npm:^8.0.0"
+    parse5: "npm:^7.0.0"
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 993ef707c1a12474c8d4094fc9706a72826c660a7e308ea54c50ad893353d32e139b7cbc67510c2e82feac572b320e3b05aeb13d0f9c6302d61261f337b46764
+  languageName: node
+  linkType: hard
+
 "hast-util-from-parse5@npm:^8.0.0":
   version: 8.0.3
   resolution: "hast-util-from-parse5@npm:8.0.3"
@@ -22044,6 +22955,15 @@ __metadata:
     vfile-location: "npm:^5.0.0"
     web-namespaces: "npm:^2.0.0"
   checksum: 40ace6c0ad43c26f721c7499fe408e639cde917b2350c9299635e6326559855896dae3c3ebf7440df54766b96c4276a7823e8f376a2b6a28b37b591f03412545
+  languageName: node
+  linkType: hard
+
+"hast-util-is-element@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-is-element@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: f5361e4c9859c587ca8eb0d8343492f3077ccaa0f58a44cd09f35d5038f94d65152288dcd0c19336ef2c9491ec4d4e45fde2176b05293437021570aa0bc3613b
   languageName: node
   linkType: hard
 
@@ -22101,6 +23021,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-html@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "hast-util-to-html@npm:9.0.5"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    ccount: "npm:^2.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    hast-util-whitespace: "npm:^3.0.0"
+    html-void-elements: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    property-information: "npm:^7.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    stringify-entities: "npm:^4.0.0"
+    zwitch: "npm:^2.0.4"
+  checksum: b7a08c30bab4371fc9b4a620965c40b270e5ae7a8e94cf885f43b21705179e28c8e43b39c72885d1647965fb3738654e6962eb8b58b0c2a84271655b4d748836
+  languageName: node
+  linkType: hard
+
 "hast-util-to-jsx-runtime@npm:^2.0.0":
   version: 2.3.0
   resolution: "hast-util-to-jsx-runtime@npm:2.3.0"
@@ -22136,6 +23075,18 @@ __metadata:
     web-namespaces: "npm:^2.0.0"
     zwitch: "npm:^2.0.0"
   checksum: 3c0c7fba026e0c4be4675daf7277f9ff22ae6da801435f1b7104f7740de5422576f1c025023c7b3df1d0a161e13a04c6ab8f98ada96eb50adb287b537849a2bd
+  languageName: node
+  linkType: hard
+
+"hast-util-to-text@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "hast-util-to-text@npm:4.0.2"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    hast-util-is-element: "npm:^3.0.0"
+    unist-util-find-after: "npm:^5.0.0"
+  checksum: 93ecc10e68fe5391c6e634140eb330942e71dea2724c8e0c647c73ed74a8ec930a4b77043b5081284808c96f73f2bee64ee416038ece75a63a467e8d14f09946
   languageName: node
   linkType: hard
 
@@ -22714,7 +23665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6, iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -23031,6 +23982,13 @@ __metadata:
   version: 2.0.3
   resolution: "internmap@npm:2.0.3"
   checksum: 8cedd57f07bbc22501516fbfc70447f0c6812871d471096fad9ea603516eacc2137b633633daf432c029712df0baefd793686388ddf5737e3ea15074b877f7ed
+  languageName: node
+  linkType: hard
+
+"internmap@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "internmap@npm:1.0.1"
+  checksum: 60942be815ca19da643b6d4f23bd0bf4e8c97abbd080fb963fe67583b60bdfb3530448ad4486bae40810e92317bded9995cc31411218acc750d72cd4e8646eee
   languageName: node
   linkType: hard
 
@@ -24909,6 +25867,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"katex@npm:^0.16.0, katex@npm:^0.16.22":
+  version: 0.16.22
+  resolution: "katex@npm:0.16.22"
+  dependencies:
+    commander: "npm:^8.3.0"
+  bin:
+    katex: cli.js
+  checksum: 07b8b1f07ae53171b5f1ea0cf6f18841d2055825c8b11cd81cfe039afcd3af2cfc84ad033531ee3875088329105195b039c267e0dd4b0c237807e3c3b2009913
+  languageName: node
+  linkType: hard
+
 "kebab-case@npm:^1.0.0":
   version: 1.0.0
   resolution: "kebab-case@npm:1.0.0"
@@ -24940,6 +25909,13 @@ __metadata:
   dependencies:
     "@keyv/serialize": "npm:^1.0.3"
   checksum: d5ffe3d2d547a50a5e1189d5acbc0480821c22c025082851a8eeb26667d789f3f7b7ee7beb933660d98c239f7e7c403c652a511693670a78a73f06cd411e04fa
+  languageName: node
+  linkType: hard
+
+"khroma@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "khroma@npm:2.1.0"
+  checksum: 634d98753ff5d2540491cafeb708fc98de0d43f4e6795256d5c8f6e3ad77de93049ea41433928fda3697adf7bbe6fe27351858f6d23b78f8b5775ef314c59891
   languageName: node
   linkType: hard
 
@@ -24985,10 +25961,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kolorist@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "kolorist@npm:1.8.0"
+  checksum: 73075db44a692bf6c34a649f3b4b3aea4993b84f6b754cbf7a8577e7c7db44c0bad87752bd23b0ce533f49de2244ce2ce03b7b1b667a85ae170a94782cc50f9b
+  languageName: node
+  linkType: hard
+
 "kuler@npm:^2.0.0":
   version: 2.0.0
   resolution: "kuler@npm:2.0.0"
   checksum: 0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
+"langium@npm:3.3.1":
+  version: 3.3.1
+  resolution: "langium@npm:3.3.1"
+  dependencies:
+    chevrotain: "npm:~11.0.3"
+    chevrotain-allstar: "npm:~0.3.0"
+    vscode-languageserver: "npm:~9.0.1"
+    vscode-languageserver-textdocument: "npm:~1.0.11"
+    vscode-uri: "npm:~3.0.8"
+  checksum: 0c54803068addb0f7c16a57fdb2db2e5d4d9a21259d477c3c7d0587c2c2f65a313f9eeef3c95ac1c2e41cd11d4f2eaf620d2c03fe839a3350ffee59d2b4c7647
   languageName: node
   linkType: hard
 
@@ -25033,6 +26029,20 @@ __metadata:
     picocolors: "npm:^1.0.0"
     shell-quote: "npm:^1.8.1"
   checksum: e18fcda6617a995306602871c7a71ddcfdd82d88a57508ae970be86bfb6685f131cf9ddb8896df4e8e4cde6d0e2d14318d2b41314eaae6abf03ca205948daa27
+  languageName: node
+  linkType: hard
+
+"layout-base@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "layout-base@npm:1.0.2"
+  checksum: 2a55d0460fd9f6ed53d7e301b9eb3dea19bda03815d616a40665ce6dc75c1f4d62e1ca19a897da1cfaf6de1b91de59cd6f2f79ba1258f3d7fccc7d46ca7f3337
+  languageName: node
+  linkType: hard
+
+"layout-base@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "layout-base@npm:2.0.1"
+  checksum: a44df9ef3cbff9916a10f616635e22b5787c89fa62b2fec6f99e8e6ee512c7cebd22668ce32dab5a83c934ba0a309c51a678aa0b40d70853de6c357893c0a88b
   languageName: node
   linkType: hard
 
@@ -25192,6 +26202,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"local-pkg@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "local-pkg@npm:1.1.2"
+  dependencies:
+    mlly: "npm:^1.7.4"
+    pkg-types: "npm:^2.3.0"
+    quansync: "npm:^0.2.11"
+  checksum: 1bcfcc5528dea95cba3caa478126a348d3985aad9f69ecf7802c13efef90897e1c5ff7851974332c5e6d4a4698efe610fef758a068c8bc3feb5322aeb35d5993
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "locate-path@npm:3.0.0"
@@ -25229,7 +26250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
+"lodash-es@npm:4.17.21, lodash-es@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
   checksum: fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
@@ -25701,6 +26722,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-react@npm:^0.541.0":
+  version: 0.541.0
+  resolution: "lucide-react@npm:0.541.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: ffa23a9c9ead0832c7e0bb1eb7ed44e9f38bbf083d94b4d36a66eb23fa2099d4a52e1677c91eb7e8ea922621fa98e730f5d513bc56b3111b14b835bd8ab823ab
+  languageName: node
+  linkType: hard
+
 "lunr@npm:^2.3.9":
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
@@ -25887,6 +26917,24 @@ __metadata:
   version: 3.0.4
   resolution: "markdown-table@npm:3.0.4"
   checksum: 1257b31827629a54c24a5030a3dac952256c559174c95ce3ef89bebd6bff0cb1444b1fd667b1a1bb53307f83278111505b3e26f0c4e7b731e0060d435d2d930b
+  languageName: node
+  linkType: hard
+
+"marked@npm:^15.0.7":
+  version: 15.0.12
+  resolution: "marked@npm:15.0.12"
+  bin:
+    marked: bin/marked.js
+  checksum: e09da211544b787ecfb25fed07af206060bf7cd6d9de6cb123f15c496a57f83b7aabea93340aaa94dae9c94e097ae129377cad6310abc16009590972e85f4212
+  languageName: node
+  linkType: hard
+
+"marked@npm:^16.1.2":
+  version: 16.3.0
+  resolution: "marked@npm:16.3.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 5a3d7da93d7692014c8764c31dc741fa6ee16d8573788a3b28d041c440e79177c46d786ad7c1fc2b3f5e301d6db32e22da45efd4c00ddbc31caf87bd8e9a673b
   languageName: node
   linkType: hard
 
@@ -26135,6 +27183,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-math@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mdast-util-math@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.1.0"
+    unist-util-remove-position: "npm:^5.0.0"
+  checksum: d4e839e38719f26872ed78aac18339805a892f1b56585a9cb8668f34e221b4f0660b9dfe49ec96dbbe79fd1b63b648608a64046d8286bcd2f9d576e80b48a0a1
+  languageName: node
+  linkType: hard
+
 "mdast-util-mdx-expression@npm:^2.0.0":
   version: 2.0.0
   resolution: "mdast-util-mdx-expression@npm:2.0.0"
@@ -26253,6 +27316,23 @@ __metadata:
     unist-util-visit: "npm:^5.0.0"
     zwitch: "npm:^2.0.0"
   checksum: 8bd37a9627a438ef6418d6642661904d0cc03c5c732b8b018a8e238ef5cc82fe8aef1940b19c6f563245e58b9659f35e527209bd3fe145f3c723ba14d18fc3e6
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-markdown@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "mdast-util-to-markdown@npm:2.1.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-phrasing: "npm:^4.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 4649722a6099f12e797bd8d6469b2b43b44e526b5182862d9c7766a3431caad2c0112929c538a972f214e63c015395e5d3f54bd81d9ac1b16e6d8baaf582f749
   languageName: node
   linkType: hard
 
@@ -26393,6 +27473,34 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"mermaid@npm:^11.0.0":
+  version: 11.11.0
+  resolution: "mermaid@npm:11.11.0"
+  dependencies:
+    "@braintree/sanitize-url": "npm:^7.0.4"
+    "@iconify/utils": "npm:^3.0.1"
+    "@mermaid-js/parser": "npm:^0.6.2"
+    "@types/d3": "npm:^7.4.3"
+    cytoscape: "npm:^3.29.3"
+    cytoscape-cose-bilkent: "npm:^4.1.0"
+    cytoscape-fcose: "npm:^2.2.0"
+    d3: "npm:^7.9.0"
+    d3-sankey: "npm:^0.12.3"
+    dagre-d3-es: "npm:7.0.11"
+    dayjs: "npm:^1.11.13"
+    dompurify: "npm:^3.2.5"
+    katex: "npm:^0.16.22"
+    khroma: "npm:^2.1.0"
+    lodash-es: "npm:^4.17.21"
+    marked: "npm:^15.0.7"
+    roughjs: "npm:^4.6.6"
+    stylis: "npm:^4.3.6"
+    ts-dedent: "npm:^2.2.0"
+    uuid: "npm:^11.1.0"
+  checksum: 92f54ea525ab8ea1086dd0f32eff37e1e8c97d88533b295bda957c09dbe6d5a3ad94176fa52af891435c902839900a0b968e17a424b4ccb3567d7a072061e5ab
   languageName: node
   linkType: hard
 
@@ -26568,6 +27676,21 @@ __metadata:
     micromark-util-combine-extensions: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
   checksum: 970e28df6ebdd7c7249f52a0dda56e0566fbfa9ae56c8eeeb2445d77b6b89d44096880cd57a1c01e7821b1f4e31009109fbaca4e89731bff7b83b8519690e5d9
+  languageName: node
+  linkType: hard
+
+"micromark-extension-math@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "micromark-extension-math@npm:3.1.0"
+  dependencies:
+    "@types/katex": "npm:^0.16.0"
+    devlop: "npm:^1.0.0"
+    katex: "npm:^0.16.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 56e6f2185a4613f9d47e7e98cf8605851c990957d9229c942b005e286c8087b61dc9149448d38b2f8be6d42cc6a64aad7e1f2778ddd86fbbb1a2f48a3ca1872f
   languageName: node
   linkType: hard
 
@@ -28373,6 +29496,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oniguruma-parser@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "oniguruma-parser@npm:0.12.1"
+  checksum: b843ea54cda833efb19f856314afcbd43e903ece3de489ab78c527ddec84859208052557daa9fad4bdba89ebdd15b0cc250de86b3daf8c7cbe37bac5a6a185d3
+  languageName: node
+  linkType: hard
+
+"oniguruma-to-es@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "oniguruma-to-es@npm:4.3.3"
+  dependencies:
+    oniguruma-parser: "npm:^0.12.1"
+    regex: "npm:^6.0.1"
+    regex-recursion: "npm:^6.0.2"
+  checksum: bc034e84dfee4dbc061cf6364023e66e1667fb8dc3afcad3b7d6a2c77e2d4a4809396ee2fb8c1fd3d6f00f76f7ca14b773586bf862c5f0c0074c059e2a219252
+  languageName: node
+  linkType: hard
+
 "open@npm:^8.0.4, open@npm:^8.0.9, open@npm:^8.4.0":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
@@ -28646,6 +29787,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-manager-detector@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "package-manager-detector@npm:1.3.0"
+  checksum: b4b54a81a3230edd66564a59ff6a2233086961e36ba91a28a0f6d6932a8dec36618ace50e8efec9c4d8c6aa9828e98814557a39fb6b106c161434ccb44a80e1c
+  languageName: node
+  linkType: hard
+
 "pako@npm:1.0.10":
   version: 1.0.10
   resolution: "pako@npm:1.0.10"
@@ -28859,6 +30007,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-data-parser@npm:0.1.0, path-data-parser@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "path-data-parser@npm:0.1.0"
+  checksum: ba22d54669a8bc4a3df27431fe667900685585d1196085b803d0aa4066b83e709bbf2be7c1d2b56e706b49cc698231d55947c22abbfc4843ca424bbf8c985745
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -28987,7 +30142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^2.0.1":
+"pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
@@ -29185,6 +30340,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-types@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "pkg-types@npm:2.3.0"
+  dependencies:
+    confbox: "npm:^0.2.2"
+    exsolve: "npm:^1.0.7"
+    pathe: "npm:^2.0.3"
+  checksum: d2bbddc5b81bd4741e1529c08ef4c5f1542bbdcf63498b73b8e1d84cff71806d1b8b1577800549bb569cb7aa20056257677b979bff48c97967cba7e64f72ae12
+  languageName: node
+  linkType: hard
+
 "pkg-up@npm:^3.1.0":
   version: 3.1.0
   resolution: "pkg-up@npm:3.1.0"
@@ -29261,6 +30427,23 @@ __metadata:
   dependencies:
     irregular-plurals: "npm:^3.2.0"
   checksum: 4d3010843dac60b980c9b83d4cdecc2c6bb4bf0a1d7620ba7229b5badcbc3c3767fddfdb61746f6253c3bd33ada3523375983cbe0b3f94868f4a475b9b6bd7d7
+  languageName: node
+  linkType: hard
+
+"points-on-curve@npm:0.2.0, points-on-curve@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "points-on-curve@npm:0.2.0"
+  checksum: f0d92343fcc2ad1f48334633e580574c1e0e28038a756133e171e537f270d6d64203feada5ee556e36f448a1b46e0306dee07b30f589f4e3ad720f6ee38ef48c
+  languageName: node
+  linkType: hard
+
+"points-on-path@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "points-on-path@npm:0.2.1"
+  dependencies:
+    path-data-parser: "npm:0.1.0"
+    points-on-curve: "npm:0.2.0"
+  checksum: a7010340f9f196976f61838e767bb7b0b7f6273ab4fb9eb37c61001fe26fbfc3fcd63c96d5e85b9a4ab579213ab366f2ddaaf60e2a9253e2b91a62db33f395ba
   languageName: node
   linkType: hard
 
@@ -30984,6 +32167,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"quansync@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "quansync@npm:0.2.11"
+  checksum: cb9a1f8ebce074069f2f6a78578873ffedd9de9f6aa212039b44c0870955c04a71c3b1311b5d97f8ac2f2ec476de202d0a5c01160cb12bc0a11b7ef36d22ef56
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -32147,6 +33337,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regex-recursion@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "regex-recursion@npm:6.0.2"
+  dependencies:
+    regex-utilities: "npm:^2.3.0"
+  checksum: 68e8b6889680e904b75d7f26edaf70a1a4dc1087406bff53face4c2929d918fd77c72223843fe816ac8ed9964f96b4160650e8d5909e26a998c6e9de324dadb1
+  languageName: node
+  linkType: hard
+
+"regex-utilities@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "regex-utilities@npm:2.3.0"
+  checksum: 78c550a80a0af75223244fff006743922591bd8f61d91fef7c86b9b56cf9bbf8ee5d7adb6d8991b5e304c57c90103fc4818cf1e357b11c6c669b782839bd7893
+  languageName: node
+  linkType: hard
+
+"regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "regex@npm:6.0.1"
+  dependencies:
+    regex-utilities: "npm:^2.3.0"
+  checksum: 687b3e063d4ca19b0de7c55c24353f868a0fb9ba21512692470d2fb412e3a410894dd5924c91ea49d8cb8fa865e36ec956e52436ae0a256bdc095ff136c30aba
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.3":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -32233,6 +33448,21 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: 99d3e4e10c8c7732eb7aa843b8da2fd8b647fe144d3711b480e4647dc3bff4b1e96691ccf17f3ace24aa866a50b064236177cb25e6e4fbbb18285d99edaed83b
+  languageName: node
+  linkType: hard
+
+"rehype-katex@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "rehype-katex@npm:7.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/katex": "npm:^0.16.0"
+    hast-util-from-html-isomorphic: "npm:^2.0.0"
+    hast-util-to-text: "npm:^4.0.0"
+    katex: "npm:^0.16.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 73c770319536128b75055d904d06951789d00a0552c11724c0dac2e244dcb21041630552d118a11cc42233fdcd1bfee525e78a0020fde635bd916cceb281dfb1
   languageName: node
   linkType: hard
 
@@ -32849,6 +34079,18 @@ __metadata:
   dependencies:
     remark-message-control: "npm:^4.0.0"
   checksum: 428560d6ccf8c7c7ad427514264c22639ca86fb855679fada281ce04ba6ae706fb054ff02bfff870e30ca713c462876a6631bfbdc882b3da3a7102d64512b79a
+  languageName: node
+  linkType: hard
+
+"remark-math@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "remark-math@npm:6.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-math: "npm:^3.0.0"
+    micromark-extension-math: "npm:^3.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 859613c4db194bb6b3c9c063661dc52b8ceda9c5cf3256b42f73d93eb8f38a6d634eb5f976fe094425f6f1035aaf329eb49ada314feb3b2b1073326b6d3aaa02
   languageName: node
   linkType: hard
 
@@ -33508,6 +34750,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"roughjs@npm:^4.6.6":
+  version: 4.6.6
+  resolution: "roughjs@npm:4.6.6"
+  dependencies:
+    hachure-fill: "npm:^0.5.2"
+    path-data-parser: "npm:^0.1.0"
+    points-on-curve: "npm:^0.2.0"
+    points-on-path: "npm:^0.2.1"
+  checksum: 68c11bf4516aa014cef2fe52426a9bab237c2f500d13e1a4f13b523cb5723667bf2d92b9619325efdc5bc2a193588ff5af8d51683df17cfb8720e96fe2b92b0c
+  languageName: node
+  linkType: hard
+
 "route-recognizer@npm:^0.3.4":
   version: 0.3.4
   resolution: "route-recognizer@npm:0.3.4"
@@ -33564,6 +34818,13 @@ __metadata:
   version: 0.3.2
   resolution: "rungen@npm:0.3.2"
   checksum: b32e89966f004720f40e1aa0f32a0bea521c2153e2d6740ec06f5a44c7d4cc7074d395b026dab1aa8dd1758e9d9e5bbe0fcc6b391d40a273c3716da4e3b88155
+  languageName: node
+  linkType: hard
+
+"rw@npm:1":
+  version: 1.3.3
+  resolution: "rw@npm:1.3.3"
+  checksum: b1e1ef37d1e79d9dc7050787866e30b6ddcb2625149276045c262c6b4d53075ddc35f387a856a8e76f0d0df59f4cd58fe24707e40797ebee66e542b840ed6a53
   languageName: node
   linkType: hard
 
@@ -34400,6 +35661,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shiki@npm:^3.9.2":
+  version: 3.12.2
+  resolution: "shiki@npm:3.12.2"
+  dependencies:
+    "@shikijs/core": "npm:3.12.2"
+    "@shikijs/engine-javascript": "npm:3.12.2"
+    "@shikijs/engine-oniguruma": "npm:3.12.2"
+    "@shikijs/langs": "npm:3.12.2"
+    "@shikijs/themes": "npm:3.12.2"
+    "@shikijs/types": "npm:3.12.2"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 86e6c6a83807069f8e6e0d5e69a301fc74fff6abd92d490a9dc59066aac2e7a8582bf0742f118ab89f4ec88965a6e8946c5deb594e4ecb8edf07d95071967ace
+  languageName: node
+  linkType: hard
+
 "showdown@npm:^1.9.1":
   version: 1.9.1
   resolution: "showdown@npm:1.9.1"
@@ -35043,6 +36320,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"streamdown@npm:1.1.1":
+  version: 1.1.1
+  resolution: "streamdown@npm:1.1.1"
+  dependencies:
+    clsx: "npm:^2.1.1"
+    harden-react-markdown: "npm:^1.0.4"
+    katex: "npm:^0.16.22"
+    lucide-react: "npm:^0.541.0"
+    marked: "npm:^16.1.2"
+    mermaid: "npm:^11.0.0"
+    react-markdown: "npm:^10.1.0"
+    rehype-katex: "npm:^7.0.1"
+    remark-gfm: "npm:^4.0.1"
+    remark-math: "npm:^6.0.0"
+    shiki: "npm:^3.9.2"
+    tailwind-merge: "npm:^3.3.1"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+  checksum: 80295c37162eacaba7c6baf22440ee961ca95fee48156f09a0671e2ce38be8ae46fccf6afc303c94e37aece7d73c97167932ea4903656bcf00712b5da0318f30
+  languageName: node
+  linkType: hard
+
 "strict-event-emitter@npm:^0.5.1":
   version: 0.5.1
   resolution: "strict-event-emitter@npm:0.5.1"
@@ -35556,6 +36855,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylis@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "stylis@npm:4.3.6"
+  checksum: e736d484983a34f7c65d362c67dc79b7bce388054b261c2b7b23d02eaaf280617033f65d44b1ea341854f4331a5074b885668ac8741f98c13a6cfd6443ae85d0
+  languageName: node
+  linkType: hard
+
 "sucrase@npm:^3.10.1, sucrase@npm:^3.35.0":
   version: 3.35.0
   resolution: "sucrase@npm:3.35.0"
@@ -35808,6 +37114,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tailwind-merge@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "tailwind-merge@npm:3.3.1"
+  checksum: b84c6a78d4669fa12bf5ab8f0cdc4400a3ce0a7c006511af4af4be70bb664a27466dbe13ee9e3b31f50ddf6c51d380e8192ce0ec9effce23ca729d71a9f63818
+  languageName: node
+  linkType: hard
+
 "tannin@npm:^1.2.0":
   version: 1.2.0
   resolution: "tannin@npm:1.2.0"
@@ -36025,6 +37338,13 @@ __metadata:
   version: 0.3.2
   resolution: "tinyexec@npm:0.3.2"
   checksum: 3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tinyexec@npm:1.0.1"
+  checksum: e1ec3c8194a0427ce001ba69fd933d0c957e2b8994808189ed8020d3e0c01299aea8ecf0083cc514ecbf90754695895f2b5c0eac07eb2d0c406f7d4fbb8feade
   languageName: node
   linkType: hard
 
@@ -36333,6 +37653,13 @@ __metadata:
   version: 2.0.0
   resolution: "ts-dedent@npm:2.0.0"
   checksum: dc22c2a7184ce80cb19b5619199dc33128750c7ffe366eecdb50fcc39a19347921d950c90af8418ef4d15271528bc75340efa23acce271aeb618c9a54fd0383c
+  languageName: node
+  linkType: hard
+
+"ts-dedent@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "ts-dedent@npm:2.2.0"
+  checksum: 175adea838468cc2ff7d5e97f970dcb798bbcb623f29c6088cb21aa2880d207c5784be81ab1741f56b9ac37840cbaba0c0d79f7f8b67ffe61c02634cafa5c303
   languageName: node
   linkType: hard
 
@@ -36933,6 +38260,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-find-after@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-find-after@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: a7cea473c4384df8de867c456b797ff1221b20f822e1af673ff5812ed505358b36f47f3b084ac14c3622cb879ed833b71b288e8aa71025352a2aab4c2925a6eb
+  languageName: node
+  linkType: hard
+
 "unist-util-generated@npm:^1.1.0":
   version: 1.1.6
   resolution: "unist-util-generated@npm:1.1.6"
@@ -37516,6 +38853,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.3.2":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
@@ -37735,6 +39081,55 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:8.2.0":
+  version: 8.2.0
+  resolution: "vscode-jsonrpc@npm:8.2.0"
+  checksum: 0789c227057a844f5ead55c84679206227a639b9fb76e881185053abc4e9848aa487245966cc2393fcb342c4541241b015a1a2559fddd20ac1e68945c95344e6
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-protocol@npm:3.17.5":
+  version: 3.17.5
+  resolution: "vscode-languageserver-protocol@npm:3.17.5"
+  dependencies:
+    vscode-jsonrpc: "npm:8.2.0"
+    vscode-languageserver-types: "npm:3.17.5"
+  checksum: 5f38fd80da9868d706eaa4a025f4aff9c3faad34646bcde1426f915cbd8d7e8b6c3755ce3fef6eebd256ba3145426af1085305f8a76e34276d2e95aaf339a90b
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-textdocument@npm:~1.0.11":
+  version: 1.0.12
+  resolution: "vscode-languageserver-textdocument@npm:1.0.12"
+  checksum: 534349894b059602c4d97615a1147b6c4c031141c2093e59657f54e38570f5989c21b376836f13b9375419869242e9efb4066643208b21ab1e1dee111a0f00fb
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:3.17.5":
+  version: 3.17.5
+  resolution: "vscode-languageserver-types@npm:3.17.5"
+  checksum: 1e1260de79a2cc8de3e46f2e0182cdc94a7eddab487db5a3bd4ee716f67728e685852707d72c059721ce500447be9a46764a04f0611e94e4321ffa088eef36f8
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver@npm:~9.0.1":
+  version: 9.0.1
+  resolution: "vscode-languageserver@npm:9.0.1"
+  dependencies:
+    vscode-languageserver-protocol: "npm:3.17.5"
+  bin:
+    installServerIntoExtension: bin/installServerIntoExtension
+  checksum: 8a0838d77c98a211c76e54bd3a6249fc877e4e1a73322673fb0e921168d8e91de4f170f1d4ff7e8b6289d0698207afc6aba6662d4c1cd8e4bd7cae96afd6b0c2
+  languageName: node
+  linkType: hard
+
+"vscode-uri@npm:~3.0.8":
+  version: 3.0.8
+  resolution: "vscode-uri@npm:3.0.8"
+  checksum: f7f217f526bf109589969fe6e66b71e70b937de1385a1d7bb577ca3ee7c5e820d3856a86e9ff2fa9b7a0bc56a3dd8c3a9a557d3fedd7df414bc618d5e6b567f9
   languageName: node
   linkType: hard
 
@@ -39041,7 +40436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zwitch@npm:^2.0.0":
+"zwitch@npm:^2.0.0, zwitch@npm:^2.0.4":
   version: 2.0.4
   resolution: "zwitch@npm:2.0.4"
   checksum: 3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,28 +308,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:0.1.10":
-  version: 0.1.10
-  resolution: "@automattic/agenttic-client@npm:0.1.10"
-  dependencies:
-    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
-    "@types/react": "npm:^18.0.0"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/element": "npm:^6.2.0"
-    "@wordpress/i18n": "npm:^6.1.0"
-    react: "npm:^18.0.0"
-    react-markdown: "npm:^10.1.0"
-    remark-gfm: "npm:^4.0.1"
-  peerDependencies:
-    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
-    react: ^18.0.0
-  peerDependenciesMeta:
-    "@wordpress/api-fetch":
-      optional: true
-  checksum: ade8f2e46632764cb4034ec60ca3e422066cc9cb7c27c0d63005c66c17d9b6d585e8ee9d564102473f371440cf3e741c48eeb355c2dfbeb246273012444fb2ea
-  languageName: node
-  linkType: hard
-
 "@automattic/agenttic-client@npm:0.1.12":
   version: 0.1.12
   resolution: "@automattic/agenttic-client@npm:0.1.12"
@@ -352,34 +330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.10, @automattic/agenttic-ui@npm:^0.1.9":
-  version: 0.1.10
-  resolution: "@automattic/agenttic-ui@npm:0.1.10"
-  dependencies:
-    "@automattic/agenttic-client": "npm:0.1.10"
-    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
-    "@radix-ui/react-scroll-area": "npm:^1.2.9"
-    "@radix-ui/react-slot": "npm:^1.2.3"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/element": "npm:^6.24.0"
-    "@wordpress/i18n": "npm:^6.1.0"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    framer-motion: "npm:^12.23.0"
-    lucide-react: "npm:^0.525.0"
-    react: "npm:^18.0.0"
-    react-dom: "npm:^18.0.0"
-    react-markdown: "npm:^10.1.0"
-    react-textarea-autosize: "npm:^8.5.9"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: c07a10f3d7fefa32d1aefcf21776fa315ba5f7608195c3704e0142a8da8c5a50ac6a474ccf24d032a03f3d1bee5807e34d3efe51446f60b6c628e21a9e492f5f
-  languageName: node
-  linkType: hard
-
-"@automattic/agenttic-ui@npm:^0.1.12":
+"@automattic/agenttic-ui@npm:^0.1.10, @automattic/agenttic-ui@npm:^0.1.12, @automattic/agenttic-ui@npm:^0.1.9":
   version: 0.1.12
   resolution: "@automattic/agenttic-ui@npm:0.1.12"
   dependencies:
@@ -18108,19 +18059,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:1 - 2":
+"d3-array@npm:1 - 2, d3-array@npm:1.2.0 - 2, d3-array@npm:^2.4.0":
   version: 2.12.1
   resolution: "d3-array@npm:2.12.1"
   dependencies:
     internmap: "npm:^1.0.0"
   checksum: 7eca10427a9f113a4ca6a0f7301127cab26043fd5e362631ef5a0edd1c4b2dd70c56ed317566700c31e4a6d88b55f3951aaba192291817f243b730cb2352882e
-  languageName: node
-  linkType: hard
-
-"d3-array@npm:1.2.0 - 2, d3-array@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "d3-array@npm:2.4.0"
-  checksum: 994b80f794bb2c605c78e8398b1009350e532b809b8c3beb049604a86b5e8f45c7a42647355f00168eb08fb1e43684f6f84d5831055bdd757abd061e28a4f857
   languageName: node
   linkType: hard
 
@@ -18682,14 +18626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.0":
-  version: 1.10.7
-  resolution: "dayjs@npm:1.10.7"
-  checksum: 2ce908776ea5b383dba2c01c72290ff12ad97cafa81b9c72a9cc4f801d736d592f20bd992ea1dff083ab80e807080b5af21f634bb09e67f89f66582a9059053a
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:^1.11.13":
+"dayjs@npm:^1.10.0, dayjs@npm:^1.11.13":
   version: 1.11.18
   resolution: "dayjs@npm:1.11.18"
   checksum: 83b67f5d977e2634edf4f5abdd91d9041a696943143638063016915d2cd8c7e57e0751e40379a07ebca8be7a48dd380bef8752d22a63670f2d15970e34f96d7a
@@ -27299,23 +27236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-markdown@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "mdast-util-to-markdown@npm:2.1.0"
-  dependencies:
-    "@types/mdast": "npm:^4.0.0"
-    "@types/unist": "npm:^3.0.0"
-    longest-streak: "npm:^3.0.0"
-    mdast-util-phrasing: "npm:^4.0.0"
-    mdast-util-to-string: "npm:^4.0.0"
-    micromark-util-decode-string: "npm:^2.0.0"
-    unist-util-visit: "npm:^5.0.0"
-    zwitch: "npm:^2.0.0"
-  checksum: 8bd37a9627a438ef6418d6642661904d0cc03c5c732b8b018a8e238ef5cc82fe8aef1940b19c6f563245e58b9659f35e527209bd3fe145f3c723ba14d18fc3e6
-  languageName: node
-  linkType: hard
-
-"mdast-util-to-markdown@npm:^2.1.0":
+"mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0":
   version: 2.1.2
   resolution: "mdast-util-to-markdown@npm:2.1.2"
   dependencies:
@@ -37645,14 +37566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-dedent@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ts-dedent@npm:2.0.0"
-  checksum: dc22c2a7184ce80cb19b5619199dc33128750c7ffe366eecdb50fcc39a19347921d950c90af8418ef4d15271528bc75340efa23acce271aeb618c9a54fd0383c
-  languageName: node
-  linkType: hard
-
-"ts-dedent@npm:^2.2.0":
+"ts-dedent@npm:^2.0.0, ts-dedent@npm:^2.2.0":
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 175adea838468cc2ff7d5e97f970dcb798bbcb623f29c6088cb21aa2880d207c5784be81ab1741f56b9ac37840cbaba0c0d79f7f8b67ffe61c02634cafa5c303

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,14 +330,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-client@npm:0.1.11":
-  version: 0.1.11
-  resolution: "@automattic/agenttic-client@npm:0.1.11"
+"@automattic/agenttic-client@npm:0.1.12":
+  version: 0.1.12
+  resolution: "@automattic/agenttic-client@npm:0.1.12"
   dependencies:
     "@automattic/charts": "npm:>=0.14.0 <1.0.0"
     "@types/react": "npm:^18.0.0"
     "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/element": "npm:^6.2.0"
     "@wordpress/i18n": "npm:^6.1.0"
     react: "npm:^18.0.0"
     react-markdown: "npm:^10.1.0"
@@ -349,7 +348,7 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: f5f5e9b72b72227df46e96b7f9e94c0e8e1e8f3c6b8ae093fd07b8b08b3040b715a236adf3ed74f1e3e6c8ba302d509e8531745cfa01d78de283cb34e95d24e5
+  checksum: bf369011dcb62e7b3534521aba0bf5f4e720149138bf13cb1f3d2d7903cd88db04eec759e78157367ea8461ab25353a973db9166e48f4ac385e3f5841a5b3121
   languageName: node
   linkType: hard
 
@@ -380,17 +379,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.11":
-  version: 0.1.11
-  resolution: "@automattic/agenttic-ui@npm:0.1.11"
+"@automattic/agenttic-ui@npm:^0.1.12":
+  version: 0.1.12
+  resolution: "@automattic/agenttic-ui@npm:0.1.12"
   dependencies:
-    "@automattic/agenttic-client": "npm:0.1.11"
-    "@automattic/charts": "npm:>=0.14.0 <1.0.0"
+    "@automattic/agenttic-client": "npm:0.1.12"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
     "@radix-ui/react-slot": "npm:^1.2.3"
     "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/element": "npm:^6.24.0"
     "@wordpress/i18n": "npm:^6.1.0"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
@@ -403,7 +399,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: f723d08fc10c14509d61add089b8ba770cbb8438f0ab1e7cf1725f1d8ec3e2a8b93d3dc45c461d0312fdd7ad38d798fdba217018dde92f9ef0d7d083903dc84a
+  checksum: d51d459343ec37671a57a021a0f2ca095c461fbfafa9020aed9556d7a9b034147e7f4fbd2854bbc54b209fede86ff80d8c91d7c869e186bbfa58932a72cc5b5a
   languageName: node
   linkType: hard
 
@@ -1914,7 +1910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.11"
+    "@automattic/agenttic-ui": "npm:^0.1.12"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"


### PR DESCRIPTION
Fixes DOTCOM-14574

## Proposed Changes
1. Re-implements ChatFooter from its components.
2. Introduces support for multi-file attachments. Caps to 5.
3. Adds a preview UI when an attachment is uploaded and only uploads it after user approval.
4. Allow canceling individual attachemnts.

## Why are these changes being made?
Users may paste private contents.

## Testing Instructions
1. Open the live link.
2. Start a chat with a human.
5. Upload a file.
6. You should see a preview.
7. Cancel the attachment; it should go away.
8. Repeat and send it. It should be sent.
9. Try dragging multiple files.
10. Try uploading multiple files using the upload button.

## Demo

https://github.com/user-attachments/assets/fc01cb9d-21cf-45bb-bdee-0b859b50ad4e

## Known issue

The primary color in the preview UI is different because I chose green as my Calypso theme. This is out of the scope of this issue. We'll need to configure Agenttic to respect the Calypso theme.
