### PR TITLE
A4A: Remove the feature flag  `a4a-client-checkout-v2` and add the `a4a-bd-checkout` feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_CLIENT_LANDING_LINK,

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -56,14 +56,11 @@ export default function () {
 		clientRender
 	);
 
-	// New v2 route for WP.com-based checkout implementation
-	if ( isEnabled( 'a4a-client-checkout-v2' ) ) {
-		page(
-			'/client/checkout/v2',
-			requireClientAccessContext,
-			controller.clientCheckoutV2Context,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/client/checkout/v2',
+		requireClientAccessContext,
+		controller.clientCheckoutV2Context,
+		makeLayout,
+		clientRender
+	);
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -46,7 +46,7 @@
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
-		"a4a-client-checkout-v2": true,
+		"a4a-bd-checkout": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -39,7 +39,7 @@
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
-		"a4a-client-checkout-v2": true,
+		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -39,7 +39,7 @@
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
-		"a4a-client-checkout-v2": true,
+		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -41,7 +41,7 @@
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
-		"a4a-client-checkout-v2": true,
+		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true


### PR DESCRIPTION
Part of Linear: A4A-1576/remove-the-old-a4a-client-checkout-v2-feature-flag

## Proposed Changes

This PR removes the previous feature flag `a4a-client-checkout-v2` and adds the new feature flag `a4a-bd-checkout` for the new Billing Dragon checkout page for agencies and clients (referrals).

## Why are these changes being made?

Remove the unused feature flag because the feature is already in production.

## Testing Instructions

- Check the code and see if the `a4a-client-checkout-v2` is no longer used in the code.
- Bonus:
  - In your sandbox, set `USE_STORE_SANDBOX` to true to be able to use testing Stripe cards.
  - As the agency sends a referral to a client
  - As a client, follow the link received, go to the checkout, and the BD checkout should appear.
- Check the new feature flag `a4a-bd-checkout`. It should only be allowed in the development environment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
