### PR TITLE
Update the ai-site-builder flow to create a garden site

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -165,11 +165,11 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 								resolveSelect( SITE_STORE ).getSite( siteId ), // To get the URL.
 							];
 
-							// Add blog sticker - this runs independently and errors are handled by the mutation's onError callback
-							addBlogSticker( siteId, 'big-sky-free-trial' );
-
-							// Create a new home page if one is not set yet (only for non-garden sites)
 							if ( ! gardenName ) {
+								// Add blog sticker - this runs independently and errors are handled by the mutation's onError callback (only for non-garden sites)
+								addBlogSticker( siteId, 'big-sky-free-trial' );
+
+								// Create a new home page if one is not set yet (only for non-garden sites)
 								pendingActions.push(
 									wpcomRequest( {
 										path: '/sites/' + siteId + '/pages',

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -2,14 +2,14 @@ import { Onboard } from '@automattic/data-stores';
 import { getAssemblerDesign } from '@automattic/design-picker';
 import { addPlanToCart, addProductsToCart, AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { resolveSelect, useDispatch as useWpDataDispatch } from '@wordpress/data';
+import { resolveSelect, useDispatch as useWpDataDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useAddBlogStickerMutation } from 'calypso/blocks/blog-stickers/use-add-blog-sticker-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { useDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -29,8 +29,6 @@ const deletePage = async ( siteId: string | number, pageId: number ): Promise< b
 		return true;
 	} catch ( error ) {
 		// fail silently here, just log an error and return false, Big Sky will still launch
-		// eslint-disable-next-line no-console
-		console.error( `Failed to delete page ${ pageId } for site ${ siteId }:`, error );
 		return false;
 	}
 };
@@ -57,26 +55,54 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	useSideEffect() {
 		const dispatch = useDispatch();
-		const siteId = useQuery().get( 'siteId' );
-		const prompt = useQuery().get( 'prompt' );
+		const { setGardenName, setGardenPartnerName } = useWpDataDispatch( ONBOARD_STORE );
+		const queryParams = useQuery();
+		const siteId = queryParams.get( 'siteId' );
+		const prompt = queryParams.get( 'prompt' );
+		const createGardenSite = queryParams.get( 'create_garden_site' );
+
 		useEffect( () => {
 			if ( siteId ) {
 				dispatch( setSelectedSiteId( parseInt( siteId ) ) );
 			}
-		}, [ siteId ] );
+		}, [ siteId, dispatch ] );
+
 		useEffect( () => {
 			if ( prompt && prompt.length > 0 ) {
 				window.sessionStorage.setItem( 'stored_ai_prompt', prompt );
 			}
 		}, [ prompt ] );
+
+		useEffect( () => {
+			// Set the garden values based on the query parameter
+			// The parameter should be exactly "1" to enable garden site creation
+			if ( createGardenSite === '1' ) {
+				setGardenName( 'commerce' );
+				setGardenPartnerName( 'wpcom' );
+			} else {
+				setGardenName( null );
+				setGardenPartnerName( null );
+			}
+		}, [ createGardenSite, setGardenName, setGardenPartnerName ] );
 	},
 	initialize,
 	useStepNavigation( _, navigate ) {
 		const { siteSlug: siteSlugFromSiteData, siteId: siteIdFromSiteData } = useSiteData();
 		const { setDesignOnSite, setStaticHomepageOnSite, setIntentOnSite } =
 			useWpDataDispatch( SITE_STORE );
+		const { gardenName } = useSelect(
+			( select ) => ( {
+				gardenName: ( select( ONBOARD_STORE ) as any ).getGardenName(),
+				gardenPartnerName: ( select( ONBOARD_STORE ) as any ).getGardenPartnerName(),
+			} ),
+			[]
+		);
 
-		const { addBlogSticker } = useAddBlogStickerMutation();
+		const { addBlogSticker } = useAddBlogStickerMutation( {
+			onError: () => {
+				// Fail silently - blog sticker addition is not essential for site creation
+			},
+		} );
 
 		const queryParams = useQuery();
 
@@ -124,8 +150,6 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							const { siteSlug, siteId } = providedDependencies;
 							// We are setting up big sky now.
 							if ( ! siteId || ! siteSlug ) {
-								// eslint-disable-next-line no-console
-								console.error( 'No siteId or siteSlug', providedDependencies );
 								return;
 							}
 							// get the prompt from the get url
@@ -137,38 +161,65 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							let sourceParam = '';
 							let specIdParam = '';
 
-							addBlogSticker( siteId, 'big-sky-free-trial' );
-
 							const pendingActions = [
 								resolveSelect( SITE_STORE ).getSite( siteId ), // To get the URL.
 							];
 
-							// Create a new home page if one is not set yet.
-							pendingActions.push(
-								wpcomRequest( {
-									path: '/sites/' + siteId + '/pages',
-									method: 'POST',
-									apiNamespace: 'wp/v2',
-									body: {
-										title: 'Home',
-										status: 'publish',
-										content: '<!-- wp:paragraph -->\n<p>Hello world!</p>\n<!-- /wp:paragraph -->',
-									},
-								} )
-							);
+							// Add blog sticker - this runs independently and errors are handled by the mutation's onError callback
+							addBlogSticker( siteId, 'big-sky-free-trial' );
 
-							pendingActions.push(
-								setDesignOnSite( siteSlug, getAssemblerDesign(), { enableThemeSetup: true } )
-							);
+							// Create a new home page if one is not set yet (only for non-garden sites)
+							if ( ! gardenName ) {
+								pendingActions.push(
+									wpcomRequest( {
+										path: '/sites/' + siteId + '/pages',
+										method: 'POST',
+										apiNamespace: 'wp/v2',
+										body: {
+											title: 'Home',
+											status: 'publish',
+											content: '<!-- wp:paragraph -->\n<p>Hello world!</p>\n<!-- /wp:paragraph -->',
+										},
+									} )
+								);
+							}
+
+							// Only apply design and delete page for non-garden sites
+							if ( ! gardenName ) {
+								pendingActions.push(
+									setDesignOnSite( siteSlug, getAssemblerDesign(), { enableThemeSetup: true } )
+								);
+								pendingActions.push( deletePage( siteId || '', 1 ) );
+							}
 							pendingActions.push( setIntentOnSite( siteSlug, SiteIntent.AIAssembler ) );
 
-							// Delete the existing boilerplate about page, always has a page ID of 1
-							pendingActions.push( deletePage( siteId || '', 1 ) );
-							const results = await Promise.all( pendingActions );
-							const siteURL = results[ 0 ].URL;
+							// Execute operations individually to identify which one fails
+							const results = [];
+							try {
+								// Execute all actions sequentially with logging
+								for ( let i = 0; i < pendingActions.length; i++ ) {
+									const result = await pendingActions[ i ];
+									results.push( result );
+								}
+							} catch ( error ) {
+								return;
+							}
 
-							const homePagePostId = results[ 1 ].id;
-							await setStaticHomepageOnSite( siteId, homePagePostId );
+							// Defensive check for site data (always first)
+							const siteData = results[ 0 ];
+							if ( ! siteData || ! siteData.URL ) {
+								return;
+							}
+							const siteURL = siteData.URL;
+
+							// Handle page creation result (only exists for non-garden sites)
+							if ( ! gardenName && results.length > 1 ) {
+								const pageCreationResult = results[ 1 ];
+								if ( pageCreationResult && pageCreationResult.id ) {
+									const homePagePostId = pageCreationResult.id;
+									await setStaticHomepageOnSite( siteId, homePagePostId );
+								}
+							}
 
 							if ( prompt ) {
 								promptParam = `&prompt=${ encodeURIComponent( prompt ) }`;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -19,6 +19,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
@@ -53,6 +54,37 @@ function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	return false;
 }
 
+async function pollForGardenProvisioning( siteId: number, maxAttempts = 10, delayMs = 3000 ) {
+	for ( let attempt = 1; attempt <= maxAttempts; attempt++ ) {
+		try {
+			const siteResponse = ( await wpcomRequest( {
+				path: `/sites/${ siteId }`,
+				apiVersion: '1.1',
+				method: 'GET',
+			} ) ) as { garden_is_provisioned?: boolean };
+
+			if ( siteResponse?.garden_is_provisioned ) {
+				return true;
+			}
+
+			if ( attempt < maxAttempts ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, delayMs ) );
+			}
+		} catch ( error ) {
+			if ( attempt < maxAttempts ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, delayMs ) );
+			}
+		}
+	}
+
+	// Throw an error to trigger the processing step's error handling
+	const error = new Error(
+		`Garden site provisioning failed to complete after ${ maxAttempts } attempts. Please try again or contact support.`
+	) as Error & { code: string };
+	error.code = 'garden_provisioning_timeout';
+	throw error;
+}
+
 const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
