### PR TITLE
Site Logs: Hide un-implemented log filters, which appear broken to the user

### DIFF
--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -43,13 +43,14 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 		siteGmtOffset === 0 ? 'UTC' : `UTC${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
 
 	const getFormattedDate = useMemo(
-		() => ( value: string ) => {
-			const dateFormat = locale === 'en' ? 'll [at] h:mm A' : 'h:mm A, ll';
-			const formattedDate = moment( value )
-				.utcOffset( siteGmtOffset * 60 )
-				.format( dateFormat );
-			return <span>{ formattedDate }</span>;
-		},
+		() =>
+			function FormattedDate( value: string ) {
+				const dateFormat = locale === 'en' ? 'll [at] h:mm A' : 'h:mm A, ll';
+				const formattedDate = moment( value )
+					.utcOffset( siteGmtOffset * 60 )
+					.format( dateFormat );
+				return <span>{ formattedDate }</span>;
+			},
 		[ locale, siteGmtOffset ]
 	);
 

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -64,6 +64,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					label: translate( 'Date & time (%(siteGsmOffsetDisplay)s)', {
 						args: { siteGsmOffsetDisplay },
 					} ),
+					filterBy: false,
 					render: ( { item }: { item: PHPLog } ) => getFormattedDate( item.timestamp ),
 					enableHiding: false,
 				},
@@ -85,6 +86,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					id: 'message',
 					type: 'text',
 					label: translate( 'Message' ),
+					filterBy: false,
 					render: ( { item }: { item: PHPLog } ) => {
 						return <span className="site-logs-table__message">{ item.message }</span>;
 					},
@@ -94,12 +96,14 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					id: 'kind',
 					type: 'text',
 					label: translate( 'Group' ),
+					filterBy: false,
 					enableSorting: false,
 				},
 				{
 					id: 'name',
 					type: 'text',
 					label: translate( 'Source' ),
+					filterBy: false,
 					render: ( { item }: { item: PHPLog } ) => {
 						return <span className="site-logs-table__name">{ item.name }</span>;
 					},
@@ -109,6 +113,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					id: 'file',
 					type: 'text',
 					label: translate( 'File' ),
+					filterBy: false,
 					render: ( { item }: { item: PHPLog } ) => {
 						return <span className="site-logs-table__file">{ item.file }</span>;
 					},
@@ -118,6 +123,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					id: 'line',
 					type: 'integer',
 					label: translate( 'Line' ),
+					filterBy: false,
 					render: ( { item }: { item: PHPLog } ) => formatNumber( item.line ),
 					enableSorting: false,
 				},
@@ -132,6 +138,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				label: translate( 'Date & time (%(siteGsmOffsetDisplay)s)', {
 					args: { siteGsmOffsetDisplay },
 				} ),
+				filterBy: false,
 				render: ( { item }: { item: ServerLog } ) => getFormattedDate( item.date ),
 				enableHiding: false,
 			},
@@ -163,6 +170,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				id: 'request_url',
 				type: 'text',
 				label: translate( 'Request URL' ),
+				filterBy: false,
 				render: ( { item }: { item: ServerLog } ) => {
 					return <span className="site-logs-table__request-url">{ item.request_url }</span>;
 				},
@@ -172,6 +180,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				id: 'body_bytes_sent',
 				type: 'integer',
 				label: translate( 'Body bytes sent' ),
+				filterBy: false,
 				render: ( { item }: { item: ServerLog } ) => formatNumber( item.body_bytes_sent ),
 				enableSorting: false,
 			},
@@ -188,11 +197,18 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					operators: [ 'isAny' as Operator ],
 				},
 			},
-			{ id: 'http_host', type: 'text', label: translate( 'HTTP Host' ), enableSorting: false },
+			{
+				id: 'http_host',
+				type: 'text',
+				label: translate( 'HTTP Host' ),
+				filterBy: false,
+				enableSorting: false,
+			},
 			{
 				id: 'http_referer',
 				type: 'text',
 				label: translate( 'HTTP Referrer' ),
+				filterBy: false,
 				render: ( { item }: { item: ServerLog } ) => {
 					return <span className="site-logs-table__http-referer">{ item.http_referer }</span>;
 				},
@@ -202,24 +218,28 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				id: 'http2',
 				type: 'text',
 				label: translate( 'HTTP/2' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'http_user_agent',
 				type: 'text',
 				label: translate( 'User Agent' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'http_version',
 				type: 'text',
 				label: translate( 'HTTP Version' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'http_x_forwarded_for',
 				type: 'text',
 				label: translate( 'X-Forwarded-For' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
@@ -239,31 +259,42 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				id: 'request_completion',
 				type: 'text',
 				label: translate( 'Request Completion' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'request_time',
 				type: 'text',
 				label: translate( 'Request Time' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'scheme',
 				type: 'text',
 				label: translate( 'Scheme' ),
+				filterBy: false,
 				enableSorting: false,
 			},
-			{ id: 'timestamp', type: 'integer', label: translate( 'Timestamp' ), enableSorting: false },
+			{
+				id: 'timestamp',
+				type: 'integer',
+				label: translate( 'Timestamp' ),
+				filterBy: false,
+				enableSorting: false,
+			},
 			{
 				id: 'type',
 				type: 'text',
 				label: translate( 'Type' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 			{
 				id: 'user_ip',
 				type: 'text',
 				label: translate( 'User IP' ),
+				filterBy: false,
 				enableSorting: false,
 			},
 		] as Field< PHPLog | ServerLog >[];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-388

## Proposed Changes

Hide PHP and web log filters that aren't implemented.
This is already working correctly in v2, but in v1, the logging interfaces are showing filters for each column even when the filtering functionality hasn't been implemented for those columns.

| PHP Before | PHP After |
| --- | --- |
| <img width="1512" height="954" alt="CleanShot 2025-09-18 at 18 07 51@2x" src="https://github.com/user-attachments/assets/7a137c83-77a8-4b92-a201-6a105600b99c" /> | <img width="1530" height="728" alt="CleanShot 2025-09-18 at 18 07 24@2x" src="https://github.com/user-attachments/assets/8e225135-742c-4cf2-87a0-e4a539ef6d50" /> |


| Web Before | Web After |
| --- | --- |
| <img width="1120" height="1548" alt="CleanShot 2025-09-18 at 18 07 58@2x" src="https://github.com/user-attachments/assets/88d9439f-fbdf-487d-aa57-4886a172c03f" /> | <img width="1832" height="858" alt="CleanShot 2025-09-18 at 18 07 33@2x" src="https://github.com/user-attachments/assets/a241874a-b35b-41ed-b0e1-bc145464e490" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It appears this bug was introduced in https://github.com/Automattic/wp-calypso/pull/103949. The `filterBy` field property went from being optional, to being "enabled unless explicitly disabled."

[This was noted in the `v5.0.0` release notes of the dataview](https://github.com/WordPress/gutenberg/blob/a9d31815cd66d2b4769cf79fd5c30a678cee4d2f/packages/dataviews/CHANGELOG.md?plain=1#L128), but I think it probably just fell through the cracks. It's from a time when we were using a fork of the dataviews package. So we weren't really carefully checking from breaking changes then.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Logs are testable at `/site-logs/{{ site slug }}/web`

Make sure to check web and php logs.

The fields that actually work can be seen [here](https://github.com/Automattic/wp-calypso/blob/a7fef72c2c30d54176a270aa261be6bf02338cb2/client/sites/logs/hooks/use-view.ts#L33). They are:
- For PHP
  - `severity`
- For web logs
  - `cached`
  - `request_type`
  - `status`
  - `renderer`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
