### PR TITLE
Domain Search Rewrite: Hide availability error notice when searching for an already registered domain

### DIFF
--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -9,7 +9,7 @@ const AVAILABLE_DOMAIN_STATUSES = [
 	DomainAvailabilityStatus.AVAILABLE,
 	DomainAvailabilityStatus.UNKNOWN,
 	DomainAvailabilityStatus.MAPPED_SAME_SITE_REGISTRABLE,
-	// For odmains that are transferrable (i.e. registered elsewhere and can be transferred to us), we want to show
+	// For domains that are transferrable (i.e. registered elsewhere and can be transferred to us), we want to show
 	// only the "Already yours? Bring it over" notice instead of the availability notice
 	DomainAvailabilityStatus.TRANSFERRABLE,
 	DomainAvailabilityStatus.TRANSFERRABLE_PREMIUM,

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -9,6 +9,10 @@ const AVAILABLE_DOMAIN_STATUSES = [
 	DomainAvailabilityStatus.AVAILABLE,
 	DomainAvailabilityStatus.UNKNOWN,
 	DomainAvailabilityStatus.MAPPED_SAME_SITE_REGISTRABLE,
+	// For odmains that are transferrable (i.e. registered elsewhere and can be transferred to us), we want to show
+	// only the "Already yours? Bring it over" notice instead of the availability notice
+	DomainAvailabilityStatus.TRANSFERRABLE,
+	DomainAvailabilityStatus.TRANSFERRABLE_PREMIUM,
 ];
 
 /**
@@ -75,17 +79,6 @@ export const SearchNotice = () => {
 		if (
 			! availability ||
 			shouldHideAvailabilityNotice( availability, includeOwnedDomainInSuggestions )
-		) {
-			return null;
-		}
-
-		// For odmains that are transferrable (i.e. registered elsewhere and can be transferred to us), we want to show
-		// only the "Already yours? Bring it over" notice instead of the availability notice
-		if (
-			[
-				DomainAvailabilityStatus.TRANSFERRABLE,
-				DomainAvailabilityStatus.TRANSFERRABLE_PREMIUM,
-			].includes( availability.status )
 		) {
 			return null;
 		}

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -79,6 +79,17 @@ export const SearchNotice = () => {
 			return null;
 		}
 
+		// For odmains that are transferrable (i.e. registered elsewhere and can be transferred to us), we want to show
+		// only the "Already yours? Bring it over" notice instead of the availability notice
+		if (
+			[
+				DomainAvailabilityStatus.TRANSFERRABLE,
+				DomainAvailabilityStatus.TRANSFERRABLE_PREMIUM,
+			].includes( availability.status )
+		) {
+			return null;
+		}
+
 		let finalAvailability = availability;
 
 		const isDomainMapped = DomainAvailabilityStatus.MAPPED === availability.mappable;


### PR DESCRIPTION
Part of [DOMAINS-1671](https://linear.app/a8c/issue/DOMAINS-1671)

## Proposed Changes

This PR hides the availability error notice that's shown when searching for a registered domain that can be transferred for us.

## Why are these changes being made?

The notice that was shown makes it seem like an error happened when it didn't.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1070" height="922" alt="Screenshot 2025-09-18 at 17 47 35" src="https://github.com/user-attachments/assets/5f5cae18-f00c-436a-bfc4-b74c637830dc" /> | <img width="1064" height="761" alt="Screenshot 2025-09-18 at 17 46 37" src="https://github.com/user-attachments/assets/747cbaea-77ed-445e-a1f3-7d70d7561a71" /> |
| <img width="1076" height="918" alt="Screenshot 2025-09-18 at 17 47 25" src="https://github.com/user-attachments/assets/0d862591-f031-40e3-a904-014ef9bdd3ef" /> | <img width="1069" height="711" alt="Screenshot 2025-09-18 at 17 46 27" src="https://github.com/user-attachments/assets/d8a27595-97ff-41d4-ba2b-adf76bf8252e" /> |

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/setup/domain`
- Search for a domain that's already registered and can be transferred to us (e.g. `zaguini.me` or `977284843.xyz`)
- Ensure the availability error notice is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
