### PR TITLE
Staging Sites: Restrict staging site creation and tab to sites on plans that support it

### DIFF
--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -160,7 +160,8 @@ export default function HeaderStagingSiteButton( {
 		! isStagingSite &&
 		! isLoadingStagingSites &&
 		( stagingSites.length === 0 || ( isCreatingStagingSite && ! isCreatedStagingSite ) ) &&
-		hasStagingSitesFeature;
+		hasStagingSitesFeature &&
+		! isA4ADevSite;
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );
@@ -180,8 +181,6 @@ export default function HeaderStagingSiteButton( {
 	let disabledReason: string | undefined;
 	if ( ! hasCompletedLoading ) {
 		disabledReason = __( 'Loading…' );
-	} else if ( isA4ADevSite ) {
-		disabledReason = __( 'Staging sites are not available for development sites.' );
 	} else if ( isErrorValidQuota ) {
 		disabledReason = __(
 			'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'

--- a/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/header-staging-site-button.tsx
@@ -1,4 +1,5 @@
 import { siteByIdQuery, hasValidQuotaQuery } from '@automattic/api-queries';
+import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { useQueryClient, useQuery } from '@tanstack/react-query';
 import { Button, Spinner } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -16,6 +17,7 @@ import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/a
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
@@ -148,12 +150,17 @@ export default function HeaderStagingSiteButton( {
 		}
 	);
 
+	const hasStagingSitesFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES )
+	);
+
 	const showAddStagingButton =
 		! hideEnvDataInHeader &&
 		isAtomic &&
 		! isStagingSite &&
 		! isLoadingStagingSites &&
-		( stagingSites.length === 0 || ( isCreatingStagingSite && ! isCreatedStagingSite ) );
+		( stagingSites.length === 0 || ( isCreatingStagingSite && ! isCreatedStagingSite ) ) &&
+		hasStagingSitesFeature;
 
 	const onAddClick = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_TRANSFERRING ) );

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo } from 'react';
@@ -10,6 +11,7 @@ import HostingFeaturesIcon from 'calypso/sites/hosting/components/hosting-featur
 import { useStagingSite } from 'calypso/sites/staging-site/hooks/use-staging-site';
 import SitesProductionBadge from 'calypso/sites-dashboard/components/sites-production-badge';
 import { useSelector } from 'calypso/state';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { canCurrentUserSwitchEnvironment } from 'calypso/state/sites/selectors/can-current-user-switch-environment';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
@@ -223,12 +225,16 @@ const DotcomPreviewPane = ( {
 		selectedFeatureId: selectedSiteFeature,
 	} );
 
+	const hasStagingSitesFeature = useSelector( ( state ) =>
+		siteHasFeature( state, site.ID, FEATURE_SITE_STAGING_SITES )
+	);
+
 	const isProduction =
 		siteWithStagingIds.is_wpcom_atomic && ! siteWithStagingIds.is_wpcom_staging_site;
 	const hasNoStagingSites = ! siteWithStagingIds.options?.wpcom_staging_blog_ids?.length;
 
 	const shouldShowProductionBadge =
