### PR TITLE
Domains: Domain forwarding: Add confirm dialog and recordTracksEvent

### DIFF
--- a/client/dashboard/domains/domain-forwardings/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwardings/delete-modal.tsx
@@ -1,0 +1,82 @@
+import { domainForwardingDeleteMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../app/analytics';
+import { ButtonStack } from '../../components/button-stack';
+import type { DomainForwarding } from '@automattic/api-core';
+
+interface DomainForwardingDeleteModalProps {
+	domainName: string;
+	domainForwarding: DomainForwarding;
+	onClose?: () => void;
+}
+
+const DomainForwardingDeleteModal = ( {
+	domainName,
+	domainForwarding,
+	onClose,
+}: DomainForwardingDeleteModalProps ) => {
+	const deleteMutation = useMutation( domainForwardingDeleteMutation( domainName ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
+
+	const onConfirm = () => {
+		deleteMutation.mutate( domainForwarding.domain_redirect_id, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Domain forwarding rule was deleted successfully.' ), {
+					type: 'snackbar',
+				} );
+
+				recordTracksEvent( 'calypso_dashboard_domain_forwardings_delete_record', {
+					domain: domainName,
+					fqdn: domainForwarding.fqdn,
+					target_host: domainForwarding.target_host,
+				} );
+
+				onClose?.();
+			},
+			onError: ( error ) => {
+				createErrorNotice( __( 'Failed to delete domain forwarding rule.' ), {
+					type: 'snackbar',
+				} );
+
+				recordTracksEvent( 'calypso_dashboard_domain_forwardings_delete_record_failure', {
+					domain: domainName,
+					fqdn: domainForwarding.fqdn,
+					target_host: domainForwarding.target_host,
+					error_message: error.message,
+				} );
+
+				onClose?.();
+			},
+		} );
+	};
+
+	return (
+		<VStack spacing={ 6 }>
+			<Text>{ __( 'Are you sure you want to delete this domain forwarding rule?' ) }</Text>
+			<ButtonStack justify="flex-end">
+				<Button onClick={ onClose } disabled={ deleteMutation.isPending }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					onClick={ onConfirm }
+					isBusy={ deleteMutation.isPending }
+					disabled={ deleteMutation.isPending }
+					variant="primary"
+				>
+					{ __( 'Delete' ) }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+};
+
+export default DomainForwardingDeleteModal;


### PR DESCRIPTION
Part of DOTDASH-408

## Proposed Changes

* Adds a confirm dialog on domain forwarding rule delete

## Why are these changes being made?

* DOTDASH-408

## Testing Instructions

* Go to `/v2/domains`
* Select any domain
* Create a domain forwarding rule
* Check if there is a confirmation dialog on delete

<img width="732" height="398" alt="Screenshot 2025-09-17 at 12 26 03" src="https://github.com/user-attachments/assets/c209809b-18db-4220-83e2-a92b9ffd4e86" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
