### PR TITLE
Domains: Add ICANN verification banner on HD

### DIFF
--- a/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
+++ b/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
@@ -1,6 +1,10 @@
 import { resendIcannVerificationEmailMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -26,13 +30,17 @@ export default function IcannSuspensionNotice( { domainName }: { domainName: str
 		} );
 	};
 	return (
-		<Notice variant="error" title={ __( 'Download failed' ) }>
-			<Text>
-				{ __(
-					'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your contact information is correct below.'
-				) }
-			</Text>
-			<Button variant="link" onClick={ onClick } />,
+		<Notice variant="error" title={ __( 'Email verification required' ) }>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ __(
+						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your contact information is correct below.'
+					) }
+				</Text>
+				<Button variant="link" onClick={ onClick }>
+					{ __( 'Resend email' ) }
+				</Button>
+			</VStack>
 		</Notice>
 	);
 }

--- a/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
+++ b/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
@@ -1,0 +1,38 @@
+import { resendIcannVerificationEmailMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { Button, __experimentalText as Text } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import Notice from '../../components/notice';
+
+export default function IcannSuspensionNotice( { domainName }: { domainName: string } ) {
+	const resendIcannVerificationEmail = useMutation(
+		resendIcannVerificationEmailMutation( domainName )
+	);
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const onClick = () => {
+		resendIcannVerificationEmail.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'ICANN verification email sent' ), {
+					type: 'snackbar',
+				} );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to send ICANN verification email' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+	return (
+		<Notice variant="error" title={ __( 'Download failed' ) }>
+			<Text>
+				{ __(
+					'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your contact information is correct below.'
+				) }
+			</Text>
+			<Button variant="link" onClick={ onClick } />,
+		</Notice>
+	);
+}

--- a/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
+++ b/client/dashboard/domains/domain-overview/icann-suspension-notice.tsx
@@ -37,8 +37,12 @@ export default function IcannSuspensionNotice( { domainName }: { domainName: str
 						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your contact information is correct below.'
 					) }
 				</Text>
-				<Button variant="link" onClick={ onClick }>
-					{ __( 'Resend email' ) }
+				<Button
+					variant="link"
+					onClick={ onClick }
+					disabled={ resendIcannVerificationEmail.isPending }
+				>
+					{ resendIcannVerificationEmail.isPending ? __( 'Sending…' ) : __( 'Resend email' ) }
 				</Button>
 			</VStack>
 		</Notice>

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -14,6 +14,7 @@ import { formatDate } from '../../utils/datetime';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import Actions from './actions';
 import FeaturedCards from './featured-cards';
+import IcannSuspensionNotice from './icann-suspension-notice';
 import DomainOverviewSettings from './settings';
 
 export default function DomainOverview() {
@@ -80,6 +81,9 @@ export default function DomainOverview() {
 				/>
 			}
 		>
+			{ domain.is_pending_icann_verification && (
+				<IcannSuspensionNotice domainName={ domain.domain } />
+			) }
 			<FeaturedCards />
 			<DomainOverviewSettings domain={ domain } />
 			<Actions />

--- a/packages/api-core/src/domain/mutators.ts
+++ b/packages/api-core/src/domain/mutators.ts
@@ -5,3 +5,9 @@ export function disconnectDomain( domainName: string ): Promise< void > {
 		path: `/domains/${ domainName }/disconnect-domain-from-site`,
 	} );
 }
+
+export function resendIcannVerificationEmail( domainName: string ): Promise< void > {
+	return wpcom.req.post( {
+		path: `/domains/${ domainName }/resend-icann`,
+	} );
+}

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -1,4 +1,4 @@
-import { fetchDomain, disconnectDomain } from '@automattic/api-core';
+import { fetchDomain, disconnectDomain, resendIcannVerificationEmail } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -14,4 +14,9 @@ export const disconnectDomainMutation = ( domainName: string ) =>
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},
+	} );
+
+export const resendIcannVerificationEmailMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: () => resendIcannVerificationEmail( domainName ),
 	} );


### PR DESCRIPTION
Closes [DOTDASH-465](https://linear.app/a8c/issue/DOTDASH-465/add-verificationsuspension-banner)

## Proposed Changes  
- Add an ICANN verification notice component for domains with a **pending** verification request or that are **suspended**.  
- Implement the **"Resend Email"** functionality to re-trigger the ICANN verification process.

<img width="1484" height="1112" alt="icann" src="https://github.com/user-attachments/assets/868290ee-2a6d-47ae-8bdf-977ec69f62dc" />

## Why Are These Changes Being Made?  
Users should be able to verify their domain contact email when required, in compliance with ICANN regulations.

## Testing Instructions  
1. Register a new domain using an email address that has **never been used before**.  
2. Verify that the **ICANN verification banner** is rendered.  
3. Test that the **resend verification email** button works correctly.

> **Note:** It may take a few minutes for the banner to appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
