### PR TITLE
Stepper Domain Flow: Isolate test users in E2E tests

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -29,6 +29,7 @@ const setInitialQuery = ( query: string ) => {
 
 const DomainSearchWithCart = ( {
 	currentSiteId,
+	currentSiteUrl,
 	flowName,
 	initialQuery: externalInitialQuery,
 	config: externalConfig,
@@ -44,8 +45,8 @@ const DomainSearchWithCart = ( {
 	} );
 
 	const initialQuery = useMemo( () => {
-		return externalInitialQuery ?? getInitialQuery();
-	}, [ externalInitialQuery ] );
+		return externalInitialQuery || currentSiteUrl || getInitialQuery();
+	}, [ externalInitialQuery, currentSiteUrl ] );
 
 	const cartItemsLength = cart.items.length;
 
@@ -75,6 +76,7 @@ const DomainSearchWithCart = ( {
 	return (
 		<DomainSearch
 			{ ...props }
+			currentSiteUrl={ currentSiteUrl }
 			config={ config }
 			cart={ cart }
 			events={ events }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -14,6 +14,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
+import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -39,7 +40,9 @@ const DomainSearchStep: StepType< {
 	submits: UseMyDomain | StepSubmission;
 } > = function DomainSearchStep( { navigation, flow } ) {
 	const site = useSite();
-	const initialQuery = useQuery().get( 'new' ) ?? site?.slug;
+	const siteSlug = useSiteSlugParam();
+	const initialQuery = useQuery().get( 'new' ) ?? '';
+	const currentSiteUrl = site?.URL ? new URL( site.URL ).host : siteSlug ?? undefined;
 	const allowedTlds = useQuery().get( 'tld' )?.split( ',' ) ?? [];
 
 	const config = {
@@ -77,6 +80,7 @@ const DomainSearchStep: StepType< {
 				<WPCOMDomainSearch
 					className="step-container-v2-domain-search"
 					currentSiteId={ site?.ID }
+					currentSiteUrl={ currentSiteUrl }
 					flowName={ flow }
 					config={ config }
 					initialQuery={ initialQuery }

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -33,20 +33,19 @@ export class SignupPickPlanPage {
 	 * @param {Plans} name Name of the plan.
 	 * @returns {Promise<SiteDetails>} Details of the newly created site.
 	 */
-	async selectPlan( name: Plans ): Promise< NewSiteResponse > {
+	async selectPlan( name: Plans, redirectUrl?: RegExp ): Promise< NewSiteResponse > {
 		await this.page.waitForURL( plansPageUrl );
 
-		let url: RegExp;
 		if ( name !== 'Free' ) {
 			// Non-free plans should redirect to the Checkout cart.
-			url = new RegExp( '.*checkout.*' );
+			redirectUrl ??= new RegExp( '.*checkout.*' );
 		} else {
-			url = new RegExp( '.*setup/site-setup.*' );
+			redirectUrl ??= new RegExp( '.*setup/site-setup.*' );
 		}
 
 		const actions = [
 			this.page.waitForResponse( /.*sites\/new\?.*/, { timeout: 30 * 1000 } ),
-			this.page.waitForURL( url, { timeout: 30 * 1000 } ),
+			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
 			this.plansPage.selectPlan( name ),
 		];
 

--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -9,13 +9,13 @@ import {
 	SelectItemsComponent,
 	CartCheckoutPage,
 	RestAPIClient,
-	TestAccount,
-	NewSiteResponse,
 	SignupPickPlanPage,
 	UseADomainIOwnPage,
+	UserSignupPage,
+	NewUserResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared/api-delete-site';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
@@ -24,24 +24,23 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 
 	const planName = 'Personal';
 	let page: Page;
-	const testAccount = new TestAccount( 'defaultUser' );
-	let newSiteDetails: NewSiteResponse;
-	let restAPIClient: RestAPIClient;
+	const testUser = DataHelper.getNewTestUser();
+	let newUserDetails: NewUserResponse;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-		await testAccount.authenticate( page );
-
-		restAPIClient = new RestAPIClient( testAccount.credentials );
-		await restAPIClient.clearMyShoppingCart( 'no-site' );
 	} );
 
 	it( 'Enter the flow', async function () {
 		const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
 
 		await page.goto( flowUrl );
+	} );
+
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 	} );
 
 	it( 'Search for a domain', async function () {
@@ -68,10 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 	it( `Select ${ planName } plan`, async function () {
 		const plansPage = new SignupPickPlanPage( page );
 
-		[ newSiteDetails ] = await Promise.all( [
-			plansPage.selectPlan( planName ),
-			page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
-		] );
+		await plansPage.selectPlan( planName );
 	} );
 
 	it( 'See plan and domain connection product at checkout', async function () {
@@ -82,14 +78,22 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 	} );
 
 	afterAll( async function () {
-		if ( ! newSiteDetails ) {
+		if ( ! newUserDetails ) {
 			return;
 		}
 
-		await apiDeleteSite( restAPIClient, {
-			url: newSiteDetails.blog_details.url,
-			id: newSiteDetails.blog_details.blogid,
-			name: newSiteDetails.blog_details.blogname,
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
 		} );
 	} );
 } );

--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -4,7 +4,6 @@
 
 import {
 	DataHelper,
-	BrowserManager,
 	RewrittenDomainSearchComponent,
 	SelectItemsComponent,
 	CartCheckoutPage,
@@ -29,7 +28,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
 	} );
 
 	it( 'Enter the flow', async function () {

--- a/test/e2e/specs/flows/setup-domain__domain-only.ts
+++ b/test/e2e/specs/flows/setup-domain__domain-only.ts
@@ -8,32 +8,35 @@ import {
 	RewrittenDomainSearchComponent,
 	SelectItemsComponent,
 	CartCheckoutPage,
+	UserSignupPage,
+	NewUserResponse,
 	RestAPIClient,
-	TestAccount,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Domain flow: Purchase only a domain' ), function () {
 	let page: Page;
 	let selectedDomain: string;
-	const testAccount = new TestAccount( 'defaultUser' );
+	const testUser = DataHelper.getNewTestUser();
+	let newUserDetails: NewUserResponse;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-		await testAccount.authenticate( page );
-
-		const restAPIClient = new RestAPIClient( testAccount.credentials );
-		await restAPIClient.clearMyShoppingCart( 'no-site' );
 	} );
 
 	it( 'Enter the flow', async function () {
 		const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
 
 		await page.goto( flowUrl );
+	} );
+
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 	} );
 
 	it( 'Search for a domain', async function () {
@@ -60,5 +63,25 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Purchase only a domain' ), 
 		const cartCheckoutPage = new CartCheckoutPage( page );
 
 		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
 	} );
 } );

--- a/test/e2e/specs/flows/setup-domain__existing-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-free-site.ts
@@ -8,85 +8,127 @@ import {
 	RewrittenDomainSearchComponent,
 	SelectItemsComponent,
 	CartCheckoutPage,
-	RestAPIClient,
-	TestAccount,
 	SignupPickPlanPage,
 	SiteSelectComponent,
-	SecretsManager,
+	UserSignupPage,
+	NewUserResponse,
+	NewSiteResponse,
+	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
 describe(
 	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for an existing free site' ),
 	function () {
-		const planName = 'Personal';
+		const siteCreationPlan = 'Free';
+		const domainAdditionPlan = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'siteEditorSimpleSiteUser';
-		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
-		const testAccount = new TestAccount( testAccountName );
-		let restAPIClient: RestAPIClient;
+		const testUser = DataHelper.getNewTestUser();
+		let newUserDetails: NewUserResponse;
+		let newSiteDetails: NewSiteResponse;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-			await testAccount.authenticate( page );
-
-			restAPIClient = new RestAPIClient( testAccount.credentials );
-			await restAPIClient.clearMyShoppingCart( 'no-site' );
 		} );
 
-		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+		describe( 'Create a free site', function () {
+			it( 'Enter the onboarding flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup' );
 
-			await page.goto( flowUrl );
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Sign up as a new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			it( 'Skip the domains step', async () => {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+				await domainSearchComponent.skipPurchase();
+			} );
+
+			it( `Select ${ siteCreationPlan } plan`, async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				newSiteDetails = await signupPickPlanPage.selectPlan(
+					siteCreationPlan,
+					new RegExp( '.*/home/.*' )
+				);
+			} );
 		} );
 
-		it( 'Search for a domain', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( DataHelper.getBlogName() );
+		describe( 'Add domain to the site', function () {
+			it( 'Enter domain flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Search for a domain', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+			} );
+
+			it( 'Add the first suggestion to the cart', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+			} );
+
+			it( 'Continue to next step', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.continue();
+			} );
+
+			it( 'Select existing site option', async function () {
+				const domainSearchComponent = new SelectItemsComponent( page );
+				await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
+			} );
+
+			it( 'Select the site', async function () {
+				const siteSelectComponent = new SiteSelectComponent( page );
+				await siteSelectComponent.selectSite(
+					newSiteDetails.blog_details.site_slug as string,
+					false
+				);
+			} );
+
+			it( `Select ${ domainAdditionPlan } plan`, async function () {
+				const plansPage = new SignupPickPlanPage( page );
+
+				await plansPage.selectPlan( domainAdditionPlan );
+			} );
+
+			it( 'See plan and domain at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ domainAdditionPlan }` );
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
 		} );
 
-		it( 'Add the first suggestion to the cart', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
-		} );
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
 
-		it( 'Continue to next step', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.continue();
-		} );
-
-		it( 'Select existing site option', async function () {
-			const domainSearchComponent = new SelectItemsComponent( page );
-			await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
-		} );
-
-		it( 'Select the site', async function () {
-			const siteSelectComponent = new SiteSelectComponent( page );
-			await siteSelectComponent.selectSite(
-				testAccountUser.testSites?.primary?.url as string,
-				false
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
 			);
-		} );
 
-		it( `Select ${ planName } plan`, async function () {
-			const plansPage = new SignupPickPlanPage( page );
-
-			await Promise.all( [
-				plansPage.selectPlan( planName ),
-				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
-			] );
-		} );
-
-		it( 'See plan and domain at checkout', async function () {
-			const cartCheckoutPage = new CartCheckoutPage( page );
-
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-paid-site.ts
@@ -8,73 +8,177 @@ import {
 	RewrittenDomainSearchComponent,
 	SelectItemsComponent,
 	CartCheckoutPage,
-	RestAPIClient,
-	TestAccount,
+	SignupPickPlanPage,
 	SiteSelectComponent,
-	SecretsManager,
+	UserSignupPage,
+	NewUserResponse,
+	NewSiteResponse,
+	RestAPIClient,
+	MyProfilePage,
+	MeSidebarComponent,
+	PurchasesPage,
+	NoticeComponent,
+	cancelAtomicPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
 describe(
 	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for an existing paid site' ),
 	function () {
+		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'atomicUser';
-		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
-		const testAccount = new TestAccount( testAccountName );
-		let restAPIClient: RestAPIClient;
+		const testUser = DataHelper.getNewTestUser();
+		let newUserDetails: NewUserResponse;
+		let newSiteDetails: NewSiteResponse;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-			await testAccount.authenticate( page );
-
-			restAPIClient = new RestAPIClient( testAccount.credentials );
-			await restAPIClient.clearMyShoppingCart( 'no-site' );
 		} );
 
-		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+		describe( 'Create a paid site', function () {
+			it( 'Enter the onboarding flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup' );
 
-			await page.goto( flowUrl );
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Sign up as a new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			it( 'Skip the domains step', async () => {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+				await domainSearchComponent.skipPurchase();
+			} );
+
+			it( `Select ${ planName } plan`, async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				newSiteDetails = await signupPickPlanPage.selectPlan( planName );
+			} );
+
+			it( 'See plan and storage add-on at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			it( 'Enter billing and payment details', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				const paymentDetails = DataHelper.getTestPaymentDetails();
+				await cartCheckoutPage.enterBillingDetails( paymentDetails );
+				await cartCheckoutPage.enterPaymentDetails( paymentDetails );
+			} );
+
+			it( 'Make purchase', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
+			} );
 		} );
 
-		it( 'Search for a domain', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( DataHelper.getBlogName() );
+		describe( 'Add domain to the site', function () {
+			it( 'Enter domain flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Search for a domain', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+			} );
+
+			it( 'Add the first suggestion to the cart', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+			} );
+
+			it( 'Continue to next step', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.continue();
+			} );
+
+			it( 'Select existing site option', async function () {
+				const domainSearchComponent = new SelectItemsComponent( page );
+				await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
+			} );
+
+			it( 'Select the site', async function () {
+				const siteSelectComponent = new SiteSelectComponent( page );
+				await siteSelectComponent.selectSite(
+					newSiteDetails.blog_details.site_slug as string,
+					false
+				);
+			} );
+
+			it( 'See domain at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
 		} );
 
