### PR TITLE
Add plan upgrade flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
@@ -1,0 +1,114 @@
+# Plan Upgrade Flow
+
+This stepper flow allows users to choose and upgrade to a new plan for their existing WordPress.com site.
+
+## Overview
+
+The plan upgrade flow is designed to provide a streamlined experience for existing site owners to upgrade their plan and proceed directly to checkout. It replaces the legacy `/plans` flow with a modern stepper-based approach.
+
+## Flow Configuration
+
+- **Flow Name**: `plan-upgrade`
+- **Route**: `/setup/plan-upgrade?siteSlug=yoursite.wordpress.com`
+- **Authentication**: Required (automatically handled by stepper framework)
+- **Authorization**: Requires `manage_options` capability for the target site
+
+## URL Parameters
+
+### Query Parameters
+- `siteSlug` - **Required** - The site slug for which to upgrade the plan
+- `redirect_to` - URL to redirect to after checkout completion
+
+### URL Format
+The flow uses query parameters (not path parameters) for the site slug:
+- `http://calypso.localhost:3000/setup/plan-upgrade?siteSlug=yoursite.wordpress.com`
+- `http://calypso.localhost:3000/setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com` (direct to plans step)
+
+## Flow Steps
+
+1. **Plans Selection** (`unified-plans`)
+   - Displays available plan upgrades for the existing site
+   - **TODO**: Currently shows all plans - needs investigation to filter to only upgrade options (no downgrades)
+   - Integrates with existing plan comparison and selection logic
+   - Proceeds directly to checkout after plan selection
+
+Note: Error handling is done via redirects rather than an error step, following the pattern of other simple flows.
+
+## Authorization
+
+The flow uses `useAssertConditions()` to verify:
+
+1. **Site Identifier**: Either `siteSlug` or `siteId` must be provided
+2. **Site Existence**: The site must exist and be accessible
+3. **User Permissions**: User must have `manage_options` capability for the site
+
+Users without proper authorization are shown an appropriate error message.
+
+## Checkout Integration
+
+After plan selection, users are redirected directly to checkout with:
+- URL format: `/checkout/{siteSlug}/{planSlug}`
+- Preserves `redirect_to` parameter for post-checkout redirection
+- No `signup=1` parameter (since this is an existing site upgrade)
+
+## Testing Instructions
+
+### Prerequisites
+- WordPress.com account with access to at least one site
+- Sites with different permission levels for testing authorization
+
+### Manual Test Cases
+
+1. **Happy Path**
+   ```
+   /setup/plan-upgrade?siteSlug=yoursite.wordpress.com
+   ```
+   - Should display plan selection for existing site
+   - Should show only upgrade options
+   - Should proceed to checkout after plan selection
+
+2. **Direct to Plans Step**
+   ```
+   /setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com
+   ```
+   - Should go directly to the plans selection step
+
+3. **With Redirect Parameter**
+   ```
+   /setup/plan-upgrade?siteSlug=yoursite.wordpress.com&redirect_to=/home
+   ```
+   - Should pass redirect parameter through to checkout
+   - After checkout completion, user should be redirected to the specified URL
+
+4. **Authorization Tests**
+   - **No site provided**: Should redirect to homepage
+   - **Invalid site**: Should display error
+   - **No manage_options permission**: Should display authorization error
+   - **Anonymous user**: Should redirect to login, then back to flow
+
+5. **Edge Cases**
+   - **Malformed URLs**: Should handle gracefully
+   - **Non-existent sites**: Should display appropriate error
+
+### Test Data Requirements
+- Test sites with different plan levels
+- User accounts with varying permission levels
+- Sites that allow/disallow plan changes
+
+## Implementation Notes
+
+- Uses FlowV2 interface with session support
+- Leverages existing `unified-plans` step for plan selection
+- Authorization handled at flow level via `useAssertConditions()`
+- Direct checkout navigation without intermediate processing
+- Follows established stepper patterns and conventions
+
+## Future Enhancements
+
+- **Plan Filtering**: Currently shows all plans - needs investigation to filter to only upgrade options (no downgrades)
+- **Page Title**: Currently shows "Create a site" - should be changed to appropriate plan upgrade title (e.g., "Upgrade your plan")
+
+## Related Files
+- Flow definition: `plan-upgrade.ts`
+- Stepper framework: `client/landing/stepper/declarative-flow/`
+- Plans step: `client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/`

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
@@ -6,114 +6,31 @@ This stepper flow allows users to choose and upgrade to a new plan for their exi
 
 The plan upgrade flow is designed to provide a streamlined experience for existing site owners to upgrade their plan and proceed directly to checkout. It replaces the legacy `/plans` flow with a modern stepper-based approach.
 
-## Flow Configuration
-
-- **Flow Name**: `plan-upgrade`
-- **Route**: `/setup/plan-upgrade?siteSlug=yoursite.wordpress.com`
-- **Authentication**: Required (automatically handled by stepper framework)
-- **Authorization**: Requires `manage_options` capability for the target site
-
-## URL Parameters
-
 ### Query Parameters
 
 - `siteSlug` - **Required** - The site slug for which to upgrade the plan
 - `redirect_to` - URL to redirect to after checkout completion
+- `feature` - Filter out all plans which don't provide this feature.
 
-### URL Format
+### Flow Steps
 
-The flow uses query parameters (not path parameters) for the site slug:
-
-- `http://calypso.localhost:3000/setup/plan-upgrade?siteSlug=yoursite.wordpress.com`
-- `http://calypso.localhost:3000/setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com` (direct to plans step)
-
-## Flow Steps
-
-1. **Plans Selection** (`unified-plans`)
+1. **Plan Selection**
    - Displays available plan upgrades for the existing site using `plans-upgrade` intent
    - Shows current plan + higher-tier plans only (no downgrades)
    - Current plan displays "Your plan" as non-clickable indicator
-   - Integrates with existing plan comparison and selection logic
+   - Any upgrade credits are displayed on-screen.
    - Proceeds directly to checkout after plan selection
-
-Note: Error handling is done via redirects rather than an error step, following the pattern of other simple flows.
-
-## Authorization
-
-The flow uses `useAssertConditions()` to verify:
-
-1. **Site Identifier**: Either `siteSlug` or `siteId` must be provided
-2. **Site Existence**: The site must exist and be accessible
-3. **User Permissions**: User must have `manage_options` capability for the site
-
-Users without proper authorization are shown an appropriate error message.
-
-## Checkout Integration
-
-After plan selection, users are redirected directly to checkout with:
-
-- URL format: `/checkout/{siteSlug}/{planSlug}`
-- Preserves `redirect_to` parameter for post-checkout redirection
-- No `signup=1` parameter (since this is an existing site upgrade)
 
 ## Testing Instructions
 
