### PR TITLE
v2 Plugins - Scheduled Updates: Add pending/submitting status to create-schedule CTA

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -173,7 +173,7 @@ function ScheduledUpdatesNew() {
 						<HStack justify="start">
 							<Button
 								variant="primary"
-								disabled={ ! isValid || isSubmitting || createBatch.isPending }
+								disabled={ ! isValid || isSubmitting }
 								onClick={ handleCreate }
 								__next40pxDefaultSize
 							>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -29,7 +29,7 @@ import { DEFAULT_FREQUENCY, DEFAULT_TIME, DEFAULT_WEEKDAY, CRON_CHECK_INTERVAL }
 import { prepareTimestamp, runWithConcurrency } from './helpers';
 import type { Site } from '@automattic/api-core';
 
-const BLOCK_CREATE = true;
+const BLOCK_CREATE = false;
 
 function ScheduledUpdatesNew() {
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
@@ -37,6 +37,7 @@ function ScheduledUpdatesNew() {
 	const [ frequency, setFrequency ] = useState< Frequency >( DEFAULT_FREQUENCY );
 	const [ weekday, setWeekday ] = useState< Weekday >( DEFAULT_WEEKDAY );
 	const [ time, setTime ] = useState( DEFAULT_TIME );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
@@ -56,6 +57,7 @@ function ScheduledUpdatesNew() {
 		}
 
 		const timestamp = prepareTimestamp( frequency, weekday, time );
+		setIsSubmitting( true );
 		const body = {
 			plugins: selectedPluginSlugs,
 			schedule: {
@@ -105,8 +107,12 @@ function ScheduledUpdatesNew() {
 					} );
 
 				await runWithConcurrency( monitorTasks, 4 );
+				setIsSubmitting( false );
 				// Navigate back to the schedules list
 				navigate( { to: pluginsScheduledUpdatesRoute.to } );
+			},
+			onError: () => {
+				setIsSubmitting( false );
 			},
 		} );
 	}, [
@@ -167,7 +173,7 @@ function ScheduledUpdatesNew() {
 						<HStack justify="start">
 							<Button
 								variant="primary"
-								disabled={ ! isValid }
+								disabled={ ! isValid || isSubmitting || createBatch.isPending }
 								onClick={ handleCreate }
 								__next40pxDefaultSize
 							>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -29,7 +29,7 @@ import { DEFAULT_FREQUENCY, DEFAULT_TIME, DEFAULT_WEEKDAY, CRON_CHECK_INTERVAL }
 import { prepareTimestamp, runWithConcurrency } from './helpers';
 import type { Site } from '@automattic/api-core';
 
-const BLOCK_CREATE = false;
+const BLOCK_CREATE = true;
 
 function ScheduledUpdatesNew() {
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Proposed Changes

- Adds a `isSubmitting` status to the "create schedule" CTA in the New Schedule screen
- This simply turns the button disabled when either the batch mutation is pending, or the selections are not filled out correctly, or the form/submission is pending (new). We don't yet have error and collision detection, which we are addressing separately - the end result is always a redirection to `/v2/plugins/scheduled-updates` (as before)


https://github.com/user-attachments/assets/79296904-be44-4547-9ff8-5c01305b094f



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/plugins/scheduled-updates/new`
  - Select a site (must have an atomic site) - ideally multiple sites for testing this
  - Select a plugin (must have a non-managed plugins installed from marketplace)
  - Select a frequency
  - Click on "Create schedule" (as in media)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
