### PR TITLE
Onboarding: Handle playground id directly within flow

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,15 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useState, createInterpolateElement, useEffect } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 import { chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
-import {
-	LOCAL_STORAGE_KEY_FOR_PG_ID,
-	LOCAL_STORAGE_KEY_FOR_PG_ID_TS,
-} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground';
 import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -95,17 +90,6 @@ const SignupFormSocialFirst = ( {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
-
-	useEffect( () => {
-		// save in localstorage for domain step in playground onboarding flow,
-		// just in case if we lose it in any possible combination of login/create-account/recover-account flow
-		const playgroundIdFromUrl = getQueryArg( window.location.href, 'playground' );
-		if ( playgroundIdFromUrl && typeof playgroundIdFromUrl === 'string' ) {
-			// ok to always overwrite with the latest playground
-			window.localStorage.setItem( LOCAL_STORAGE_KEY_FOR_PG_ID, playgroundIdFromUrl );
-			window.localStorage.setItem( LOCAL_STORAGE_KEY_FOR_PG_ID_TS, '' + Date.now() );
-		}
-	}, [] );
 
 	const renderTermsOfService = () => {
 		let tosText;

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -98,6 +98,8 @@ const onboarding: FlowV2< typeof initialize > = {
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
+		const playgroundId = useQuery().get( 'playground' );
+
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
 		 */
@@ -108,7 +110,6 @@ const onboarding: FlowV2< typeof initialize > = {
 				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
 
-			const playgroundId = getQueryArg( window.location.href, 'playground' );
 			if ( playgroundId && providedDependencies.siteSlug ) {
 				return [
 					addQueryArgs( withLocale( '/setup/site-setup/importerPlayground', locale ), {
@@ -306,7 +307,15 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 		};
 
-		return { submit };
+		const getGoBack = () => {
+			if ( currentStepSlug === STEPS.UNIFIED_DOMAINS.slug && playgroundId ) {
+				return () => {
+					return navigate( STEPS.PLAYGROUND.slug );
+				};
+			}
+		};
+
+		return { submit, goBack: getGoBack() };
 	},
 	useAssertConditions() {
 		const [ isLoading ] = useIsDomainSearchV2Enabled( this.name );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -306,16 +306,7 @@ const onboarding: FlowV2< typeof initialize > = {
 					return;
 			}
 		};
-
-		const getGoBack = () => {
-			if ( currentStepSlug === STEPS.UNIFIED_DOMAINS.slug && playgroundId ) {
-				return () => {
-					return navigate( STEPS.PLAYGROUND.slug );
-				};
-			}
-		};
-
-		return { submit, goBack: getGoBack() };
+		return { submit };
 	},
 	useAssertConditions() {
 		const [ isLoading ] = useIsDomainSearchV2Enabled( this.name );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -18,17 +18,11 @@ import type { Flow, FlowV2, Navigate, ProvidedDependencies, StepperStep } from '
 
 interface Params {
 	flow: Flow | FlowV2< any >;
-	stepSlugs: string[];
 	currentStepRoute: StepperStep[ 'slug' ];
 	navigate: Navigate;
 }
 
-export const useStepNavigationWithTracking = ( {
-	flow,
-	currentStepRoute,
-	navigate,
-	stepSlugs,
-}: Params ) => {
+export const useStepNavigationWithTracking = ( { flow, currentStepRoute, navigate }: Params ) => {
 	// We don't know the type of the return value of useStepNavigation, because we don't know which flow is this.
 	// So we cast it to any.
 	const stepNavigation: any = flow.useStepNavigation( currentStepRoute, navigate );
@@ -54,7 +48,6 @@ export const useStepNavigationWithTracking = ( {
 	 */
 	const canUserGoBack =
 		( stepData?.previousStep &&
-			currentStepRoute !== stepSlugs[ 0 ] &&
 			history.length > 1 &&
 			stepData.previousStep !== currentStepRoute ) ||
 		canUseAutomaticGoBack();

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -195,10 +195,17 @@ export const FlowRenderer: React.FC< {
 		}
 
 		if ( step.slug === PRIVATE_STEPS.USER.slug ) {
+			const postAuthStepPath = createPath( {
+				pathname: generatePath( '/setup/:flow/', {
+					flow: flow.variantSlug ?? flow.name,
+				} ),
+				search: window.location.search,
+				hash: window.location.hash,
+			} );
 			// In this case, the user step is not able to determine the next step after auth. This happens when users somehow land in /flow/user directly.
 			// So we navigate to the landing page of the flow and let the flow decide what to do.
 			// If you intend to land in /flow/user, please point your URL to the step itself and Stepper will automatically redirect to the user step if needed.
-			return <Navigate to={ `/${ flow.variantSlug ?? flow.name }/` } replace />;
+			return <Navigate to={ postAuthStepPath } replace />;
 		}
 
 		return (

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -196,12 +196,13 @@ export const FlowRenderer: React.FC< {
 
 		if ( step.slug === PRIVATE_STEPS.USER.slug ) {
 			const postAuthStepPath = createPath( {
-				pathname: generatePath( '/setup/:flow/', {
+				pathname: generatePath( '/:flow/', {
 					flow: flow.variantSlug ?? flow.name,
 				} ),
 				search: window.location.search,
 				hash: window.location.hash,
 			} );
+
 			// In this case, the user step is not able to determine the next step after auth. This happens when users somehow land in /flow/user directly.
 			// So we navigate to the landing page of the flow and let the flow decide what to do.
 			// If you intend to land in /flow/user, please point your URL to the step itself and Stepper will automatically redirect to the user step if needed.

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -97,7 +97,6 @@ export const FlowRenderer: React.FC< {
 
 	const stepNavigation = useStepNavigationWithTracking( {
 		flow,
-		stepSlugs: stepPaths,
 		currentStepRoute,
 		navigate,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -8,9 +8,6 @@ import { logToLogstash } from 'calypso/lib/logstash';
 import { getBlueprint } from './blueprint';
 
 const OPFS_PATH_PREFIX = '/wpcom-onboarding';
-export const LOCAL_STORAGE_KEY_FOR_PG_ID = 'pg_flow_pg_id';
-export const LOCAL_STORAGE_KEY_FOR_PG_ID_TS = 'pg_flow_pg_ts';
-export const LOCAL_STORAGE_KEY_FOR_PG_VALIDITY = 180000; // ms - 180 seconds / 3 minutes
 
 export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -37,11 +37,6 @@ import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
 import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import {
-	LOCAL_STORAGE_KEY_FOR_PG_ID as PG_ID,
-	LOCAL_STORAGE_KEY_FOR_PG_ID_TS as PG_TS,
-	LOCAL_STORAGE_KEY_FOR_PG_VALIDITY as PG_ID_VALIDITY,
-} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {
@@ -184,25 +179,6 @@ class RenderDomainsStepComponent extends Component {
 		}
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
 
-		// Get playground ID from either GET param or localStorage
-		const playgroundIdFromUrl = getQueryArg( window.location.href, 'playground' );
-		const playgroundIdFromStorage = window.localStorage.getItem( PG_ID );
-		const playgroundIdTimestamp = window.localStorage.getItem( PG_TS );
-		const playgroundId =
-			playgroundIdFromUrl ||
-			( Date.now() - playgroundIdTimestamp < PG_ID_VALIDITY ? playgroundIdFromStorage : null );
-
-		// Clean up localStorage regardless of whether we used the value
-		window.localStorage.removeItem( PG_ID );
-		window.localStorage.removeItem( PG_TS );
-
-		// Update URL if we got the ID from localStorage
-		if ( playgroundId && playgroundIdFromStorage && ! playgroundIdFromUrl ) {
-			const url = new URL( window.location.href );
-			url.searchParams.set( 'playground', playgroundId );
-			window.history.replaceState( {}, '', url.toString() );
-		}
-
 		this.state = {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
@@ -217,7 +193,6 @@ class RenderDomainsStepComponent extends Component {
 			checkDomainAvailabilityPromises: [],
 			removeDomainTimeout: 0,
 			addDomainTimeout: 0,
-			playgroundId,
 		};
 	}
 
@@ -1632,10 +1607,7 @@ class RenderDomainsStepComponent extends Component {
 		} else if ( ! isNewHostedSiteCreationFlow( flowName ) ) {
 			backUrl = getStepUrl( flowName, stepName, null, this.getLocale() );
 
-			if ( this.state.playgroundId ) {
-				backUrl = `/setup/onboarding/playground?playground=${ this.state.playgroundId }`;
-				backLabelText = translate( 'Back' );
-			} else if ( 'site' === source && siteUrl ) {
+			if ( 'site' === source && siteUrl ) {
 				backUrl = siteUrl;
 				backLabelText = translate( 'Back to My Site' );
 				isExternalBackUrl = true;


### PR DESCRIPTION
Closes DOMAINS-1630.

## Proposed Changes

Instead of relying on local storage to save and retrieve the playground ID which is initially part of the query parameters, simply let Stepper do that.

@zaerl, I understand that's why we're saving the playground ID to local storage and retrieving it in the domains step, right? Because it's being lost after the user redirect. Correct?

**But we shouldn't lose the query param after the authentication redirect. That's the purpose of https://github.com/Automattic/wp-calypso/pull/100832 which was introduced months ago.** @alshakero, it seems we have a bug there as even in the test instructions from the Stepper PR (linked in this paragraph), if I go to `/setup/newsletter?param=random`, that query param is lost after redirecting. I think we have a bug there.

EDIT: We were indeed losing the query parameters. This is fixed.

## Why are these changes being made?

Decoupling with the legacy unified domains step. We shouldn't need that logic within it.

## Testing Instructions

**As a logged-in user**:
1. Enter `/setup/onboarding/playground`. You should see the `playgroundId` query parameter get attached.
2. Click "Launch on WordPress.com" and verify you're redirected to the domains step.
3. Click "Back" and you should be sent back to the playground step, with the playground ID being preserved.

**As a logged-out user**:
1. Enter `/setup/onboarding/playground`. You should see the `playgroundId` query parameter get attached.
2. Click "Launch on WordPress.com" and verify you're redirected to the signup step.
3. Signup with a random email and you should see the domains step.
4. Click "Back" and you should be sent back to the playground step, with the playground ID being preserved.