### PR TITLE
Port basic snackbar notifications to use meta.snackbar feature

### DIFF
--- a/client/dashboard/docs/typography-and-copy.md
+++ b/client/dashboard/docs/typography-and-copy.md
@@ -1,0 +1,50 @@
+# Typography and Copy
+
+## General
+
+End sentences with a period. Even short ones. Button and form labels do not end in periods, and neither to headings.
+
+Use curly quotes and apostrophes.
+e.g. “like this” instead of "like this"
+e.g. it’s instead of it's
+
+## Capitalization
+
+Rule of thumb: use sentence case for almost everything.
+
+Button labels, modal titles, and form labels; they all use sentence case.
+
+## Snackbars
+
+When a network request completes it will often pop up a “snackbar” notification. The copy in these notifications should be informative.
+
+When the setting is/or behaves like a feature toggle (like SSH access, Defensive mode) let’s use:
+
+> {Setting name} enabled.
+> {Setting name} disabled.
+
+When it’s not a toggle let’s use:
+
+> {Setting name} saved.
+
+When it is being deleted:
+
+> {Setting name} deleted.
+
+There will be exceptions, such as when the setting can't be changed instantly, but we still want to show success to the user:
+
+> Change of domain ownership requested.
+
+But note that the setting name is still used, and the message ends with the past-tense verb.
+
+Error message should be helpful where possible, although it is not always possible. The message should begin with “Failed”:
+
+> Failed to enable {setting name}.
+> Failed to disable {setting name}.
+> Failed to save {setting name}.
+> Failed to change domain ownership.
+
+In the final case the copy can be simplified by not including the nuance that a success would have actually resulted in a request being made.
+
+And remember, snackbar messages end with a period.
+

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -8,9 +8,7 @@ import {
 	CheckboxControl,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import type { DnsRecord } from '@automattic/api-core';
@@ -31,9 +29,16 @@ export default function DnsImportDialog( {
 	onCancel,
 }: DnsImportDialogProps ) {
 	const [ selectedRecords, setSelectedRecords ] = useState< Set< string > >( new Set() );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
+	const updateDnsMutation = useMutation( {
+		...domainDnsMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'DNS records imported successfully!' ),
+				error: __( 'Failed to import DNS records.' ),
+			},
+		},
+	} );
 
 	// Initialize all records as selected when records change
 	useEffect( () => {
@@ -87,15 +92,9 @@ export default function DnsImportDialog( {
 			},
 			{
 				onSuccess: () => {
-					createSuccessNotice( __( 'DNS records imported successfully!' ), {
-						type: 'snackbar',
-					} );
 					onConfirm();
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to import DNS records.' ), {
-						type: 'snackbar',
-					} );
 					onCancel();
 				},
 			}

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -179,7 +179,7 @@ export default function DnsImportDialog( {
 						onClick={ handleConfirm }
 						disabled={ numberOfSelectedRecords === 0 || updateDnsMutation.isPending }
 					>
-						{ __( 'Import Selected Records' ) }
+						{ __( 'Import selected records' ) }
 					</Button>
 				</ButtonStack>
 			</VStack>

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -34,8 +34,8 @@ export default function DnsImportDialog( {
 		...domainDnsMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'DNS records imported successfully!' ),
-				error: __( 'Failed to import DNS records.' ),
+				success: __( 'DNS records saved.' ),
+				error: __( 'Failed to save DNS records.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -47,8 +47,14 @@ export default function EmailSetupForm( {
 		...domainDnsApplyTemplateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Email setup completed successfully.' ),
-				error: __( 'Failed to complete email setup.' ),
+				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365
+				success: sprintf( __( '%(provider)s email set up.' ), {
+					provider: label,
+				} ),
+				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365
+				error: sprintf( __( 'Failed to complete %(provider)s email setup.' ), {
+					provider: label,
+				} ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -2,10 +2,8 @@ import { type DnsTemplateVariables } from '@automattic/api-core';
 import { domainDnsApplyTemplateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm, Field, isItemValid } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { domainRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
@@ -44,9 +42,16 @@ export default function EmailSetupForm( {
 }: EmailSetupFormProps ) {
 	const { domainName } = domainRoute.useParams();
 	const [ formData, setFormData ] = useState< EmailSetupFormData >( defaultFormData );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const mutation = useMutation( domainDnsApplyTemplateMutation( domainName ) );
+	const mutation = useMutation( {
+		...domainDnsApplyTemplateMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Email setup completed successfully.' ),
+				error: __( 'Failed to complete email setup.' ),
+			},
+		},
+	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
@@ -65,16 +70,6 @@ export default function EmailSetupForm( {
 				variables,
 			},
 			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'Email setup completed successfully.' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to complete email setup.' ), {
-						type: 'snackbar',
-					} );
-				},
 				onSettled: () => {
 					setFormData( defaultFormData );
 				},

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -62,7 +62,15 @@ export default function DomainDns() {
 	const { domainName } = domainRoute.useParams();
 	const router = useRouter();
 	const updateDnsMutation = useMutation( domainDnsMutation( domainName ) );
-	const restoreDefaultEmailRecordsMutation = useMutation( domainDnsEmailMutation( domainName ) );
+	const restoreDefaultEmailRecordsMutation = useMutation( {
+		...domainDnsEmailMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'The default email DNS records were successfully fixed!' ),
+				error: __( 'There was a problem when restoring default email DNS records' ),
+			},
+		},
+	} );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const {
@@ -177,16 +185,6 @@ export default function DomainDns() {
 
 	const handleRestoreDefaultEmailRecords = () => {
 		restoreDefaultEmailRecordsMutation.mutate( undefined, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'The default email DNS records were successfully fixed!' ), {
-					type: 'snackbar',
-				} );
-			},
-			onError: () => {
-				createErrorNotice( __( 'There was a problem when restoring default email DNS records' ), {
-					type: 'snackbar',
-				} );
-			},
 			onSettled: () => {
 				setIsRestoreDefaultEmailRecordsDialogOpen( false );
 			},

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -66,8 +66,8 @@ export default function DomainDns() {
 		...domainDnsEmailMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'The default email DNS records were successfully fixed!' ),
-				error: __( 'There was a problem when restoring default email DNS records' ),
+				success: __( 'Default email DNS records restored.' ),
+				error: __( 'Failed to restore default email DNS records.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -18,8 +18,8 @@ export default function AddDomainForwarding() {
 		...domainForwardingSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule created successfully.' ),
-				error: __( 'Failed to create domain forwarding rule.' ),
+				success: __( 'Domain forwarding rule saved.' ),
+				error: __( 'Failed to save domain forwarding rule.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -1,9 +1,7 @@
 import { domainQuery, domainForwardingSaveMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -16,8 +14,15 @@ import type { DomainForwardingSaveData } from '@automattic/api-core';
 export default function AddDomainForwarding() {
 	const router = useRouter();
 	const { domainName } = domainRoute.useParams();
-	const saveMutation = useMutation( domainForwardingSaveMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const saveMutation = useMutation( {
+		...domainForwardingSaveMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Domain forwarding rule created successfully.' ),
+				error: __( 'Failed to create domain forwarding rule.' ),
+			},
+		},
+	} );
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 
@@ -26,16 +31,10 @@ export default function AddDomainForwarding() {
 
 		saveMutation.mutate( submitData, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Domain forwarding rule created successfully.' ), {
-					type: 'snackbar',
-				} );
 				router.navigate( {
 					to: domainForwardingRoute.fullPath,
 					params: { domainName },
 				} );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to create domain forwarding rule.' ), { type: 'snackbar' } );
 			},
 		} );
 	};

--- a/client/dashboard/domains/domain-forwarding/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwarding/delete-modal.tsx
@@ -5,9 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainForwarding } from '@automattic/api-core';
@@ -23,17 +21,20 @@ const DomainForwardingDeleteModal = ( {
 	domainForwarding,
 	onClose,
 }: DomainForwardingDeleteModalProps ) => {
-	const deleteMutation = useMutation( domainForwardingDeleteMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const deleteMutation = useMutation( {
+		...domainForwardingDeleteMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Domain forwarding rule was deleted successfully.' ),
+				error: __( 'Failed to delete domain forwarding rule.' ),
+			},
+		},
+	} );
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {
 		deleteMutation.mutate( domainForwarding.domain_redirect_id, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Domain forwarding rule was deleted successfully.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_forwarding_delete_record', {
 					domain: domainName,
 					fqdn: domainForwarding.fqdn,
@@ -43,10 +44,6 @@ const DomainForwardingDeleteModal = ( {
 				onClose?.();
 			},
 			onError: ( error ) => {
-				createErrorNotice( __( 'Failed to delete domain forwarding rule.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_forwarding_delete_record_failure', {
 					domain: domainName,
 					fqdn: domainForwarding.fqdn,

--- a/client/dashboard/domains/domain-forwarding/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwarding/delete-modal.tsx
@@ -25,7 +25,7 @@ const DomainForwardingDeleteModal = ( {
 		...domainForwardingDeleteMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule was deleted successfully.' ),
+				success: __( 'Domain forwarding rule deleted.' ),
 				error: __( 'Failed to delete domain forwarding rule.' ),
 			},
 		},

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -5,10 +5,8 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound, useRouter } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -22,8 +20,15 @@ export default function EditDomainForwarding() {
 	const router = useRouter();
 	const { domainName, forwardingId } = domainRoute.useParams();
 	const { data: forwardingData } = useSuspenseQuery( domainForwardingQuery( domainName ) );
-	const saveMutation = useMutation( domainForwardingSaveMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const saveMutation = useMutation( {
+		...domainForwardingSaveMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Domain forwarding rule updated successfully.' ),
+				error: __( 'Failed to update domain forwarding rule.' ),
+			},
+		},
+	} );
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 
@@ -53,16 +58,10 @@ export default function EditDomainForwarding() {
 
 		saveMutation.mutate( submitData, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Domain forwarding rule updated successfully.' ), {
-					type: 'snackbar',
-				} );
 				router.navigate( {
 					to: domainForwardingRoute.fullPath,
 					params: { domainName },
 				} );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to update domain forwarding rule.' ), { type: 'snackbar' } );
 			},
 		} );
 	};

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -24,8 +24,8 @@ export default function EditDomainForwarding() {
 		...domainForwardingSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule updated successfully.' ),
-				error: __( 'Failed to update domain forwarding rule.' ),
+				success: __( 'Domain forwarding rule saved.' ),
+				error: __( 'Failed to save domain forwarding rule.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -16,8 +16,8 @@ export default function AddDomainGlueRecords() {
 		...domainGlueRecordCreateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record created successfully.' ),
-				error: __( 'Failed to create glue record.' ),
+				success: __( 'Glue record saved.' ),
+				error: __( 'Failed to save glue record.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -2,9 +2,7 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordCreateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -14,17 +12,20 @@ import DomainGlueRecordsForm from './form';
 export default function AddDomainGlueRecords() {
 	const navigate = useNavigate();
 	const { domainName } = domainRoute.useParams();
-	const createMutation = useMutation( domainGlueRecordCreateMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const createMutation = useMutation( {
+		...domainGlueRecordCreateMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Glue record created successfully.' ),
+				error: __( 'Failed to create glue record.' ),
+			},
+		},
+	} );
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleSubmit = ( glueRecord: DomainGlueRecord ) => {
 		createMutation.mutate( glueRecord, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Glue record created successfully.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_add_record', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,
@@ -37,8 +38,6 @@ export default function AddDomainGlueRecords() {
 				} );
 			},
 			onError: ( error ) => {
-				createErrorNotice( __( 'Failed to create glue record.' ), { type: 'snackbar' } );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_add_record_failure', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,

--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -25,7 +25,7 @@ const DomainGlueRecordDeleteModal = ( {
 		...domainGlueRecordDeleteMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record was deleted successfully.' ),
+				success: __( 'Glue record deleted.' ),
 				error: __( 'Failed to delete glue record.' ),
 			},
 		},

--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -5,9 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainGlueRecord } from '@automattic/api-core';
@@ -23,17 +21,20 @@ const DomainGlueRecordDeleteModal = ( {
 	domainName,
 	onClose,
 }: DomainGlueRecordDeleteModalProps ) => {
-	const deleteMutation = useMutation( domainGlueRecordDeleteMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const deleteMutation = useMutation( {
+		...domainGlueRecordDeleteMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Glue record was deleted successfully.' ),
+				error: __( 'Failed to delete glue record.' ),
+			},
+		},
+	} );
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {
 		deleteMutation.mutate( glueRecord, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Glue record was deleted successfully.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_delete_record', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,
@@ -43,10 +44,6 @@ const DomainGlueRecordDeleteModal = ( {
 				onClose?.();
 			},
 			onError: ( error ) => {
-				createErrorNotice( __( 'Failed to delete glue record.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_delete_record_failure', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -17,8 +17,8 @@ export default function EditDomainGlueRecords() {
 		...domainGlueRecordUpdateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record updated successfully.' ),
-				error: __( 'Failed to update glue record.' ),
+				success: __( 'Glue record saved.' ),
+				error: __( 'Failed to save glue record.' ),
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -2,9 +2,7 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordsQuery, domainGlueRecordUpdateMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -15,8 +13,15 @@ export default function EditDomainGlueRecords() {
 	const navigate = useNavigate();
 	const { domainName, nameServer } = domainRoute.useParams();
 	const { data: glueRecordsData } = useSuspenseQuery( domainGlueRecordsQuery( domainName ) );
-	const updateMutation = useMutation( domainGlueRecordUpdateMutation( domainName ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const updateMutation = useMutation( {
+		...domainGlueRecordUpdateMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'Glue record updated successfully.' ),
+				error: __( 'Failed to update glue record.' ),
+			},
+		},
+	} );
 	const { recordTracksEvent } = useAnalytics();
 	const glueRecord = glueRecordsData.find(
 		( glueRecord: DomainGlueRecord ) => glueRecord.nameserver === nameServer
@@ -25,10 +30,6 @@ export default function EditDomainGlueRecords() {
 	const handleSubmit = ( updatedGlueRecord: DomainGlueRecord ) => {
 		updateMutation.mutate( updatedGlueRecord, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Glue record updated successfully.' ), {
-					type: 'snackbar',
-				} );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_update_record', {
 					domain: domainName,
 					nameserver: updatedGlueRecord.nameserver,
@@ -41,8 +42,6 @@ export default function EditDomainGlueRecords() {
 				} );
 			},
 			onError: ( error ) => {
-				createErrorNotice( __( 'Failed to update glue record.' ), { type: 'snackbar' } );
-
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_update_record_failure', {
 					domain: domainName,
 					nameserver: updatedGlueRecord.nameserver,

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -8,9 +8,7 @@ import {
 	__experimentalVStack as VStack,
 	ToggleControl,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { DnsSecRecordTextarea } from './dnssec-record-textarea';
 import type { Domain } from '@automattic/api-core';
 
@@ -20,23 +18,20 @@ interface DnsSecProps {
 }
 
 export default function DnsSec( { domainName, domain }: DnsSecProps ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	const mutation = useMutation( domainDnssecMutation( domainName ) );
+	const mutation = useMutation( {
+		...domainDnssecMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'DNSSEC setting saved.' ),
+				error: __( 'Failed to save DNSSEC settings.' ),
+			},
+		},
+	} );
 
 	const { isPending } = mutation;
 
 	const handleToggleChange = ( enabled: boolean ) => {
-		mutation.mutate( enabled, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'DNSSEC setting saved.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to save DNSSEC settings.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( enabled );
 	};
 
 	return (

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -11,10 +11,8 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { ReactElement } from 'react';
 import { domainSecurityRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
@@ -29,9 +27,15 @@ interface SslCertificateProps {
 }
 
 export default function SslCertificate( { domainName, domain, sslDetails }: SslCertificateProps ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	const mutation = useMutation( provisionSslCertificateMutation( domainName ) );
+	const mutation = useMutation( {
+		...provisionSslCertificateMutation( domainName ),
+		meta: {
+			snackbar: {
+				success: __( 'New certificate requested.' ),
+				error: __( 'Failed to provision SSL certificate.' ),
+			},
+		},
+	} );
 
 	const getSslStatusMessage = ( sslDetails: SslDetails ) => {
 		const hasFailureReasons =
@@ -84,16 +88,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 
 	const handleOnClick = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( undefined, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'New certificate requested.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to provision SSL certificate.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( undefined );
 	};
 
 	const renderFailureReasons = (

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -31,7 +31,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 		...provisionSslCertificateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'New certificate requested.' ),
+				success: __( 'New SSL certificate requested.' ),
 				error: __( 'Failed to provision SSL certificate.' ),
 			},
 		},

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -60,8 +60,8 @@ export default function TransferDomainToAnyUser() {
 			...deleteDomainTransferRequestMutation( domainName, domain.site_slug ),
 			meta: {
 				snackbar: {
-					success: __( 'Your domain transfer has been cancelled.' ),
-					error: __( 'The domain transfer cannot be cancelled at this time.' ),
+					success: __( 'Domain transfer cancelled.' ),
+					error: __( 'Failed to cancel domain transfer.' ),
 				},
 			},
 		} );
@@ -71,7 +71,7 @@ export default function TransferDomainToAnyUser() {
 			meta: {
 				snackbar: {
 					success: __( 'A domain transfer request has been emailed to the recipient’s address.' ),
-					error: __( 'An error occurred while initiating the domain transfer.' ),
+					error: __( 'Failed to initiate domain transfer.' ),
 				},
 			},
 		} );

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -14,11 +14,9 @@ import {
 	Button,
 	Modal,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm, isItemValid } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
@@ -58,10 +56,25 @@ export default function TransferDomainToAnyUser() {
 		domainTransferRequestQuery( domainName, domain.site_slug )
 	);
 	const { mutate: deleteDomainTransferRequest, isPending: isDeletingDomainTransferRequest } =
-		useMutation( deleteDomainTransferRequestMutation( domainName, domain.site_slug ) );
+		useMutation( {
+			...deleteDomainTransferRequestMutation( domainName, domain.site_slug ),
+			meta: {
+				snackbar: {
+					success: __( 'Your domain transfer has been cancelled.' ),
+					error: __( 'The domain transfer cannot be cancelled at this time.' ),
+				},
+			},
+		} );
 	const { mutate: updateDomainTransferRequest, isPending: isUpdatingDomainTransferRequest } =
-		useMutation( updateDomainTransferRequestMutation( domainName, domain.site_slug ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+		useMutation( {
+			...updateDomainTransferRequestMutation( domainName, domain.site_slug ),
+			meta: {
+				snackbar: {
+					success: __( 'A domain transfer request has been emailed to the recipient’s address.' ),
+					error: __( 'An error occurred while initiating the domain transfer.' ),
+				},
+			},
+		} );
 	const locale = useLocale();
 	const transferEmail = domainTransferRequest?.email;
 	const requestedAt = domainTransferRequest?.requested_at;
@@ -83,17 +96,8 @@ export default function TransferDomainToAnyUser() {
 
 	const onConfirm = () => {
 		updateDomainTransferRequest( formData.email, {
-			onSuccess: () => {
-				createSuccessNotice(
-					__( 'A domain transfer request has been emailed to the recipient’s address.' )
-				);
-				setIsTransferDialogOpen( false );
-			},
-			onError: () => {
-				createErrorNotice( __( 'An error occurred while initiating the domain transfer.' ) );
-				setIsTransferDialogOpen( false );
-			},
 			onSettled: () => {
+				setIsTransferDialogOpen( false );
 				setFormData( { email: '' } );
 			},
 		} );
@@ -105,12 +109,7 @@ export default function TransferDomainToAnyUser() {
 
 	const onConfirmCancel = () => {
 		deleteDomainTransferRequest( undefined, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'Your domain transfer has been cancelled.' ) );
-				setIsCancelDialogOpen( false );
-			},
-			onError: () => {
-				createErrorNotice( __( 'The domain transfer cannot be cancelled at this time.' ) );
+			onSettled: () => {
 				setIsCancelDialogOpen( false );
 			},
 		} );

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -174,7 +174,7 @@ export default function TransferDomainToAnyUser() {
 								isBusy={ isUpdatingDomainTransferRequest }
 								disabled={ isSaveDisabled || isUpdatingDomainTransferRequest }
 							>
-								{ __( 'Transfer Domain' ) }
+								{ __( 'Transfer domain' ) }
 							</Button>
 						</HStack>
 					</VStack>
@@ -216,7 +216,7 @@ export default function TransferDomainToAnyUser() {
 							onClick={ onConfirm }
 							disabled={ isUpdatingDomainTransferRequest }
 						>
-							{ __( 'Confirm Transfer' ) }
+							{ __( 'Confirm transfer' ) }
 						</Button>
 					</ButtonStack>
 				</VStack>
@@ -246,7 +246,7 @@ export default function TransferDomainToAnyUser() {
 							onClick={ () => setIsCancelDialogOpen( false ) }
 							disabled={ isDeletingDomainTransferRequest }
 						>
-							{ __( 'Keep Transfer' ) }
+							{ __( 'Keep transfer' ) }
 						</Button>
 						<Button
 							__next40pxDefaultSize
@@ -256,7 +256,7 @@ export default function TransferDomainToAnyUser() {
 							onClick={ onConfirmCancel }
 							disabled={ isDeletingDomainTransferRequest }
 						>
-							{ __( 'Cancel Transfer' ) }
+							{ __( 'Cancel transfer' ) }
 						</Button>
 					</ButtonStack>
 				</VStack>
@@ -301,7 +301,7 @@ export default function TransferDomainToAnyUser() {
 						disabled={ isDeletingDomainTransferRequest }
 						onClick={ handleCancelTransfer }
 					>
-						{ __( 'Cancel Transfer' ) }
+						{ __( 'Cancel transfer' ) }
 					</Button>
 				</HStack>
 			</VStack>

--- a/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
@@ -12,10 +12,8 @@ import {
 	__experimentalHStack as HStack,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { getSettings, getSettingsKeys, SubscriptionSettingsForm, type SettingsData } from './form';
 
 const isDirty = ( dataState: SettingsData, originalSettings: SettingsData ) => {
@@ -32,30 +30,16 @@ export const SubscriptionSettings = () => {
 	const { data: rawSettings } = useSuspenseQuery( userSettingsQuery() );
 	const originalSettings = getSettings( rawSettings );
 	const [ dataState, setDataState ] = useState< SettingsData >( originalSettings );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const {
-		mutate: saveSettings,
-		isPending: isSaving,
-		isSuccess: isSuccessSaving,
-		isError: isErrorSaving,
-	} = useMutation( userSettingsMutation() );
-
-	useEffect( () => {
-		if ( isSuccessSaving ) {
-			createSuccessNotice( __( 'Settings saved successfully.' ), {
-				type: 'snackbar',
-			} );
-		}
-	}, [ isSuccessSaving, createSuccessNotice ] );
-
-	useEffect( () => {
-		if ( isErrorSaving ) {
-			createErrorNotice( __( 'Failed to save settings.' ), {
-				type: 'snackbar',
-			} );
-		}
-	}, [ isErrorSaving, createErrorNotice ] );
+	const { mutate: saveSettings, isPending: isSaving } = useMutation( {
+		...userSettingsMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Settings saved successfully.' ),
+				error: __( 'Failed to save settings.' ),
+			},
+		},
+	} );
 
 	const isDataStateDirty = useMemo(
 		() => isDirty( dataState, originalSettings ),

--- a/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/index.tsx
@@ -35,8 +35,8 @@ export const SubscriptionSettings = () => {
 		...userSettingsMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'Settings saved successfully.' ),
-				error: __( 'Failed to save settings.' ),
+				success: __( 'Subscription settings saved.' ),
+				error: __( 'Failed to save subsription settings.' ),
 			},
 		},
 	} );

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -201,7 +201,7 @@ describe( 'SubscriptionSettings', () => {
 		await waitFor( () => {
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( 'Subscription settings saved.' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -2,11 +2,9 @@ import { closeAccountMutation, userPurchasesQuery } from '@automattic/api-querie
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Icon } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { useAuth } from '../../app/auth';
 import { ActionList } from '../../components/action-list';
 import AccountDeletionConfirmModal from './account-deletion-modal';
@@ -14,22 +12,23 @@ import AccountDeletionConfirmModal from './account-deletion-modal';
 export default function AccountDeletionSection() {
 	const { user } = useAuth();
 	const navigate = useNavigate();
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
-	const mutation = useMutation( closeAccountMutation() );
+	const mutation = useMutation( {
+		...closeAccountMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Account deletion initiated.' ),
+				error: __( 'Failed to delete account.' ),
+			},
+		},
+	} );
 	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( userPurchasesQuery() );
 
 	const handleConfirmDelete = () => {
 		mutation.mutate( void 0, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Account deletion initiated.' ), { type: 'snackbar' } );
 				navigate( {
 					to: '/me/account/closed',
-				} );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to delete account.' ), {
-					type: 'snackbar',
 				} );
 			},
 		} );

--- a/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
@@ -48,8 +48,8 @@ export default function SshKeyForm( {
 		...createSshKeyMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'SSH key added.' ),
-				error: __( 'Failed to add SSH key.' ),
+				success: __( 'SSH key saved.' ),
+				error: __( 'Failed to save SSH key.' ),
 			},
 		},
 	} );
@@ -57,8 +57,8 @@ export default function SshKeyForm( {
 		...updateSshKeyMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'SSH key updated.' ),
-				error: __( 'Failed to update SSH key.' ),
+				success: __( 'SSH key saved.' ),
+				error: __( 'Failed to save SSH key.' ),
 			},
 		},
 	} );

--- a/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
@@ -38,51 +38,37 @@ export default function SshKeyForm( {
 	setIsEditing?: ( isEditing: boolean ) => void;
 	username: string;
 } ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const [ formData, setFormData ] = useState< SshKeyFormData >( {
 		key: '',
 	} );
 
-	const { mutate: createSshKey, isPending: isCreatingSshKey } = useMutation(
-		createSshKeyMutation()
-	);
-	const { mutate: updateSshKey, isPending: isUpdatingSshKey } = useMutation(
-		updateSshKeyMutation()
-	);
+	const { mutate: createSshKey, isPending: isCreatingSshKey } = useMutation( {
+		...createSshKeyMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'SSH key added.' ),
+				error: __( 'Failed to add SSH key.' ),
+			},
+		},
+	} );
+	const { mutate: updateSshKey, isPending: isUpdatingSshKey } = useMutation( {
+		...updateSshKeyMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'SSH key updated.' ),
+				error: __( 'Failed to update SSH key.' ),
+			},
+		},
+	} );
 
 	const handleUpdateSshKey = () => {
-		updateSshKey( formData.key, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'SSH key updated.' ), {
-					type: 'snackbar',
-				} );
-				setIsEditing?.( false );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to update SSH key.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		updateSshKey( formData.key );
 	};
 
 	const handleCreateSshKey = () => {
-		createSshKey(
-			{ key: formData.key, name: 'default' },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'SSH key added.' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to add SSH key.' ), {
-						type: 'snackbar',
-					} );
-				},
-			}
-		);
+		createSshKey( { key: formData.key, name: 'default' } );
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -35,8 +35,8 @@ export default function SshKey( {
 		...deleteSshKeyMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'SSH key removed.' ),
-				error: __( 'Failed to remove SSH key.' ),
+				success: __( 'SSH key deleted.' ),
+				error: __( 'Failed to delete SSH key.' ),
 			},
 		},
 	} );

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -10,10 +10,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { edit, trash } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useLocale } from '../../app/locale';
 import { ButtonStack } from '../../components/button-stack';
@@ -31,13 +29,17 @@ export default function SshKey( {
 } ) {
 	const userLocale = useLocale();
 
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-
 	const [ isRemoveDialogOpen, setIsRemoveDialogOpen ] = useState( false );
 
-	const { mutate: deleteSshKey, isPending: isDeletingSshKey } = useMutation(
-		deleteSshKeyMutation()
-	);
+	const { mutate: deleteSshKey, isPending: isDeletingSshKey } = useMutation( {
+		...deleteSshKeyMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'SSH key removed.' ),
+				error: __( 'Failed to remove SSH key.' ),
+			},
+		},
+	} );
 
 	const handleEdit = () => {
 		setIsEditing( true );
@@ -45,16 +47,6 @@ export default function SshKey( {
 
 	const handleRemove = () => {
 		deleteSshKey( undefined, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'SSH key removed.' ), {
-					type: 'snackbar',
-				} );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to remove SSH key.' ), {
-					type: 'snackbar',
-				} );
-			},
 			onSettled: () => {
 				setIsRemoveDialogOpen( false );
 			},

--- a/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
+++ b/client/dashboard/me/security-two-step-auth-sms/setup-phone-number.tsx
@@ -33,9 +33,15 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 	const { mutate: setupTwoStepAuthSMS, isPending: isSetupSMSPending } = useMutation(
 		setupTwoStepAuthSMSMutation()
 	);
-	const { mutate: resendTwoStepAuthSMSCode, isPending: isResending } = useMutation(
-		resendTwoStepAuthSMSCodeMutation()
-	);
+	const { mutate: resendTwoStepAuthSMSCode, isPending: isResending } = useMutation( {
+		...resendTwoStepAuthSMSCodeMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Verification code sent to your phone.' ),
+				error: __( 'Failed to send verification code. Please try again.' ),
+			},
+		},
+	} );
 
 	const initialCountryCode = userSettings.two_step_sms_country;
 	const initialPhoneNumber = userSettings.two_step_sms_phone_number || '';
