### PR TITLE
Domains: Update site column; add attach site CTA

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-site.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-site.tsx
@@ -1,14 +1,29 @@
+import { DomainSubtype, type DomainSummary } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { domainTransferToOtherSiteRoute } from '../../app/router/domains';
 import { siteRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
 import SiteIcon from '../../sites/site-icon';
-import type { DomainSummary } from '@automattic/api-core';
+import { IneligibleIndicator } from './ineligible-indicator';
 
 export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
 	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
+
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+		return <IneligibleIndicator />;
+	}
+
+	if ( domain.is_domain_only_site ) {
+		return (
+			<Link to={ domainTransferToOtherSiteRoute.fullPath } params={ { domainName: domain.domain } }>
+				{ __( 'Attach site' ) }
+			</Link>
+		);
+	}
 
 	return (
 		<HStack spacing={ 2 } alignment="left">

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -8,12 +8,11 @@ import { DomainNameField } from './field-domain-name';
 import { DomainSiteField } from './field-domain-site';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
+import { IneligibleIndicator } from './ineligible-indicator';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 const THREE_DAYS_IN_MINUTES = 3 * 1440;
-
-const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;
 
 export const useFields = ( {
 	site,

--- a/client/dashboard/domains/dataviews/ineligible-indicator.tsx
+++ b/client/dashboard/domains/dataviews/ineligible-indicator.tsx
@@ -1,0 +1,3 @@
+import { __experimentalText as Text } from '@wordpress/components';
+
+export const IneligibleIndicator = () => <Text color="#CCCCCC">-</Text>;

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -40,6 +40,7 @@ export interface DomainSummary {
 	expired: boolean;
 	expiry: string | false;
 	has_registration: boolean;
+	is_domain_only_site: boolean;
 	is_eligible_for_inbound_transfer: boolean;
 	is_hundred_year_domain: boolean;
 	is_redeemable: boolean;


### PR DESCRIPTION
Part of DOTDASH-343

## Proposed Changes

* Show empty "-" value for the connected domains
* Show "Attach site" CTA for domain only domains

## Why are these changes being made?

* DOTDASH-343

## Testing Instructions

* Go to `/v2/domains`
* Check the Site column

<img width="1361" height="417" alt="Screenshot 2025-09-17 at 18 13 01" src="https://github.com/user-attachments/assets/ea19e0c2-5c2b-4eb5-abab-9e8a5e378f81" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
