### PR TITLE
Marketing: Add simple site check to Fediverse card

### DIFF
--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'calypso/state';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import * as T from 'calypso/types';
 import MarketingToolsFeature from './feature';
@@ -32,6 +33,7 @@ export default function MarketingTools() {
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
 	const items = [
 		{ key: '', text: translate( 'All' ) },
 		{ key: 'new', text: translate( 'New tools' ) },
@@ -52,7 +54,8 @@ export default function MarketingTools() {
 		translate,
 		localizeUrl,
 		activityPubStatus,
-		isPrivate
+		isPrivate,
+		isSimple
 	);
 
 	const marketingFeaturesFiltered = useMemo( () => {

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -18,7 +18,8 @@ export const getMarketingFeaturesData = (
 	translate: ( text: string, options?: any ) => string,
 	localizeUrl: ( url: string ) => string,
 	activityPubStatus: any,
-	isPrivate: boolean | null
+	isPrivate: boolean | null,
+	isSimple: boolean | null
 ): MarketingToolsFeatureData[] => {
 	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( getLocaleSlug() ?? '' );
 	const currentDate = new Date();
@@ -107,7 +108,7 @@ export const getMarketingFeaturesData = (
 		} );
 	}
 
-	if ( ! activityPubStatus?.isEnabled ) {
+	if ( isSimple && ! isPrivate && ! activityPubStatus?.isEnabled ) {
 		result.splice( 3, 0, {
 			title: translate( 'Share your blog with a new audience' ),
 			description: translate(


### PR DESCRIPTION
Limits showing the Fediverse card to simple sites that are not private, to prevent interoperability issues for private sites and JEtpack & WoA sites needing to install a plugin for it.

## Proposed Changes

* Adds a simple site and private site check to showing the Fediverse card.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent awkward results when trying to enable the feature for Jetpack and WoA sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the calypso.live link, navigate to /marketing/tools.
* Select various site types and make sure the card only shows up for simple sites that are not private and don't already have Activitypub (Fediverse) enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