@@ -107,15 +113,9 @@ export default function SetupPhoneNumber( { userSettings }: { userSettings: User
 		setIsSMSResendThrottled( true );
 		resendTwoStepAuthSMSCode( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Verification code sent to your phone.' ), {
-					type: 'snackbar',
-				} );
 				handleThrottleSMSRequests();
 			},
 			onError: () => {
-				createErrorNotice( __( 'Failed to send verification code. Please try again.' ), {
-					type: 'snackbar',
-				} );
 				setIsSMSResendThrottled( false );
 			},
 		} );

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -43,8 +43,8 @@ const SecurityKeysList = ( {
 		...deleteTwoStepAuthSecurityKeyMutation(),
 		meta: {
 			snackbar: {
-				success: __( 'Security key removed.' ),
-				error: __( 'Failed to remove security key.' ),
+				success: __( 'Security key deleted.' ),
+				error: __( 'Failed to delete security key.' ),
 			},
 		},
 	} );

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -4,12 +4,10 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button, Card, CardHeader, CardBody, Icon } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import ConfirmModal from '../../../../components/confirm-modal';
 import InlineSupportLink from '../../../../components/inline-support-link';
@@ -41,11 +39,15 @@ const SecurityKeysList = ( {
 	data: SecurityKeyRegistration[];
 	isLoading: boolean;
 } ) => {
-	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation(
-		deleteTwoStepAuthSecurityKeyMutation()
-	);
-
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation( {
+		...deleteTwoStepAuthSecurityKeyMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Security key removed.' ),
+				error: __( 'Failed to remove security key.' ),
+			},
+		},
+	} );
 
 	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
 		useState< SecurityKeyRegistration | null >( null );
