### PR TITLE
Hosting Dashboard: Fix 500 when sorting domains by "Primary".

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -43,7 +43,8 @@ export const useFields = ( {
 			{
 				id: 'is_primary_domain',
 				label: __( 'Primary' ),
-				getValue: ( { item }: { item: DomainSummary } ) => item.primary_domain,
+				getValue: ( { item }: { item: DomainSummary } ) =>
+					item.primary_domain ? __( 'Primary' ) : '',
 				render: ( { field, item } ) =>
 					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : <IneligibleIndicator />,
 			},

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -43,8 +43,15 @@ export const useFields = ( {
 			{
 				id: 'is_primary_domain',
 				label: __( 'Primary' ),
-				getValue: ( { item }: { item: DomainSummary } ) =>
-					item.primary_domain ? __( 'Primary' ) : '',
+				getValue: ( { item }: { item: DomainSummary } ) => item.primary_domain,
+				sort: ( a, b, direction ) => {
+					if ( a.primary_domain === b.primary_domain ) {
+						return 0;
+					}
+
+					const factor = direction === 'asc' ? 1 : -1;
+					return a.primary_domain ? -1 * factor : 1 * factor;
+				},
 				render: ( { field, item } ) =>
 					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : <IneligibleIndicator />,
 			},


### PR DESCRIPTION
Fixes DOTDASH-485

## Proposed Changes
Add a new sort function.

Currently, it will throw a 500 error because we are returning a Boolean for the value.


## Testing Instructions
* Visit `/v2/sites/{domain}/domains`
* Click "gear" icon
* Select "Primary" in the dropdown
* Click an arrow icon beside the dropdown

Repeat on `v2/domains`, which also includes a domain list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
