### PR TITLE
Domains: Site overview: Handle Add/Attach for domain only case

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,8 +1,9 @@
 import { Domain, DomainSubtype } from '@automattic/api-core';
 import { siteByIdQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 import OverviewCard from '../../sites/overview-card';
 import SiteIcon from '../../sites/site-icon';
 
@@ -35,7 +36,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			description={ shouldShowAddAttachSite ? __( 'Attach to an existing site' ) : domain.domain }
 			bottom={
 				shouldShowAddAttachSite && (
-					<HStack>
+					<ButtonStack>
 						<Button
 							size="compact"
 							variant="primary"
@@ -43,7 +44,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 						>
 							{ __( 'Add a new site' ) }
 						</Button>
-					</HStack>
+					</ButtonStack>
 				)
 			}
 		/>

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,6 +1,7 @@
-import { Domain } from '@automattic/api-core';
+import { Domain, DomainSubtype } from '@automattic/api-core';
 import { siteByIdQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import OverviewCard from '../../sites/overview-card';
 import SiteIcon from '../../sites/site-icon';
@@ -16,13 +17,35 @@ export default function FeaturedCardSite( { domain }: Props ) {
 		return null;
 	}
 
+	const shouldShowAddAttachSite =
+		domain.is_domain_only_site &&
+		! domain.is_gravatar_restricted_domain &&
+		domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER;
+
 	return (
 		<OverviewCard
 			title={ __( 'Site' ) }
 			heading={ <span style={ { wordBreak: 'break-all' } }>{ site.name }</span> }
-			link={ `/sites/${ site.slug }` }
+			link={
+				shouldShowAddAttachSite
+					? `/domains/${ domain.domain }/transfer/other-site`
+					: `/sites/${ site.slug }`
+			}
 			icon={ <SiteIcon site={ site } /> }
-			description={ domain.domain }
+			description={ shouldShowAddAttachSite ? __( 'Attach to an existing site' ) : domain.domain }
+			bottom={
+				shouldShowAddAttachSite && (
+					<HStack>
+						<Button
+							size="compact"
+							variant="primary"
+							href={ `/start/site-selected/?siteSlug=${ site.slug }&siteId=${ site.ID }` }
+						>
+							{ __( 'Add a new site' ) }
+						</Button>
+					</HStack>
+				)
+			}
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -33,7 +33,9 @@ export default function FeaturedCardSite( { domain }: Props ) {
 					: `/sites/${ site.slug }`
 			}
 			icon={ <SiteIcon site={ site } /> }
-			description={ shouldShowAddAttachSite ? __( 'Attach to an existing site' ) : domain.domain }
+			description={
+				shouldShowAddAttachSite ? __( 'Attach to an existing site' ) : domain.site_slug
+			}
 			bottom={
 				shouldShowAddAttachSite && (
 					<ButtonStack>

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -20,6 +20,7 @@ export interface SiteCapabilities {
 export interface SiteOptions {
 	admin_url: string;
 	created_at?: string;
+	is_domain_only?: boolean;
 	is_difm_lite_in_progress?: boolean;
 	is_summer_special_2025?: boolean;
 	is_wpforteams_site?: boolean;


### PR DESCRIPTION
Part of DOTDASH-402

## Proposed Changes

* Updates the Site overview card for the domain-only case

<img width="718" height="561" alt="Screenshot 2025-09-16 at 18 51 17" src="https://github.com/user-attachments/assets/82985d5b-66fc-4be8-a1a7-bc3e6ff58501" />
<img width="348" height="258" alt="Screenshot 2025-09-16 at 18 51 24" src="https://github.com/user-attachments/assets/b591a537-020c-4850-b4f1-fba593c96ee0" />

## Why are these changes being made?

* DOTDASH-402

## Testing Instructions

* Go to `/v2/domains`
* Choose a domain-only domain
* Check the Site overview card
* Select the overview card and check if you ended up on "Attach to another site"
* Also, click on "Add a new site" and check if you ended up on `/start/site-selected` flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
