### PR TITLE
Help Center: Modernize the fading gradient at the bottom of the container

### DIFF
--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -13,4 +13,38 @@
 			}
 		}
 	}
+
+	// Only show the blender when the footer is present.
+	&:has( .help-center__container-footer ) {
+		.help-center__container-content {
+			scroll-timeline-name: --help-center-scroll;
+			scroll-timeline-axis: block;
+
+			&::after {
+				content: '';
+				height: 80px;
+				margin-top: -79px;
+				z-index: 1;
+				background: linear-gradient( to bottom, transparent, #fff );
+				position: absolute;
+				width: 100%;
+				pointer-events: none;
+				opacity: 1;
+				animation: linear hideOnScroll both;
+				animation-timeline: --help-center-scroll;
+
+				@keyframes hideOnScroll {
+					0% {
+						opacity: 1;
+					}
+					80% {
+						opacity: 1;
+					}
+					100% {
+						opacity: 0;
+					}
+				}
+			}
+		}
+	}
 }

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -18,15 +18,16 @@
 	&:has( .help-center__container-footer ) {
 		.help-center__container-content {
 			&::after {
+				$height: 80;
 				content: '';
-				height: 80px;
+				height: #{$height}px;
 				margin-top: -79px;
 				z-index: 1;
 				background: linear-gradient( to bottom, transparent, #fff );
 				position: absolute;
 				width: 100%;
 				pointer-events: none;
-				opacity: var( --blender-opacity, 1 );
+				opacity: calc( var( --scroll-progress, 1 ) / $height );
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -17,9 +17,6 @@
 	// Only show the blender when the footer is present.
 	&:has( .help-center__container-footer ) {
 		.help-center__container-content {
-			scroll-timeline-name: --help-center-scroll;
-			scroll-timeline-axis: block;
-
 			&::after {
 				content: '';
 				height: 80px;
@@ -29,23 +26,7 @@
 				position: absolute;
 				width: 100%;
 				pointer-events: none;
-				opacity: 1;
-				animation-timing-function: linear;
-				animation-name: hideOnScroll;
-				animation-fill-mode: both;
-				animation-timeline: --help-center-scroll;
-
-				@keyframes hideOnScroll {
-					0% {
-						opacity: 1;
-					}
-					80% {
-						opacity: 1;
-					}
-					100% {
-						opacity: 0;
-					}
-				}
+				opacity: var( --blender-opacity, 1 );
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -27,7 +27,7 @@
 				position: absolute;
 				width: 100%;
 				pointer-events: none;
-				opacity: calc( var( --scroll-progress, 1 ) / $height );
+				opacity: calc( var( --scroll-progress, $height ) / $height );
 			}
 		}
 	}

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -30,7 +30,9 @@
 				width: 100%;
 				pointer-events: none;
 				opacity: 1;
-				animation: linear hideOnScroll both;
+				animation-timing-function: linear;
+				animation-name: hideOnScroll;
+				animation-fill-mode: both;
 				animation-timeline: --help-center-scroll;
 
 				@keyframes hideOnScroll {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -92,7 +92,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			const target = event.currentTarget as HTMLDivElement;
 			const { clientHeight, scrollHeight, scrollTop } = target;
 
-			// Sadly, Safari doesn't animation-timeline yet, once it does, you can use the CSS linked below and delete the JS.
+			// Sadly, Safari doesn't support animation-timeline yet, once it does, you can use the CSS linked below and delete the JS.
 			// https://github.com/Automattic/wp-calypso/pull/105777/commits/e07a4f09b045ed5008c1892641f45acd1ebfc514
 			target.style.setProperty(
 				'--blender-opacity',

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -22,8 +22,6 @@ import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
-const BLENDER_HEIGHT = 80;
-
 import './help-center-content.scss';
 
 // Disabled component only applies the class if isDisabled is true, we want it always.
@@ -95,9 +93,9 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			// Sadly, Safari doesn't support animation-timeline yet, once it does, you can use the CSS linked below and delete the JS.
 			// https://github.com/Automattic/wp-calypso/pull/105777/commits/e07a4f09b045ed5008c1892641f45acd1ebfc514
 			target.style.setProperty(
-				'--blender-opacity',
+				'--scroll-progress',
 				// This keeps opacity at 1 until the scroll reaches bottom - BLENDER_HEIGHT.
-				Math.min( 1, ( scrollHeight - clientHeight - scrollTop ) / BLENDER_HEIGHT ).toString()
+				( scrollHeight - clientHeight - scrollTop ).toString()
 			);
 		}
 

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -22,6 +22,8 @@ import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
+const BLENDER_HEIGHT = 80;
+
 import './help-center-content.scss';
 
 // Disabled component only applies the class if isDisabled is true, we want it always.
@@ -86,13 +88,33 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	}, [ navigate, navigateToRoute, setNavigateToRoute, location ] );
 
 	useEffect( () => {
-		if (
-			containerRef.current &&
-			! location.hash &&
-			! location.pathname.includes( '/odie' ) &&
-			! location.pathname.includes( '/post' )
-		) {
-			containerRef.current.scrollTo( 0, 0 );
+		function handler( event: Event ) {
+			const target = event.currentTarget as HTMLDivElement;
+			const { clientHeight, scrollHeight, scrollTop } = target;
+
+			// Sadly, Safari doesn't animation-timeline yet, once it does, you can use the CSS linked below and delete the JS.
+			// https://github.com/Automattic/wp-calypso/pull/105777/commits/e07a4f09b045ed5008c1892641f45acd1ebfc514
+			target.style.setProperty(
+				'--blender-opacity',
+				// This keeps opacity at 1 until the scroll reaches bottom - BLENDER_HEIGHT.
+				Math.min( 1, ( scrollHeight - clientHeight - scrollTop ) / BLENDER_HEIGHT ).toString()
+			);
+		}
+
+		if ( containerRef.current ) {
+			const container = containerRef.current;
+			container.addEventListener( 'scroll', handler );
+
+			if (
+				! location.hash &&
+				! location.pathname.includes( '/odie' ) &&
+				! location.pathname.includes( '/post' )
+			) {
+				container.scrollTo( 0, 0 );
+			}
+			return () => {
+				container?.removeEventListener( 'scroll', handler );
+			};
 		}
 	}, [ location ] );
 

--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -6,15 +6,6 @@
 	position: relative;
 	padding: 0;
 
-	.help-center-footer-blender {
-		height: 80px;
-		margin-top: -80px;
-		background: linear-gradient(to bottom, transparent, #fff);
-		position: absolute;
-		width: 100%;
-		pointer-events: none;
-	}
-
 	// hide when empty
 	&:empty {
 		display: none;
@@ -22,7 +13,6 @@
 
 	.button.help-center-contact-page__button {
 		margin: 16px;
-		margin-top: 0;
 		width: calc(100% - 32px);
 		border-radius: 8px;
 	}

--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -27,29 +27,28 @@ export const HelpCenterContactButton = () => {
 	};
 
 	return (
-		<Button
-			onClick={ handleClick }
-			variant="secondary"
-			className="button help-center-contact-page__button"
-			__next40pxDefaultSize
-		>
-			{ __( 'Need help? Get in touch', __i18n_text_domain__ ) }
-		</Button>
+		<CardFooter className="help-center__container-footer">
+			<Button
+				onClick={ handleClick }
+				variant="secondary"
+				className="button help-center-contact-page__button"
+				__next40pxDefaultSize
+			>
+				{ __( 'Need help? Get in touch', __i18n_text_domain__ ) }
+			</Button>
+		</CardFooter>
 	);
 };
 
 const HelpCenterFooter: React.FC = () => {
 	return (
 		<>
-			<CardFooter className="help-center__container-footer">
-				<div className="help-center-footer-blender"></div>
-				<Routes>
-					<Route path="/" element={ <HelpCenterContactButton /> } />
-					<Route path="/post" element={ <HelpCenterContactButton /> } />
-					<Route path="/chat-history" element={ <HelpCenterContactButton /> } />
-					<Route path="*" element={ null } />
-				</Routes>
-			</CardFooter>
+			<Routes>
+				<Route path="/" element={ <HelpCenterContactButton /> } />
+				<Route path="/post" element={ <HelpCenterContactButton /> } />
+				<Route path="/chat-history" element={ <HelpCenterContactButton /> } />
+				<Route path="*" element={ null } />
+			</Routes>
 		</>
 	);
 };

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -37,10 +37,7 @@ export const HelpCenterMoreResources = () => {
 			<h3 className="help-center__section-title">
 				{ __( 'More resources', __i18n_text_domain__ ) }
 			</h3>
-			<ul
-				className="help-center-more-resources__resources"
-				aria-labelledby="help-center-more-resources__resources"
-			>
+			<ul aria-labelledby="help-center-more-resources__resources">
 				<li className="help-center-more-resources__resource-item help-center-link__item">
 					<div className="help-center-more-resources__resource-cell help-center-link__cell">
 						<button


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14580/fade-applied-at-the-bottom-too

## Proposed Changes

This migrates the blending gradient to modern scroll timeline and automatically hide it when scrolling reaches the botton.

## Why are these changes being made?
Better UX.

## Testing Instructions
1. Open the HC.
2. Scroll down.
3. The blender should disappear gradually as you scroll.
4. Test the article page as well.