### PR TITLE
A4A: Add back Not Eligible badge

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -64,17 +64,17 @@ export const WooPaymentsStatusColumn = ( {
 	}
 
 	const getStatusProps = () => {
-		// Check if site exists in woopaymentsData
-		const siteExistsInWooPaymentsData = woopaymentsData?.data?.total?.sites?.[ siteId ];
+		// Check if site is commission eligible.
+		const siteExistsInWooPaymentsData =
+			woopaymentsData?.data?.commission_eligible_sites?.includes( siteId );
 
-		// If site is active but not in woopaymentsData, it's not eligible
+		// If site is active but not commission eligible, show "Not eligible" status.
 		if ( state === 'active' && ! siteExistsInWooPaymentsData ) {
-			// @todo Temporarily disabled until this is fixed: p1757331076213279-slack-C091P0A65U5
-			// return {
-			// 	statusText: translate( 'Not eligible' ),
-			// 	statusType: 'error',
-			// 	showInfoIcon: true,
-			// };
+			return {
+				statusText: translate( 'Not eligible' ),
+				statusType: 'error',
+				showInfoIcon: true,
+			};
 		}
 
 		switch ( state ) {

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -57,6 +57,7 @@ export interface WooPaymentsData {
 				};
 			};
 		};
+		commission_eligible_sites?: Array< number >;
 	};
 	status: string;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Adds back the "Not eligible" badge previously introduced here: https://github.com/Automattic/wp-calypso/pull/105545
* Makes use of the new `commission_eligible_sites` property in `woopaymentsData` that returns a list of blog ids that are eligible for commissions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 192572-ghe-Automattic/wpcom to your sandbox if not merged yet.
* Go to the Referrals dashboard and find an agency with sites that are not eligible for incentives (sort by Total Referred Amount).
* Go to the agency owner profile, click the Switch to A4A button
* Open the live link on the window impersonating the agency owner
* Go to WooPayments > Dashboard and confirm some sites have Not eligible status while others have Active status.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?