### PR TITLE
A4A: Fix broken 'Add payment method' link on the Jetpack Manage's purchase screen.

### DIFF
--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -28,6 +28,7 @@ import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	getDisplayName,
 	isExpired,
@@ -647,7 +648,13 @@ export function PurchaseItemPaymentMethod( {
 		e.preventDefault();
 		e.stopPropagation();
 
-		page( `/me/purchases/${ siteSlug }/${ purchaseId }/payment-method/add` );
+		if ( isJetpackCloud() ) {
+			window.open(
+				`https://wordpress.com/me/purchases/${ siteSlug }/${ purchaseId }/payment-method/add`
+			);
+		} else {
+			page( `/me/purchases/${ siteSlug }/${ purchaseId }/payment-method/add` );
+		}
 	};
 
 	if (
@@ -726,7 +733,15 @@ export function BackupPaymentMethodNotice() {
 		'If the renewal fails, a {{link}}backup payment method{{/link}} may be used.',
 		{
 			components: {
-				link: <a href="/me/purchases/payment-methods" />,
+				link: (
+					<a
+						href={
+							isJetpackCloud()
+								? 'https://wordpress.com/me/purchases/payment-methods'
+								: '/me/purchases/payment-methods'
+						}
+					/>
+				),
 			},
 		}
 	);


### PR DESCRIPTION
This PR fixes a broken link on the Purchase screen in the Jetpack Manage dashboard.

<img width="1047" height="523" alt="Screenshot 2025-09-19 at 6 31 48 PM" src="https://github.com/user-attachments/assets/407670d0-24ff-4789-8b5c-68e99292c804" />


Closes https://linear.app/a8c/issue/PAY-384/jetpack-cloud-dashboard-broken-link-to-add-payment-method

## Proposed Changes

* Ensure the link opens a new tab and directs users to the WPCOM purchase screen within the Jetpack Manage environment.

## Why are these changes being made?

* Users will have a bad experience when adding a payment method via the Jetpack Manage dashboard.

## Testing Instructions

* Spin up a JN site and link it to your Jetpack account.
* Purchase any license at https://cloud.jetpack.com/pricing and assign it to your site, making sure not to buy it as a Jetpack-managed agency.
* Use the Jetpack cloud live link and go to `/dashboard`.
* Find your site and expand it.
* Go to the Purchases tab and locate the license you assigned.
* Verify that clicking the 'Add payment method' button redirects to the correct page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
