### PR TITLE
Site overview: don't show domains card for self-hosted sites

### DIFF
--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -88,6 +88,8 @@ function SiteOverview( {
 		isSmallViewport,
 	} );
 
+	const isSelfHostedJetpackConnectedSite = isSelfHostedJetpackConnected( site );
+
 	return (
 		<PageLayout
 			header={
@@ -128,7 +130,7 @@ function SiteOverview( {
 							if ( site.is_a4a_dev_site ) {
 								return <AgencySiteShareCard site={ site } />;
 							}
-							if ( isSelfHostedJetpackConnected( site ) ) {
+							if ( isSelfHostedJetpackConnectedSite ) {
 								return <SubscribersCard site={ site } />;
 							}
 							if ( site.plan?.is_free && ! site.is_wpcom_staging_site ) {
@@ -152,10 +154,12 @@ function SiteOverview( {
 					alignment="flex-start"
 				>
 					<LatestActivityCard site={ site } isCompact={ isSmallViewport } />
-					<VStack spacing={ spacing } justify="start">
-						<DomainsCard site={ site } isCompact={ isSmallViewport } />
-						<DIFMUpsellCard site={ site } />
-					</VStack>
+					{ ! isSelfHostedJetpackConnectedSite && (
+						<VStack spacing={ spacing } justify="start">
+							<DomainsCard site={ site } isCompact={ isSmallViewport } />
+							<DIFMUpsellCard site={ site } />
+						</VStack>
+					) }
 				</HStack>
 			</VStack>
 		</PageLayout>


### PR DESCRIPTION
Context: pgz0xU-cR-p2#comment-186

## Proposed Changes

This PR removes domain-related cards from self-hosted sites' Overview page.

### Before

<img width="1360" height="881" alt="image" src="https://github.com/user-attachments/assets/082ba9d9-b3fa-41f9-ad18-6acd4481b4b1" />


### After

<img width="1366" height="888" alt="image" src="https://github.com/user-attachments/assets/82db494f-d872-490d-af40-fca140518bda" />

### Caveat

The latest activity card is a bit longer now... we can follow-up with this later if needed.

## Why this change is made

It's because clicking on any CTAs will lead in a broken page:

<img width="500" height="804" alt="image" src="https://github.com/user-attachments/assets/90d2af14-21de-4dc0-bea7-de2ca4dfdc5b" />


## Testing Instructions

Go to `/v2/sites/:slug` of a self-hosted site, verify you don't see the domain card as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?