### PR TITLE
Domains: Data Views: Add domain filters

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -24,24 +24,23 @@ export const useFields = ( {
 } = {} ) => {
 	const { data: domains } = useQuery( domainsQuery() );
 
-	const siteElements = useMemo(
-		() =>
-			Object.values(
-				domains
-					?.filter(
-						( domain ) =>
-							! domain.is_domain_only_site && domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION
-					)
-					.reduce(
-						( acc, domain ) => ( {
-							...acc,
-							[ domain.blog_id ]: { value: domain.blog_id.toString(), label: domain.blog_name },
-						} ),
-						{} as Record< number, { value: string; label: string } >
-					) ?? {}
-			),
-		[ domains ]
-	);
+	const siteElements = useMemo( () => {
+		if ( ! domains ) {
+			return [];
+		}
+		const siteMap = new Map< number, { value: string; label: string } >();
+
+		for ( const domain of domains ) {
+			if ( ! domain.is_domain_only_site && domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION ) {
+				siteMap.set( domain.blog_id, {
+					value: domain.blog_id.toString(),
+					label: domain.blog_name,
+				} );
+			}
+		}
+
+		return Array.from( siteMap.values() );
+	}, [ domains ] );
 
 	const fields: Field< DomainSummary >[] = useMemo(
 		() => [

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -91,9 +91,39 @@ export const useFields = ( {
 				label: __( 'Expires/Renews on' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainSummary } ) =>
-					item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '',
-				render: ( { field, item } ) => {
+				elements: [
+					{ value: 'next-7-days', label: __( 'Next 7 days' ) },
+					{ value: 'next-30-days', label: __( 'Next 30 days' ) },
+					{ value: 'next-90-days', label: __( 'Next 90 days' ) },
+					{ value: 'expired', label: __( 'Expired' ) },
+				],
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
+				},
+				getValue: ( { item }: { item: DomainSummary } ) => {
+					if ( ! item.expiry ) {
+						return '';
+					}
+
+					const expiryDate = new Date( item.expiry );
+					const now = new Date();
+					const diffInDays = Math.ceil(
+						( expiryDate.getTime() - now.getTime() ) / ( 1000 * 60 * 60 * 24 )
+					);
+
+					if ( diffInDays < 0 ) {
+						return 'expired';
+					} else if ( diffInDays <= 7 ) {
+						return 'next-7-days';
+					} else if ( diffInDays <= 30 ) {
+						return 'next-30-days';
+					} else if ( diffInDays <= 90 ) {
+						return 'next-90-days';
+					}
+
+					return 'later';
+				},
+				render: ( { item } ) => {
 					// Site Overview does not show the Status column, so we use this column for error messages.
 					if (
 						site &&
@@ -107,7 +137,7 @@ export const useFields = ( {
 					return (
 						<DomainExpiryField
 							domain={ item }
-							value={ field.getValue( { item } ) }
+							value={ item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '' }
 							isCompact={ !! site }
 						/>
 					);

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -1,4 +1,6 @@
 import { DomainSubtype } from '@automattic/api-core';
+import { domainsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -11,7 +13,6 @@ import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
-
 const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
 export const useFields = ( {
@@ -21,6 +22,27 @@ export const useFields = ( {
 	site?: Site;
 	showPrimaryDomainBadge?: boolean;
 } = {} ) => {
+	const { data: domains } = useQuery( domainsQuery() );
+
+	const siteElements = useMemo(
+		() =>
+			Object.values(
+				domains
+					?.filter(
+						( domain ) =>
+							! domain.is_domain_only_site && domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION
+					)
+					.reduce(
+						( acc, domain ) => ( {
+							...acc,
+							[ domain.blog_id ]: { value: domain.blog_id.toString(), label: domain.blog_name },
+						} ),
+						{} as Record< number, { value: string; label: string } >
+					) ?? {}
+			),
+		[ domains ]
+	);
+
 	const fields: Field< DomainSummary >[] = useMemo(
 		() => [
 			{
@@ -72,12 +94,12 @@ export const useFields = ( {
 				label: __( 'Site' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainSummary } ) => {
-					return item.blog_name ?? '';
+				elements: siteElements,
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
 				},
-				render: ( { field, item } ) => (
-					<DomainSiteField domain={ item } value={ field.getValue( { item } ) } />
-				),
+				getValue: ( { item }: { item: DomainSummary } ) => item.blog_id.toString(),
+				render: ( { item } ) => <DomainSiteField domain={ item } value={ item.blog_name ?? '' } />,
 			},
 			{
 				id: 'ssl_status',
@@ -162,7 +184,7 @@ export const useFields = ( {
 				},
 			},
 		],
-		[ site, showPrimaryDomainBadge ]
+		[ site, showPrimaryDomainBadge, siteElements ]
 	);
 
 	return fields;

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -10,7 +10,7 @@ import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
 import type { DomainSummary, Site } from '@automattic/api-core';
-import type { Field } from '@wordpress/dataviews';
+import type { Field, Operator } from '@wordpress/dataviews';
 
 const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
@@ -118,10 +118,17 @@ export const useFields = ( {
 				label: __( 'Status' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainSummary } ) => item.domain_status?.status ?? '',
-				render: ( { field, item } ) => {
-					const value = field.getValue( { item } );
-					return value || <IneligibleIndicator />;
+				elements: [
+					{ value: 'success', label: __( 'Active' ) },
+					{ value: 'neutral', label: __( 'Parked' ) },
+					{ value: 'error', label: __( 'Expiring soon' ) },
+				],
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
+				},
+				getValue: ( { item } ) => item.domain_status?.status_type,
+				render: ( { item } ) => {
+					return item.domain_status?.status || <IneligibleIndicator />;
 				},
 			},
 		],

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -39,6 +39,7 @@ export interface DomainSummary {
 	domain: string;
 	domain_status?: {
 		status: string;
+		status_type: 'success' | 'neutral' | 'error';
 	};
 	expired: boolean;
 	expiry: string | false;


### PR DESCRIPTION
Part of DOTDASH-189

## Proposed Changes

* Add domain filters for site, renew/expiry, and status field

NOTE: The rest field will be handled once we introduce a new `all-domains` api, which will support more data

## Why are these changes being made?

* DOTDASH-189

## Testing Instructions

* Go to `/v2/domains`
* Play with filters and check if everything make sense to you

<img width="464" height="322" alt="Screenshot 2025-09-18 at 22 24 49" src="https://github.com/user-attachments/assets/38868da3-d578-4781-9f70-07dd841abee0" />
<img width="1382" height="517" alt="Screenshot 2025-09-18 at 22 22 53" src="https://github.com/user-attachments/assets/c3805123-bda7-4dd5-a07d-df1191108be8" />
<img width="1377" height="403" alt="Screenshot 2025-09-18 at 22 23 23" src="https://github.com/user-attachments/assets/36ee8fd1-5a15-4fe7-b7e0-9be2b258eb6d" />
<img width="1393" height="410" alt="Screenshot 2025-09-18 at 22 23 45" src="https://github.com/user-attachments/assets/d2e0adb9-02a3-4ae8-8902-e178a14aa436" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
