### PR TITLE
Scan Dashboard: add threat details card

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -1,7 +1,14 @@
-import { Icon } from '@wordpress/components';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Icon,
+} from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
+import { ButtonStack } from '../../../components/button-stack';
+import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions(): Action< Threat >[] {
@@ -13,13 +20,31 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Fix threat' ),
 			modalHeader: __( 'Fix threat' ),
 			supportsBulk: true,
-			// @TODO: render the proper fix modal
-			RenderModal: ( { items } ) => {
-				if ( items.length > 1 ) {
-					return <p>Fix threats { items.map( ( threat ) => threat.id ).join( ', ' ) }</p>;
-				}
+			RenderModal: ( { items, closeModal } ) => {
+				const fixButtonLabel = items.length === 1 ? __( 'Fix threat' ) : __( 'Fix all threats' );
+				const description =
+					items.length === 1
+						? __( 'Jetpack will be fixing the following threat:' )
+						: __( 'Jetpack will be fixing the following threats:' );
 
-				return <p>Fix threat #{ items[ 0 ].id }</p>;
+				return (
+					<VStack spacing={ 4 }>
+						<Text variant="muted">{ description }</Text>
+						<ThreatsDetailCard threats={ items } />
+
+						{ /* @TODO: render the proper threat description here */ }
+
+						<ButtonStack justify="flex-end">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel' ) }
+							</Button>
+							{ /* @TODO: implement the auto-fix threat action and remove the disabled prop */ }
+							<Button variant="primary" disabled>
+								{ fixButtonLabel }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				);
 			},
 			isEligible: ( threat: Threat ) => !! threat.fixable,
 		},
@@ -28,28 +53,24 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Ignore threat' ),
 			modalHeader: __( 'Ignore threat' ),
 			supportsBulk: false,
-			// @TODO: render the proper ignore modal
-			RenderModal: ( { items } ) => <p>Ignore threat { items[ 0 ].id }</p>,
-		},
-		{
-			id: 'view_details',
-			label: __( 'View details' ),
-			modalHeader: __( 'Active threat' ),
-			supportsBulk: false,
-			// @TODO: render the proper details modal
-			RenderModal: ( { items } ) => <p>Details of thread { items[ 0 ].id }</p>,
-		},
-		{
-			id: 'view_source',
-			label: __( 'View vulnerability source' ),
-			supportsBulk: false,
-			callback: ( items: Threat[] ) => {
-				const threat = items[ 0 ];
-				if ( threat.source ) {
-					window.open( threat.source, '_blank' );
-				}
-			},
-			isEligible: ( threat: Threat ) => !! threat.source,
+			RenderModal: ( { items, closeModal } ) => (
+				<VStack spacing={ 4 }>
+					<Text variant="muted">{ __( 'Jetpack will be ignoring the following threat:' ) }</Text>
+					<ThreatsDetailCard threats={ items } />
+
+					{ /* @TODO: render the proper threat description here */ }
+
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" onClick={ closeModal }>
+							{ __( 'Cancel' ) }
+						</Button>
+						{ /* @TODO: implement the ignore threat action and remove the disabled prop */ }
+						<Button variant="primary" disabled>
+							{ __( 'Ignore threat' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			),
 		},
 	];
 }

--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -3,12 +3,16 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Icon,
+	ExternalLink,
 } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
 import { ButtonStack } from '../../../components/button-stack';
+import { Notice } from '../../../components/notice';
 import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
