### PR TITLE
MCP: Migrate MCP Settings from Site Settings to User Settings

### DIFF
--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -14,9 +14,10 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import wpcom from 'calypso/lib/wp';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
-import { getSiteMcpAbilities, createSiteSpecificApiPayload, saveMcpAbilities } from './utils';
+import { getSiteMcpAbilities, createSiteSpecificApiPayload } from './utils';
 import type { SiteMcpAbilities } from '@automattic/api-core';
 
 function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
@@ -24,7 +25,13 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const { data: userSettings } = useQuery( userSettingsQuery() );
-	const saveMcpMutation = useMutation( { mutationFn: saveMcpAbilities } );
+	// Custom mutation that bypasses the saveableKeys filtering
+	const saveMcpMutation = useMutation( {
+		mutationFn: async ( data: { mcp_abilities: any } ) => {
+			// Use wpcom API call to bypass saveableKeys filtering
+			return await wpcom.req.post( '/me/settings', data );
+		},
+	} );
 
 	// Get tools from user settings using the new nested structure
 	const availableTools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {

--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -1,10 +1,5 @@
-import {
-	isAutomatticianQuery,
-	siteBySlugQuery,
-	siteSettingsQuery,
-	siteSettingsMutation,
-} from '@automattic/api-queries';
-import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { isAutomatticianQuery, siteBySlugQuery, userSettingsQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
 	Button,
@@ -18,105 +13,89 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
-import type { SiteMcpAbilities, SiteSettings } from '@automattic/api-core';
+import { getSiteMcpAbilities, createSiteSpecificApiPayload, saveMcpAbilities } from './utils';
+import type { SiteMcpAbilities } from '@automattic/api-core';
 
-export default function SettingsMcp( { siteSlug }: { siteSlug: string } ) {
+function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
-	const mutation = useMutation( siteSettingsMutation( site.ID ) );
+	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const saveMcpMutation = useMutation( { mutationFn: saveMcpAbilities } );
 
-	// Get tools from the site settings data
-	const availableTools: [ string, SiteMcpAbilities[ string ] ][] = Object.entries(
-		siteSettings?.mcp_abilities || {}
-	);
+	// Get tools from user settings using the new nested structure
+	const availableTools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {
+		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+		const abilities = getSiteMcpAbilities( userSettings, site.ID );
+		return Object.entries( abilities );
+	}, [ userSettings, site.ID ] );
+
 	const hasTools = availableTools.length > 0;
 
-	const [ formData, setFormData ] = useState< SiteMcpAbilities >(
-		siteSettings?.mcp_abilities ?? {}
+	const [ formData, setFormData ] = useState< SiteMcpAbilities >( () =>
+		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+		getSiteMcpAbilities( userSettings, site.ID )
 	);
 
 	// Calculate if any tools are enabled in form data (for master toggle state)
 	const anyToolsEnabled = hasTools && Object.values( formData ).some( ( tool ) => tool.enabled );
 
-	// Auto-disable master toggle if all tools are disabled
+	// Update form data when userSettings changes
 	useEffect( () => {
-		const enabledToolsCount = Object.values( formData ).filter( ( tool ) => tool.enabled ).length;
+		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+		const abilities = getSiteMcpAbilities( userSettings, site.ID );
+		setFormData( abilities );
+	}, [ userSettings, site.ID ] );
 
-		// If we have tools but none are enabled, and the master toggle is on,
-		// we need to turn off all tools (which will turn off the master toggle)
-		if ( hasTools && enabledToolsCount === 0 && anyToolsEnabled ) {
-			const disabledTools: SiteMcpAbilities = {};
-			Object.entries( siteSettings?.mcp_abilities || {} ).forEach( ( [ toolId, tool ] ) => {
-				disabledTools[ toolId ] = {
-					...tool,
-					enabled: false,
-				};
-			} );
-			setFormData( disabledTools );
-		}
-	}, [ formData, hasTools, anyToolsEnabled, siteSettings?.mcp_abilities ] );
+	const handleSubmit = useCallback(
+		( e: React.FormEvent ) => {
+			e.preventDefault();
 
-	// Gate access to Automatticians only and only if there are tools to configure
-	if ( ! isAutomattician ) {
-		return null;
-	}
+			try {
+				// Create optimized API payload using the new structure
+				// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+				const apiData = createSiteSpecificApiPayload( userSettings, site.ID, formData );
 
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
-
-		// Convert the tools object to a simple key-value array with enabled status
-		const toolsArray: Record< string, number > = {};
-		Object.entries( formData ).forEach( ( [ toolId, tool ] ) => {
-			toolsArray[ toolId ] = tool.enabled ? 1 : 0;
-		} );
-
-		// Create mutation data with the proper type for the API
-		// Note: We use double type assertion (as unknown as Partial<SiteSettings>) because
-		// the API expects simplified mcp_abilities (Record<string, number>) but the TypeScript
-		// type defines full objects (SiteMcpAbilities). The mutation logic handles the transformation.
-		const mutationData = { mcp_abilities: toolsArray } as unknown as Partial< SiteSettings >;
-
-		mutation.mutate( mutationData, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'MCP tools saved.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to save MCP tools.' ), { type: 'snackbar' } );
-			},
-		} );
-	};
-
-	const handleMasterToggle = ( enabled: boolean ) => {
-		setFormData( () => {
-			if ( enabled ) {
-				// When enabling MCP, auto-enable all available tools
-				const autoEnabledTools: SiteMcpAbilities = {};
-				Object.entries( siteSettings?.mcp_abilities || {} ).forEach( ( [ toolId, tool ] ) => {
-					autoEnabledTools[ toolId ] = {
-						...tool,
-						enabled: true, // Auto-enable all tools
-					};
+				// Save using custom mutation (bypasses saveableKeys filtering)
+				saveMcpMutation.mutate( apiData, {
+					onSuccess: () => {
+						createSuccessNotice( __( 'MCP tools saved.' ), { type: 'snackbar' } );
+					},
+					onError: () => {
+						createErrorNotice( __( 'Failed to save MCP tools.' ), { type: 'snackbar' } );
+					},
 				} );
-				return autoEnabledTools;
+			} catch ( error ) {
+				createErrorNotice( __( 'Failed to save MCP tools.' ), { type: 'snackbar' } );
 			}
-			// When disabling MCP, disable all tools
-			const disabledTools: SiteMcpAbilities = {};
-			Object.entries( siteSettings?.mcp_abilities || {} ).forEach( ( [ toolId, tool ] ) => {
-				disabledTools[ toolId ] = {
+		},
+		[ formData, userSettings, site.ID, saveMcpMutation, createSuccessNotice, createErrorNotice ]
+	);
+
+	const handleMasterToggle = useCallback(
+		( enabled: boolean ) => {
+			// Get the complete list of available tools from userSettings
+			// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+			const currentAbilities = getSiteMcpAbilities( userSettings, site.ID );
+			const updatedTools: SiteMcpAbilities = {};
+
+			// Update all available tools to the same enabled state
+			Object.entries( currentAbilities ).forEach( ( [ toolId, tool ] ) => {
+				updatedTools[ toolId ] = {
 					...tool,
-					enabled: false,
+					enabled,
 				};
 			} );
-			return disabledTools;
-		} );
-	};
 
-	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+			setFormData( updatedTools );
+		},
+		[ userSettings, site.ID ]
+	);
+
+	const handleToolChange = useCallback( ( toolId: string, enabled: boolean ) => {
 		setFormData( ( prev ) => ( {
 			...prev,
 			[ toolId ]: {
@@ -124,18 +103,23 @@ export default function SettingsMcp( { siteSlug }: { siteSlug: string } ) {
 				enabled,
 			},
 		} ) );
-	};
+	}, [] );
 
-	// Get tools from the site settings data, but use form data for current state
-	const tools: [ string, SiteMcpAbilities[ string ] ][] = availableTools.map(
-		( [ toolId, tool ] ) => [
+	// Get tools from user settings, but use form data for current state
+	const tools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {
+		return availableTools.map( ( [ toolId, tool ] ) => [
 			toolId,
 			{
 				...tool,
 				enabled: formData[ toolId ]?.enabled ?? tool.enabled,
 			},
-		]
-	);
+		] );
+	}, [ availableTools, formData ] );
+
+	// Gate access to Automatticians only and only if there are tools to configure
+	if ( ! isAutomattician ) {
+		return null;
+	}
 
 	// Group tools by type first, then by category
 	const groupedByType: Record<
@@ -244,7 +228,6 @@ export default function SettingsMcp( { siteSlug }: { siteSlug: string } ) {
 																checked={ tool.enabled }
 																onChange={ ( checked ) => handleToolChange( toolId, checked ) }
 																label={ tool.title }
-																disabled={ ! anyToolsEnabled }
 																help={ tool.description }
 															/>
 														</VStack>
@@ -264,10 +247,10 @@ export default function SettingsMcp( { siteSlug }: { siteSlug: string } ) {
 						<Button
 							variant="primary"
 							type="submit"
-							isBusy={ mutation.isPending }
-							disabled={ mutation.isPending }
+							isBusy={ saveMcpMutation.isPending }
+							disabled={ saveMcpMutation.isPending }
 						>
-							{ mutation.isPending ? __( 'Saving…' ) : __( 'Save MCP tools' ) }
+							{ saveMcpMutation.isPending ? __( 'Saving…' ) : __( 'Save MCP tools' ) }
 						</Button>
 					</div>
 				) }
@@ -300,3 +283,5 @@ export default function SettingsMcp( { siteSlug }: { siteSlug: string } ) {
 		</PageLayout>
 	);
 }
+
+export default SettingsMcpComponent;

--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -34,7 +34,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 
 	// Get tools from user settings using the new nested structure
 	const availableTools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {
-		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 		const abilities = getSiteMcpAbilities( userSettings, site.ID );
 		return Object.entries( abilities );
 	}, [ userSettings, site.ID ] );
