### PR TITLE
Hosting Dashboard > Security: Implement Connected Applications

### DIFF
--- a/client/dashboard/app/hooks/use-intl-collator.ts
+++ b/client/dashboard/app/hooks/use-intl-collator.ts
@@ -1,0 +1,20 @@
+import { useLocale } from '../locale';
+
+const useIntlCollator = () => {
+	const userLocale = useLocale();
+
+	// Backup locale in case the user's locale isn't supported
+	const backupLocale = 'en';
+
+	const sortLocales = userLocale
+		? /*
+		   * Locale slugs could contain underscores, but Intl.Collator expects them to use dashes
+		   * @see https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag
+		   */
+		  [ userLocale.replace( /_/g, '-' ), backupLocale ]
+		: [ backupLocale ];
+
+	return new Intl.Collator( sortLocales );
+};
+
+export default useIntlCollator;

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -10,6 +10,7 @@ import {
 	smsCountryCodesQuery,
 	twoStepAuthAppSetupQuery,
 	sshKeysQuery,
+	connectedApplicationsQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
@@ -406,6 +407,7 @@ export const securityConnectedAppsRoute = createRoute( {
 	} ),
 	getParentRoute: () => securityRoute,
 	path: '/connected-apps',
+	loader: () => queryClient.ensureQueryData( connectedApplicationsQuery() ),
 } ).lazy( () =>
 	import( '../../me/security-connected-apps' ).then( ( d ) =>
 		createLazyRoute( 'security-connected-apps' )( {

--- a/client/dashboard/components/confirm-modal/index.tsx
+++ b/client/dashboard/components/confirm-modal/index.tsx
@@ -1,11 +1,7 @@
-import {
-	Modal,
-	Button,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useRef } from 'react';
+import { Text } from '../../components/text';
 import { ButtonStack } from '../button-stack';
 import type { ButtonProps } from '@wordpress/components/build-types/button/types';
 

--- a/client/dashboard/me/security-connected-apps/application-details-modal.tsx
+++ b/client/dashboard/me/security-connected-apps/application-details-modal.tsx
@@ -1,0 +1,121 @@
+import { Badge } from '@automattic/ui';
+import {
+	Modal,
+	ExternalLink,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useLocale } from '../../app/locale';
+import type { ConnectedApplication } from '@automattic/api-core';
+
+interface Props {
+	application: ConnectedApplication;
+	onClose: () => void;
+}
+
+const getAccessScopeDetails = ( scope: string, site?: { site_name: string; site_URL: string } ) => {
+	switch ( scope ) {
+		case 'global':
+			return {
+				label: __( 'Global' ),
+				value: __(
+					'This connection is allowed to manage all of your blogs on WordPress.com, including any Jetpack blogs that are connected to your WordPress.com account.'
+				),
+			};
+		case 'auth':
+			return {
+				label: __( 'Authentication' ),
+				value: __( 'This connection is not allowed to manage any of your blogs.' ),
+			};
+		default:
+			return site
+				? {
+						label: site.site_name,
+						value: createInterpolateElement(
+							// translators: %(siteLink)s will be replaced with the site name.
+							__( 'This connection is only allowed to access <siteLink />' ),
+							{
+								siteLink: <ExternalLink href={ site.site_URL }>{ site.site_name }</ExternalLink>,
+							}
+						),
+				  }
+				: {
+						label: '',
+						value: '',
+				  };
+	}
+};
+
+const DetailItem = ( { label, value }: { label: string; value: React.ReactNode } ) => {
+	return (
+		<VStack spacing={ 2 }>
+			<Text upperCase lineHeight="16px" size={ 11 } weight={ 500 }>
+				{ label }
+			</Text>
+			<Text lineHeight="16px" size={ 13 } weight={ 400 }>
+				{ value }
+			</Text>
+		</VStack>
+	);
+};
+
+export default function ApplicationDetailsModal( { application, onClose }: Props ) {
+	const userLocale = useLocale();
+
+	const siteObj =
+		application.site && typeof application.site === 'object' ? application.site : undefined;
+
+	const accessScopeDetails = getAccessScopeDetails( application.scope, siteObj );
+
+	return (
+		<Modal onRequestClose={ onClose } title={ application.title } size="medium">
+			<VStack spacing={ 6 }>
+				<DetailItem
+					label={ __( 'Application website' ) }
+					value={ <ExternalLink href={ application.URL }>{ application.URL }</ExternalLink> }
+				/>
+				<DetailItem
+					label={ __( 'Authorized on' ) }
+					value={ new Intl.DateTimeFormat( userLocale, {
+						dateStyle: 'long',
+						timeStyle: 'medium',
+					} ).format( new Date( application.authorized ) ) }
+				/>
+				{ accessScopeDetails && (
+					<DetailItem
+						label={ __( 'Access scope' ) }
+						value={
+							<VStack spacing={ 2 }>
+								<Badge
+									intent="default"
+									style={ {
+										maxWidth: 'fit-content',
+									} }
+								>
+									{ accessScopeDetails.label }
+								</Badge>
+								<Text lineHeight="16px" size={ 13 } weight={ 400 }>
+									{ accessScopeDetails.value }
+								</Text>
+							</VStack>
+						}
+					/>
+				) }
+				<DetailItem
+					label={ __( 'Access permissions' ) }
+					value={
+						<ul style={ { paddingInlineStart: '20px', margin: 0 } }>
+							{ application.permissions.map( ( permission ) => (
+								<Text as="li" lineHeight="20px" size={ 13 } weight={ 400 } key={ permission.name }>
+									{ permission.description }
+								</Text>
+							) ) }
+						</ul>
+					}
+				/>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -1,11 +1,125 @@
+import {
+	connectedApplicationsQuery,
+	deleteConnectedApplicationMutation,
+} from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataViews } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import ConfirmModal from '../../components/confirm-modal';
+import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import SecurityPageHeader from '../security-page-header';
+import ApplicationDetailsModal from './application-details-modal';
+import type { ConnectedApplication } from '@automattic/api-core';
 
 export default function SecurityConnectedApps() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const { data: connectedApplications, isLoading } = useSuspenseQuery(
+		connectedApplicationsQuery()
+	);
+
+	const [ selectedApplicationToRemove, setSelectedApplicationToRemove ] =
+		useState< ConnectedApplication | null >( null );
+	const [ selectedApplicationToView, setSelectedApplicationToView ] =
+		useState< ConnectedApplication | null >( null );
+
+	const { mutate: deleteConnectedApplication, isPending: isDeletingConnectedApplication } =
+		useMutation( deleteConnectedApplicationMutation() );
+
+	const handleDisconnect = () => {
+		if ( selectedApplicationToRemove ) {
+			deleteConnectedApplication( selectedApplicationToRemove.ID, {
+				onSuccess: () => {
+					createSuccessNotice(
+						sprintf(
+							/* translators: %s is the name of the application */
+							'The application %s no longer has access to your WordPress.com account.',
+							selectedApplicationToRemove.title
+						),
+						{
+							type: 'snackbar',
+						}
+					);
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to disconnect application.' ), {
+						type: 'snackbar',
+					} );
+				},
+				onSettled: () => {
+					setSelectedApplicationToRemove( null );
+				},
+			} );
+		}
+	};
+
+	const totalItems = connectedApplications.length;
+
+	const fields =
+		totalItems > 0
+			? [
+					{
+						id: 'application',
+						label: __( 'Application' ),
+						getValue: ( { item }: { item: ConnectedApplication } ) => item.title,
+					},
+					{
+						id: 'icon',
+						render: ( { item }: { item: ConnectedApplication } ) => (
+							<img
+								className="icon"
+								src={ item.icon }
+								alt={ item.title }
+								loading="lazy"
+								style={ { width: 32, height: 32 } }
+							/>
+						),
+					},
+			  ]
+			: [];
+
+	const view = {
+		type: 'table' as const,
+		showMedia: true,
+		mediaField: 'icon',
+		titleField: 'application',
+		...( totalItems > 0 ? { fields: [ '' ] } : {} ),
+	};
+
+	const actions =
+		totalItems > 0
+			? [
+					{
+						id: 'disconnect',
+						isPrimary: true,
+						icon: <Icon icon={ trash } />,
+						label: __( 'Disconnect' ),
+						callback: ( items: ConnectedApplication[] ) => {
+							const item = items[ 0 ];
+							setSelectedApplicationToRemove( item );
+						},
+					},
+					{
+						id: 'view-details',
+						label: __( 'View details' ),
+						callback: ( items: ConnectedApplication[] ) => {
+							const item = items[ 0 ];
+							setSelectedApplicationToView( item );
+						},
+					},
+			  ]
+			: [];
+
 	return (
 		<PageLayout
 			size="small"
@@ -20,8 +134,9 @@ export default function SecurityConnectedApps() {
 							link: (
 								<InlineSupportLink
 									supportPostId={ 17288 }
-									// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-									supportLink="https://wordpress.com/support/third-party-applications/"
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/third-party-applications/'
+									) }
 								/>
 							),
 						}
@@ -29,7 +144,50 @@ export default function SecurityConnectedApps() {
 				/>
 			}
 		>
-			<Text>Content goes here</Text>
+			<DataViewsCard>
+				<DataViews< ConnectedApplication >
+					getItemId={ ( item ) => item.ID }
+					data={ connectedApplications }
+					fields={ totalItems > 0 ? fields : [] }
+					actions={ actions }
+					view={ view }
+					isLoading={ isLoading }
+					onChangeView={ () => {} }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ { totalItems, totalPages: 1 } }
+					empty={
+						<Text as="p" variant="muted" style={ { paddingBlock: '48px' } }>
+							{ __( 'You haven’t connected any apps yet.' ) }
+						</Text>
+					}
+				>
+					<DataViews.Layout />
+				</DataViews>
+			</DataViewsCard>
+			<ConfirmModal
+				isOpen={ !! selectedApplicationToRemove }
+				confirmButtonProps={ {
+					label: __( 'Disconnect' ),
+					isBusy: isDeletingConnectedApplication,
+					disabled: isDeletingConnectedApplication,
+				} }
+				onCancel={ () => setSelectedApplicationToRemove( null ) }
+				onConfirm={ handleDisconnect }
+			>
+				{ createInterpolateElement(
+					/* translators: <applicationName /> is the name of the application */
+					__( 'Are you sure you want to disconnect application <applicationName />?' ),
+					{
+						applicationName: <strong>{ selectedApplicationToRemove?.title }</strong>,
+					}
+				) }
+			</ConfirmModal>
+			{ selectedApplicationToView && (
+				<ApplicationDetailsModal
+					application={ selectedApplicationToView }
+					onClose={ () => setSelectedApplicationToView( null ) }
+				/>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -12,6 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import useIntlCollator from '../../app/hooks/use-intl-collator';
 import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -28,6 +29,8 @@ export default function SecurityConnectedApps() {
 		connectedApplicationsQuery()
 	);
 
+	const intlCollator = useIntlCollator();
+
 	const [ selectedApplicationToRemove, setSelectedApplicationToRemove ] =
 		useState< ConnectedApplication | null >( null );
 	const [ selectedApplicationToView, setSelectedApplicationToView ] =
@@ -43,7 +46,7 @@ export default function SecurityConnectedApps() {
 					createSuccessNotice(
 						sprintf(
 							/* translators: %s is the name of the application */
-							'The application %s no longer has access to your WordPress.com account.',
+							__( 'The application %s no longer has access to your WordPress.com account.' ),
 							selectedApplicationToRemove.title
 						),
 						{
@@ -64,6 +67,11 @@ export default function SecurityConnectedApps() {
 	};
 
 	const totalItems = connectedApplications.length;
+
+	// Sort applications alphabetically by title using the intlCollator
+	const sortedConnectedApplications = connectedApplications.sort( ( a, b ) => {
+		return intlCollator.compare( a.title, b.title );
+	} );
 
 	const fields =
 		totalItems > 0
@@ -147,7 +155,7 @@ export default function SecurityConnectedApps() {
 			<DataViewsCard>
 				<DataViews< ConnectedApplication >
 					getItemId={ ( item ) => item.ID }
-					data={ connectedApplications }
+					data={ sortedConnectedApplications }
 					fields={ totalItems > 0 ? fields : [] }
 					actions={ actions }
 					view={ view }

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -26,6 +26,7 @@ export * from './me';
 export * from './me-account';
 export * from './me-account-recovery';
 export * from './me-blocked-sites';
+export * from './me-connected-applications';
 export * from './me-dpa';
 export * from './me-payment-methods';
 export * from './me-preferences';

--- a/packages/api-core/src/me-connected-applications/fetchers.ts
+++ b/packages/api-core/src/me-connected-applications/fetchers.ts
@@ -1,0 +1,7 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ConnectedApplication } from './types';
+
+export async function fetchConnectedApplications(): Promise< ConnectedApplication[] > {
+	const response = await wpcom.req.get( '/me/connected-applications' );
+	return response.connected_applications;
+}

--- a/packages/api-core/src/me-connected-applications/index.tsx
+++ b/packages/api-core/src/me-connected-applications/index.tsx
@@ -1,0 +1,3 @@
+export * from './fetchers';
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/me-connected-applications/mutators.ts
+++ b/packages/api-core/src/me-connected-applications/mutators.ts
@@ -1,0 +1,13 @@
+import { wpcom } from '../wpcom-fetcher';
+import { ConnectedApplicationSuccess } from './types';
+
+export async function deleteConnectedApplication(
+	appId: string
+): Promise< ConnectedApplicationSuccess > {
+	return wpcom.req.post( {
+		path: `/me/connected-applications/${ appId }/delete`,
+		body: {
+			apiVersion: '1.1',
+		},
+	} );
+}

--- a/packages/api-core/src/me-connected-applications/types.ts
+++ b/packages/api-core/src/me-connected-applications/types.ts
@@ -1,0 +1,24 @@
+export interface ConnectedApplication {
+	ID: string;
+	URL: string;
+	authorized: string;
+	description: string;
+	icon: string;
+	permissions: {
+		description: string;
+		name: string;
+	}[];
+	scope: string;
+	site:
+		| {
+				site_ID: string;
+				site_URL: string;
+				site_name: string;
+		  }
+		| boolean;
+	title: string;
+}
+
+export interface ConnectedApplicationSuccess {
+	success: true;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -21,6 +21,7 @@ export * from './me-a8c';
 export * from './me-account';
 export * from './me-account-recovery';
 export * from './me-blocked-sites';
+export * from './me-connected-applications';
 export * from './me-dpa';
 export * from './me-payment-methods';
 export * from './me-preferences';

--- a/packages/api-queries/src/me-connected-applications.ts
+++ b/packages/api-queries/src/me-connected-applications.ts
@@ -1,0 +1,15 @@
+import { fetchConnectedApplications, deleteConnectedApplication } from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+
+export const connectedApplicationsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'me', 'connected-applications' ],
+		queryFn: fetchConnectedApplications,
+	} );
+
+export const deleteConnectedApplicationMutation = () =>
+	mutationOptions( {
+		mutationFn: deleteConnectedApplication,
+		onSuccess: () => queryClient.invalidateQueries( connectedApplicationsQuery() ),
+	} );


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/DOTDASH-174/implement-account-security-connected-apps-to-the-hosting-dashboard

## Proposed Changes

This PR implements:

- List view for connected applications with empty state
- Disconnect the connected application
- View details of connected application

## Why are these changes being made?

* To display all the connected applications of a user and allow them to disconnect it or view details.

## Testing Instructions

* Open the Calypso live link
* Go to /v2/me/security/connected-apps
* Verify that the screen displayed is shown when there are no connected applications

<img width="1920" height="630" alt="Screenshot 2025-09-17 at 12 30 52 PM" src="https://github.com/user-attachments/assets/949f4478-dbd4-4165-a3c6-681136574031" />

* [Connect an application](https://wordpress.com/support/third-party-applications/) & verify that the application is connected, as shown below. Verify the actions (Disconnect: primary & View details) are displayed

<img width="1920" height="836" alt="Screenshot 2025-09-17 at 12 33 48 PM" src="https://github.com/user-attachments/assets/07eb53a7-8a8a-4d6f-bb69-d3599dce3d97" />

<img width="1920" height="588" alt="Screenshot 2025-09-17 at 12 30 31 PM" src="https://github.com/user-attachments/assets/daafa14a-e55e-4351-bcf2-487a96d4c95a" />

<img width="1920" height="836" alt="Screenshot 2025-09-17 at 12 33 54 PM" src="https://github.com/user-attachments/assets/2dce8e71-d2c7-4fa8-ab60-fd950351119e" />

* Click the "View details" button > Verify the modal is displayed with the application details

When the scope is "global"

<img width="523" height="597" alt="Screenshot 2025-09-17 at 12 21 55 PM" src="https://github.com/user-attachments/assets/3a66eaf8-d48d-4930-a460-aa89f1dcf772" />

When the scope is "auth"

<img width="524" height="403" alt="Screenshot 2025-09-17 at 12 21 30 PM" src="https://github.com/user-attachments/assets/0d934876-482e-45b2-9bf9-1bdca8c8e744" />

When the scope is a site. I tested this using a different account with site connection, as I was unable to find a way to connect. Feel free to skip this.

<img width="524" height="567" alt="Screenshot 2025-09-17 at 12 20 27 PM" src="https://github.com/user-attachments/assets/a1aa453a-3711-4b32-9094-805cccfc4739" />

* Click the "Disconnect" button > Verify a confirmation modal is displayed > Go ahead a disconnect > Verify the appplication is disconnected 

<img width="1920" height="630" alt="Screenshot 2025-09-17 at 12 30 41 PM" src="https://github.com/user-attachments/assets/32638a67-4663-4485-87f2-cfeae8b6b791" />

<img width="617" height="100" alt="Screenshot 2025-09-17 at 12 30 47 PM" src="https://github.com/user-attachments/assets/ec6bc709-3d30-4aa8-988b-4e42b9b1f637" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
