### PR TITLE
Hosting Dashboard: Switch to support link in WordPress version setting.

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -616,6 +616,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/wordpress-com-secure-sign-on-sso/',
 		post_id: 175831,
 	},
+	'switch-to-staging-site': {
+		link: 'https://wordpress.com/support/check-your-wordpress-version/#switch-to-a-previous-or-future-version-of-wordpress',
+		post_id: 225525,
+	},
 };
 
 export default contextLinks;

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -17,6 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
+import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -118,11 +119,10 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 						<Text as="p">
 							{ createInterpolateElement(
 								__(
-									'Switch to a <a>staging site</a> to test a beta version of the next WordPress release.'
+									'Switch to a staging site to test a beta version of the next WordPress release. <a>Learn more</a>'
 								),
 								{
-									// TODO: use correct v2 staging site URL when it's available.
-									a: <a href={ `/staging-site/${ site.slug }` } />,
+									a: <InlineSupportLink supportContext="switch-to-staging-site" />,
 								}
 							) }
 						</Text>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -119,10 +119,10 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 						<Text as="p">
 							{ createInterpolateElement(
 								__(
-									'Switch to a staging site to test a beta version of the next WordPress release. <a>Learn more</a>'
+									'Switch to a staging site to test a beta version of the next WordPress release. <learnMore>Learn more</learnMore>'
 								),
 								{
-									a: <InlineSupportLink supportContext="switch-to-staging-site" />,
+									learnMore: <InlineSupportLink supportContext="switch-to-staging-site" />,
 								}
 							) }
 						</Text>


### PR DESCRIPTION
Fixes: DOTCOM-14606

## Proposed Changes

Update the staging sites link on `v2/sites/{domain}/settings/wordpress` to open the help center instead of linking to the staging sites list.

## Why are these changes being made?

As we turn on the beta for the new Hosting Dashboard, users who are using the new dashboard don't have access to the old staging sites list on the current Hosting Dashboard (V1). In the new Hosting Dashboard, there currently isn't an equivalent.

We discussed (p1758156982485629-slack-CRWCHQGUB) whether we should keep both experiences and decided to move ahead with this one. It isn't a well used flow and handling two experiences is probably not necessary. 

## Screenshot

**Hosting Dashboard V2**
| Screenshot | 
|--------|
| ![Screen Capture on 2025-09-18 at 10-07-52](https://github.com/user-attachments/assets/0ce0e7de-1805-428b-9406-9a79a4659b3f) |

**Hosting Dashboard V1**
| Before | After |
|--------|--------|
| ![Screen Capture on 2025-09-18 at 12-59-21](https://github.com/user-attachments/assets/df5127f3-b82c-4d62-9aa1-5bd455f3c632) | ![Screen Capture on 2025-09-18 at 13-01-38](https://github.com/user-attachments/assets/127229c3-c09b-4c26-9169-333f4491c5f9) |





## Testing Instructions

* Navgiate to `v2/sites/{domain}/settings/wordpress`, click "Learn more"
* It should open the Help Center for https://wordpress.com/support/check-your-wordpress-version/#switch-to-a-previous-or-future-version-of-wordpress

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?