@@ -55,16 +57,6 @@ const SecurityKeysList = ( {
 			deleteSecurityKey(
 				{ credential_id: selectedKeyToRemove.id },
 				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Security key removed.' ), {
-							type: 'snackbar',
-						} );
-					},
-					onError: () => {
-						createErrorNotice( __( 'Failed to remove security key.' ), {
-							type: 'snackbar',
-						} );
-					},
 					onSettled: () => {
 						setSelectedKeyToRemove( null );
 					},

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -14,11 +14,9 @@ import {
 	CheckboxControl,
 	ExternalLink,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
@@ -60,14 +58,21 @@ const form = {
 };
 
 export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: siteSettings } = useQuery( siteSettingsQuery( site.ID ) );
 	const { data: agencyBlog, isLoading: isLoadingAgencyBlog } = useQuery( {
 		...siteAgencyBlogQuery( site.ID ),
 		enabled: site.is_wpcom_atomic,
 	} );
-	const mutation = useMutation( siteSettingsMutation( site.ID ) );
+	const mutation = useMutation( {
+		...siteSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Agency settings saved.' ),
+				error: __( 'Failed to save agency settings.' ),
+			},
+		},
+	} );
 
 	const [ formData, setFormData ] = useState( {
 		is_fully_managed_agency_site: siteSettings?.is_fully_managed_agency_site,
@@ -94,17 +99,7 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 
 		const handleSubmit = ( e: React.FormEvent ) => {
 			e.preventDefault();
-			mutation.mutate(
-				{ ...formData },
-				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Agency settings saved.' ), { type: 'snackbar' } );
-					},
-					onError: () => {
-						createErrorNotice( __( 'Failed to save agency settings.' ), { type: 'snackbar' } );
-					},
-				}
-			);
+			mutation.mutate( { ...formData } );
 		};
 
 		return (

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -51,8 +51,8 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 		...siteSettingsMutation( site.ID ),
 		meta: {
 			snackbar: {
-				success: __( 'Settings saved.' ),
-				error: __( 'Failed to save settings.' ),
+				success: __( 'Legacy settings saved.' ),
+				error: __( 'Failed to save legacy settings.' ),
 			},
 		},
 	} );

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -8,11 +8,9 @@ import {
 	CardBody,
 	ExternalLink,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
@@ -47,10 +45,17 @@ const form = {
 };
 
 export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: string } ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
