### PR TITLE
Hosting Dashboard: Welcome message for opt-in users

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -12,6 +12,7 @@ import {
 	domainTransferRequestQuery,
 	domainWhoisQuery,
 	domainConnectionSetupInfoQuery,
+	rawUserPreferencesQuery,
 } from '@automattic/api-queries';
 import {
 	createRoute,
@@ -42,7 +43,11 @@ export const domainsRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'domains',
-	loader: () => queryClient.ensureQueryData( domainsQuery() ),
+	loader: () =>
+		Promise.all( [
+			queryClient.ensureQueryData( domainsQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+		] ),
 } ).lazy( () =>
 	import( '../../domains' ).then( ( d ) =>
 		createLazyRoute( 'domains' )( {

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -1,4 +1,4 @@
-import { emailsQuery, queryClient } from '@automattic/api-queries';
+import { emailsQuery, queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { rootRoute } from './root';
@@ -13,7 +13,11 @@ export const emailsRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'emails',
-	loader: () => queryClient.ensureQueryData( emailsQuery() ),
+	loader: () =>
+		Promise.all( [
+			queryClient.ensureQueryData( emailsQuery() ),
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+		] ),
 } ).lazy( () =>
 	import( '../../emails' ).then( ( d ) =>
 		createLazyRoute( 'emails' )( {

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -1,4 +1,4 @@
-import { sitesQuery, queryClient } from '@automattic/api-queries';
+import { sitesQuery, queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, redirect } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { rootRoute } from './root';
@@ -65,6 +65,7 @@ export const pluginsManageRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: 'manage',
+	loader: () => queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 } ).lazy( () =>
 	import( '../../plugins/manage' ).then( ( d ) =>
 		createLazyRoute( 'plugins-manage' )( {

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -15,7 +15,7 @@ import { caution } from './icons';
 import type { NoticeVariant, NoticeProps } from './types';
 import './style.scss';
 
-const icons: { [ key in NoticeVariant ]: any } = {
+const icons: { [ key in NoticeVariant ]: React.ReactNode } = {
 	info,
 	warning: caution,
 	success: published,
@@ -46,7 +46,7 @@ const icons: { [ key in NoticeVariant ]: any } = {
  * ```
  */
 function UnforwardedNotice(
-	{ variant = 'info', title, children, actions, density = 'low', onClose }: NoticeProps,
+	{ variant = 'info', title, children, actions, density = 'low', onClose, icon }: NoticeProps,
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	const hasLowDensity = density === 'low';
@@ -58,7 +58,7 @@ function UnforwardedNotice(
 		>
 			<CardBody className="dashboard-notice__body">
 				<HStack spacing={ hasLowDensity ? 2 : 1 } justify="flex-start" alignment="flex-start">
-					<Icon className="dashboard-notice__icon" icon={ icons[ variant ] } />
+					<Icon className="dashboard-notice__icon" icon={ icon ?? icons[ variant ] } />
 					<VStack className="dashboard-notice__content" spacing={ 3 }>
 						<VStack className="dashboard-notice__heading" spacing={ 1 }>
 							{ title && <span className="dashboard-notice__title">{ title }</span> }

--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -5,6 +5,7 @@ import {
 	Card,
 	CardBody,
 	Icon,
+	type IconType,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { info, published, error, closeSmall } from '@wordpress/icons';
@@ -15,7 +16,7 @@ import { caution } from './icons';
 import type { NoticeVariant, NoticeProps } from './types';
 import './style.scss';
 
-const icons: { [ key in NoticeVariant ]: React.ReactNode } = {
+const icons: { [ key in NoticeVariant ]: IconType } = {
 	info,
 	warning: caution,
 	success: published,

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { IconType } from '@wordpress/components';
 
 type NoticeDensity = 'low' | 'medium' | 'high';
 
@@ -36,7 +37,7 @@ export interface NoticeProps {
 	/**
 	 * Custom icon to use instead of the default one for each variant.
 	 */
-	icon?: React.ReactNode;
+	icon?: IconType;
 
 	/**
 	 * An optional action to close the component.

--- a/client/dashboard/components/notice/types.ts
+++ b/client/dashboard/components/notice/types.ts
@@ -34,6 +34,11 @@ export interface NoticeProps {
 	density?: NoticeDensity;
 
 	/**
+	 * Custom icon to use instead of the default one for each variant.
+	 */
+	icon?: React.ReactNode;
+
+	/**
 	 * An optional action to close the component.
 	 */
 	onClose?: () => void;

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import Notice from '../../components/notice';
+import ComponentViewTracker from '../component-view-tracker';
 
 export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	const { data: isDismissedPersisted } = useSuspenseQuery(
@@ -24,12 +25,25 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 
 	return (
 		<Notice onClose={ () => dismiss( new Date().toISOString() ) } variant="info" icon={ starEmpty }>
+			<ComponentViewTracker
+				eventName="calypso_hosting_dashboard_welcome_banner_impression"
+				properties={ { context: tracksContext } }
+			/>
 			{ createInterpolateElement(
 				__(
 					'Welcome to your new hosting dashboard. Share your feedback anytime by <feedbackLink>clicking here</feedbackLink>. To switch back to the previous version, go to <preferencesLink>Preferences</preferencesLink>.'
 				),
 				{
-					preferencesLink: <Link to="/me/preferences" />,
+					preferencesLink: (
+						<Link
+							to="/me/preferences"
+							onClick={ () => {
+								recordTracksEvent( 'calypso_hosting_dashboard_welcome_banner_preferences_click', {
+									context: tracksContext,
+								} );
+							} }
+						/>
+					),
 					feedbackLink: (
 						<ExternalLink
 							href="https://automattic.survey.fm/new-hosting-dashboard-opt-in-survey"

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -1,0 +1,34 @@
+import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { starEmpty } from '@wordpress/icons';
+import Notice from '../../components/notice';
+
+export function OptInWelcome() {
+	const { data: isDismissedPersisted } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
+	);
+	const { mutate: dismiss, isPending: isDismissing } = useMutation(
+		userPreferenceMutation( 'hosting-dashboard-welcome-notice-dismissed' )
+	);
+
+	// Optimistically hide the banner assuming the preference will get saved.
+	if ( isDismissing || isDismissedPersisted ) {
+		return null;
+	}
+
+	return (
+		<Notice onClose={ () => dismiss( new Date().toISOString() ) } variant="info" icon={ starEmpty }>
+			{ createInterpolateElement(
+				__(
+					'Welcome to your new hosting dashboard. To switch back to the previous version, go to <preferencesLink>Preferences</preferencesLink>.'
+				),
+				{
+					preferencesLink: <Link to="/me/preferences" />,
+				}
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -1,18 +1,21 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
+import { useAnalytics } from '../../app/analytics';
 import Notice from '../../components/notice';
 
-export function OptInWelcome() {
+export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
 	);
 	const { mutate: dismiss, isPending: isDismissing } = useMutation(
 		userPreferenceMutation( 'hosting-dashboard-welcome-notice-dismissed' )
 	);
+	const { recordTracksEvent } = useAnalytics();
 
 	// Optimistically hide the banner assuming the preference will get saved.
 	if ( isDismissing || isDismissedPersisted ) {
@@ -23,10 +26,21 @@ export function OptInWelcome() {
 		<Notice onClose={ () => dismiss( new Date().toISOString() ) } variant="info" icon={ starEmpty }>
 			{ createInterpolateElement(
 				__(
-					'Welcome to your new hosting dashboard. To switch back to the previous version, go to <preferencesLink>Preferences</preferencesLink>.'
+					'Welcome to your new hosting dashboard. Share your feedback anytime by <feedbackLink>clicking here</feedbackLink>. To switch back to the previous version, go to <preferencesLink>Preferences</preferencesLink>.'
 				),
 				{
 					preferencesLink: <Link to="/me/preferences" />,
+					feedbackLink: (
+						<ExternalLink
+							href="https://automattic.survey.fm/new-hosting-dashboard-opt-in-survey"
+							onClick={ () =>
+								recordTracksEvent( 'calypso_hosting_dashboard_welcome_banner_survey_click', {
+									context: tracksContext,
+								} )
+							}
+							children={ null }
+						/>
+					),
 				}
 			) }
 		</Notice>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { DataViewsCard } from '../components/dataviews-card';
+import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
@@ -49,6 +50,7 @@ function Domains() {
 					}
 				/>
 			}
+			notices={ <OptInWelcome /> }
 		>
 			<DataViewsCard>
 				<DataViews< DomainSummary >

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -50,7 +50,7 @@ function Domains() {
 					}
 				/>
 			}
-			notices={ <OptInWelcome /> }
+			notices={ <OptInWelcome tracksContext="domains" /> }
 		>
 			<DataViewsCard>
 				<DataViews< DomainSummary >

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -137,7 +137,7 @@ function Emails() {
 			}
 			notices={
 				<>
-					<OptInWelcome />
+					<OptInWelcome tracksContext="emails" />
 					<Notice status="warning" isDismissible={ false }>
 						{ __( 'This is using fake data for the moment' ) }
 					</Notice>

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -6,6 +6,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { DataViewsCard } from '../components/dataviews-card';
+import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import type { Email } from '@automattic/api-core';
@@ -135,9 +136,12 @@ function Emails() {
 				/>
 			}
 			notices={
-				<Notice status="warning" isDismissible={ false }>
-					{ __( 'This is using fake data for the moment' ) }
-				</Notice>
+				<>
+					<OptInWelcome />
+					<Notice status="warning" isDismissible={ false }>
+						{ __( 'This is using fake data for the moment' ) }
+					</Notice>
+				</>
 			}
 		>
 			<DataViewsCard>

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -52,7 +52,7 @@ export default function PluginsList() {
 		<PageLayout
 			size="large"
 			header={ <PageHeader title={ __( 'Manage plugins' ) } /> }
-			notices={ <OptInWelcome /> }
+			notices={ <OptInWelcome tacksContext="plugins" /> }
 		>
 			<DataViewsCard>
 				<DataViews

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -52,7 +52,7 @@ export default function PluginsList() {
 		<PageLayout
 			size="large"
 			header={ <PageHeader title={ __( 'Manage plugins' ) } /> }
-			notices={ <OptInWelcome tacksContext="plugins" /> }
+			notices={ <OptInWelcome tracksContext="plugins" /> }
 		>
 			<DataViewsCard>
 				<DataViews

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -4,6 +4,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../../components/dataviews-card';
+import { OptInWelcome } from '../../components/opt-in-welcome';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getActions } from './actions';
@@ -48,7 +49,11 @@ export default function PluginsList() {
 	}, [ filteredPlugins, iconsBySlug ] );
 
 	return (
-		<PageLayout size="large" header={ <PageHeader title={ __( 'Manage plugins' ) } /> }>
+		<PageLayout
+			size="large"
+			header={ <PageHeader title={ __( 'Manage plugins' ) } /> }
+			notices={ <OptInWelcome /> }
+		>
 			<DataViewsCard>
 				<DataViews
 					isLoading={ isLoadingPlugins || isLoadingMarketplace }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -153,8 +153,8 @@ export default function Sites() {
 						}
 					/>
 				}
+				notices={ <SitesNotices /> }
 			>
-				<SitesNotices />
 				<DataViewsCard>
 					<DataViews< Site >
 						getItemId={ ( item ) => item.ID.toString() }

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -1,10 +1,10 @@
 import { useNavigate } from '@tanstack/react-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { sitesRoute } from '../app/router/sites';
 import InlineSupportLink from '../components/inline-support-link';
 import Notice from '../components/notice';
+import { OptInWelcome } from '../components/opt-in-welcome';
 
 const RestoringSitesNotices = ( { onClose }: { onClose?: () => void } ) => {
 	return (
@@ -30,9 +30,15 @@ export const SitesNotices = () => {
 	const currentSearchParams = sitesRoute.useSearch();
 	const isRestoringAccount = !! currentSearchParams.restored;
 
-	if ( isRestoringAccount ) {
-		return (
-			<VStack className="sites-notices">
+	if ( ! window?.location?.pathname?.startsWith( '/v2' ) ) {
+		// Notices should not appear in the backported sites list.
+		return null;
+	}
+
+	return (
+		<>
+			<OptInWelcome />
+			{ isRestoringAccount && (
 				<RestoringSitesNotices
 					onClose={ () =>
 						navigate( {
@@ -44,9 +50,7 @@ export const SitesNotices = () => {
 						} )
 					}
 				/>
-			</VStack>
-		);
-	}
-
-	return null;
+			) }
+		</>
+	);
 };

--- a/client/dashboard/sites/notices.tsx
+++ b/client/dashboard/sites/notices.tsx
@@ -37,7 +37,7 @@ export const SitesNotices = () => {
 
 	return (
 		<>
-			<OptInWelcome />
+			<OptInWelcome tracksContext="sites" />
 			{ isRestoringAccount && (
 				<RestoringSitesNotices
 					onClose={ () =>

--- a/client/sites/v2/sites-list/style.scss
+++ b/client/sites/v2/sites-list/style.scss
@@ -32,10 +32,6 @@
 		height: 100%;
 	}
 
-	.sites-notices {
-		display: none;
-	}
-
 	.dataviews-wrapper {
 		iframe {
 			max-width: unset;

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -27,10 +27,11 @@ export interface ReaderLandingPage extends LandingPagePreference {
 }
 
 export interface UserPreferences {
-	'sites-view'?: SitesViewPreferences;
-	'sites-landing-page'?: SitesLandingPage;
-	'reader-landing-page'?: ReaderLandingPage;
-	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 	'hosting-dashboard-opt-in'?: HostingDashboardOptIn;
+	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 	[ key: `hosting-dashboard-tours-${ string }` ]: string; // ISO date string when the user completed the tours
+	'hosting-dashboard-welcome-notice-dismissed'?: string; // Timestamp when the user dismissed the notice
+	'reader-landing-page'?: ReaderLandingPage;
+	'sites-landing-page'?: SitesLandingPage;
+	'sites-view'?: SitesViewPreferences;
 }

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -4,17 +4,17 @@ import { queryClient } from './query-client';
 import type { UserPreferences } from '@automattic/api-core';
 
 const defaultValues: Required< UserPreferences > = {
-	'sites-view': {},
-	'sites-landing-page': {
-		useSitesAsLandingPage: false,
-		updatedAt: 0,
-	},
+	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
+	'hosting-dashboard-welcome-notice-dismissed': '',
 	'reader-landing-page': {
 		useReaderAsLandingPage: false,
 		updatedAt: 0,
 	},
-	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
-	'hosting-dashboard-tours-sites': '',
+	'sites-landing-page': {
+		useSitesAsLandingPage: false,
+		updatedAt: 0,
+	},
+	'sites-view': {},
 };
 
 // Returns all user preferences, without applying any defaults.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-487

## Proposed Changes

* Adds a new "Promote" variant to the `<Notice>` component.
* Add welcome banner to "sites", "domains", "emails", and "plugins top-level pages
* Load the banner dismiss state in the router to prevent layout shift
* Links to feedback survey

<img width="2200" height="508" alt="CleanShot 2025-09-22 at 16 07 33@2x" src="https://github.com/user-attachments/assets/9c0a92ad-0332-43af-9ee1-20f5eb1b73f1" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Ensures users have been informed that this is a preference they can opt-out of.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check the notice looks correct on different screen sizes.

Try dismissing the message.

Ensure Preferences goes to correct location.

You can reset the dismissed state by
- navigating to v1 calypso
- hovering over the dev menu
- hovering over preferences
- delete the `hosting-dashboard-welcome-notice-dismissed` preference

Test that the notice doesn't appear in the backport at `/sites`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
