### PR TITLE
Add a hook to introduce variance based on app context in the sites list

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,10 +6,9 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, Modal } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { sitesRoute } from '../app/router/sites';
@@ -19,10 +18,10 @@ import { GuidedTourContextProvider, GuidedTourStep } from '../components/guided-
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { getActions } from './actions';
-import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import noSitesIllustration from './no-sites-illustration.svg';
 import { SitesNotices } from './notices';
+import { useAppContextForSitesList } from './use-app-context-for-sites-list';
 import {
 	getView,
 	mergeViews,
@@ -88,7 +87,8 @@ export default function Sites() {
 	const actions = getActions( router );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { newSiteButtonProps, newSiteButtonText, newSiteModalComponent, pageTitle } =
+		useAppContextForSitesList( 'sites-dashboard' );
 
 	const handleViewChange = ( nextView: View ) => {
 		if ( nextView.type === 'list' ) {
@@ -133,22 +133,14 @@ export default function Sites() {
 
 	return (
 		<>
-			{ isModalOpen && (
-				<Modal title={ __( 'Add new site' ) } onRequestClose={ () => setIsModalOpen( false ) }>
-					<AddNewSite context="sites-dashboard" />
-				</Modal>
-			) }
+			{ newSiteModalComponent }
 			<PageLayout
 				header={
 					<PageHeader
-						title={ __( 'Sites' ) }
+						title={ pageTitle }
 						actions={
-							<Button
-								variant="primary"
-								onClick={ () => setIsModalOpen( true ) }
-								__next40pxDefaultSize
-							>
-								{ __( 'Add new site' ) }
+							<Button variant="primary" { ...newSiteButtonProps } __next40pxDefaultSize>
+								{ newSiteButtonText }
 							</Button>
 						}
 					/>
@@ -194,12 +186,8 @@ export default function Sites() {
 												{ __( 'Clear search' ) }
 											</Button>
 										) }
-										<Button
-											__next40pxDefaultSize
-											variant="primary"
-											onClick={ () => setIsModalOpen( true ) }
-										>
-											{ __( 'Add new site' ) }
+										<Button variant="primary" { ...newSiteButtonProps } __next40pxDefaultSize>
+											{ newSiteButtonText }
 										</Button>
 									</>
 								}

--- a/client/dashboard/sites/use-app-context-for-sites-list.tsx
+++ b/client/dashboard/sites/use-app-context-for-sites-list.tsx
@@ -1,0 +1,81 @@
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAppContext } from '../app/context';
+import AddNewSite from './add-new-site';
+
+interface AppContextForSitesListReturn {
+	/**
+	 * Props to pass to the button component
+	 */
+	newSiteButtonProps: {
+		onClick?: () => void;
+		href?: string;
+	};
+	/**
+	 * The text to display on the button
+	 */
+	newSiteButtonText: string;
+	/**
+	 * The modal component to render (null if not needed)
+	 */
+	newSiteModalComponent: React.ReactNode | null;
+	/**
+	 * The page title to display in the PageHeader
+	 */
+	pageTitle: string;
+	/**
+	 * Whether the modal is currently open
+	 */
+	isModalOpen: boolean;
+	/**
+	 * Function to close the modal (only relevant when modal is used)
+	 */
+	closeModal: () => void;
+}
+
+/**
+ * Hook that provides context-aware behavior for the sites list page.
+ *
+ * In WP.com context: Shows "Sites" title, "Add new site" button that opens modal
+ * In CIAB context: Shows "Stores" title, "Add new store" button that navigates to URL
+ * @param source - The context string to pass to AddNewSite component
+ * @returns Object with page title, button props, button text, modal component, and modal state
+ */
+export function useAppContextForSitesList(
+	source: string = 'sites-dashboard'
+): AppContextForSitesListReturn {
+	const { name: appContextName } = useAppContext();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	const openModal = () => setIsModalOpen( true );
+	const closeModal = () => setIsModalOpen( false );
+
+	if ( appContextName === 'CIAB' ) {
+		return {
+			newSiteButtonProps: {
+				href: `/start?source=${ source }`,
+			},
+			newSiteButtonText: __( 'Add new store' ),
+			newSiteModalComponent: null,
+			pageTitle: __( 'Stores' ),
+			isModalOpen: false,
+			closeModal,
+		};
+	}
+
+	return {
+		newSiteButtonProps: {
+			onClick: openModal,
+		},
+		newSiteButtonText: __( 'Add new site' ),
+		newSiteModalComponent: isModalOpen ? (
+			<Modal title={ __( 'Add new site' ) } onRequestClose={ closeModal }>
+				<AddNewSite context={ source } />
+			</Modal>
+		) : null,
+		pageTitle: __( 'Sites' ),
+		isModalOpen,
+		closeModal,
+	};
+}


### PR DESCRIPTION
## Proposed Changes

* This PR introduces context variance in the sites list screen with a hook that controls different properties and behaviors.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are some slight variations in the behavior for the ciab context on the sites list that should be handled. In this approach, we are trying varying key parts of the page rather than having two separate components since the structure of both component trees between the app variants is the same.

## Testing Instructions

* on the /ciab URL, you should see the /sites route showing "Stores" as the title and "Add new store" as the button text. The "Add new store" button just links to the /start flow for now as a placeholder
* The default /v2 url should still retain the same behavior, with an "add new site" button that opens the AddNewSite modal.

<img width="1498" height="193" alt="Screenshot 2025-09-22 at 11 35 43 AM" src="https://github.com/user-attachments/assets/b996423b-f9b9-43bd-8854-20ce070cc0bf" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
