### PR TITLE
Hosting Dashboard: Make the icon the right size and remove box-shadow for site icons.

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -27,3 +27,7 @@ a.dataviews-url-field {
 		text-decoration: none;
 	}
 }
+
+.dataviews-column-primary__media::after {
+	box-shadow: none;
+}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -109,7 +109,7 @@ export function SiteIconLink( { site }: { site: Site } ) {
 			disabled={ site.is_deleted }
 			style={ { textDecoration: 'none' } }
 		>
-			<SiteIcon site={ site } />
+			<SiteIcon site={ site } size={ 32 } />
 		</Link>
 	);
 }


### PR DESCRIPTION
> [!WARNING]
> Don't merge read not below.

Fixes DOTCOM-14633.

## Proposed Changes

Make the site icon smaller and remove the default box-shadow to match the designs. 

**Note:** The icon appears misaligned because the spacing between the site title and the site link is larger than the design. That's due to a min-height in the [underlying dataview component](https://github.com/WordPress/gutenberg/blob/c168df2b5dcfa8a32233366a98ae900d2f41abef/packages/dataviews/src/dataviews-layouts/table/style.scss#L163). 

We can't simply override that, as it controls how many of the fields appear vertically centered. I'll open a new PR to solve that. They will need to be merged together.

Opened: #105877


## Screenshot
| Before | After |
|--------|--------|
|  <img width="448" height="201" alt="Screenshot 2025-09-19 at 10 53 30 AM" src="https://github.com/user-attachments/assets/054d4ea2-cdb7-45f4-8238-3322c2722810" /> | <img width="484" height="221" alt="Screenshot 2025-09-19 at 10 52 56 AM" src="https://github.com/user-attachments/assets/19e3a772-c016-4eb4-a189-7132cca9fdd6" /> |
| <img width="2644" height="1868" alt="wpcalypso wordpress com_v2_sites" src="https://github.com/user-attachments/assets/eec8de22-0524-4776-a4d8-c946f1913400" /> | <img width="2644" height="1868" alt="calypso localhost_3000_v2" src="https://github.com/user-attachments/assets/3da0eb6c-7eeb-4ce9-bc61-680a3c9b4c40" />|
| <img width="2644" height="1868" alt="wpcalypso wordpress com_" src="https://github.com/user-attachments/assets/6e853e07-3859-4fad-aaa7-1cbe61799e57" /> | <img width="2644" height="1868" alt="calypso localhost_3000_sites" src="https://github.com/user-attachments/assets/3736d491-f368-4d2d-86a1-29952132b353" /> | 

If we combine it with #105877, we get:

| Before | After |
|--------|--------|
| <img width="2644" height="1868" alt="wpcalypso wordpress com_v2_sites" src="https://github.com/user-attachments/assets/eec8de22-0524-4776-a4d8-c946f1913400" /> | <img width="2644" height="1868" alt="calypso localhost_3000_v2_sites_view=%7B%22type%22%3A%22grid%22%2C%22perPage%22%3A96%7D" src="https://github.com/user-attachments/assets/972470c4-507b-43e5-ac05-307c7c2eff33" /> | 

## Testing Instructions

- Visit the following tables and verify alignment:
  - /sites
  - v2/sites
  - v2/me/billing/purchases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
