### PR TITLE
Make the site-spec assests to load via https

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -208,7 +208,7 @@
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"site_spec": {
-		"script_url": "http://widgets.wp.com/site-spec/bundle-1.0.1.umd.js",
-		"css_url": "http://widgets.wp.com/site-spec/style-1.0.1.css"
+		"script_url": "https://widgets.wp.com/site-spec/bundle-1.0.1.umd.js",
+		"css_url": "https://widgets.wp.com/site-spec/style-1.0.1.css"
 	}
 }


### PR DESCRIPTION
## Description

This PR tries to tweak the site-spec asset URL and loads them via `https`. This is required as calypso staging/production  are loading on https.

## Steps to test
1. Checkout PR branch and run `yarn` and `yarn start`
2. Navigate to http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec
3. View the source and verify that CSS and JS are loading with https endpoints. You can find `https://widgets.wp.com/site-spec/style-1.0.1.css` in the source.