### PR TITLE
Remove duplicate signup events in launch-site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -115,6 +115,9 @@ const SiteMigrationCredentials: StepType< {
 			automated_migration: true,
 		} );
 
+		// Fire Google Ads tracking event when credentials are skipped
+		recordMigrationCredentialsEvent( 'SiteMigrationCredentials' );
+
 		try {
 			await sendTicketAsync( {
 				locale,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -10,6 +10,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
+import { recordMigrationCredentialsEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
@@ -95,6 +96,10 @@ const SiteMigrationCredentials: StepType< {
 		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => {
 		const action = getAction( siteInfo, applicationPasswordsInfo );
+
+		// Fire Google Ads tracking event when credentials are submitted
+		recordMigrationCredentialsEvent( 'SiteMigrationCredentials' );
+
 		siteId && dispatch( resetSite( siteId ) );
 		return navigation.submit?.( {
 			action,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -10,7 +10,10 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
-import { recordMigrationCredentialsEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
+import {
+	recordMigrationCredentialsEvent,
+	recordMigrationCredentialsFacebookEvent,
+} from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
@@ -99,6 +102,7 @@ const SiteMigrationCredentials: StepType< {
 
 		// Fire Google Ads tracking event when credentials are submitted
 		recordMigrationCredentialsEvent( 'SiteMigrationCredentials' );
+		recordMigrationCredentialsFacebookEvent( 'SiteMigrationCredentials' );
 
 		siteId && dispatch( resetSite( siteId ) );
 		return navigation.submit?.( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -2,7 +2,10 @@ import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { recordMigrationCredentialsEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
+import {
+	recordMigrationCredentialsEvent,
+	recordMigrationCredentialsFacebookEvent,
+} from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { CredentialsForm } from './components/credentials-form';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -26,6 +29,7 @@ const SiteMigrationFallbackCredentials: StepType< {
 
 		// Fire Google Ads tracking event when credentials are submitted
 		recordMigrationCredentialsEvent( 'SiteMigrationFallbackCredentials' );
+		recordMigrationCredentialsFacebookEvent( 'SiteMigrationFallbackCredentials' );
 
 		return navigation.submit?.( { action, from } );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -2,6 +2,7 @@ import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { recordMigrationCredentialsEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { CredentialsForm } from './components/credentials-form';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -22,6 +23,10 @@ const SiteMigrationFallbackCredentials: StepType< {
 
 	const handleSubmit = ( from?: string ) => {
 		const action = 'submit';
+
+		// Fire Google Ads tracking event when credentials are submitted
+		recordMigrationCredentialsEvent( 'SiteMigrationFallbackCredentials' );
+
 		return navigation.submit?.( { action, from } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -13,7 +13,7 @@ import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hos
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import {
 	recordMigrationStartEvent,
-	recordMigrationFlowStartFacebookEvent,
+	recordMigrationStartFacebookEvent,
 } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
@@ -72,7 +72,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 	// Fire Google Ads tracking event when component loads
 	useEffect( () => {
 		recordMigrationStartEvent( 'SiteMigrationImportOrMigrate' );
-		recordMigrationFlowStartFacebookEvent( 'SiteMigrationImportOrMigrate' );
+		recordMigrationStartFacebookEvent( 'SiteMigrationImportOrMigrate' );
 	}, [] );
 
 	const handleClick = ( destination: 'migrate' | 'import' | 'upgrade' ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -5,12 +5,14 @@ import { Step } from '@automattic/onboarding';
 import { canInstallPlugins } from '@automattic/sites';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useMigrationCancellation } from 'calypso/data/site-migration/landing/use-migration-cancellation';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
+import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -64,6 +66,21 @@ const SiteMigrationImportOrMigrate: StepType< {
 	const hostingProviderName = hostingProviderDetails.name;
 	const shouldDisplayHostIdentificationMessage =
 		! hostingProviderDetails.is_unknown && ! hostingProviderDetails.is_a8c;
+
+	// Fire Google Ads tracking event when component loads
+	useEffect( () => {
+		if ( mayWeTrackByTracker( 'googleAds' ) ) {
+			const params = [
+				'event',
+				'conversion',
+				{
+					send_to: TRACKING_IDS.wpcomGoogleAdsGtagMigrationStart,
+				},
+			];
+			debug( 'SiteMigrationImportOrMigrate: [Google Ads Gtag] Migration Start', params );
+			window.gtag( ...params );
+		}
+	}, [] );
 
 	const handleClick = ( destination: 'migrate' | 'import' | 'upgrade' ) => {
 		if ( destination === 'migrate' && ! siteCanInstallPlugins ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -11,8 +11,7 @@ import { useMigrationCancellation } from 'calypso/data/site-migration/landing/us
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
-import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
+import { recordMigrationStartEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -69,17 +68,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 
 	// Fire Google Ads tracking event when component loads
 	useEffect( () => {
-		if ( mayWeTrackByTracker( 'googleAds' ) ) {
-			const params = [
-				'event',
-				'conversion',
-				{
-					send_to: TRACKING_IDS.wpcomGoogleAdsGtagMigrationStart,
-				},
-			];
-			debug( 'SiteMigrationImportOrMigrate: [Google Ads Gtag] Migration Start', params );
-			window.gtag( ...params );
-		}
+		recordMigrationStartEvent( 'SiteMigrationImportOrMigrate' );
 	}, [] );
 
 	const handleClick = ( destination: 'migrate' | 'import' | 'upgrade' ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -11,7 +11,10 @@ import { useMigrationCancellation } from 'calypso/data/site-migration/landing/us
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { recordMigrationStartEvent } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
+import {
+	recordMigrationStartEvent,
+	recordMigrationFlowStartFacebookEvent,
+} from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -69,6 +72,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 	// Fire Google Ads tracking event when component loads
 	useEffect( () => {
 		recordMigrationStartEvent( 'SiteMigrationImportOrMigrate' );
+		recordMigrationFlowStartFacebookEvent( 'SiteMigrationImportOrMigrate' );
 	}, [] );
 
 	const handleClick = ( destination: 'migrate' | 'import' | 'upgrade' ) => {

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -42,4 +42,17 @@ export async function adTrackSignupStart( flow ) {
 		debug( 'adTrackSignupStart: [Google Ads Gtag]', params );
 		window.gtag( ...params );
 	}
+
+	// Google Ads for site-migration flow.
+	if ( mayWeTrackByTracker( 'googleAds' ) && 'site-migration' === flow ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagMigrationSignup,
+			},
+		];
+		debug( 'adTrackSignupStart: [Google Ads Gtag] Site Migration Signup', params );
+		window.gtag( ...params );
+	}
 }

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -4,6 +4,7 @@ import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
+import { recordMigrationSignupEvent } from './record-migration-events';
 
 // Ensure setup has run.
 import './setup';
@@ -44,15 +45,7 @@ export async function adTrackSignupStart( flow ) {
 	}
 
 	// Google Ads for site-migration flow.
-	if ( mayWeTrackByTracker( 'googleAds' ) && 'site-migration' === flow ) {
-		const params = [
-			'event',
-			'conversion',
-			{
-				send_to: TRACKING_IDS.wpcomGoogleAdsGtagMigrationSignup,
-			},
-		];
-		debug( 'adTrackSignupStart: [Google Ads Gtag] Site Migration Signup', params );
-		window.gtag( ...params );
+	if ( 'site-migration' === flow ) {
+		recordMigrationSignupEvent( 'adTrackSignupStart' );
 	}
 }

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -4,7 +4,10 @@ import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
-import { recordMigrationSignupEvent } from './record-migration-events';
+import {
+	recordMigrationSignupEvent,
+	recordMigrationSignupFacebookEvent,
+} from './record-migration-events';
 
 // Ensure setup has run.
 import './setup';
@@ -44,8 +47,9 @@ export async function adTrackSignupStart( flow ) {
 		window.gtag( ...params );
 	}
 
-	// Google Ads for site-migration flow.
+	// Google Ads and Facebook for site-migration flow.
 	if ( 'site-migration' === flow ) {
 		recordMigrationSignupEvent( 'adTrackSignupStart' );
+		recordMigrationSignupFacebookEvent( 'adTrackSignupStart' );
 	}
 }

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -59,6 +59,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -61,6 +61,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
 	wpcomGoogleAdsGtagMigrationStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
 	wpcomGoogleAdsGtagMigrationCredentials: 'AW-946162814/59yUCNG15tYZEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationSignup: 'AW-946162814/Uev_COubnpkbEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -60,6 +60,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
 	wpcomGoogleAdsGtagMigrationStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationCredentials: 'AW-946162814/59yUCNG15tYZEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -59,9 +59,9 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
-	wpcomGoogleAdsGtagMigrationStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
-	wpcomGoogleAdsGtagMigrationCredentials: 'AW-946162814/59yUCNG15tYZEP6YlcMD',
-	wpcomGoogleAdsGtagMigrationSignup: 'AW-946162814/Uev_COubnpkbEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationSignupStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationFlowStart: 'AW-946162814/59yUCNG15tYZEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationCredentials: 'AW-946162814/Uev_COubnpkbEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -33,7 +33,7 @@ export function recordMigrationEvent( eventName, trackingId, componentName ) {
 export function recordMigrationStartEvent( componentName ) {
 	recordMigrationEvent(
 		'Migration Start',
-		TRACKING_IDS.wpcomGoogleAdsGtagMigrationStart,
+		TRACKING_IDS.wpcomGoogleAdsGtagMigrationFlowStart,
 		componentName
 	);
 }
@@ -59,7 +59,7 @@ export function recordMigrationCredentialsEvent( componentName ) {
 export function recordMigrationSignupEvent( componentName ) {
 	recordMigrationEvent(
 		'Migration Signup Start',
-		TRACKING_IDS.wpcomGoogleAdsGtagMigrationSignup,
+		TRACKING_IDS.wpcomGoogleAdsGtagMigrationSignupStart,
 		componentName
 	);
 }

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -1,0 +1,52 @@
+import { mayWeTrackByTracker } from '../tracker-buckets';
+import { debug, TRACKING_IDS } from './constants';
+
+/**
+ * Fires a Google Ads conversion event for migration tracking
+ * @param {string} eventName - The name of the migration event (e.g., 'Migration Start', 'Migration Credentials Submit')
+ * @param {string} trackingId - The tracking ID from TRACKING_IDS to use for the event
+ * @param {string} componentName - The name of the component firing the event (for debug logging)
+ * @returns {void}
+ */
+export function recordMigrationEvent( eventName, trackingId, componentName ) {
+	if ( ! mayWeTrackByTracker( 'googleAds' ) ) {
+		debug( `${ componentName }: skipping Google Ads tracking as ad tracking is disallowed` );
+		return;
+	}
+
+	const params = [
+		'event',
+		'conversion',
+		{
+			send_to: trackingId,
+		},
+	];
+	debug( `${ componentName }: [Google Ads Gtag] ${ eventName }`, params );
+	window.gtag( ...params );
+}
+
+/**
+ * Fires a Google Ads conversion event for migration start
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationStartEvent( componentName ) {
+	recordMigrationEvent(
+		'Migration Start',
+		TRACKING_IDS.wpcomGoogleAdsGtagMigrationStart,
+		componentName
+	);
+}
+
+/**
+ * Fires a Google Ads conversion event for migration credentials submission
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationCredentialsEvent( componentName ) {
+	recordMigrationEvent(
+		'Migration Credentials Submit',
+		TRACKING_IDS.wpcomGoogleAdsGtagMigrationCredentials,
+		componentName
+	);
+}

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -63,3 +63,35 @@ export function recordMigrationSignupEvent( componentName ) {
 		componentName
 	);
 }
+
+/**
+ * Fires a Facebook custom event for migration flow start
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationFlowStartFacebookEvent( componentName ) {
+	if ( ! mayWeTrackByTracker( 'facebook' ) ) {
+		debug( `${ componentName }: skipping Facebook tracking as ad tracking is disallowed` );
+		return;
+	}
+
+	const params = [ 'trackCustom', 'MigrationFlowStart' ];
+	debug( `${ componentName }: [Facebook] Migration Flow Start`, params );
+	window.fbq( ...params );
+}
+
+/**
+ * Fires a Facebook custom event for migration credentials submission
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationCredentialsFacebookEvent( componentName ) {
+	if ( ! mayWeTrackByTracker( 'facebook' ) ) {
+		debug( `${ componentName }: skipping Facebook tracking as ad tracking is disallowed` );
+		return;
+	}
+
+	const params = [ 'trackCustom', 'MigrationCredentials' ];
+	debug( `${ componentName }: [Facebook] Migration Credentials`, params );
+	window.fbq( ...params );
+}

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -65,18 +65,18 @@ export function recordMigrationSignupEvent( componentName ) {
 }
 
 /**
- * Fires a Facebook custom event for migration flow start
+ * Fires a Facebook custom event for migration start
  * @param {string} componentName - The name of the component firing the event
  * @returns {void}
  */
-export function recordMigrationFlowStartFacebookEvent( componentName ) {
+export function recordMigrationStartFacebookEvent( componentName ) {
 	if ( ! mayWeTrackByTracker( 'facebook' ) ) {
 		debug( `${ componentName }: skipping Facebook tracking as ad tracking is disallowed` );
 		return;
 	}
 
-	const params = [ 'trackCustom', 'MigrationFlowStart' ];
-	debug( `${ componentName }: [Facebook] Migration Flow Start`, params );
+	const params = [ 'trackCustom', 'MigrationStart' ];
+	debug( `${ componentName }: [Facebook] Migration Start`, params );
 	window.fbq( ...params );
 }
 
@@ -93,5 +93,21 @@ export function recordMigrationCredentialsFacebookEvent( componentName ) {
 
 	const params = [ 'trackCustom', 'MigrationCredentials' ];
 	debug( `${ componentName }: [Facebook] Migration Credentials`, params );
+	window.fbq( ...params );
+}
+
+/**
+ * Fires a Facebook custom event for migration signup start
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationSignupFacebookEvent( componentName ) {
+	if ( ! mayWeTrackByTracker( 'facebook' ) ) {
+		debug( `${ componentName }: skipping Facebook tracking as ad tracking is disallowed` );
+		return;
+	}
+
+	const params = [ 'trackCustom', 'MigrationSignup' ];
+	debug( `${ componentName }: [Facebook] Migration Signup`, params );
 	window.fbq( ...params );
 }

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -50,3 +50,16 @@ export function recordMigrationCredentialsEvent( componentName ) {
 		componentName
 	);
 }
+
+/**
+ * Fires a Google Ads conversion event for migration signup start
+ * @param {string} componentName - The name of the component firing the event
+ * @returns {void}
+ */
+export function recordMigrationSignupEvent( componentName ) {
+	recordMigrationEvent(
+		'Migration Signup Start',
+		TRACKING_IDS.wpcomGoogleAdsGtagMigrationSignup,
+		componentName
+	);
+}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1078,7 +1078,16 @@ function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 }
 
 export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { siteDomains, submitSignupStep } = nextProps;
+	const { siteDomains, submitSignupStep, flowName } = nextProps;
+
+	// Prevent duplicate processing for launch-site flow's domains-launch step
+	if (
+		flowName === 'launch-site' &&
+		stepName === 'domains-launch' &&
+		includes( flows.excludedSteps, stepName )
+	) {
+		return;
+	}
 
 	if ( siteDomains && siteDomains.length > 1 ) {
 		const tracksEventValue = siteDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-247

## Proposed Changes

* Ensure a the `domains-launch` is only excluded once as each call triggers two events and this is causing issues with tracking

## Why are these changes being made?

* Requested by @skim1220 on Linear

## Testing Instructions

* Start with wordpress.com /domains, create a site that has 1 free domain and no paid plan, and is not launched. Video here: https://d.pr/v/qGawCk
* Open the network tab
* Click the launch button for this site
* filter by domains-launch
* Observe 1 calypso_signup_actions_submit_step, one calypso_signup_actions_exclude_step, and one calypso_signup_actions_complete_step



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
