### PR TITLE
PoC: Conditional checkout redirect

### DIFF
--- a/client/lib/trials/get-trial-checkout-url.ts
+++ b/client/lib/trials/get-trial-checkout-url.ts
@@ -5,16 +5,22 @@ interface TrialCheckoutUrlArguments {
 	productSlug: string;
 	siteSlug: string;
 	addOn?: MinimalRequestCartProduct;
+	fromPlansGrid?: boolean;
 }
 
 export function getTrialCheckoutUrl( {
 	productSlug,
 	siteSlug,
 	addOn,
+	fromPlansGrid = false,
 }: TrialCheckoutUrlArguments ): string {
-	const checkoutUrl = addOn
-		? `/checkout/${ siteSlug }/${ productSlug },${ addOn.product_slug }:-q-${ addOn.quantity }`
+	const checkoutBasePath = fromPlansGrid
+		? `/checkout/from-plans/${ siteSlug }/${ productSlug }`
 		: `/checkout/${ siteSlug }/${ productSlug }`;
+
+	const checkoutUrl = addOn
+		? `${ checkoutBasePath },${ addOn.product_slug }:-q-${ addOn.quantity }`
+		: checkoutBasePath;
 
 	return addQueryArgs(
 		{ redirect_to: `/plans/my-plan/trial-upgraded/${ siteSlug }` },

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -275,9 +275,23 @@ export function redirectWpcomPlansToPlansGrid( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
+	// Handle common plan aliases like the checkout system does
+	const planAliasMap = {
+		personal: 'personal-bundle',
+		premium: 'value_bundle',
+		business: 'business-bundle',
+		ecommerce: 'ecommerce-bundle',
+		'personal-monthly': 'personal-bundle-monthly',
+		'premium-monthly': 'value_bundle_monthly',
+		'business-monthly': 'business-bundle-monthly',
+		'ecommerce-monthly': 'ecommerce-bundle-monthly',
+	};
+
+	const actualProduct = planAliasMap[ product ] || product;
+
 	// Only redirect direct /checkout requests, not /checkout/from-plans, and only for WordPress.com plans
 	if (
-		isWpComPlan( product ) &&
+		isWpComPlan( actualProduct ) &&
 		config.isEnabled( 'enforce_interstitial_plans_grid' ) &&
 		! context.pathname.startsWith( '/checkout/from-plans/' )
 	) {
@@ -285,10 +299,10 @@ export function redirectWpcomPlansToPlansGrid( context, next ) {
 		const existingQuery = context.querystring ? `&${ context.querystring }` : '';
 		const redirectUrl = `/plans/${
 			selectedSite?.slug || ''
-		}?product=${ product }${ existingQuery }`;
+		}?product=${ actualProduct }${ existingQuery }`;
 
 		debug(
-			`Redirecting WordPress.com plan checkout to plans grid: ${ context.pathname } -> ${ redirectUrl }`
+			`Redirecting WordPress.com plan checkout to plans grid: ${ context.pathname } -> ${ redirectUrl } (alias: ${ product } -> ${ actualProduct })`
 		);
 		page( redirectUrl );
 		return;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,4 +1,9 @@
-import { isJetpackLegacyItem, isJetpackLegacyTermUpgrade } from '@automattic/calypso-products';
+import config from '@automattic/calypso-config';
+import {
+	isWpComPlan,
+	isJetpackLegacyItem,
+	isJetpackLegacyTermUpgrade,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -259,6 +264,33 @@ export function redirectJetpackLegacyPlans( context, next ) {
 				`?${ COMPARE_PLANS_QUERY_PARAM }=${ product },${ recommendedItems }`
 		);
 
+		return;
+	}
+
+	next();
+}
+
+export function redirectWpcomPlansToPlansGrid( context, next ) {
+	const product = getProductSlugFromContext( context );
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	// Only redirect direct /checkout requests, not /checkout/from-plans, and only for WordPress.com plans
+	if (
+		isWpComPlan( product ) &&
+		config.isEnabled( 'enforce_interstitial_plans_grid' ) &&
+		! context.pathname.startsWith( '/checkout/from-plans/' )
+	) {
+		// Preserve all query parameters when redirecting
+		const existingQuery = context.querystring ? `&${ context.querystring }` : '';
+		const redirectUrl = `/plans/${
+			selectedSite?.slug || ''
+		}?product=${ product }${ existingQuery }`;
+
+		debug(
+			`Redirecting WordPress.com plan checkout to plans grid: ${ context.pathname } -> ${ redirectUrl }`
+		);
+		page( redirectUrl );
 		return;
 	}
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -33,6 +33,7 @@ import {
 	transferDomainToAnyUser,
 	checkoutFailedPurchases,
 	refreshUserSession,
+	redirectWpcomPlansToPlansGrid,
 } from './controller';
 
 export default function () {
@@ -324,6 +325,7 @@ export default function () {
 		redirectLoggedOut,
 		siteSelection,
 		redirectJetpackLegacyPlans,
+		redirectWpcomPlansToPlansGrid,
 		checkout,
 		makeLayout,
 		clientRender
@@ -336,6 +338,7 @@ export default function () {
 		redirectLoggedOut,
 		siteSelection,
 		redirectJetpackLegacyPlans,
+		redirectWpcomPlansToPlansGrid,
 		checkout,
 		makeLayout,
 		clientRender
@@ -369,6 +372,31 @@ export default function () {
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
 		redirectLoggedOut,
 		siteSelection,
+		makeLayout,
+		clientRender
+	);
+
+	// Routes for plans grid selections - bypass the redirect middleware
+	page(
+		'/checkout/from-plans/:site/:product',
+		setLocaleMiddleware(),
+		redirectMyJetpack,
+		redirectLoggedOut,
+		siteSelection,
+		redirectJetpackLegacyPlans,
+		checkout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/from-plans/:site/:product/:domainOrProduct',
+		setLocaleMiddleware(),
+		redirectMyJetpack,
+		redirectLoggedOut,
+		siteSelection,
+		redirectJetpackLegacyPlans,
+		checkout,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import {
 	applyTestFiltersToPlansList,
 	PRODUCT_1GB_SPACE,
@@ -7,7 +6,6 @@ import {
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
 	getPlanPath,
-	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
@@ -60,15 +58,8 @@ function useUpgradeHandler( {
 				? getPlanPath( cartItemForPlan.product_slug )
 				: '';
 
-			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
-			const shouldUseFromPlansPath =
-				config.isEnabled( 'enforce_interstitial_plans_grid' ) &&
-				cartItemForPlan?.product_slug &&
-				isWpComPlan( cartItemForPlan.product_slug );
-
-			const checkoutBasePath = shouldUseFromPlansPath
-				? `/checkout/from-plans/${ siteSlug }/${ planPath }`
-				: `/checkout/${ siteSlug }/${ planPath }`;
+			// Always use /checkout/from-plans for plan grid flows to indicate user has already selected via plans grid
+			const checkoutBasePath = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
 
 			const checkoutUrl = cartItemForStorageAddOn
 				? `${ checkoutBasePath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import {
 	applyTestFiltersToPlansList,
 	PRODUCT_1GB_SPACE,
@@ -6,6 +7,7 @@ import {
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
 	getPlanPath,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
@@ -58,9 +60,19 @@ function useUpgradeHandler( {
 				? getPlanPath( cartItemForPlan.product_slug )
 				: '';
 
-			const checkoutUrl = cartItemForStorageAddOn
-				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
+			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
+			const shouldUseFromPlansPath =
+				config.isEnabled( 'enforce_interstitial_plans_grid' ) &&
+				cartItemForPlan?.product_slug &&
+				isWpComPlan( cartItemForPlan.product_slug );
+
+			const checkoutBasePath = shouldUseFromPlansPath
+				? `/checkout/from-plans/${ siteSlug }/${ planPath }`
 				: `/checkout/${ siteSlug }/${ planPath }`;
+
+			const checkoutUrl = cartItemForStorageAddOn
+				? `${ checkoutBasePath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
+				: checkoutBasePath;
 
 			const checkoutUrlWithArgs = addQueryArgs( { ...( coupon && { coupon } ) }, checkoutUrl );
 

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	getPlanPath,
 	isWooExpressPlan,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
@@ -89,9 +91,18 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 
 			const planPath = getPlanPath( upgradePlanSlug ) ?? '';
 
-			const checkoutUrl = isWooExpressPlan( upgradePlanSlug )
-				? getTrialCheckoutUrl( { productSlug: planPath, siteSlug } )
-				: `/checkout/${ siteSlug }/${ planPath }`;
+			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
+			const shouldUseFromPlansPath =
+				config.isEnabled( 'enforce_interstitial_plans_grid' ) && isWpComPlan( upgradePlanSlug );
+
+			let checkoutUrl;
+			if ( isWooExpressPlan( upgradePlanSlug ) ) {
+				checkoutUrl = getTrialCheckoutUrl( { productSlug: planPath, siteSlug } );
+			} else if ( shouldUseFromPlansPath ) {
+				checkoutUrl = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
+			} else {
+				checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+			}
 
 			page( checkoutUrl );
 		},

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -1,11 +1,9 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	getPlanPath,
 	isWooExpressPlan,
-	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
@@ -91,17 +89,16 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 
 			const planPath = getPlanPath( upgradePlanSlug ) ?? '';
 
-			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
-			const shouldUseFromPlansPath =
-				config.isEnabled( 'enforce_interstitial_plans_grid' ) && isWpComPlan( upgradePlanSlug );
-
+			// Use trial checkout URL for WooExpress plans (with trial-specific redirect) or /checkout/from-plans for others
 			let checkoutUrl;
 			if ( isWooExpressPlan( upgradePlanSlug ) ) {
-				checkoutUrl = getTrialCheckoutUrl( { productSlug: planPath, siteSlug } );
-			} else if ( shouldUseFromPlansPath ) {
-				checkoutUrl = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
+				checkoutUrl = getTrialCheckoutUrl( {
+					productSlug: planPath,
+					siteSlug,
+					fromPlansGrid: true,
+				} );
 			} else {
-				checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+				checkoutUrl = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
 			}
 
 			page( checkoutUrl );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -230,10 +230,8 @@ class PlansComponent extends Component {
 			},
 		} = this.props;
 
-		// Use new /checkout/from-plans path if feature flag is enabled to avoid redirect loop
-		const checkoutPath = isEnabled( 'enforce_interstitial_plans_grid' )
-			? `/checkout/from-plans/${ selectedSite.slug }/${ item.product_slug }/`
-			: `/checkout/${ selectedSite.slug }/${ item.product_slug }/`;
+		// Always use /checkout/from-plans path for plan grid flows to indicate user has already selected via plans grid
+		const checkoutPath = `/checkout/from-plans/${ selectedSite.slug }/${ item.product_slug }/`;
 
 		page(
 			discount

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -117,7 +117,11 @@ function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteS
 		// show Warning only on free plans.
 		isFreePlan
 			? dispatch( WpcomPlansUI.store ).setShowDomainUpsellDialog( true )
-			: page( `/checkout/${ siteSlug }` );
+			: page(
+					isEnabled( 'enforce_interstitial_plans_grid' )
+						? `/checkout/from-plans/${ siteSlug }`
+						: `/checkout/${ siteSlug }`
+			  );
 	};
 
 	const subtitle = isFreePlan
@@ -225,7 +229,11 @@ class PlansComponent extends Component {
 				query: { discount },
 			},
 		} = this.props;
-		const checkoutPath = `/checkout/${ selectedSite.slug }/${ item.product_slug }/`;
+
+		// Use new /checkout/from-plans path if feature flag is enabled to avoid redirect loop
+		const checkoutPath = isEnabled( 'enforce_interstitial_plans_grid' )
+			? `/checkout/from-plans/${ selectedSite.slug }/${ item.product_slug }/`
+			: `/checkout/${ selectedSite.slug }/${ item.product_slug }/`;
 
 		page(
 			discount

--- a/client/my-sites/plans/trials/business-trial-plans-page/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans-page/index.tsx
@@ -39,6 +39,7 @@ const BusinessTrialPlansPage = ( props: BusinessTrialPlansPageProps ) => {
 		const checkoutUrl = getTrialCheckoutUrl( {
 			productSlug: PLAN_BUSINESS,
 			siteSlug: selectedSite?.slug ?? '',
+			fromPlansGrid: true,
 		} );
 
 		page.redirect( checkoutUrl );

--- a/client/my-sites/plans/trials/business-trial-plans/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans/index.tsx
@@ -1,10 +1,8 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PRODUCT_1GB_SPACE,
 	getPlanPath,
 	isBusinessPlan,
-	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useCallback } from 'react';
@@ -34,21 +32,20 @@ export function BusinessTrialPlans( props: BusinessTrialPlansProps ) {
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
 
-			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
-			const shouldUseFromPlansPath =
-				config.isEnabled( 'enforce_interstitial_plans_grid' ) && isWpComPlan( upgradePlanSlug );
-
+			// Use trial checkout URL for business plans (with trial-specific redirect) or /checkout/from-plans for others
 			let checkoutUrl;
 			if ( isBusinessPlan( upgradePlanSlug ) ) {
 				checkoutUrl = getTrialCheckoutUrl( {
 					productSlug: planPath,
 					siteSlug,
 					addOn: cartItemForStorageAddOn,
+					fromPlansGrid: true,
 				} );
-			} else if ( shouldUseFromPlansPath ) {
-				checkoutUrl = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
 			} else {
-				checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+				const checkoutBasePath = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
+				checkoutUrl = cartItemForStorageAddOn
+					? `${ checkoutBasePath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
+					: checkoutBasePath;
 			}
 
 			page( checkoutUrl );

--- a/client/my-sites/plans/trials/business-trial-plans/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans/index.tsx
@@ -1,8 +1,10 @@
+import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PRODUCT_1GB_SPACE,
 	getPlanPath,
 	isBusinessPlan,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useCallback } from 'react';
@@ -32,9 +34,22 @@ export function BusinessTrialPlans( props: BusinessTrialPlansProps ) {
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
 
-			const checkoutUrl = isBusinessPlan( upgradePlanSlug )
-				? getTrialCheckoutUrl( { productSlug: planPath, siteSlug, addOn: cartItemForStorageAddOn } )
-				: `/checkout/${ siteSlug }/${ planPath }`;
+			// Use /checkout/from-plans if feature flag is enabled to avoid redirect loop for WordPress.com plans
+			const shouldUseFromPlansPath =
+				config.isEnabled( 'enforce_interstitial_plans_grid' ) && isWpComPlan( upgradePlanSlug );
+
+			let checkoutUrl;
+			if ( isBusinessPlan( upgradePlanSlug ) ) {
+				checkoutUrl = getTrialCheckoutUrl( {
+					productSlug: planPath,
+					siteSlug,
+					addOn: cartItemForStorageAddOn,
+				} );
+			} else if ( shouldUseFromPlansPath ) {
+				checkoutUrl = `/checkout/from-plans/${ siteSlug }/${ planPath }`;
+			} else {
+				checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+			}
 
 			page( checkoutUrl );
 		},

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -7,7 +7,9 @@
 	"boom_analytics_key": false,
 	"client_slug": false,
 	"facebook_api_key": false,
-	"features": {},
+	"features": {
+		"enforce_interstitial_plans_grid": false
+	},
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"survicate_enabled": false,

--- a/config/development.json
+++ b/config/development.json
@@ -59,6 +59,7 @@
 		"dev/auth-helper": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,
+		"enforce_interstitial_plans_grid": true,
 		"dev/react-query-devtools": true,
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-455

## Proposed Changes

Redirect direct checkout access for wpcom plans back to the plans grid.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want upgrade nudges etc to explicitly allow users to choose a plan on the plans grid rather than restricting them to choosing the plan we have decided is best for that nudge.

This is just a proof-of-concept using the existing plans grid rather than the distraction free grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