-		isProduction && ( hasNoStagingSites || ! isStagingStatusFinished );
+		isProduction && ( hasNoStagingSites || ! isStagingStatusFinished ) && hasStagingSitesFeature;
 
 	return (
 		<ItemView

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -229,12 +229,17 @@ const DotcomPreviewPane = ( {
 		siteHasFeature( state, site.ID, FEATURE_SITE_STAGING_SITES )
 	);
 
+	const isA4ADevSite = site?.is_a4a_dev_site || false;
+
 	const isProduction =
 		siteWithStagingIds.is_wpcom_atomic && ! siteWithStagingIds.is_wpcom_staging_site;
 	const hasNoStagingSites = ! siteWithStagingIds.options?.wpcom_staging_blog_ids?.length;
 
 	const shouldShowProductionBadge =
-		isProduction && ( hasNoStagingSites || ! isStagingStatusFinished ) && hasStagingSitesFeature;
+		isProduction &&
+		( hasNoStagingSites || ! isStagingStatusFinished ) &&
+		hasStagingSitesFeature &&
+		! isA4ADevSite;
 
 	return (
 		<ItemView

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -67,6 +67,11 @@ const DotcomPreviewPane = ( {
 	const isPlanExpired = !! site.plan?.expired;
 	const isInProgress = isMigrationInProgress( site );
 	const isHostingFeaturesCalloutEnabled = isEnabled( 'hosting/hosting-features-callout' );
+	const isA4ADevSite = !! site?.is_a4a_dev_site;
+
+	const hasStagingSitesFeature = useSelector( ( state ) =>
+		siteHasFeature( state, site.ID, FEATURE_SITE_STAGING_SITES )
+	);
 
 	const features: FeaturePreviewInterface[] = useMemo( () => {
 		const isActiveAtomicSite = isAtomicSite && ! isPlanExpired;
@@ -110,7 +115,7 @@ const DotcomPreviewPane = ( {
 			{
 				label: __( 'Staging Site' ),
 				// We don't have the callout for the staging site tab since we'll retire the tab.
-				enabled: isActiveAtomicSite,
+				enabled: hasStagingSitesFeature && ! isA4ADevSite,
 				featureIds: [ STAGING_SITE ],
 			},
 			{
@@ -168,6 +173,8 @@ const DotcomPreviewPane = ( {
 		selectedSiteFeature,
 		selectedSiteFeaturePreview,
 		isHostingFeaturesCalloutEnabled,
+		hasStagingSitesFeature,
+		isA4ADevSite,
 	] );
 
 	const itemData: ItemData = {
@@ -224,12 +231,6 @@ const DotcomPreviewPane = ( {
 		features,
 		selectedFeatureId: selectedSiteFeature,
 	} );
-
-	const hasStagingSitesFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site.ID, FEATURE_SITE_STAGING_SITES )
-	);
-
-	const isA4ADevSite = site?.is_a4a_dev_site || false;
 
 	const isProduction =
 		siteWithStagingIds.is_wpcom_atomic && ! siteWithStagingIds.is_wpcom_staging_site;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-443

## Proposed Changes

ℹ️ All these changes are related to the V1 dashboard only.

* Hide `+ Add staging site` button from sites on _WordPress.com Pro_ plan and A4A Development sites.
  * Remove tooltip that was used on the disabled `+ Add staging site` button when it was rendered on a A4A Development site dashboard.
* Hide `Production` badge from sites that don't support staging sites.
* Hide the `Staging Site` tab from sites that don't support staging sites. Sidenote: Initially I thought about displaying an upgrade callout, but the aim has been to remove the tab completely anyways (and then migrate to the V2 dashboard). Because of the timeframe and unnecessary effort, I decided to hide the tab completely (for now from the sites that cannot use staging sites).

| Before | After |
|--------|--------|
| <img width="2316" height="1364" alt="Markup on 2025-09-22 at 16:28:23" src="https://github.com/user-attachments/assets/e5b1d75c-7cac-4e99-8d7c-623d47460bb6" /> | <img width="2282" height="1228" alt="Markup on 2025-09-22 at 16:29:24" src="https://github.com/user-attachments/assets/ecf495ae-1fb6-41cf-9280-104424d6d5eb" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix the issue brought up in DOTDASH-443.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to your SA of your account and assign WordPress.com Pro plan to one of your test sites (ensure there is not other plan linked with that site).
2. Check out the PR and build the app with `yarn && yarn start` (or use the Calypso Live link below).
3. Head over to the V1 dashboard and select your test site from the list on the side.
4. There should be no `Staging Site` tab, no `+ Add Staging site` button, no `Production` badge (as can be seen in the _After_ screenshot above).
5. Try to click through other sites on your account. There should be no regressions. The `Staging Site` tab, `+ Add Staging site` button (or Environment Switcher) and `Production` / `Staging` badges should still be displayed on sites where it makes sense (sites on Business plan with activated Hosting features). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
