### PR TITLE
Hosting Dashboard: Update spacing for beta card.

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -117,7 +117,7 @@ export default function PreferencesLanguageForm() {
 		<Card>
 			<FlashMessage value="dashboard" message={ __( 'Successfully saved preference.' ) } />
 			<CardBody>
-				<VStack as="form" onSubmit={ handleSubmit } spacing={ 6 } alignment="flex-start">
+				<VStack as="form" onSubmit={ handleSubmit } spacing={ 4 } alignment="flex-start">
 					<DataForm< OptInFormData >
 						data={ formData }
 						fields={ fields }


### PR DESCRIPTION
Related to #105913

## Proposed Changes

Fix spacing to match other cards and designs.


| Before | After |
|--------|--------|
| <img width="705" height="239" alt="Screenshot 2025-09-22 at 8 10 15 AM" src="https://github.com/user-attachments/assets/a5cefbb5-71c9-416a-a03d-0dd1e41a0eb5" /> | <img width="699" height="227" alt="Screenshot 2025-09-22 at 8 13 15 AM" src="https://github.com/user-attachments/assets/141d7050-a61b-4ba1-998c-36d78a4e7367" /> | 


## Testing Instructions

Visit `v2/me/preferences`, expect the spacing to be consistent in "Try the new Hosting Dashboard" seciton. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
