### PR TITLE
Scan Dashboard: add threat ignore/unignore feature

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -3,20 +3,17 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Icon,
-	ExternalLink,
 } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
 import { ButtonStack } from '../../../components/button-stack';
-import { Notice } from '../../../components/notice';
+import { IgnoreThreatModal } from '../../scan/components/ignore-threat-modal';
 import { ThreatDescription } from '../../scan/components/threat-description';
 import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
-import { CODEABLE_JETPACK_SCAN_URL } from '../../scan/constants';
 import type { Threat } from '@automattic/api-core';
 
-export function getActions(): Action< Threat >[] {
+export function getActions( siteId: number ): Action< Threat >[] {
 	return [
 		{
 			id: 'fix',
@@ -56,31 +53,13 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Ignore threat' ),
 			modalHeader: __( 'Ignore threat' ),
 			supportsBulk: false,
-			RenderModal: ( { items, closeModal } ) => (
-				<VStack spacing={ 4 }>
-					<Text variant="muted">{ __( 'Jetpack will be ignoring the following threat:' ) }</Text>
-					<ThreatsDetailCard threats={ items } />
-					<ThreatDescription threat={ items[ 0 ] } />
-					<Notice variant="error">
-						{ createInterpolateElement(
-							__(
-								'By ignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site. If you are unsure please request an estimate with <codeable />.'
-							),
-							{
-								codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
-							}
-						) }
-					</Notice>
-					<ButtonStack justify="flex-end">
-						<Button variant="tertiary" onClick={ closeModal }>
-							{ __( 'Cancel' ) }
-						</Button>
-						{ /* @TODO: implement the ignore threat action and remove the disabled prop */ }
-						<Button variant="primary" disabled>
-							{ __( 'Ignore threat' ) }
-						</Button>
-					</ButtonStack>
-				</VStack>
+			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+				<IgnoreThreatModal
+					items={ items }
+					closeModal={ closeModal }
+					onActionPerformed={ onActionPerformed }
+					siteId={ siteId }
+				/>
 			),
 		},
 	];

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -23,7 +23,7 @@ export function ActiveThreatsDataViews( { site }: { site: Site } ) {
 	const threats = scan?.threats.filter( ( threat ) => threat.status === 'current' ) || [];
 
 	const fields = getFields();
-	const actions = getActions();
+	const actions = getActions( site.ID );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
 	const lastScanTime = scan?.most_recent?.timestamp;
 	const recentScanRelativeTime = useTimeSince( lastScanTime || '' );

--- a/client/dashboard/sites/scan-history/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/actions.tsx
@@ -1,20 +1,12 @@
-import {
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-	ExternalLink,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ButtonStack } from '../../../components/button-stack';
-import { Notice } from '../../../components/notice';
 import { ThreatDescription } from '../../scan/components/threat-description';
 import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
-import { CODEABLE_JETPACK_SCAN_URL } from '../../scan/constants';
+import { UnignoreThreatModal } from '../../scan/components/unignore-threat-modal';
 import type { Threat } from '@automattic/api-core';
 
-export function getActions(): Action< Threat >[] {
+export function getActions( siteId: number ): Action< Threat >[] {
 	return [
 		{
 			id: 'unignore',
@@ -22,31 +14,13 @@ export function getActions(): Action< Threat >[] {
 			label: __( 'Unignore threat' ),
 			modalHeader: __( 'Unignore threat' ),
 			supportsBulk: false,
-			RenderModal: ( { items, closeModal } ) => (
-				<VStack spacing={ 4 }>
-					<Text variant="muted">{ __( 'Jetpack will be unignoring the following threat:' ) }</Text>
-					<ThreatsDetailCard threats={ items } />
-					{ items.length === 1 && <ThreatDescription threat={ items[ 0 ] } /> }
-					<Notice variant="warning">
-						{ createInterpolateElement(
-							__(
-								'By unignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site as an active threat. If you are unsure please request an estimate with <codeable />.'
-							),
-							{
-								codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
-							}
-						) }
-					</Notice>
-					<ButtonStack justify="flex-end">
-						<Button variant="tertiary" onClick={ closeModal }>
-							{ __( 'Cancel' ) }
-						</Button>
-						{ /* @TODO: implement the unignore threat action and remove the disabled prop */ }
-						<Button variant="primary" disabled>
-							{ __( 'Unignore threat' ) }
-						</Button>
-					</ButtonStack>
-				</VStack>
+			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+				<UnignoreThreatModal
+					items={ items }
+					closeModal={ closeModal }
+					onActionPerformed={ onActionPerformed }
+					siteId={ siteId }
+				/>
 			),
 		},
 		{

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -25,7 +25,7 @@ export function ScanHistoryDataViews( { site }: { site: Site } ) {
 	const threats = scanHistory?.threats || [];
 
 	const fields = getFields();
-	const actions = getActions();
+	const actions = getActions( site.ID );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
 
 	const NoArchivedThreatsFound = () => {

--- a/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
@@ -41,6 +41,7 @@ export function IgnoreThreatModal( {
 				createSuccessNotice( __( 'Threat ignored.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
+				closeModal?.();
 				createErrorNotice( __( 'Failed to ignore threat. Please try again.' ), {
 					type: 'snackbar',
 				} );

--- a/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
@@ -1,0 +1,81 @@
+import { ignoreThreatMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	ExternalLink,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../../components/button-stack';
+import { Notice } from '../../../components/notice';
+import { CODEABLE_JETPACK_SCAN_URL } from '../constants';
+import { ThreatDescription } from './threat-description';
+import { ThreatsDetailCard } from './threats-detail-card';
+import type { Threat } from '@automattic/api-core';
+import type { RenderModalProps } from '@wordpress/dataviews';
+
+interface IgnoreThreatModalProps extends RenderModalProps< Threat > {
+	siteId: number;
+}
+
+export function IgnoreThreatModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+	siteId,
+}: IgnoreThreatModalProps ) {
+	const threat = items[ 0 ];
+
+	const ignoreThreat = useMutation( ignoreThreatMutation( siteId ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleIgnoreThreat = () => {
+		ignoreThreat.mutate( threat.id, {
+			onSuccess: () => {
+				closeModal?.();
+				onActionPerformed?.( [ threat ] );
+				createSuccessNotice( __( 'Threat ignored.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to ignore threat. Please try again.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text variant="muted">{ __( 'Jetpack will be ignoring the following threat:' ) }</Text>
+			<ThreatsDetailCard threats={ [ threat ] } />
+			<ThreatDescription threat={ threat } />
+			<Notice variant="error">
+				{ createInterpolateElement(
+					__(
+						'By ignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site. If you are unsure please request an estimate with <codeable />.'
+					),
+					{
+						codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
+					}
+				) }
+			</Notice>
+			<ButtonStack justify="flex-end">
+				<Button variant="tertiary" onClick={ closeModal }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleIgnoreThreat }
+					isBusy={ ignoreThreat.isPending }
+					disabled={ ignoreThreat.isPending }
+				>
+					{ __( 'Ignore threat' ) }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/scan/components/threats-detail-card.tsx
+++ b/client/dashboard/sites/scan/components/threats-detail-card.tsx
@@ -35,13 +35,13 @@ export function ThreatsDetailCard( { threats }: { threats: Threat[] } ) {
 	return (
 		<Card>
 			{ threats.map( ( threat, index ) => (
-				<>
+				<div key={ threat.id }>
 					<CardBody>
-						<ThreatDetail key={ threat.id } threat={ threat } />
+						<ThreatDetail threat={ threat } />
 					</CardBody>
 
 					{ index < threats.length - 1 && <CardDivider /> }
-				</>
+				</div>
 			) ) }
 		</Card>
 	);

--- a/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
@@ -1,0 +1,80 @@
+import { unignoreThreatMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	ExternalLink,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../../components/button-stack';
+import { Notice } from '../../../components/notice';
+import { CODEABLE_JETPACK_SCAN_URL } from '../constants';
+import { ThreatDescription } from './threat-description';
+import { ThreatsDetailCard } from './threats-detail-card';
+import type { Threat } from '@automattic/api-core';
+import type { RenderModalProps } from '@wordpress/dataviews';
+
+interface UnignoreThreatModalProps extends RenderModalProps< Threat > {
+	siteId: number;
+}
+
+export function UnignoreThreatModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+	siteId,
+}: UnignoreThreatModalProps ) {
+	const threat = items[ 0 ];
+	const unignoreThreat = useMutation( unignoreThreatMutation( siteId ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleUnignoreThreat = () => {
+		unignoreThreat.mutate( threat.id, {
+			onSuccess: () => {
+				closeModal?.();
+				onActionPerformed?.( [ threat ] );
+				createSuccessNotice( __( 'Threat unignored.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to unignore threat. Please try again.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text variant="muted">{ __( 'Jetpack will be unignoring the following threat:' ) }</Text>
+			<ThreatsDetailCard threats={ [ threat ] } />
+			<ThreatDescription threat={ threat } />
+			<Notice variant="warning">
+				{ createInterpolateElement(
+					__(
+						'By unignoring this threat you confirm that you have reviewed the detected code and assume the risks of keeping a potentially malicious file on your site as an active threat. If you are unsure please request an estimate with <codeable />.'
+					),
+					{
+						codeable: <ExternalLink href={ CODEABLE_JETPACK_SCAN_URL }>Codeable</ExternalLink>,
+					}
+				) }
+			</Notice>
+			<ButtonStack justify="flex-end">
+				<Button variant="tertiary" onClick={ closeModal }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleUnignoreThreat }
+					isBusy={ unignoreThreat.isPending }
+					disabled={ unignoreThreat.isPending }
+				>
+					{ __( 'Unignore threat' ) }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
@@ -40,6 +40,7 @@ export function UnignoreThreatModal( {
 				createSuccessNotice( __( 'Threat unignored.' ), { type: 'snackbar' } );
 			},
 			onError: () => {
+				closeModal?.();
 				createErrorNotice( __( 'Failed to unignore threat. Please try again.' ), {
 					type: 'snackbar',
 				} );

--- a/packages/api-core/src/site-scan/fetchers.ts
+++ b/packages/api-core/src/site-scan/fetchers.ts
@@ -1,13 +1,6 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { SiteScan, SiteScanHistory } from './types';
 
-export function enqueueSiteScan( siteId: number ): Promise< void > {
-	return wpcom.req.post( {
-		path: `/sites/${ siteId }/scan/enqueue`,
-		apiNamespace: 'wpcom/v2',
-	} );
-}
-
 export async function fetchSiteScan( siteId: number ): Promise< SiteScan > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/scan`,

--- a/packages/api-core/src/site-scan/index.ts
+++ b/packages/api-core/src/site-scan/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/site-scan/mutators.ts
+++ b/packages/api-core/src/site-scan/mutators.ts
@@ -1,0 +1,42 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { SiteScan, ThreatActionOptions } from './types';
+
+export function enqueueSiteScan( siteId: number ): Promise< void > {
+	return wpcom.req.post( {
+		path: `/sites/${ siteId }/scan/enqueue`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function updateThreat(
+	siteId: number,
+	threatId: number,
+	options: ThreatActionOptions
+): Promise< SiteScan > {
+	const queryParams = new URLSearchParams();
+
+	if ( options.ignore ) {
+		queryParams.set( 'ignore', 'true' );
+	} else if ( options.unignore ) {
+		queryParams.set( 'unignore', 'true' );
+	} else if ( options.fix ) {
+		queryParams.set( 'fix', 'true' );
+	}
+
+	return wpcom.req.post( {
+		path: `/sites/${ siteId }/alerts/${ threatId }?${ queryParams.toString() }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}
+
+export async function ignoreThreat( siteId: number, threatId: number ): Promise< SiteScan > {
+	return updateThreat( siteId, threatId, { ignore: true } );
+}
+
+export async function unignoreThreat( siteId: number, threatId: number ): Promise< SiteScan > {
+	return updateThreat( siteId, threatId, { unignore: true } );
+}
+
+export async function fixThreat( siteId: number, threatId: number ): Promise< SiteScan > {
+	return updateThreat( siteId, threatId, { fix: true } );
+}

--- a/packages/api-core/src/site-scan/types.ts
+++ b/packages/api-core/src/site-scan/types.ts
@@ -72,3 +72,9 @@ export interface SiteScanHistory {
 		threats_resolved: number;
 	};
 }
+
+export interface ThreatActionOptions {
+	ignore?: boolean;
+	unignore?: boolean;
+	fix?: boolean;
+}

--- a/packages/api-queries/src/site-scan.ts
+++ b/packages/api-queries/src/site-scan.ts
@@ -34,6 +34,7 @@ export const ignoreThreatMutation = ( siteId: number ) =>
 		mutationFn: ( threatId: number ) => ignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+			queryClient.invalidateQueries( siteScanHistoryQuery( siteId ) );
 		},
 	} );
 
@@ -42,6 +43,7 @@ export const unignoreThreatMutation = ( siteId: number ) =>
 		mutationFn: ( threatId: number ) => unignoreThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+			queryClient.invalidateQueries( siteScanHistoryQuery( siteId ) );
 		},
 	} );
 
@@ -50,5 +52,6 @@ export const fixThreatMutation = ( siteId: number ) =>
 		mutationFn: ( threatId: number ) => fixThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+			queryClient.invalidateQueries( siteScanHistoryQuery( siteId ) );
 		},
 	} );

--- a/packages/api-queries/src/site-scan.ts
+++ b/packages/api-queries/src/site-scan.ts
@@ -1,4 +1,11 @@
-import { enqueueSiteScan, fetchSiteScan, fetchSiteScanHistory } from '@automattic/api-core';
+import {
+	enqueueSiteScan,
+	fetchSiteScan,
+	fetchSiteScanHistory,
+	ignoreThreat,
+	unignoreThreat,
+	fixThreat,
+} from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -17,6 +24,30 @@ export const siteScanHistoryQuery = ( siteId: number ) =>
 export const siteScanEnqueueMutation = ( siteId: number ) =>
 	mutationOptions( {
 		mutationFn: () => enqueueSiteScan( siteId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+		},
+	} );
+
+export const ignoreThreatMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( threatId: number ) => ignoreThreat( siteId, threatId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+		},
+	} );
+
+export const unignoreThreatMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( threatId: number ) => unignoreThreat( siteId, threatId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteScanQuery( siteId ) );
+		},
+	} );
+
+export const fixThreatMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( threatId: number ) => fixThreat( siteId, threatId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteScanQuery( siteId ) );
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-506, resolves DOTDASH-417, resolves DOTDASH-416

## Proposed Changes

* Add data layer mutations for threat actions (ignore, unignore, fix) in `api-core` and `api-queries` packages.
* Implement ignore and unignore threat modal components with proper loading states and snackbars.
* Refactor `scan-active` and `scan-history` DataViews actions to use specialized modal components.

**Bonus:**
* Fix React key warning in ThreatsDetailCard component
  <img width="70%" alt="CleanShot 2025-09-19 at 14 12 41@2x" src="https://github.com/user-attachments/assets/2da8c044-4351-49b8-bc9b-200b4373397a" />

### Demo

https://github.com/user-attachments/assets/5ca95be1-3860-4f5d-9b0b-862168702eae

### Screenshots (snackbars)

<img width="282" height="112" alt="CleanShot 2025-09-19 at 14 26 10@2x" src="https://github.com/user-attachments/assets/056f5e5c-fc8e-4b04-9a3a-4238c8e80b71" />

<img width="316" height="104" alt="CleanShot 2025-09-19 at 14 26 34@2x" src="https://github.com/user-attachments/assets/094cb569-4b78-4cf8-b1a9-a92586958d8c" />

<img width="572" height="98" alt="CleanShot 2025-09-19 at 14 28 09@2x" src="https://github.com/user-attachments/assets/312ff5ec-c3a3-4e70-842f-110f1d5bcc94" />

<img width="604" height="102" alt="CleanShot 2025-09-19 at 14 28 21@2x" src="https://github.com/user-attachments/assets/4a732880-41e6-4b4e-bd17-fcdc59d4b8dc" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Hosting Dashboard had placeholder ignore/unignore threat actions with disabled buttons and TODO comments. This implements the complete functionality, allowing users to manage threat states in the scan feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> If you have a Jetpack (self-hosted) site with threats available for test, checkout this branch locally and make [this function](https://github.com/Automattic/wp-calypso/blob/76b23c1267b6d0fcdcbc70e7ced492cba5e63983/client/dashboard/utils/site-types.ts#L4) to return false.

For testing, you need a site with the Scan feature and some test threats. Here are example threats you can add to your site for testing purposes: DOTDASH-412 (check last comment).

1. Navigate to `/v2/sites/{site-slug}/scan` in the Hosting Dashboard.
2. Click on “Ignore threat” on any active threat.
3. Ensure the modal is displayed with the relevant information and the “Ignore threat” button active.
4. `Cancel` button should close the modal.
5. `Ignore threat` button should switch to the `isBusy` state once pressed.
6. Once it succeeds, it should close the modal and show a `Threat ignored` snackbar.
7. Once it fails, it should close the modal and show a `Failed to unignore threat. Please try again.`
8. Repeat the same but with the “Unignore threat” action in the “History” tab panel.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
