### PR TITLE
Domains: Update connected domain overview section

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -1,0 +1,20 @@
+import { DomainSubtype } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
+import { domainConnectionSetupRoute } from '../../app/router/domains';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Domain } from '@automattic/api-core';
+
+export default function DomainConnectionSetupSummary( { domain }: { domain: Domain } ) {
+	if ( domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION || domain.points_to_wpcom ) {
+		return null;
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ domainConnectionSetupRoute.fullPath }
+			params={ { domainName: domain.domain } }
+			title={ __( 'Domain connection setup' ) }
+			density={ 'medium' as const }
+		/>
+	);
+}

--- a/client/dashboard/domains/domain-contact-details/summary.tsx
+++ b/client/dashboard/domains/domain-contact-details/summary.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '@automattic/api-core';
@@ -9,6 +10,10 @@ export default function DomainContactDetailsSettingsSummary( { domain }: { domai
 		badges.push( { text: __( 'Privacy protection on' ), intent: 'success' as const } );
 	} else {
 		badges.push( { text: __( 'Privacy protection off' ), intent: undefined } );
+	}
+
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+		return null;
 	}
 
 	return (

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -17,11 +17,11 @@ export default function FeaturedCards() {
 			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
 				<FeaturedCardRenew domain={ domain } />
 			) }
-			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
-				<FeaturedCardSite domain={ domain } />
-			) }
+			<FeaturedCardSite domain={ domain } />
 			<FeaturedCardEmails domain={ domain } />
-			<FeaturedCardPrivacy domain={ domain } />
+			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
+				<FeaturedCardPrivacy domain={ domain } />
+			) }
 		</Grid>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { domainQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
@@ -13,8 +14,12 @@ export default function FeaturedCards() {
 
 	return (
 		<Grid columns={ 2 }>
-			<FeaturedCardRenew domain={ domain } />
-			<FeaturedCardSite domain={ domain } />
+			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
+				<FeaturedCardRenew domain={ domain } />
+			) }
+			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
+				<FeaturedCardSite domain={ domain } />
+			) }
 			<FeaturedCardEmails domain={ domain } />
 			<FeaturedCardPrivacy domain={ domain } />
 		</Grid>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { domainQuery, sitePurchaseQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
@@ -35,6 +36,10 @@ export default function DomainOverview() {
 		);
 	}, [ domain.domain ] );
 
+	const formattedRegistrationDate = formatDate( new Date( domain.registration_date ), locale, {
+		dateStyle: 'long',
+	} );
+
 	return (
 		<PageLayout
 			size="small"
@@ -45,14 +50,11 @@ export default function DomainOverview() {
 						<HStack spacing={ 2 } alignment="center" justify="flex-start">
 							{ domain.subtype?.label && <Badge>{ domain.subtype.label }</Badge> }
 							<span>
-								{
-									// translators: date is the date the domain was registered.
-									sprintf( __( 'Registered on %(date)s' ), {
-										date: formatDate( new Date( domain.registration_date ), locale, {
-											dateStyle: 'long',
-										} ),
-									} )
-								}
+								{ domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
+									? // translators: date is the date the domain was connected.
+									  sprintf( __( 'Connected on %(date)s' ), { date: formattedRegistrationDate } )
+									: // translators: date is the date the domain was registered.
+									  sprintf( __( 'Registered on %(date)s' ), { date: formattedRegistrationDate } ) }
 							</span>
 						</HStack>
 					}

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { domainRoute } from '../../app/router/domains';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
+import DomainConnectionSetupSummary from '../domain-connection-setup/summary';
 import DomainContactDetailsSettingsSummary from '../domain-contact-details/summary';
 import DnsSettingsSummary from '../domain-dns/summary';
 import DomainForwardingsSettingsSummary from '../domain-forwardings/summary';
@@ -19,6 +20,7 @@ export default function DomainOverviewSettings() {
 		<VStack spacing={ 3 }>
 			<SectionHeader title={ __( 'Settings' ) } level={ 3 } />
 			<SummaryButtonList>
+				<DomainConnectionSetupSummary domain={ domain } />
 				<NameServersSettingsSummary domain={ domain } />
 				<DnsSettingsSummary domain={ domain } />
 				<DomainForwardingsSettingsSummary domain={ domain } />


### PR DESCRIPTION
Part of DOTDASH-444

## Proposed Changes

* Updates domain overview description based on subtype: "Connected on: " / "Registered on: "
* Removes the "Renews" and "Whois Privacy" cards for the connected domain
* Adds missing "Domain connection setup" settings link

## Why are these changes being made?

* DOTDASH-444

## Testing Instructions

* Go to `/v2/domains`
* Select a connected domain
* Make sure that domain doesn't point to the wpcom
* Check if there is "Connected on" description
* Check if Renews and Privacy is hidden
* Check if there is a Settings "Domain connection setup" link

<img width="728" height="509" alt="Screenshot 2025-09-16 at 14 53 15" src="https://github.com/user-attachments/assets/f1bafe48-1d9a-44a9-9b57-ae0ced5e2ad0" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
