### PR TITLE
Fix "sources" link on mobile in chat with AI

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -236,6 +236,12 @@ $blueberry-color: #3858e9;
 				}
 			}
 
+			.foldable-card__secondary {
+				@media (max-width: #{ ($break-mobile) }) {
+					flex: 1 1;
+				}
+			}
+
 			.foldable-card__content {
 				margin-top: 12px;
 				border: none;


### PR DESCRIPTION
Fix https://linear.app/a8c/issue/DOTCOM-14619/fix-mobile-sources-link

## Why

<img width="434" height="526" alt="image" src="https://github.com/user-attachments/assets/645004b7-e583-4d49-8e4c-d1cf0947c259" />


## Testing steps

1. Open a chat with AI and ask something, on mobile