### PR TITLE
AI Site Spec: Bump to `v1.1.1` and enable tracks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -11,7 +11,7 @@ const SiteSpec: StepType = function SiteSpec() {
 	return (
 		<>
 			<DocumentHead title={ translate( 'Build Your Site with AI' ) } />
-			<div id="site-spec-container" />
+			<div id="site-spec-container" style={ { height: '100vh' } } />
 		</>
 	);
 };

--- a/client/lib/site-spec/script-loader.ts
+++ b/client/lib/site-spec/script-loader.ts
@@ -107,6 +107,7 @@ function injectResource( url: string, type: ResourceType ): Promise< void > {
 			const scriptElement = element as HTMLScriptElement;
 			scriptElement.src = url;
 			scriptElement.async = true;
+			scriptElement.type = 'module';
 		} else {
 			const linkElement = element as HTMLLinkElement;
 			linkElement.href = url;

--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -170,7 +170,7 @@ describe( 'SiteSpec Utils', () => {
 		it( 'should always include tracking configuration with correct values', () => {
 			mockConfig.mockReturnValueOnce( {} );
 
-			const result = getSiteSpecConfig();
+			const result = getDefaultSiteSpecConfig();
 
 			expect( result.tracking ).toEqual( {
 				enabled: true,

--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -122,7 +122,7 @@ describe( 'SiteSpec Utils', () => {
 	} );
 
 	describe( 'getDefaultSiteSpecConfig', () => {
-		it( 'should return configuration object with all values', () => {
+		it( 'should return configuration object with all values including tracking', () => {
 			mockConfig.mockReturnValueOnce( {
 				agent_url: 'https://api.example.com/agent',
 				agent_id: 'test-agent-id',
@@ -135,6 +135,11 @@ describe( 'SiteSpec Utils', () => {
 				agentUrl: 'https://api.example.com/agent',
 				agentId: 'test-agent-id',
 				buildSiteUrl: 'https://example.com/build?spec_id=',
+				tracking: {
+					enabled: true,
+					prefix: 'jetpack_calypso',
+					getOverrides: expect.any( Function ),
+				},
 			} );
 		} );
 
@@ -154,6 +159,29 @@ describe( 'SiteSpec Utils', () => {
 
 			expect( result ).toEqual( {
 				agentId: 'test-agent-id',
+				tracking: {
+					enabled: true,
+					prefix: 'jetpack_calypso',
+					getOverrides: expect.any( Function ),
+				},
+			} );
+		} );
+
+		it( 'should always include tracking configuration with correct values', () => {
+			mockConfig.mockReturnValueOnce( {} );
+
+			const result = getSiteSpecConfig();
+
+			expect( result.tracking ).toEqual( {
+				enabled: true,
+				prefix: 'jetpack_calypso',
+				getOverrides: expect.any( Function ),
+			} );
+
+			// Test that getOverrides function returns expected values
+			const overrides = result.tracking?.getOverrides?.( 'test-event' );
+			expect( overrides ).toEqual( {
+				client: 'calypso',
 			} );
 		} );
 	} );

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -14,6 +14,11 @@ export interface SiteSpecConfig {
 	agentUrl?: string;
 	agentId?: string;
 	buildSiteUrl?: string;
+	tracking?: {
+		enabled?: boolean;
+		prefix?: string;
+		getOverrides?: ( eventName: string ) => Record< string, string >;
+	};
 }
 
 // Config key for URL functions
@@ -67,5 +72,12 @@ export function getDefaultSiteSpecConfig(): SiteSpecConfig {
 		agentUrl: siteSpecConfig?.agent_url,
 		agentId: siteSpecConfig?.agent_id,
 		buildSiteUrl: siteSpecConfig?.build_site_url,
+		tracking: {
+			enabled: true,
+			prefix: 'jetpack_calypso',
+			getOverrides: () => ( {
+				client: 'calypso',
+			} ),
+		},
 	};
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -208,7 +208,7 @@
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/bundle-1.0.1.umd.js",
-		"css_url": "https://widgets.wp.com/site-spec/style-1.0.1.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.1.1/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.1.1/style.css"
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Update the site-spec version to `v1.1.1`
* Enable tracks

## Testing Instructions

1. Pull this PR and run: `NODE_OPTIONS='--max-old-space-size=8192' yarn start`. Do `yarn` first if your deps are outdated.
3. Go to http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec and test.
4. Ensure that the events for site-spec are being recorded. You can do so by looking at the network calls and filtering by `t.gif`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
