### PR TITLE
Fix Help Center build

### DIFF
--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -23,7 +23,8 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"teamcity:build-app": "yarn run build",
-		"build": "NODE_ENV=production yarn dev",
+		"code-comment": "The find command below is a terrible hack to quickly fix DOTCOM-14617",
+		"build": "NODE_ENV=production yarn dev && find dist -maxdepth 1 -type f ! -name '*.min.js' -name '*.js' -delete",
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",
 		"prepack": "yarn run clean && yarn run build",


### PR DESCRIPTION
Fixes DOTCOM-14617

Currently the Help Center build contains a lot of unminified files that don't need to be deployed. From what I see, even the minified files are largely unused but will need a lengthy investigation to understand.

**Here's what I know:**

1. The issue stems from the `agenttic-client` package.
2. We don't use that package, only `agenttic-ui`, but `agenttic-ui` declares that it depends on `agenttic-client` (but it doesn't).