### PR TITLE
Domain Search Rewrite: Add use my domain form to Start variant

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -54,6 +54,7 @@ function UseMyDomain( props ) {
 		stepLocation,
 		registerNowAction,
 		hideHeader,
+		render,
 	} = props;
 
 	const { __ } = useI18n();
@@ -471,6 +472,10 @@ function UseMyDomain( props ) {
 		}
 	}, [ stepLocation, updateMode, isStepper ] );
 
+	if ( render ) {
+		return render( { onGoBack, headerText, content: renderContent() } );
+	}
+
 	return (
 		<>
 			{ renderHeader() }
@@ -497,6 +502,7 @@ UseMyDomain.propTypes = {
 	stepLocation: PropTypes.object,
 	registerNowAction: PropTypes.func,
 	hideHeader: PropTypes.bool,
+	render: PropTypes.func,
 };
 
 export default connect( ( state ) => ( {

--- a/client/components/domains/wpcom-domain-search/domain-search-cart-provider.tsx
+++ b/client/components/domains/wpcom-domain-search/domain-search-cart-provider.tsx
@@ -1,0 +1,14 @@
+import { ShoppingCartProvider } from '@automattic/shopping-cart';
+import { shoppingCartManagerClient } from 'calypso/dashboard/app/shopping-cart';
+
+const OPTIONS = {
+	refetchOnWindowFocus: true,
+};
+
+export const WPCOMDomainSearchCartProvider = ( { children }: { children: React.ReactNode } ) => {
+	return (
+		<ShoppingCartProvider managerClient={ shoppingCartManagerClient } options={ OPTIONS }>
+			{ children }
+		</ShoppingCartProvider>
+	);
+};

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -1,7 +1,7 @@
 import { DomainSearch } from '@automattic/domain-search';
-import { ResponseCartProduct, ShoppingCartProvider } from '@automattic/shopping-cart';
+import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps } from 'react';
-import { shoppingCartManagerClient } from 'calypso/dashboard/app/shopping-cart';
+import { WPCOMDomainSearchCartProvider } from './domain-search-cart-provider';
 import { useWPCOMShoppingCartForDomainSearch } from './use-wpcom-shopping-cart-for-domain-search';
 
 type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | 'events' > & {
@@ -87,8 +87,8 @@ const DomainSearchWithCart = ( {
 
 export const WPCOMDomainSearch = ( props: DomainSearchProps ) => {
 	return (
-		<ShoppingCartProvider managerClient={ shoppingCartManagerClient }>
+		<WPCOMDomainSearchCartProvider>
 			<DomainSearchWithCart { ...props } />
-		</ShoppingCartProvider>
+		</WPCOMDomainSearchCartProvider>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -78,7 +78,7 @@ const DomainSearchStep: StepType< {
 				heading={ <Step.Heading text={ text } subText={ subText } /> }
 			>
 				<WPCOMDomainSearch
-					className="step-container-v2-domain-search"
+					className="domain-search--step-container-v2"
 					currentSiteId={ site?.ID }
 					currentSiteUrl={ currentSiteUrl }
 					flowName={ flow }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -1,7 +1,7 @@
 @layer module, consumer-styles;
 
 @layer consumer-styles {
-	.step-container-v2-domain-search {
+	.domain-search--step-container-v2 {
 		--domain-search-mini-cart-inline-padding: var( --step-container-v2-content-inline-padding );
 		--domain-search-content-max-width: var( --step-container-v2-content-row-max-width );
 		--domain-search-full-cart-z-index: 3;

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -76,6 +76,10 @@ export class NavigationLink extends Component {
 	}
 
 	getBackUrl() {
+		if ( this.props.goToPreviousStep ) {
+			return;
+		}
+
 		if ( this.props.direction !== 'back' ) {
 			return;
 		}

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -82,10 +82,11 @@ describe( 'NavigationLink', () => {
 
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
 		expect( getStepUrl ).not.toHaveBeenCalled();
+		const { goToPreviousStep, ...actualProps } = props;
 
 		const { rerender } = render(
 			// We're mocking a logged-out user to ensure locale is being considered
-			<NavigationLink { ...props } userLoggedIn={ false } direction="back" />
+			<NavigationLink { ...actualProps } userLoggedIn={ false } direction="back" />
 		);
 
 		// It should call getStepUrl()
@@ -107,7 +108,12 @@ describe( 'NavigationLink', () => {
 		] );
 
 		rerender(
-			<NavigationLink { ...props } userLoggedIn={ false } direction="back" stepName="test:step1" />
+			<NavigationLink
+				{ ...actualProps }
+				userLoggedIn={ false }
+				direction="back"
+				stepName="test:step1"
+			/>
 		);
 		expect( getStepUrl ).toHaveBeenCalled();
 		expect( getStepUrl ).toHaveBeenCalledWith( 'test:flow', null, '', 'en', undefined );
@@ -115,7 +121,7 @@ describe( 'NavigationLink', () => {
 		// The href should be backUrl when exist.
 		rerender(
 			<NavigationLink
-				{ ...props }
+				{ ...actualProps }
 				userLoggedIn={ false }
 				direction="back"
 				backUrl="test:back-url"

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -12,6 +12,8 @@ import { getStepUrl } from '../../utils';
 import { USE_MY_DOMAIN_SECTION_NAME, UseMyDomain } from './use-my-domain';
 import type { StepProps } from './types';
 
+import './style.scss';
+
 function DomainSearchStep( props: StepProps & { locale: string } ) {
 	const {
 		flowName,
@@ -67,11 +69,13 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 	return (
 		<StepWrapper
 			{ ...props }
+			className="step-wrapper--domain-search"
 			hideSkip
 			headerText="Domain Search"
 			subHeaderText="Domain Search"
 			stepContent={
 				<WPCOMDomainSearch
+					className="domain-search--step-wrapper"
 					flowName={ flowName }
 					events={ {
 						onExternalDomainClick( initialQuery ) {

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -1,46 +1,103 @@
+import { useMyDomainInputMode } from '@automattic/api-core';
+import page from '@automattic/calypso-router';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { localize } from 'i18n-calypso';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getStepUrl } from '../../utils';
+import { USE_MY_DOMAIN_SECTION_NAME, UseMyDomain } from './use-my-domain';
+import type { StepProps } from './types';
 
-export type StepProps = {
-	stepSectionName: string | null;
-	stepName: string;
-	flowName: string;
-	goToStep: () => void;
-	goToNextStep: () => void;
-	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
-	queryObject: Record< string, string | undefined >;
-};
+function DomainSearchStep( props: StepProps & { locale: string } ) {
+	const {
+		flowName,
+		stepName,
+		locale: externalLocale,
+		submitSignupStep,
+		goToNextStep,
+		stepSectionName,
+		queryObject,
+	} = props;
 
-export default function DomainSearchStep( props: StepProps ) {
-	const allowedTlds = props.queryObject.tld?.split( ',' ) ?? [];
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const locale = ! isLoggedIn ? externalLocale : '';
 
-	const getContent = () => {
+	if ( stepSectionName === USE_MY_DOMAIN_SECTION_NAME ) {
+		const handleUseMyDomainSubmit = ( domainItem: MinimalRequestCartProduct ) => {
+			submitSignupStep(
+				{
+					stepName: stepName,
+					domainItem,
+					isPurchasingItem: true,
+					siteUrl: domainItem.meta,
+					stepSectionName: stepSectionName,
+					domainCart: {},
+				},
+				{ domainItem, siteUrl: domainItem.meta, domainCart: {} }
+			);
+
+			goToNextStep();
+		};
+
+		const handleSkip = () => {
+			submitSignupStep(
+				{ stepName, suggestion: undefined, domainCart: {}, siteUrl: '' },
+				{ suggestion: undefined, domainCart: {}, siteUrl: '' }
+			);
+
+			goToNextStep();
+		};
+
 		return (
-			<WPCOMDomainSearch
-				flowName={ props.flowName }
-				config={ {
-					vendor: getSuggestionsVendor( {
-						isSignup: true,
-						isDomainOnly: props.flowName === 'domain',
-						flowName: props.flowName,
-					} ),
-					priceRules: {
-						forceRegularPrice: isMonthlyOrFreeFlow( props.flowName ),
-					},
-					allowedTlds,
-				} }
+			<UseMyDomain
+				{ ...props }
+				locale={ ! isLoggedIn ? locale : '' }
+				onSubmit={ handleUseMyDomainSubmit }
+				onSkip={ handleSkip }
 			/>
 		);
-	};
+	}
+
+	const allowedTlds = queryObject.tld?.split( ',' ) ?? [];
 
 	return (
 		<StepWrapper
+			{ ...props }
+			hideSkip
 			headerText="Domain Search"
 			subHeaderText="Domain Search"
-			stepContent={ getContent() }
-			{ ...props }
+			stepContent={
+				<WPCOMDomainSearch
+					flowName={ flowName }
+					events={ {
+						onExternalDomainClick( initialQuery ) {
+							page(
+								getStepUrl( flowName, stepName, USE_MY_DOMAIN_SECTION_NAME, locale, {
+									step: useMyDomainInputMode.domainInput,
+									initialQuery: initialQuery,
+								} )
+							);
+						},
+					} }
+					config={ {
+						vendor: getSuggestionsVendor( {
+							isSignup: true,
+							isDomainOnly: flowName === 'domain',
+							flowName: flowName,
+						} ),
+						priceRules: {
+							forceRegularPrice: isMonthlyOrFreeFlow( flowName ),
+						},
+						allowedTlds,
+					} }
+				/>
+			}
 		/>
 	);
 }
+
+export default localize( DomainSearchStep );

--- a/client/signup/steps/domain-search/style.scss
+++ b/client/signup/steps/domain-search/style.scss
@@ -1,0 +1,31 @@
+.signup__step.is-domain-search:has( .step-wrapper--domain-search ) {
+	height: 100vh;
+	box-sizing: border-box;
+
+	.step-wrapper {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+
+	.step-wrapper__header {
+		margin-top: 0 !important;
+		padding-top: 24px;
+
+		@include break-large {
+			padding-top: 48px;
+		}
+	}
+
+	.step-wrapper__content {
+		display: flex;
+		flex: 1;
+		padding-bottom: 36px;
+	}
+}
+
+.domain-search--step-wrapper {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}

--- a/client/signup/steps/domain-search/types.ts
+++ b/client/signup/steps/domain-search/types.ts
@@ -1,0 +1,10 @@
+export type StepProps = {
+	stepSectionName: string | null;
+	stepName: string;
+	flowName: string;
+	goToStep: () => void;
+	goToNextStep: () => void;
+	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
+	queryObject: Record< string, string | undefined >;
+	locale: string;
+};

--- a/client/signup/steps/domain-search/use-my-domain.tsx
+++ b/client/signup/steps/domain-search/use-my-domain.tsx
@@ -1,0 +1,82 @@
+import { useMyDomainInputMode } from '@automattic/api-core';
+import page from '@automattic/calypso-router';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import UseMyDomainForm from 'calypso/components/domains/use-my-domain';
+import { WPCOMDomainSearchCartProvider } from 'calypso/components/domains/wpcom-domain-search/domain-search-cart-provider';
+import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
+import StepWrapper from '../../step-wrapper';
+import { getStepUrl } from '../../utils';
+import type { StepProps } from './types';
+
+export const USE_MY_DOMAIN_SECTION_NAME = 'use-your-domain';
+
+export const UseMyDomain = ( {
+	flowName,
+	stepName,
+	locale,
+	onSubmit,
+	onSkip,
+}: StepProps & { onSubmit( domain: MinimalRequestCartProduct ): void; onSkip(): void } ) => {
+	const queryObject = new URLSearchParams( window.location.search );
+	const initialQuery = queryObject.get( 'initialQuery' ) ?? '';
+	const mode = queryObject.get( 'step' ) ?? useMyDomainInputMode.domainInput;
+
+	return (
+		<WPCOMDomainSearchCartProvider>
+			<UseMyDomainForm
+				analyticsSection={ flowName === 'domain' ? 'domain-first' : 'signup' }
+				initialQuery={ initialQuery }
+				initialMode={ mode }
+				isSignupStep
+				onNextStep={ ( { mode: newStep, domain }: { mode: string; domain: string } ) => {
+					page(
+						getStepUrl( flowName, stepName, USE_MY_DOMAIN_SECTION_NAME, locale, {
+							step: newStep,
+							initialQuery: domain,
+						} )
+					);
+				} }
+				goBack={ () => {
+					page( getStepUrl( flowName, stepName, '', locale ) );
+				} }
+				onTransfer={ ( { domain, authCode }: { domain: string; authCode: string } ) => {
+					const domainItem = domainTransfer( {
+						domain,
+						extra: {
+							auth_code: authCode,
+							signup: true,
+						},
+					} );
+
+					onSubmit( domainItem );
+				} }
+				onConnect={ ( { domain }: { domain: string } ) => {
+					const domainItem = domainMapping( { domain } );
+
+					onSubmit( domainItem );
+				} }
+				onSkip={ onSkip }
+				render={ ( {
+					onGoBack,
+					headerText,
+					content,
+				}: {
+					onGoBack: () => void;
+					headerText: string;
+					content: React.ReactNode;
+				} ) => (
+					<StepWrapper
+						goToPreviousStep={ onGoBack }
+						flowName={ flowName }
+						stepName={ stepName }
+						stepSectionName={ USE_MY_DOMAIN_SECTION_NAME }
+						hideSkip
+						fallbackHeaderText={ headerText }
+						subHeaderText=""
+						stepContent={ content }
+					/>
+				) }
+			/>
+		</WPCOMDomainSearchCartProvider>
+	);
+};


### PR DESCRIPTION
Closes DOMAINS-1625.

## Proposed Changes


https://github.com/user-attachments/assets/cd064c2c-d745-44bf-86b5-21d6fb9f3f47



## Testing Instructions

Enter `/start/free` and verify you can add a transferrable domain to the cart by clicking the use my domain CTA at the bottom of the page.

Type a transferrable domain in the search page, click "Bring it over" and verify you can perform the same steps.

Test the behavior compared to production.