### PR TITLE
Domain Search Rewrite: Hide availability notice for WPCOM managed subdomains

### DIFF
--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -1,4 +1,4 @@
-import { DomainAvailabilityStatus } from '@automattic/api-core';
+import { DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getAvailabilityNotice } from '../../helpers/get-availability-notice';
@@ -10,6 +10,53 @@ const AVAILABLE_DOMAIN_STATUSES = [
 	DomainAvailabilityStatus.UNKNOWN,
 	DomainAvailabilityStatus.MAPPED_SAME_SITE_REGISTRABLE,
 ];
+
+/**
+ * Determines whether the availability notice should be hidden for a given domain availability
+ *
+ * @param availability - Domain availability returned from the availability endpoint
+ * @returns True if the availability notice should be hidden, false otherwise.
+ */
+const shouldHideAvailabilityNotice = (
+	availability: DomainAvailability,
+	includeOwnedDomainInSuggestions: boolean
+): boolean => {
+	if ( AVAILABLE_DOMAIN_STATUSES.includes( availability.status ) ) {
+		return true;
+	}
+
+	if (
+		includeOwnedDomainInSuggestions &&
+		availability.status === DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER
+	) {
+		return true;
+	}
+
+	if (
+		availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM &&
+		availability.is_supported_premium_domain
+	) {
+		return true;
+	}
+
+	// We don't want to show the availability notice for *.wpcomstaging.com subdomains and other managed subdomains,
+	// such as *.tech.blog, *.water.blog, etc.
+	if (
+		[
+			DomainAvailabilityStatus.WPCOM_STAGING_DOMAIN,
+			DomainAvailabilityStatus.DOTBLOG_SUBDOMAIN,
+		].includes( availability.status )
+	) {
+		return true;
+	}
+
+	// *.wordpress.com and *.wp.com subdomains have `mappable = restricted`
+	if ( availability.mappable === DomainAvailabilityStatus.RESTRICTED ) {
+		return true;
+	}
+
+	return false;
+};
 
 export const SearchNotice = () => {
 	const {
@@ -25,37 +72,10 @@ export const SearchNotice = () => {
 	);
 
 	const notice = useMemo( () => {
-		if ( ! availability || AVAILABLE_DOMAIN_STATUSES.includes( availability.status ) ) {
-			return null;
-		}
-
 		if (
-			includeOwnedDomainInSuggestions &&
-			availability.status === DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER
+			! availability ||
+			shouldHideAvailabilityNotice( availability, includeOwnedDomainInSuggestions )
 		) {
-			return null;
-		}
-
-		if (
-			availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM &&
-			availability.is_supported_premium_domain
-		) {
-			return null;
-		}
-
-		// We don't want to show the availability notice for *.wpcomstaging.com subdomains and other managed subdomains,
-		// such as *.tech.blog, *.water.blog, etc.
-		if (
-			[
-				DomainAvailabilityStatus.WPCOM_STAGING_DOMAIN,
-				DomainAvailabilityStatus.DOTBLOG_SUBDOMAIN,
-			].includes( availability.status )
-		) {
-			return null;
-		}
-
-		// *.wordpress.com and *.wp.com subdomains have `mappable = restricted`, and we don't want to show the availability notice for them
-		if ( availability.mappable === DomainAvailabilityStatus.RESTRICTED ) {
 			return null;
 		}
 

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -43,6 +43,22 @@ export const SearchNotice = () => {
 			return null;
 		}
 
+		// We don't want to show the availability notice for *.wpcomstaging.com subdomains and other managed subdomains,
+		// such as *.tech.blog, *.water.blog, etc.
+		if (
+			[
+				DomainAvailabilityStatus.WPCOM_STAGING_DOMAIN,
+				DomainAvailabilityStatus.DOTBLOG_SUBDOMAIN,
+			].includes( availability.status )
+		) {
+			return null;
+		}
+
+		// *.wordpress.com and *.wp.com subdomains have `mappable = restricted`, and we don't want to show the availability notice for them
+		if ( availability.mappable === DomainAvailabilityStatus.RESTRICTED ) {
+			return null;
+		}
+
 		let finalAvailability = availability;
 
 		const isDomainMapped = DomainAvailabilityStatus.MAPPED === availability.mappable;


### PR DESCRIPTION
Part of [DOMAINS-1655](https://linear.app/a8c/issue/DOMAINS-1655)

## Proposed Changes

This PR hides the domain availability notice that's shown when a user searches for a FQDN (fully qualified domain name, i.e. the domain with its extension) for certain cases. These are:
- `*.wordpress.com` subdomains
- `*.wpcomstaging.com` subdomains
- `*.wp.com` subdomains
- `.blog` managed subdomains such as `*.tech.blog`, `*.water.blog` and others

## Why are these changes being made?

Showing "This is a free WordPress.com subdomain. You can’t map it to another site" or "This domain is a reserved WordPress.com staging domain" notices doesn't add value for users that are searching for domain name suggestions.

## Screenshots

| Subdomain | Before | After |
| --- | --- | --- |
| `*.wordpress.com` | <img width="1070" height="715" alt="Screenshot 2025-09-18 at 15 59 33" src="https://github.com/user-attachments/assets/fba90a2f-1706-4863-9e00-b0e6c33875c4" /> | <img width="1160" height="663" alt="Screenshot 2025-09-18 at 15 59 13" src="https://github.com/user-attachments/assets/c33e4275-83d4-4274-89db-27ee4a3d4cf4" /> |
| `*.wpcomstaging.com` | <img width="1077" height="742" alt="Screenshot 2025-09-18 at 15 59 44" src="https://github.com/user-attachments/assets/a9ea3a94-1fa3-44e2-895c-aea71953b856" /> | <img width="1161" height="681" alt="Screenshot 2025-09-18 at 15 59 53" src="https://github.com/user-attachments/assets/efdd3871-ad79-4424-9ee2-d4320ec3ec27" /> |
| `*.wp.com` | <img width="1081" height="796" alt="Screenshot 2025-09-18 at 16 00 05" src="https://github.com/user-attachments/assets/921e2b79-12dd-47bc-a3a1-6ee4d268f6a6" /> | <img width="1177" height="725" alt="Screenshot 2025-09-18 at 16 00 24" src="https://github.com/user-attachments/assets/7e7c19c4-6158-4368-a218-573f027e404d" /> |
| `*.tech.blog` | <img width="1075" height="742" alt="Screenshot 2025-09-18 at 16 00 46" src="https://github.com/user-attachments/assets/05174ea9-038c-41ee-b30d-ee5ef9baf6a4" /> | <img width="1181" height="686" alt="Screenshot 2025-09-18 at 16 00 37" src="https://github.com/user-attachments/assets/c1bd5bdf-699c-4608-bb15-136683ba64cb" /> |

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/setup/domain`
- Search for all the specific cases mentioned in the PR description:
    - `*.wordpress.com` subdomain
    - `*.wpcomstaging.com` subdomain
    - `*.wp.com` subdomain
    - `.blog` managed subdomain such as `*.tech.blog` and `*.water.blog`
- Ensure that the availability notice is not shown for any of them

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
