### PR TITLE
Help Center: Recommended guides icons not aligned

### DIFF
--- a/packages/help-center/src/components/_mixins.scss
+++ b/packages/help-center/src/components/_mixins.scss
@@ -65,6 +65,10 @@
 				min-width: 0;
 				box-sizing: border-box;
 
+				svg {
+					flex-shrink: 0;
+				}
+
 				> svg:first-child {
 					margin-right: 10px;
 					fill: $gray-700;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14577/recommended-guides-icons-not-aligned

## Proposed Changes

Before:
<img width="136" height="515" alt="image" src="https://github.com/user-attachments/assets/09bc8e56-b544-4978-8dbf-46881062bd5b" />

After

<img width="130" height="497" alt="image" src="https://github.com/user-attachments/assets/802e1739-858d-4eaa-9920-2fdd24b40a0a" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help center
