### PR TITLE
Set CALYPSO_BASE_URL environment variable for AuthenticationE2ETests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1366,6 +1366,7 @@ object AuthenticationE2ETests : E2EBuildType(
 	concurrentBuilds = 1,
 	testGroup = "authentication",
 	buildParams = {
+		param("env.CALYPSO_BASE_URL", "https://wordpress.com")
 		param("env.VIEWPORT_NAME", "desktop")
 	},
 	buildFeatures = {


### PR DESCRIPTION

## Proposed Changes

Set the URL for the e2e tests in the Authentication build configuration. Since #105614 the default URL changed and these tests started failing.


## Testing Instructions

Go to TeamCity, and run the Authentication E2E Tests against this branch. 


