### PR TITLE
Staging Sites in V2: Update Sync modal design

### DIFF
--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -1,0 +1,28 @@
+import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { staging, production } from '../icons';
+import { EnvironmentType } from '../site-environment-badge';
+
+interface EnvironmentProps {
+	environmentType: EnvironmentType;
+}
+
+const Environment = ( { environmentType }: EnvironmentProps ) => {
+	if ( environmentType === 'staging' ) {
+		return (
+			<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
+				<Icon icon={ staging } />
+				<span>{ __( 'Staging' ) }</span>
+			</HStack>
+		);
+	}
+
+	return (
+		<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
+			<Icon icon={ production } />
+			<span>{ __( 'Production' ) }</span>
+		</HStack>
+	);
+};
+
+export default Environment;

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -1,7 +1,8 @@
 import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { staging, production } from '../icons';
-import { EnvironmentType } from '../site-environment-badge';
+
+export type EnvironmentType = 'production' | 'staging';
 
 interface EnvironmentProps {
 	environmentType: EnvironmentType;

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -10,7 +10,7 @@ interface EnvironmentProps {
 const Environment = ( { environmentType }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
-			<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
+			<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
 				<Icon icon={ staging } />
 				<span>{ __( 'Staging' ) }</span>
 			</HStack>
@@ -18,7 +18,7 @@ const Environment = ( { environmentType }: EnvironmentProps ) => {
 	}
 
 	return (
-		<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
+		<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
 			<Icon icon={ production } />
 			<span>{ __( 'Production' ) }</span>
 		</HStack>

--- a/client/dashboard/components/site-environment-badge/index.tsx
+++ b/client/dashboard/components/site-environment-badge/index.tsx
@@ -1,7 +1,6 @@
 import { Badge } from '@automattic/ui';
 import { __ } from '@wordpress/i18n';
-
-export type EnvironmentType = 'production' | 'staging';
+import { EnvironmentType } from '../environment';
 
 interface SiteEnvironmentBadgeProps {
 	environmentType: EnvironmentType;

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -26,7 +26,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, chevronDownSmall, plus } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useHelpCenter } from '../../app/help-center';
-import { production, staging } from '../../components/icons';
+import Environment from '../../components/environment';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import {
 	isAtomicTransferInProgress,
@@ -36,32 +36,12 @@ import { getProductionSiteId, getStagingSiteId } from '../../utils/site-staging-
 import { canManageSite, canCreateStagingSite } from '../features';
 import type { Site } from '@automattic/api-core';
 
-type EnvironmentType = 'production' | 'staging';
-
-const Environment = ( { env }: { env: EnvironmentType } ) => {
-	if ( env === 'staging' ) {
-		return (
-			<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
-				<Icon icon={ staging } />
-				<span>{ __( 'Staging' ) }</span>
-			</HStack>
-		);
-	}
-
-	return (
-		<HStack justify="flex-start" style={ { width: 'auto', flexShrink: 0 } }>
-			<Icon icon={ production } />
-			<span>{ __( 'Production' ) }</span>
-		</HStack>
-	);
-};
-
 const CurrentEnvironment = ( { site }: { site: Site } ) => {
 	if ( site.is_wpcom_staging_site ) {
-		return <Environment env="staging" />;
+		return <Environment environmentType="staging" />;
 	}
 
-	return <Environment env="production" />;
+	return <Environment environmentType="production" />;
 };
 
 const StagingSiteActionButton = ( {
@@ -133,12 +113,12 @@ const EnvironmentSwitcherDropdown = ( {
 			<MenuGroup>
 				{ productionSite && canManageSite( productionSite ) && (
 					<RouterLinkMenuItem to={ `/sites/${ productionSite.slug }` } onClick={ onClose }>
-						<Environment env="production" />
+						<Environment environmentType="production" />
 					</RouterLinkMenuItem>
 				) }
 				{ showStagingSite && (
 					<RouterLinkMenuItem to={ `/sites/${ stagingSite.slug }` } onClick={ onClose }>
-						<Environment env="staging" />
+						<Environment environmentType="staging" />
 					</RouterLinkMenuItem>
 				) }
 				{ showActionButton && (

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -24,7 +24,7 @@ import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-env
 
 const DirectionArrow = () => {
 	return (
-		<div style={ { marginTop: '44px' } }>
+		<div style={ { marginTop: '5px' } }>
 			<Icon
 				icon={ isRTL() ? chevronLeft : chevronRight }
 				style={ {

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -235,11 +235,7 @@ export default function StagingSiteSyncModal( {
 	const isSubmitDisabled = showDomainConfirmation && domainConfirmation !== productionSiteSlug;
 
 	return (
-		<Modal
-			title={ syncConfig[ environment ].title }
-			onRequestClose={ handleClose }
-			style={ { maxWidth: '668px' } }
-		>
+		<Modal title={ syncConfig[ environment ].title } onRequestClose={ handleClose } size="large">
 			<VStack spacing={ 5 }>
 				<Text>
 					{ createInterpolateElement( syncConfig[ environment ].description, {

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -47,6 +47,7 @@ const EnvironmentLabel = ( { environmentType, siteTitle }: EnvironmentLabelProps
 				<SiteEnvironmentBadge environmentType={ environmentType } />
 				{ siteTitle && (
 					<Text
+						variant="muted"
 						style={ {
 							whiteSpace: 'nowrap',
 							overflow: 'hidden',

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -19,8 +19,9 @@ import { createInterpolateElement, useState, useCallback } from '@wordpress/elem
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { ButtonStack } from '../../components/button-stack';
+import Environment from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
-import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
+import { EnvironmentType } from '../../components/site-environment-badge';
 
 const DirectionArrow = () => {
 	return (
@@ -44,7 +45,7 @@ const EnvironmentLabel = ( { environmentType, siteTitle }: EnvironmentLabelProps
 	return (
 		<VStack spacing={ 1 }>
 			<HStack spacing={ 2 }>
-				<SiteEnvironmentBadge environmentType={ environmentType } />
+				<Environment environmentType={ environmentType } />
 				{ siteTitle && (
 					<Text
 						variant="muted"

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -25,14 +25,12 @@ import { EnvironmentType } from '../../components/site-environment-badge';
 
 const DirectionArrow = () => {
 	return (
-		<div style={ { marginTop: '5px' } }>
-			<Icon
-				icon={ isRTL() ? chevronLeft : chevronRight }
-				style={ {
-					fill: '#949494',
-				} }
-			/>
-		</div>
+		<Icon
+			icon={ isRTL() ? chevronLeft : chevronRight }
+			style={ {
+				fill: '#949494',
+			} }
+		/>
 	);
 };
 

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -19,9 +19,8 @@ import { createInterpolateElement, useState, useCallback } from '@wordpress/elem
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { ButtonStack } from '../../components/button-stack';
-import Environment from '../../components/environment';
+import Environment, { EnvironmentType } from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
-import { EnvironmentType } from '../../components/site-environment-badge';
 
 const DirectionArrow = () => {
 	return (

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -90,7 +90,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 			staging: {
 				title: __( 'Pull from Production' ),
 				description: __(
-					'Pulling will replace the existing files and database of the staging site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+					'Pulling will replace the existing files and database of the staging site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 				),
 				syncFrom: 'production',
 				syncTo: 'staging',
@@ -98,7 +98,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 			production: {
 				title: __( 'Pull from Staging' ),
 				description: __(
-					'Pulling will replace the existing files and database of the production site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+					'Pulling will replace the existing files and database of the production site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 				),
 				syncFrom: 'staging',
 				syncTo: 'production',
@@ -112,7 +112,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 		staging: {
 			title: __( 'Push to Production' ),
 			description: __(
-				'Pushing will replace the existing files and database of the production site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+				'Pushing will replace the existing files and database of the production site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 			),
 			syncFrom: 'staging',
 			syncTo: 'production',
@@ -120,7 +120,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 		production: {
 			title: __( 'Push to Staging' ),
 			description: __(
-				'Pushing will replace the existing files and database of the staging site. An automatic backup of your environment will be created, allowing you to revert changes from the <a>Activity log</a> if needed.'
+				'Pushing will replace the existing files and database of the staging site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 			),
 			syncFrom: 'production',
 			syncTo: 'staging',

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -20,7 +20,6 @@ import { __, isRTL } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
-import { SectionHeader } from '../../components/section-header';
 import SiteEnvironmentBadge, { EnvironmentType } from '../../components/site-environment-badge';
 
 const DirectionArrow = () => {
@@ -37,15 +36,13 @@ const DirectionArrow = () => {
 };
 
 interface EnvironmentLabelProps {
-	label: string;
 	environmentType: EnvironmentType;
 	siteTitle?: string;
 }
 
-const EnvironmentLabel = ( { label, environmentType, siteTitle }: EnvironmentLabelProps ) => {
+const EnvironmentLabel = ( { environmentType, siteTitle }: EnvironmentLabelProps ) => {
 	return (
 		<VStack spacing={ 1 }>
-			<SectionHeader level={ 3 } title={ label } />
 			<HStack spacing={ 2 }>
 				<SiteEnvironmentBadge environmentType={ environmentType } />
 				{ siteTitle && (
@@ -84,8 +81,6 @@ interface EnvironmentConfig {
 interface SyncConfig {
 	staging: EnvironmentConfig;
 	production: EnvironmentConfig;
-	fromLabel: string;
-	toLabel: string;
 	learnMore: string;
 	submit: string;
 }
@@ -109,8 +104,6 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 				syncFrom: 'staging',
 				syncTo: 'production',
 			},
-			fromLabel: __( 'Pull' ),
-			toLabel: __( 'To' ),
 			learnMore: __( 'Read more about <a>environment pull</a>.' ),
 			submit: __( 'Pull' ),
 		};
@@ -133,8 +126,6 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 			syncFrom: 'production',
 			syncTo: 'staging',
 		},
-		fromLabel: __( 'Push' ),
-		toLabel: __( 'To' ),
 		learnMore: __( 'Read more about <a>environment push</a>.' ),
 		submit: __( 'Push' ),
 	};
@@ -256,17 +247,9 @@ export default function StagingSiteSyncModal( {
 					} ) }
 				</Text>
 				<HStack spacing={ 4 } alignment="left">
-					<EnvironmentLabel
-						label={ syncConfig.fromLabel }
-						environmentType={ sourceEnvironment }
-						siteTitle={ sourceSiteTitle }
-					/>
+					<EnvironmentLabel environmentType={ sourceEnvironment } siteTitle={ sourceSiteTitle } />
 					<DirectionArrow />
-					<EnvironmentLabel
-						label={ syncConfig.toLabel }
-						environmentType={ targetEnvironment }
-						siteTitle={ targetSiteTitle }
-					/>
+					<EnvironmentLabel environmentType={ targetEnvironment } siteTitle={ targetSiteTitle } />
 				</HStack>
 				<VStack spacing={ 6 }>
 					{ showDomainConfirmation && (

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -27,11 +27,10 @@ import { chevronRight, chevronLeft } from '@wordpress/icons';
 import clsx from 'clsx';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
+import { EnvironmentType } from 'calypso/dashboard/components/environment';
 import InlineSupportLink from 'calypso/dashboard/components/inline-support-link';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
-import SiteEnvironmentBadge, {
-	EnvironmentType,
-} from 'calypso/dashboard/components/site-environment-badge';
+import SiteEnvironmentBadge from 'calypso/dashboard/components/site-environment-badge';
 import FileBrowser from 'calypso/my-sites/backup/backup-contents-page/file-browser';
 import {
 	FileBrowserProvider,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14591

## Proposed Changes

* remove words `Pull` / `Push` and `To`
* replace the Staging and Production badges with related symbols used in the Environment Switcher
* use `muted` variant for site names
* use wider `Large` component variant for the modal 
* update copy of the modal description slightly

As a part of the above changes this PR also:
* extracts out the `Environment` - so it can be reused in both: the Environment Switcher and Sync modal
* moves `EnvironmentType` from the `SiteEnvironmentBadge` to the new `Environment` component (as we will be likely removing the `SiteEnvironmentBadge` component after launching the new Hosting Dashboard)

| Before | After |
|--------|--------|
| <img width="1354" height="614" alt="Markup on 2025-09-17 at 15:23:54" src="https://github.com/user-attachments/assets/8534343d-87bd-4ced-ad0b-a4628fb80d1c" /> | <img width="1718" height="522" alt="Markup on 2025-09-18 at 10:32:08" src="https://github.com/user-attachments/assets/05189212-ead0-4c6d-9181-e1172fe5f184" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTCOM-14591

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn start` (or use the Calypso Live link in the comment below).
2. Head over to the new Hosting Dashboard and select one of your WoA sites with staging site created.
3. Click on the Sync dropdown and select any of the two options.
4. Review the Sync modal. It should match the new design: QOBjujZah0UlGDDdLKZhzi-fi-15664_206678.
5. Please note that we are still yet to implement the granular sync part (i.e. File Browser and Database checkboxes are missing).
6. Head over to the equivalent Sync modal in the V1 dashboard. There should be no changes there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?