### PR TITLE
Domain Search Rewrite: Only allow multiple domains in cart for select flows

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -11,6 +11,7 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 		onContinue?: ( items: ResponseCartProduct[] ) => void;
 	};
 	isFirstDomainFreeForFirstYear?: boolean;
+	flowAllowsMultipleDomainsInCart: boolean;
 };
 
 const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
@@ -34,14 +35,18 @@ const DomainSearchWithCart = ( {
 	initialQuery: externalInitialQuery,
 	config: externalConfig,
 	isFirstDomainFreeForFirstYear,
+	flowAllowsMultipleDomainsInCart,
 	...props
 }: DomainSearchProps ) => {
 	const cartKey = currentSiteId ?? 'no-site';
+	const { onContinue } = props.events ?? {};
 
 	const { cart, isNextDomainFree, items } = useWPCOMShoppingCartForDomainSearch( {
 		cartKey,
 		flowName,
 		isFirstDomainFreeForFirstYear: isFirstDomainFreeForFirstYear ?? false,
+		flowAllowsMultipleDomainsInCart,
+		onContinue,
 	} );
 
 	const initialQuery = useMemo( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -133,6 +133,9 @@ const DomainSearchStep: StepType< {
 			initialQuery={ initialQuery }
 			isFirstDomainFreeForFirstYear={ isOnboardingFlow( flow ) || isDomainFlow( flow ) }
 			events={ events }
+			flowAllowsMultipleDomainsInCart={
+				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isNewHostedSiteCreationFlow( flow )
+			}
 		/>
 	);
 

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -64,6 +64,7 @@ export default function DomainSearch() {
 			flowName={ FLOW_NAME }
 			config={ config }
 			events={ events }
+			flowAllowsMultipleDomainsInCart
 		/>
 	);
 }

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -108,6 +108,7 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 					initialQuery={ queryObject.new }
 					events={ events }
 					config={ config }
+					flowAllowsMultipleDomainsInCart={ isDomainOnlyFlow }
 				/>
 			}
 		/>


### PR DESCRIPTION
Closes DOMAINS-1661.

## Proposed Changes

Only some flows allow multiple domains in the cart. These are:
- `/start/domain`
- `/setup/domain`
- `/setup/onboarding`
- `/setup/new-hosted-site?showDomainStep`
- `/domains/add/%s`

## Testing Instructions

Allow you can add multiple domains to the cart when browsing these flows. All other flows should submit the picked domain immediately.