### PR TITLE
Try replace functionality with canGoBack.

### DIFF
--- a/client/dashboard/sites/settings-page-header/index.tsx
+++ b/client/dashboard/sites/settings-page-header/index.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from '@tanstack/react-router';
+import { useRouter, useCanGoBack } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
@@ -15,19 +15,32 @@ export default function SettingsPageHeader( props: SettingsPageHeaderProps ) {
 	const { siteSlug } = siteRoute.useParams();
 	const { backPath, backLabel, ...pageHeaderProps } = props;
 	const router = useRouter();
+	const canGoBack = useCanGoBack();
 
 	const defaultBackPath = `/sites/${ siteSlug }/settings`;
-	const defaultBackLabel = __( 'Settings' );
+	const defaultBackLabel = __( 'Back' );
+	const fallbackBackLabel = __( 'Settings' );
+
+	const getLabel = () => {
+		if ( backLabel ) {
+			return backLabel;
+		}
+		return canGoBack ? defaultBackLabel : fallbackBackLabel;
+	};
 
 	const backButton = (
 		<Button
 			className="dashboard-page-header__back-button"
 			icon={ isRTL() ? chevronRight : chevronLeft }
 			onClick={ () => {
-				router.navigate( { to: backPath || defaultBackPath } );
+				if ( canGoBack ) {
+					router.history.back();
+				} else {
+					router.navigate( { to: backPath || defaultBackPath } );
+				}
 			} }
 		>
-			{ backLabel || defaultBackLabel }
+			{ getLabel() }
 		</Button>
 	);
 


### PR DESCRIPTION
An early PR for DOTCOM-14598 

## Proposed Changes

This is an experimental PR that tests the use of `canGoBack` as a breadcrumb.

## Caveats
If the user resets, they won't get back to their period page, they'll go back to the default.

## Questions

We will have multiple versions of this code across different pages. Should we centralize?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
