### PR TITLE
Domain Search Rewrite: Make eligible flows skippable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -77,7 +77,10 @@ const DomainSearchStep: StepType< {
 				oneTimePrice: isHundredYearDomainFlow( flow ),
 			},
 			includeDotBlogSubdomain: isNewsletterFlow( flow ),
-			skippable: isNewsletterFlow( flow ) || isOnboardingFlow( flow ),
+			skippable:
+				! isHundredYearPlanFlow( flow ) &&
+				! isHundredYearDomainFlow( flow ) &&
+				! isDomainFlow( flow ),
 			allowedTlds,
 			allowsUsingOwnDomain:
 				! isDomainFlow( flow ) &&

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -85,7 +85,7 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 				forceRegularPrice: isMonthlyOrFreeFlow( flowName ),
 			},
 			allowedTlds,
-			skippable: isDomainOnlyFlow,
+			skippable: ! isDomainOnlyFlow && ! isDomainForGravatarFlow( flowName ),
 			allowsUsingOwnDomain:
 				! isDomainForGravatarFlow( flowName ) &&
 				! isDomainOnlyFlow &&


### PR DESCRIPTION
Closes DOMAINS-1659.

## Proposed Changes

All flows should be skippable except the domain only flows and the hundred year flows.

## Testing Instructions

These flows should not be skippable:
- `/start/domain`
- `/setup/domain`
- `/start/domain-for-gravatar`
- `/setup/hundred-year-plan`
- `/setup/hundred-year-domain`
- `/domains/add/%s`

All the other flows should be skippable after searching for a domain.