### PR TITLE
Hosting Dashboard: Normalize Language control spacing.

### DIFF
--- a/client/dashboard/me/preferences-language/index.tsx
+++ b/client/dashboard/me/preferences-language/index.tsx
@@ -120,6 +120,8 @@ export default function PreferencesLanguageForm() {
 			Edit: ( { field, data, onChange } ) => {
 				return (
 					<ComboboxControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						value={ field.getValue( { item: data } ) ?? '' }
 						label={ __( 'Interface language' ) }
 						onChange={ ( newValue ) => {
@@ -130,7 +132,6 @@ export default function PreferencesLanguageForm() {
 						placeholder={ __( 'Select a language' ) }
 						options={ field.elements || [] }
 						allowReset={ false } // a language is required so we're not allowing to reset it and have an empty state.
-						__next40pxDefaultSize
 						help={
 							<>
 								{ __(
@@ -167,6 +168,7 @@ export default function PreferencesLanguageForm() {
 					! data.language || data.language === '' || !! isDefaultLocale( data.language );
 				return (
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						checked={ isEmpathyModeFieldDisabled ? false : field.getValue( { item: data } ) }
 						label={ field.label }
 						disabled={ isEmpathyModeFieldDisabled }
@@ -187,6 +189,7 @@ export default function PreferencesLanguageForm() {
 			Edit: ( { field, data, onChange } ) => {
 				return (
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						checked={ field.getValue( { item: data } ) }
 						label={ field.label }
 						onChange={ ( newValue ) => {


### PR DESCRIPTION
Fixes: DOTCOM-14605

## Proposed Changes

This PR updates the spacing in the Language card to match the spacing in [settings](https://github.com/Automattic/wp-calypso/blob/0957ca0caee7cb46bc60559bc24a8006d0e05830/client/dashboard/sites/settings-subscription-gifting/index.tsx#L117) and QOBjujZah0UlGDDdLKZhzi-fi-8976_123221.

| Before | After |
|--------|--------|
| <img width="694" height="401" alt="Screenshot 2025-09-22 at 7 54 58 AM" src="https://github.com/user-attachments/assets/7f20929f-0dd4-4b06-8862-e79a3b82199c" /> | <img width="688" height="375" alt="Screenshot 2025-09-22 at 7 56 46 AM" src="https://github.com/user-attachments/assets/85273e7a-5738-4e38-882f-7d479f1e2cbd" /> |
| <img width="691" height="251" alt="Screenshot 2025-09-22 at 7 58 52 AM" src="https://github.com/user-attachments/assets/459b6d53-a2e3-4ddf-8985-b4990c25c0cf" /> | <img width="697" height="253" alt="Screenshot 2025-09-22 at 7 58 16 AM" src="https://github.com/user-attachments/assets/cc5a7d7b-bf83-4262-8c46-db1e704dc2d6" /> | 



## Testing Instructions

- Navigate to v2/me/preference, expect the spacing to be consistent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?