### PR TITLE
Hosting Dashboard: Fix PageHeader layout on mobile viewports.

### DIFF
--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
@@ -25,6 +26,9 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const Stack = isMobileViewport ? VStack : HStack;
+
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }
@@ -36,20 +40,24 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 3 }>
+				<Stack
+					justify="space-between"
+					alignment={ isMobileViewport ? 'flex-start' : 'center' }
+					spacing={ 3 }
+				>
 					<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 						{ title }
 					</HeadingTag>
 					{ /* The wrapper is always needed for view transitions. */ }
 					<ButtonStack
-						justify="flex-end"
+						justify={ isMobileViewport ? 'flex-start' : 'center' }
 						expanded={ false }
 						alignment="center"
 						className="dashboard-section-header__actions"
 					>
 						{ actions }
 					</ButtonStack>
-				</HStack>
+				</Stack>
 			</HStack>
 			{ description && (
 				<Text variant="muted" className="dashboard-section-header__description">

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -28,7 +28,6 @@ export const SectionHeader = ( {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const Stack = isMobileViewport ? VStack : HStack;
-
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }


### PR DESCRIPTION
Fixes: DOTCOM-14593

## Proposed Changes

On mobile, use a vertical stack for the header + actions.

## Why are these changes being made?

On mobile the actions are overlayed on the header.

## Screenshots

| Before | After |
|--------|--------|
| <img width="800" height="1694" alt="calypso localhost_3000_v2_sites_abstracting blog_monitoring" src="https://github.com/user-attachments/assets/5207a439-8ca8-4593-9ed6-926dfb37e50e" /> | <img width="800" height="1694" alt="calypso localhost_3000_v2_sites_abstracting blog" src="https://github.com/user-attachments/assets/5a5cd77b-7f5d-40ac-b5bc-c54b93462944" /> |
| <img width="800" height="1694" alt="calypso localhost_3000_v2_sites_abstracting blog_monitoring (1)" src="https://github.com/user-attachments/assets/62dba715-ca1e-4dd2-b78b-02071ff693b2" />  | <img width="800" height="1694" alt="calypso localhost_3000_v2_sites_abstracting blog (1)" src="https://github.com/user-attachments/assets/66850fa7-b295-4562-820a-e71d2aa47689" /> |


## Considerations

- The `<HStack>` has a [direction](https://developer.wordpress.org/block-editor/reference-guides/components/h-stack/#direction) property that we could set to `column` turning the `<HStack>` to a `<VStack>`. I chose just set the stack type to a variable because its easier to read for me. I can easily be convinced otherwise.
- The spacing between the header and the actions is smaller in the designs. That is due to the line-height and font-size of the `<h1>`. 

We'll address that in a future PR.

Designs: QOBjujZah0UlGDDdLKZhzi-fi-5807_154783

| Designs| Current |
|--------|--------|
| <img width="401" height="201" alt="Screenshot 2025-09-18 at 1 39 34 PM" src="https://github.com/user-attachments/assets/5e16c230-1ddc-4fad-94cb-c8f91fb6a220" /> |  <img width="395" height="217" alt="Screenshot 2025-09-18 at 1 40 54 PM" src="https://github.com/user-attachments/assets/649de956-3109-449d-be4c-cd69e9591b0b" /> | 

## Testing Instructions

- Visit your site overview and deployments on mobile. Expect the layout to stack.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?