### PR TITLE
Hosting Dashboard Plugins Inspector: Update action icons

### DIFF
--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -161,17 +161,18 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			},
 		],
 		[
-			isFetching,
 			pluginBySiteId,
 			isActivating,
 			isDeactivating,
+			isFetching,
+			activateMutate,
+			plugin?.id,
+			deactivateMutate,
 			isEnablingAutoupdate,
 			isDisablingAutoupdate,
-			activateMutate,
-			deactivateMutate,
 			enableAutoupdateMutate,
 			disableAutoupdateMutate,
-			plugin?.id,
+			pluginSlug,
 		]
 	);
 

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -11,7 +11,7 @@ import { useMutation } from '@tanstack/react-query';
 import { __experimentalText as Text, Button, Icon, ToggleControl } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { check, close, trash } from '@wordpress/icons';
+import { link, linkOff, trash } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
 import ActionRenderModal, { getModalHeader } from '../manage/components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../manage/utils';
@@ -189,7 +189,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				actions={ [
 					{
 						id: 'activate',
-						icon: check,
+						icon: link,
 						label: __( 'Activate' ),
 						modalHeader: getModalHeader( 'activate' ),
 						RenderModal: ( { items, closeModal } ) => {
@@ -211,7 +211,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 					},
 					{
 						id: 'deactivate',
-						icon: close,
+						icon: linkOff,
 						label: __( 'Deactivate' ),
 						modalHeader: getModalHeader( 'deactivate' ),
 						RenderModal: ( { items, closeModal } ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-209

## Proposed Changes

* Update the `Activate`/`Deactivate` action icons with design's suggestions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See [this comment](https://linear.app/a8c/project/hosting-dashboard-plugins-e31435ab03dc/updates#projectUpdate-1db34223&comment-8c18f8ab).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `/v2/plugins`
* Click on any plugin
* Make a bulk selection that both contains sites that have the plugin active and inactive
* Check the icons at the bottom of the table:

<img width="2144" height="594" alt="chrome-capture-2025-09-17" src="https://github.com/user-attachments/assets/68f70158-ef18-4db5-8bac-d8fc116fe9c9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
