### PR TITLE
Hosting Dashboard: Force vertical center for table row content.

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -27,3 +27,11 @@ a.dataviews-url-field {
 		text-decoration: none;
 	}
 }
+
+.dataviews-view-table tbody td {
+	vertical-align: middle;
+}
+
+.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
+	min-height: unset;
+}

--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -32,6 +32,7 @@ a.dataviews-url-field {
 	vertical-align: middle;
 }
 
-.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
+// Remove the min-height because if there is a subtitle, it gets pushed down and visually looks off-grid.
+.dataviews-view-table tbody .dataviews-title-field {
 	min-height: unset;
 }


### PR DESCRIPTION
Part of DOTCOM-14633

Related to #105876, DOTDASH-84

## Proposed Changes

Our Dataview lists all have their content vertically centered. 
- Force `td` to be `vertical-align: middle`
- Remove `min-height` on `dataviews-title-field `

I'll admit that it isn't clear to me why there is a [min-height](https://github.com/WordPress/gutenberg/blob/c168df2b5dcfa8a32233366a98ae900d2f41abef/packages/dataviews/src/dataviews-layouts/table/style.scss#L163), the [pull request](https://github.com/WordPress/gutenberg/pull/63694) doesn't provide that answer. I can't think of a way that it breaks.


### Screenshots
| Before | After |
|--------|--------|
 | <img width="2644" height="1868" alt="calypso localhost_3000_v2_sites (1)" src="https://github.com/user-attachments/assets/639955a8-e7f1-4456-924b-ed116a70e293" /> | <img width="2644" height="1868" alt="calypso localhost_3000_v2_sites" src="https://github.com/user-attachments/assets/2e834669-f0fc-4e64-8be9-a6d3d78e3a79" /> | 

## Testing Instructions

- Visit the following tables and verify alignment: 
  - v2/sites
  - v2/domains
  - v2/sites/{domain}/domains
  - v2/sites/{domain}/logs/activity
  - v2/me/billing/purchases

Expect everything to look centered aligned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