@@ -69,6 +101,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		siteUrl,
 		progress,
 		partnerBundle,
+		gardenName,
+		gardenPartnerName,
 	} = useSelect(
 		( select: ( arg: string ) => OnboardSelect ) => ( {
 			domainItem: select( ONBOARD_STORE ).getSelectedDomain(),
@@ -80,6 +114,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			siteUrl: select( ONBOARD_STORE ).getSiteUrl(),
 			progress: select( ONBOARD_STORE ).getProgress(),
 			partnerBundle: select( ONBOARD_STORE ).getPartnerBundle(),
+			gardenName: select( ONBOARD_STORE ).getGardenName(),
+			gardenPartnerName: select( ONBOARD_STORE ).getGardenPartnerName(),
 		} ),
 		[]
 	);
@@ -193,8 +229,16 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			siteUrl,
 			domainItem,
 			sourceSlug,
-			siteIntent
+			siteIntent,
+			undefined, // siteGoals
+			gardenName,
+			gardenPartnerName
 		);
+
+		// Poll for garden provisioning status if this is a garden site
+		if ( gardenName && site?.siteId ) {
+			await pollForGardenProvisioning( site.siteId );
+		}
 
 		if ( isEntrepreneurFlow( flow ) && site ) {
 			await addEcommerceTrial( { siteId: site.siteId } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -79,7 +79,7 @@ async function pollForGardenProvisioning( siteId: number, maxAttempts = 10, dela
 
 	// Throw an error to trigger the processing step's error handling
 	const error = new Error(
-		`Garden site provisioning failed to complete after ${ maxAttempts } attempts. Please try again or contact support.`
+		'We were unable to create your site. Please try again or contact support.'
 	) as Error & { code: string };
 	error.code = 'garden_provisioning_timeout';
 	throw error;

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -363,6 +363,16 @@ export const setPartnerBundle = ( partnerBundle: string | null ) => ( {
 	partnerBundle,
 } );
 
+export const setGardenName = ( gardenName: string | null ) => ( {
+	type: 'SET_GARDEN_NAME' as const,
+	gardenName,
+} );
+
+export const setGardenPartnerName = ( gardenPartnerName: string | null ) => ( {
+	type: 'SET_GARDEN_PARTNER_NAME' as const,
+	gardenPartnerName,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -422,4 +432,6 @@ export type OnboardAction = ReturnType<
 	| typeof setPaidSubscribers
 	| typeof setPartnerBundle
 	| typeof setSignupDomainOrigin
+	| typeof setGardenName
+	| typeof setGardenPartnerName
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -612,6 +612,29 @@ const signupDomainOrigin: Reducer< string | undefined, OnboardAction > = (
 	return state;
 };
 
+export const gardenName: Reducer< string | null, OnboardAction > = ( state = null, action ) => {
+	if ( action.type === 'SET_GARDEN_NAME' ) {
+		return action.gardenName;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return null;
+	}
+	return state;
+};
+
+export const gardenPartnerName: Reducer< string | null, OnboardAction > = (
+	state = null,
+	action
+) => {
+	if ( action.type === 'SET_GARDEN_PARTNER_NAME' ) {
+		return action.gardenPartnerName;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return null;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -660,6 +683,8 @@ const reducer = combineReducers( {
 	paidSubscribers,
 	partnerBundle,
 	signupDomainOrigin,
+	gardenName,
+	gardenPartnerName,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -81,3 +81,5 @@ export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;
 export const getProfilerData = ( state: State ) => state.profilerData;
 export const getPaidSubscribers = ( state: State ) => state.paidSubscribers;
 export const getPartnerBundle = ( state: State ) => state.partnerBundle;
+export const getGardenName = ( state: State ) => state.gardenName;
+export const getGardenPartnerName = ( state: State ) => state.gardenPartnerName;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of BSKY-1135
Part of BSKY-1163

## Proposed Changes

This is a PoC which allows the `ai-site-builder` flow to create a Garden site instead of a regular WPCOM Simple site.

We added `gardenName` and `gardenPartnerName` to the `ONBOARD_STORE`.

If the `?create_garden_site=1` parameter is present when the `ai-site-builder` flow starts, we pass that parameter along to the `/sites/new` call.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See 192669-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?