### PR TITLE
Site overview: show Subscribers card for self-hosted sites

### DIFF
--- a/client/dashboard/sites/overview-subscribers-card/index.tsx
+++ b/client/dashboard/sites/overview-subscribers-card/index.tsx
@@ -1,0 +1,18 @@
+import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import OverviewCard from '../overview-card';
+import type { Site } from '@automattic/api-core';
+
+export default function SubscribersCard( { site }: { site: Site } ) {
+	return (
+		<OverviewCard
+			icon={ people }
+			title={ __( 'Subscribers' ) }
+			heading={ site.subscribers_count }
+			description={ __( 'Total subscribers.' ) }
+			externalLink={ `https://cloud.jetpack.com/subscribers/${ site.slug }` }
+			intent="success"
+			tracksId="subscribers"
+		/>
+	);
+}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { chartBar, wordpress } from '@wordpress/icons';
+import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -17,7 +17,6 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
-import OverviewCard from '../overview-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
 import DomainsCard from '../overview-domains-card';
 import LatestActivityCard from '../overview-latest-activity-card';
@@ -28,6 +27,7 @@ import ScanCard from '../overview-scan-card';
 import SiteActionMenu from '../overview-site-action-menu';
 import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
+import SubscribersCard from '../overview-subscribers-card';
 import VisibilityCard from '../overview-visibility-card';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
@@ -129,15 +129,7 @@ function SiteOverview( {
 								return <AgencySiteShareCard site={ site } />;
 							}
 							if ( isSelfHostedJetpackConnected( site ) ) {
-								return (
-									<OverviewCard
-										title="TBA"
-										icon={ chartBar }
-										heading="TBA"
-										description="TBA"
-										disabled
-									/>
-								);
+								return <SubscribersCard site={ site } />;
 							}
 							if ( site.plan?.is_free && ! site.is_wpcom_staging_site ) {
 								return <MigrateSiteCard site={ site } />;


### PR DESCRIPTION
Fixes DSGCOM-263

This PR replaces the "TBA" card in self hosted sites' Overview page with a Subscribers card.

The card will link to Jetpack Cloud (`https://cloud.jetpack.com/subscribers/:siteSlug`).

## Proposed Changes

### Before

<img width="1012" height="313" alt="image" src="https://github.com/user-attachments/assets/57d94d60-a6f4-429a-aeb3-7bc4f9ec41d7" />

### After

<img width="1011" height="316" alt="image" src="https://github.com/user-attachments/assets/27a8ad12-3402-4b11-a380-54609bb9ee8b" />

### Caveats

- For new sites, the subscriber is 1 already, but if I go to the corresponding Jetpack Cloud page, there are no subscribers. I wonder why? Maybe the current admins are counted? In any case, if this needs fixing, I believe we need to fix it in backend side...
- @lucasmendes-design I'm not totally sure about the copy `Total subscribers.`. I added a full stop (`.`) to align with all other copy, but in this case it's not a full sentence, so it looks kinda weird.

## Testing Instructions

Go to `/v2/sites/:slug` of a self-hosted Jetpack site (e.g. Jurassic Ninja); verify you see the card as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