-		it( 'Add the first suggestion to the cart', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+		describe( 'Cancel and remove plan', function () {
+			it( 'Navigate to Me > Purchases', async function () {
+				const mePage = new MyProfilePage( page );
+				await mePage.visit();
+
+				const meSidebarComponent = new MeSidebarComponent( page );
+				await meSidebarComponent.openMobileMenu();
+				await meSidebarComponent.navigate( 'Purchases' );
+			} );
+
+			it( 'View details of purchased plan and cancel plan renewal', async function () {
+				const purchasesPage = new PurchasesPage( page );
+
+				await purchasesPage.clickOnPurchase(
+					`WordPress.com ${ planName }`,
+					newSiteDetails.blog_details.site_slug as string
+				);
+				await purchasesPage.cancelPurchase( 'Cancel plan' );
+			} );
+
+			it( 'Cancel plan renewal', async function () {
+				await cancelAtomicPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
+
+				const noticeComponent = new NoticeComponent( page );
+				await noticeComponent.noticeShown(
+					'Your refund has been processed and your purchase removed.',
+					{
+						timeout: 30 * 1000,
+					}
+				);
+			} );
 		} );
 
-		it( 'Continue to next step', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.continue();
-		} );
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
 
-		it( 'Select existing site option', async function () {
-			const domainSearchComponent = new SelectItemsComponent( page );
-			await domainSearchComponent.clickButton( 'Existing WordPress.com site', 'Select a site' );
-		} );
-
-		it( 'Select the site', async function () {
-			const siteSelectComponent = new SiteSelectComponent( page );
-			await siteSelectComponent.selectSite(
-				testAccountUser.testSites?.primary?.url as string,
-				false
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
 			);
-		} );
 
