### PR TITLE
A4A > WooPayments: Remove WooPayments license requirements

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +8,6 @@ import {
 	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
 	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
@@ -18,24 +18,14 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
 
-	const { issueAndAssignLicenses, isLoading } = useIssueAndAssignLicenses(
-		selectedSite ? { ID: selectedSite.rawSite.blog_id, domain: selectedSite.site } : null,
-		{
-			redirectTo: addQueryArgs( A4A_WOOPAYMENTS_SITE_SETUP_LINK, {
-				site_id: selectedSite?.rawSite.blog_id,
-			} ),
-		}
-	);
-
 	const handleAddSite = () => {
 		if ( selectedSite ) {
 			dispatch( recordTracksEvent( 'calypso_a4a_woopayments_add_site_button_click' ) );
-			issueAndAssignLicenses( [
-				{
-					slug: 'woocommerce-woopayments',
-					quantity: 1,
-				},
-			] );
+			page.redirect(
+				addQueryArgs( A4A_WOOPAYMENTS_SITE_SETUP_LINK, {
+					site_id: selectedSite?.rawSite.blog_id,
+				} )
+			);
 		}
 	};
 
@@ -63,12 +53,7 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 			) }
 			onClose={ onClose }
 			extraActions={
-				<Button
-					variant="primary"
-					onClick={ handleAddSite }
-					disabled={ ! selectedSite || isLoading }
-					isBusy={ isLoading }
-				>
+				<Button variant="primary" onClick={ handleAddSite } disabled={ ! selectedSite }>
 					{ translate( 'Add WooPayments to selected site' ) }
 				</Button>
 			}

--- a/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.ts
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
-export default function useFetchWooPaymentsData( autoRefresh: boolean, isEnabled: boolean ) {
+export default function useFetchWooPaymentsData( isEnabled: boolean ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
@@ -16,6 +16,5 @@ export default function useFetchWooPaymentsData( autoRefresh: boolean, isEnabled
 		enabled: !! agencyId && isEnabled,
 		refetchOnWindowFocus: true,
 		staleTime: 0,
-		refetchInterval: autoRefresh ? 1000 * 10 : undefined,
 	} );
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1550/agencies-shouldnt-need-to-have-the-woopayments-license-issued-in-a4a

## Proposed Changes

This PR:

- Removes the requirement of WooPayments license to be assigned to a site for it to be displayed on the dashboard
- Removes the logic to assign a license to a site when adding WooPayments and directly redirects to the setup page

## Why are these changes being made?

* Since it is not a requirement for a site to have a WooPayments license assigned to get the commissions or to track TPV, we are removing the logic on the frontend that enforces a site to have a WooPayments license assigned for it to be displayed on the dashboard. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Assign a WooPayments license to a site
* Go to WooPayments: Dashboard > Click the "Add WooPayments to site" button > Select a site > Click the "Add WooPayments to a selected site" button > Verify a WooPayments license is no longer being assigned to a site and you are directly redirected to the site set up page > Click the "Install and activate plugin ↗" button > Go to WooPayments dashboard > Verify both the sites are shown > Sites without WooPayments plugin installed & with WooPayments license should show "Continue setup" and sites with WooPayments plugin (with or without WooPayments license) should show "Active" or "Disconnected" based on the state.

<img width="1920" height="968" alt="Screenshot 2025-09-17 at 11 17 33 AM" src="https://github.com/user-attachments/assets/60677a16-c332-4827-b6d0-1313b8da94c9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
