### PR TITLE
Domains: Add missing cancel domain

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -27,6 +27,7 @@ import {
 	shouldShowTransferAction,
 	shouldShowDisconnectAction,
 	shouldShowDeleteAction,
+	shouldShowCancelAction,
 	getDeleteTitle,
 	getDeleteLabel,
 	getDeleteDescription,
@@ -143,6 +144,22 @@ export default function Actions() {
 								isBusy={ isDeleting }
 								disabled={ isDeleting }
 								onClick={ () => setIsDeleteDialogOpen( true ) }
+							>
+								{ getDeleteLabel( domain ) }
+							</Button>
+						}
+					/>
+				) }
+				{ shouldShowCancelAction( domain, purchase ) && (
+					<ActionList.ActionItem
+						title={ getDeleteTitle( domain ) }
+						description={ getDeleteDescription( domain ) }
+						actions={
+							<Button
+								size="compact"
+								variant="secondary"
+								isDestructive
+								href={ `/me/purchases/${ domain.domain }/${ purchase?.ID }/cancel` }
 							>
 								{ getDeleteLabel( domain ) }
 							</Button>

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -60,6 +60,23 @@ export const shouldShowDeleteAction = ( domain: Domain, purchase?: Purchase, sit
 	return true;
 };
 
+export const shouldShowCancelAction = ( domain: Domain, purchase?: Purchase ) => {
+	if (
+		! domain.current_user_is_owner ||
+		domain.pending_registration ||
+		domain.move_to_new_site_pending ||
+		domain.transfer_status === DomainTransferStatus.PENDING_ASYNC
+	) {
+		return false;
+	}
+
+	if ( ! purchase || ! purchase.is_cancelable ) {
+		return false;
+	}
+
+	return true;
+};
+
 // Delete action utils
 export const getDeleteTitle = ( domain: Domain ) => {
 	switch ( domain.subtype.id ) {


### PR DESCRIPTION
Part of DOTDASH-453

## Proposed Changes

* Add missing domain cancel option

## Why are these changes being made?

* DOTDASH-453

## Testing Instructions

* Go to `/v2/domains`
* Select a domain
* Make sure that auto-renew is turned on
* Scroll down and click delete
* Check if you ended up to the purchase cancel path

<img width="766" height="389" alt="Screenshot 2025-09-15 at 21 30 46" src="https://github.com/user-attachments/assets/a0fab59f-b301-4e6e-ad74-4c1bbc28279e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
