### PR TITLE
Update/social previews/linkedin

### DIFF
--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -29,6 +29,74 @@ export const truncatedAtSpace: ( a: number, b: number ) => ConditionalFormatter 
 export const hardTruncation: ( n: number ) => Formatter = ( limit ) => ( title ) =>
 	title.slice( 0, limit ).concat( '…' );
 
+export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( text ) => {
+	if ( text.length <= limit ) {
+		return text;
+	}
+	// Abbreviations that contain periods but are not sentence endings
+	const abbreviations: Record<string, string> = {
+		'a.m.': 'a-m-',
+		'p.m.': 'p-m-',
+		'e.g.': 'e-g-',
+		'i.e.': 'i-e-',
+		'etc.': 'etc-',
+		'cf.': 'cf-',
+		'viz.': 'viz-',
+		'vs.': 'vs-',
+		'dr.': 'dr-',
+		'mr.': 'mr-',
+		'mrs.': 'mrs-',
+		'ms.': 'ms-',
+		'mx.': 'mx-',
+		'prof.': 'prof-',
+		'sr.': 'sr-',
+		'jr.': 'jr-',
+		'hon.': 'hon-',
+		'rev.': 'rev-',
+		'capt.': 'capt-',
+		'col.': 'col-',
+		'gen.': 'gen-',
+		'lt.': 'lt-',
+		'sgt.': 'sgt-',
+		'st.': 'st-',
+		'mt.': 'mt-',
+		'ft.': 'ft-',
+		'inc.': 'inc-',
+		'ltd.': 'ltd-',
+		'co.': 'co-',
+		'corp.': 'corp-',
+		'llc.': 'llc-',
+		'no.': 'no-',
+		'vol.': 'vol-',
+		'ed.': 'ed-',
+		'ch.': 'ch-',
+		'fig.': 'fig-',
+		'pp.': 'pp-',
+		'p.': 'p-',
+		'al.': 'al-',
+	};
+
+	// Take the first 'limit' characters
+	const truncated = text.slice( 0, limit );
+
+	// Replace abbreviations with hyphenated versions to avoid false sentence endings
+	let processedText = truncated;
+	Object.entries( abbreviations ).forEach( ( [ abbrev, replacement ] ) => {
+		const regex = new RegExp( `\\b${ abbrev.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) }\\b`, 'gi' );
+		processedText = processedText.replace( regex, replacement );
+	} );
+
+	// Find the last sentence ending (., !, ?) within the processed text
+	const lastSentenceEnd = processedText.lastIndexOf( '.' );
+	// If we found a sentence end and it's not too close to the beginning, use it
+	if ( lastSentenceEnd > 0 && lastSentenceEnd > limit * 0.5 ) {
+		return truncated.slice( 0, lastSentenceEnd + 1 );
+	}
+
+	// Otherwise, fall back to hard truncation
+	return truncated.concat( '…' );
+};
+
 export const firstValid: ( ...args: ConditionalFormatter[] ) => NullableFormatter =
 	( ...predicates ) =>
 	( a ) =>
@@ -123,16 +191,14 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		// Instagram doesn't support hyperlink URLs at the moment.
 		hyperlinkUrls = 'instagram' !== platform,
 	} = options;
-
 	let result = stripHtmlTags( text );
