### PR TITLE
Domains: Glue records: Update empty state

### DIFF
--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -136,24 +136,23 @@ function DomainGlueRecords() {
 			}
 		>
 			<DataViewsCard>
-				{ glueRecordsData?.length === 0 && ! isLoading ? (
-					<div style={ { padding: '20px', textAlign: 'center' } }>
-						{ __( 'No glue records found for this domain.' ) }
-					</div>
-				) : (
-					<DataViews< DomainGlueRecord >
-						data={ filteredData || [] }
-						fields={ fields }
-						onChangeView={ ( view: View ) => setView( view as GlueRecordsView ) }
-						view={ view }
-						actions={ actions }
-						search
-						paginationInfo={ paginationInfo }
-						getItemId={ ( item: DomainGlueRecord ) => item.nameserver }
-						isLoading={ isLoading }
-						defaultLayouts={ DEFAULT_LAYOUTS }
-					/>
-				) }
+				<DataViews< DomainGlueRecord >
+					data={ filteredData || [] }
+					fields={ fields }
+					onChangeView={ ( view: View ) => setView( view as GlueRecordsView ) }
+					view={ view }
+					actions={ actions }
+					search
+					paginationInfo={ paginationInfo }
+					getItemId={ ( item: DomainGlueRecord ) => item.nameserver }
+					isLoading={ isLoading }
+					defaultLayouts={ DEFAULT_LAYOUTS }
+					empty={
+						view.search
+							? __( 'No glue records found.' )
+							: __( 'No glue records found for this domain.' )
+					}
+				/>
 			</DataViewsCard>
 		</PageLayout>
 	);


### PR DESCRIPTION
Part of DOTDASH-407

## Proposed Changes

* Replace the empty state handler with the DataViews option

## Why are these changes being made?

* To be consistence between domain management related screens

## Testing Instructions

* Go to `/v2/domains`
* Select a domain
* Select "Glue records" settings
* Enter any random string and check the empty state
* Remove the "record" and check the empty state

**Before:**
<img width="693" height="215" alt="Screenshot 2025-09-17 at 16 50 31" src="https://github.com/user-attachments/assets/8e2ff7de-4bee-4fbd-b519-ada80fca3355" />

**After:**
<img width="690" height="300" alt="Screenshot 2025-09-17 at 16 45 12" src="https://github.com/user-attachments/assets/02f678ba-2388-4154-aa2d-3401cb617f41" />
<img width="704" height="284" alt="Screenshot 2025-09-17 at 16 45 22" src="https://github.com/user-attachments/assets/14d325a5-95d6-493d-85af-4092545f036c" />
<img width="690" height="272" alt="Screenshot 2025-09-17 at 16 45 59" src="https://github.com/user-attachments/assets/d83b4976-4bfa-4479-b610-0a8d310f7dbd" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