-	const mutation = useMutation( siteSettingsMutation( site.ID ) );
+	const mutation = useMutation( {
+		...siteSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Settings saved.' ),
+				error: __( 'Failed to save settings.' ),
+			},
+		},
+	} );
 
 	const [ formData, setFormData ] = useState( {
 		wpcom_legacy_contact: settings?.wpcom_legacy_contact,
@@ -73,21 +78,7 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate(
-			{ ...formData },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'Settings saved.' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to save settings.' ), {
-						type: 'snackbar',
-					} );
-				},
-			}
-		);
+		mutation.mutate( { ...formData } );
 	};
 
 	return (

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -6,10 +6,8 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardBody, __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { ButtonStack } from '../../components/button-stack';
@@ -27,8 +25,15 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		...sitePHPVersionQuery( site.ID ),
 		enabled: hasHostingFeature( site, HostingFeatures.PHP ),
 	} );
-	const mutation = useMutation( sitePHPVersionMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...sitePHPVersionMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'PHP version saved.' ),
+				error: __( 'Failed to save PHP version.' ),
+			},
+		},
+	} );
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',
@@ -61,16 +66,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData.version, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'PHP version saved.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to save PHP version.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( formData.version );
 	};
 
 	const description = hasPlanFeature( site, HostingFeatures.PHP )

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -10,10 +10,8 @@ import {
 	Panel,
 	PanelBody,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
@@ -27,27 +25,20 @@ export default function EnableSftpCard( {
 	siteId: number;
 	canUseSsh: boolean;
 } ) {
-	const mutation = useMutation( siteSftpUsersCreateMutation( siteId ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteSftpUsersCreateMutation( siteId ),
+		meta: {
+			snackbar: {
+				success: __( 'Credentials have been successfully created.' ),
+				error: __(
+					'Sorry, we had a problem retrieving your SFTP user details. Please refresh the page and try again.'
+				),
+			},
+		},
+	} );
 
 	const handleCreateCredentials = () => {
-		mutation.mutate( undefined, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'Credentials have been successfully created.' ), {
-					type: 'snackbar',
-				} );
-			},
-			onError: () => {
-				createErrorNotice(
-					__(
-						'Sorry, we had a problem retrieving your SFTP user details. Please refresh the page and try again.'
-					),
-					{
-						type: 'snackbar',
-					}
-				);
-			},
-		} );
+		mutation.mutate( undefined );
 	};
 
 	return (

--- a/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/enable-sftp-card.tsx
@@ -29,10 +29,8 @@ export default function EnableSftpCard( {
 		...siteSftpUsersCreateMutation( siteId ),
 		meta: {
 			snackbar: {
-				success: __( 'Credentials have been successfully created.' ),
-				error: __(
-					'Sorry, we had a problem retrieving your SFTP user details. Please refresh the page and try again.'
-				),
+				success: __( 'SFTP/SSH credentials saved.' ),
+				error: __( 'Failed to save SFTP/SSH credentials. Please refresh the page and try again.' ),
 			},
 		},
 	} );

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,9 +1,4 @@
-import {
-	siteLaunchMutation,
-	siteBySlugQuery,
-	siteSettingsMutation,
-	siteSettingsQuery,
-} from '@automattic/api-queries';
+import { siteLaunchMutation, siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -22,7 +17,6 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
-	const settingsMutation = useMutation( siteSettingsMutation( site.ID ) );
 	const launchMutation = useMutation( siteLaunchMutation( site.ID ) );
 
 	const [ isAgencyDevelopmentSiteLaunchModalOpen, setIsAgencyDevelopmentSiteLaunchModalOpen ] =
@@ -83,7 +77,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 			);
 		}
 
