### PR TITLE
Domain: hide Actions section in case when there are no actions in the list

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -80,11 +80,24 @@ export default function Actions() {
 		[ purchase, deleteDomain, createSuccessNotice, createErrorNotice, router ]
 	);
 
+	const availableActions = {
+		renew: purchase?.is_renewable,
+		transfer: shouldShowTransferAction( domain ),
+		disconnect: shouldShowDisconnectAction( domain ),
+		delete: shouldShowDeleteAction( domain, purchase, site ),
+		cancel: shouldShowCancelAction( domain, purchase ),
+	};
+
+	// If none of the actions are available, don't render the actions section
+	if ( Object.values( availableActions ).every( ( action ) => ! action ) ) {
+		return null;
+	}
+
 	return (
 		<VStack spacing={ 4 }>
 			<SectionHeader level={ 3 } title={ __( 'Actions' ) } />
 			<ActionList>
-				{ purchase?.is_renewable && (
+				{ availableActions.renew && (
 					<ActionList.ActionItem
 						title={ __( 'Renew' ) }
 						description={ __( 'Renew domain registration.' ) }
@@ -92,14 +105,14 @@ export default function Actions() {
 							<Button
 								size="compact"
 								variant="secondary"
-								href={ getDomainRenewalUrl( domain, purchase ) }
+								href={ getDomainRenewalUrl( domain, purchase! ) }
 							>
 								{ __( 'Renew' ) }
 							</Button>
 						}
 					/>
 				) }
-				{ shouldShowTransferAction( domain ) && (
+				{ availableActions.transfer && (
 					<ActionList.ActionItem
 						title={ __( 'Transfer' ) }
 						description={ __( 'Transfer this domain to another site or WordPress.com user.' ) }
@@ -115,7 +128,7 @@ export default function Actions() {
 						}
 					/>
 				) }
-				{ shouldShowDisconnectAction( domain ) && (
+				{ availableActions.disconnect && (
 					<ActionList.ActionItem
 						title={ __( 'Detach' ) }
 						description={ __( 'Detach this domain from the site.' ) }
@@ -132,7 +145,7 @@ export default function Actions() {
 						}
 					/>
 				) }
-				{ shouldShowDeleteAction( domain, purchase, site ) && (
+				{ availableActions.delete && (
 					<ActionList.ActionItem
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }
@@ -150,7 +163,7 @@ export default function Actions() {
 						}
 					/>
 				) }
-				{ shouldShowCancelAction( domain, purchase ) && (
+				{ availableActions.cancel && (
 					<ActionList.ActionItem
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }


### PR DESCRIPTION
Part of DOTDASH-456

## Proposed Changes

* hide Actions section in case when there are no actions in the list

<img width="748" height="202" alt="Screenshot 2025-09-16 at 11 28 50" src="https://github.com/user-attachments/assets/bfda819d-4676-4281-9661-6e8438ccdf4c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Avoiding empty Actions section

## Testing Instructions

* Go to `/v2/domains`
* Select a domain without actions (eg. a8c.tv)
* Check the Actions section, it should not be there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
