### PR TITLE
Hosting Dashboard: Update enum to const

### DIFF
--- a/client/dashboard/sites/hosting-feature-gate/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/activation.tsx
@@ -4,11 +4,11 @@ import { addQueryArgs } from '@wordpress/url';
 import { lazy, useEffect, useState, ReactNode, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import HostingFeatureActivationModal from '../hosting-feature-activation-modal';
-import type { HostingFeatures, Site } from '@automattic/api-core';
+import type { HostingFeatureSlug, Site } from '@automattic/api-core';
 
 interface HostingFeatureActivationProps {
 	site: Site;
-	feature: HostingFeatures;
+	feature: HostingFeatureSlug;
 	tracksFeatureId: string;
 	renderActivationComponent: ( { onClick }: { onClick: () => void } ) => ReactNode;
 }

--- a/client/dashboard/sites/hosting-feature-gate/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/index.tsx
@@ -2,11 +2,11 @@ import React, { ReactNode } from 'react';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import HostingFeatureActivation from './activation';
 import HostingFeatureUpsell from './upsell';
-import type { HostingFeatures, Site } from '@automattic/api-core';
+import type { HostingFeatureSlug, Site } from '@automattic/api-core';
 
 export interface HostingFeatureGateProps {
 	site: Site;
-	feature: HostingFeatures;
+	feature: HostingFeatureSlug;
 	tracksFeatureId: string;
 	children: ReactNode;
 	renderUpsellComponent: ( { onClick }: { onClick: () => void } ) => ReactNode;

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,13 +1,17 @@
-import {
-	DotcomFeatures,
-	HostingFeatures,
-	JetpackFeatures,
-	JetpackModules,
+import { DotcomFeatures } from '@automattic/api-core';
+import type {
+	DotcomFeatureSlug,
+	HostingFeatureSlug,
+	JetpackFeatureSlug,
+	JetpackModuleSlug,
+	Site,
 } from '@automattic/api-core';
-import type { Site } from '@automattic/api-core';
 
 // Returns whether the plan supports a specific feature.
-export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures | JetpackFeatures }` ) {
+export function hasPlanFeature(
+	site: Site,
+	feature: `${ DotcomFeatureSlug | JetpackFeatureSlug }`
+) {
 	if ( ! site.plan ) {
 		return false;
 	}
@@ -17,7 +21,7 @@ export function hasPlanFeature( site: Site, feature: `${ DotcomFeatures | Jetpac
 
 // Returns whether the plan supports a specific "hosting feature",
 // which is a feature that requires Atomic or self-hosted infrastructure.
-export function hasHostingFeature( site: Site, feature: HostingFeatures ) {
+export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) ) {
 		if ( site.plan?.expired || ! site.is_wpcom_atomic ) {
 			return false;
@@ -26,6 +30,6 @@ export function hasHostingFeature( site: Site, feature: HostingFeatures ) {
 	return hasPlanFeature( site, feature );
 }
 
-export function hasJetpackModule( site: Site, module: `${ JetpackModules }` ) {
+export function hasJetpackModule( site: Site, module: `${ JetpackModuleSlug }` ) {
 	return site.jetpack && site.jetpack_modules?.includes( module );
 }

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -1,4 +1,9 @@
-import { DotcomPlans, JetpackFeatures, type Site } from '@automattic/api-core';
+import {
+	DotcomPlans,
+	JetpackFeatures,
+	type JetpackFeatureSlug,
+	type Site,
+} from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import {
 	chartBar,
@@ -69,7 +74,7 @@ export const JETPACK_PRODUCTS = [
 
 export function getJetpackProductsForSite( site: Site ) {
 	return JETPACK_PRODUCTS.filter( ( product ) =>
-		hasPlanFeature( site, product.id as JetpackFeatures )
+		hasPlanFeature( site, product.id as JetpackFeatureSlug )
 	);
 }
 

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -17,64 +17,72 @@ export enum DotcomPlans {
 	PREMIUM_3_YEARS = 'value_bundle-3y',
 }
 
-export enum DotcomFeatures {
-	ATOMIC = 'atomic',
-	BACKUPS = 'backups',
-	SUBSCRIPTION_GIFTING = 'subscription-gifting',
-	COPY_SITE = 'copy-site',
-	LEGACY_CONTACT = 'legacy-contact',
-	LOCKED_MODE = 'locked-mode',
-	SCAN = 'scan',
-	SECURITY_SETTINGS = 'security-settings',
-	SET_PRIMARY_CUSTOM_DOMAIN = 'set-primary-custom-domain',
-	SFTP = 'sftp',
-	SSH = 'ssh',
-	SITE_PREVIEW_LINKS = 'site-preview-links',
-	STAGING_SITES = 'staging-sites',
-}
+export const DotcomFeatures = {
+	ATOMIC: 'atomic',
+	BACKUPS: 'backups',
+	SUBSCRIPTION_GIFTING: 'subscription-gifting',
+	COPY_SITE: 'copy-site',
+	LEGACY_CONTACT: 'legacy-contact',
+	LOCKED_MODE: 'locked-mode',
+	SCAN: 'scan',
+	SECURITY_SETTINGS: 'security-settings',
+	SET_PRIMARY_CUSTOM_DOMAIN: 'set-primary-custom-domain',
+	SFTP: 'sftp',
+	SSH: 'ssh',
+	SITE_PREVIEW_LINKS: 'site-preview-links',
+	STAGING_SITES: 'staging-sites',
+} as const;
+
+export type DotcomFeatureSlug = ( typeof DotcomFeatures )[ keyof typeof DotcomFeatures ];
 
 // Features that are used to identify the paid product.
 // Feature slug extracted from https://github.com/Automattic/jetpack/tree/trunk/projects/packages/my-jetpack/src/products.
-export enum JetpackFeatures {
-	ANTISPAM = 'antispam',
-	BACKUPS = 'backups',
-	CLOUD_CRITICAL_CSS = 'cloud-critical-css',
-	MONITOR = 'monitor',
-	SCAN = 'scan',
-	SOCIAL_ENHANCED_PUBLISHING = 'social-enhanced-publishing',
-	STATS = 'stats-paid',
-	SEARCH = 'search',
-	VIDEOPRESS = 'videopress',
-}
+export const JetpackFeatures = {
+	ANTISPAM: 'antispam',
+	BACKUPS: 'backups',
+	CLOUD_CRITICAL_CSS: 'cloud-critical-css',
+	MONITOR: 'monitor',
+	SCAN: 'scan',
+	SOCIAL_ENHANCED_PUBLISHING: 'social-enhanced-publishing',
+	STATS: 'stats-paid',
+	SEARCH: 'search',
+	VIDEOPRESS: 'videopress',
+} as const;
 
-export enum JetpackModules {
-	MONITOR = 'monitor',
-	PROTECT = 'protect',
-	SSO = 'sso',
-	STATS = 'stats',
-	WAF = 'waf',
-}
+export type JetpackFeatureSlug = ( typeof JetpackFeatures )[ keyof typeof JetpackFeatures ];
+
+export const JetpackModules = {
+	MONITOR: 'monitor',
+	PROTECT: 'protect',
+	SSO: 'sso',
+	STATS: 'stats',
+	WAF: 'waf',
+} as const;
+
+export type JetpackModuleSlug = ( typeof JetpackModules )[ keyof typeof JetpackModules ];
 
 // Features that needs Atomic or self-hosted infrastructure,
 // mapped to the required WordPress.com plan feature.
-export enum HostingFeatures {
-	BACKUPS = DotcomFeatures.BACKUPS,
-	CACHING = DotcomFeatures.ATOMIC,
-	DATABASE = DotcomFeatures.SFTP,
-	DEFENSIVE_MODE = DotcomFeatures.SFTP,
-	DEPLOYMENT = DotcomFeatures.ATOMIC,
-	LOGS = DotcomFeatures.ATOMIC,
-	MONITOR = DotcomFeatures.ATOMIC,
-	PERFORMANCE = DotcomFeatures.ATOMIC,
-	PHP = DotcomFeatures.SFTP,
-	PRIMARY_DATA_CENTER = DotcomFeatures.SFTP,
-	SCAN = DotcomFeatures.SCAN,
-	SECURITY_SETTINGS = DotcomFeatures.SECURITY_SETTINGS,
-	SFTP = DotcomFeatures.SFTP,
-	SSH = DotcomFeatures.SSH,
-	STAGING_SITE = DotcomFeatures.STAGING_SITES,
-	STATIC_FILE_404 = DotcomFeatures.SFTP,
-}
+export const HostingFeatures = {
+	BACKUPS: DotcomFeatures.BACKUPS,
+	CACHING: DotcomFeatures.ATOMIC,
+	DATABASE: DotcomFeatures.SFTP,
+	DEFENSIVE_MODE: DotcomFeatures.SFTP,
+	DEPLOYMENT: DotcomFeatures.ATOMIC,
+	LOGS: DotcomFeatures.ATOMIC,
+	MONITOR: DotcomFeatures.ATOMIC,
+	PERFORMANCE: DotcomFeatures.ATOMIC,
+	PHP: DotcomFeatures.SFTP,
+	PRIMARY_DATA_CENTER: DotcomFeatures.SFTP,
+	SCAN: DotcomFeatures.SCAN,
+	SECURITY_SETTINGS: DotcomFeatures.SECURITY_SETTINGS,
+	SFTP: DotcomFeatures.SFTP,
+	SSH: DotcomFeatures.SSH,
+	STAGING_SITE: DotcomFeatures.STAGING_SITES,
+	STATIC_FILE_404: DotcomFeatures.SFTP,
+} as const;
+
+export type HostingFeatureSlug = ( typeof HostingFeatures )[ keyof typeof HostingFeatures ];
 
 export const SubscriptionBillPeriod = {
 	PLAN_ONE_TIME_PERIOD: -1,


### PR DESCRIPTION
## Proposed Changes

Related to 105776. This PR updates several constants in `@automattic/api-core` to use const instead of enum.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure all tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