-### Prerequisites
+1.  Go to /setup/plan-upgrade?siteSlug=foo.wordpress.com where foo is a site you admin
+2.  You should see the plans grid, if the site already has a plan, then it should only show that plan and plans you can upgrade to.
+3.  You should be able to select and checkout a plan.
 
-- WordPress.com account with access to at least one site
-- Sites with different permission levels for testing authorization
+## Owned by
 
-### Manual Test Cases
+Hosting Platform team (@dsas)
 
-1. **Happy Path**
+## Context
 
-   ```
-   /setup/plan-upgrade?siteSlug=yoursite.wordpress.com
-   ```
-
-   - Should display plan selection for existing site
-   - Should show only current plan + upgrade options (no downgrades)
-   - Current plan should show "Your plan" instead of upgrade button
-   - Should proceed to checkout after plan selection
-
-2. **Direct to Plans Step**
-
-   ```
-   /setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com
-   ```
-
-   - Should go directly to the plans selection step
-
-3. **With Redirect Parameter**
-
-   ```
-   /setup/plan-upgrade?siteSlug=yoursite.wordpress.com&redirect_to=/home
-   ```
-
-   - Should pass redirect parameter through to checkout
-   - After checkout completion, user should be redirected to the specified URL
-
-4. **Authorization Tests**
-
-   - **No site provided**: Should redirect to homepage
-   - **Invalid site**: Should display error
-   - **No manage_options permission**: Should display authorization error
-   - **Anonymous user**: Should redirect to login, then back to flow
-
-5. **Edge Cases**
-   - **Malformed URLs**: Should handle gracefully
-   - **Non-existent sites**: Should display appropriate error
-
-### Test Data Requirements
-
-- Test sites with different plan levels
-- User accounts with varying permission levels
-- Sites that allow/disallow plan changes
-
-## Implementation Notes
-
-- Uses FlowV2 interface with session support
-- Leverages existing `unified-plans` step for plan selection
-- Authorization handled at flow level via `useAssertConditions()`
-- Direct checkout navigation without intermediate processing
-- Follows established stepper patterns and conventions
+<https://wp.me/p58i-nge>

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/README.md
@@ -16,19 +16,23 @@ The plan upgrade flow is designed to provide a streamlined experience for existi
 ## URL Parameters
 
 ### Query Parameters
+
 - `siteSlug` - **Required** - The site slug for which to upgrade the plan
 - `redirect_to` - URL to redirect to after checkout completion
 
 ### URL Format
+
 The flow uses query parameters (not path parameters) for the site slug:
+
 - `http://calypso.localhost:3000/setup/plan-upgrade?siteSlug=yoursite.wordpress.com`
 - `http://calypso.localhost:3000/setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com` (direct to plans step)
 
 ## Flow Steps
 
 1. **Plans Selection** (`unified-plans`)
-   - Displays available plan upgrades for the existing site
-   - **TODO**: Currently shows all plans - needs investigation to filter to only upgrade options (no downgrades)
+   - Displays available plan upgrades for the existing site using `plans-upgrade` intent
+   - Shows current plan + higher-tier plans only (no downgrades)
+   - Current plan displays "Your plan" as non-clickable indicator
    - Integrates with existing plan comparison and selection logic
    - Proceeds directly to checkout after plan selection
 
@@ -47,6 +51,7 @@ Users without proper authorization are shown an appropriate error message.
 ## Checkout Integration
 
 After plan selection, users are redirected directly to checkout with:
+
 - URL format: `/checkout/{siteSlug}/{planSlug}`
 - Preserves `redirect_to` parameter for post-checkout redirection
 - No `signup=1` parameter (since this is an existing site upgrade)
@@ -54,33 +59,42 @@ After plan selection, users are redirected directly to checkout with:
 ## Testing Instructions
 
 ### Prerequisites
+
 - WordPress.com account with access to at least one site
 - Sites with different permission levels for testing authorization
 
 ### Manual Test Cases
 
 1. **Happy Path**
+
    ```
    /setup/plan-upgrade?siteSlug=yoursite.wordpress.com
    ```
+
    - Should display plan selection for existing site
-   - Should show only upgrade options
+   - Should show only current plan + upgrade options (no downgrades)
+   - Current plan should show "Your plan" instead of upgrade button
    - Should proceed to checkout after plan selection
 
 2. **Direct to Plans Step**
+
    ```
    /setup/plan-upgrade/plans?siteSlug=yoursite.wordpress.com
    ```
+
    - Should go directly to the plans selection step
 
 3. **With Redirect Parameter**
+
    ```
    /setup/plan-upgrade?siteSlug=yoursite.wordpress.com&redirect_to=/home
    ```
+
    - Should pass redirect parameter through to checkout
    - After checkout completion, user should be redirected to the specified URL
 
 4. **Authorization Tests**
+
    - **No site provided**: Should redirect to homepage
    - **Invalid site**: Should display error
    - **No manage_options permission**: Should display authorization error
@@ -91,6 +105,7 @@ After plan selection, users are redirected directly to checkout with:
    - **Non-existent sites**: Should display appropriate error
 
 ### Test Data Requirements
+
 - Test sites with different plan levels
 - User accounts with varying permission levels
 - Sites that allow/disallow plan changes
@@ -102,13 +117,3 @@ After plan selection, users are redirected directly to checkout with:
 - Authorization handled at flow level via `useAssertConditions()`
 - Direct checkout navigation without intermediate processing
 - Follows established stepper patterns and conventions
