### PR TITLE
Allow site-spec config overrides in useSiteSpec hook

### DIFF
--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -12,7 +12,7 @@ import {
 	isSiteSpecEnabled,
 	getSiteSpecUrl,
 	getSiteSpecUrlByType,
-	getSiteSpecConfig,
+	getDefaultSiteSpecConfig,
 } from '../utils';
 
 interface MockWithIsEnabled extends jest.Mock {
@@ -121,7 +121,7 @@ describe( 'SiteSpec Utils', () => {
 		} );
 	} );
 
-	describe( 'getSiteSpecConfig', () => {
+	describe( 'getDefaultSiteSpecConfig', () => {
 		it( 'should return configuration object with all values', () => {
 			mockConfig.mockReturnValueOnce( {
 				agent_url: 'https://api.example.com/agent',
@@ -129,7 +129,7 @@ describe( 'SiteSpec Utils', () => {
 				build_site_url: 'https://example.com/build?spec_id=',
 			} );
 
-			const result = getSiteSpecConfig();
+			const result = getDefaultSiteSpecConfig();
 
 			expect( result ).toEqual( {
 				agentUrl: 'https://api.example.com/agent',
@@ -140,7 +140,7 @@ describe( 'SiteSpec Utils', () => {
 
 		it( 'should return empty object when config is undefined', () => {
 			mockConfig.mockReturnValueOnce( undefined );
-			const result = getSiteSpecConfig();
+			const result = getDefaultSiteSpecConfig();
 			expect( result ).toEqual( {} );
 		} );
 
@@ -150,7 +150,7 @@ describe( 'SiteSpec Utils', () => {
 				// Missing agent_url and build_site_url
 			} );
 
-			const result = getSiteSpecConfig();
+			const result = getDefaultSiteSpecConfig();
 
 			expect( result ).toEqual( {
 				agentId: 'test-agent-id',

--- a/client/lib/site-spec/use-site-spec.ts
+++ b/client/lib/site-spec/use-site-spec.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { loadSiteSpecScriptAndCSS, resetSiteSpecScriptState } from './script-loader';
-import { getSiteSpecConfig, isSiteSpecEnabled } from './utils';
+import { getDefaultSiteSpecConfig, isSiteSpecEnabled, SiteSpecConfig } from './utils';
 
 declare global {
 	interface Window {
@@ -33,6 +33,7 @@ type UseSiteSpecOptions = {
 	container?: string | HTMLElement;
 	onMessage?: ( message: unknown ) => void;
 	onError?: ( error: unknown ) => void;
+	siteSpecConfig?: SiteSpecConfig;
 };
 
 /**
@@ -40,7 +41,7 @@ type UseSiteSpecOptions = {
  * Cleans up global loader state on unmount.
  */
 export function useSiteSpec( options: UseSiteSpecOptions = {} ) {
-	const { container = '#site-spec-container', onMessage, onError } = options;
+	const { container = '#site-spec-container', onMessage, onError, siteSpecConfig } = options;
 
 	useEffect( () => {
 		// SSR/Non-browser guard
@@ -71,9 +72,11 @@ export function useSiteSpec( options: UseSiteSpecOptions = {} ) {
 					return;
 				}
 
+				const config = siteSpecConfig || getDefaultSiteSpecConfig();
+
 				window.SiteSpec.init( {
 					container: containerEl,
-					...getSiteSpecConfig(),
+					...config,
 					onMessage,
 					onError,
 				} );

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -10,7 +10,7 @@ interface SiteSpecRawConfig {
 }
 
 // Config structure for the client
-interface SiteSpecConfig {
+export interface SiteSpecConfig {
 	agentUrl?: string;
 	agentId?: string;
 	buildSiteUrl?: string;
@@ -56,7 +56,7 @@ export function getSiteSpecUrlByType( type: ResourceType ): string | null {
  * Retrieves the SiteSpec configuration object for initializing the widget.
  * @returns {SiteSpecConfig} Configuration object containing agent settings and build URLs
  */
-export function getSiteSpecConfig(): SiteSpecConfig {
+export function getDefaultSiteSpecConfig(): SiteSpecConfig {
 	const siteSpecConfig = config( 'site_spec' ) as SiteSpecRawConfig | undefined;
 
 	if ( ! siteSpecConfig ) {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -208,7 +208,7 @@
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"site_spec": {
-		"script_url": "http://widgets.wp.com/site-spec/bundle-1.0.1.umd.js",
-		"css_url": "http://widgets.wp.com/site-spec/style-1.0.1.css"
+		"script_url": "https://widgets.wp.com/site-spec/bundle-1.0.1.umd.js",
+		"css_url": "https://widgets.wp.com/site-spec/style-1.0.1.css"
 	}
 }


### PR DESCRIPTION
## Description

This PR tries to add overrides to the `useSiteSpec` hook inorder to have multiple buildSiteUrls. We are now allowing customisable options to the hook and fallback to the default options configured.

Requirement was brought up in this comment: https://github.com/Automattic/wp-calypso/pull/105543#discussion_r2352915203

## Steps to test

1. Checkout PR branch and run calypso locally [ `yarn` and `yarn start` ]
2. Apply the following patch to verify if customisation is working fine
```diff
diff --git a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
index 7bf6a31ed36..01ecfd436af 100644
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -6,7 +6,11 @@ import type { Step as StepType } from '../../types';
 const SiteSpec: StepType = function SiteSpec() {
        const translate = useTranslate();
        // Use the SiteSpec hook to handle the loading and initialization of the SiteSpec widget
-       useSiteSpec();
+       useSiteSpec( {
+               siteSpecConfig: {
+                       buildSiteUrl: 'https://test0029281.com/site-spec/build-site/?spec_id=',
+               },
+       } );
 
        return (
                <>
```
3. Navigate to http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec
4. Create the site-spec and verify that the build site url that you are redirected to is - `https://test0029281.com/site-spec/build-site/?spec_id=<UUID>`