### PR TITLE
Help Center: Fix font size mismatch

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -125,7 +125,6 @@ $blueberry-color: #3858e9;
 
 	.odie-chatbox-message__content {
 		p {
-			font-size: $font-body-small;
 			margin-bottom: 0;
 			margin-top: 0;
 		}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14646/font-sizes-mismatch

Messages now have font-size of 15px