-
-## Future Enhancements
-
-- **Plan Filtering**: Currently shows all plans - needs investigation to filter to only upgrade options (no downgrades)
-- **Page Title**: Currently shows "Create a site" - should be changed to appropriate plan upgrade title (e.g., "Upgrade your plan")
-
-## Related Files
-- Flow definition: `plan-upgrade.ts`
-- Stepper framework: `client/landing/stepper/declarative-flow/`
-- Plans step: `client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/`

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -60,7 +60,7 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 
 	useStepsProps() {
 		const query = useQuery();
-		const selectedFeature = query.get( 'feature' );
+		const selectedFeature = query.get( 'feature' ) ?? undefined;
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,4 +1,5 @@
 import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import {
@@ -7,13 +8,13 @@ import {
 	FlowV2,
 	SubmitHandler,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { useCanUserManageOptions } from 'calypso/landing/stepper/hooks/use-user-can-manage-options';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
-import type { SiteSelect } from '@automattic/data-stores';
+import type { SiteSelect, UserSelect } from '@automattic/data-stores';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
 
@@ -43,42 +44,71 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 	},
 
 	useAssertConditions(): AssertConditionResult {
-		const { siteSlug, siteId } = useSiteData();
+		const { site, siteSlug, siteId } = useSiteData();
+
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
 		const fetchingSiteError = useSelect(
 			( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
 			[]
 		);
 
+		const { isAdmin, isFetching } = useIsSiteAdmin();
+
+		// Track how long we've been waiting for site data
+		const [ waitingTooLong, setWaitingTooLong ] = useState( false );
+
+		useEffect( () => {
+			if ( ( siteSlug || siteId ) && ! site ) {
+				// Set a timeout - if no site after 5 seconds, give up
+				const timeoutId = setTimeout( () => {
+					setWaitingTooLong( true );
+				}, 5000 );
+
+				return () => clearTimeout( timeoutId );
+			}
+			setWaitingTooLong( false );
+		}, [ siteSlug, siteId, site ] );
+
+		// All hooks called - now we can use conditional logic
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		if ( ! siteSlug && ! siteId ) {
+		if ( ! userIsLoggedIn ) {
+			window.location.assign( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'User must be logged in to access plan upgrade flow.',
+			};
+		} else if ( ! siteSlug && ! siteId ) {
 			window.location.assign( '/' );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: 'plan-upgrade did not provide the site slug or site id it is configured to.',
 			};
-		}
-
-		if ( fetchingSiteError ) {
+		} else if ( fetchingSiteError ) {
 			window.location.assign( '/' );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: fetchingSiteError.message,
 			};
-		}
-
-		const { canManageOptions, isLoading } = useCanUserManageOptions();
-
-		if ( isLoading ) {
-			result = { state: AssertConditionState.CHECKING };
-		}
-
-		if ( ! isLoading && ( canManageOptions === false || canManageOptions === null ) ) {
-			// Redirect to sites page since user doesn't have permission for this specific site
-			window.location.assign( '/sites' );
+		} else if ( waitingTooLong ) {
+			window.location.assign( '/' );
 			result = {
 				state: AssertConditionState.FAILURE,
-				message: 'You need manage_options capability to upgrade plans for this site.',
+				message: 'Site not found or you do not have access to this site.',
+			};
+		} else if ( isFetching || ! site || isAdmin === null ) {
+			// Still loading site data or waiting for admin check
+			result = { state: AssertConditionState.CHECKING };
+		} else if ( isAdmin === false ) {
+			// Site loaded and user is definitely not admin
+			window.location.assign( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'You need to be an admin to upgrade plans for this site.',
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,3 +1,4 @@
+import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
@@ -24,7 +25,7 @@ function initialize() {
 }
 
 const planUpgradeFlow: FlowV2< typeof initialize > = {
-	name: 'plan-upgrade',
+	name: PLAN_UPGRADE_FLOW,
 	title: __( 'Upgrade plan' ),
 	isSignupFlow: false,
 	__experimentalUseSessions: true,

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,4 +1,5 @@
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
@@ -24,6 +25,7 @@ function initialize() {
 
 const planUpgradeFlow: FlowV2< typeof initialize > = {
 	name: 'plan-upgrade',
+	title: __( 'Upgrade plan' ),
 	isSignupFlow: false,
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -35,6 +35,9 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 
 				// This flag enables upgrade-specific behavior in PlansFeaturesMain
 				isStepperUpgradeFlow: true,
+
+				// This is NOT a signup flow - use logged-in behavior for current plans
+				isInSignup: false,
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,12 +1,14 @@
 import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { FlowV2, SubmitHandler } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { isExternal } from 'calypso/lib/url';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
 
@@ -61,6 +63,10 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 	useStepsProps() {
 		const query = useQuery();
 		const selectedFeature = query.get( 'feature' ) ?? undefined;
+		const backTo = query.get( 'back_to' );
+
+		// Validate back_to to prevent open redirect - must not be external
+		const safeBackTo = backTo && ! isExternal( backTo ) ? backTo : '/sites';
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {
@@ -74,6 +80,13 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 
 				// Pass the feature parameter for feature-based plan filtering
 				selectedFeature,
+
+				// Provide a custom back handler that goes to back_to or /sites
+				wrapperProps: {
+					goBack: () => {
+						window.location.assign( safeBackTo );
+					},
+				},
 			},
 		};
 	},
@@ -92,18 +105,16 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 					if ( providedDependencies?.cartItems && providedDependencies.cartItems.length > 0 ) {
 						const selectedPlan = providedDependencies.cartItems[ 0 ]?.product_slug;
 						if ( selectedPlan && siteSlug ) {
-							// Build checkout URL with plan
 							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ selectedPlan }`;
+							const currentPath = window.location.href.replace( window.location.origin, '' );
 
-							// Add redirect_to parameter if provided
-							const queryParams = new URLSearchParams();
-							if ( redirectTo ) {
-								queryParams.set( 'redirect_to', redirectTo );
-							}
-
-							const finalUrl = queryParams.toString()
-								? `${ checkoutUrl }?${ queryParams.toString() }`
-								: checkoutUrl;
+							// Build checkout URL with query params
+							// Note: Not using goToCheckout utility because it hardcodes signup=1
+							// Checkout validates redirect_to to prevent open redirects
+							const finalUrl = addQueryArgs( checkoutUrl, {
+								redirect_to: redirectTo || '/sites',
+								cancel_to: currentPath,
+							} );
 
 							window.location.assign( finalUrl );
 						}

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -28,6 +28,17 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	initialize,
 
+	useStepsProps() {
+		return {
+			[ STEPS.UNIFIED_PLANS.slug ]: {
+				// Note that this step uses this flow name to select the `plans-upgrade` intent.
+
+				// This flag enables upgrade-specific behavior in PlansFeaturesMain
+				isStepperUpgradeFlow: true,
+			},
+		};
+	},
+
 	useAssertConditions(): AssertConditionResult {
 		const { siteSlug, siteId } = useSiteData();
 		const fetchingSiteError = useSelect(

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,26 +1,52 @@
 import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-	FlowV2,
-	SubmitHandler,
-} from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
+import { FlowV2, SubmitHandler } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
-import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
-import type { SiteSelect, UserSelect } from '@automattic/data-stores';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
 
-function initialize() {
+/**
+ * Checks if the user has access to upgrade plans for the given site
+ */
+async function checkUserHasAccess(): Promise< boolean > {
+	// Get site slug or ID from query params
+	const queryParams = getCurrentQueryParams();
+	const siteSlugFromQuery = queryParams.get( 'siteSlug' );
+	const siteIdFromQuery = queryParams.get( 'siteId' );
+
+	const siteIdOrSlug = siteSlugFromQuery || siteIdFromQuery;
+
+	if ( ! siteIdOrSlug ) {
+		return false;
+	}
+
+	try {
+		const site = await resolveSelect( SITE_STORE ).getSite( siteIdOrSlug );
+
+		if ( ! site ) {
+			return false;
+		}
+
+		// Check if user can manage the site using the capabilities from the site object
+		return site.capabilities?.manage_options === true;
+	} catch ( error ) {
+		return false;
+	}
+}
+
+async function initialize() {
+	const hasAccess = await checkUserHasAccess();
+
+	if ( ! hasAccess ) {
+		window.location.assign( '/' );
+		return false;
+	}
+
 	return stepsWithRequiredLogin( BASE_STEPS );
 }
 
@@ -52,87 +78,10 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		};
 	},
 
-	useAssertConditions(): AssertConditionResult {
-		const { site, siteSlug, siteId } = useSiteData();
-
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-
-		const fetchingSiteError = useSelect(
-			( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
-			[]
-		);
-
-		const { isAdmin, isFetching } = useIsSiteAdmin();
-
-		// Track how long we've been waiting for site data
-		const [ waitingTooLong, setWaitingTooLong ] = useState( false );
-
-		useEffect( () => {
-			if ( ( siteSlug || siteId ) && ! site ) {
-				// Set a timeout - if no site after 5 seconds, give up
-				const timeoutId = setTimeout( () => {
-					setWaitingTooLong( true );
-				}, 5000 );
-
-				return () => clearTimeout( timeoutId );
-			}
-			setWaitingTooLong( false );
-		}, [ siteSlug, siteId, site ] );
-
-		// All hooks called - now we can use conditional logic
-		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! userIsLoggedIn ) {
-			window.location.assign( '/' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'User must be logged in to access plan upgrade flow.',
-			};
-		} else if ( ! siteSlug && ! siteId ) {
-			window.location.assign( '/' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'plan-upgrade did not provide the site slug or site id it is configured to.',
-			};
-		} else if ( fetchingSiteError ) {
-			window.location.assign( '/' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: fetchingSiteError.message,
-			};
-		} else if ( waitingTooLong ) {
-			window.location.assign( '/' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'Site not found or you do not have access to this site.',
-			};
-		} else if ( isFetching || ! site || isAdmin === null ) {
-			// Still loading site data or waiting for admin check
-			result = { state: AssertConditionState.CHECKING };
-		} else if ( isAdmin === false ) {
-			// Site loaded and user is definitely not admin
-			window.location.assign( '/' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'You need to be an admin to upgrade plans for this site.',
-			};
-		}
-
-		return result;
-	},
-
 	useStepNavigation() {
-		const { siteSlug } = useSiteData();
-		const urlParams = useParams< { siteSlug?: string } >();
-		const siteSlugFromParam = useSiteSlugParam();
 		const query = useQuery();
+		const siteSlug = query.get( 'siteSlug' );
 		const redirectTo = query.get( 'redirect_to' );
-
-		// Use URL path parameter first, then query parameter fallback
-		const finalSiteSlug = siteSlug || urlParams.siteSlug || siteSlugFromParam;
 
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
@@ -142,11 +91,9 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 					// User selected plan, go directly to checkout
 					if ( providedDependencies?.cartItems && providedDependencies.cartItems.length > 0 ) {
 						const selectedPlan = providedDependencies.cartItems[ 0 ]?.product_slug;
-						if ( selectedPlan && finalSiteSlug ) {
+						if ( selectedPlan && siteSlug ) {
 							// Build checkout URL with plan
-							const checkoutUrl = `/checkout/${ encodeURIComponent(
-								finalSiteSlug
-							) }/${ selectedPlan }`;
+							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ selectedPlan }`;
 
 							// Add redirect_to parameter if provided
 							const queryParams = new URLSearchParams();

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,0 +1,124 @@
+import { useSelect } from '@wordpress/data';
+import { useParams } from 'react-router-dom';
+import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	FlowV2,
+	SubmitHandler,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { useCanUserManageOptions } from 'calypso/landing/stepper/hooks/use-user-can-manage-options';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import type { SiteSelect } from '@automattic/data-stores';
+
+const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
+
+function initialize() {
+	return stepsWithRequiredLogin( BASE_STEPS );
+}
+
+const planUpgradeFlow: FlowV2< typeof initialize > = {
+	name: 'plan-upgrade',
+	isSignupFlow: false,
+	__experimentalUseSessions: true,
+	__experimentalUseBuiltinAuth: true,
+	initialize,
+
+	useAssertConditions(): AssertConditionResult {
+		const { siteSlug, siteId } = useSiteData();
+		const fetchingSiteError = useSelect(
+			( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
+			[]
+		);
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! siteSlug && ! siteId ) {
+			window.location.assign( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'plan-upgrade did not provide the site slug or site id it is configured to.',
+			};
+		}
+
+		if ( fetchingSiteError ) {
+			window.location.assign( '/' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: fetchingSiteError.message,
+			};
+		}
+
+		const { canManageOptions, isLoading } = useCanUserManageOptions();
+
+		if ( isLoading ) {
+			result = { state: AssertConditionState.CHECKING };
+		}
+
+		if ( ! isLoading && ( canManageOptions === false || canManageOptions === null ) ) {
+			// Redirect to sites page since user doesn't have permission for this specific site
+			window.location.assign( '/sites' );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'You need manage_options capability to upgrade plans for this site.',
+			};
+		}
+
+		return result;
+	},
+
+	useStepNavigation() {
+		const { siteSlug } = useSiteData();
+		const urlParams = useParams< { siteSlug?: string } >();
+		const siteSlugFromParam = useSiteSlugParam();
+		const query = useQuery();
+		const redirectTo = query.get( 'redirect_to' );
+
+		// Use URL path parameter first, then query parameter fallback
+		const finalSiteSlug = siteSlug || urlParams.siteSlug || siteSlugFromParam;
+
+		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
+			const { slug, providedDependencies } = submittedStep;
+
+			switch ( slug ) {
+				case STEPS.UNIFIED_PLANS.slug: {
+					// User selected plan, go directly to checkout
+					if ( providedDependencies?.cartItems && providedDependencies.cartItems.length > 0 ) {
+						const selectedPlan = providedDependencies.cartItems[ 0 ]?.product_slug;
+						if ( selectedPlan && finalSiteSlug ) {
+							// Build checkout URL with plan
+							const checkoutUrl = `/checkout/${ encodeURIComponent(
+								finalSiteSlug
+							) }/${ selectedPlan }`;
+
+							// Add redirect_to parameter if provided
+							const queryParams = new URLSearchParams();
+							if ( redirectTo ) {
+								queryParams.set( 'redirect_to', redirectTo );
+							}
+
+							const finalUrl = queryParams.toString()
+								? `${ checkoutUrl }?${ queryParams.toString() }`
+								: checkoutUrl;
+
+							window.location.assign( finalUrl );
+						}
+						return;
+					}
+
+					// If no cart items, something went wrong - redirect to sites
+					window.location.assign( '/sites' );
+					break;
+				}
+			}
+		};
+
+		return { submit };
+	},
+};
+
+export default planUpgradeFlow;

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -33,6 +33,9 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 	initialize,
 
 	useStepsProps() {
+		const query = useQuery();
+		const selectedFeature = query.get( 'feature' );
+
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {
 				// Note that this step uses this flow name to select the `plans-upgrade` intent.
@@ -42,6 +45,9 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 
 				// This is NOT a signup flow - use logged-in behavior for current plans
 				isInSignup: false,
+
+				// Pass the feature parameter for feature-based plan filtering
+				selectedFeature,
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -6,6 +6,7 @@ import {
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
 	DOMAIN_FLOW,
+	PLAN_UPGRADE_FLOW,
 } from '@automattic/onboarding';
 
 const FLOWS_USING_STEP_CONTAINER_V2 = [
@@ -16,6 +17,7 @@ const FLOWS_USING_STEP_CONTAINER_V2 = [
 	SITE_MIGRATION_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
 	DOMAIN_FLOW,
+	PLAN_UPGRADE_FLOW,
 ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -70,6 +70,8 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			break;
 		case ONBOARDING_UNIFIED_FLOW:
 			return 'plans-affiliate';
+		case 'plan-upgrade':
+			return 'plans-upgrade';
 		default:
 			return null;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -7,6 +7,7 @@ import {
 	NEWSLETTER_FLOW,
 	ONBOARDING_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	PLAN_UPGRADE_FLOW,
 	START_WRITING_FLOW,
 	Step,
 	useStepPersistedState,
@@ -70,7 +71,7 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			break;
 		case ONBOARDING_UNIFIED_FLOW:
 			return 'plans-affiliate';
-		case 'plan-upgrade':
+		case PLAN_UPGRADE_FLOW:
 			return 'plans-upgrade';
 		default:
 			return null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -90,9 +90,15 @@ const PlansStepAdaptor: StepType< {
 		isInSignup?: boolean;
 		isStepperUpgradeFlow?: boolean;
 		selectedFeature?: string;
+		wrapperProps?: {
+			hideBack?: boolean;
+			goBack?: () => void;
+			isFullLayout?: boolean;
+			isExtraWideLayout?: boolean;
+		};
 	};
 } > = ( props ) => {
-	const { isInSignup, isStepperUpgradeFlow, selectedFeature } = props;
+	const { isInSignup, isStepperUpgradeFlow, selectedFeature, wrapperProps } = props;
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
@@ -219,10 +225,10 @@ const PlansStepAdaptor: StepType< {
 			onPlanIntervalUpdate={ onPlanIntervalUpdate }
 			intervalType={ planInterval }
 			wrapperProps={ {
-				hideBack: false,
-				goBack: props.navigation.goBack,
-				isFullLayout: true,
-				isExtraWideLayout: false,
+				hideBack: wrapperProps?.hideBack ?? false,
+				goBack: wrapperProps?.goBack ?? props.navigation.goBack,
+				isFullLayout: wrapperProps?.isFullLayout ?? true,
+				isExtraWideLayout: wrapperProps?.isExtraWideLayout ?? false,
 			} }
 			useStepperWrapper
 			useStepContainerV2={ isUsingStepContainerV2 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -86,6 +86,8 @@ type ProvidedDependencies = {
 const PlansStepAdaptor: StepType< {
 	submits: ProvidedDependencies;
 } > = ( props ) => {
+	// Extract step-specific props from the flow configuration
+	const { isInSignup } = props as typeof props & { isInSignup?: boolean };
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
@@ -219,6 +221,7 @@ const PlansStepAdaptor: StepType< {
 			} }
 			useStepperWrapper
 			useStepContainerV2={ isUsingStepContainerV2 }
+			isInSignup={ isInSignup }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -88,7 +88,10 @@ const PlansStepAdaptor: StepType< {
 	submits: ProvidedDependencies;
 } > = ( props ) => {
 	// Extract step-specific props from the flow configuration
-	const { isInSignup } = props as typeof props & { isInSignup?: boolean };
+	const { isInSignup, isStepperUpgradeFlow } = props as typeof props & {
+		isInSignup?: boolean;
+		isStepperUpgradeFlow?: boolean;
+	};
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
@@ -223,6 +226,7 @@ const PlansStepAdaptor: StepType< {
 			useStepperWrapper
 			useStepContainerV2={ isUsingStepContainerV2 }
 			isInSignup={ isInSignup }
+			isStepperUpgradeFlow={ isStepperUpgradeFlow }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -88,9 +88,10 @@ const PlansStepAdaptor: StepType< {
 	submits: ProvidedDependencies;
 } > = ( props ) => {
 	// Extract step-specific props from the flow configuration
-	const { isInSignup, isStepperUpgradeFlow } = props as typeof props & {
+	const { isInSignup, isStepperUpgradeFlow, selectedFeature } = props as typeof props & {
 		isInSignup?: boolean;
 		isStepperUpgradeFlow?: boolean;
+		selectedFeature?: string;
 	};
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
@@ -227,6 +228,7 @@ const PlansStepAdaptor: StepType< {
 			useStepContainerV2={ isUsingStepContainerV2 }
 			isInSignup={ isInSignup }
 			isStepperUpgradeFlow={ isStepperUpgradeFlow }
+			selectedFeature={ selectedFeature }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -86,13 +86,13 @@ type ProvidedDependencies = {
 
 const PlansStepAdaptor: StepType< {
 	submits: ProvidedDependencies;
-} > = ( props ) => {
-	// Extract step-specific props from the flow configuration
-	const { isInSignup, isStepperUpgradeFlow, selectedFeature } = props as typeof props & {
+	accepts: {
 		isInSignup?: boolean;
 		isStepperUpgradeFlow?: boolean;
 		selectedFeature?: string;
 	};
+} > = ( props ) => {
+	const { isInSignup, isStepperUpgradeFlow, selectedFeature } = props;
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -176,6 +176,12 @@ export interface UnifiedPlansStepProps {
 	isCustomDomainAllowedOnFreePlan?: boolean;
 
 	useStepContainerV2?: boolean;
+
+	/**
+	 * Whether this step is being used in a signup flow context.
+	 * Defaults to true to preserve existing behavior.
+	 */
+	isInSignup?: boolean;
 }
 
 /**
@@ -225,6 +231,7 @@ function UnifiedPlansStep( {
 	queryParams: queryParamsFromProps,
 	shouldHideNavButtons,
 	onIntentChange,
+	isInSignup = true,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = reduxUseDispatch();
@@ -527,7 +534,7 @@ function UnifiedPlansStep( {
 				siteId={ selectedSite?.ID }
 				isDomainTransfer={ domainCartItem ? isDomainTransfer( domainCartItem ) : false }
 				isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-				isInSignup
+				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
 				intervalType={
 					intervalTypeValue as 'monthly' | 'yearly' | '2yearly' | '3yearly' | undefined

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -182,6 +182,11 @@ export interface UnifiedPlansStepProps {
 	 * Defaults to true to preserve existing behavior.
 	 */
 	isInSignup?: boolean;
+
+	/**
+	 * Whether this step is being used in a stepper upgrade flow context.
+	 */
+	isStepperUpgradeFlow?: boolean;
 }
 
 /**
@@ -232,6 +237,7 @@ function UnifiedPlansStep( {
 	shouldHideNavButtons,
 	onIntentChange,
 	isInSignup = true,
+	isStepperUpgradeFlow = false,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = reduxUseDispatch();
@@ -546,6 +552,7 @@ function UnifiedPlansStep( {
 				plansWithScroll={ isDesktop }
 				intent={ intent }
 				flowName={ flowName }
+				isStepperUpgradeFlow={ isStepperUpgradeFlow }
 				hideFreePlan={ hideFreePlan && ! deemphasizeFreePlan }
 				hidePersonalPlan={ hidePersonalPlan }
 				hidePremiumPlan={ hidePremiumPlan }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -127,6 +127,7 @@ export interface UnifiedPlansStepProps {
 	onIntentChange?: ( intent: PlansIntent ) => void;
 	isLaunchPage?: boolean;
 	intervalType?: string;
+	selectedFeature?: string;
 	fallbackSubHeaderText?: string;
 
 	/**
@@ -238,6 +239,7 @@ function UnifiedPlansStep( {
 	onIntentChange,
 	isInSignup = true,
 	isStepperUpgradeFlow = false,
+	selectedFeature,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = reduxUseDispatch();
@@ -564,6 +566,7 @@ function UnifiedPlansStep( {
 				showPlanTypeSelectorDropdown={ config.isEnabled( 'onboarding/interval-dropdown' ) }
 				onPlanIntervalUpdate={ onPlanIntervalUpdate }
 				selectedThemeType={ selectedThemeType }
+				selectedFeature={ selectedFeature }
 				renderSiblingWhenLoaded={ () => {
 					if ( ! isNewHostedSiteCreationFlow( flowName ) ) {
 						return null;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -123,7 +123,9 @@ export type UseStepNavigationHookV2< FlowSteps extends StepperStep[] > = (
 };
 
 export type SubmitHandler< InitializeFunction extends DefaultFlowStepsConfig > = (
-	submittedStep: MapStepToItsSubmitData< Awaited< ReturnType< InitializeFunction > >[ number ] >
+	submittedStep: MapStepToItsSubmitData<
+		ExtractSteps< ReturnType< InitializeFunction > >[ number ]
+	>
 ) => /* return unknown, not void, to activate type checks against function params */ unknown;
 /**
  * This type is complex because it's tricky to keep the mapping between slug and the steps submitted data type.
@@ -234,7 +236,14 @@ export type Flow = {
  */
 export type FlowV1 = Flow;
 
-type DefaultFlowStepsConfig = ( reduxStore: Store ) => StepperStep[] | Promise< StepperStep[] >;
+type DefaultFlowStepsConfig = (
+	reduxStore: Store
+) => StepperStep[] | false | Promise< StepperStep[] | false >;
+
+/**
+ * Helper type to extract the steps array from the initialize return type, excluding false
+ */
+type ExtractSteps< T > = Exclude< Awaited< T >, false >;
 
 export interface FlowV2< FlowStepsInitialize extends DefaultFlowStepsConfig > {
 	/**
@@ -259,7 +268,9 @@ export interface FlowV2< FlowStepsInitialize extends DefaultFlowStepsConfig > {
 	/**
 	 * Use this method to pass props to the steps from the flow.
 	 */
-	useStepsProps?(): MapStepsToTheirAcceptedProps< Awaited< ReturnType< FlowStepsInitialize > > >;
+	useStepsProps?(): MapStepsToTheirAcceptedProps<
+		ExtractSteps< ReturnType< FlowStepsInitialize > >
+	>;
 
 	name: string;
 	/**
@@ -290,11 +301,11 @@ export interface FlowV2< FlowStepsInitialize extends DefaultFlowStepsConfig > {
 	 */
 	initialize: FlowStepsInitialize;
 
-	useStepNavigation: UseStepNavigationHookV2< Awaited< ReturnType< FlowStepsInitialize > > >;
+	useStepNavigation: UseStepNavigationHookV2< ExtractSteps< ReturnType< FlowStepsInitialize > > >;
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
-	useSideEffect?: UseSideEffectHook< Awaited< ReturnType< FlowStepsInitialize > > >;
+	useSideEffect?: UseSideEffectHook< ExtractSteps< ReturnType< FlowStepsInitialize > > >;
 	useTracksEventProps?: UseTracksEventPropsHook;
 	/**
 	 * @deprecated Use `initialize` instead. `initialize` will run before the flow is rendered and you can make any decisions there.

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -18,6 +18,7 @@ import {
 	AI_SITE_BUILDER_SPEC_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
 	DOMAIN_AND_PLAN_FLOW,
+	PLAN_UPGRADE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
 
@@ -49,7 +50,7 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 		import(
 			/* webpackChunkName: "ai-site-builder-spec-flow" */ './flows/ai-site-builder-spec/ai-site-builder-spec'
 		),
-	'plan-upgrade': () =>
+	[ PLAN_UPGRADE_FLOW ]: () =>
 		import( /* webpackChunkName: "plan-upgrade-flow" */ './flows/plan-upgrade/plan-upgrade' ),
 };
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -49,6 +49,8 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 		import(
 			/* webpackChunkName: "ai-site-builder-spec-flow" */ './flows/ai-site-builder-spec/ai-site-builder-spec'
 		),
+	'plan-upgrade': () =>
+		import( /* webpackChunkName: "plan-upgrade-flow" */ './flows/plan-upgrade/plan-upgrade' ),
 };
 
 /**

--- a/client/my-sites/plans-features-main/components/plan-notice-plan-to-higher-plan-credit.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-plan-to-higher-plan-credit.tsx
@@ -7,12 +7,14 @@ import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import type { PlanSlug } from '@automattic/calypso-products';
+import type { PlansIntent } from '@automattic/plans-grid-next';
 
 type Props = {
 	className?: string;
 	onDismissClick?: () => void;
 	siteId: number;
 	visiblePlans?: PlanSlug[];
+	intent?: PlansIntent;
 };
 
 const PlanNoticePlanToHigherPlanCredit = ( {
@@ -20,6 +22,7 @@ const PlanNoticePlanToHigherPlanCredit = ( {
 	onDismissClick,
 	siteId,
 	visiblePlans,
+	intent,
 }: Props ) => {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -32,10 +35,25 @@ const PlanNoticePlanToHigherPlanCredit = ( {
 		planUpgradeCreditsApplicable !== null &&
 		planUpgradeCreditsApplicable > 0;
 
+	// Check if this is the plans-upgrade flow which requires compact styling
+	const isUpgradeFlow = intent === 'plans-upgrade';
+
 	return (
 		<>
 			<QuerySitePlans siteId={ siteId } />
-			{ showNotice && (
+			{ showNotice && isUpgradeFlow && (
+				<div className="plan-upgrade-credit-notice-compact">
+					{ translate( 'You have %(amountInCurrency)s in upgrade credits available', {
+						args: {
+							amountInCurrency: formatCurrency( planUpgradeCreditsApplicable, currencyCode ?? '', {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ),
+						},
+					} ) }
+				</div>
+			) }
+			{ showNotice && ! isUpgradeFlow && (
 				<Notice
 					className={ className }
 					showDismiss={ !! onDismissClick }

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,5 +1,6 @@
 import { PlanSlug, isProPlan, isStarterPlan } from '@automattic/calypso-products';
 import { Site, SiteMediaStorage } from '@automattic/data-stores';
+import { PlansIntent } from '@automattic/plans-grid-next';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
@@ -22,6 +23,7 @@ export type PlanNoticeProps = {
 	isInSignup?: boolean;
 	showLegacyStorageFeature?: boolean;
 	mediaStorage?: SiteMediaStorage;
+	intent?: PlansIntent;
 	discountInformation?: {
 		coupon: string;
 		discountEndDate: Date;
@@ -96,7 +98,7 @@ function useResolveNoticeType(
 }
 
 export default function PlanNotice( props: PlanNoticeProps ) {
-	const { siteId, visiblePlans, discountInformation } = props;
+	const { siteId, visiblePlans, discountInformation, intent } = props;
 	const translate = useTranslate();
 	const [ isNoticeDismissed, setIsNoticeDismissed ] = useState( false );
 	const noticeType = useResolveNoticeType( props, isNoticeDismissed );
@@ -178,6 +180,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 					onDismissClick={ handleDismissNotice }
 					siteId={ siteId }
 					visiblePlans={ visiblePlans }
+					intent={ intent }
 				/>
 			);
 		case PLAN_RETIREMENT_NOTICE:

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -212,7 +212,7 @@ const PlansPageSubheader = ( {
 			return <PlanBenefitHeader />;
 		}
 
-		if ( isOnboarding ) {
+		if ( isOnboarding || intent === 'plans-upgrade' ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -226,7 +226,7 @@ const PlansPageSubheader = ( {
 	return (
 		<>
 			{ renderSubheader() }
-			{ isDisplayingPlansNeededForFeature && (
+			{ isDisplayingPlansNeededForFeature && intent !== 'plans-upgrade' && (
 				<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeature } />
 			) }
 		</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -824,6 +824,7 @@ const PlansFeaturesMain = ( {
 						siteId={ siteId }
 						isInSignup={ isInSignup }
 						showLegacyStorageFeature={ showLegacyStorageFeature }
+						intent={ intent }
 						{ ...( coupon &&
 							discountEndDate && {
 								discountInformation: {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -289,14 +289,6 @@ const PlansFeaturesMain = ( {
 		};
 	}, [ signupFlowSubdomain, wpcomFreeDomainSuggestion ] );
 
-	const isDisplayingPlansNeededForFeature =
-		!! selectedFeature &&
-		isValidFeatureKey( selectedFeature ) &&
-		!! selectedPlan &&
-		!! getPlan( selectedPlan ) &&
-		! isPersonalPlan( selectedPlan ) &&
-		( 'interval' === planTypeSelector || ! previousRoute.startsWith( '/plans/' ) );
-
 	const filteredDisplayedIntervals = useFilteredDisplayedIntervals( {
 		productSlug: currentPlan?.productSlug,
 		displayedIntervals,
@@ -349,6 +341,15 @@ const PlansFeaturesMain = ( {
 		intentFromSiteMeta.processing,
 		defaultWpcomPlansIntent,
 	] );
+
+	const isDisplayingPlansNeededForFeature =
+		!! selectedFeature &&
+		isValidFeatureKey( selectedFeature ) && // For plans-upgrade intent, enable feature filtering without requiring selectedPlan
+		( intent === 'plans-upgrade' ||
+			( !! selectedPlan &&
+				!! getPlan( selectedPlan ) &&
+				! isPersonalPlan( selectedPlan ) &&
+				( 'interval' === planTypeSelector || ! previousRoute.startsWith( '/plans/' ) ) ) );
 
 	const showEscapeHatch =
 		intentFromSiteMeta.intent &&

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -75,6 +75,18 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
+.plan-upgrade-credit-notice-compact {
+	position: absolute;
+	inset-block-start: 20px;
+	inset-inline-end: 20px;
+	background-color: #D6DDF966;
+	border-radius: 3px;
+	padding: 2px 10px;
+	font-size: 13px;
+	line-height: 20px;
+	color: var(--gray-gray-90, #1d2327);
+}
+
 /*TODO: Remove the section below when the 2023 pricing grid is live to all locales */
 .plans-features-main__group.is-scrollable:not(.is-2023-pricing-grid) {
 	position: relative;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -38,6 +38,7 @@ export const ONBOARDING_UNIFIED_FLOW = 'onboarding-unified';
 export const AI_SITE_BUILDER_FLOW = 'ai-site-builder';
 export const AI_SITE_BUILDER_SPEC_FLOW = 'ai-site-builder-spec';
 export const PLAYGROUND_FLOW = 'playground';
+export const PLAN_UPGRADE_FLOW = 'plan-upgrade';
 
 export const isNewsletterFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && NEWSLETTER_FLOW === flowName );

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -168,6 +168,33 @@ export const usePlanTypesWithIntent = ( {
 				TYPE_ECOMMERCE,
 			];
 			break;
+		case 'plans-upgrade': {
+			// Show current plan plus all higher-tier plans (upgrade options only)
+			const upgradePlanTypes = [
+				TYPE_FREE,
+				TYPE_PERSONAL,
+				TYPE_PREMIUM,
+				TYPE_BUSINESS,
+				TYPE_ECOMMERCE,
+			];
+			if ( isEnterpriseAvailable ) {
+				upgradePlanTypes.push( TYPE_ENTERPRISE_GRID_WPCOM );
+			}
+
+			// Find the index of the current plan in the hierarchy
+			const currentPlanIndex = currentSitePlanType
+				? upgradePlanTypes.findIndex( ( planType ) => planType === currentSitePlanType )
+				: -1;
+
+			if ( currentPlanIndex >= 0 ) {
+				// Show current plan and all plans after it (higher tiers)
+				planTypes = upgradePlanTypes.slice( currentPlanIndex );
+			} else {
+				// If current plan not found or no current plan, show all plans
+				planTypes = upgradePlanTypes;
+			}
+			break;
+		}
 		case 'plans-jetpack-app':
 			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -23,6 +23,8 @@ import {
 	isPremiumPlan,
 	isFreePlan,
 	isPersonalPlan,
+	planHasFeature,
+	getPlanClass,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { isSamePlan } from '../../lib/is-same-plan';
@@ -51,39 +53,57 @@ const isGridPlanVisible = ( {
 		hideEcommercePlan,
 	} = {},
 	isDisplayingPlansNeededForFeature,
-	planSlug,
+	gridPlanSlug,
 	planSlugsForIntent,
 	selectedPlan,
+	selectedFeature,
+	currentPlanSlug,
 }: {
 	hiddenPlans?: HiddenPlans;
 	isDisplayingPlansNeededForFeature?: boolean;
-	planSlug: PlanSlug;
+	gridPlanSlug: PlanSlug;
 	planSlugsForIntent: PlanSlug[];
 	selectedPlan?: PlanSlug;
+	selectedFeature?: string | null;
+	currentPlanSlug?: PlanSlug;
 } ): boolean => {
-	let isVisible = planSlugsForIntent.includes( planSlug );
+	let isVisible = planSlugsForIntent.includes( gridPlanSlug );
 
-	if ( isDisplayingPlansNeededForFeature && selectedPlan ) {
-		if ( isEcommercePlan( selectedPlan ) ) {
-			isVisible = isEcommercePlan( planSlug );
+	if ( isDisplayingPlansNeededForFeature ) {
+		// Feature-based filtering: Show the plan being evaluated if it includes the selected feature,
+		// or if it's the user's current plan (ignoring billing term length)
+		if ( selectedFeature && ! selectedPlan ) {
+			const hasFeature = planHasFeature( gridPlanSlug, selectedFeature );
+			const isCurrentPlan =
+				currentPlanSlug && getPlanClass( currentPlanSlug ) === getPlanClass( gridPlanSlug );
+			isVisible = isVisible && ( isCurrentPlan || hasFeature );
 		}
+		// Plan-tier-based filtering: When a specific plan is pre-selected,
+		// show that plan tier and all higher tiers (e.g., if Premium is selected, show Premium + Business + Commerce)
+		else if ( selectedPlan ) {
+			if ( isEcommercePlan( selectedPlan ) ) {
+				isVisible = isEcommercePlan( gridPlanSlug );
+			}
 
-		if ( isBusinessPlan( selectedPlan ) ) {
-			isVisible = isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
-		}
+			if ( isBusinessPlan( selectedPlan ) ) {
+				isVisible = isBusinessPlan( gridPlanSlug ) || isEcommercePlan( gridPlanSlug );
+			}
 
-		if ( isPremiumPlan( selectedPlan ) ) {
-			isVisible =
-				isPremiumPlan( planSlug ) || isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
+			if ( isPremiumPlan( selectedPlan ) ) {
+				isVisible =
+					isPremiumPlan( gridPlanSlug ) ||
+					isBusinessPlan( gridPlanSlug ) ||
+					isEcommercePlan( gridPlanSlug );
+			}
 		}
 	}
 
 	if (
-		( hideFreePlan && isFreePlan( planSlug ) ) ||
-		( hidePersonalPlan && isPersonalPlan( planSlug ) ) ||
-		( hidePremiumPlan && isPremiumPlan( planSlug ) ) ||
-		( hideBusinessPlan && isBusinessPlan( planSlug ) ) ||
-		( hideEcommercePlan && isEcommercePlan( planSlug ) )
+		( hideFreePlan && isFreePlan( gridPlanSlug ) ) ||
+		( hidePersonalPlan && isPersonalPlan( gridPlanSlug ) ) ||
+		( hidePremiumPlan && isPremiumPlan( gridPlanSlug ) ) ||
+		( hideBusinessPlan && isBusinessPlan( gridPlanSlug ) ) ||
+		( hideEcommercePlan && isEcommercePlan( gridPlanSlug ) )
 	) {
 		isVisible = false;
 	}
@@ -268,6 +288,7 @@ const useGridPlans: UseGridPlansType = ( {
 	term = TERM_MONTHLY,
 	intent,
 	selectedPlan,
+	selectedFeature,
 	hiddenPlans,
 	isInSignup,
 	eligibleForFreeHostingTrial,
@@ -376,9 +397,11 @@ const useGridPlans: UseGridPlansType = ( {
 				  };
 
 		const isVisible = isGridPlanVisible( {
-			planSlug,
+			gridPlanSlug: planSlug,
 			planSlugsForIntent,
 			selectedPlan,
+			selectedFeature,
+			currentPlanSlug: sitePlanSlug,
 			hiddenPlans,
 			isDisplayingPlansNeededForFeature,
 		} );

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -77,6 +77,7 @@ export type PlansIntent =
 	| 'plans-site-selected-legacy'
 	| 'plans-playground'
 	| 'plans-playground-premium' // This plan intent is currently not utilized but will be soon
+	| 'plans-upgrade'
 	| 'plans-wordpress-hosting'
 	| 'plans-website-builder'
 	| 'default';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-454

## Proposed Changes

Add a new super simple stepper flow that just exists to allow people to upgrade their plans in a distraction-free way.

In future we might want to test adding a domain step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We should unify all upgrade entry points into a single, full-screen PlansGrid because it creates a consistent and focused upgrade experience that reduces friction and confusion for users. Instead of pulling people out of context into the dashboard navigation, we can direct them to a clear, distraction-free surface that’s designed solely to help them compare plans and make a decision.

See also p58i-nge-p2

This change is looking to get the user interface right within the existing system, it's not looking at "hosting dashboardifying" the internals of how it works.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="1090" height="1253" alt="Screenshot 2025-10-08 at 18 37 31" src="https://github.com/user-attachments/assets/96229d3c-19ce-4097-9f98-100b9715f9b2" />


1. Go to /setup/plan-upgrade/plans?siteSlug=:siteSlug&redirect_to=/themes/:siteSlug



### Happy Path
3. You should see a plans grid
4. You should be able to select a plan
5. You should be able to increase the payment interval, or keep it the same, but not decrease it.
6. You should be able to complete checkout
7. You should be redirected to the url specified in `redirect_to` GET var.

### Other scenarios

1. **Authentication**: Anonymous user gets redirected to login
2. **Authorization**: User without access to :siteSlug gets treated appropriately
3. **Redirect**: Post-checkout redirect works with various URLs
4. **Plan Restrictions**: Verify unified-plans step shows only upgrade options (not downgrades) for existing sites
5. **Feature Restrictions**: Verify that the unified-plans step shows only upgrade options that provide the said feature if a feature GET var is supplieed, e.g. `&feature=sftp-and-database-access` should mean that only the current plan + business and e-commerce is listed.
6. Check the other onboarding flows to ensure their plans grids continue to work as before
8. Check /plans/:siteSlug to ensure that it continues to work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?