@@ -42,7 +41,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const hasTools = availableTools.length > 0;
 
 	const [ formData, setFormData ] = useState< SiteMcpAbilities >( () =>
-		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 		getSiteMcpAbilities( userSettings, site.ID )
 	);
 
@@ -51,7 +49,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 
 	// Update form data when userSettings changes
 	useEffect( () => {
-		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 		const abilities = getSiteMcpAbilities( userSettings, site.ID );
 		setFormData( abilities );
 	}, [ userSettings, site.ID ] );
@@ -62,7 +59,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 
 			try {
 				// Create optimized API payload using the new structure
-				// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 				const apiData = createSiteSpecificApiPayload( userSettings, site.ID, formData );
 
 				// Save using custom mutation (bypasses saveableKeys filtering)
@@ -84,7 +80,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const handleMasterToggle = useCallback(
 		( enabled: boolean ) => {
 			// Get the complete list of available tools from userSettings
-			// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 			const currentAbilities = getSiteMcpAbilities( userSettings, site.ID );
 			const updatedTools: SiteMcpAbilities = {};
 

--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -18,7 +18,7 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { getSiteMcpAbilities, createSiteSpecificApiPayload } from './utils';
@@ -28,7 +28,7 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
-	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	// Use the standard userSettingsMutation (now supports mcp_abilities)
 	const saveMcpMutation = useMutation( userSettingsMutation() );
 
@@ -47,12 +47,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	// Calculate if any tools are enabled in form data (for master toggle state)
 	const anyToolsEnabled = hasTools && Object.values( formData ).some( ( tool ) => tool.enabled );
 
-	// Update form data when userSettings changes
-	useEffect( () => {
-		const abilities = getSiteMcpAbilities( userSettings, site.ID );
-		setFormData( abilities );
-	}, [ userSettings, site.ID ] );
-
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
 			e.preventDefault();
@@ -62,7 +56,7 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 				const apiData = createSiteSpecificApiPayload( userSettings, site.ID, formData );
 
 				// Save using custom mutation (bypasses saveableKeys filtering)
-				saveMcpMutation.mutate( apiData, {
+				saveMcpMutation.mutate( apiData as any, {
 					onSuccess: () => {
 						createSuccessNotice( __( 'MCP tools saved.' ), { type: 'snackbar' } );
 					},

--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -1,4 +1,9 @@
-import { isAutomatticianQuery, siteBySlugQuery, userSettingsQuery } from '@automattic/api-queries';
+import {
+	isAutomatticianQuery,
+	siteBySlugQuery,
+	userSettingsQuery,
+	userSettingsMutation,
+} from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
@@ -14,7 +19,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import wpcom from 'calypso/lib/wp';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { getSiteMcpAbilities, createSiteSpecificApiPayload } from './utils';
@@ -25,13 +29,8 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const { data: userSettings } = useQuery( userSettingsQuery() );
-	// Custom mutation that bypasses the saveableKeys filtering
-	const saveMcpMutation = useMutation( {
-		mutationFn: async ( data: { mcp_abilities: any } ) => {
-			// Use wpcom API call to bypass saveableKeys filtering
-			return await wpcom.req.post( '/me/settings', data );
-		},
-	} );
+	// Use the standard userSettingsMutation (now supports mcp_abilities)
+	const saveMcpMutation = useMutation( userSettingsMutation() );
 
 	// Get tools from user settings using the new nested structure
 	const availableTools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {

--- a/client/dashboard/sites/settings-mcp/setup.tsx
+++ b/client/dashboard/sites/settings-mcp/setup.tsx
@@ -128,7 +128,6 @@ function McpSetupComponent( { siteSlug }: { siteSlug: string } ) {
 
 	// Check if any tools are enabled using the new userSettings structure
 	const hasEnabledTools = useMemo( () => {
-		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 		const abilities = getSiteMcpAbilities( userSettings, site.ID );
 		return Object.values( abilities ).some( ( tool ) => tool.enabled );
 	}, [ userSettings, site.ID ] );

--- a/client/dashboard/sites/settings-mcp/setup.tsx
+++ b/client/dashboard/sites/settings-mcp/setup.tsx
@@ -1,5 +1,5 @@
-import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { siteBySlugQuery, userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery, useQuery } from '@tanstack/react-query';
 import {
 	Button,
 	ExternalLink,
@@ -13,13 +13,14 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
+import { getSiteMcpAbilities } from './utils';
 
-export default function McpSetup( { siteSlug }: { siteSlug: string } ) {
+function McpSetupComponent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
+	const { data: userSettings } = useQuery( userSettingsQuery() );
 	// MCP client selection for configuration format
 	const [ selectedMcpClient, setSelectedMcpClient ] = useState< string >( 'claude' );
 
@@ -125,10 +126,12 @@ export default function McpSetup( { siteSlug }: { siteSlug: string } ) {
 		}
 	};
 
-	// Check if any tools are enabled
-	const hasEnabledTools =
-		siteSettings?.mcp_abilities &&
-		Object.values( siteSettings.mcp_abilities ).some( ( tool ) => tool.enabled );
+	// Check if any tools are enabled using the new userSettings structure
+	const hasEnabledTools = useMemo( () => {
+		// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+		const abilities = getSiteMcpAbilities( userSettings, site.ID );
+		return Object.values( abilities ).some( ( tool ) => tool.enabled );
+	}, [ userSettings, site.ID ] );
 
 	if ( ! hasEnabledTools ) {
 		return (
@@ -354,3 +357,5 @@ export default function McpSetup( { siteSlug }: { siteSlug: string } ) {
 		</PageLayout>
 	);
 }
+
+export default McpSetupComponent;

--- a/client/dashboard/sites/settings-mcp/summary.tsx
+++ b/client/dashboard/sites/settings-mcp/summary.tsx
@@ -1,8 +1,9 @@
-import { isAutomatticianQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { isAutomatticianQuery, userSettingsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { SVG, Path } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { getSiteMcpAbilities } from './utils';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -16,7 +17,7 @@ const McpIcon = ( { style }: { style?: React.CSSProperties } ) => (
 );
 
 export default function McpSettingsSummary( { site, density }: { site: Site; density?: Density } ) {
-	const { data: siteSettings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data: userSettings } = useQuery( userSettingsQuery() );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 
 	// Gate access to Automatticians only
@@ -24,14 +25,18 @@ export default function McpSettingsSummary( { site, density }: { site: Site; den
 		return null;
 	}
 
-	if ( ! siteSettings?.mcp_abilities ) {
+	// Get MCP abilities from user settings using the new nested structure
+	// @ts-ignore - userSettings type doesn't include mcp_abilities yet
+	const mcpAbilities = getSiteMcpAbilities( userSettings, site.ID );
+
+	if ( ! mcpAbilities || Object.keys( mcpAbilities ).length === 0 ) {
 		return null;
 	}
 
 	let badgeText: string;
 	let badgeIntent: 'success' | 'info' | undefined;
 
-	const enabledTools = Object.entries( siteSettings.mcp_abilities )
+	const enabledTools = Object.entries( mcpAbilities )
 		.filter( ( [ , tool ] ) => tool.enabled )
 		.map( ( [ toolId ] ) => toolId );
 

--- a/client/dashboard/sites/settings-mcp/summary.tsx
+++ b/client/dashboard/sites/settings-mcp/summary.tsx
@@ -26,7 +26,6 @@ export default function McpSettingsSummary( { site, density }: { site: Site; den
 	}
 
 	// Get MCP abilities from user settings using the new nested structure
-	// @ts-ignore - userSettings type doesn't include mcp_abilities yet
 	const mcpAbilities = getSiteMcpAbilities( userSettings, site.ID );
 
 	if ( ! mcpAbilities || Object.keys( mcpAbilities ).length === 0 ) {

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -1,10 +1,4 @@
-import type { SiteMcpAbilities } from '@automattic/api-core';
-
-export type McpAbilitiesStructure = {
-	account?: SiteMcpAbilities;
-	site?: SiteMcpAbilities; // Default values for all sites
-	sites?: Record< string, Record< string, number > >; // Custom overrides per site (0/1 values only)
-};
+import type { SiteMcpAbilities, McpAbilities } from '@automattic/api-core';
 
 // API payload structure (simplified format for API calls)
 export type McpAbilitiesApiStructure = {
@@ -18,7 +12,7 @@ export type McpAbilitiesApiStructure = {
  * Falls back to default site abilities, then account-level abilities
  */
 export function getSiteMcpAbilities(
-	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
+	userSettings: { mcp_abilities?: McpAbilities } | null | undefined,
 	siteId: string | number
 ): SiteMcpAbilities {
 	const siteIdStr = String( siteId );
@@ -66,7 +60,7 @@ export function getSiteMcpAbilities(
 export function getSiteAbilityState(
 	abilityName: string,
 	siteId: string | number,
-	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined
+	userSettings: { mcp_abilities?: McpAbilities } | null | undefined
 ): boolean {
 	const siteIdStr = String( siteId );
 	const mcpData = userSettings?.mcp_abilities;
@@ -98,7 +92,7 @@ export function getSiteAbilityState(
  * Get account-level MCP abilities
  */
 export function getAccountMcpAbilities(
-	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null
+	userSettings: { mcp_abilities?: McpAbilities } | null
 ): SiteMcpAbilities {
 	return userSettings?.mcp_abilities?.account || {};
 }
@@ -108,10 +102,10 @@ export function getAccountMcpAbilities(
  * Only stores differences from the default site abilities
  */
 export function updateSiteMcpAbilities(
-	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
+	userSettings: { mcp_abilities?: McpAbilities } | null | undefined,
 	siteId: string | number,
 	abilities: SiteMcpAbilities
-): McpAbilitiesStructure {
+): McpAbilities {
 	const siteIdStr = String( siteId );
 	const mcpData = userSettings?.mcp_abilities;
 	const defaultSiteAbilities = mcpData?.site || {};
@@ -178,7 +172,7 @@ export function convertAbilitiesFromApi(
  * Uses the new 'site' key format for single site updates
  */
 export function createSiteSpecificApiPayload(
-	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
+	userSettings: { mcp_abilities?: McpAbilities } | null | undefined,
 	siteId: string | number,
 	abilities: SiteMcpAbilities
 ): { mcp_abilities: McpAbilitiesApiStructure } {

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -3,7 +3,7 @@ import type { SiteMcpAbilities } from '@automattic/api-core';
 export type McpAbilitiesStructure = {
 	account?: SiteMcpAbilities;
 	site?: SiteMcpAbilities; // Default values for all sites
-	sites?: Record< string, SiteMcpAbilities >; // Custom overrides per site
+	sites?: Record< string, Record< string, number > >; // Custom overrides per site (0/1 values only)
 };
 
 // API payload structure (simplified format for API calls)
@@ -32,7 +32,7 @@ export function getSiteMcpAbilities(
 	const defaultSiteAbilities = mcpData.site || {};
 
 	// Apply site-specific overrides if they exist (now only contains enabled/disabled values: 0 or 1)
-	const siteOverrides = mcpData.sites?.[ siteIdStr ] || {};
+	const siteOverrides: Record< string, number > = mcpData.sites?.[ siteIdStr ] || {};
 
 	// Merge defaults with overrides
 	const mergedAbilities: SiteMcpAbilities = {};
@@ -51,7 +51,7 @@ export function getSiteMcpAbilities(
 		if ( mergedAbilities[ abilityName ] ) {
 			mergedAbilities[ abilityName ] = {
 				...mergedAbilities[ abilityName ],
-				enabled: enabledValue === 1,
+				enabled: ( enabledValue as number ) === 1,
 			};
 		}
 	} );
@@ -76,8 +76,9 @@ export function getSiteAbilityState(
 	}
 
 	// Check if site has custom override (now just 0 or 1)
-	if ( mcpData.sites?.[ siteIdStr ]?.[ abilityName ] !== undefined ) {
-		return mcpData.sites[ siteIdStr ][ abilityName ] === 1;
+	const siteOverrides: Record< string, number > = mcpData.sites?.[ siteIdStr ] || {};
+	if ( siteOverrides[ abilityName ] !== undefined ) {
+		return ( siteOverrides[ abilityName ] as number ) === 1;
 	}
 
 	// Fall back to default from 'site' section
@@ -127,7 +128,7 @@ export function updateSiteMcpAbilities(
 	} );
 
 	// If no overrides needed, remove the site from sites object
-	const newSites = { ...mcpData?.sites };
+	const newSites: Record< string, Record< string, number > > = { ...mcpData?.sites };
 	if ( Object.keys( siteOverrides ).length === 0 ) {
 		delete newSites[ siteIdStr ];
 	} else {

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -18,7 +18,7 @@ export type McpAbilitiesApiStructure = {
  * Falls back to default site abilities, then account-level abilities
  */
 export function getSiteMcpAbilities(
-	userSettings: any,
+	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
 	siteId: string | number
 ): SiteMcpAbilities {
 	const siteIdStr = String( siteId );
@@ -66,7 +66,7 @@ export function getSiteMcpAbilities(
 export function getSiteAbilityState(
 	abilityName: string,
 	siteId: string | number,
-	userSettings: any
+	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined
 ): boolean {
 	const siteIdStr = String( siteId );
 	const mcpData = userSettings?.mcp_abilities;
@@ -107,7 +107,7 @@ export function getAccountMcpAbilities(
  * Only stores differences from the default site abilities
  */
 export function updateSiteMcpAbilities(
-	userSettings: any,
+	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
 	siteId: string | number,
 	abilities: SiteMcpAbilities
 ): McpAbilitiesStructure {
@@ -177,7 +177,7 @@ export function convertAbilitiesFromApi(
  * Uses the new 'site' key format for single site updates
  */
 export function createSiteSpecificApiPayload(
-	userSettings: any,
+	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null | undefined,
 	siteId: string | number,
 	abilities: SiteMcpAbilities
 ): { mcp_abilities: McpAbilitiesApiStructure } {

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -1,4 +1,3 @@
-import { wpcom } from '@automattic/api-core';
 import type { SiteMcpAbilities } from '@automattic/api-core';
 
 export type McpAbilitiesStructure = {
@@ -32,7 +31,7 @@ export function getSiteMcpAbilities(
 	// Start with default site abilities
 	const defaultSiteAbilities = mcpData.site || {};
 
-	// Apply site-specific overrides if they exist
+	// Apply site-specific overrides if they exist (now only contains enabled/disabled values: 0 or 1)
 	const siteOverrides = mcpData.sites?.[ siteIdStr ] || {};
 
 	// Merge defaults with overrides
@@ -46,11 +45,14 @@ export function getSiteMcpAbilities(
 		}
 	} );
 
-	// Then, apply any site-specific overrides
-	Object.entries( siteOverrides ).forEach( ( [ abilityName, ability ] ) => {
-		if ( ability && typeof ability === 'object' ) {
-			// @ts-ignore - TypeScript spread operator issue with potentially undefined values
-			mergedAbilities[ abilityName ] = { ...ability };
+	// Then, apply any site-specific overrides (only enabled/disabled state)
+	Object.entries( siteOverrides ).forEach( ( [ abilityName, enabledValue ] ) => {
+		// enabledValue is now just 0 or 1, not a full ability object
+		if ( mergedAbilities[ abilityName ] ) {
+			mergedAbilities[ abilityName ] = {
+				...mergedAbilities[ abilityName ],
+				enabled: enabledValue === 1,
+			};
 		}
 	} );
 
@@ -73,9 +75,9 @@ export function getSiteAbilityState(
 		return false;
 	}
 
-	// Check if site has custom override
-	if ( mcpData.sites?.[ siteIdStr ]?.[ abilityName ] ) {
-		return mcpData.sites[ siteIdStr ][ abilityName ].enabled;
+	// Check if site has custom override (now just 0 or 1)
+	if ( mcpData.sites?.[ siteIdStr ]?.[ abilityName ] !== undefined ) {
+		return mcpData.sites[ siteIdStr ][ abilityName ] === 1;
 	}
 
 	// Fall back to default from 'site' section
@@ -113,14 +115,14 @@ export function updateSiteMcpAbilities(
 	const mcpData = userSettings?.mcp_abilities;
 	const defaultSiteAbilities = mcpData?.site || {};
 
-	// Find only the abilities that differ from defaults
-	const siteOverrides: SiteMcpAbilities = {};
+	// Find only the abilities that differ from defaults (store only enabled/disabled values)
+	const siteOverrides: Record< string, number > = {};
 	Object.entries( abilities ).forEach( ( [ abilityName, ability ] ) => {
 		const defaultAbility = defaultSiteAbilities[ abilityName ];
 
 		// Only store if it differs from the default
 		if ( ! defaultAbility || defaultAbility.enabled !== ability.enabled ) {
-			siteOverrides[ abilityName ] = Object.assign( {}, ability );
+			siteOverrides[ abilityName ] = ability.enabled ? 1 : 0;
 		}
 	} );
 
@@ -233,11 +235,4 @@ export function createSiteSpecificApiPayload(
 	}
 
 	return { mcp_abilities: payload };
-}
-
-/**
- * Custom mutation function for saving MCP abilities that bypasses the saveableKeys filtering
- */
-export async function saveMcpAbilities( data: { mcp_abilities: McpAbilitiesApiStructure } ) {
-	return await wpcom.req.post( '/me/settings', data );
 }

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -89,15 +89,6 @@ export function getSiteAbilityState(
 }
 
 /**
- * Get account-level MCP abilities
- */
-export function getAccountMcpAbilities(
-	userSettings: { mcp_abilities?: McpAbilities } | null
-): SiteMcpAbilities {
-	return userSettings?.mcp_abilities?.account || {};
-}
-
-/**
  * Update MCP abilities for a specific site
  * Only stores differences from the default site abilities
  */

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -1,0 +1,243 @@
+import { wpcom } from '@automattic/api-core';
+import type { SiteMcpAbilities } from '@automattic/api-core';
+
+export type McpAbilitiesStructure = {
+	account?: SiteMcpAbilities;
+	site?: SiteMcpAbilities; // Default values for all sites
+	sites?: Record< string, SiteMcpAbilities >; // Custom overrides per site
+};
+
+// API payload structure (simplified format for API calls)
+export type McpAbilitiesApiStructure = {
+	account?: Record< string, number >;
+	site?: Record< string | number, Record< string, number > >; // site_id => abilities mapping
+	sites?: Record< string | number, Record< string, number > >; // Custom overrides per site
+};
+
+/**
+ * Get MCP abilities for a specific site using the new optimized structure
+ * Falls back to default site abilities, then account-level abilities
+ */
+export function getSiteMcpAbilities(
+	userSettings: any,
+	siteId: string | number
+): SiteMcpAbilities {
+	const siteIdStr = String( siteId );
+	const mcpData = userSettings?.mcp_abilities;
+
+	if ( ! mcpData ) {
+		return {};
+	}
+
+	// Start with default site abilities
+	const defaultSiteAbilities = mcpData.site || {};
+
+	// Apply site-specific overrides if they exist
+	const siteOverrides = mcpData.sites?.[ siteIdStr ] || {};
+
+	// Merge defaults with overrides
+	const mergedAbilities: SiteMcpAbilities = {};
+
+	// First, add all default abilities
+	Object.entries( defaultSiteAbilities ).forEach( ( [ abilityName, ability ] ) => {
+		if ( ability && typeof ability === 'object' ) {
+			// @ts-ignore - TypeScript spread operator issue with potentially undefined values
+			mergedAbilities[ abilityName ] = { ...ability };
+		}
+	} );
+
+	// Then, apply any site-specific overrides
+	Object.entries( siteOverrides ).forEach( ( [ abilityName, ability ] ) => {
+		if ( ability && typeof ability === 'object' ) {
+			// @ts-ignore - TypeScript spread operator issue with potentially undefined values
+			mergedAbilities[ abilityName ] = { ...ability };
+		}
+	} );
+
+	return mergedAbilities;
+}
+
+/**
+ * Get the effective state of a specific ability for a site
+ * Implements the fallback logic: site override -> default site -> account
+ */
+export function getSiteAbilityState(
+	abilityName: string,
+	siteId: string | number,
+	userSettings: any
+): boolean {
+	const siteIdStr = String( siteId );
+	const mcpData = userSettings?.mcp_abilities;
+
+	if ( ! mcpData ) {
+		return false;
+	}
+
+	// Check if site has custom override
+	if ( mcpData.sites?.[ siteIdStr ]?.[ abilityName ] ) {
+		return mcpData.sites[ siteIdStr ][ abilityName ].enabled;
+	}
+
+	// Fall back to default from 'site' section
+	if ( mcpData.site?.[ abilityName ] ) {
+		return mcpData.site[ abilityName ].enabled;
+	}
+
+	// Final fallback to account-level (for backward compatibility)
+	if ( mcpData.account?.[ abilityName ] ) {
+		return mcpData.account[ abilityName ].enabled;
+	}
+
+	return false;
+}
+
+/**
+ * Get account-level MCP abilities
+ */
+export function getAccountMcpAbilities(
+	userSettings: { mcp_abilities?: McpAbilitiesStructure } | null
+): SiteMcpAbilities {
+	return userSettings?.mcp_abilities?.account || {};
+}
+
+/**
+ * Update MCP abilities for a specific site
+ * Only stores differences from the default site abilities
+ */
+export function updateSiteMcpAbilities(
+	userSettings: any,
+	siteId: string | number,
+	abilities: SiteMcpAbilities
+): McpAbilitiesStructure {
+	const siteIdStr = String( siteId );
+	const mcpData = userSettings?.mcp_abilities;
+	const defaultSiteAbilities = mcpData?.site || {};
+
+	// Find only the abilities that differ from defaults
+	const siteOverrides: SiteMcpAbilities = {};
+	Object.entries( abilities ).forEach( ( [ abilityName, ability ] ) => {
+		const defaultAbility = defaultSiteAbilities[ abilityName ];
+
+		// Only store if it differs from the default
+		if ( ! defaultAbility || defaultAbility.enabled !== ability.enabled ) {
+			siteOverrides[ abilityName ] = Object.assign( {}, ability );
+		}
+	} );
+
+	// If no overrides needed, remove the site from sites object
+	const newSites = { ...mcpData?.sites };
+	if ( Object.keys( siteOverrides ).length === 0 ) {
+		delete newSites[ siteIdStr ];
+	} else {
+		newSites[ siteIdStr ] = siteOverrides;
+	}
+
+	return {
+		...mcpData,
+		sites: newSites,
+	};
+}
+
+/**
+ * Convert SiteMcpAbilities to the simplified format expected by the API
+ * (enabled status as 1/0 instead of boolean)
+ */
+export function convertAbilitiesForApi( abilities: SiteMcpAbilities ): Record< string, number > {
+	const result: Record< string, number > = {};
+	Object.entries( abilities ).forEach( ( [ toolId, tool ] ) => {
+		result[ toolId ] = tool.enabled ? 1 : 0;
+	} );
+	return result;
+}
+
+/**
+ * Convert API response back to SiteMcpAbilities format
+ * (1/0 back to boolean enabled status)
+ */
+export function convertAbilitiesFromApi(
+	apiAbilities: Record< string, number >,
+	originalAbilities: SiteMcpAbilities
+): SiteMcpAbilities {
+	const result: SiteMcpAbilities = {};
+	Object.entries( apiAbilities ).forEach( ( [ toolId, enabled ] ) => {
+		if ( originalAbilities[ toolId ] ) {
+			result[ toolId ] = {
+				...originalAbilities[ toolId ],
+				enabled: enabled === 1,
+			};
+		}
+	} );
+	return result;
+}
+
+/**
+ * Create optimized API payload for site-specific updates
+ * Uses the new 'site' key format for single site updates
+ */
+export function createSiteSpecificApiPayload(
+	userSettings: any,
+	siteId: string | number,
+	abilities: SiteMcpAbilities
+): { mcp_abilities: McpAbilitiesApiStructure } {
+	const siteIdNum = Number( siteId );
+	const mcpData = userSettings?.mcp_abilities;
+	const defaultSiteAbilities = mcpData?.site || {};
+
+	// Check if all abilities are disabled (master toggle off)
+	const allAbilitiesDisabled = Object.values( abilities ).every( ( ability ) => ! ability.enabled );
+
+	// Check if all abilities are enabled (master toggle on)
+	const allAbilitiesEnabled = Object.values( abilities ).every( ( ability ) => ability.enabled );
+
+	// Find only the abilities that differ from defaults
+	const siteOverrides: Record< string, number > = {};
+	Object.entries( abilities ).forEach( ( [ abilityName, ability ] ) => {
+		const defaultAbility = defaultSiteAbilities[ abilityName ];
+
+		// Only store if it differs from the default
+		if ( ! defaultAbility || defaultAbility.enabled !== ability.enabled ) {
+			siteOverrides[ abilityName ] = ability.enabled ? 1 : 0;
+		}
+	} );
+
+	// Create the optimized payload (only include site-specific overrides)
+	const payload: McpAbilitiesApiStructure = {};
+
+	// Special case: If all abilities are disabled, we need to explicitly store this state
+	// to ensure the master toggle is properly disabled
+	if ( allAbilitiesDisabled && Object.keys( abilities ).length > 0 ) {
+		// Store all abilities as disabled overrides
+		const allDisabledOverrides: Record< string, number > = {};
+		Object.keys( abilities ).forEach( ( abilityName ) => {
+			allDisabledOverrides[ abilityName ] = 0;
+		} );
+
+		payload.sites = {
+			[ siteIdNum ]: allDisabledOverrides,
+		};
+	} else if ( allAbilitiesEnabled && Object.keys( abilities ).length > 0 ) {
+		// Special case: If all abilities are enabled, we need to send them to clear any existing disabled overrides
+		const allEnabledOverrides: Record< string, number > = {};
+		Object.keys( abilities ).forEach( ( abilityName ) => {
+			allEnabledOverrides[ abilityName ] = 1;
+		} );
+
+		payload.sites = {
+			[ siteIdNum ]: allEnabledOverrides,
+		};
+	} else if ( Object.keys( siteOverrides ).length > 0 ) {
+		// Only include site if there are overrides
+		payload.sites = {
+			[ siteIdNum ]: siteOverrides,
+		};
+	}
+
+	return { mcp_abilities: payload };
+}
+
+/**
+ * Custom mutation function for saving MCP abilities that bypasses the saveableKeys filtering
+ */
+export async function saveMcpAbilities( data: { mcp_abilities: McpAbilitiesApiStructure } ) {
+	return await wpcom.req.post( '/me/settings', data );
+}

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -1,6 +1,18 @@
 /**
  * Get account-level MCP abilities from user settings
  * This is for the /me/mcp route which manages account-level settings
+ * @typedef {Object} McpAbility
+ * @property {string} name
+ * @property {string} title
+ * @property {string} description
+ * @property {string} category
+ * @property {string} type
+ * @property {boolean} enabled
+ */
+/**
+ * Get account-level MCP abilities from user settings
+ * @param {Object} userSettings - The user settings object
+ * @returns {Record<string, McpAbility>} An object containing account-level MCP abilities
  */
 export function getAccountMcpAbilities( userSettings ) {
 	const mcpData = userSettings?.mcp_abilities;
@@ -27,6 +39,9 @@ export function getAccountMcpAbilities( userSettings ) {
 /**
  * Create API payload for account-level MCP abilities updates
  * This creates the new nested structure for account-level settings
+ * @param {Object} userSettings - The user settings object
+ * @param {Record<string, McpAbility>} abilities - The abilities object from form data
+ * @returns {Object} The API payload with mcp_abilities.account structure
  */
 export function createAccountApiPayload( userSettings, abilities ) {
 	// Convert abilities to the format expected by the API (1/0 instead of boolean)
@@ -48,6 +63,8 @@ export function createAccountApiPayload( userSettings, abilities ) {
 
 /**
  * Check if any account-level tools are enabled
+ * @param {Object} userSettings - The user settings object
+ * @returns {boolean} True if any account-level tools are enabled
  */
 export function hasEnabledAccountTools( userSettings ) {
 	const abilities = getAccountMcpAbilities( userSettings );

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -33,7 +33,10 @@ const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL
  * ex. advertising_targeting_opt_out should fail quietly in the event they have an expired 2fa token
  * and a success notification is not standard when accepting or denying cookies
  */
-const PROPERTIES_TO_SUPRESS_NOTIFICATIONS = new Set( [ 'advertising_targeting_opt_out' ] );
+const PROPERTIES_TO_SUPRESS_NOTIFICATIONS = new Set( [
+	'advertising_targeting_opt_out',
+	'mcp_abilities',
+] );
 
 export const fromApi = ( apiResponse ) =>
 	mapValues( apiResponse, ( value, name ) =>

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -33,10 +33,7 @@ const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL
  * ex. advertising_targeting_opt_out should fail quietly in the event they have an expired 2fa token
  * and a success notification is not standard when accepting or denying cookies
  */
-const PROPERTIES_TO_SUPRESS_NOTIFICATIONS = new Set( [
-	'advertising_targeting_opt_out',
-	'mcp_abilities',
-] );
+const PROPERTIES_TO_SUPRESS_NOTIFICATIONS = new Set( [ 'advertising_targeting_opt_out' ] );
 
 export const fromApi = ( apiResponse ) =>
 	mapValues( apiResponse, ( value, name ) =>
@@ -151,6 +148,15 @@ export const userSettingsSaveSuccess =
 			Object.keys( settingsOverride ).every( ( key ) =>
 				PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
 			)
+		) {
+			return;
+		}
+
+		// Suppress notifications for site-specific MCP updates (they handle their own notifications)
+		if (
+			settingsOverride?.mcp_abilities &&
+			settingsOverride.mcp_abilities.sites &&
+			Object.keys( settingsOverride.mcp_abilities.sites ).length > 0
 		) {
 			return;
 		}

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -1,3 +1,18 @@
+export type McpAbility = {
+	name: string;
+	title: string;
+	description: string;
+	category: string;
+	type: string;
+	enabled: boolean;
+};
+
+export type McpAbilities = {
+	account?: Record< string, McpAbility >;
+	site?: Record< string, McpAbility >; // Default values for all sites
+	sites?: Record< string, Record< string, number > >; // Custom overrides per site (0/1 values only)
+};
+
 export interface UserSettings {
 	advertising_targeting_opt_out: boolean;
 	avatar_URL: string;
@@ -34,5 +49,5 @@ export interface UserSettings {
 	subscription_delivery_hour: number;
 	subscription_delivery_jabber_default: boolean;
 	p2_disable_autofollow_on_comment: boolean;
-	mcp_abilities?: any;
+	mcp_abilities?: McpAbilities;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AIINT-117/add-mcp-settings-page-to-wp-calypso

## Proposed Changes

This PR migrates MCP (Model Context Protocol) settings from site-specific storage to user-level storage with a new nested structure that supports account-level defaults, site-level defaults, and site-specific overrides. This change enables better scalability and centralized management of MCP abilities across all user sites.

### **Key Changes**

#### **1. Data Source Migration**
- **Before**: Used `siteSettingsQuery` and `siteSettingsMutation` for site-specific MCP data
- **After**: Migrated to `userSettingsQuery` and `userSettingsMutation` for centralized user-level storage

#### **2. New Data Structure**
```typescript
// New nested structure in userSettings.mcp_abilities
{
  account?: SiteMcpAbilities,           // Account-level defaults
  site?: SiteMcpAbilities,             // Default values for all sites  
  sites?: Record<string, Record<string, number>> // Site-specific overrides (0/1 only)
}
```

#### **3. Fallback Logic Implementation**
- **Priority**: Site-specific override → Site-level default → Account-level default
- **Optimization**: Only stores differences from defaults to minimize payload size
- **Efficiency**: Site overrides stored as simple 0/1 values instead of full objects

### **Technical Improvements**

#### **New Utility Functions** (`utils.ts`)
- `getSiteMcpAbilities()` - Implements fallback logic for site abilities
- `createSiteSpecificApiPayload()` - Creates optimized API payloads
- `getSiteAbilityState()` - Gets effective state of individual abilities
- `updateSiteMcpAbilities()` - Updates site-specific overrides

#### **Component Updates**
- **`index.tsx`**: Main settings component with improved state management
- **`setup.tsx`**: Setup component using new user settings structure  
- **`summary.tsx`**: Summary component with accurate ability counting


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 192352-ghe-Automattic/wpcom to sandbox
* Sandbox public-api.wordpress.com
* Test `/sites/{test site}settings/mcp` and confirm UX works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?