### PR TITLE
Hosting Dashboard: Implement getPlanName()

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
@@ -1,4 +1,4 @@
-import { DotcomPlans, getPlanName } from '@automattic/api-core';
+import { DotcomPlans, getPlanNames } from '@automattic/api-core';
 import {
 	__experimentalVStack as VStack,
 	Card,
@@ -93,10 +93,10 @@ const HoldingMessages: Partial< Record< EligibilityErrors, HoldingMessage > > = 
 	[ EligibilityErrors.NO_BUSINESS_PLAN ]: {
 		code: EligibilityErrors.NO_BUSINESS_PLAN,
 		title: sprintf(
-			// translators: %(businessPlanName)s is the name of the Business plan
-			__( '%(businessPlanName)s plan required' ),
+			// translators: %(planName)s is the name of the plan
+			__( '%(planName)s plan required' ),
 			{
-				businessPlanName: getPlanName()[ DotcomPlans.BUSINESS ],
+				planName: getPlanNames()[ DotcomPlans.BUSINESS ],
 			}
 		),
 		description: __( 'You’ll also get to install custom themes, plugins, and have more storage.' ),

--- a/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/error-content-info.tsx
@@ -1,3 +1,4 @@
+import { DotcomPlans, getPlanName } from '@automattic/api-core';
 import {
 	__experimentalVStack as VStack,
 	Card,
@@ -6,7 +7,7 @@ import {
 	CardHeader,
 	ExternalLink,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Notice } from '../../components/notice';
@@ -91,8 +92,13 @@ type HoldingMessage = {
 const HoldingMessages: Partial< Record< EligibilityErrors, HoldingMessage > > = {
 	[ EligibilityErrors.NO_BUSINESS_PLAN ]: {
 		code: EligibilityErrors.NO_BUSINESS_PLAN,
-		// TODO: Resolve plan name instead of hardcoding it.
-		title: __( 'Business plan required' ),
+		title: sprintf(
+			// translators: %(businessPlanName)s is the name of the Business plan
+			__( '%(businessPlanName)s plan required' ),
+			{
+				businessPlanName: getPlanName()[ DotcomPlans.BUSINESS ],
+			}
+		),
 		description: __( 'You’ll also get to install custom themes, plugins, and have more storage.' ),
 	},
 	[ EligibilityErrors.NON_ADMIN_USER ]: {

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -1,4 +1,4 @@
-import { DotcomPlans, getPlanName } from '@automattic/api-core';
+import { DotcomPlans, getPlanNames } from '@automattic/api-core';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
@@ -70,8 +70,8 @@ export default function UpsellCallout( {
 								'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.'
 							),
 							{
-								businessPlanName: getPlanName()[ DotcomPlans.BUSINESS ],
-								commercePlanName: getPlanName()[ DotcomPlans.ECOMMERCE ],
+								businessPlanName: getPlanNames()[ DotcomPlans.BUSINESS ],
+								commercePlanName: getPlanNames()[ DotcomPlans.ECOMMERCE ],
 							}
 						) }
 					</Text>

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -1,5 +1,6 @@
+import { DotcomPlans, getPlanName } from '@automattic/api-core';
 import { __experimentalText as Text } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { Callout } from '../../components/callout';
@@ -63,7 +64,16 @@ export default function UpsellCallout( {
 				<>
 					<Text variant="muted">{ upsellDescription ?? defaultProps.description }</Text>
 					<Text variant="muted">
-						{ __( 'Available on the WordPress.com Business and Commerce plans.' ) }
+						{ sprintf(
+							// translators: %(businessPlanName)s is the name of the Business plan, %(commercePlanName)s is the name of the Commerce plan
+							__(
+								'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.'
+							),
+							{
+								businessPlanName: getPlanName()[ DotcomPlans.BUSINESS ],
+								commercePlanName: getPlanName()[ DotcomPlans.ECOMMERCE ],
+							}
+						) }
 					</Text>
 				</>
 			}

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -1,11 +1,11 @@
-import { DotcomPlans, type DotcomPlan, type Site } from '@automattic/api-core';
+import { DotcomPlans, type DotcomPlanSlug, type Site } from '@automattic/api-core';
 
-export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlan[] ) => {
+export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlanSlug[] ) => {
 	if ( ! site.plan ) {
 		return false;
 	}
 
-	return ! plans.includes( site.plan.product_slug as DotcomPlan );
+	return ! plans.includes( site.plan.product_slug as DotcomPlanSlug );
 };
 
 export const isSitePlanBigSkyTrial = ( site: Site ) => {
@@ -51,7 +51,7 @@ export function isSitePlanTrial( site: Site ) {
 		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
 		DotcomPlans.HOSTING_TRIAL_MONTHLY,
 		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
-	] as DotcomPlan[];
+	] as DotcomPlanSlug[];
 
-	return trialPlans.includes( site.plan?.product_slug as DotcomPlan );
+	return trialPlans.includes( site.plan?.product_slug as DotcomPlanSlug );
 }

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -1,11 +1,11 @@
-import { DotcomPlans, type Site } from '@automattic/api-core';
+import { DotcomPlans, type DotcomPlan, type Site } from '@automattic/api-core';
 
-export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlans[] ) => {
+export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlan[] ) => {
 	if ( ! site.plan ) {
 		return false;
 	}
 
-	return ! plans.includes( site.plan.product_slug as DotcomPlans );
+	return ! plans.includes( site.plan.product_slug as DotcomPlan );
 };
 
 export const isSitePlanBigSkyTrial = ( site: Site ) => {
@@ -47,9 +47,11 @@ export const isSitePlanLaunchable = ( site: Site ) => {
 };
 
 export function isSitePlanTrial( site: Site ) {
-	return [
+	const trialPlans = [
 		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
 		DotcomPlans.HOSTING_TRIAL_MONTHLY,
 		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
-	].includes( site.plan?.product_slug as DotcomPlans );
+	] as DotcomPlan[];
+
+	return trialPlans.includes( site.plan?.product_slug as DotcomPlan );
 }

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -1,4 +1,4 @@
-import { DotcomPlans, getPlanName } from '@automattic/api-core';
+import { DotcomPlans, getPlanNames } from '@automattic/api-core';
 import { sitePlanBySlugQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
@@ -33,7 +33,7 @@ const PlanPrice = lazy( () =>
 const getProduct = ( site: Site ) => {
 	if ( wasEcommerceTrial( site ) ) {
 		return {
-			name: getPlanName()[ DotcomPlans.ECOMMERCE ],
+			name: getPlanNames()[ DotcomPlans.ECOMMERCE ],
 			tagline: __( 'Grow your online store with commerce-optimized extensions.' ),
 			slug: 'ecommerce-bundle',
 			pathSlug: 'ecommerce',
@@ -41,7 +41,7 @@ const getProduct = ( site: Site ) => {
 	}
 
 	return {
-		name: getPlanName()[ DotcomPlans.BUSINESS ],
+		name: getPlanNames()[ DotcomPlans.BUSINESS ],
 		tagline: __( 'Unlock next-level WordPress with custom plugins and themes.' ),
 		slug: 'business-bundle',
 		pathSlug: 'business',

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -1,3 +1,4 @@
+import { DotcomPlans, getPlanName } from '@automattic/api-core';
 import { sitePlanBySlugQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
@@ -32,7 +33,7 @@ const PlanPrice = lazy( () =>
 const getProduct = ( site: Site ) => {
 	if ( wasEcommerceTrial( site ) ) {
 		return {
-			name: __( 'Commerce' ),
+			name: getPlanName()[ DotcomPlans.ECOMMERCE ],
 			tagline: __( 'Grow your online store with commerce-optimized extensions.' ),
 			slug: 'ecommerce-bundle',
 			pathSlug: 'ecommerce',
@@ -40,7 +41,7 @@ const getProduct = ( site: Site ) => {
 	}
 
 	return {
-		name: __( 'Business' ),
+		name: getPlanName()[ DotcomPlans.BUSINESS ],
 		tagline: __( 'Unlock next-level WordPress with custom plugins and themes.' ),
 		slug: 'business-bundle',
 		pathSlug: 'business',

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -18,7 +18,7 @@ export const DotcomPlans = {
 	PREMIUM_3_YEARS: 'value_bundle-3y',
 } as const;
 
-export type DotcomPlan = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
+export type DotcomPlanSlug = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
 
 export enum DotcomFeatures {
 	ATOMIC = 'atomic',

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -254,7 +254,7 @@ export const getDataCenterOptions = (): Record< DataCenterOption, string > => ( 
 	ams: __( 'EU West (Amsterdam, Netherlands)' ),
 } );
 
-export const getPlanName = () => ( {
+export const getPlanNames = () => ( {
 	[ DotcomPlans.BUSINESS ]: __( 'Business' ),
 	[ DotcomPlans.ECOMMERCE ]: __( 'Commerce' ),
 	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -1,21 +1,24 @@
 import { __ } from '@wordpress/i18n';
 import { DataCenterOption } from './site-hosting/types';
 
-export enum DotcomPlans {
-	BUSINESS = 'business-bundle',
-	BUSINESS_MONTHLY = 'business-bundle-monthly',
-	BUSINESS_2_YEARS = 'business-bundle-2y',
-	BUSINESS_3_YEARS = 'business-bundle-3y',
-	ECOMMERCE_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly',
-	FREE_PLAN = 'free_plan',
-	HOSTING_TRIAL_MONTHLY = 'wp_bundle_hosting_trial_monthly',
-	JETPACK_FREE = 'jetpack_free',
-	MIGRATION_TRIAL_MONTHLY = 'wp_bundle_migration_trial_monthly',
-	PREMIUM = 'value_bundle',
-	PREMIUM_MONTHLY = 'value_bundle_monthly',
-	PREMIUM_2_YEARS = 'value_bundle-2y',
-	PREMIUM_3_YEARS = 'value_bundle-3y',
-}
+export const DotcomPlans = {
+	BUSINESS: 'business-bundle',
+	BUSINESS_MONTHLY: 'business-bundle-monthly',
+	BUSINESS_2_YEARS: 'business-bundle-2y',
+	BUSINESS_3_YEARS: 'business-bundle-3y',
+	ECOMMERCE: 'ecommerce-bundle',
+	ECOMMERCE_TRIAL_MONTHLY: 'ecommerce-trial-bundle-monthly',
+	FREE_PLAN: 'free_plan',
+	HOSTING_TRIAL_MONTHLY: 'wp_bundle_hosting_trial_monthly',
+	JETPACK_FREE: 'jetpack_free',
+	MIGRATION_TRIAL_MONTHLY: 'wp_bundle_migration_trial_monthly',
+	PREMIUM: 'value_bundle',
+	PREMIUM_MONTHLY: 'value_bundle_monthly',
+	PREMIUM_2_YEARS: 'value_bundle-2y',
+	PREMIUM_3_YEARS: 'value_bundle-3y',
+} as const;
+
+export type DotcomPlan = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
 
 export enum DotcomFeatures {
 	ATOMIC = 'atomic',
@@ -249,4 +252,10 @@ export const getDataCenterOptions = (): Record< DataCenterOption, string > => ( 
 	dfw: __( 'US Central (Dallas-Fort Worth, Texas)' ),
 	dca: __( 'US East (Washington, D.C.)' ),
 	ams: __( 'EU West (Amsterdam, Netherlands)' ),
+} );
+
+export const getPlanName = () => ( {
+	[ DotcomPlans.BUSINESS ]: __( 'Business' ),
+	[ DotcomPlans.ECOMMERCE ]: __( 'Commerce' ),
+	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),
 } );


### PR DESCRIPTION
## Proposed Changes

This PR removes hardcoded plan names in favor of a centralized utility function placed in `@automattic/api-core`. Since we're in the area, we also update DotcomPlans so that it doesn't use enum.

As a follow-up PR, we could also update the other enums below (DotcomFeatures, JetpackFeatures, JetpackModules, and HostingFeatures).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2 and select a simple site.
* Click on the Deployments tab.
* Ensure that the callout still displays "Business" and "Commerce" as before. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
