### PR TITLE
A4A: Make reasons a required field for the cancel license modal.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -217,7 +217,7 @@ const CancelLicenseFeedbackModal = ( {
 						isDestructive
 						onClick={ handleOnCancel }
 						variant="secondary"
-						disabled={ isLoading }
+						disabled={ isLoading || ( suggestion && ! isHostingLicense && ! suggestions.length ) }
 						isBusy={ isLoading }
 					>
 						{ translate( 'Cancel license' ) }
@@ -275,7 +275,7 @@ const CancelLicenseFeedbackModal = ( {
 
 				{ suggestion && ! isHostingLicense && (
 					<FormFieldset>
-						<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion">
+						<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion" required>
 							{ suggestion.label }
 						</FormLabel>
 						<div className="a4a-feedback__suggestions">

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -165,8 +165,8 @@
 		color: var(--color-primary-50);
 	}
 
-	.components-button.is-destructive,
-	.button.is-scary {
+	.components-button.is-destructive:not(:disabled),
+	.button.is-scary:not(:disabled) {
 		color: var(--color-scary-50);
 		border-color: var(--color-scary-50);
 
@@ -176,6 +176,7 @@
 			border-color: var(--color-scary-60);
 			color: var(--color-scary-60);
 		}
+
 	}
 
 	.components-button.is-primary.is-destructive,


### PR DESCRIPTION
This PR updates the Cancel license modal to make the reason field required, forcing users to provide feedback.

<img width="836" height="697" alt="Screenshot 2025-09-15 at 10 51 08 PM" src="https://github.com/user-attachments/assets/3fad441b-83ab-4df4-b957-1c8d6e6857f3" />


Closes https://linear.app/a8c/issue/A4A-1459/require-that-agencies-provide-a-reason-for-cancelling

## Proposed Changes

* Update the Cancel License Feedback modal to make the reason field required.
* **Additional**: Fix global styling for the disabled 'destructive' button.

## Why are these changes being made?


* We want to get more actionable feedback about our program and products. To do this, we're going to require that agencies fill out the field "Can you tell us why {Product name} didn't meet your needs?" question. 

## Testing Instructions

* Use the A4A live link and navigate to `/purchases/licenses`
* Cancel a product license.
* Confirm that the Cancel button is disabled until you select a reason for cancellation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
