### PR TITLE
Help Center: Bell icon with line over

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -65,6 +65,22 @@ const SupportModeTitle = () => {
 	}
 };
 
+const MutedBellIcon = () => (
+	<div style={ { position: 'relative', display: 'inline-block' } }>
+		<Icon icon={ bell } width={ 24 } height={ 24 } />
+		<svg
+			style={ { position: 'absolute', top: 0, left: 0 } }
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+		>
+			<path d="M2 22L22 2" stroke="#757575" strokeWidth="1.5" />
+		</svg>
+	</div>
+);
+
 const EllipsisMenu = () => {
 	const { __ } = useI18n();
 	const navigate = useNavigate();
@@ -123,7 +139,13 @@ const EllipsisMenu = () => {
 				<Menu.Separator />
 				<Menu.Item
 					onClick={ toggleSoundNotifications }
-					prefix={ <Icon icon={ bell } width={ 24 } height={ 24 } /> }
+					prefix={
+						areSoundNotificationsEnabled ? (
+							<MutedBellIcon />
+						) : (
+							<Icon icon={ bell } width={ 24 } height={ 24 } />
+						)
+					}
 				>
 					<Menu.ItemLabel>
 						{ areSoundNotificationsEnabled


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-14571/make-sound-notifications-toggle-clearer

@Automattic/t-rex do you have a better option in mind or a better icon to use?

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="308" height="269" alt="image" src="https://github.com/user-attachments/assets/9f534008-7a37-43ce-ba75-031954bce9da" /> | <img width="327" height="268" alt="image" src="https://github.com/user-attachments/assets/d703bdfe-448b-45e6-a28b-0ed09469d324" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The bell icon was pretty much the same when sounds were on or off

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the option panel in the Help Center