### PR TITLE
Dashboard v2 - Enables per-page pagination for activity logs

### DIFF
--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -82,7 +82,7 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 							onChange={ handleDateRangeChangeWrapper }
 						/>
 					) }
-					<Card className="site-logs-card">
+					<Card className={ `site-logs-card site-logs-card--${ logType }` }>
 						<CardHeader style={ { paddingBottom: '0' } }>
 							<TabPanel
 								className="site-logs-tabs"

--- a/client/dashboard/sites/logs/style.scss
+++ b/client/dashboard/sites/logs/style.scss
@@ -1,4 +1,6 @@
-.site-logs-card .dataviews-pagination__page-select {
-	display: none !important;
+.site-logs-card {
+	// Hide per-page pagination everywhere except activity logs.
+	&:not(&--activity) .dataviews-pagination__page-select {
+		display: none !important;
+	}
 }
-


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-442/add-dropdown-numbered-pagination-for-activity-logs

## Proposed Changes

Due to API limitations, per-page pagination was disabled for Web and PHP logs. This shouldn't apply to activity logs, so this PR makes the CSS selector more specific to achieve that.

More details on when/why it was hidden here: https://github.com/Automattic/wp-calypso/pull/105332

## Why are these changes being made?

To make the site activity logs on Dashboard v2 honor designs.

## Testing Instructions

- Open http://calypso.localhost:3000/v2/sites/
- Navigate to a site then open the logs page: http://calypso.localhost:3000/v2/sites/brunobasto.wpcomstaging.com/logs/activity
- Verify that the dropdown showing per-page pagination is visible at the bottom of the table:

<img width="275" height="83" alt="Screenshot 2025-09-23 at 09 10 58" src="https://github.com/user-attachments/assets/4aea5d53-0632-4394-b782-0e2fbb856ae2" />

- Verify that navigating between pages works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
