### PR TITLE
Do not show "Skip purchase" button as busy when selecting domain

### DIFF
--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -88,7 +88,7 @@ const DomainSearchSkipSuggestion = ( {
 					label={ sprintf( __( 'Skip purchase and continue with %(domain)s' ), { domain } ) }
 					onClick={ onSkip }
 					disabled={ disabled }
-					isBusy={ isBusy }
+					isBusy={ isBusy && ! disabled }
 					__next40pxDefaultSize
 				>
 					{ __( 'Skip purchase' ) }


### PR DESCRIPTION
Closes [DOMAINS-1656](https://linear.app/a8c/issue/DOMAINS-1656)

## Proposed Changes

This PR updates the "Skip purchase" button shown in the domain step in onboarding to not be in the "busy" animation when a user selects a domain to purchase.

## Why are these changes being made?

It's a little weird for the "Skip purchase" button to be busy when a user selects a domain. Now it shows as disabled when a domain is selected.

## Demo

- Before

https://github.com/user-attachments/assets/21b0205f-f092-4695-9b1d-d2f6014d15dd 

- After
 
https://github.com/user-attachments/assets/60e121e7-0791-4e30-b5cb-416b93af508a

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/setup`
- Do a domain search and select any of the suggestions
- Ensure the "Skip purchase" button is disabled and not busy, as in the demo recording

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
