### PR TITLE
Fix Help Center Build

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -1,6 +1,7 @@
 @import '@automattic/typography/styles/variables';
 @import '@automattic/components/src/styles/typography';
 @import '@wordpress/base-styles/variables';
+@import "@wordpress/base-styles/breakpoints";
 @import '@wordpress/base-styles/mixins';
 
 $blueberry-color: #3858e9;


### PR DESCRIPTION
Adds a missing dependency to `packages/odie-client/src/components/message/style.scss`