+import { CODEABLE_JETPACK_SCAN_URL } from '../../scan/constants';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions(): Action< Threat >[] {
@@ -60,6 +64,16 @@ export function getActions(): Action< Threat >[] {
 
 					{ /* @TODO: render the proper threat description here */ }
 
+					<Notice variant="error">
+						{ createInterpolateElement(
+							__(
+								'By ignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site. If you are unsure please request an estimate with <codeable />.'
+							),
+							{
+								codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
+							}
+						) }
+					</Notice>
 					<ButtonStack justify="flex-end">
 						<Button variant="tertiary" onClick={ closeModal }>
 							{ __( 'Cancel' ) }

--- a/client/dashboard/sites/scan-active/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/fields.tsx
@@ -42,7 +42,7 @@ export function getFields(): Field< Threat >[] {
 			label: __( 'Threat' ),
 			getValue: ( { item } ) => getThreatMessage( item ),
 			render: ( { item } ) => (
-				<HStack spacing={ 2 } justify="flex-start" wrap>
+				<HStack spacing={ 2 } justify="flex-start">
 					<Icon
 						className="site-scan-threats__type-icon"
 						icon={ getThreatIcon( item ) }

--- a/client/dashboard/sites/scan-history/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/actions.tsx
@@ -2,11 +2,15 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
+	ExternalLink,
 } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ButtonStack } from '../../../components/button-stack';
+import { Notice } from '../../../components/notice';
 import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
+import { CODEABLE_JETPACK_SCAN_URL } from '../../scan/constants';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions(): Action< Threat >[] {
@@ -24,6 +28,16 @@ export function getActions(): Action< Threat >[] {
 
 					{ /* @TODO: render the proper threat description here */ }
 
+					<Notice variant="warning">
+						{ createInterpolateElement(
+							__(
+								'By unignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site as an active threat. If you are unsure please request an estimate with <codeable />.'
+							),
+							{
+								codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
+							}
+						) }
+					</Notice>
 					<ButtonStack justify="flex-end">
 						<Button variant="tertiary" onClick={ closeModal }>
 							{ __( 'Cancel' ) }

--- a/client/dashboard/sites/scan-history/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/actions.tsx
@@ -1,5 +1,12 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../../components/button-stack';
+import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions(): Action< Threat >[] {
@@ -10,17 +17,38 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Unignore threat' ),
 			modalHeader: __( 'Unignore threat' ),
 			supportsBulk: false,
-			// @TODO: render the proper unignore modal
-			RenderModal: ( { items } ) => <p>Unignore threat { items[ 0 ].id }</p>,
+			RenderModal: ( { items, closeModal } ) => (
+				<VStack spacing={ 4 }>
+					<Text variant="muted">{ __( 'Jetpack will be unignoring the following threat:' ) }</Text>
+					<ThreatsDetailCard threats={ items } />
+
+					{ /* @TODO: render the proper threat description here */ }
+
+					<ButtonStack justify="flex-end">
+						<Button variant="tertiary" onClick={ closeModal }>
+							{ __( 'Cancel' ) }
+						</Button>
+						{ /* @TODO: implement the unignore threat action and remove the disabled prop */ }
+						<Button variant="primary" disabled>
+							{ __( 'Unignore threat' ) }
+						</Button>
+					</ButtonStack>
+				</VStack>
+			),
 		},
 		{
 			id: 'view_details',
 			isEligible: ( threat: Threat ) => threat.status !== 'ignored',
 			label: __( 'View details' ),
-			modalHeader: __( 'Threat' ),
+			modalHeader: __( 'View threat details' ),
 			supportsBulk: false,
-			// @TODO: render the proper details modal
-			RenderModal: ( { items } ) => <p>Details of threat { items[ 0 ].id }</p>,
+			RenderModal: ( { items } ) => (
+				<VStack spacing={ 4 }>
+					<ThreatsDetailCard threats={ items } />
+
+					{ /* @TODO: render the proper threat description here */ }
+				</VStack>
+			),
 		},
 	];
 }

--- a/client/dashboard/sites/scan/components/threats-detail-card.tsx
+++ b/client/dashboard/sites/scan/components/threats-detail-card.tsx
@@ -1,0 +1,48 @@
+import {
+	Card,
+	CardBody,
+	CardDivider,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Icon,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { SeverityBadge } from '../severity-badge';
+import { getThreatIcon } from '../utils';
+import type { Threat } from '@automattic/api-core';
+
+export function ThreatsDetailCard( { threats }: { threats: Threat[] } ) {
+	const ThreatDetail = ( { threat }: { threat: Threat } ) => {
+		return (
+			<HStack justify="space-between">
+				<HStack justify="flex-start" alignment="center" spacing={ 4 }>
+					<Icon
+						className="site-scan-threats__type-icon"
+						icon={ getThreatIcon( threat ) }
+						size={ 32 }
+						style={ { flexShrink: 0 } }
+					/>
+					<VStack justify="flex-start" spacing={ 1 } wrap>
+						<Text weight={ 500 }>{ threat.vulnerability_description }</Text>
+						<Text variant="muted">{ threat.title }</Text>
+					</VStack>
+				</HStack>
+				<SeverityBadge severity={ threat.severity } />
+			</HStack>
+		);
+	};
+
+	return (
+		<Card>
+			{ threats.map( ( threat, index ) => (
+				<>
+					<CardBody>
+						<ThreatDetail key={ threat.id } threat={ threat } />
+					</CardBody>
+
+					{ index < threats.length - 1 && <CardDivider /> }
+				</>
+			) ) }
+		</Card>
+	);
+}

--- a/client/dashboard/sites/scan/constants.ts
+++ b/client/dashboard/sites/scan/constants.ts
@@ -1,0 +1,1 @@
+export const CODEABLE_JETPACK_SCAN_URL = 'https://www.codeable.io/partners/jetpack-scan/';

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -28,5 +28,9 @@ export const getSeverityIntent = ( severity: number ): 'default' | 'error' | 'wa
 export const SeverityBadge = ( { severity }: { severity: number } ) => {
 	const intent = getSeverityIntent( severity );
 	const label = getSeverityLabel( severity );
-	return <Badge intent={ intent }>{ label }</Badge>;
+	return (
+		<Badge intent={ intent } style={ { flexShrink: 0 } }>
+			{ label }
+		</Badge>
+	);
 };

--- a/client/dashboard/sites/scan/style.scss
+++ b/client/dashboard/sites/scan/style.scss
@@ -4,5 +4,6 @@
 	background-color: $gray-100;
 	border-radius: $radius-small;
 	fill: $gray-700;
+	flex-shrink: 0;
 	padding: 4px;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-500

## Proposed Changes

* Add `ThreatsDetailCard` component to centralize logic of displaying the summary info on actions modals
* Implement `ThreatsDetailCard` into all modals, including bulk fix.
* Add `flex-shrink: 0` to icon type and badge to ensure they don't break.
* Add error/warning notice for the ignore and unignore actions.
 
| Before | After |
|---|---|
| <img width="1062" height="348" alt="CleanShot 2025-09-18 at 12 18 42@2x" src="https://github.com/user-attachments/assets/6703f99d-b456-4743-8c2b-d299789a0b88" /> | <img width="1058" height="558" alt="CleanShot 2025-09-18 at 12 21 17@2x" src="https://github.com/user-attachments/assets/172e9ee7-1a54-47c5-bb00-ef3bec7e1da1" /> |
| <img width="1050" height="332" alt="CleanShot 2025-09-18 at 12 19 04@2x" src="https://github.com/user-attachments/assets/70a26d51-0f78-4a74-863e-8f7778076f1f" /> | <img width="1052" height="1112" alt="CleanShot 2025-09-18 at 12 21 44@2x" src="https://github.com/user-attachments/assets/7a53fc8c-eaa8-4e0f-a0a1-f9ba93964ad7" /> |
| <img width="1066" height="346" alt="CleanShot 2025-09-18 at 12 19 41@2x" src="https://github.com/user-attachments/assets/54d7b1bb-98e2-43e9-9a74-2ee752f42797" /> | <img width="1050" height="828" alt="CleanShot 2025-09-18 at 12 32 52@2x" src="https://github.com/user-attachments/assets/cbfa88d5-016c-43ad-9cec-ff2e6d6eb1c1" /> |
| <img width="1064" height="346" alt="CleanShot 2025-09-18 at 12 20 53@2x" src="https://github.com/user-attachments/assets/41d46122-c4e6-408f-9f83-23de02ad1a20" /> | <img width="1054" height="830" alt="CleanShot 2025-09-18 at 12 32 43@2x" src="https://github.com/user-attachments/assets/0a361b47-09c6-4510-8d34-0a14857f6316" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

All action modals should include a threat detail card like this:

<img width="930" height="176" alt="CleanShot 2025-09-18 at 12 16 26@2x" src="https://github.com/user-attachments/assets/da636b80-1ccd-4715-9c68-ff7b9a9646dd" />

This PR aims to create a component for that purpose and implement it on all action modals.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> If you have a Jetpack (self-hosted) site with threats available for test, checkout this branch locally and make [this function](https://github.com/Automattic/wp-calypso/blob/76b23c1267b6d0fcdcbc70e7ced492cba5e63983/client/dashboard/utils/site-types.ts#L4) to return false.

For testing, you need a site with the Scan feature and some test threats. Here are example threats you can add to your site for testing purposes: DOTDASH-412 (check last comment).

1. Navigate to `/v2/sites/{site-slug}/scan` in the Hosting Dashboard
2. Click on the actions and ensure the modal is displayed as shown above, including the threat details card.
  - Active threats dataviews
    - Fix threat
    - Ignore threat
  - History dataviews
    - Unignore threat
    - View details
3. Try also with clicking multiple threats checkboxes and try the [bulk threat fix](https://github.com/user-attachments/assets/80556452-5b70-4fe4-98f1-7b1de9ba93d6)
  - You should see all threats you selected on that modal 
5. Ensure clicking on "Cancel" closes the modal


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
