### PR TITLE
Stepper Domain Flow: Add domains to cart when picking existing paid site

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -75,10 +75,10 @@ const domain: FlowV2< typeof initialize > = {
 
 		const { siteSlug, site } = useSiteData();
 
-		const { signupDomainOrigin, productCartItems } = useSelect(
+		const { signupDomainOrigin, domainCartItems } = useSelect(
 			( select ) => ( {
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
-				productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
+				domainCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItems(),
 			} ),
 			[]
 		);
@@ -226,7 +226,9 @@ const domain: FlowV2< typeof initialize > = {
 					}
 
 					setPendingAction( async () => {
-						await addProductsToCart( providedDependencies.siteSlug, this.name, productCartItems );
+						if ( domainCartItems ) {
+							await addProductsToCart( providedDependencies.siteSlug, this.name, domainCartItems );
+						}
 
 						return {
 							siteSlug: providedDependencies.siteSlug,

--- a/test/e2e/specs/flows/setup-domain__domain-only.ts
+++ b/test/e2e/specs/flows/setup-domain__domain-only.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Purchase only a domain' ), 
 
 	it( 'Search for a domain', async function () {
 		const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-		await domainSearchComponent.search( 'example' );
+		await domainSearchComponent.search( DataHelper.getBlogName() );
 	} );
 
 	it( 'Add the first suggestion to the cart', async function () {

--- a/test/e2e/specs/flows/setup-domain__existing-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-free-site.ts
@@ -47,7 +47,7 @@ describe(
 
 		it( 'Search for a domain', async function () {
 			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( 'example' );
+			await domainSearchComponent.search( DataHelper.getBlogName() );
 		} );
 
 		it( 'Add the first suggestion to the cart', async function () {

--- a/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
@@ -45,7 +45,7 @@ describe(
 
 		it( 'Search for a domain', async function () {
 			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( 'example' );
+			await domainSearchComponent.search( DataHelper.getBlogName() );
 		} );
 
 		it( 'Add the first suggestion to the cart', async function () {

--- a/test/e2e/specs/flows/setup-domain__new-site.ts
+++ b/test/e2e/specs/flows/setup-domain__new-site.ts
@@ -46,7 +46,7 @@ describe(
 
 		it( 'Search for a domain', async function () {
 			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( 'example' );
+			await domainSearchComponent.search( DataHelper.getBlogName() );
 		} );
 
 		it( 'Add the first suggestion to the cart', async function () {

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -47,7 +47,7 @@ describe(
 
 		it( 'Search for a domain', async function () {
 			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( 'example' );
+			await domainSearchComponent.search( DataHelper.getBlogName() );
 		} );
 
 		it( 'Add the first suggestion to the cart', async function () {

--- a/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
@@ -45,7 +45,7 @@ describe(
 
 		it( 'Search for a domain', async function () {
 			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( 'example' );
+			await domainSearchComponent.search( DataHelper.getBlogName() );
 		} );
 
 		it( 'Add the first suggestion to the cart', async function () {


### PR DESCRIPTION
Related to #105725 and #105639.

## Proposed Changes

On the PR that introduced the flow, the existing paid site variant wasn't adding the domains to the cart after picking a site in the site picker step. This PR fixes that.

## Testing Instructions

Verify [E2E tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/15706497) are green. Also, test manually:

1. Go to `/setup/domain`;
2. Search and add a domain to the cart;
3. In the new or existing site step, pick "Existing site";
4. Pick an existing paid site;
5. Verify you see the added domain at checkout.