### PR TITLE
Notification Settings: Fix use notice deletion

### DIFF
--- a/client/dashboard/me/notifications-emails/pause-all-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/pause-all-emails/index.tsx
@@ -8,9 +8,10 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect, useCallback } from 'react';
-import { useNotice } from '../../../app/hooks/use-notice';
 import { ConfirmationModal } from './confirmation-modal';
 
 const isAllWpcomEmailsDisabled = ( settings: UserSettings ) => {
@@ -19,7 +20,8 @@ const isAllWpcomEmailsDisabled = ( settings: UserSettings ) => {
 
 export const PauseAllEmails = () => {
 	const { data: settings } = useSuspenseQuery( userSettingsQuery() );
-	const { createSuccessNotice } = useNotice();
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
 	const {
 		mutate: updateSettings,
 		isPending: isSaving,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

The [PR](https://github.com/Automattic/wp-calypso/pull/105784) removed the useNotice hook, but due to an unknown reason, the git auto-merge flow kept it, causing a crash on the pipeline


## Proposed Changes

* Remove reference to use-notice hook

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