-		return <PrivacyForm site={ site } settings={ settings } mutation={ settingsMutation } />;
+		return <PrivacyForm site={ site } settings={ settings } />;
 	};
 
 	return (

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -6,10 +6,8 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Card, CardBody, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
@@ -56,8 +54,15 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 		...siteStaticFile404SettingQuery( site.ID ),
 		enabled: hasHostingFeature( site, HostingFeatures.STATIC_FILE_404 ),
 	} );
-	const mutation = useMutation( siteStaticFile404SettingMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteStaticFile404SettingMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Settings saved.' ),
+				error: __( 'Failed to save settings.' ),
+			},
+		},
+	} );
 
 	const [ formData, setFormData ] = useState< { setting: string } >( {
 		setting: currentSetting ?? 'default',
@@ -68,16 +73,7 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData.setting, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to save settings.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( formData.setting );
 	};
 
 	return (

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -58,8 +58,8 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 		...siteStaticFile404SettingMutation( site.ID ),
 		meta: {
 			snackbar: {
-				success: __( 'Settings saved.' ),
-				error: __( 'Failed to save settings.' ),
+				success: __( 'Nonexistent assets settings saved.' ),
+				error: __( 'Failed to save nonexistent asset settings.' ),
 			},
 		},
 	} );

--- a/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/allow-list-form.tsx
@@ -8,11 +8,9 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
@@ -56,8 +54,15 @@ const form = {
 
 export default function AllowListForm( { site }: { site: Site } ) {
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
-	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteJetpackSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Allowed IP addresses saved.' ),
+				error: __( 'Failed to save allowed IP addresses.' ),
+			},
+		},
+	} );
 
 	const currentEnabled = jetpackSettings?.jetpack_waf_ip_allow_list_enabled ?? false;
 	const currentList = jetpackSettings?.jetpack_waf_ip_allow_list ?? '';
