### PR TITLE
Add warning to sync modal in HD for when the database checkbox is checked

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -32,6 +32,7 @@ import { useLocale } from '../../app/locale';
 import { ButtonStack } from '../../components/button-stack';
 import Environment, { EnvironmentType } from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
+import { Notice } from '../../components/notice';
 import type { FileBrowserConfig } from '../../../my-sites/backup/backup-contents-page/file-browser';
 
 // File browser config used for granular selection
@@ -449,7 +450,9 @@ function StagingSiteSyncModalInner( {
 							spacing={ 2 }
 							style={ {
 								borderTop: '1px solid var(--wp-components-color-gray-300, #ddd)',
-								borderBottom: '1px solid var(--wp-components-color-gray-300, #ddd)',
+								borderBottom: hasWarning
+									? 'none'
+									: '1px solid var(--wp-components-color-gray-300, #ddd)',
 								padding: '16px 0',
 								marginTop: isFileBrowserVisible ? '16px' : '0',
 							} }
@@ -462,6 +465,15 @@ function StagingSiteSyncModalInner( {
 								onChange={ handleDatabaseCheckboxChange }
 							/>
 						</HStack>
+						{ hasWarning && (
+							<VStack style={ { marginTop: '20px' } }>
+								<Notice variant="warning" title={ __( 'Warning! Database will be overwritten' ) }>
+									{ __(
+										'Selecting database option will overwrite the site database, including any posts, pages, products, or orders.'
+									) }
+								</Notice>
+							</VStack>
+						) }
 					</VStack>
 
 					{ showDomainConfirmation && (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14616

## Proposed Changes

This PR adds warning about database to the Sync modal for when the `Database` box is checked. 

<img width="1027" height="600" alt="Screenshot 2025-09-19 at 2 31 21 PM" src="https://github.com/user-attachments/assets/14699289-f3db-45ba-a67a-c3fe66cfd810" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The warning is currently missing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso live link
* Ensure that you have an Atomic site along with the staging site
* Navigate to `/v2/sites/{yourAtomicSite}`
* Click the `Sync` button in the top right corner to open the modal
* Check the database checkbox
* Confirm that you can see the warning about the database 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
