### PR TITLE
Update/hd scan threats info

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -1,7 +1,16 @@
-import { Icon } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	Icon,
+	Button,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
+import { ButtonStack } from '../../../components/button-stack';
+import { Notice } from '../../../components/notice';
+import { ThreatDescription } from '../../scan/components/threat-description';
+import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions(): Action< Threat >[] {
@@ -13,13 +22,24 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Fix threat' ),
 			modalHeader: __( 'Fix threat' ),
 			supportsBulk: true,
-			// @TODO: render the proper fix modal
-			RenderModal: ( { items } ) => {
-				if ( items.length > 1 ) {
-					return <p>Fix threats { items.map( ( threat ) => threat.id ).join( ', ' ) }</p>;
-				}
+			RenderModal: ( { items, closeModal } ) => {
+				const fixButtonLabel = items.length === 1 ? __( 'Fix threat' ) : __( 'Fix all threats' );
+				return (
+					<VStack spacing={ 4 }>
+						<Text variant="muted">{ __( 'Jetpack will be fixing the following threats:' ) }</Text>
+						<ThreatsDetailCard threats={ items } />
 
-				return <p>Fix threat #{ items[ 0 ].id }</p>;
+						{ items.length === 1 && <ThreatDescription threat={ items[ 0 ] } /> }
+
+						<ButtonStack justify="flex-end">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel' ) }
+							</Button>
+							{ /* @TODO: implement the auto-fix threat action */ }
+							<Button variant="primary">{ fixButtonLabel }</Button>
+						</ButtonStack>
+					</VStack>
+				);
 			},
 			isEligible: ( threat: Threat ) => !! threat.fixable,
 		},
@@ -28,8 +48,26 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Ignore threat' ),
 			modalHeader: __( 'Ignore threat' ),
 			supportsBulk: false,
-			// @TODO: render the proper ignore modal
-			RenderModal: ( { items } ) => <p>Ignore threat { items[ 0 ].id }</p>,
+			RenderModal: ( { items, closeModal } ) => {
+				return (
+					<VStack spacing={ 4 }>
+						<Text variant="muted">{ __( 'Jetpack will ignore the following threat:' ) }</Text>
+						<ThreatsDetailCard threats={ items } />
+						<Notice variant="error">
+							{ __(
+								'By ignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site. If you are unsure please request an estimate with Codeable.'
+							) }
+						</Notice>
+						<ButtonStack justify="flex-end">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel' ) }
+							</Button>
+							{ /* @TODO: implement the ignore threat action */ }
+							<Button variant="primary">{ __( 'Ignore threat' ) }</Button>
+						</ButtonStack>
+					</VStack>
+				);
+			},
 		},
 		{
 			id: 'view_details',
@@ -38,18 +76,6 @@ export function getActions(): Action< Threat >[] {
 			supportsBulk: false,
 			// @TODO: render the proper details modal
 			RenderModal: ( { items } ) => <p>Details of thread { items[ 0 ].id }</p>,
-		},
-		{
-			id: 'view_source',
-			label: __( 'View vulnerability source' ),
-			supportsBulk: false,
-			callback: ( items: Threat[] ) => {
-				const threat = items[ 0 ];
-				if ( threat.source ) {
-					window.open( threat.source, '_blank' );
-				}
-			},
-			isEligible: ( threat: Threat ) => !! threat.source,
 		},
 	];
 }

