### PR TITLE
Domains: Add Nominet Contact Verification form

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -27,6 +27,7 @@ import {
 	checkDomainTransferPermissions,
 	checkDomainContactInfoPermissions,
 	checkDomainDnsRecordsPermissions,
+	checkDomainContactVerificationPermissions,
 } from '../../utils/domain-permissions';
 import { rootRoute } from './root';
 
@@ -67,6 +68,7 @@ export const domainRoute = createRoute( {
 		const isTransferSubRoute = location.pathname.includes( '/transfer' );
 		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
 		const isDnsSubRoute = location.pathname.includes( '/dns' );
+		const isContactVerificationSubRoute = location.pathname.includes( '/contact-verification' );
 
 		// For generic sub-routes permissions checks,
 		// throw error and handle it with the global error boundary
@@ -84,6 +86,10 @@ export const domainRoute = createRoute( {
 
 		if ( isDnsSubRoute ) {
 			checkDomainDnsRecordsPermissions( domain );
+		}
+
+		if ( isContactVerificationSubRoute ) {
+			checkDomainContactVerificationPermissions( domain );
 		}
 
 		return domain;
@@ -290,6 +296,30 @@ export const domainContactInfoRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../domains/domain-contact-details' ).then( ( d ) =>
 		createLazyRoute( 'domain-contact-info' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const domainContactVerificationRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Contact verification' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'contact-verification',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainWhoisQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../domains/domain-contact-verification' ).then( ( d ) =>
+		createLazyRoute( 'domain-contact-verification' )( {
 			component: d.default,
 		} )
 	)
@@ -522,6 +552,7 @@ export const createDomainsRoutes = () => {
 			domainDnsAddRoute,
 			domainDnsEditRoute,
 			domainConnectionSetupRoute,
+			domainContactVerificationRoute,
 			domainForwardingsRoute,
 			domainForwardingAddRoute,
 			domainForwardingEditRoute,

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -22,6 +22,8 @@ import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { findRegistrantWhois } from '../../utils/domain';
 
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 export default function DomainContactVerification() {
 	const { domainName } = domainRoute.useParams();
 	const [ selectedFiles, setSelectedFiles ] = useState< FileList | null >( null );
@@ -48,6 +50,14 @@ export default function DomainContactVerification() {
 
 		if ( files.length > 3 ) {
 			createErrorNotice( __( 'You can only upload up to three documents.' ), { type: 'snackbar' } );
+			setSelectedFiles( null );
+			return;
+		}
+
+		const oversizedFiles = [ ...files ].filter( ( file: File ) => file.size > MAX_FILE_SIZE );
+		if ( oversizedFiles.length > 0 ) {
+			createErrorNotice( __( 'Files must be under 5MB each.' ), { type: 'snackbar' } );
+			setSelectedFiles( null );
 			return;
 		}
 

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -1,0 +1,225 @@
+import { domainWhoisQuery, domainContactVerificationMutation } from '@automattic/api-queries';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Card,
+	CardBody,
+	FormFileUpload,
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { domainContactInfoRoute, domainRoute } from '../../app/router/domains';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import { findRegistrantWhois } from '../../utils/domain';
+
+export default function DomainContactVerification() {
+	const { domainName } = domainRoute.useParams();
+	const [ selectedFiles, setSelectedFiles ] = useState< FileList | null >( null );
+	const { data: domainWhois } = useSuspenseQuery( domainWhoisQuery( domainName ) );
+	const registrantWhoisData = findRegistrantWhois( domainWhois );
+	const [ submitted, setSubmitted ] = useState( false );
+	const [ error, setError ] = useState( false );
+	const { mutate: domainContactVerification, isPending: isSubmitting } = useMutation(
+		domainContactVerificationMutation( domainName )
+	);
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+	const router = useRouter();
+
+	if ( ! registrantWhoisData ) {
+		return null;
+	}
+
+	const handleFilesSelected = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const files = event.currentTarget.files;
+		if ( ! files ) {
+			setSelectedFiles( null );
+			return;
+		}
+
+		if ( files.length > 3 ) {
+			createErrorNotice( __( 'You can only upload up to three documents.' ), { type: 'snackbar' } );
+			return;
+		}
+
+		setSelectedFiles( files );
+	};
+
+	const renderSelectedFileList = () => {
+		if ( ! selectedFiles || selectedFiles.length === 0 ) {
+			return <Text variant="muted">{ __( 'No selected files yet' ) }</Text>;
+		}
+
+		const fileList = [ ...selectedFiles ].map( ( file: File ) => (
+			<li key={ file.name }>{ file.name }</li>
+		) );
+		return (
+			<>
+				<Text as="p">{ __( 'Selected files:' ) }</Text>
+				<ul>{ fileList }</ul>
+			</>
+		);
+	};
+
+	const submitFiles = () => {
+		if ( ! selectedFiles || selectedFiles.length === 0 ) {
+			createErrorNotice( __( 'Please select at least one file.' ), { type: 'snackbar' } );
+			return;
+		}
+
+		const formData: [ string, File, string ][] = [];
+		[ ...selectedFiles ].forEach( ( file: File ) => {
+			formData.push( [ 'files[]', file, file.name ] );
+		} );
+		domainContactVerification( formData, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Files submitted successfully.' ), { type: 'snackbar' } );
+				setSubmitted( true );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to submit files.' ), { type: 'snackbar' } );
+				setError( true );
+			},
+		} );
+	};
+
+	const renderSubmittedMessage = () => {
+		return (
+			<Notice status="success">
+				{ __(
+					'Thank you for submitting your documents for contact verification! If your domain was suspended, it may take up to a week for it to be unsuspended. Our support team will contact you via email if further actions are needed.'
+				) }
+			</Notice>
+		);
+	};
+
+	const renderErrorMessage = () => {
+		return (
+			<Notice status="error">
+				{ __(
+					'An error occurred when uploading your files. Please try submitting them again. If the error persists, please contact our support team.'
+				) }
+			</Notice>
+		);
+	};
+
+	const renderInstructions = () => {
+		return (
+			<>
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							'Please verify that the above information is correct and either <link>update</link> it or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:'
+						),
+						{
+							link: (
+								<Button
+									variant="link"
+									onClick={ () =>
+										router.navigate( {
+											to: domainContactInfoRoute.fullPath,
+											params: { domainName },
+										} )
+									}
+								/>
+							),
+						}
+					) }
+				</Text>
+				<ul>
+					<li>{ __( "Valid drivers' license" ) }</li>
+					<li>{ __( 'Valid national ID cards (for non-UK residents)' ) }</li>
+					<li>{ __( 'Utility bills (last 3 months)' ) }</li>
+					<li>{ __( 'Bank statement (last 3 months)' ) }</li>
+					<li>{ __( 'HMRC tax notification (last 3 months)' ) }</li>
+				</ul>
+				<Text>
+					{ __(
+						'Please upload a photo of the document on which the above name and address are clearly visible.'
+					) }
+				</Text>
+			</>
+		);
+	};
+
+	const renderContactInformation = () => {
+		return (
+			<>
+				<Text as="p">{ __( 'This is your current contact information:' ) }</Text>
+				<VStack style={ { backgroundColor: '#f0f0f0', padding: '16px' } } spacing={ 1 }>
+					<Text as="p">
+						{ registrantWhoisData.fname } { registrantWhoisData.lname }
+					</Text>
+					{ registrantWhoisData.org && <Text>{ registrantWhoisData.org }</Text> }
+					<Text as="p">{ registrantWhoisData.email }</Text>
+					<Text as="p">{ registrantWhoisData.sa1 }</Text>
+					{ registrantWhoisData.sa2 && <Text>{ registrantWhoisData.sa2 }</Text> }
+					<Text as="p">
+						{ registrantWhoisData.city }
+						{ registrantWhoisData.sp && <span>, { registrantWhoisData.sp }</span> }
+						<span> { registrantWhoisData.pc }</span>
+					</Text>
+					<Text as="p">{ registrantWhoisData.country_code }</Text>
+					<Text as="p">{ registrantWhoisData.phone }</Text>
+					{ registrantWhoisData.fax && <Text>{ registrantWhoisData.fax }</Text> }
+				</VStack>
+			</>
+		);
+	};
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Contact Verification' ) } /> }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 3 }>
+						<SectionHeader
+							title={ __( 'Additional contact verification required for your domain' ) }
+							level={ 3 }
+						/>
+						<Text as="p">
+							{ __(
+								'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.'
+							) }
+						</Text>
+						{ renderContactInformation() }
+						{ renderInstructions() }
+						<FormFileUpload
+							accept="image/*,.pdf"
+							multiple
+							onChange={ handleFilesSelected }
+							disabled={ isSubmitting }
+							render={ ( { openFileDialog } ) => (
+								<Button variant="secondary" __next40pxDefaultSize onClick={ openFileDialog }>
+									{ __( 'Select files' ) }
+								</Button>
+							) }
+						/>
+						{ renderSelectedFileList() }
+						<HStack>
+							<Button
+								variant="secondary"
+								__next40pxDefaultSize
+								disabled={ ! selectedFiles || selectedFiles.length === 0 || isSubmitting }
+								isBusy={ isSubmitting }
+								onClick={ submitFiles }
+							>
+								{ __( 'Submit' ) }
+							</Button>
+						</HStack>
+						{ submitted && renderSubmittedMessage() }
+						{ error && renderErrorMessage() }
+					</VStack>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -1,6 +1,5 @@
 import { domainWhoisQuery, domainContactVerificationMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -9,7 +8,6 @@ import {
 	CardBody,
 	FormFileUpload,
 	Button,
-	Notice,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -17,8 +15,10 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { domainContactInfoRoute, domainRoute } from '../../app/router/domains';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { findRegistrantWhois } from '../../utils/domain';
 
@@ -35,7 +35,6 @@ export default function DomainContactVerification() {
 		domainContactVerificationMutation( domainName )
 	);
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
-	const router = useRouter();
 
 	if ( ! registrantWhoisData ) {
 		return null;
@@ -104,7 +103,7 @@ export default function DomainContactVerification() {
 
 	const renderSubmittedMessage = () => {
 		return (
-			<Notice status="success">
+			<Notice variant="success">
 				{ __(
 					'Thank you for submitting your documents for contact verification! If your domain was suspended, it may take up to a week for it to be unsuspended. Our support team will contact you via email if further actions are needed.'
 				) }
@@ -114,7 +113,7 @@ export default function DomainContactVerification() {
 
 	const renderErrorMessage = () => {
 		return (
-			<Notice status="error">
+			<Notice variant="error">
 				{ __(
 					'An error occurred when uploading your files. Please try submitting them again. If the error persists, please contact our support team.'
 				) }
@@ -132,14 +131,10 @@ export default function DomainContactVerification() {
 						),
 						{
 							link: (
-								<Button
+								<RouterLinkButton
 									variant="link"
-									onClick={ () =>
-										router.navigate( {
-											to: domainContactInfoRoute.fullPath,
-											params: { domainName },
-										} )
-									}
+									to={ domainContactInfoRoute.fullPath }
+									params={ { domainName } }
 								/>
 							),
 						}
@@ -188,6 +183,8 @@ export default function DomainContactVerification() {
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Contact Verification' ) } /> }>
+			{ submitted && renderSubmittedMessage() }
+			{ error && renderErrorMessage() }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 3 }>
@@ -216,7 +213,7 @@ export default function DomainContactVerification() {
 						{ renderSelectedFileList() }
 						<HStack>
 							<Button
-								variant="secondary"
+								variant="primary"
 								__next40pxDefaultSize
 								disabled={ ! selectedFiles || selectedFiles.length === 0 || isSubmitting }
 								isBusy={ isSubmitting }
@@ -225,8 +222,6 @@ export default function DomainContactVerification() {
 								{ __( 'Submit' ) }
 							</Button>
 						</HStack>
-						{ submitted && renderSubmittedMessage() }
-						{ error && renderErrorMessage() }
 					</VStack>
 				</CardBody>
 			</Card>

--- a/packages/api-core/src/domain-contact-verification/index.ts
+++ b/packages/api-core/src/domain-contact-verification/index.ts
@@ -1,0 +1,1 @@
+export * from './mutators';

--- a/packages/api-core/src/domain-contact-verification/mutators.ts
+++ b/packages/api-core/src/domain-contact-verification/mutators.ts
@@ -1,0 +1,12 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export function domainContactVerification(
+	domain: string,
+	formData: [ string, File, string ][]
+): Promise< void > {
+	return wpcom.req.post( {
+		path: `/domains/${ domain }/contact-verification`,
+		apiVersion: '1.1',
+		formData,
+	} );
+}

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -39,6 +39,8 @@ export interface Domain extends DomainSummary {
 	is_subdomain: boolean;
 	is_pending_icann_verification: boolean;
 	move_to_new_site_pending: boolean;
+	nominet_pending_contact_verification_request: boolean;
+	nominet_domain_suspended: boolean;
 	owner: string;
 	is_pending_registration: boolean;
 	is_pending_registration_at_registry: boolean;

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -6,6 +6,7 @@ export * from './agency';
 export * from './domain';
 export * from './domain-availability';
 export * from './domain-connection-setup';
+export * from './domain-contact-verification';
 export * from './domain-dns-records';
 export * from './domain-dnssec';
 export * from './domain-forwarding';

--- a/packages/api-queries/src/domain-contact-verification.ts
+++ b/packages/api-queries/src/domain-contact-verification.ts
@@ -1,0 +1,8 @@
+import { domainContactVerification } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+
+export const domainContactVerificationMutation = ( domainName: string ) =>
+	mutationOptions( {
+		mutationFn: ( formData: [ string, File, string ][] ) =>
+			domainContactVerification( domainName, formData ),
+	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -2,6 +2,7 @@ export * from './query-client';
 
 export * from './domain-availability';
 export * from './domain-connection-setup';
+export * from './domain-contact-verification';
 export * from './domain-dns-records';
 export * from './domain-dnssec';
 export * from './domain-forwarding';


### PR DESCRIPTION
Closes [DOTDASH-464](https://linear.app/a8c/issue/DOTDASH-464/add-nominet-verification-form)

## Proposed Changes
- Add new contact verification workflow for UK domains (.uk) managed by Nominet
- Implement file upload functionality allowing users to submit verification documents
- Create new /domains/{domain}/contact-verification route in Dashboard app
- Add API integration for document submission with proper permission checks
- Extend Domain type with `nominet_pending_contact_verification_request` and `nominet_domain_suspended` properties

<img width="1418" height="1634" alt="verification-1" src="https://github.com/user-attachments/assets/f8dac120-24d2-4e39-94f7-e2cfece1e472" />

![Screenshot 2025-09-18 alle 19 15 01](https://github.com/user-attachments/assets/489f7f03-a6f9-4790-90fc-d9a2046a6416)

![Screenshot 2025-09-18 alle 19 15 26](https://github.com/user-attachments/assets/0a56925c-c8cc-4743-9a87-6247fe3a956e)

## Why are these changes being made?
This is part of domains HD project.

## Testing Instructions

**Prerequisites:**
In order to test it, you need a .uk domain with a pending verification request. Otherwise, you can just comment these line in `client/dashboard/app/router/domains.ts`:
```
if ( isContactVerificationSubRoute ) {
	checkDomainContactVerificationPermissions( domain );
}
```


1. **Access the feature:**
   - Navigate to `/domains/{your-uk-domain}/contact-verification` in Dashboard app
   - Verify page is loading correctly

2. **Review displayed information:**
   - Confirm current contact information is displayed correctly
   - Check that Nominet explanation text appears
   - Verify link to update contact info navigates to correct page

3. **Test file upload workflow:**
   - Click "Select files" button
   - Choose 1-3 files (images or PDFs under 5MB each)
   - Verify selected files are listed with names and sizes
   - Attempt to select more than 3 files (should show error)
   - Try uploading files larger than 5MB (should show error)

4. **Test submission:**
   - With valid files selected, click "Submit" button
   - Verify loading state appears during submission
   - Check for success message after successful upload
   - Test error handling by simulating network issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
