### PR TITLE
Site overview: point Backups & Scan card to v2 page if on v2

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import { upsell } from '../../components/icons';
-import { isRelativeUrl } from '../../utils/url';
 import HostingFeatureGate from '../hosting-feature-gate';
 import OverviewCard from '../overview-card';
 import type { HostingFeatureGateProps } from '../hosting-feature-gate';
@@ -28,7 +27,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 		icon: upsell,
 		description: upsellDescription,
 		variant: 'upsell' as const,
-		...( isRelativeUrl( upsellLink ) ? { link: upsellLink } : { externalLink: upsellLink } ),
+		link: upsellLink,
 	};
 
 	return (

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -33,7 +33,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No backups yet' ) }
 				description={ __( 'Your first backup will be ready soon.' ) }
-				externalLink={ getBackupUrl( site ) }
+				link={ getBackupUrl( site ) }
 			/>
 		);
 	}
@@ -43,7 +43,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 			{ ...CARD_PROPS }
 			heading={ timeSinceLastBackup }
 			description={ formattedLastBackupTime }
-			externalLink={ getBackupUrl( site ) }
+			link={ getBackupUrl( site ) }
 			intent="success"
 		/>
 	);

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -17,6 +17,7 @@ import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
 import { TextSkeleton } from '../../components/text-skeleton';
+import { isRelativeUrl } from '../../utils/url';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import './style.scss';
 
@@ -34,8 +35,17 @@ export interface OverviewCardProps {
 	intent?: 'upsell' | 'success' | 'warning' | 'error';
 	disabled?: boolean;
 	isLoading?: boolean;
+
+	/**
+	 * Will open in the same tab if the link is relative, otherwise it will open in a new tab.
+	 */
 	link?: string;
+
+	/**
+	 * Will always open in a new tab.
+	 */
 	externalLink?: string;
+
 	tracksId?: string;
 	bottom?: ReactNode;
 	onClick?: () => void;
@@ -51,7 +61,7 @@ export default function OverviewCard( {
 	disabled,
 	isLoading,
 	link,
-	externalLink,
+	externalLink: externalLinkProp,
 	tracksId,
 	bottom,
 	onClick,
@@ -78,6 +88,19 @@ export default function OverviewCard( {
 		return <>&nbsp;</>;
 	};
 
+	const isRelativeLink = link && isRelativeUrl( link );
+
+	let relativeLink: string | undefined = undefined;
+	let externalLink: string | undefined = undefined;
+
+	if ( externalLinkProp ) {
+		externalLink = externalLinkProp;
+	} else if ( isRelativeLink ) {
+		relativeLink = link;
+	} else {
+		externalLink = link;
+	}
+
 	const topContent = (
 		<HStack
 			className="dashboard-overview-card__content"
@@ -99,7 +122,7 @@ export default function OverviewCard( {
 							{ title }
 						</Text>
 					</HStack>
-					{ link && ! progress && (
+					{ relativeLink && ! progress && (
 						<Icon className="dashboard-overview-card__link-icon" icon={ chevronRight } />
 					) }
 					{ externalLink && ! progress && (
@@ -172,9 +195,9 @@ export default function OverviewCard( {
 	};
 
 	const renderContent = () => {
-		if ( link ) {
+		if ( relativeLink ) {
 			return (
-				<Link to={ link } className="dashboard-overview-card__link" onClick={ handleClick }>
+				<Link to={ relativeLink } className="dashboard-overview-card__link" onClick={ handleClick }>
 					{ topContent }
 				</Link>
 			);

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -16,8 +16,12 @@ const CARD_PROPS = {
 };
 
 function getScanURL( site: Site ) {
-	return isSelfHostedJetpackConnected( site )
-		? `https://cloud.jetpack.com/scan/${ site.slug }`
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return `https://cloud.jetpack.com/scan/${ site.slug }`;
+	}
+
+	return window?.location?.pathname?.startsWith( '/v2' )
+		? `/sites/${ site.slug }/scan`
 		: `https://wordpress.com/scan/${ site.slug }`;
 }
 
@@ -34,7 +38,7 @@ function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 			{ ...CARD_PROPS }
 			heading={ description }
 			description={ __( 'Auto fixes are available.' ) }
-			externalLink={ getScanURL( site ) }
+			link={ getScanURL( site ) }
 			intent="error"
 		/>
 	);
@@ -57,7 +61,7 @@ function ScanCardNoThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
 			{ ...CARD_PROPS }
 			heading={ __( 'No risks found' ) }
 			description={ description }
-			externalLink={ getScanURL( site ) }
+			link={ getScanURL( site ) }
 			intent="success"
 		/>
 	);


### PR DESCRIPTION
Fixes DOTDASH-115
Fixes DOTDASH-116

## Proposed Changes

This PR updates the link for these Backup & Scan cards:

<img width="673" height="163" alt="image" src="https://github.com/user-attachments/assets/c86814b4-9d6c-43b0-b04a-edad52db1290" />

to point to:

||v1|v2|Self-hosted (v1 & v2)|
|-|-|-|-|
|Backups|`/backup/:slug`|`/v2/sites/:slug/backup`|`https://cloud.jetpack.com/backup/:slug`
|Scan|`/scan/:slug`|`/v2/sites/:slug/scan`|`https://cloud.jetpack.com/scan/:slug`

## Testing Instructions

Please test each of the case in the above matrix. (Go to the site overview and verify the links in the cards)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