-
 	// Replace multiple new lines (2+) with 2 new lines
 	// There can be any whitespace characters in empty lines
 	// That is why "\s*"
 	result = result.replaceAll( /(?:\s*[\n\r]){2,}/g, '\n\n' );
 
 	if ( maxChars && result.length > maxChars ) {
-		result = hardTruncation( maxChars )( result );
+		result = truncateAtSentence( maxChars )( result );
 	}
 
 	if ( maxLines ) {

--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -29,10 +29,90 @@ export const truncatedAtSpace: ( a: number, b: number ) => ConditionalFormatter 
 export const hardTruncation: ( n: number ) => Formatter = ( limit ) => ( title ) =>
 	title.slice( 0, limit ).concat( '…' );
 
-export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( text ) => {
-	if ( text.length <= limit ) {
-		return text;
+/**
+ * Helper function to get the current locale
+ * Falls back to 'en' if locale cannot be determined
+ */
+const getCurrentLocale = (): string => {
+	try {
+		// Try to get the locale from the HTML lang attribute first
+		if ( typeof document !== 'undefined' && document.documentElement ) {
+			const htmlLang = document.documentElement.lang;
+			if ( htmlLang ) {
+				// Convert WordPress locale format (e.g., 'en_US') to BCP 47 format (e.g., 'en-US')
+				return htmlLang.replace( '_', '-' );
+			}
+		}
+
+		// Fallback to browser's navigator.language
+		if ( typeof navigator !== 'undefined' && navigator.language ) {
+			return navigator.language;
+		}
+
+		// Final fallback to English
+		return 'en';
+	} catch ( error ) {
+		// Fallback to English if locale detection fails
+		return 'en';
 	}
+};
+
+/**
+ * Truncate text using Intl.Segmenter for better sentence detection
+ * @param text - The text to truncate
+ * @param limit - The character limit
+ * @returns The truncated text or null if Intl.Segmenter is not available or fails
+ */
+const truncateWithIntlSegmenter = ( text: string, limit: number ): string | null => {
+	if ( typeof Intl === 'undefined' || !( 'Segmenter' in Intl ) ) {
+		return null;
+	}
+
+	try {
+		const locale = getCurrentLocale();
+		const segmenter = new Intl.Segmenter( locale, { granularity: 'sentence' } );
+
+		// Segment the full text, not the truncated version
+		const segments = Array.from( segmenter.segment( text ) );
+
+		// Find the last complete sentence that fits within the limit
+		let result = '';
+		let currentLength = 0;
+
+		for ( const segment of segments ) {
+			const segmentText = segment.segment;
+			// Check if adding this segment would exceed the limit
+			if ( currentLength + segmentText.length <= limit ) {
+				result += segmentText;
+				currentLength += segmentText.length;
+			} else {
+				// If this segment would exceed the limit, stop here
+				break;
+			}
+		}
+
+		// If we found at least one complete sentence and it's not too short, use it
+		if ( result.trim().length > 0 && result.length > limit * 0.3 ) {
+			return result.trim();
+		}
+
+		return null;
+	} catch ( error ) {
+		// If Intl.Segmenter fails, return null to fall back to manual method
+		console.warn( 'Intl.Segmenter failed, falling back to manual sentence detection:', error );
+		return null;
+	}
+};
+
+/**
+ * Truncate text using manual sentence detection with abbreviation handling
+ * @param text - The text to truncate
+ * @param limit - The character limit
+ * @returns The truncated text
+ */
+const truncateWithManualDetection = ( text: string, limit: number ): string => {
+	const truncated = text.slice( 0, limit );
+
 	// Abbreviations that contain periods but are not sentence endings
 	const abbreviations: Record<string, string> = {
 		'a.m.': 'a-m-',
@@ -76,9 +156,6 @@ export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( tex
 		'al.': 'al-',
 	};
 
-	// Take the first 'limit' characters
-	const truncated = text.slice( 0, limit );
-
 	// Replace abbreviations with hyphenated versions to avoid false sentence endings
 	let processedText = truncated;
 	Object.entries( abbreviations ).forEach( ( [ abbrev, replacement ] ) => {
@@ -95,6 +172,26 @@ export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( tex
 
 	// Otherwise, fall back to hard truncation
 	return truncated.concat( '…' );
+};
+
+/**
+ * Truncate text at the last complete sentence.
+ * @param limit - The character limit.
+ * @returns The truncated text.
+ */
+export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( text ) => {
+	if ( text.length <= limit ) {
+		return text;
+	}
+
+	// Try to use Intl.Segmenter for better sentence detection
+	const intlResult = truncateWithIntlSegmenter( text, limit );
+	if ( intlResult !== null ) {
+		return intlResult;
+	}
+
+	// Fallback to manual sentence detection
+	return truncateWithManualDetection( text, limit );
 };
 
 export const firstValid: ( ...args: ConditionalFormatter[] ) => NullableFormatter =

--- a/packages/social-previews/src/helpers.tsx
+++ b/packages/social-previews/src/helpers.tsx
@@ -98,80 +98,10 @@ const truncateWithIntlSegmenter = ( text: string, limit: number ): string | null
 
 		return null;
 	} catch ( error ) {
-		// If Intl.Segmenter fails, return null to fall back to manual method
-		console.warn( 'Intl.Segmenter failed, falling back to manual sentence detection:', error );
+		// If Intl.Segmenter fails, return null to fall back to simple truncation
+		console.warn( 'Intl.Segmenter failed, falling back to simple truncation:', error );
 		return null;
 	}
-};
-
-/**
- * Truncate text using manual sentence detection with abbreviation handling
- * @param text - The text to truncate
- * @param limit - The character limit
- * @returns The truncated text
- */
-const truncateWithManualDetection = ( text: string, limit: number ): string => {
-	const truncated = text.slice( 0, limit );
-
-	// Abbreviations that contain periods but are not sentence endings
-	const abbreviations: Record<string, string> = {
-		'a.m.': 'a-m-',
-		'p.m.': 'p-m-',
-		'e.g.': 'e-g-',
-		'i.e.': 'i-e-',
-		'etc.': 'etc-',
-		'cf.': 'cf-',
-		'viz.': 'viz-',
-		'vs.': 'vs-',
-		'dr.': 'dr-',
-		'mr.': 'mr-',
-		'mrs.': 'mrs-',
-		'ms.': 'ms-',
-		'mx.': 'mx-',
-		'prof.': 'prof-',
-		'sr.': 'sr-',
-		'jr.': 'jr-',
-		'hon.': 'hon-',
-		'rev.': 'rev-',
-		'capt.': 'capt-',
-		'col.': 'col-',
-		'gen.': 'gen-',
-		'lt.': 'lt-',
-		'sgt.': 'sgt-',
-		'st.': 'st-',
-		'mt.': 'mt-',
-		'ft.': 'ft-',
-		'inc.': 'inc-',
-		'ltd.': 'ltd-',
-		'co.': 'co-',
-		'corp.': 'corp-',
-		'llc.': 'llc-',
-		'no.': 'no-',
-		'vol.': 'vol-',
-		'ed.': 'ed-',
-		'ch.': 'ch-',
-		'fig.': 'fig-',
-		'pp.': 'pp-',
-		'p.': 'p-',
-		'al.': 'al-',
-	};
-
-	// Replace abbreviations with hyphenated versions to avoid false sentence endings
-	let processedText = truncated;
-	Object.entries( abbreviations ).forEach( ( [ abbrev, replacement ] ) => {
-		const regex = new RegExp( `\\b${ abbrev.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) }\\b`, 'gi' );
-		processedText = processedText.replace( regex, replacement );
-	} );
-
-	// Find the last sentence ending (., !, ?) within the processed text
-	const lastSentenceEnd = processedText.lastIndexOf( '.' );
-	// If we found a sentence end and it's not too close to the beginning, use it
-	if ( lastSentenceEnd > 0 && lastSentenceEnd > limit * 0.5 ) {
-		return truncated.slice( 0, lastSentenceEnd + 1 );
-	}
-
-	// Otherwise, fall back to hard truncation
-	return truncated.concat( '…' );
 };
 
 /**
@@ -190,8 +120,8 @@ export const truncateAtSentence: ( n: number ) => Formatter = ( limit ) => ( tex
 		return intlResult;
 	}
 
-	// Fallback to manual sentence detection
-	return truncateWithManualDetection( text, limit );
+	// Fallback to hard truncation.
+	return hardTruncation( limit )( text );
 };
 
 export const firstValid: ( ...args: ConditionalFormatter[] ) => NullableFormatter =

--- a/packages/social-previews/src/linkedin-preview/constants.ts
+++ b/packages/social-previews/src/linkedin-preview/constants.ts
@@ -1,2 +1,2 @@
-export const FEED_TEXT_MAX_LENGTH = 212;
+export const FEED_TEXT_MAX_LENGTH = 500;
 export const FEED_TEXT_MAX_LINES = 3;


### PR DESCRIPTION
Related to: 
- T51ENG-465
- 186145-ghe-Automattic/wpcom
- pepd2X-y1-p2#comment-3087


## Proposed Changes

* Add the `truncateAtSentence` function to truncate the post description (content) to the last sentence within the max characters limit
* Increase Linkedin's `FEED_TEXT_MAX_LENGTH` to 500 

## Why are these changes being made?

* In pepd2X-y1-p2#comment-3087 it was decided to improve the Linkedin social sharing:

>On posts from [ma.tt](http://ma.tt/) that get's published to LinkedIn, we want to modify the message field.
>
>Basically, we should adapt what Bluesky and Mastodon do today with some slight modifications:
>
>Grab the excerpt, and try to mitigate the auto-truncation.
>
>The order of preferred sharing text is:
>
>1. custom text set in the publicize inputs when making a post.
>2. A manually set post excerpt
>3. The calculated share text: e.g this ask.

>Instead of grabbing 300 characters and finding the next sentence end, let's instead:
>
>Grab 500 characters and find the last sentence end looking backward.
>
>If none is found, go back to 500 chars and find the last full word, trim the string there and add elipsis.

## Testing Instructions

* Ensure Jetpack Social is enabled and has some enabled connections, including Linkedin
* Create a post with a long content (more than 500 characters). It can include images, formatting, etc
* Click the button to preview how the post will be shared in Linkedin and confirm that:
    * If the post has a custom sharing text, this is the text that will appear in the preview
    * If the post doesn't have a custom sharing text but has an excerpt, the exerpt will be used instead
    * If the post doesn't have a custom sharing text or excerpt, the text that will get shared is the post's content, truncated to the last sentence within the first 500 characters.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?