--- a/client/dashboard/sites/scan/components/threat-description.tsx
+++ b/client/dashboard/sites/scan/components/threat-description.tsx
@@ -1,0 +1,202 @@
+import { Threat } from '@automattic/api-core';
+import {
+	ExternalLink,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+export function ThreatDescription( { threat }: { threat: Threat } ) {
+	const isFixable = threat.fixable && threat.status === 'current';
+
+	const renderFixTitle = () => {
+		switch ( threat.status ) {
+			case 'fixed':
+				return __( 'How did Jetpack fix it?' );
+			case 'current':
+				if ( isFixable ) {
+					return __( 'How will we fix it?' );
+				}
+				return __( 'How to resolve or handle this detection?' );
+			default:
+				return __( 'How we will fix it?' );
+		}
+	};
+
+	const renderFilename = () => {
+		const { filename } = threat;
+		if ( ! filename ) {
+			return null;
+		}
+
+		return (
+			<>
+				<Text>
+					{
+						/* translators: filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`" */
+						__( 'Threat found in file:' )
+					}
+				</Text>
+				<Text as="pre">{ filename }</Text>
+			</>
+		);
+	};
+
+	const renderDatabaseRows = () => {
+		const { table, details, pk_column, value } = threat;
+
+		if ( ! table || ! details ) {
+			return null;
+		}
+
+		const row = {
+			table,
+			primary_key_column: pk_column,
+			primary_key_value: value,
+			details,
+		};
+		const content = JSON.stringify( row, null, ' \t' ) + '\n';
+
+		return (
+			<>
+				<Text>
+					{ sprintf(
+						/* translators: %s: table name */
+						__( 'Threat found in the table %s, in the following rows:' ),
+						table
+					) }
+				</Text>
+				<Text as="pre">{ content }</Text>
+			</>
+		);
+	};
+
+	const getThreatFix = () => {
+		const { fixable } = threat;
+
+		if ( ! fixable ) {
+			return null;
+		}
+
+		switch ( fixable.fixer ) {
+			case 'replace':
+				return __( 'Jetpack Scan will replace the affected file or directory.' );
+			case 'delete':
+				return __( 'Jetpack Scan will delete the affected file or directory.' );
+			case 'update':
+				if ( fixable.target ) {
+					return sprintf(
+						/** translators: %s: version */
+						__( 'Jetpack Scan will update to a newer version (%s).' ),
+						fixable.target
+					);
+				}
+				return __( 'Jetpack Scan will update to a newer version.' );
+			case 'edit':
+				return __( 'Jetpack Scan will edit the affected file or directory.' );
+			case 'rollback':
+				if ( fixable.target ) {
+					return sprintf(
+						/** translators: %s: version */
+						__( 'Jetpack Scan will rollback the affected file to the version from %s.' ),
+						fixable.target
+					);
+				}
+				return __( 'Jetpack Scan will rollback the affected file to an older (clean) version.' );
+			default:
+				return __( 'Jetpack Scan will resolve the threat.' );
+		}
+	};
+
+	const renderFix = () => {
+		if ( threat.status === 'fixed' ) {
+			return;
+		}
+
+		if ( ! threat.fixable ) {
+			return (
+				<>
+					{ ! threat.rows && (
+						<Text>
+							{ __(
+								'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
+									'ensure that WordPress, your theme, and all of your plugins are up to date, and remove ' +
+									'the offending code, theme, or plugin from your site.'
+							) }
+						</Text>
+					) }
+					{ threat.rows && (
+						<Text>
+							{ __(
+								'Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ' +
+									'ensure that WordPress, your theme, and all of your plugins are up to date, and remove or edit ' +
+									'the offending post from your site.'
+							) }
+						</Text>
+					) }
+					{ 'current' === threat.status && (
+						<Text>
+							{ createInterpolateElement(
+								__(
+									'If you need more help to resolve this threat, we recommend <codeable />, a trusted freelancer marketplace of highly vetted WordPress experts. ' +
+										'They have identified a select group of security experts to help with these projects. ' +
+										'Pricing ranges from $70–120/hour, and you can get a free estimate with no obligation to hire.'
+								),
+								{
+									codeable: <Text weight={ 400 }>Codeable</Text>,
+								}
+							) }
+						</Text>
+					) }
+				</>
+			);
+		}
+
+		return (
+			<>
+				<Text>
+					{ __(
+						'Jetpack Scan is able to automatically fix this threat for you. Since it will replace the affected file or directory the site’s look-and-feel or features can be compromised. We recommend that you check if your latest backup was performed successfully in case a restore is needed.'
+					) }
+				</Text>
+				<Text>{ getThreatFix() }</Text>
+			</>
+		);
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text size="large" weight={ 500 }>
+				{ __( 'What did Jetpack find?' ) }
+			</Text>
+			<Text>{ threat.description }</Text>
+			{ threat.payload_description && <Text>{ threat.payload_description }</Text> }
+			{ threat.source && (
+				<ExternalLink href={ threat.source }>
+					{ __( 'Learn more about this vulnerability' ) }
+				</ExternalLink>
+			) }
+			{ ( threat.filename || threat.context || threat.diff || threat.rows ) && (
+				<Text weight={ 500 }>{ __( 'The technical details' ) }</Text>
+			) }
+			{ renderFilename() }
+			{ renderDatabaseRows() }
+			{ threat.context && (
+				/* @TODO: Maybe use MarkedLines component */
+				<Text as="pre">
+					{ Object.entries( threat.context )
+						.filter( ( [ key ] ) => ! isNaN( Number( key ) ) )
+						.map( ( [ , value ] ) => value )
+						.join( '\n' ) }
+				</Text>
+			) }
+			{ threat.fixable && (
+				<Text size="large" weight={ 500 }>
+					{ renderFixTitle() }
+				</Text>
+			) }
+			{ threat.fixable && renderFix() }
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/scan/components/threats-detail-card.tsx
+++ b/client/dashboard/sites/scan/components/threats-detail-card.tsx
@@ -1,0 +1,48 @@
+import {
+	Card,
+	CardBody,
+	CardDivider,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { SeverityBadge } from '../severity-badge';
+import { getThreatIcon } from '../utils';
+import type { Threat } from '@automattic/api-core';
+
+export function ThreatsDetailCard( { threats }: { threats: Threat[] } ) {
+	const ThreatDetail = ( { threat }: { threat: Threat } ) => {
+		return (
+			<HStack justify="space-between">
+				<HStack justify="flex-start" alignment="center" spacing={ 4 }>
+					<Icon
+						className="site-scan-threats__type-icon"
+						icon={ getThreatIcon( threat ) }
+						size={ 32 }
+						style={ { flexShrink: 0 } }
+					/>
+					<VStack justify="flex-start" spacing={ 1 } wrap>
+						<Text weight={ 500 }>{ threat.vulnerability_description }</Text>
+						<Text variant="muted">{ threat.title }</Text>
+					</VStack>
+				</HStack>
+				<SeverityBadge severity={ threat.severity } />
+			</HStack>
+		);
+	};
+
+	return (
+		<Card>
+			{ threats.map( ( threat, index ) => (
+				<>
+					<CardBody>
+						<ThreatDetail key={ threat.id } threat={ threat } />
+					</CardBody>
+
+					{ index < threats.length - 1 && <CardDivider /> }
+				</>
+			) ) }
+		</Card>
+	);
+}

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -28,5 +28,9 @@ export const getSeverityIntent = ( severity: number ): 'default' | 'error' | 'wa
 export const SeverityBadge = ( { severity }: { severity: number } ) => {
 	const intent = getSeverityIntent( severity );
 	const label = getSeverityLabel( severity );
-	return <Badge intent={ intent }>{ label }</Badge>;
+	return (
+		<Badge intent={ intent } style={ { flexShrink: 0 } }>
+			{ label }
+		</Badge>
+	);
 };

--- a/packages/api-core/src/site-scan/types.ts
+++ b/packages/api-core/src/site-scan/types.ts
@@ -1,5 +1,5 @@
 export interface ThreatFixer {
-	fixer: 'update' | 'delete';
+	fixer: 'update' | 'delete' | 'replace' | 'edit' | 'rollback' | string;
 	target?: string;
 	file?: string;
 	extensionStatus?: 'active' | 'inactive';
@@ -31,7 +31,7 @@ export interface Threat {
 	fixer?: ThreatFixer | null;
 	fixed_on?: string;
 	status: 'current' | 'fixed' | 'ignored';
-	fixable?: ThreatFixer | boolean;
+	fixable?: ThreatFixer;
 	extension?: ThreatExtension;
 	source?: string;
 	filename?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
