### PR TITLE
e2e tests: add TeamCity build template

### DIFF
--- a/.teamcity/_self/e2eTestsBuildTemplate.kt
+++ b/.teamcity/_self/e2eTestsBuildTemplate.kt
@@ -1,0 +1,13 @@
+package TeamcitySandbox_QualityOpsSandbox.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.*
+
+object Calypso_e2e_Tests_BuildTemplate : Template({
+    name = "Calypso E2E Tests Build Template"
+    description = "Runs Calypso Playwright e2e tests using Playwright Test runner"
+
+    vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+})

--- a/.teamcity/_self/e2eTestsBuildTemplate.kt
+++ b/.teamcity/_self/e2eTestsBuildTemplate.kt
@@ -1,6 +1,6 @@
-package TeamcitySandbox_QualityOpsSandbox.buildTypes
+package _self
 
-import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
 
 object Calypso_e2e_Tests_BuildTemplate : Template({
     name = "Calypso E2E Tests Build Template"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -2,6 +2,7 @@ package _self.projects
 
 import Settings
 import _self.bashNodeScript
+import _self.Calypso_e2e_Tests_BuildTemplate
 import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.mergeTrunk
 
@@ -907,15 +908,16 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PlaywrightTestPRMatrix : BuildType({
+	templates(TeamcitySandbox_QualityOpsSandbox_BuildTemplateOne)
 	id("calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix")
 	uuid = "074d8ae0-0859-4b4d-bf66-709f24ae5406"
 	name = "E2E Tests (Playwright Test)"
-	description = "Runs Calypso e2e tests using Playwright Test runner with build matrix"
+	description = "Runs Calypso e2e tests on pull requests using Playwright Test runner with build matrix"
 
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
+	// vcs {
+	// 	root(Settings.WpCalypso)
+	// 	cleanCheckout = true
+	// }
 
 	features {
 		matrix {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -908,7 +908,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PlaywrightTestPRMatrix : BuildType({
-	templates(TeamcitySandbox_QualityOpsSandbox_BuildTemplateOne)
+	templates(Calypso_e2e_Tests_BuildTemplate)
 	id("calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix")
 	uuid = "074d8ae0-0859-4b4d-bf66-709f24ae5406"
 	name = "E2E Tests (Playwright Test)"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -2,7 +2,6 @@ package _self.projects
 
 import Settings
 import _self.bashNodeScript
-import _self.Calypso_e2e_Tests_BuildTemplate
 import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.mergeTrunk
 
@@ -908,7 +907,6 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PlaywrightTestPRMatrix : BuildType({
-	templates(Calypso_e2e_Tests_BuildTemplate)
 	id("calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix")
 	uuid = "074d8ae0-0859-4b4d-bf66-709f24ae5406"
 	name = "E2E Tests (Playwright Test)"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -908,16 +908,15 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PlaywrightTestPRMatrix : BuildType({
-	templates(Calypso_e2e_Tests_BuildTemplate)
 	id("calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix")
 	uuid = "074d8ae0-0859-4b4d-bf66-709f24ae5406"
 	name = "E2E Tests (Playwright Test)"
 	description = "Runs Calypso e2e tests on pull requests using Playwright Test runner with build matrix"
 
-	// vcs {
-	// 	root(Settings.WpCalypso)
-	// 	cleanCheckout = true
-	// }
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
 
 	features {
 		matrix {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -908,6 +908,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 }
 
 object PlaywrightTestPRMatrix : BuildType({
+	templates(Calypso_e2e_Tests_BuildTemplate)
 	id("calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix")
 	uuid = "074d8ae0-0859-4b4d-bf66-709f24ae5406"
 	name = "E2E Tests (Playwright Test)"


### PR DESCRIPTION

Part of https://github.com/Automattic/wp-calypso/issues/105466, DOTCOM-14356

## Proposed Changes

Add a build configuration template for e2e tests running with Playwright Test.
For now them template is empty to be picked up by TC and will move most of the configuration into it in follow ups

## Testing Instructions

The e2e build passes in TC