@@ -69,17 +74,7 @@ export default function AllowListForm( { site }: { site: Site } ) {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate(
-			{ ...formData },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'Allowed IP addresses saved.' ), { type: 'snackbar' } );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to save allowed IP addresses.' ), { type: 'snackbar' } );
-				},
-			}
-		);
+		mutation.mutate( { ...formData } );
 	};
 
 	const isDirty =

--- a/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/block-list-form.tsx
@@ -8,10 +8,8 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
@@ -57,8 +55,15 @@ const form = {
 
 export default function BlockListForm( { site }: { site: Site } ) {
 	const { data: jetpackSettings } = useSuspenseQuery( siteJetpackSettingsQuery( site.ID ) );
-	const mutation = useMutation( siteJetpackSettingsMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteJetpackSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Blocked IP addresses saved.' ),
+				error: __( 'Failed to save blocked IP addresses.' ),
+			},
+		},
+	} );
 
 	// The WAF module is only supported on self-hosted Jetpack sites, and not supported on VIP
 	const isFirewallModuleSupported =
@@ -76,17 +81,7 @@ export default function BlockListForm( { site }: { site: Site } ) {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate(
-			{ ...formData },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'Blocked IP addresses saved.' ), { type: 'snackbar' } );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to save blocked IP addresses.' ), { type: 'snackbar' } );
-				},
-			}
-		);
+		mutation.mutate( { ...formData } );
 	};
 
 	const isDirty =

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -11,11 +11,9 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
@@ -34,8 +32,15 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 		...siteWordPressVersionQuery( site.ID ),
 		enabled: canView,
 	} );
