### PR TITLE
Fix Help Center styles in wp admin

### DIFF
--- a/packages/help-center/src/components/_mixins.scss
+++ b/packages/help-center/src/components/_mixins.scss
@@ -51,13 +51,10 @@
             }
 
             a,
-            button {
-                background-color: transparent;
-                border-width: 0;
+button {
+                all: unset;
                 padding-top: 16px;
                 padding-bottom: 16px;
-                padding-inline-start: 0;
-                padding-inline-end: 0;
                 display: flex;
                 text-decoration: none;
                 color: var(--studio-gray-100);

--- a/packages/help-center/src/components/_mixins.scss
+++ b/packages/help-center/src/components/_mixins.scss
@@ -3,96 +3,103 @@
 @import "variables";
 
 @mixin help-center-link {
-	> ul {
-		list-style: none;
-		padding: 0;
-		text-align: left;
-		border: 1px solid var(--studio-gray-5);
-		border-radius: 8px;
-		margin: 0 0 16px;
-		overflow: hidden;
-	}
+    > ul {
+        list-style: none;
+        padding: 0;
+        text-align: left;
+        border: 1px solid var(--studio-gray-5);
+        border-radius: 8px;
+        margin: 0 0 16px;
+        overflow: hidden;
+    }
 
-	.help-center-link__item {
-		line-height: 1.3;
-		border-bottom: 1px solid var(--studio-gray-5);
-		display: block;
+    .help-center-link__item {
+        
+        border-bottom: 1px solid var(--studio-gray-5);
+        display: block;
+        line-height: 1.3;
+        margin-bottom: 0;
 
-		&:first-child {
-			a:focus, button:focus {
-				border-radius: 8px 8px 0 0;
-			}
-		}
+        &:first-child {
+            a:focus, button:focus {
+                border-radius: 8px 8px 0 0;
+            }
+        }
 
-		&:last-child {
-			border-bottom: 0;
+        &:last-child {
+            border-bottom: 0;
 
-			a:focus, button:focus {
-				border-radius: 0 0 8px 8px;
-			}
-		}
+            a:focus, button:focus {
+                border-radius: 0 0 8px 8px;
+            }
+        }
 
-		.help-center-link__cell {
-			display: block;
-			width: 100%;
+        .help-center-link__cell {
+            display: block;
+            width: 100%;
 
-			&:hover {
-				a, button {
-					background: color-mix(in srgb, #fff 98%, var(--wp-admin-theme-color, $help-center-blue));
-					color: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
-					cursor: pointer;
-				}
+            &:hover {
+                a, button {
+                    background: color-mix(in srgb, #fff 98%, var(--wp-admin-theme-color, $help-center-blue));
+                    color: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
+                    cursor: pointer;
+                }
 
-				svg {
-					fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
-				}
-			}
+                svg {
+                    fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, $help-center-blue));
+                }
+            }
 
-			a,
-			button {
-				padding-top: 16px;
-				padding-bottom: 16px;
-				display: flex;
-				text-decoration: none;
-				color: var(--studio-gray-100);
-				font-size: $font-body-small;
-				border-radius: 2px;
-				font-weight: normal;
-				align-items: center;
-				transition: background-color 0.3s ease;
-				line-height: 1.4;
-				width: 100%;
-				min-width: 0;
-				box-sizing: border-box;
+            a,
+            button {
+                background-color: transparent;
+                border-width: 0;
+                padding-top: 16px;
+                padding-bottom: 16px;
+                padding-inline-start: 0;
+                padding-inline-end: 0;
+                display: flex;
+                text-decoration: none;
+                color: var(--studio-gray-100);
+                font-size: $font-body-small;
+                border-radius: 2px;
+                font-weight: normal;
+                align-items: center;
+                transition: background-color 0.3s ease;
+                line-height: 1.4;
+                width: 100%;
+                min-width: 0;
+                box-sizing: border-box;
 
-				svg {
-					flex-shrink: 0;
-				}
+                svg {
+                    flex-shrink: 0;
+                }
 
-				> svg:first-child {
-					margin-right: 10px;
-					fill: $gray-700;
-					padding-left: 24px;
-					display: block;
-				}
+                > svg:first-child {
+                    margin-right: 10px;
+                    fill: $gray-700;
+                    padding-left: 24px;
+                    display: block;
+                }
 
-				> svg:last-child {
-					fill: var($gray-700);
-					padding-right: 24px;
-				}
+                > svg:last-child {
+                    fill: var($gray-700);
+                    padding-right: 24px;
+                }
 
-				span {
-					flex: 1 1 auto;
-					min-width: 0;
-					text-align: left;
-				}
+                span {
+                    flex: 1 1 auto;
+                    min-width: 0;
+                    text-align: left;
+                }
 
-				&:focus {
-					color: var(--studio-gray-100);
-					outline: $help-center-blue solid 2px;
-					outline-offset: -2px;
-				}
-			}
-		}
-	}
+                &:focus {
+                    color: var(--studio-gray-100);
+                    outline: $help-center-blue solid 2px;
+                    outline-offset: -2px;
+                }
+            }
+        }
+    }
 }
+

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -121,6 +121,7 @@ $blueberry-color: #3858e9;
 
 	.odie-chatbox-message__content {
 		p {
+			font-size: $font-body-small;
 			margin-bottom: 0;
 			margin-top: 0;
 		}

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -208,6 +208,7 @@ $blueberry-color: #3858e9;
 		.odie-sources-foldable-card {
 			box-shadow: none;
 			margin-bottom: 0;
+			padding: 0;
 
 			&:not( .is-expanded ) {
 				.foldable-card__content {

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -35,7 +35,7 @@ $blueberry-blue: #3858e9;
 	height: 100%;
 	overscroll-behavior: contain;
 	padding-top: 16px;
-	gap: 28px;
+	gap: 24px;
 	box-sizing: border-box;
 
 	.chatbox-loading-chat__spinner {

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -106,4 +106,8 @@ $blueberry-blue: #3858e9;
 			fill: #8C0B0B;
 		}
 	}
+
+	.Textarea-module_textarea:focus {
+		box-shadow: none;
+	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14583/fix-styles-in-wp-admin

## Proposed Changes

Check the things that were not working here: pdtkmj-3Wm-p2#comment-7580

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox widgets.wordpress.com
* `yarn dev --sync` from `apps/help-center`