### PR TITLE
Dashboard v2 - Account closed page

### DIFF
--- a/client/dashboard/app/hooks/use-route-static-data.ts
+++ b/client/dashboard/app/hooks/use-route-static-data.ts
@@ -1,0 +1,16 @@
+import { useRouterState } from '@tanstack/react-router';
+
+/**
+ * Returns the staticData object of the currently matched route.
+ *
+ * Example:
+ *   const staticData = useRouteStaticData();
+ *   if (staticData?.hideHeaders) { ... }
+ */
+type RouteStaticData = { hideHeaders?: boolean };
+
+export default function useRouteStaticData(): RouteStaticData | undefined {
+	const routerState = useRouterState();
+	const lastMatch = routerState.matches?.at( -1 ) as { staticData?: unknown } | undefined;
+	return lastMatch?.staticData as RouteStaticData | undefined;
+}

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -8,6 +8,7 @@ import NotFound from '../404';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import Header from '../header';
+import useRouteStaticData from '../hooks/use-route-static-data';
 import Snackbars from '../snackbars';
 import './style.scss';
 
@@ -27,12 +28,14 @@ function Root() {
 	// empty, but remain set after subsequent navigations.
 	// https://tanstack.com/router/latest/docs/framework/react/api/router/RouterStateType#resolvedlocation-property
 	const isInitialLoad = ! router.resolvedLocation;
+	const routeStaticData = useRouteStaticData();
+	const hideHeaders = routeStaticData?.hideHeaders;
 
 	return (
 		<div className="dashboard-root__layout">
 			{ ( isFetching > 0 || isNavigating ) && <LoadingLine /> }
 			{ isInitialLoad && <LoadingLogo className="wpcom-site__logo" /> }
-			{ ! isInitialLoad && <Header /> }
+			{ ! isInitialLoad && ! hideHeaders && <Header /> }
 			<main>
 				<CatchNotFound fallback={ NotFound }>
 					<Outlet />

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -364,6 +364,18 @@ export const appsRoute = createRoute( {
 	)
 );
 
+export const accountClosedRoute = createRoute( {
+	getParentRoute: () => meRoute,
+	path: 'account/closed',
+	staticData: { hideHeaders: true },
+} ).lazy( () =>
+	import( '../../me/account-closed' ).then( ( d ) =>
+		createLazyRoute( 'account-closed' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createMeRoutes = ( config: AppConfig ) => {
 	if ( ! config.supports.me ) {
 		return [];
@@ -393,6 +405,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		notificationsEmailsRoute,
 		notificationsCommentsRoute,
 		notificationsExtrasRoute,
+		accountClosedRoute,
 	];
 
 	if ( config.supports.me.privacy ) {

--- a/client/dashboard/me/account-closed/index.tsx
+++ b/client/dashboard/me/account-closed/index.tsx
@@ -1,0 +1,106 @@
+import { restoreAccountMutation } from '@automattic/api-queries';
+import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+interface SearchParams {
+	token?: string;
+}
+
+export default function AccountClosed() {
+	const navigate = useNavigate();
+	const search = useSearch( { strict: false } ) as SearchParams;
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const [ restoreToken, setRestoreToken ] = useState< string | null >( null );
+	const restoreMutation = useMutation( restoreAccountMutation() );
+
+	// Get token from URL params or stored state
+	useEffect( () => {
+		if ( search.token ) {
+			setRestoreToken( search.token );
+		}
+	}, [ search.token ] );
+
+	const handleRestoreAccount = () => {
+		if ( ! restoreToken ) {
+			return;
+		}
+
+		restoreMutation.mutate( restoreToken, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Your account has been successfully restored!' ), {
+					type: 'snackbar',
+				} );
+				navigate( { to: '/me/profile' } );
+			},
+			onError: () => {
+				const errorMessage = __(
+					'Sorry, there was a problem restoring your account. Please contact support.'
+				);
+
+				createErrorNotice( errorMessage, {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const handleCreateAccount = () => {
+		window.location.href = '/start';
+	};
+
+	const onCancelClick = () => {
+		window.location.href = '/';
+	};
+
+	return (
+		<VStack spacing={ 0 } style={ { minHeight: '100vh' } }>
+			<HStack justify="space-between" style={ { padding: '20px 24px', width: 'auto' } }>
+				<WordPressLogo size={ 24 } className="dashboard-account-closed__logo" />
+				<Button variant="link" onClick={ handleCreateAccount }>
+					{ __( 'Create an account' ) }
+				</Button>
+			</HStack>
+			<VStack spacing={ 12 } alignment="center" style={ { flex: 1, textAlign: 'center' } }>
+				<VStack spacing={ 4 } style={ { maxWidth: '450px' } }>
+					<Heading level={ 1 } weight={ 400 }>
+						{ __( 'Your account has been deleted' ) }
+					</Heading>
+					<Text>
+						{ __(
+							'Thanks for flying with WordPress.com. You have 30 days to restore your account if you change your mind.'
+						) }
+					</Text>
+				</VStack>
+
+				<VStack alignment="center" spacing={ 4 }>
+					{ restoreToken && (
+						<Button
+							variant="secondary"
+							onClick={ handleRestoreAccount }
+							isBusy={ restoreMutation.isPending }
+							disabled={ restoreMutation.isPending }
+						>
+							{ __( 'I made a mistake! Restore my account' ) }
+						</Button>
+					) }
+
+					<Button variant="link" onClick={ onCancelClick }>
+						{ __( 'Return to WordPress.com' ) }
+					</Button>
+				</VStack>
+			</VStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -2,12 +2,18 @@ import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import useRouteStaticData from '../app/hooks/use-route-static-data';
 import HeaderBar from '../components/header-bar';
 import MenuDivider from '../components/menu-divider';
 import MeMenu from './me-menu';
 
 function Me() {
 	const isDesktop = useViewportMatch( 'medium' );
+	const staticData = useRouteStaticData();
+
+	if ( staticData?.hideHeaders ) {
+		return <Outlet />;
+	}
 
 	return (
 		<>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-381/implement-the-meaccountclosed-page

## Proposed Changes

This is a follow-up on https://github.com/Automattic/wp-calypso/pull/105544

After [deleting their account](https://github.com/Automattic/wp-calypso/pull/105544), users are redirected to `/me/account/closed`.  The changes in this pull request add this page to the Dashboard v2.

<img width="1800" height="1620" alt="Account Closed Token" src="https://github.com/user-attachments/assets/88d71188-518a-44a8-9be5-2159fd40e3d4" />

The new mockups don't contemplate this page, so I tried to match the existing page for Dashboard v2 as close as I could.

## Why are these changes being made?

This is part of the work to implement the user profile pages on Dashboard v2.

## Testing Instructions

1. Visit http://calypso.localhost:3000/v2/me/account/closed?token=abc
2. Make sure the page closely matches http://calypso.localhost:3000/me/account/closed?token=abc 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
