### PR TITLE
Domains/HD: Add transfer status card

### DIFF
--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -16,6 +16,7 @@ import Actions from './actions';
 import FeaturedCards from './featured-cards';
 import IcannSuspensionNotice from './icann-suspension-notice';
 import DomainOverviewSettings from './settings';
+import TransferredDomainDetails from './transferred-domain-details';
 
 export default function DomainOverview() {
 	const locale = useLocale();
@@ -81,6 +82,9 @@ export default function DomainOverview() {
 				/>
 			}
 		>
+			{ domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER && (
+				<TransferredDomainDetails domain={ domain } />
+			) }
 			{ domain.is_pending_icann_verification && (
 				<IcannSuspensionNotice domainName={ domain.domain } />
 			) }

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -121,6 +121,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 		);
 	};
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const renderStartTransferButton = () => {
 		if ( ! current_user_is_owner || DomainTransferStatus.PENDING_START !== transfer_status ) {
 			return null;
@@ -140,7 +141,8 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 		<Notice variant={ errorLevel ? 'error' : 'info' }>
 			<VStack spacing={ 4 }>
 				{ renderDescriptionText() }
-				{ renderStartTransferButton() }
+				{ /* To do: add cta once we implemented the transfer flow */ }
+				{ /* { renderStartTransferButton() } */ }
 			</VStack>
 		</Notice>
 	);

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -1,0 +1,146 @@
+import { Domain, DomainTransferStatus } from '@automattic/api-core';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+export default function TransferredDomainDetails( { domain }: { domain: Domain } ) {
+	const {
+		current_user_is_owner,
+		last_transfer_error,
+		domain: domain_name,
+		owner,
+		transfer_status,
+	} = domain;
+
+	const renderDescriptionText = () => {
+		if ( last_transfer_error ) {
+			return current_user_is_owner ? (
+				<>
+					<Text as="p">
+						{ createInterpolateElement(
+							__(
+								/* translators: <domain/> is the domain name */
+								'We tried to start a transfer for your domain <domain/> but we got the following error:'
+							),
+							{
+								domain: <strong>{ domain_name }</strong>,
+							}
+						) }
+					</Text>
+					<Text as="p">
+						<code>{ last_transfer_error }</code>
+					</Text>
+					<Text as="p">
+						{ __(
+							'Please restart the transfer or contact your current domain provider for more details.'
+						) }
+					</Text>
+				</>
+			) : (
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							/* translators: <domain/> is the domain name, <owner/> is the domain owner */
+							'We tried to start a transfer for your domain <domain/> but an error occurred. Please contact the domain owner, <owner/>, for more details.'
+						),
+						{
+							domain: <strong>{ domain_name }</strong>,
+							owner: <strong>{ owner }</strong>,
+						}
+					) }
+				</Text>
+			);
+		}
+
+		if ( DomainTransferStatus.PENDING_START === transfer_status ) {
+			return current_user_is_owner ? (
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							/* translators: <domain/> is the domain name */
+							'We need you to complete a couple of steps before we can transfer <domain/> from your current domain provider to WordPress.com. Your domain will stay at your current provider until the transfer is completed.'
+						),
+						{
+							domain: <strong>{ domain_name }</strong>,
+						}
+					) }
+				</Text>
+			) : (
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							/* translators: <owner/> is the domain owner */
+							'This domain transfer is waiting to be initiated. Please contact the domain owner, <owner/>, to start it.'
+						),
+						{
+							owner: <strong>{ owner }</strong>,
+						}
+					) }
+				</Text>
+			);
+		} else if ( DomainTransferStatus.CANCELLED === transfer_status ) {
+			return current_user_is_owner ? (
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							/* translators: <domain/> is the domain name */
+							'We were unable to complete the transfer of <domain/>. You can remove the transfer from your account or try to start the transfer again.'
+						),
+						{
+							domain: <strong>{ domain_name }</strong>,
+						}
+					) }
+				</Text>
+			) : (
+				<Text as="p">
+					{ createInterpolateElement(
+						__(
+							'The domain transfer failed to complete. Please contact the domain owner, <owner/>, to restart it.'
+						),
+						{
+							owner: <strong>{ owner }</strong>,
+						}
+					) }
+				</Text>
+			);
+		}
+
+		return (
+			<Text as="p">
+				{ __(
+					'Your transfer has been started and is waiting for authorization from your current domain provider. Your current domain provider should allow you to speed this process up, either through their website or an email they’ve already sent you.'
+				) }
+			</Text>
+		);
+	};
+
+	const renderStartTransferButton = () => {
+		if ( ! current_user_is_owner || DomainTransferStatus.PENDING_START !== transfer_status ) {
+			return null;
+		}
+		return (
+			// To do: add cta once we implemented the transfer flow
+			<HStack>
+				<Button variant="primary">
+					{ last_transfer_error ? __( 'Restart Transfer' ) : __( 'Start Transfer' ) }
+				</Button>
+			</HStack>
+		);
+	};
+
+	const errorLevel = last_transfer_error || DomainTransferStatus.CANCELLED === transfer_status;
+	return (
+		<Notice variant={ errorLevel ? 'error' : 'info' }>
+			<VStack spacing={ 4 }>
+				{ renderDescriptionText() }
+				{ renderStartTransferButton() }
+			</VStack>
+		</Notice>
+	);
+}

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -101,6 +101,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 				<Text as="p">
 					{ createInterpolateElement(
 						__(
+							/* translators: <owner/> is the domain owner */
 							'The domain transfer failed to complete. Please contact the domain owner, <owner/>, to restart it.'
 						),
 						{

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -134,7 +134,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 		);
 	};
 
-	const errorLevel = last_transfer_error || DomainTransferStatus.CANCELLED === transfer_status;
+	const errorLevel = !! last_transfer_error || DomainTransferStatus.CANCELLED === transfer_status;
 	return (
 		<Notice variant={ errorLevel ? 'error' : 'info' }>
 			<VStack spacing={ 4 }>

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -26,7 +26,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 						{ createInterpolateElement(
 							__(
 								/* translators: <domain/> is the domain name */
-								'We tried to start a transfer for your domain <domain/> but we got the following error:'
+								'We tried to start a transfer for your domain <domain/>, but we got the following error:'
 							),
 							{
 								domain: <strong>{ domain_name }</strong>,
@@ -47,7 +47,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 					{ createInterpolateElement(
 						__(
 							/* translators: <domain/> is the domain name, <owner/> is the domain owner */
-							'We tried to start a transfer for your domain <domain/> but an error occurred. Please contact the domain owner, <owner/>, for more details.'
+							'We tried to start a transfer for your domain <domain/>, but an error occurred. Please contact the domain owner, <owner/>, for more details.'
 						),
 						{
 							domain: <strong>{ domain_name }</strong>,
@@ -90,7 +90,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 					{ createInterpolateElement(
 						__(
 							/* translators: <domain/> is the domain name */
-							'We were unable to complete the transfer of <domain/>. You can remove the transfer from your account or try to start the transfer again.'
+							'We were unable to complete the transfer of <domain/>. You can remove the transfer from your account or try to start it again.'
 						),
 						{
 							domain: <strong>{ domain_name }</strong>,

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -5,14 +5,17 @@ export enum DomainTypes {
 	TRANSFER = 'transfer',
 }
 
-export enum DomainTransferStatus {
-	PENDING_OWNER = 'pending_owner',
-	PENDING_REGISTRY = 'pending_registry',
-	CANCELLED = 'cancelled',
-	COMPLETED = 'completed',
-	PENDING_START = 'pending_start',
-	PENDING_ASYNC = 'pending_async',
-}
+export const DomainTransferStatus = {
+	PENDING_OWNER: 'pending_owner',
+	PENDING_REGISTRY: 'pending_registry',
+	CANCELLED: 'cancelled',
+	COMPLETED: 'completed',
+	PENDING_START: 'pending_start',
+	PENDING_ASYNC: 'pending_async',
+} as const;
+
+export type DomainTransferStatus =
+	( typeof DomainTransferStatus )[ keyof typeof DomainTransferStatus ];
 
 export enum DomainSubtype {
 	DEFAULT_ADDRESS = 'default_address',


### PR DESCRIPTION
Closes [DOTDASH-508](https://linear.app/a8c/issue/DOTDASH-508/add-transfer-status-card)

## Proposed Changes

This PR adds a new `TransferredDomainDetails` component to the dashboard domain overview page to provide users with clear information and actions for domain transfers.

## Why are these changes being made?
This is part of the Domains Hosting Dashboard project.


|![Screenshot 2025-09-19 alle 13 38 56](https://github.com/user-attachments/assets/d7b58a7c-fea9-4c4b-b10c-5683039c3328)|
|:---:|
|**Pending registry**|

|![Screenshot 2025-09-19 alle 13 53 15](https://github.com/user-attachments/assets/532a0771-6621-4413-a2e1-2ffcbe489390)|
|:---:|
|**Pending start - owner**|

|![Screenshot 2025-09-19 alle 13 25 45](https://github.com/user-attachments/assets/15d5fff0-4f3e-4de4-80cb-03407059c9c6)|
|:---:|
|**Pending start - not owner**|

|![Screenshot 2025-09-19 alle 13 26 55](https://github.com/user-attachments/assets/788395b2-101f-4cee-a716-e2b6d3c5aa94)|
|:---:|
|**Cancelled - owner**|

|![Screenshot 2025-09-19 alle 13 27 56](https://github.com/user-attachments/assets/a7d8c5d8-5100-4444-8c7f-454e1fae2f70)|
|:---:|
|**Cancelled - not owner**|

|![Screenshot 2025-09-19 alle 13 29 30](https://github.com/user-attachments/assets/0dc91446-ee90-4a21-9d50-f662cfcc4ec6)|
|:---:|
|**Error - owner**|

|![Screenshot 2025-09-19 alle 13 30 31](https://github.com/user-attachments/assets/28f38f78-dac6-429f-ab66-38c2ca68ebac)|
|:---:|
|**Error - not owner**|

## Testing Instructions
You can test the different statuses hacking the domain details api.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
