### PR TITLE
Dashboard v2: Don't push environment switcher of the site header to right on the mobile

### DIFF
--- a/client/dashboard/components/header-bar/index.tsx
+++ b/client/dashboard/components/header-bar/index.tsx
@@ -24,10 +24,7 @@ function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: R
 
 Header.Title = function HeaderBarTitle( { children }: { children: React.ReactNode } ) {
 	return (
-		<HStack
-			style={ { width: 'auto', flexGrow: 1, flexShrink: 0 } }
-			className="dashboard-header-bar-title"
-		>
+		<HStack style={ { width: 'auto', flexShrink: 0 } } className="dashboard-header-bar-title">
 			{ children }
 		</HStack>
 	);

--- a/client/dashboard/components/header-bar/index.tsx
+++ b/client/dashboard/components/header-bar/index.tsx
@@ -24,7 +24,11 @@ function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: R
 
 Header.Title = function HeaderBarTitle( { children }: { children: React.ReactNode } ) {
 	return (
-		<HStack style={ { width: 'auto', flexShrink: 0 } } className="dashboard-header-bar-title">
+		<HStack
+			style={ { width: 'auto', flexShrink: 0 } }
+			className="dashboard-header-bar-title"
+			spacing={ 3 }
+		>
 			{ children }
 		</HStack>
 	);

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -66,6 +66,12 @@ function Site() {
 								</MenuGroup>
 							) }
 						</Switcher>
+						{ canSwitchEnvironment( site ) && (
+							<>
+								<MenuDivider />
+								<EnvironmentSwitcher site={ site } />
+							</>
+						) }
 					</HeaderBar.Title>
 					{ isAddSiteModalOpen && (
 						<Modal
@@ -74,12 +80,6 @@ function Site() {
 						>
 							<AddNewSite context="sites-dashboard" />
 						</Modal>
-					) }
-					{ canSwitchEnvironment( site ) && (
-						<>
-							<MenuDivider />
-							<EnvironmentSwitcher site={ site } />
-						</>
 					) }
 					{ ! isSiteMigrationInProgress( site ) && (
 						<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14599

## Proposed Changes

* Don't push environment switcher of the site header to right on the mobile

| Before | After |
| - | - |
|<img width="735" height="64" alt="image" src="https://github.com/user-attachments/assets/248509ad-ee96-4645-94b9-da2407c222b3" />|<img width="746" height="61" alt="image" src="https://github.com/user-attachments/assets/c9d83c83-011c-4c4e-afb5-0754a999fa3c" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site with the staging site
* Switch to mobile view
* Ensure the position of the environment switcher is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
