### PR TITLE
Hosting Dashboard: Hide overflow from SitePreview in sites list.

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -124,7 +124,13 @@ export function Preview( { site }: { site: Site } ) {
 		<Link
 			to={ getSiteManagementUrl( site ) }
 			disabled={ site.is_deleted }
-			style={ { display: 'block', height: '100%', width: '100%' } }
+			style={ {
+				display: 'block',
+				height: '100%',
+				width: '100%',
+				borderRadius: 'inherit',
+				overflow: 'hidden',
+			} }
 		>
 			{ resizeListener }
 			{ iframeDisabled && (


### PR DESCRIPTION
Fixes DOTCOM-14607.

## Proposed Changes

Update styles to make sure the iframe doesn't overflow it's `<Link>` component by adding `borderRadius: inherit` and `overflow: hidden`. 

## Why are these changes being made?

Gutenberg `<DataViews />` add a border radius to `dataviews-view-grid__media` but don't hide it's overflow. Because of that, our iframes in the site list are escaping the container. 

| Before | After |
|--------|--------|
| <img width="566" height="703" alt="Screenshot 2025-09-18 at 9 26 29 AM" src="https://github.com/user-attachments/assets/4c0430da-aabe-4746-866f-8225de916ddf" /> | <img width="558" height="675" alt="Screenshot 2025-09-18 at 9 26 04 AM" src="https://github.com/user-attachments/assets/fe160344-f96a-41c4-a683-0ae1100c98ab" /> |
| <img width="1383" height="467" alt="Screenshot 2025-09-18 at 9 24 43 AM" src="https://github.com/user-attachments/assets/8ba21a95-c951-4baa-8f35-742ec0a04065" /> | <img width="1154" height="382" alt="Screenshot 2025-09-18 at 9 25 31 AM" src="https://github.com/user-attachments/assets/88c80b5e-c58d-4840-8a87-da5d01d51448" /> | 

## Considerations

Why not update Gutenberg? 

There are legitimate reasons why `overflow: hidden` is excluded from `dataviews-view-grid__media`. One specific use case would be tooltips or anything on hover.  We wouldn't want to clip those.

We currently don't have any of that functionality, so it feels ok to do this.

## Testing Instructions

* Visits you site list (/sites, v2/sites),
* Expect the corners of your Site Preview to appear round.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
