### PR TITLE
Domain Search Rewrite: Accept initial query in site-specific search; deemphasize blog TLD in ecommerce flow

### DIFF
--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -62,6 +62,7 @@ export default function DomainSearch() {
 			currentSiteId={ selectedSite?.ID }
 			currentSiteUrl={ selectedSite?.URL }
 			flowName={ FLOW_NAME }
+			initialQuery={ queryArguments?.suggestion.toString() ?? '' }
 			config={ config }
 			events={ events }
 			flowAllowsMultipleDomainsInCart

--- a/client/signup/steps/domain-search/index.tsx
+++ b/client/signup/steps/domain-search/index.tsx
@@ -1,6 +1,6 @@
 import { FreeDomainSuggestion, useMyDomainInputMode } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
-import { isDomainForGravatarFlow, isFreeFlow } from '@automattic/onboarding';
+import { isDomainForGravatarFlow, isEcommerceFlow, isFreeFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -95,6 +95,7 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 				forceRegularPrice: isMonthlyOrFreeFlow( flowName ),
 			},
 			allowedTlds,
+			deemphasizedTlds: isEcommerceFlow( flowName ) ? [ 'blog' ] : [],
 			skippable: ! isDomainOnlyFlow && ! isDomainForGravatarFlow( flowName ),
 			allowsUsingOwnDomain:
 				! isDomainForGravatarFlow( flowName ) &&

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -14,6 +14,8 @@ export const WRITE_FLOW = 'write';
 export const START_WRITING_FLOW = 'start-writing';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
+export const ECOMMERCE_FLOW = 'ecommerce';
+export const ECOMMERCE_MONTHLY_FLOW = 'ecommerce-monthly';
 
 export const READYMADE_TEMPLATE_FLOW = 'readymade-template';
 
@@ -74,6 +76,10 @@ export const isCopySiteFlow = ( flowName: string | null ) => {
 
 export const isEntrepreneurFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ ENTREPRENEUR_FLOW ].includes( flowName ) );
+};
+
+export const isEcommerceFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ ECOMMERCE_FLOW, ECOMMERCE_MONTHLY_FLOW ].includes( flowName ) );
 };
 
 export const isNewSiteMigrationFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
Closes DOMAINS-1664. Closes DOMAINS-1667.

## Proposed Changes

- Accepts `suggestion` query parameter in `/domains/add/%s`;
- Deemphasize `.blog` TLD in `/start/ecommerce` so they show in the regular results list.

Bundled those changes together as they're small enough and the pipeline takes a long time. It's not in production so it won't affect anything if it's broken.

## Testing Instructions

Verify the proposed changes are in fact what you see when browsing these pages.
