### PR TITLE
v2 Plugins - Scheduled Updates: Time slot collision/validation checks when creating a new schedule

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/new/components/frequency-selection/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/components/frequency-selection/index.tsx
@@ -7,17 +7,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-export type Weekday =
-	| 'Monday'
-	| 'Tuesday'
-	| 'Wednesday'
-	| 'Thursday'
-	| 'Friday'
-	| 'Saturday'
-	| 'Sunday';
-
-export type Frequency = 'daily' | 'weekly';
+import type { Frequency, Weekday } from '../../../types';
 
 type Props = {
 	frequency: Frequency;

--- a/client/dashboard/plugins/scheduled-updates/new/constants.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/constants.ts
@@ -1,4 +1,4 @@
-import type { Frequency, Weekday } from './components/frequency-selection';
+import type { Frequency, Weekday } from '../types';
 
 export const DEFAULT_TIME = '04:00';
 export const DEFAULT_FREQUENCY: Frequency = 'daily';

--- a/client/dashboard/plugins/scheduled-updates/new/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/helpers.ts
@@ -1,5 +1,5 @@
 import type { Frequency, Weekday } from './components/frequency-selection';
-import type { MultisiteScheduledUpdatesResponse } from '@automattic/api-core';
+import type { HostingUpdateSchedulesResponse } from '@automattic/api-core';
 
 export function prepareTimestamp(
 	frequency: Frequency,
@@ -73,7 +73,7 @@ export function hasTimeSlotCollision( proposed: TimeSlot, existing: TimeSlot[] =
 
 // Build per-site time slots from the multisite aggregated response
 export function getTimeSlotsBySiteFromMultisite(
-	data: MultisiteScheduledUpdatesResponse
+	data: HostingUpdateSchedulesResponse
 ): Record< number, TimeSlot[] > {
 	const result: Record< number, TimeSlot[] > = {};
 	const sites = data?.sites;

--- a/client/dashboard/plugins/scheduled-updates/new/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/helpers.ts
@@ -37,6 +37,39 @@ export function prepareTimestamp(
 	return event.getTime() / 1000;
 }
 
+export type TimeSlot = { frequency: Frequency; timestamp: number };
+
+export function hasTimeSlotCollision( proposed: TimeSlot, existing: TimeSlot[] = [] ): boolean {
+	const newDate = new Date( proposed.timestamp * 1000 );
+	// Future check (legacy parity)
+	if ( newDate < new Date() ) {
+		return true;
+	}
+
+	for ( const slot of existing ) {
+		const existingDate = new Date( slot.timestamp * 1000 );
+
+		// If either side is daily, same hour collides (legacy parity)
+		if (
+			( proposed.frequency === 'daily' || slot.frequency === 'daily' ) &&
+			existingDate.getHours() === newDate.getHours()
+		) {
+			return true;
+		}
+
+		// Weekly-only collision: same weekday and same hour (legacy parity)
+		if (
+			proposed.frequency === 'weekly' &&
+			slot.frequency === 'weekly' &&
+			newDate.getDay() === existingDate.getDay() &&
+			newDate.getHours() === existingDate.getHours()
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Limited concurrency runner
  */

--- a/client/dashboard/plugins/scheduled-updates/new/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/helpers.ts
@@ -1,5 +1,5 @@
-import type { Frequency, Weekday } from './components/frequency-selection';
-import type { HostingUpdateSchedulesResponse } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
+import type { TimeSlot, Frequency, Weekday } from '../types';
 
 export function prepareTimestamp(
 	frequency: Frequency,
@@ -38,57 +38,34 @@ export function prepareTimestamp(
 	return event.getTime() / 1000;
 }
 
-export type TimeSlot = { frequency: Frequency; timestamp: number };
-
-export function hasTimeSlotCollision( proposed: TimeSlot, existing: TimeSlot[] = [] ): boolean {
+export function getTimeSlotCollisionError( proposed: TimeSlot, existing: TimeSlot[] = [] ): string {
 	const newDate = new Date( proposed.timestamp * 1000 );
-	// Future check (legacy parity)
+
 	if ( newDate < new Date() ) {
-		return true;
+		return __( 'Please choose a time in the future for this schedule.' );
 	}
 
 	for ( const slot of existing ) {
 		const existingDate = new Date( slot.timestamp * 1000 );
 
-		// If either side is daily, same hour collides (legacy parity)
 		if (
 			( proposed.frequency === 'daily' || slot.frequency === 'daily' ) &&
 			existingDate.getHours() === newDate.getHours()
 		) {
-			return true;
+			return __( 'Please choose another time, as this slot is already scheduled.' );
 		}
 
-		// Weekly-only collision: same weekday and same hour (legacy parity)
 		if (
 			proposed.frequency === 'weekly' &&
 			slot.frequency === 'weekly' &&
 			newDate.getDay() === existingDate.getDay() &&
 			newDate.getHours() === existingDate.getHours()
 		) {
-			return true;
+			return __( 'Please choose another time, as this slot is already scheduled.' );
 		}
 	}
-	return false;
-}
 
-// Build per-site time slots from the multisite aggregated response
-export function getTimeSlotsBySiteFromMultisite(
-	data: HostingUpdateSchedulesResponse
-): Record< number, TimeSlot[] > {
-	const result: Record< number, TimeSlot[] > = {};
-	const sites = data?.sites;
-	if ( ! sites ) {
-		return result;
-	}
-	Object.entries( sites ).forEach( ( [ siteIdStr, schedulesMap ] ) => {
-		const siteId = Number( siteIdStr );
-		const slots: TimeSlot[] = [];
-		Object.values( schedulesMap || {} ).forEach( ( sched ) => {
-			slots.push( { frequency: sched.schedule, timestamp: sched.timestamp } );
-		} );
-		result[ siteId ] = slots;
-	} );
-	return result;
+	return '';
 }
 
 /**

--- a/client/dashboard/plugins/scheduled-updates/new/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/helpers.ts
@@ -1,4 +1,5 @@
 import type { Frequency, Weekday } from './components/frequency-selection';
+import type { MultisiteScheduledUpdatesResponse } from '@automattic/api-core';
 
 export function prepareTimestamp(
 	frequency: Frequency,
@@ -68,6 +69,26 @@ export function hasTimeSlotCollision( proposed: TimeSlot, existing: TimeSlot[] =
 		}
 	}
 	return false;
+}
+
+// Build per-site time slots from the multisite aggregated response
+export function getTimeSlotsBySiteFromMultisite(
+	data: MultisiteScheduledUpdatesResponse
+): Record< number, TimeSlot[] > {
+	const result: Record< number, TimeSlot[] > = {};
+	const sites = data?.sites;
+	if ( ! sites ) {
+		return result;
+	}
+	Object.entries( sites ).forEach( ( [ siteIdStr, schedulesMap ] ) => {
+		const siteId = Number( siteIdStr );
+		const slots: TimeSlot[] = [];
+		Object.values( schedulesMap || {} ).forEach( ( sched ) => {
+			slots.push( { frequency: sched.schedule, timestamp: sched.timestamp } );
+		} );
+		result[ siteId ] = slots;
+	} );
+	return result;
 }
 
 /**

--- a/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
@@ -1,43 +1,64 @@
-import { siteUpdateSchedulesQuery } from '@automattic/api-queries';
-import { useQueries } from '@tanstack/react-query';
-import { hasTimeSlotCollision, type TimeSlot } from '../helpers';
-import type { Frequency } from '../components/frequency-selection';
+import { hostingUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { prepareTimestamp, getTimeSlotCollisionError } from '../helpers';
+import type { TimeSlot, Frequency, Weekday } from '../../types';
+import type { HostingUpdateSchedulesResponse } from '@automattic/api-core';
 
-export function useTimeSlotCollisionCheck(
+/**
+ * Build per-site time slots from the multisite aggregated response
+ */
+function getTimeSlotsBySiteFromMultisite(
+	data: HostingUpdateSchedulesResponse
+): Record< number, TimeSlot[] > {
+	const result: Record< number, TimeSlot[] > = {};
+	const sites = data?.sites;
+
+	if ( ! sites ) {
+		return result;
+	}
+
+	Object.entries( sites ).forEach( ( [ siteIdStr, schedulesMap ] ) => {
+		const siteId = Number( siteIdStr );
+		const slots: TimeSlot[] = [];
+		Object.values( schedulesMap || {} ).forEach( ( sched ) => {
+			slots.push( { frequency: sched.schedule, timestamp: sched.timestamp } );
+		} );
+		result[ siteId ] = slots;
+	} );
+
+	return result;
+}
+
+/**
+ * Given a list of site IDs, frequency, and timestamp,
+ * return an error message if there is a collision,
+ * along with the sites that have a collision, if any.
+ * Uses `getTimeSlotCollisionError` to check for collisions.
+ */
+export function useTimeSlotCollisionsFromMultisite(
 	siteIds: number[],
 	frequency: Frequency,
-	timestamp: number
-): { loading: boolean; error: string; sitesWithCollisions: number[] } {
-	const queries = useQueries( {
-		queries: siteIds.map( ( siteId ) => siteUpdateSchedulesQuery( siteId ) ),
-	} );
+	weekday: Weekday,
+	time: string
+): { isLoading: boolean; error: string; collidingSiteIds: number[] } {
+	const { data, isLoading } = useQuery( hostingUpdateSchedulesQuery() );
 
-	const loading = queries.some( ( query ) => query.isLoading );
-	if ( loading ) {
-		return { loading: true, error: '', sitesWithCollisions: [] };
+	if ( isLoading ) {
+		return { isLoading: true, error: '', collidingSiteIds: [] };
 	}
 
-	const schedulesBySite: Record< number, TimeSlot[] > = {};
-	queries.forEach( ( query, idx ) => {
-		const siteId = siteIds[ idx ];
-		const data = ( query.data as Array< { schedule: Frequency; timestamp: number } > ) || [];
-		schedulesBySite[ siteId ] = data.map( ( { schedule, timestamp } ) => ( {
-			frequency: schedule,
-			timestamp,
-		} ) );
-	} );
-
+	const timestamp = prepareTimestamp( frequency, weekday, time );
 	const proposed: TimeSlot = { frequency, timestamp };
-	const sitesWithCollisions = siteIds.filter( ( siteId ) =>
-		hasTimeSlotCollision( proposed, schedulesBySite[ siteId ] || [] )
-	);
+	const bySite = data ? getTimeSlotsBySiteFromMultisite( data ) : {};
 
-	let error = '';
-	if ( new Date( timestamp * 1000 ) < new Date() ) {
-		error = 'Please choose a time in the future for this schedule.';
-	} else if ( sitesWithCollisions.length > 0 ) {
-		error = 'Please choose another time, as this slot is already scheduled.';
-	}
+	let firstError = '';
+	const collidingSiteIds: number[] = siteIds.filter( ( id ) => {
+		const error = getTimeSlotCollisionError( proposed, bySite[ id ] || [] );
+		if ( error && ! firstError ) {
+			firstError = error;
+		}
+		return !! error;
+	} );
 
-	return { loading: false, error, sitesWithCollisions };
+	return { isLoading: false, error: firstError, collidingSiteIds };
 }

--- a/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
@@ -1,0 +1,43 @@
+import { siteScheduledUpdatesQuery } from '@automattic/api-queries';
+import { useQueries } from '@tanstack/react-query';
+import { hasTimeSlotCollision, type TimeSlot } from '../helpers';
+import type { Frequency } from '../components/frequency-selection';
+
+export function useTimeSlotCollisionCheck(
+	siteIds: number[],
+	frequency: Frequency,
+	timestamp: number
+): { loading: boolean; error: string; sitesWithCollisions: number[] } {
+	const queries = useQueries( {
+		queries: siteIds.map( ( siteId ) => siteScheduledUpdatesQuery( siteId ) ),
+	} );
+
+	const loading = queries.some( ( query ) => query.isLoading );
+	if ( loading ) {
+		return { loading: true, error: '', sitesWithCollisions: [] };
+	}
+
+	const schedulesBySite: Record< number, TimeSlot[] > = {};
+	queries.forEach( ( query, idx ) => {
+		const siteId = siteIds[ idx ];
+		const data = ( query.data as Array< { schedule: Frequency; timestamp: number } > ) || [];
+		schedulesBySite[ siteId ] = data.map( ( { schedule, timestamp } ) => ( {
+			frequency: schedule,
+			timestamp,
+		} ) );
+	} );
+
+	const proposed: TimeSlot = { frequency, timestamp };
+	const sitesWithCollisions = siteIds.filter( ( siteId ) =>
+		hasTimeSlotCollision( proposed, schedulesBySite[ siteId ] || [] )
+	);
+
+	let error = '';
+	if ( new Date( timestamp * 1000 ) < new Date() ) {
+		error = 'Please choose a time in the future for this schedule.';
+	} else if ( sitesWithCollisions.length > 0 ) {
+		error = 'Please choose another time, as this slot is already scheduled.';
+	}
+
+	return { loading: false, error, sitesWithCollisions };
+}

--- a/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/hooks/use-time-slot-collisions.ts
@@ -1,4 +1,4 @@
-import { siteScheduledUpdatesQuery } from '@automattic/api-queries';
+import { siteUpdateSchedulesQuery } from '@automattic/api-queries';
 import { useQueries } from '@tanstack/react-query';
 import { hasTimeSlotCollision, type TimeSlot } from '../helpers';
 import type { Frequency } from '../components/frequency-selection';
@@ -9,7 +9,7 @@ export function useTimeSlotCollisionCheck(
 	timestamp: number
 ): { loading: boolean; error: string; sitesWithCollisions: number[] } {
 	const queries = useQueries( {
-		queries: siteIds.map( ( siteId ) => siteScheduledUpdatesQuery( siteId ) ),
+		queries: siteIds.map( ( siteId ) => siteUpdateSchedulesQuery( siteId ) ),
 	} );
 
 	const loading = queries.some( ( query ) => query.isLoading );

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -32,7 +32,7 @@ import { useTimeSlotCollisionsFromMultisite } from './hooks/use-time-slot-collis
 import type { Frequency, Weekday } from '../types';
 import type { Site } from '@automattic/api-core';
 
-const BLOCK_CREATE = false;
+const BLOCK_CREATE = true;
 
 function ScheduledUpdatesNew() {
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -55,20 +55,21 @@ function ScheduledUpdatesNew() {
 		siteJetpackMonitorSettingsCreateMutation()
 	);
 
-	const { error: collisionsError, collidingSiteIds } = useTimeSlotCollisionsFromMultisite(
-		siteIdsAsNumbers,
-		frequency,
-		weekday,
-		time
-	);
+	const {
+		error: collisionsError,
+		collidingSiteIds,
+		isLoading: isCollisionsLoading,
+	} = useTimeSlotCollisionsFromMultisite( siteIdsAsNumbers, frequency, weekday, time );
 
 	const handleCreate = useCallback( () => {
 		setValidationError( '' );
 
-		if ( ! isValid ) {
+		if ( ! isValid || isCollisionsLoading ) {
 			return;
 		}
 
+		// show error if there are collisions
+		// along with the list of sites that have collisions, if less than all selected sites
 		if ( collisionsError ) {
 			const siteMap = new Map( eligibleSites.map( ( s ) => [ s.ID, s ] ) );
 			const shouldListSites =
@@ -87,12 +88,11 @@ function ScheduledUpdatesNew() {
 				message = `${ collisionsError }\n${ sitesLine }`;
 			}
 			setValidationError( message );
-
+			setIsSubmitting( false );
 			return;
 		}
 
 		setIsSubmitting( true );
-
 		const timestamp = prepareTimestamp( frequency, weekday, time );
 		const body = {
 			plugins: selectedPluginSlugs,
@@ -154,7 +154,6 @@ function ScheduledUpdatesNew() {
 			},
 		} );
 	}, [
-		isValid,
 		frequency,
 		weekday,
 		time,
@@ -167,6 +166,8 @@ function ScheduledUpdatesNew() {
 		collidingSiteIds,
 		collisionsError,
 		siteIdsAsNumbers.length,
+		isCollisionsLoading,
+		isValid,
 	] );
 
 	return (
@@ -221,7 +222,7 @@ function ScheduledUpdatesNew() {
 						<HStack justify="start">
 							<Button
 								variant="primary"
-								disabled={ ! isValid || isSubmitting }
+								disabled={ ! isValid || isSubmitting || isCollisionsLoading }
 								onClick={ handleCreate }
 								__next40pxDefaultSize
 							>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -78,9 +78,9 @@ function ScheduledUpdatesNew() {
 				const eventDate = new Date( timestamp * 1000 );
 				const hours = eventDate.getHours();
 				const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
+				const siteMap = new Map( eligibleSites.map( ( site ) => [ site.ID, site ] ) );
 
 				// Create monitor settings for each successful site using per-site mutation (with retry)
-				const siteMap = new Map( eligibleSites.map( ( site ) => [ site.ID, site ] ) );
 				const monitorTasks = successfulSiteIds
 					.map( ( siteId ) => siteMap.get( siteId ) )
 					.filter( ( site ): site is Site => Boolean( site ) )

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -55,12 +55,8 @@ function ScheduledUpdatesNew() {
 		siteJetpackMonitorSettingsCreateMutation()
 	);
 
-	const { error: collisionsError, collidingSiteIds } = useTimeSlotCollisionsFromMultisite(
-		siteIdsAsNumbers,
-		frequency,
-		weekday,
-		time
-	);
+	const { error: timeSlotCollisionsError, collidingSiteIds: timeSlotCollisionsSiteIds } =
+		useTimeSlotCollisionsFromMultisite( siteIdsAsNumbers, frequency, weekday, time );
 
 	const handleCreate = useCallback( () => {
 		setValidationError( '' );
@@ -69,25 +65,29 @@ function ScheduledUpdatesNew() {
 			return;
 		}
 
-		const timestamp = prepareTimestamp( frequency, weekday, time );
-
-		if ( collisionsError ) {
+		if ( timeSlotCollisionsError ) {
 			const siteMap = new Map( eligibleSites.map( ( s ) => [ s.ID, s ] ) );
 			const shouldListSites =
-				collidingSiteIds.length > 0 && collidingSiteIds.length < siteIdsAsNumbers.length;
+				timeSlotCollisionsSiteIds.length > 0 &&
+				timeSlotCollisionsSiteIds.length < siteIdsAsNumbers.length;
 			const siteList = shouldListSites
-				? collidingSiteIds.map( ( id ) => siteMap.get( id )?.slug || String( id ) ).join( ', ' )
+				? timeSlotCollisionsSiteIds
+						.map( ( id ) => siteMap.get( id )?.slug || String( id ) )
+						.join( ', ' )
 				: '';
+
 			setValidationError(
 				shouldListSites
-					? `${ collisionsError }\n${ __( 'Sites:' ) } ${ siteList }`
-					: collisionsError
+					? `${ timeSlotCollisionsError }\n${ __( 'Sites:' ) } ${ siteList }`
+					: timeSlotCollisionsError
 			);
+
 			return;
 		}
 
 		setIsSubmitting( true );
 
+		const timestamp = prepareTimestamp( frequency, weekday, time );
 		const body = {
 			plugins: selectedPluginSlugs,
 			schedule: {
@@ -158,8 +158,8 @@ function ScheduledUpdatesNew() {
 		createMonitorForSite,
 		navigate,
 		recordTracksEvent,
-		collidingSiteIds,
-		collisionsError,
+		timeSlotCollisionsSiteIds,
+		timeSlotCollisionsError,
 		siteIdsAsNumbers.length,
 	] );
 

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -12,7 +12,7 @@ import {
 	__experimentalHStack as HStack,
 	Notice,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import {
@@ -55,8 +55,12 @@ function ScheduledUpdatesNew() {
 		siteJetpackMonitorSettingsCreateMutation()
 	);
 
-	const { error: timeSlotCollisionsError, collidingSiteIds: timeSlotCollisionsSiteIds } =
-		useTimeSlotCollisionsFromMultisite( siteIdsAsNumbers, frequency, weekday, time );
+	const { error: collisionsError, collidingSiteIds } = useTimeSlotCollisionsFromMultisite(
+		siteIdsAsNumbers,
+		frequency,
+		weekday,
+		time
+	);
 
 	const handleCreate = useCallback( () => {
 		setValidationError( '' );
@@ -65,22 +69,24 @@ function ScheduledUpdatesNew() {
 			return;
 		}
 
-		if ( timeSlotCollisionsError ) {
+		if ( collisionsError ) {
 			const siteMap = new Map( eligibleSites.map( ( s ) => [ s.ID, s ] ) );
 			const shouldListSites =
-				timeSlotCollisionsSiteIds.length > 0 &&
-				timeSlotCollisionsSiteIds.length < siteIdsAsNumbers.length;
+				collidingSiteIds.length > 0 && collidingSiteIds.length < siteIdsAsNumbers.length;
 			const siteList = shouldListSites
-				? timeSlotCollisionsSiteIds
-						.map( ( id ) => siteMap.get( id )?.slug || String( id ) )
-						.join( ', ' )
+				? collidingSiteIds.map( ( id ) => siteMap.get( id )?.slug || String( id ) ).join( ', ' )
 				: '';
 
-			setValidationError(
-				shouldListSites
-					? `${ timeSlotCollisionsError }\n${ __( 'Sites:' ) } ${ siteList }`
-					: timeSlotCollisionsError
-			);
+			let message = collisionsError;
+			if ( shouldListSites ) {
+				const sitesLine = sprintf(
+					/* translators: %s is a comma-separated list of site slugs with time collisions. */
+					__( 'Sites: %s' ),
+					siteList
+				);
+				message = `${ collisionsError }\n${ sitesLine }`;
+			}
+			setValidationError( message );
 
 			return;
 		}
@@ -158,8 +164,8 @@ function ScheduledUpdatesNew() {
 		createMonitorForSite,
 		navigate,
 		recordTracksEvent,
-		timeSlotCollisionsSiteIds,
-		timeSlotCollisionsError,
+		collidingSiteIds,
+		collisionsError,
 		siteIdsAsNumbers.length,
 	] );
 

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -86,7 +86,6 @@ function ScheduledUpdatesNew() {
 			setValidationError(
 				siteList ? `${ baseError }\n${ __( 'Sites:' ) } ${ siteList }` : baseError
 			);
-			window.scrollTo( { top: 0, behavior: 'smooth' } );
 			return;
 		}
 
@@ -149,7 +148,6 @@ function ScheduledUpdatesNew() {
 				setValidationError(
 					( error as { message?: string } )?.message || __( 'Failed to create schedule.' )
 				);
-				window.scrollTo( { top: 0, behavior: 'smooth' } );
 			},
 		} );
 	}, [
@@ -179,13 +177,6 @@ function ScheduledUpdatesNew() {
 				/>
 			}
 		>
-			{ validationError && (
-				<Notice status="error" isDismissible={ false }>
-					{ validationError.split( '\n' ).map( ( line, idx ) => (
-						<div key={ idx }>{ line }</div>
-					) ) }
-				</Notice>
-			) }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 6 }>
@@ -216,6 +207,13 @@ function ScheduledUpdatesNew() {
 								setTime( next.time );
 							} }
 						/>
+						{ validationError && (
+							<Notice status="error" isDismissible={ false }>
+								{ validationError.split( '\n' ).map( ( line, idx ) => (
+									<div key={ idx }>{ line }</div>
+								) ) }
+							</Notice>
+						) }
 						<HStack justify="start">
 							<Button
 								variant="primary"

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -1,9 +1,8 @@
 import {
 	updateSchedulesBatchCreateMutation,
 	siteJetpackMonitorSettingsCreateMutation,
-	hostingUpdateSchedulesQuery,
 } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	Button,
@@ -24,16 +23,13 @@ import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { SectionHeader } from '../../../components/section-header';
 import { useEligibleSites } from '../hooks/use-eligible-sites';
-import FrequencySelection, { type Frequency, type Weekday } from './components/frequency-selection';
+import FrequencySelection from './components/frequency-selection';
 import PluginsSelection from './components/plugins-selection';
 import SitesSelection from './components/sites-selection';
 import { DEFAULT_FREQUENCY, DEFAULT_TIME, DEFAULT_WEEKDAY, CRON_CHECK_INTERVAL } from './constants';
-import {
-	getTimeSlotsBySiteFromMultisite,
-	hasTimeSlotCollision,
-	prepareTimestamp,
-	runWithConcurrency,
-} from './helpers';
+import { prepareTimestamp, runWithConcurrency } from './helpers';
+import { useTimeSlotCollisionsFromMultisite } from './hooks/use-time-slot-collisions';
+import type { Frequency, Weekday } from '../types';
 import type { Site } from '@automattic/api-core';
 
 const BLOCK_CREATE = false;
@@ -58,38 +54,40 @@ function ScheduledUpdatesNew() {
 	const { mutateAsync: createMonitorForSite } = useMutation(
 		siteJetpackMonitorSettingsCreateMutation()
 	);
-	const { data: hostingSchedules } = useQuery( hostingUpdateSchedulesQuery() );
+
+	const { error: collisionsError, collidingSiteIds } = useTimeSlotCollisionsFromMultisite(
+		siteIdsAsNumbers,
+		frequency,
+		weekday,
+		time
+	);
 
 	const handleCreate = useCallback( () => {
 		setValidationError( '' );
+
 		if ( ! isValid ) {
 			return;
 		}
 
 		const timestamp = prepareTimestamp( frequency, weekday, time );
 
-		// Pre-flight multi-site collision check
-		const slotsBySite = hostingSchedules ? getTimeSlotsBySiteFromMultisite( hostingSchedules ) : {};
-		const collidingSiteIds = siteIdsAsNumbers.filter( ( siteId ) =>
-			hasTimeSlotCollision( { frequency, timestamp }, slotsBySite[ siteId ] || [] )
-		);
-		if ( collidingSiteIds.length > 0 || new Date( timestamp * 1000 ) < new Date() ) {
-			// Build error string (legacy parity) + add sites on a new line
-			const baseError =
-				new Date( timestamp * 1000 ) < new Date()
-					? __( 'Please choose a time in the future for this schedule.' )
-					: __( 'Please choose another time, as this slot is already scheduled.' );
+		if ( collisionsError ) {
 			const siteMap = new Map( eligibleSites.map( ( s ) => [ s.ID, s ] ) );
-			const siteList = collidingSiteIds
-				.map( ( id ) => siteMap.get( id )?.slug || String( id ) )
-				.join( ', ' );
+			const shouldListSites =
+				collidingSiteIds.length > 0 && collidingSiteIds.length < siteIdsAsNumbers.length;
+			const siteList = shouldListSites
+				? collidingSiteIds.map( ( id ) => siteMap.get( id )?.slug || String( id ) ).join( ', ' )
+				: '';
 			setValidationError(
-				siteList ? `${ baseError }\n${ __( 'Sites:' ) } ${ siteList }` : baseError
+				shouldListSites
+					? `${ collisionsError }\n${ __( 'Sites:' ) } ${ siteList }`
+					: collisionsError
 			);
 			return;
 		}
 
 		setIsSubmitting( true );
+
 		const body = {
 			plugins: selectedPluginSlugs,
 			schedule: {
@@ -140,7 +138,6 @@ function ScheduledUpdatesNew() {
 
 				await runWithConcurrency( monitorTasks, 4 );
 				setIsSubmitting( false );
-				// Navigate back to the schedules list
 				navigate( { to: pluginsScheduledUpdatesRoute.to } );
 			},
 			onError: ( error ) => {
@@ -161,8 +158,9 @@ function ScheduledUpdatesNew() {
 		createMonitorForSite,
 		navigate,
 		recordTracksEvent,
-		hostingSchedules,
-		siteIdsAsNumbers,
+		collidingSiteIds,
+		collisionsError,
+		siteIdsAsNumbers.length,
 	] );
 
 	return (

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -1,8 +1,9 @@
 import {
 	updateSchedulesBatchCreateMutation,
 	siteJetpackMonitorSettingsCreateMutation,
+	hostingUpdateSchedulesQuery,
 } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	Button,
@@ -10,6 +11,7 @@ import {
 	CardBody,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
@@ -26,10 +28,15 @@ import FrequencySelection, { type Frequency, type Weekday } from './components/f
 import PluginsSelection from './components/plugins-selection';
 import SitesSelection from './components/sites-selection';
 import { DEFAULT_FREQUENCY, DEFAULT_TIME, DEFAULT_WEEKDAY, CRON_CHECK_INTERVAL } from './constants';
-import { prepareTimestamp, runWithConcurrency } from './helpers';
+import {
+	getTimeSlotsBySiteFromMultisite,
+	hasTimeSlotCollision,
+	prepareTimestamp,
+	runWithConcurrency,
+} from './helpers';
 import type { Site } from '@automattic/api-core';
 
-const BLOCK_CREATE = true;
+const BLOCK_CREATE = false;
 
 function ScheduledUpdatesNew() {
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
@@ -37,6 +44,7 @@ function ScheduledUpdatesNew() {
 	const [ frequency, setFrequency ] = useState< Frequency >( DEFAULT_FREQUENCY );
 	const [ weekday, setWeekday ] = useState< Weekday >( DEFAULT_WEEKDAY );
 	const [ time, setTime ] = useState( DEFAULT_TIME );
+	const [ validationError, setValidationError ] = useState< string >( '' );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
 	const { recordTracksEvent } = useAnalytics();
@@ -50,13 +58,38 @@ function ScheduledUpdatesNew() {
 	const { mutateAsync: createMonitorForSite } = useMutation(
 		siteJetpackMonitorSettingsCreateMutation()
 	);
+	const { data: hostingSchedules } = useQuery( hostingUpdateSchedulesQuery() );
 
 	const handleCreate = useCallback( () => {
+		setValidationError( '' );
 		if ( ! isValid ) {
 			return;
 		}
 
 		const timestamp = prepareTimestamp( frequency, weekday, time );
+
+		// Pre-flight multi-site collision check
+		const slotsBySite = hostingSchedules ? getTimeSlotsBySiteFromMultisite( hostingSchedules ) : {};
+		const collidingSiteIds = siteIdsAsNumbers.filter( ( siteId ) =>
+			hasTimeSlotCollision( { frequency, timestamp }, slotsBySite[ siteId ] || [] )
+		);
+		if ( collidingSiteIds.length > 0 || new Date( timestamp * 1000 ) < new Date() ) {
+			// Build error string (legacy parity) + add sites on a new line
+			const baseError =
+				new Date( timestamp * 1000 ) < new Date()
+					? __( 'Please choose a time in the future for this schedule.' )
+					: __( 'Please choose another time, as this slot is already scheduled.' );
+			const siteMap = new Map( eligibleSites.map( ( s ) => [ s.ID, s ] ) );
+			const siteList = collidingSiteIds
+				.map( ( id ) => siteMap.get( id )?.slug || String( id ) )
+				.join( ', ' );
+			setValidationError(
+				siteList ? `${ baseError }\n${ __( 'Sites:' ) } ${ siteList }` : baseError
+			);
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+			return;
+		}
+
 		setIsSubmitting( true );
 		const body = {
 			plugins: selectedPluginSlugs,
@@ -111,8 +144,12 @@ function ScheduledUpdatesNew() {
 				// Navigate back to the schedules list
 				navigate( { to: pluginsScheduledUpdatesRoute.to } );
 			},
-			onError: () => {
+			onError: ( error ) => {
 				setIsSubmitting( false );
+				setValidationError(
+					( error as { message?: string } )?.message || __( 'Failed to create schedule.' )
+				);
+				window.scrollTo( { top: 0, behavior: 'smooth' } );
 			},
 		} );
 	}, [
@@ -126,6 +163,8 @@ function ScheduledUpdatesNew() {
 		createMonitorForSite,
 		navigate,
 		recordTracksEvent,
+		hostingSchedules,
+		siteIdsAsNumbers,
 	] );
 
 	return (
@@ -140,6 +179,13 @@ function ScheduledUpdatesNew() {
 				/>
 			}
 		>
+			{ validationError && (
+				<Notice status="error" isDismissible={ false }>
+					{ validationError.split( '\n' ).map( ( line, idx ) => (
+						<div key={ idx }>{ line }</div>
+					) ) }
+				</Notice>
+			) }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 6 }>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -80,7 +80,7 @@ function ScheduledUpdatesNew() {
 			let message = collisionsError;
 			if ( shouldListSites ) {
 				const sitesLine = sprintf(
-					/* translators: %s is a comma-separated list of site slugs with time collisions. */
+					/* translators: %s is a comma-separated list of site slugs. */
 					__( 'Sites: %s' ),
 					siteList
 				);

--- a/client/dashboard/plugins/scheduled-updates/types.ts
+++ b/client/dashboard/plugins/scheduled-updates/types.ts
@@ -1,0 +1,12 @@
+export type Weekday =
+	| 'Monday'
+	| 'Tuesday'
+	| 'Wednesday'
+	| 'Thursday'
+	| 'Friday'
+	| 'Saturday'
+	| 'Sunday';
+
+export type Frequency = 'daily' | 'weekly';
+
+export type TimeSlot = { frequency: Frequency; timestamp: number };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Proposed Changes

For creating a new scheduled update:

- Add client-side time slot validation when creating a new scheduled update. 
  - The backend/endpoints apply time-slot validations before creating schedules. The original frontend code (v1) included some time collision validations on the per-site edit/create logic.
  - When the user bulk-creates schedules for multiple sites, relying entirely on backend validations may lead to a case where only some of the schedules are created (there is no rollback logic in the backend - bulk-create is a batch process on the frontend). We can either orchestrate a rollback on the client (unlikely) or wire a pre-check in the batch create (as done here).
- Show a notice when a time slot collision exists so users can address and retry the bulk operation (either exclude a site from the schedule or choose a different time, or go back and delete an existing schedule and try again - I think these are the options).

> [!NOTE]
> We may ship something to present the validations and revisit the display on top.

## Media

### One option: Show the notice right above the CTA

<img width="600" alt="Screenshot 2025-09-19 at 12 02 21 PM" src="https://github.com/user-attachments/assets/87dea9ba-7594-45bd-98c2-0340a70299a2" />

### Another option: Show the notice at the top and scroll to the top

<img width="600" alt="Screenshot 2025-09-19 at 12 03 06 PM" src="https://github.com/user-attachments/assets/e8c97cf2-af4b-455a-8682-2824629641ea" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/plugins/scheduled-updates/new`
  - Select a site (must have an atomic site) - ideally multiple sites for testing this
  - Select a plugin (must have a non-managed plugins installed from marketplace)
  - Select a frequency
- Create a new schedule and repeat: 
  - with the same time (sites/plugins same) - collision detection
    - confirm a notice is shown and the schedules are not created
  - with different time (site/plugins same) 
    - no validation. We will implement this separately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
