### PR TITLE
Domain Search Rewrite: Allow using existing domain in eligible flows

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -15,7 +15,7 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 
 const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
 
-const getInitialQuery = () => {
+const getSessionStorageQuery = () => {
 	try {
 		return sessionStorage.getItem( SESSION_STORAGE_QUERY_KEY ) ?? '';
 	} catch {
@@ -23,7 +23,7 @@ const getInitialQuery = () => {
 	}
 };
 
-const setInitialQuery = ( query: string ) => {
+const setSessionStorageQuery = ( query: string ) => {
 	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
 };
 
@@ -45,7 +45,15 @@ const DomainSearchWithCart = ( {
 	} );
 
 	const initialQuery = useMemo( () => {
-		return externalInitialQuery || currentSiteUrl || getInitialQuery();
+		if ( externalInitialQuery ) {
+			return externalInitialQuery;
+		}
+
+		if ( currentSiteUrl ) {
+			return new URL( currentSiteUrl ).host.replace( /\.(wordpress|wpcomstaging)\.com$/, '' );
+		}
+
+		return getSessionStorageQuery();
 	}, [ externalInitialQuery, currentSiteUrl ] );
 
 	const cartItemsLength = cart.items.length;
@@ -65,7 +73,7 @@ const DomainSearchWithCart = ( {
 		return {
 			...props.events,
 			onQueryChange: ( query: string ) => {
-				setInitialQuery( query );
+				setSessionStorageQuery( query );
 			},
 			onContinue: () => {
 				props.events?.onContinue?.( items );

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -27,6 +28,10 @@ import type { DomainSuggestion } from '@automattic/api-core';
 import type { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import type { Store } from 'redux';
 
+const DOMAINS_STEP = shouldRenderRewrittenDomainSearch()
+	? STEPS.DOMAIN_SEARCH
+	: STEPS.UNIFIED_DOMAINS;
+
 async function initialize( reduxStore: Store ) {
 	const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;
 
@@ -41,7 +46,7 @@ async function initialize( reduxStore: Store ) {
 	const steps = [];
 
 	if ( showDomainStep ) {
-		steps.push( STEPS.UNIFIED_DOMAINS );
+		steps.push( DOMAINS_STEP );
 	}
 
 	const utmSource = queryParams.get( 'utm_source' );
@@ -113,7 +118,7 @@ const hosting: FlowV2< typeof initialize > = {
 
 		const getGoBack = () => {
 			if ( _currentStepSlug === STEPS.UNIFIED_PLANS.slug && showDomainStep ) {
-				return () => navigate( STEPS.UNIFIED_DOMAINS.slug );
+				return () => navigate( DOMAINS_STEP.slug );
 			}
 
 			if ( _currentStepSlug === STEPS.TRIAL_ACKNOWLEDGE.slug ) {
@@ -125,9 +130,13 @@ const hosting: FlowV2< typeof initialize > = {
 			const { slug, providedDependencies } = submittedStep;
 
 			switch ( slug ) {
-				case STEPS.UNIFIED_DOMAINS.slug: {
+				case DOMAINS_STEP.slug: {
 					if ( ! providedDependencies ) {
 						throw new Error( 'No provided dependencies found' );
+					}
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						throw new Error( 'Navigation to use my domain is not supported for this flow' );
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -1,26 +1,28 @@
+import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { useSelector } from '../../../state';
 import getCurrentQueryArguments from '../../../state/selectors/get-current-query-arguments';
 
 export default function DomainSearch() {
+	const flowName = 'domains';
 	const queryArguments = useSelector( getCurrentQueryArguments );
 
-	const allowedTlds = Array.isArray( queryArguments?.tld )
-		? queryArguments.tld
-		: queryArguments?.tld?.split( ',' ) ?? [];
+	const tldQuery = queryArguments?.tld;
 
-	return (
-		<WPCOMDomainSearch
-			flowName="domains"
-			config={ {
-				vendor: getSuggestionsVendor( {
-					isSignup: false,
-					isDomainOnly: false,
-					flowName: 'domains',
-				} ),
-				allowedTlds,
-			} }
-		/>
-	);
+	const config = useMemo( () => {
+		const allowedTlds = Array.isArray( tldQuery ) ? tldQuery : tldQuery?.split( ',' ) ?? [];
+
+		return {
+			vendor: getSuggestionsVendor( {
+				isSignup: false,
+				isDomainOnly: false,
+				flowName,
+			} ),
+			allowedTlds,
+			skippable: false,
+		};
+	}, [ flowName, tldQuery ] );
+
+	return <WPCOMDomainSearch flowName={ flowName } config={ config } />;
 }

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -1,12 +1,19 @@
+import page from '@automattic/calypso-router';
+import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { useMyDomainInputMode } from '../../../components/domains/connect-domain-step/constants';
 import { useSelector } from '../../../state';
 import getCurrentQueryArguments from '../../../state/selectors/get-current-query-arguments';
+import { domainAddEmailUpsell, domainUseMyDomain } from '../paths';
+
+const FLOW_NAME = 'domains';
 
 export default function DomainSearch() {
-	const flowName = 'domains';
 	const queryArguments = useSelector( getCurrentQueryArguments );
+	const selectedSite = useSelector( getSelectedSite );
 
 	const tldQuery = queryArguments?.tld;
 
@@ -16,13 +23,47 @@ export default function DomainSearch() {
 		return {
 			vendor: getSuggestionsVendor( {
 				isSignup: false,
-				isDomainOnly: false,
-				flowName,
+				isDomainOnly: true,
+				flowName: FLOW_NAME,
 			} ),
 			allowedTlds,
 			skippable: false,
 		};
-	}, [ flowName, tldQuery ] );
+	}, [ tldQuery ] );
 
-	return <WPCOMDomainSearch flowName={ flowName } config={ config } />;
+	const selectedSiteSlug = selectedSite?.slug;
+
+	const events = useMemo( () => {
+		return {
+			onExternalDomainClick: ( domainName?: string ) => {
+				if ( ! selectedSiteSlug ) {
+					throw new Error( 'Selected site slug is required' );
+				}
+
+				page(
+					domainUseMyDomain( selectedSiteSlug, {
+						domain: domainName,
+						initialMode: useMyDomainInputMode.transferOrConnect,
+					} )
+				);
+			},
+			onContinue: ( items: ResponseCartProduct[] ) => {
+				if ( items.length === 1 ) {
+					page( domainAddEmailUpsell( selectedSiteSlug, items[ 0 ].meta ) );
+				} else {
+					page( `/checkout/${ selectedSiteSlug }` );
+				}
+			},
+		};
+	}, [ selectedSiteSlug ] );
+
+	return (
+		<WPCOMDomainSearch
+			currentSiteId={ selectedSite?.ID }
+			currentSiteUrl={ selectedSite?.URL }
+			flowName={ FLOW_NAME }
+			config={ config }
+			events={ events }
+		/>
+	);
 }

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -1,5 +1,6 @@
 import { useMyDomainInputMode } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
+import { isDomainForGravatarFlow, isFreeFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
@@ -26,6 +27,8 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 	} = props;
 
 	const isDomainOnlyFlow = flowName === 'domain';
+	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
+
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const locale = ! isLoggedIn ? externalLocale : '';
 
@@ -132,6 +135,11 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 						},
 						allowedTlds,
 						skippable: isDomainOnlyFlow,
+						allowsUsingOwnDomain:
+							! isDomainForGravatarFlow( flowName ) &&
+							! isDomainOnlyFlow &&
+							! isOnboardingWithEmailFlow &&
+							! isFreeFlow( flowName ),
 					} }
 				/>
 			}

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -81,6 +81,7 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 				<WPCOMDomainSearch
 					className="domain-search--step-wrapper"
 					flowName={ flowName }
+					initialQuery={ queryObject.new }
 					events={ {
 						onExternalDomainClick( initialQuery ) {
 							page(

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -1,8 +1,9 @@
-import { useMyDomainInputMode } from '@automattic/api-core';
+import { FreeDomainSuggestion, useMyDomainInputMode } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
 import { isDomainForGravatarFlow, isFreeFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
@@ -15,19 +16,112 @@ import type { StepProps } from './types';
 
 import './style.scss';
 
+const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
+	const { flowName, stepName, submitSignupStep, goToNextStep, locale, queryObject } = props;
+
+	const isDomainOnlyFlow = flowName === 'domain';
+	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
+
+	const allowedTldParam = queryObject.tld;
+
+	const events = useMemo( () => {
+		return {
+			onExternalDomainClick( initialQuery?: string ) {
+				page(
+					getStepUrl( flowName, stepName, USE_MY_DOMAIN_SECTION_NAME, locale, {
+						step: useMyDomainInputMode.domainInput,
+						initialQuery: initialQuery,
+					} )
+				);
+			},
+			onContinue( domainCart: MinimalRequestCartProduct[] ) {
+				const domainItem = domainCart[ 0 ];
+
+				submitSignupStep(
+					{
+						stepName,
+						domainItem,
+						isPurchasingItem: true,
+						siteUrl: domainItem.meta,
+						stepSectionName: '',
+						domainCart,
+					},
+					{ domainItem, siteUrl: domainItem.meta, domainCart }
+				);
+
+				goToNextStep();
+			},
+			onSkip( suggestion?: FreeDomainSuggestion ) {
+				const siteUrl = suggestion?.domain_name.replace( '.wordpress.com', '' );
+
+				submitSignupStep(
+					{
+						stepName,
+						domainItem: undefined,
+						isPurchasingItem: false,
+						domainCart: [],
+						siteUrl,
+					},
+					{ domainCart: [], siteUrl }
+				);
+
+				goToNextStep();
+			},
+		};
+	}, [ flowName, stepName, submitSignupStep, goToNextStep, locale ] );
+
+	const config = useMemo( () => {
+		const allowedTlds = Array.isArray( allowedTldParam )
+			? allowedTldParam
+			: allowedTldParam?.split( ',' ) ?? [];
+
+		return {
+			vendor: getSuggestionsVendor( {
+				isSignup: true,
+				isDomainOnly: isDomainOnlyFlow,
+				flowName: flowName,
+			} ),
+			priceRules: {
+				forceRegularPrice: isMonthlyOrFreeFlow( flowName ),
+			},
+			allowedTlds,
+			skippable: isDomainOnlyFlow,
+			allowsUsingOwnDomain:
+				! isDomainForGravatarFlow( flowName ) &&
+				! isDomainOnlyFlow &&
+				! isOnboardingWithEmailFlow &&
+				! isFreeFlow( flowName ),
+		};
+	}, [ flowName, isDomainOnlyFlow, isOnboardingWithEmailFlow, allowedTldParam ] );
+
+	return (
+		<StepWrapper
+			{ ...props }
+			className="step-wrapper--domain-search"
+			hideSkip
+			headerText="Domain Search"
+			subHeaderText="Domain Search"
+			stepContent={
+				<WPCOMDomainSearch
+					className="domain-search--step-wrapper"
+					flowName={ flowName }
+					initialQuery={ queryObject.new }
+					events={ events }
+					config={ config }
+				/>
+			}
+		/>
+	);
+};
+
 function DomainSearchStep( props: StepProps & { locale: string } ) {
 	const {
-		flowName,
 		stepName,
 		locale: externalLocale,
 		submitSignupStep,
 		goToNextStep,
 		stepSectionName,
-		queryObject,
 	} = props;
-
-	const isDomainOnlyFlow = flowName === 'domain';
-	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const locale = ! isLoggedIn ? externalLocale : '';
@@ -68,84 +162,7 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 		);
 	}
 
-	const allowedTlds = queryObject.tld?.split( ',' ) ?? [];
-
-	return (
-		<StepWrapper
-			{ ...props }
-			className="step-wrapper--domain-search"
-			hideSkip
-			headerText="Domain Search"
-			subHeaderText="Domain Search"
-			stepContent={
-				<WPCOMDomainSearch
-					className="domain-search--step-wrapper"
-					flowName={ flowName }
-					initialQuery={ queryObject.new }
-					events={ {
-						onExternalDomainClick( initialQuery ) {
-							page(
-								getStepUrl( flowName, stepName, USE_MY_DOMAIN_SECTION_NAME, locale, {
-									step: useMyDomainInputMode.domainInput,
-									initialQuery: initialQuery,
-								} )
-							);
-						},
-						onContinue( domainCart ) {
-							const domainItem = domainCart[ 0 ];
-
-							submitSignupStep(
-								{
-									stepName,
-									domainItem,
-									isPurchasingItem: true,
-									siteUrl: domainItem.meta,
-									stepSectionName: '',
-									domainCart,
-								},
-								{ domainItem, siteUrl: domainItem.meta, domainCart }
-							);
-
-							goToNextStep();
-						},
-						onSkip( suggestion ) {
-							const siteUrl = suggestion?.domain_name.replace( '.wordpress.com', '' );
-
-							submitSignupStep(
-								{
-									stepName,
-									domainItem: undefined,
-									isPurchasingItem: false,
-									domainCart: [],
-									siteUrl,
-								},
-								{ domainCart: [], siteUrl }
-							);
-
-							goToNextStep();
-						},
-					} }
-					config={ {
-						vendor: getSuggestionsVendor( {
-							isSignup: true,
-							isDomainOnly: isDomainOnlyFlow,
-							flowName: flowName,
-						} ),
-						priceRules: {
-							forceRegularPrice: isMonthlyOrFreeFlow( flowName ),
-						},
-						allowedTlds,
-						skippable: isDomainOnlyFlow,
-						allowsUsingOwnDomain:
-							! isDomainForGravatarFlow( flowName ) &&
-							! isDomainOnlyFlow &&
-							! isOnboardingWithEmailFlow &&
-							! isFreeFlow( flowName ),
-					} }
-				/>
-			}
-		/>
-	);
+	return <DomainSearchUI { ...props } locale={ locale } />;
 }
 
 export default localize( DomainSearchStep );

--- a/packages/domain-search/src/components/unavailable-search-result/index.tsx
+++ b/packages/domain-search/src/components/unavailable-search-result/index.tsx
@@ -7,7 +7,12 @@ import { DomainSuggestion } from '../../ui';
 import type { UnavailableProps } from '../../ui/domain-suggestion/unavailable';
 
 export const UnavailableSearchResult = () => {
-	const { query, queries, events } = useDomainSearch();
+	const {
+		query,
+		queries,
+		events,
+		config: { allowsUsingOwnDomain },
+	} = useDomainSearch();
 	const { data: availability } = useQuery( queries.domainAvailability( query ) );
 
 	const { onExternalDomainClick } = events;
@@ -55,11 +60,12 @@ export const UnavailableSearchResult = () => {
 			domain: domainArgument.replace( `.${ availability.tld }`, '' ),
 			tld: availability.tld,
 			reason: 'already-registered',
-			onTransferClick: onExternalDomainClick
-				? () => onExternalDomainClick( domainArgument )
-				: undefined,
+			onTransferClick:
+				allowsUsingOwnDomain && onExternalDomainClick
+					? () => onExternalDomainClick( domainArgument )
+					: undefined,
 		};
-	}, [ availability, onExternalDomainClick ] );
+	}, [ availability, onExternalDomainClick, allowsUsingOwnDomain ] );
 
 	if ( ! props ) {
 		return null;

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -46,6 +46,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		skippable: false,
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
+		allowsUsingOwnDomain: true,
+		allowedTlds: [],
 		priceRules: {
 			hidePrice: false,
 			oneTimePrice: false,

--- a/packages/domain-search/src/page/initial-state.tsx
+++ b/packages/domain-search/src/page/initial-state.tsx
@@ -5,12 +5,13 @@ import { useDomainSearch } from './context';
 export const InitialState = () => {
 	const {
 		events: { onExternalDomainClick },
+		config,
 	} = useDomainSearch();
 
 	return (
 		<div className="domain-search--initial-state">
 			<SearchForm />
-			{ onExternalDomainClick && (
+			{ config.allowsUsingOwnDomain && onExternalDomainClick && (
 				<div className="domain-search--initial-state__already-own-domain-cta">
 					<DomainSearchAlreadyOwnDomainCTA onClick={ () => onExternalDomainClick() } />
 				</div>

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -48,7 +48,8 @@ export interface DomainSearchConfig {
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;
-	allowedTlds?: string[];
+	allowsUsingOwnDomain: boolean;
+	allowedTlds: string[];
 }
 
 export interface DomainSearchProps {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -122,6 +122,10 @@ export const ecommerceFlowRecurTypes = {
 	'3Y': '3Y',
 };
 
+export const isFreeFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ FREE_FLOW ].includes( flowName ) );
+};
+
 export const isDomainForGravatarFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && [ DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
Closes DOMAINS-1660.

## Proposed Changes

Title. Uses the matrix as reference.

## Testing Instructions

Verify the following flows don't accept using an external domain:
- `/start/free`
- `/start/domain`
- `/setup/ai-site-builder/domains?siteId=%d`
- `/start/domain-for-gravatar`
- `/setup/new-hosted-site?showDomainStep`
- `/start/onboarding-with-email`

All other flows should allow you to add an existing domain to your site.