### PR TITLE
Plugins: Use universal header for the logged-in plugins on the global view

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -436,7 +436,11 @@ export default withCurrentRoute(
 				[ 'themes', 'theme' ].includes( sectionName ) ) ||
 			( config.isEnabled( 'plugins/universal-header' ) &&
 				! siteId &&
-				[ 'plugins' ].includes( sectionName ) );
+				[ 'plugins' ].includes( sectionName ) &&
+				! (
+					currentRoute.startsWith( '/plugins/manage' ) ||
+					currentRoute.startsWith( '/plugins/scheduled-updates' )
+				) );
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -431,9 +431,12 @@ export default withCurrentRoute(
 			( isCheckoutSection && hasGravatarDomainQueryParam( state ) );
 
 		const hasUniversalHeader =
-			config.isEnabled( 'themes/universal-header' ) &&
-			! siteId &&
-			[ 'themes', 'theme' ].includes( sectionName );
+			( config.isEnabled( 'themes/universal-header' ) &&
+				! siteId &&
+				[ 'themes', 'theme' ].includes( sectionName ) ) ||
+			( config.isEnabled( 'plugins/universal-header' ) &&
+				! siteId &&
+				[ 'plugins' ].includes( sectionName ) );
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -84,9 +84,10 @@ export default function SidebarItem( props ) {
 						</Badge>
 					) }
 				</span>
-				{ ( showAsExternal || props.forceShowExternalIcon ) && ! sidebarIsCollapsed && (
-					<Icon icon={ external } size={ 18 } />
-				) }
+				{ ( showAsExternal || props.forceShowExternalIcon ) &&
+					! ( sidebarIsCollapsed || props.sidebarIsCollapsed ) && (
+						<Icon icon={ external } size={ 18 } />
+					) }
 				{ props.forceChevronIcon && <Icon icon={ chevronRightSmall } size={ 24 } /> }
 				{ props.children }
 			</a>
@@ -112,4 +113,5 @@ SidebarItem.propTypes = {
 	tipTarget: PropTypes.string,
 	count: PropTypes.number,
 	badge: PropTypes.string,
+	sidebarIsCollapsed: PropTypes.bool,
 };

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -136,6 +136,10 @@ body.command-palette-modal-open {
 		.has-no-sidebar & {
 			padding-left: 0;
 		}
+
+		.is-section-plugins.has-no-sidebar.is-logged-in & {
+			padding: calc(var(--masterbar-height) + 1px) 0 0;
+		}
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -94,12 +94,14 @@ body.command-palette-modal-open {
 		}
 	}
 
