### PR TITLE
MCP: update account MCP settings structure

### DIFF
--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -23,6 +23,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { hasEnabledAccountTools } from './utils';
 
 function McpSetupComponent( { path, userSettings } ) {
 	const translate = useTranslate();
@@ -131,10 +132,8 @@ function McpSetupComponent( { path, userSettings } ) {
 		}
 	};
 
-	// Check if any tools are enabled
-	const hasEnabledTools =
-		userSettings?.mcp_abilities &&
-		Object.values( userSettings.mcp_abilities ).some( ( tool ) => tool.enabled );
+	// Check if any account-level tools are enabled using the new nested structure
+	const hasEnabledTools = hasEnabledAccountTools( userSettings );
 
 	if ( ! isAutomattician ) {
 		return null;

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -1,0 +1,55 @@
+/**
+ * Get account-level MCP abilities from user settings
+ * This is for the /me/mcp route which manages account-level settings
+ */
+export function getAccountMcpAbilities( userSettings ) {
+	const mcpData = userSettings?.mcp_abilities;
+
+	if ( ! mcpData ) {
+		return {};
+	}
+
+	// For account-level settings, we want to get the account-level abilities
+	// If account-level abilities don't exist, fall back to the old flat structure for backward compatibility
+	if ( mcpData.account ) {
+		return mcpData.account;
+	}
+
+	// Backward compatibility: if mcp_abilities is a flat object (old structure),
+	// treat it as account-level abilities
+	if ( typeof mcpData === 'object' && ! mcpData.site && ! mcpData.sites ) {
+		return mcpData;
+	}
+
+	return {};
+}
+
+/**
+ * Create API payload for account-level MCP abilities updates
+ * This creates the new nested structure for account-level settings
+ */
+export function createAccountApiPayload( userSettings, abilities ) {
+	// Convert abilities to the format expected by the API (1/0 instead of boolean)
+	const accountAbilities = {};
+	Object.entries( abilities ).forEach( ( [ toolId, tool ] ) => {
+		// Handle both old structure (tool.enabled) and new structure (tool is just 1/0)
+		const enabled = typeof tool === 'object' ? tool.enabled : tool === 1;
+		accountAbilities[ toolId ] = enabled ? 1 : 0;
+	} );
+
+	// For account-level settings, we only send the account section
+	// This matches the pattern from the site settings PR
+	return {
+		mcp_abilities: {
+			account: accountAbilities,
+		},
+	};
+}
+
+/**
+ * Check if any account-level tools are enabled
+ */
+export function hasEnabledAccountTools( userSettings ) {
+	const abilities = getAccountMcpAbilities( userSettings );
+	return Object.values( abilities ).some( ( tool ) => tool.enabled );
+}

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -28,6 +28,7 @@ export async function updateUserSettings(
 		'p2_disable_autofollow_on_comment',
 		'two_step_sms_country',
 		'two_step_sms_phone_number',
+		'mcp_abilities',
 	];
 	const payload = Object.fromEntries(
 		saveableKeys.filter( ( key ) => key in data ).map( ( key ) => [ key, data[ key ] ] )

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -33,4 +33,5 @@ export interface UserSettings {
 	subscription_delivery_hour: number;
 	subscription_delivery_jabber_default: boolean;
 	p2_disable_autofollow_on_comment: boolean;
+	mcp_abilities?: any;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AIINT-117/add-mcp-settings-page-to-wp-calypso

Account-level MCP settings now use the new nested API structure (`mcp_abilities.account`) while maintaining backward compatibility with existing flat structure.

## Proposed Changes

1. **Created `/client/me/mcp/utils.js`** - Added helper functions for account-level MCP abilities management with backward compatibility

2. **Updated `/client/me/mcp/main.jsx`** - Migrated from direct `userSettings.mcp_abilities` access to new nested structure using `getAccountMcpAbilities()` and `createAccountApiPayload()`

3. **Updated `/client/me/mcp/setup.jsx`** - Changed tool detection to use `hasEnabledAccountTools()` for the new nested structure

4. **Added `mcp_abilities` to API-Core** - Updated `/packages/api-core/src/me-settings/types.ts` and `mutators.ts` to support the new field in `/me/settings` endpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
