### PR TITLE
A4A: Make Reason suggestion required on Cancel Hosting plan feedback modal.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -217,7 +217,7 @@ const CancelLicenseFeedbackModal = ( {
 						isDestructive
 						onClick={ handleOnCancel }
 						variant="secondary"
-						disabled={ isLoading || ( suggestion && ! isHostingLicense && ! suggestions.length ) }
+						disabled={ isLoading || ( suggestion && ! suggestions.length ) }
 						isBusy={ isLoading }
 					>
 						{ translate( 'Cancel license' ) }
@@ -273,7 +273,7 @@ const CancelLicenseFeedbackModal = ( {
 					</div>
 				</div>
 
-				{ suggestion && ! isHostingLicense && (
+				{ suggestion && (
 					<FormFieldset>
 						<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion" required>
 							{ suggestion.label }
@@ -295,21 +295,13 @@ const CancelLicenseFeedbackModal = ( {
 				) }
 				<FormFieldset>
 					<FormLabel className="a4a-feedback__comments-label" htmlFor="comments">
-						{ isHostingLicense
-							? translate( "Can you tell us why you're canceling the %(productName)s plan?", {
-									args: { productName },
-							  } )
-							: translate( 'Anything else we should know?' ) }
+						{ translate( 'Anything else we should know?' ) }
 					</FormLabel>
 					<FormTextarea
 						className="a4a-feedback__comments"
 						name="comments"
 						id="comments"
-						placeholder={
-							isHostingLicense
-								? translate( 'Enter your reason' )
-								: translate( 'Enter the issues you encountered' )
-						}
+						placeholder={ translate( 'Enter the issues you encountered' ) }
 						value={ comments }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setComments( event.target.value )


### PR DESCRIPTION

<img width="839" height="715" alt="Screenshot 2025-09-15 at 11 01 58 PM" src="https://github.com/user-attachments/assets/6f1b4be2-431f-4baa-a02d-3c27a8d1f255" />


Closes https://linear.app/a8c/issue/A4A-1457/hosting-cancellation-modals-dont-show-the-cancellation-reason-list

## Proposed Changes

* Update the Cancel Hosting plan feedback modal to include suggested reasons, similar to how canceling a product license works.

## Why are these changes being made?


* We need to ensure cancellation modals are consistent across all of our products.

## Testing Instructions

* Use the A4A live link and navigate to `/purchases/licenses`
* Cancel a Hosting plan.
* Confirm you see the reason lists as shown in the screenshot above.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
