### PR TITLE
Fix density on the warning for staging sync modal database

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -472,7 +472,11 @@ function StagingSiteSyncModalInner( {
 						</HStack>
 						{ hasWarning && (
 							<VStack style={ { marginTop: '20px' } }>
-								<Notice variant="warning" title={ __( 'Warning! Database will be overwritten' ) }>
+								<Notice
+									density="medium"
+									variant="warning"
+									title={ __( 'Warning! Database will be overwritten' ) }
+								>
 									<VStack spacing={ 2 }>
 										<Text as="p">
 											{ __(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14616

## Proposed Changes

This PR fixes density on the warning that appears when the database checkbox is checked in the `Sync` modal:

<img width="838" height="243" alt="Screenshot 2025-09-22 at 11 49 54 AM" src="https://github.com/user-attachments/assets/a52c416a-21f6-4e97-b5ee-d1573fec4503" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make the notice consistent with the design. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso live link
* Ensure that you have an Atomic site along with the staging site
* Navigate to `/v2/sites/{yourAtomicSite}`
* Click the `Sync` button in the top right corner to open the modal
* Check the database checkbox
* Confirm that you can see the warning about the database 
* Confirm that the borders are **NOT** rounded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