-	.is-logged-in & {
+	.is-section-plugins.is-logged-in & {
 		// The plugins site view needs the header to be full width, so the padding
 		// is added on the header and .plugins-browser__content-wrapper instead
-		.is-section-plugins & {
-			padding: 47px 0 32px calc(var(--sidebar-width-max) + 1px);
-		}
+		padding: 47px 0 32px calc(var(--sidebar-width-max) + 1px);
+	}
+
+	.is-section-plugins.is-logged-in.has-no-sidebar & {
+		padding: 79px 32px 32px;
 	}
 
 	// Tablets
@@ -118,6 +120,10 @@ body.command-palette-modal-open {
 
 		.is-section-themes.has-no-sidebar.is-logged-in & {
 			padding: 47px 0 0;
+		}
+
+		.is-section-plugins.has-no-sidebar.is-logged-in & {
+			padding: 71px 24px 24px;
 		}
 	}
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -389,9 +389,14 @@ export function renderPluginsSidebar( context, next ) {
 	}
 
 	if ( ! siteUrl ) {
-		context.secondary = isEnabled( 'plugins/universal-header' ) ? null : (
-			<PluginsSidebar path={ context.path } />
-		);
+		context.secondary =
+			isEnabled( 'plugins/universal-header' ) &&
+			! (
+				context.path.startsWith( '/plugins/manage' ) ||
+				context.path.startsWith( '/plugins/scheduled-updates' )
+			) ? null : (
+				<PluginsSidebar path={ context.path } />
+			);
 	}
 
 	next();

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { includes, some } from 'lodash';
 import { createElement } from 'react';
@@ -388,7 +389,9 @@ export function renderPluginsSidebar( context, next ) {
 	}
 
 	if ( ! siteUrl ) {
-		context.secondary = <PluginsSidebar path={ context.path } />;
+		context.secondary = isEnabled( 'plugins/universal-header' ) ? null : (
+			<PluginsSidebar path={ context.path } />
+		);
 	}
 
 	next();

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -11,12 +11,15 @@ const PLUGIN_DETAILS_LINK_TYPES = {
 };
 
 const Container = styled( FoldableCard )`
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	width: 100%;
-	margin-bottom: 0;
-	box-shadow: none;
+	&& {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		width: 100%;
+		margin-bottom: 0;
+		box-shadow: none;
+	}
+
 	${ ( props ) => props.showAsAccordion && 'border-bottom: 1px solid #eeeeee' };
 	${ ( props ) => props.showAsAccordion && 'border-top: 1px solid var( --studio-gray-5)' };
 	${ ( props ) => props.showAsAccordion && props.first && 'border-top: 0' };

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -27,21 +27,18 @@
 	}
 }
 
-.plugins-browser-list__elements {
+.card.plugins-browser-list__elements {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	padding: 0;
+	// Card margin interferes with section spacing.
+	margin-bottom: 0;
 	box-shadow: none;
 	background: none;
 	gap: 0 18px;
 
 	&::after {
 		display: none;
-	}
-
-	&.card {
-		// Card margin interferes with section spacing.
-		margin-bottom: 0;
 	}
 }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -204,12 +204,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 							searchTerm={ search }
 							isSearching={ isFetchingPluginsBySearchTerm }
 							title={ __( 'Flex your site’s features with plugins' ) }
-							subtitle={
-								! isLoggedIn &&
-								__(
-									'Add new functionality and integrations to your site with thousands of plugins.'
-								)
-							}
+							subtitle={ __(
+								'Add new functionality and integrations to your site with thousands of plugins.'
+							) }
 							searchTerms={ searchTerms }
 							renderTitleInH1={ ! category }
 						/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -109,7 +109,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 		? category.charAt( 0 ).toUpperCase() + category.slice( 1 )
 		: __( 'Plugins' );
 	const categoryName = categories[ category ]?.menu || fallbackCategoryName;
-	const shouldUseLoggedOutView = isEnabled( 'plugins/universal-header' );
+	const shouldUseLoggedInView = isEnabled( 'plugins/universal-header' ) ? siteId : isLoggedIn;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
@@ -153,7 +153,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				'plugins-browser--site-view': !! selectedSite,
 			} ) }
 			wideLayout
-			isLoggedOut={ shouldUseLoggedOutView || ! isLoggedIn }
+			isLoggedOut={ ! shouldUseLoggedInView }
 		>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
@@ -182,7 +182,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
-				{ ! shouldUseLoggedOutView && isLoggedIn ? (
+				{ shouldUseLoggedInView ? (
 					<>
 						<div ref={ loggedInSearchBoxRef } />
 						<SearchCategories

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -108,6 +109,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 		? category.charAt( 0 ).toUpperCase() + category.slice( 1 )
 		: __( 'Plugins' );
 	const categoryName = categories[ category ]?.menu || fallbackCategoryName;
+	const shouldUseLoggedOutView = isEnabled( 'plugins/universal-header' );
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
@@ -151,7 +153,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				'plugins-browser--site-view': !! selectedSite,
 			} ) }
 			wideLayout
-			isLoggedOut={ ! isLoggedIn }
+			isLoggedOut={ shouldUseLoggedOutView || ! isLoggedIn }
 		>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
@@ -180,7 +182,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
-				{ isLoggedIn ? (
+				{ ! shouldUseLoggedOutView && isLoggedIn ? (
 					<>
 						<div ref={ loggedInSearchBoxRef } />
 						<SearchCategories

--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Icon, link, linkOff, trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { navigate } from 'calypso/lib/navigate';
@@ -45,9 +46,19 @@ export function useActions(
 			href: 'some-url',
 			callback: ( plugins: Array< Plugin > ) => {
 				recordIntentionEvent( plugins, 'manage-plugin' );
-				plugins.length && navigate( '/plugins/' + plugins[ 0 ].slug );
+				const pluginSlug = plugins?.[ 0 ]?.slug;
+				if ( pluginSlug ) {
+					const url = `/plugins/${ pluginSlug }`;
+					if ( isEnabled( 'plugins/universal-header' ) ) {
+						window.open( url, '_blank' );
+					} else {
+						navigate( url );
+					}
+				}
 			},
-			label: translate( 'Manage plugin' ),
+			label: isEnabled( 'plugins/universal-header' )
+				? translate( 'Manage plugin ↗' )
+				: translate( 'Manage plugin' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: false,

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -171,6 +171,11 @@
 			.layout__secondary ~ .layout__primary & {
 				left: calc(var(--sidebar-width-max) + 1px);
 				width: calc(100% - var(--sidebar-width-max) - 1px);
+
+				.has-no-sidebar & {
+					left: 0;
+					width: 100%;
+				}
 			}
 		}
 

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { SyntheticEvent } from '@wordpress/element';
 import { settings } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -44,19 +45,21 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			}
 		>
 			<SidebarMenu>
-				<SidebarItem
-					className="sidebar__menu-item--plugins"
-					link="/plugins"
-					label={ translate( 'Marketplace' ) }
-					tooltip={ isCollapsed && translate( 'Marketplace' ) }
-					onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
-					selected={
-						path.startsWith( '/plugins' ) &&
-						! path.startsWith( '/plugins/scheduled-updates' ) &&
-						! isManagedPluginSelected
-					}
-					customIcon={ <SidebarIconPlugins /> }
-				/>
+				{ ! isEnabled( 'plugins/universal-header' ) && (
+					<SidebarItem
+						className="sidebar__menu-item--plugins"
+						link="/plugins"
+						label={ translate( 'Marketplace' ) }
+						tooltip={ isCollapsed && translate( 'Marketplace' ) }
+						onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
+						selected={
+							path.startsWith( '/plugins' ) &&
+							! path.startsWith( '/plugins/scheduled-updates' ) &&
+							! isManagedPluginSelected
+						}
+						customIcon={ <SidebarIconPlugins /> }
+					/>
+				) }
 
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
@@ -76,6 +79,24 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					selected={ path.startsWith( '/plugins/scheduled-updates' ) }
 					customIcon={ <SidebarIconCalendar /> }
 				/>
+
+				{ isEnabled( 'plugins/universal-header' ) && (
+					<SidebarItem
+						className="sidebar__menu-item--plugins"
+						link="/plugins"
+						label={ translate( 'Marketplace' ) }
+						tooltip={ isCollapsed && translate( 'Marketplace' ) }
+						onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
+						selected={
+							path.startsWith( '/plugins' ) &&
+							! path.startsWith( '/plugins/scheduled-updates' ) &&
+							! isManagedPluginSelected
+						}
+						customIcon={ <SidebarIconPlugins /> }
+						forceExternalLink
+						sidebarIsCollapsed={ isCollapsed }
+					/>
+				) }
 			</SidebarMenu>
 		</GlobalSidebar>
 	);

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	.navigation-header {
-		@media ( max-width: $break-small ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-bottom: 16px;
 			margin-bottom: 0;
 		}
@@ -171,6 +171,23 @@ body.is-section-plugins {
 
 		@include breakpoint-deprecated( '<660px' ) {
 			padding: 1rem;
+		}
+	}
+}
+
+.is-section-plugins.has-no-sidebar .main {
+	&:not( .hosting-dashboard-layout ):not( .hosting-dashboard-layout-column ):not( .plugins-browser ) {
+		padding: 0;
+	}
+
+	&.is-plugin-details {
+		.navigation-header {
+			padding-top: 0;
+			margin-top: -47px;
+
+			@include breakpoint-deprecated( '<660px' ) {
+				padding: 16px;
+			}
 		}
 	}
 }

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -69,7 +69,8 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 			navigationLabel: translate( 'Plugins' ),
 			type: 'menu-item',
 			url: '/plugins',
-			forceChevronIcon: true,
+			forceChevronIcon: ! isEnabled( 'plugins/universal-header' ),
+			forceExternalLink: isEnabled( 'plugins/universal-header' ),
 		},
 	];
 }

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -68,9 +68,8 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'Plugins' ),
 			type: 'menu-item',
-			url: '/plugins',
-			forceChevronIcon: ! isEnabled( 'plugins/universal-header' ),
-			forceExternalLink: isEnabled( 'plugins/universal-header' ),
+			url: isEnabled( 'plugins/universal-header' ) ? '/plugins/manage/sites' : '/plugins',
+			forceChevronIcon: true,
 		},
 	];
 }

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,7 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/universal-header": true,
+		"plugins/universal-header": true,
 		"titan/iframe-control-panel": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,6 +122,7 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": false,
+		"plugins/universal-header": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -157,6 +157,7 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": false,
+		"plugins/universal-header": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -153,6 +153,7 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": false,
+		"plugins/universal-header": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,6 +157,7 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": false,
+		"plugins/universal-header": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -19,14 +19,21 @@ $studio-blue-15: #e5f4ff;
 }
 
 .is-section-plugins.has-no-sidebar {
-	.masterbar {
+	.lpc-header-nav-wrapper .masterbar {
 		height: 56px;
 		position: relative;
 		background: $studio-blue-15;
 		border-bottom: 1px solid $studio-blue-15;
 	}
+
 	.search-box-header.fixed-top .search-box-header__search {
 		margin-top: -32px;
+	}
+
+	&:has(header.masterbar) {
+		.search-box-header.fixed-top .search-box-header__search {
+			margin-top: 0;
+		}
 	}
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -18,7 +18,7 @@ $studio-blue-15: #e5f4ff;
 	width: 1px;
 }
 
-.is-section-plugins.has-no-sidebar:not(.is-logged-in) {
+.is-section-plugins.has-no-sidebar {
 	.masterbar {
 		height: 56px;
 		position: relative;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-441

## Proposed Changes

* We want to make the `Plugins` an independent page, separate from both HD ~and the site view~. As part of this, this PR updates the behavior so that logged-in users will now see the global Plugins with the logged-out header.
* Introduce the `plugins/universal-header` flag to determine whether to display `<UniversalNavbarHeader />` on the global view.
* Make the `Plugins` in the sidebar an external link.
* Fix some CSS issues

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?flags=plugins/universal-header
* Click Plugins on the sidebar
* It opens in a new window and shows the header from the logged-out version.
* Select any plugins
* Manage sites
* Ensure it shows the site selector modal
* Select a site
* It navigates to the Checkout page
* Go to /plugins/:site?flags=plugins/universal-header
* Ensure the Plugins on the site view looks the same as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
