### PR TITLE
Dotcom 14584 focus on the chatfooter on mounting

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -41,6 +41,11 @@ export const OdieSendMessageButton = () => {
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 
+	// Focus the textarea when the component mounts
+	useEffect( () => {
+		textareaRef.current?.focus();
+	}, [ textareaRef ] );
+
 	// Prioritize connection status notice over message size notice
 	const notice = connectionNotice || messageSizeNotice;
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14584/focus-on-the-chatfooter-on-mounting

1. Start a new convo.
2. Textarea should be in focus.