### PR TITLE
Hosting Dashboard: Link plan card to billing section

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -104,17 +104,28 @@ function WpcomPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
+	const isV2Page = window?.location?.pathname?.startsWith( '/v2' );
+	const isFreePlan = site.plan?.is_free;
+
+	const getBillingLinkProps = () => {
+		if ( isFreePlan ) {
+			return { externalLink: `/plans/${ site.slug }` };
+		}
+
+		if ( isV2Page ) {
+			return { link: `/me/billing/purchases/purchase/${ purchase?.ID }` };
+		}
+
+		return { externalLink: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }` };
+	};
+
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			externalLink={
-				site.plan?.is_free
-					? `/plans/${ site.slug }`
-					: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }`
-			}
+			{ ...getBillingLinkProps() }
 			tracksId="plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of CHE-253

## Proposed Changes
The Plan Card in the site overview now links to the new 'Plans & Add-ons' billing section if the site has a paid plan and the v2 dashboard is being used.

Free sites, and the v1 dashboard continue to link to /plans in a new tab as before.

This is a re-do of #105670 which was previously reverted by #105900.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So users get access to the new and improved hosting dashboard billing UI for their site plan when relevant, rather than the older calypso interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### v2 hosting dashboard

 1. Use the calypso live links below to access the new hosting dashboard UI at /v2/sites
 2. Select a wpcom site with a paid plan.
 3. In the overview click on the plan card
 4. You should be taken to the **new** UI at `/me/billing/purchases/purchase/${ purchase?.ID }` in the same tab
 5. Go back to the overview and select a site with the free plan
 6. In the overview click on the plan card
 7. You should be taken to the plans page at /plans/:site-slug in a new tab to select a new plan

### v1 hosting dashboard
 1. Go to the old hosting dashboard UI at /sites
 2. Repeat steps 2 onwards from above
 3. In both free and paid cases, you should be taken to the plans page at /plans/:site-slug in a new tab.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