-	const mutation = useMutation( siteWordPressVersionMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteWordPressVersionMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'WordPress version saved.' ),
+				error: __( 'Failed to save WordPress version.' ),
+			},
+		},
+	} );
 
 	const [ formData, setFormData ] = useState< { version: string } >( {
 		version: currentVersion ?? '',
@@ -63,16 +68,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData.version, {
-			onSuccess: () => {
-				createSuccessNotice( __( 'WordPress version saved.' ), { type: 'snackbar' } );
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to save WordPress version.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( formData.version );
 	};
 
 	const renderForm = () => {

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -2,9 +2,7 @@ import { DotcomFeatures } from '@automattic/api-core';
 import { sitePlanSoftwareRestoreMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { ActionList } from '../../components/action-list';
 import { SectionHeader } from '../../components/section-header';
@@ -13,23 +11,18 @@ import { canViewSiteActions } from '../features';
 import type { Site } from '@automattic/api-core';
 
 const RestorePlanSoftware = ( { site }: { site: Site } ) => {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const mutation = useMutation( sitePlanSoftwareRestoreMutation( site.ID ) );
+	const mutation = useMutation( {
+		...sitePlanSoftwareRestoreMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Requested restoration of plugins and themes that come with your plan.' ),
+				error: __( 'Failed to request restoration of plan plugin and themes.' ),
+			},
+		},
+	} );
 
 	const handleClick = () => {
-		mutation.mutate( undefined, {
-			onSuccess: () => {
-				createSuccessNotice(
-					__( 'Requested restoration of plugins and themes that come with your plan.' ),
-					{ type: 'snackbar' }
-				);
-			},
-			onError: () => {
-				createErrorNotice( __( 'Failed to request restoration of plan plugin and themes.' ), {
-					type: 'snackbar',
-				} );
-			},
-		} );
+		mutation.mutate( undefined );
 	};
 
 	return (

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -63,7 +63,7 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 			createMutation.mutate( undefined );
 		} else {
 			links.forEach( ( { code } ) => {
-				deleteMutation.mutate( code, {} );
+				deleteMutation.mutate( code );
 			} );
 		}
 	};

--- a/client/dashboard/sites/site-preview-links/index.tsx
+++ b/client/dashboard/sites/site-preview-links/index.tsx
@@ -34,9 +34,25 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 		...sitePreviewLinksQuery( site.ID ),
 		enabled: linksPermitted,
 	} );
-	const createMutation = useMutation( sitePreviewLinkCreateMutation( site.ID ) );
-	const deleteMutation = useMutation( sitePreviewLinkDeleteMutation( site.ID ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const createMutation = useMutation( {
+		...sitePreviewLinkCreateMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Preview link enabled.' ),
+				error: __( 'Failed to enable preview link.' ),
+			},
+		},
+	} );
+	const deleteMutation = useMutation( {
+		...sitePreviewLinkDeleteMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Preview link disabled.' ),
+				error: __( 'Failed to disable preview link.' ),
+			},
+		},
+	} );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	if ( ! linksPermitted ) {
 		return null;
@@ -44,24 +60,10 @@ export default function SitePreviewLinks( { site, title, description }: SitePrev
 
 	const handleChange = ( { enabled }: { enabled?: boolean } ) => {
 		if ( enabled ) {
-			createMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Preview link enabled.' ), { type: 'snackbar' } );
-				},
-				onError: () => {
-					createErrorNotice( __( 'Failed to enable preview link.' ), { type: 'snackbar' } );
-				},
-			} );
+			createMutation.mutate( undefined );
 		} else {
 			links.forEach( ( { code } ) => {
-				deleteMutation.mutate( code, {
-					onSuccess: () => {
-						createSuccessNotice( __( 'Preview link disabled.' ), { type: 'snackbar' } );
-					},
-					onError: () => {
-						createErrorNotice( __( 'Failed to disable preview link.' ), { type: 'snackbar' } );
-					},
-				} );
+				deleteMutation.mutate( code, {} );
 			} );
 		}
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDASH-40

## Proposed Changes

* Starts a markdown doc for copy/typography conventions.
* Updates copy of many snackbars to follow the conventions.
  * The snackbars that I edited in this round were the ones that had the most simple implementation. Don't depend on the submitted or returned data.
* Took the opportunity to port a whole bunch of snackbars to the declarative `meta: { snackbar }` method
  * Only removed a net ~100 lines of code, but those lines that were added are more declarative and simpler 🤞 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related to DOTDASH-40. We're starting to have a whole bunch of snackbars now, and the copy isn't super consistent. Hopefully this is a step in the right direction.

In terms of the snackbar infrastructure, I wanted to get a gauge on how many snackbars were simple static text, and how many snackbar messages currently depend on logic that depends on the data sent to the server. So I only ported the snackbars that were simple static text. And also only ported the ones where I both the success and error messages were simple static text.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There's quite a few snackbar messages that have been changed ...

Take a look at the code to find a snackbar that's been changed and smoke test it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