-		it( 'See domain at checkout', async function () {
-			const cartCheckoutPage = new CartCheckoutPage( page );
-
-			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__new-site.ts
+++ b/test/e2e/specs/flows/setup-domain__new-site.ts
@@ -9,12 +9,12 @@ import {
 	SelectItemsComponent,
 	CartCheckoutPage,
 	RestAPIClient,
-	TestAccount,
-	NewSiteResponse,
 	SignupPickPlanPage,
+	UserSignupPage,
+	NewUserResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared/api-delete-site';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
@@ -24,24 +24,23 @@ describe(
 		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccount = new TestAccount( 'defaultUser' );
-		let newSiteDetails: NewSiteResponse;
-		let restAPIClient: RestAPIClient;
+		const testUser = DataHelper.getNewTestUser();
+		let newUserDetails: NewUserResponse;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-			await testAccount.authenticate( page );
-
-			restAPIClient = new RestAPIClient( testAccount.credentials );
-			await restAPIClient.clearMyShoppingCart( 'no-site' );
 		} );
 
 		it( 'Enter the flow', async function () {
 			const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
 
 			await page.goto( flowUrl );
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
 		it( 'Search for a domain', async function () {
@@ -67,10 +66,7 @@ describe(
 		it( `Select ${ planName } plan`, async function () {
 			const plansPage = new SignupPickPlanPage( page );
 
-			[ newSiteDetails ] = await Promise.all( [
-				plansPage.selectPlan( planName ),
-				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
-			] );
+			await plansPage.selectPlan( planName );
 		} );
 
 		it( 'See plan and domain at checkout', async function () {
@@ -81,14 +77,22 @@ describe(
 		} );
 
 		afterAll( async function () {
-			if ( ! newSiteDetails ) {
+			if ( ! newUserDetails ) {
 				return;
 			}
 
-			await apiDeleteSite( restAPIClient, {
-				url: newSiteDetails.blog_details.url,
-				id: newSiteDetails.blog_details.blogid,
-				name: newSiteDetails.blog_details.blogname,
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
+			);
+
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
 			} );
 		} );
 	}

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -8,11 +8,13 @@ import {
 	RewrittenDomainSearchComponent,
 	CartCheckoutPage,
 	RestAPIClient,
-	TestAccount,
+	NewSiteResponse,
 	SignupPickPlanPage,
-	SecretsManager,
+	UserSignupPage,
+	NewUserResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
@@ -22,58 +24,90 @@ describe(
 		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'siteEditorSimpleSiteUser';
-		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
-		const testAccount = new TestAccount( testAccountName );
-		let restAPIClient: RestAPIClient;
+		const testUser = DataHelper.getNewTestUser();
+		let newUserDetails: NewUserResponse;
+		let newSiteDetails: NewSiteResponse;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-			await testAccount.authenticate( page );
-
-			restAPIClient = new RestAPIClient( testAccount.credentials );
-			await restAPIClient.clearMyShoppingCart( testAccountUser.testSites?.primary?.id as number );
 		} );
 
-		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL(
-				`/setup/domain?siteSlug=${ testAccountUser.testSites?.primary?.url as string }`
+		describe( 'Create a free site', function () {
+			it( 'Enter the onboarding flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup' );
+
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Sign up as a new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			it( 'Skip the domains step', async () => {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+				await domainSearchComponent.skipPurchase();
+			} );
+
+			it( `Select ${ planName } plan`, async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				newSiteDetails = await signupPickPlanPage.selectPlan( planName );
+			} );
+		} );
+
+		describe( 'Add domain to the site', function () {
+			it( 'Enter the flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL(
+					`/setup/domain?siteSlug=${ newSiteDetails.blog_details.site_slug as string }`
+				);
+
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Add the first suggestion to the cart', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+			} );
+
+			it( 'Continue to next step', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.continue();
+			} );
+
+			it( `Select ${ planName } plan`, async function () {
+				const plansPage = new SignupPickPlanPage( page );
+
+				await plansPage.selectPlan( planName );
+			} );
+
+			it( 'See plan and domain at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
 			);
 
-			await page.goto( flowUrl );
-		} );
-
-		it( 'Search for a domain', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( DataHelper.getBlogName() );
-		} );
-
-		it( 'Add the first suggestion to the cart', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
-		} );
-
-		it( 'Continue to next step', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.continue();
-		} );
-
-		it( `Select ${ planName } plan`, async function () {
-			const plansPage = new SignupPickPlanPage( page );
-
-			await Promise.all( [
-				plansPage.selectPlan( planName ),
-				page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
-			] );
-		} );
-
-		it( 'See plan and domain at checkout', async function () {
-			const cartCheckoutPage = new CartCheckoutPage( page );
-
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-paid-site.ts
@@ -8,60 +8,160 @@ import {
 	RewrittenDomainSearchComponent,
 	CartCheckoutPage,
 	RestAPIClient,
-	TestAccount,
-	SecretsManager,
+	NewSiteResponse,
+	SignupPickPlanPage,
+	UserSignupPage,
+	NewUserResponse,
+	NoticeComponent,
+	cancelAtomicPurchaseFlow,
+	MyProfilePage,
+	MeSidebarComponent,
+	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
 describe(
 	DataHelper.createSuiteTitle( 'Domain flow: Purchase a domain for a pre-selected paid site' ),
 	function () {
+		const planName = 'Personal';
 		let page: Page;
 		let selectedDomain: string;
-		const testAccountName = 'atomicUser';
-		const testAccountUser = SecretsManager.secrets.testAccounts[ testAccountName ];
-		const testAccount = new TestAccount( testAccountName );
-		let restAPIClient: RestAPIClient;
+		const testUser = DataHelper.getNewTestUser();
+		let newUserDetails: NewUserResponse;
+		let newSiteDetails: NewSiteResponse;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-			await testAccount.authenticate( page );
-
-			restAPIClient = new RestAPIClient( testAccount.credentials );
-			await restAPIClient.clearMyShoppingCart( testAccountUser.testSites?.primary?.id as number );
 		} );
 
-		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL(
-				`/setup/domain?siteSlug=${ testAccountUser.testSites?.primary?.url as string }`
+		describe( 'Create a paid site', function () {
+			it( 'Enter the onboarding flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup' );
+
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Sign up as a new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			it( 'Skip the domains step', async () => {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.search( DataHelper.getBlogName() );
+				await domainSearchComponent.skipPurchase();
+			} );
+
+			it( `Select ${ planName } plan`, async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				newSiteDetails = await signupPickPlanPage.selectPlan( planName );
+			} );
+
+			it( 'See plan and storage add-on at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			it( 'Enter billing and payment details', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				const paymentDetails = DataHelper.getTestPaymentDetails();
+				await cartCheckoutPage.enterBillingDetails( paymentDetails );
+				await cartCheckoutPage.enterPaymentDetails( paymentDetails );
+			} );
+
+			it( 'Make purchase', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
+			} );
+		} );
+
+		describe( 'Add domain to the site', function () {
+			it( 'Enter the flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL(
+					`/setup/domain?siteSlug=${ newSiteDetails.blog_details.site_slug as string }`
+				);
+
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Add the first suggestion to the cart', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+			} );
+
+			it( 'Continue to next step', async function () {
+				const domainSearchComponent = new RewrittenDomainSearchComponent( page );
+				await domainSearchComponent.continue();
+			} );
+
+			it( 'See domain at checkout', async function () {
+				const cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
+		} );
+
+		describe( 'Cancel and remove plan', function () {
+			it( 'Navigate to Me > Purchases', async function () {
+				const mePage = new MyProfilePage( page );
+				await mePage.visit();
+
+				const meSidebarComponent = new MeSidebarComponent( page );
+				await meSidebarComponent.openMobileMenu();
+				await meSidebarComponent.navigate( 'Purchases' );
+			} );
+
+			it( 'View details of purchased plan and cancel plan renewal', async function () {
+				const purchasesPage = new PurchasesPage( page );
+
+				await purchasesPage.clickOnPurchase(
+					`WordPress.com ${ planName }`,
+					newSiteDetails.blog_details.site_slug as string
+				);
+				await purchasesPage.cancelPurchase( 'Cancel plan' );
+			} );
+
+			it( 'Cancel plan renewal', async function () {
+				await cancelAtomicPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
+
+				const noticeComponent = new NoticeComponent( page );
+				await noticeComponent.noticeShown(
+					'Your refund has been processed and your purchase removed.',
+					{
+						timeout: 30 * 1000,
+					}
+				);
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
 			);
 
-			await page.goto( flowUrl );
-		} );
-
-		it( 'Search for a domain', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.search( DataHelper.getBlogName() );
-		} );
-
-		it( 'Add the first suggestion to the cart', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			selectedDomain = await domainSearchComponent.selectFirstSuggestion();
-		} );
-
-		it( 'Continue to next step', async function () {
-			const domainSearchComponent = new RewrittenDomainSearchComponent( page );
-			await domainSearchComponent.continue();
-		} );
-
-		it( 'See domain at checkout', async function () {
-			const cartCheckoutPage = new CartCheckoutPage( page );
-
-			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
 		} );
 	}
 );

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -9,13 +9,13 @@ import {
 	SelectItemsComponent,
 	CartCheckoutPage,
 	RestAPIClient,
-	TestAccount,
-	NewSiteResponse,
 	SignupPickPlanPage,
 	UseADomainIOwnPage,
+	UserSignupPage,
+	NewUserResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared/api-delete-site';
+import { apiCloseAccount } from '../shared/api-close-account';
 
 declare const browser: Browser;
 
@@ -24,24 +24,23 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 
 	const planName = 'Personal';
 	let page: Page;
-	const testAccount = new TestAccount( 'defaultUser' );
-	let newSiteDetails: NewSiteResponse;
-	let restAPIClient: RestAPIClient;
+	const testUser = DataHelper.getNewTestUser();
+	let newUserDetails: NewUserResponse;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-
-		await testAccount.authenticate( page );
-
-		restAPIClient = new RestAPIClient( testAccount.credentials );
-		await restAPIClient.clearMyShoppingCart( 'no-site' );
 	} );
 
 	it( 'Enter the flow', async function () {
 		const flowUrl = DataHelper.getCalypsoURL( '/setup/domain' );
 
 		await page.goto( flowUrl );
+	} );
+
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 	} );
 
 	it( 'Search for a domain', async function () {
@@ -68,10 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 	it( `Select ${ planName } plan`, async function () {
 		const plansPage = new SignupPickPlanPage( page );
 
-		[ newSiteDetails ] = await Promise.all( [
-			plansPage.selectPlan( planName ),
-			page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
-		] );
+		await plansPage.selectPlan( planName );
 	} );
 
 	it( 'See plan and domain transfer product at checkout', async function () {
@@ -82,14 +78,22 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 	} );
 
 	afterAll( async function () {
-		if ( ! newSiteDetails ) {
+		if ( ! newUserDetails ) {
 			return;
 		}
 
-		await apiDeleteSite( restAPIClient, {
-			url: newSiteDetails.blog_details.url,
-			id: newSiteDetails.blog_details.blogid,
-			name: newSiteDetails.blog_details.blogname,
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
 		} );
 	} );
 } );

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -4,7 +4,6 @@
 
 import {
 	DataHelper,
-	BrowserManager,
 	RewrittenDomainSearchComponent,
 	SelectItemsComponent,
 	CartCheckoutPage,
@@ -29,7 +28,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
 	} );
 
 	it( 'Enter the flow', async function () {


### PR DESCRIPTION
Iterates on #105725.

## Proposed Changes

I'm seeing some flakiness in E2E tests of the flow because of cart operations.

As we're using the same user for most of the tests, their cart is shared and there's a race condition when clearing it (before starting each test) as that might happen in different times for different tests since they run concurrently. Example: a test starts just before another test gets to the checkout page. The cart gets cleared so nothing shows up to pay, failing the test.

This PR makes every flow completely isolated. That is, it starts with creating the user, and finishes deleting their account. It performs the domain flow operations in between, without interference from other tests.

## Testing Instructions

Verify [Pre-Release E2E tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/15712740) are still 🟢. They're failing because of flakiness on an unrelated flow, so I'll merge it anyway.