### PR TITLE
Domains: Handle permissions for transfers or contact editing in the router

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -25,6 +25,7 @@ import {
 	checkDomainNameServersPermissions,
 	checkDomainTransferPermissions,
 	checkDomainContactInfoPermissions,
+	checkDomainDnsRecordsPermissions,
 } from '../../utils/domain-permissions';
 import { rootRoute } from './root';
 
@@ -50,6 +51,7 @@ export const domainRoute = createRoute( {
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
 		const isTransferSubRoute = location.pathname.includes( '/transfer' );
 		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
+		const isDnsSubRoute = location.pathname.includes( '/dns' );
 
 		// For generic sub-routes permissions checks,
 		// throw error and handle it with the global error boundary
@@ -63,6 +65,10 @@ export const domainRoute = createRoute( {
 
 		if ( isContactInfoSubRoute ) {
 			checkDomainContactInfoPermissions( domain );
+		}
+
+		if ( isDnsSubRoute ) {
+			checkDomainDnsRecordsPermissions( domain );
 		}
 
 		return domain;

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -20,8 +20,12 @@ import {
 	redirect,
 	lazyRouteComponent,
 } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
 import { StepName } from '../../domains/domain-connection-setup/types';
+import {
+	checkDomainNameServersPermissions,
+	checkDomainTransferPermissions,
+	checkDomainContactInfoPermissions,
+} from '../../utils/domain-permissions';
 import { rootRoute } from './root';
 
 // Standalone domains route - requires rootRoute
@@ -44,14 +48,21 @@ export const domainRoute = createRoute( {
 	loader: async ( { params: { domainName }, location } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
+		const isTransferSubRoute = location.pathname.includes( '/transfer' );
+		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
 
-		// If navigating to name-servers sub-route and user doesn't have permission,
+		// For generic sub-routes permissions checks,
 		// throw error and handle it with the global error boundary
-		if ( isNameServersSubRoute && ! domain.can_manage_name_servers ) {
-			throw new Error(
-				domain.cannot_manage_name_servers_reason ||
-					__( 'You do not have permission to manage name servers.' )
-			);
+		if ( isNameServersSubRoute ) {
+			checkDomainNameServersPermissions( domain );
+		}
+
+		if ( isTransferSubRoute ) {
+			checkDomainTransferPermissions( domain );
+		}
+
+		if ( isContactInfoSubRoute ) {
+			checkDomainContactInfoPermissions( domain );
 		}
 
 		return domain;

--- a/client/dashboard/domains/domain-transfer/internal-transfer-options.tsx
+++ b/client/dashboard/domains/domain-transfer/internal-transfer-options.tsx
@@ -1,90 +1,150 @@
 import { DomainSubtype } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import { domainTransferToOtherSiteRoute } from '../../app/router/domains';
 import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
 import { getTopLevelOfTld } from '../../utils/domain';
 import type { Domain } from '@automattic/api-core';
 
-const RESTRICTED_TRANSFER_TLDS = [ 'uk', 'fr', 'ca', 'de', 'jp' ];
+/**
+ * TLDs that have restricted transfer capabilities
+ */
+const RESTRICTED_TRANSFER_TLDS = [ 'uk', 'fr', 'ca', 'de', 'jp' ] as const;
+
+/**
+ * Transfer action configuration type
+ */
+interface TransferAction {
+	key: string;
+	title: string;
+	description: string;
+	route: string;
+	routeParams?: Record< string, string >;
+}
 
 interface InternalTransferOptionsProps {
 	domain: Domain;
 }
 
-export default function InternalTransferOptions( { domain }: InternalTransferOptionsProps ) {
-	const actions = [];
+/**
+ * Checks if a domain's TLD is restricted for transfers
+ */
+function isDomainTransferRestricted( domain: Domain ): boolean {
+	const tld = getTopLevelOfTld( domain.domain );
+	return ( RESTRICTED_TRANSFER_TLDS as readonly string[] ).includes( tld );
+}
 
-	if ( ! domain.is_domain_only_site && domain.can_transfer_to_any_user ) {
-		const description =
-			domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
-				? __( 'Transfer this domain connection to any administrator on this site.' )
-				: __( 'Transfer this domain to any administrator on this site.' );
-		actions.push(
-			<ActionList.ActionItem
-				key="transfer-to-another-user"
-				title={ __( 'Transfer to another user' ) }
-				description={ description }
-				actions={
-					<RouterLinkButton
-						variant="secondary"
-						size="compact"
-						to={ `/domains/${ domain.domain }/transfer/other-user` }
-					>
-						{ __( 'Continue' ) }
-					</RouterLinkButton>
-				}
-			/>
-		);
-	} else if (
-		! RESTRICTED_TRANSFER_TLDS.includes( getTopLevelOfTld( domain.domain ) ) &&
-		domain.can_transfer_to_other_site
-	) {
-		actions.push(
-			<ActionList.ActionItem
-				key="transfer-to-any-user"
-				title={ __( 'To another WordPress.com user' ) }
-				description={ __( 'Transfer this domain to another WordPress.com user' ) }
-				actions={
-					<RouterLinkButton
-						variant="secondary"
-						size="compact"
-						to={ `/domains/${ domain.domain }/transfer/any-user` }
-					>
-						{ __( 'Continue' ) }
-					</RouterLinkButton>
-				}
-			/>
-		);
+/**
+ * Gets the appropriate description text based on domain type
+ */
+function getTransferDescription(
+	domain: Domain,
+	transferType: 'user' | 'site' | 'any-user'
+): string {
+	const isDomainConnection = domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION;
+
+	if ( isDomainConnection ) {
+		switch ( transferType ) {
+			case 'user':
+				return __( 'Transfer this domain connection to any administrator on this site.' );
+			case 'site':
+				return __( 'Transfer this domain connection to any site you are an administrator on.' );
+			case 'any-user':
+				return __( 'Transfer this domain connection to another WordPress.com user' );
+			default:
+				return '';
+		}
 	}
 
+	switch ( transferType ) {
+		case 'user':
+			return __( 'Transfer this domain to any administrator on this site.' );
+		case 'site':
+			return __( 'Transfer this domain to any site you are an administrator on.' );
+		case 'any-user':
+			return __( 'Transfer this domain to another WordPress.com user' );
+		default:
+			return '';
+	}
+}
+
+/**
+ * Creates transfer action configurations based on domain capabilities
+ */
+function createTransferActions( domain: Domain ): TransferAction[] {
+	const actions: TransferAction[] = [];
+	const isRestricted = isDomainTransferRestricted( domain );
+
+	// Transfer to another user on the same site
+	if ( ! domain.is_domain_only_site && domain.can_transfer_to_any_user && ! isRestricted ) {
+		actions.push( {
+			key: 'transfer-to-another-user',
+			title: __( 'Transfer to another user' ),
+			description: getTransferDescription( domain, 'user' ),
+			route: `/domains/${ domain.domain }/transfer/other-user`,
+		} );
+	}
+
+	// Transfer to any WordPress.com user (domain-only sites)
+	if ( domain.is_domain_only_site && domain.can_transfer_to_any_user && ! isRestricted ) {
+		actions.push( {
+			key: 'transfer-to-any-user',
+			title: __( 'To another WordPress.com user' ),
+			description: getTransferDescription( domain, 'any-user' ),
+			route: `/domains/${ domain.domain }/transfer/any-user`,
+		} );
+	}
+
+	// Transfer to another site
 	if ( domain.can_transfer_to_other_site ) {
-		const description =
-			domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
-				? __( 'Transfer this domain connection to any site you are an administrator on.' )
-				: __( 'Transfer this domain to any site you are an administrator on.' );
-		actions.push(
-			<ActionList.ActionItem
-				key="transfer-to-another-site"
-				title={ __( 'To another WordPress.com site' ) }
-				description={ description }
-				actions={
-					<RouterLinkButton
-						variant="secondary"
-						size="compact"
-						to={ domainTransferToOtherSiteRoute.fullPath }
-						params={ { domainName: domain.domain } }
-					>
-						{ __( 'Continue' ) }
-					</RouterLinkButton>
-				}
-			/>
-		);
+		actions.push( {
+			key: 'transfer-to-another-site',
+			title: __( 'To another WordPress.com site' ),
+			description: getTransferDescription( domain, 'site' ),
+			route: domainTransferToOtherSiteRoute.fullPath,
+			routeParams: { domainName: domain.domain },
+		} );
 	}
 
-	if ( actions.length > 0 ) {
-		return <ActionList>{ actions }</ActionList>;
+	return actions;
+}
+
+/**
+ * Creates an ActionList.ActionItem component from transfer action configuration
+ */
+function createActionItem( action: TransferAction ) {
+	return (
+		<ActionList.ActionItem
+			key={ action.key }
+			title={ action.title }
+			description={ action.description }
+			actions={
+				<RouterLinkButton
+					variant="secondary"
+					size="compact"
+					to={ action.route }
+					params={ action.routeParams }
+				>
+					{ __( 'Continue' ) }
+				</RouterLinkButton>
+			}
+		/>
+	);
+}
+
+/**
+ * InternalTransferOptions component renders transfer options available for a domain
+ * @param props - Component props
+ * @param props.domain - The domain object containing transfer capabilities
+ * @returns JSX element with transfer options or null if no options available
+ */
+export default function InternalTransferOptions( { domain }: InternalTransferOptionsProps ) {
+	const transferActions = useMemo( () => createTransferActions( domain ), [ domain ] );
+
+	if ( transferActions.length === 0 ) {
+		return null;
 	}
 
-	return null;
+	return <ActionList>{ transferActions.map( createActionItem ) }</ActionList>;
 }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -309,8 +309,6 @@ export default function TransferDomainToAnyUser() {
 		);
 	};
 
-	// TO DO: render notices if the domain is not transferable
-
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
 			<Card>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -263,8 +263,6 @@ export default function TransferDomainToOtherUser() {
 		);
 	};
 
-	// TO DO: render notices if the domain is not transferable
-
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
 			<Card>

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -112,12 +112,6 @@ const DOMAIN_PERMISSION_CHECKS = {
 				domain.cannot_manage_name_servers_reason ||
 				__( 'You do not have permission to manage name servers.' ),
 		},
-		{
-			check: checkCanManageNameServers,
-			getErrorMessage: ( domain: Domain ) =>
-				domain.cannot_manage_name_servers_reason ||
-				__( 'You do not have permission to manage name servers.' ),
-		},
 	],
 	[ PermissionCheck.CONTACT_INFO ]: [
 		{

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -36,10 +36,14 @@ const checkCanUpdateContactInfo: DomainCheckFunction = ( domain: Domain ) =>
 const checkNotPendingWhoisUpdate: DomainCheckFunction = ( domain: Domain ) =>
 	! domain.is_pending_whois_update;
 
+const checkCanManageDnsRecords: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.can_manage_dns_records;
+
 export const PermissionCheck = {
 	TRANSFER: 'transfer',
 	NAME_SERVERS: 'name-servers',
 	CONTACT_INFO: 'contact-info',
+	DNS_RECORDS: 'dns-records',
 } as const;
 
 /**
@@ -113,6 +117,14 @@ const DOMAIN_PERMISSION_CHECKS = {
 				__( 'You do not have permission to manage name servers.' ),
 		},
 	],
+	[ PermissionCheck.DNS_RECORDS ]: [
+		{
+			check: checkCanManageDnsRecords,
+			getErrorMessage: ( domain: Domain ) =>
+				domain.cannot_manage_dns_records_reason ||
+				__( 'You do not have permission to manage DNS.' ),
+		},
+	],
 	[ PermissionCheck.CONTACT_INFO ]: [
 		{
 			check: checkNotInSupportSession,
@@ -166,4 +178,8 @@ export function checkDomainNameServersPermissions( domain: Domain ): void {
 
 export function checkDomainContactInfoPermissions( domain: Domain ): void {
 	checkDomainPermissions( domain, PermissionCheck.CONTACT_INFO );
+}
+
+export function checkDomainDnsRecordsPermissions( domain: Domain ): void {
+	checkDomainPermissions( domain, PermissionCheck.DNS_RECORDS );
 }

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -1,0 +1,175 @@
+import { isSupportSession } from '@automattic/calypso-support-session';
+import { __, sprintf } from '@wordpress/i18n';
+import type { Domain } from '@automattic/api-core';
+
+/**
+ * Individual domain check functions
+ * Each function checks a specific condition and returns true if the check passes, false if it fails
+ */
+type DomainCheckFunction = ( domain: Domain ) => boolean;
+
+const checkNotInSupportSession: DomainCheckFunction = () => ! isSupportSession();
+
+const checkCurrentUserIsOwner: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.current_user_is_owner;
+
+const checkNotRedeemable: DomainCheckFunction = ( domain: Domain ) => ! domain.is_redeemable;
+
+const checkNotHundredYearDomain: DomainCheckFunction = ( domain: Domain ) =>
+	! domain.is_hundred_year_domain;
+
+const checkNotPendingRegistration: DomainCheckFunction = ( domain: Domain ) =>
+	! domain.is_pending_registration && ! domain.is_pending_registration_at_registry;
+
+const checkNotAftermarketAuction: DomainCheckFunction = ( domain: Domain ) =>
+	! domain.aftermarket_auction;
+
+const checkCanTransferToAnyUser: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.can_transfer_to_any_user;
+
+const checkCanManageNameServers: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.can_manage_name_servers;
+
+const checkCanUpdateContactInfo: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.can_update_contact_info;
+
+const checkNotPendingWhoisUpdate: DomainCheckFunction = ( domain: Domain ) =>
+	! domain.is_pending_whois_update;
+
+export const PermissionCheck = {
+	TRANSFER: 'transfer',
+	NAME_SERVERS: 'name-servers',
+	CONTACT_INFO: 'contact-info',
+} as const;
+
+/**
+ * Permission configuration maps
+ * Each permission type defines which checks are required and their corresponding error messages
+ */
+const DOMAIN_PERMISSION_CHECKS = {
+	[ PermissionCheck.TRANSFER ]: [
+		{
+			check: checkNotInSupportSession,
+			getErrorMessage: () =>
+				__(
+					'Transfers cannot be initiated in a support session - please ask the user to do it instead'
+				),
+		},
+		{
+			check: checkCurrentUserIsOwner,
+			getErrorMessage: ( domain: Domain ) =>
+				sprintf(
+					/* translators: domain is the domain name, owner is the owner of the domain */
+					__( '%(domain)s can be transferred only by the user {{strong}}%(owner)s{{/strong}}.' ),
+					{ domain: domain.domain, owner: domain.owner }
+				),
+		},
+		{
+			check: checkNotRedeemable,
+			getErrorMessage: ( domain: Domain ) =>
+				sprintf(
+					/* translators: domain is the domain name */
+					__( '%(domain)s is in redemption so it is not possible to transfer it.' ),
+					{ domain: domain.domain }
+				),
+		},
+		{
+			check: checkNotHundredYearDomain,
+			getErrorMessage: ( domain: Domain ) =>
+				sprintf(
+					/* translators: domain is the domain name */
+					__( '%(domain)s is a 100-year domain and cannot be transferred.' ),
+					{ domain: domain.domain }
+				),
+		},
+		{
+			check: checkNotPendingRegistration,
+			getErrorMessage: () =>
+				__(
+					'We are still setting up your domain. You will not be able to transfer it until the registration setup is done.'
+				),
+		},
+		{
+			check: checkNotAftermarketAuction,
+			getErrorMessage: ( domain: Domain ) =>
+				sprintf(
+					/* translators: domain is the domain name */
+					__(
+						'%(domain)s expired over 30 days ago and has been offered for sale at auction. Currently it is not possible to renew it.'
+					),
+					{ domain: domain.domain }
+				),
+		},
+		{
+			check: checkCanTransferToAnyUser,
+			getErrorMessage: () => __( 'You do not have permission to transfer this domain.' ),
+		},
+	],
+	[ PermissionCheck.NAME_SERVERS ]: [
+		{
+			check: checkCanManageNameServers,
+			getErrorMessage: ( domain: Domain ) =>
+				domain.cannot_manage_name_servers_reason ||
+				__( 'You do not have permission to manage name servers.' ),
+		},
+		{
+			check: checkCanManageNameServers,
+			getErrorMessage: ( domain: Domain ) =>
+				domain.cannot_manage_name_servers_reason ||
+				__( 'You do not have permission to manage name servers.' ),
+		},
+	],
+	[ PermissionCheck.CONTACT_INFO ]: [
+		{
+			check: checkNotInSupportSession,
+			getErrorMessage: () =>
+				__(
+					'Contact info cannot be managed in a support session - please ask the user to do it instead'
+				),
+		},
+		{
+			check: checkCurrentUserIsOwner,
+			getErrorMessage: ( domain: Domain ) =>
+				sprintf(
+					/* translators: domain is the domain name, owner is the owner of the domain */
+					__( '%(domain)s contact info can be managed only by the user %(owner)s.' ),
+					{ domain: domain.domain, owner: domain.owner }
+				),
+		},
+		{
+			check: checkCanUpdateContactInfo,
+			getErrorMessage: ( domain: Domain ) =>
+				domain.cannot_update_contact_info_reason ||
+				__( 'You do not have permission to update contact info.' ),
+		},
+		{
+			check: checkNotPendingWhoisUpdate,
+			getErrorMessage: () => __( 'Domain is pending contact information update.' ),
+		},
+	],
+} as const;
+
+function checkDomainPermissions(
+	domain: Domain,
+	permissionType: ( typeof PermissionCheck )[ keyof typeof PermissionCheck ]
+): void {
+	const checks = DOMAIN_PERMISSION_CHECKS[ permissionType ];
+
+	for ( const { check, getErrorMessage } of checks ) {
+		if ( ! check( domain ) ) {
+			throw new Error( getErrorMessage( domain ) );
+		}
+	}
+}
+
+export function checkDomainTransferPermissions( domain: Domain ): void {
+	checkDomainPermissions( domain, PermissionCheck.TRANSFER );
+}
+
+export function checkDomainNameServersPermissions( domain: Domain ): void {
+	checkDomainPermissions( domain, PermissionCheck.NAME_SERVERS );
+}
+
+export function checkDomainContactInfoPermissions( domain: Domain ): void {
+	checkDomainPermissions( domain, PermissionCheck.CONTACT_INFO );
+}

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -40,6 +40,9 @@ export interface Domain extends DomainSummary {
 	is_subdomain: boolean;
 	is_pending_icann_verification: boolean;
 	move_to_new_site_pending: boolean;
+	owner: string;
+	is_pending_registration: boolean;
+	is_pending_registration_at_registry: boolean;
 	private_domain: boolean;
 	privacy_available: boolean;
 	renewable_until: string;

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -21,7 +21,6 @@ export interface Domain extends DomainSummary {
 	can_manage_name_servers: boolean;
 	can_transfer_to_any_user: boolean;
 	can_transfer_to_other_site: boolean;
-	cannot_manage_name_servers_reason: null | string;
 	contact_info_disclosure_available: boolean;
 	contact_info_disclosed: boolean;
 	dnssec_records?: {

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -32,6 +32,7 @@ export interface DomainSummary {
 	can_set_as_primary: boolean;
 	cannot_update_contact_info_reason: string | null;
 	cannot_manage_name_servers_reason: string | null;
+	cannot_manage_dns_records_reason: string | null;
 	current_user_can_create_site_from_domain_only: boolean;
 	current_user_can_manage: boolean;
 	current_user_is_owner: boolean | null;

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -30,6 +30,8 @@ export interface DomainSummary {
 	can_manage_dns_records: boolean;
 	can_update_contact_info: boolean;
 	can_set_as_primary: boolean;
+	cannot_update_contact_info_reason: string | null;
+	cannot_manage_name_servers_reason: string | null;
 	current_user_can_create_site_from_domain_only: boolean;
 	current_user_can_manage: boolean;
 	current_user_is_owner: boolean | null;
@@ -42,6 +44,7 @@ export interface DomainSummary {
 	has_registration: boolean;
 	is_eligible_for_inbound_transfer: boolean;
 	is_hundred_year_domain: boolean;
+	is_pending_whois_update: boolean;
 	is_redeemable: boolean;
 	is_renewable: boolean;
 	is_wpcom_staging_domain: boolean;


### PR DESCRIPTION
Closes [DOTDASH-410](https://linear.app/a8c/issue/DOTDASH-410/handle-permissions-for-transfers-or-contact-editing)

## Proposed Changes
This PR creates a centralized domain permissions system with a new permissions scheme for some hosting dashboard domains sub-routes:
- transfers
- nameserver
- contact info editing
- dns records

It also improve internal transfer options component with better code organization and type safety.

![Screenshot 2025-09-16 alle 17 26 08](https://github.com/user-attachments/assets/bb90717b-7a34-4884-88bc-f2a07ef3ed6e)


## Why are these changes being made?
We want to prevent certain domain routes from being rendered, depending on the user’s permissions for the domain.
If the required permissions are not met, a message is displayed using the Hosting Dashboard’s default component.

## Testing Instructions
The simplest way to test it is just trying to open the routes using a domain you don't own (also, on a site where you are not the admin).

If you want to see specific message you can hack the backend endpoint to return different values, to trigger different messages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
