### PR TITLE
Ensure the signup events are not called twice for domains-launch step of the launch-site flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1078,7 +1078,16 @@ function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 }
 
 export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { siteDomains, submitSignupStep } = nextProps;
+	const { siteDomains, submitSignupStep, flowName } = nextProps;
+
+	// Prevent duplicate processing for launch-site flow's domains-launch step
+	if (
+		flowName === 'launch-site' &&
+		stepName === 'domains-launch' &&
+		includes( flows.excludedSteps, stepName )
+	) {
+		return;
+	}
 
 	if ( siteDomains && siteDomains.length > 1 ) {
 		const tracksEventValue = siteDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-247

## Proposed Changes

* Ensure a the `domains-launch` is only excluded once as each call triggers two events and this is causing issues with tracking

## Why are these changes being made?

* Requested by @skim1220 on Linear

## Testing Instructions

* Start with wordpress.com /domains, create a site that has 1 free domain and no paid plan, and is not launched. Video here: https://d.pr/v/qGawCk
* Open the network tab
* Click the launch button for this site
* filter by domains-launch
* Observe 1 calypso_signup_actions_submit_step, one calypso_signup_actions_exclude_step, and one calypso_signup_actions_complete_step



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?