### PR TITLE
Backup FileBrowser: move download/restore buttons from header to parent component

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,58 +1,18 @@
 import {
-	Button,
 	CheckboxControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useFileBrowserContext } from './file-browser-context';
 
-interface FileBrowserHeaderProps {
-	rewindId: number;
-	siteId: number;
-	siteSlug: string;
-	hasCredentials?: boolean;
-	isRestoreEnabled?: boolean;
-	onTrackEvent?: ( eventName: string, properties?: Record< string, unknown > ) => void;
-	onRequestGranularDownload?: (
-		siteId: number,
-		rewindId: number,
-		includePaths: string,
-		excludePaths: string
-	) => void;
-	onRequestGranularRestore: ( siteSlug: string, rewindId: number ) => void;
-}
-
-function FileBrowserHeader( {
-	rewindId,
-	siteId,
-	siteSlug,
-	hasCredentials,
-	isRestoreEnabled,
-	onTrackEvent,
-	onRequestGranularDownload,
-	onRequestGranularRestore,
-}: FileBrowserHeaderProps ) {
+function FileBrowserHeader() {
 	const { fileBrowserState } = useFileBrowserContext();
 	const { getNode, getCheckList, setNodeCheckState } = fileBrowserState;
 	const rootNode = getNode( '/' );
 	const browserCheckList = getCheckList();
 
-	const onDownloadClick = () => {
-		const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
-		const excludePaths = browserCheckList.excludeList.map( ( item ) => item.id ).join( ',' );
-
-		onRequestGranularDownload?.( siteId, rewindId, includePaths, excludePaths );
-		onTrackEvent?.( 'calypso_jetpack_backup_browser_download_multiple_files' );
-	};
-	const onRestoreClick = () => {
-		onRequestGranularRestore( siteSlug, rewindId );
-		onTrackEvent?.( 'calypso_jetpack_backup_browser_restore_multiple_files', {
-			...( hasCredentials !== undefined && { has_credentials: hasCredentials } ),
-		} );
-	};
 	// A simple toggle.  Mixed will go to unchecked.
 	const onCheckboxChange = () => {
 		const newCheckState = rootNode && rootNode.checkState === 'unchecked' ? 'checked' : 'unchecked';
@@ -61,21 +21,6 @@ function FileBrowserHeader( {
 
 	return (
 		<VStack className="file-browser-header">
-			{ browserCheckList.totalItems > 0 && (
-				<ButtonStack justify="flex-start">
-					<Button __next40pxDefaultSize onClick={ onDownloadClick }>
-						{ __( 'Download selected files' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						onClick={ onRestoreClick }
-						disabled={ ! isRestoreEnabled }
-						variant="primary"
-					>
-						{ __( 'Restore selected files' ) }
-					</Button>
-				</ButtonStack>
-			) }
 			<HStack className="file-browser-header__selecting" justify="flex-start" spacing={ 0 }>
 				<CheckboxControl
 					__nextHasNoMarginBottom

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -36,14 +36,6 @@ interface FileBrowserProps {
 	// Tracks analytics callback
 	onTrackEvent?: ( eventName: string, properties?: Record< string, unknown > ) => void;
 
-	// Granular download action callback
-	onRequestGranularDownload?: (
-		siteId: number,
-		rewindId: number,
-		includePaths: string,
-		excludePaths: string
-	) => void;
-
 	// Granular restore action callback
 	onRequestGranularRestore?: ( siteSlug: string, rewindId: number ) => void;
 }
@@ -57,7 +49,6 @@ function FileBrowser( {
 	isRestoreEnabled,
 	displayBackupDate,
 	onTrackEvent,
-	onRequestGranularDownload,
 	onRequestGranularRestore = () => {},
 }: FileBrowserProps ) {
 	// This is the path of the node that is clicked
@@ -75,18 +66,8 @@ function FileBrowser( {
 
 	return (
 		<div>
-			{ ( fileBrowserConfig?.showHeader ?? true ) && (
-				<FileBrowserHeader
-					rewindId={ rewindId }
-					siteId={ siteId }
-					siteSlug={ siteSlug }
-					hasCredentials={ hasCredentials }
-					isRestoreEnabled={ isRestoreEnabled }
-					onTrackEvent={ onTrackEvent }
-					onRequestGranularDownload={ onRequestGranularDownload }
-					onRequestGranularRestore={ onRequestGranularRestore }
-				/>
-			) }
+			{ ( fileBrowserConfig?.showHeader ?? true ) && <FileBrowserHeader /> }
+			{ /* @TODO: remove this block once the new Staging Sync Modal is live */ }
 			{ fileBrowserConfig?.showBackupTime && displayBackupDate && (
 				<HStack alignment="left" spacing={ 1 }>
 					<Text

--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -72,6 +72,17 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 		page.redirect( backupGranularRestorePath( siteSlug, rewindId as unknown as string ) );
 	}, [] );
 
+	const onGranularRestoreClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_browser_restore_multiple_files', {
+				...( hasCredentials !== undefined && {
+					has_credentials: hasCredentials,
+				} ),
+			} )
+		);
+		handleRequestGranularRestore( siteSlug, rewindId );
+	}, [ dispatch, hasCredentials, handleRequestGranularRestore, siteSlug, rewindId ] );
+
 	return (
 		<>
 			<QuerySiteCredentials siteId={ siteId } />
@@ -116,19 +127,7 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 									</Button>
 									<Button
 										__next40pxDefaultSize
-										onClick={ () => {
-											dispatch(
-												recordTracksEvent(
-													'calypso_jetpack_backup_browser_restore_multiple_files',
-													{
-														...( hasCredentials !== undefined && {
-															has_credentials: hasCredentials,
-														} ),
-													}
-												)
-											);
-											handleRequestGranularRestore( siteSlug, rewindId );
-										} }
+										onClick={ onGranularRestoreClick }
 										disabled={ ! isRestoreEnabled }
 										variant="primary"
 									>

--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -12,6 +12,7 @@ import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/us
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindRequestGranularBackup } from 'calypso/state/activity-log/actions';
@@ -37,6 +38,10 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 	const moment = useLocalizedMoment();
 	const displayDate = getDisplayDate( moment.unix( rewindId ), false );
 	const { fileBrowserState } = useFileBrowserContext();
+	const browserCheckList = fileBrowserState.getCheckList();
+	const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
+	const excludePaths = browserCheckList.excludeList.map( ( item ) => item.id ).join( ',' );
+
 	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
@@ -57,13 +62,11 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 		[ dispatch ]
 	);
 
-	const handleRequestGranularDownload = useCallback(
-		( siteId: number, rewindId: number, includePaths: string, excludePaths: string ) => {
-			dispatch( rewindRequestGranularBackup( siteId, rewindId, includePaths, excludePaths ) );
-			page.redirect( backupDownloadPath( siteSlug, rewindId as unknown as string ) );
-		},
-		[ dispatch, siteSlug ]
-	);
+	const handleRequestGranularDownload = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_browser_download_multiple_files' ) );
+		dispatch( rewindRequestGranularBackup( siteId, rewindId, includePaths, excludePaths ) );
+		page.redirect( backupDownloadPath( siteSlug, rewindId.toString() ) );
+	}, [ dispatch, siteId, rewindId, siteSlug, includePaths, excludePaths ] );
 
 	const handleRequestGranularRestore = useCallback( ( siteSlug: string, rewindId: number ) => {
 		page.redirect( backupGranularRestorePath( siteSlug, rewindId as unknown as string ) );
@@ -99,11 +102,41 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 							</div>
 						</div>
 						<div className="status-card__title">{ displayDate }</div>
-						{ fileBrowserState.getCheckList().totalItems === 0 && (
-							<Spacer marginBottom={ 2 }>
+						<Spacer marginBottom={ 2 }>
+							{ fileBrowserState.getCheckList().totalItems === 0 ? (
 								<ActionButtons isMultiSite={ isMultiSite } rewindId={ rewindId.toString() } />
-							</Spacer>
-						) }
+							) : (
+								<ButtonStack justify="flex-start">
+									<Button
+										__next40pxDefaultSize
+										onClick={ handleRequestGranularDownload }
+										variant="secondary"
+									>
+										{ translate( 'Download selected files' ) }
+									</Button>
+									<Button
+										__next40pxDefaultSize
+										onClick={ () => {
+											dispatch(
+												recordTracksEvent(
+													'calypso_jetpack_backup_browser_restore_multiple_files',
+													{
+														...( hasCredentials !== undefined && {
+															has_credentials: hasCredentials,
+														} ),
+													}
+												)
+											);
+											handleRequestGranularRestore( siteSlug, rewindId );
+										} }
+										disabled={ ! isRestoreEnabled }
+										variant="primary"
+									>
+										{ translate( 'Restore selected files' ) }
+									</Button>
+								</ButtonStack>
+							) }
+						</Spacer>
 					</div>
 					<div className="backup-contents-page__body">
 						<FileBrowser
@@ -113,7 +146,6 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 							hasCredentials={ hasCredentials }
 							isRestoreEnabled={ isRestoreEnabled }
 							onTrackEvent={ handleTrackEvent }
-							onRequestGranularDownload={ handleRequestGranularDownload }
 							onRequestGranularRestore={ handleRequestGranularRestore }
 						/>
 					</div>

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -65,6 +65,10 @@
 			box-shadow: none;
 			margin-bottom: 0;
 		}
+
+		.components-button.is-secondary {
+			box-shadow: none;
+		}
 	}
 
 	&__body {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-522

## Proposed Changes

- Move download and restore action buttons from `FileBrowserHeader` to backup-contents-page
- Remove `onRequestGranularDownload` prop from the FileBrowser component interface
- Remove props interface from `FileBrowserHeader` as they are no longer needed

https://github.com/user-attachments/assets/d99540d3-6304-4089-982a-ab28649d3d1a

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change is part of the FileBrowser migration strategy to make the component compatible with the Hosting Dashboard. Since those actions are [not required in the Staging Sync Modal](https://github.com/Automattic/wp-calypso/blob/c341b5cdd9ff3c086d4de80aa6dfbf538c6aba22/client/dashboard/sites/staging-site-sync-modal/index.tsx#L48) and will not be used on the Backup page in the Hosting Dashboard, it makes sense to decouple them from the component itself.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Pick a site with Jetpack VaultPress Backup
* Click on `View files` on any full backup to navigate to the file browser
* Try clicking the checkboxes on some files
* Ensure the buttons switch to `Download selected files` / `Restore selected files` when there are items selected.
* Try restoring selected files.
  * Ensure the files you selected are visible in the restore confirmation page, like this:
    <img width="1402" height="1244" alt="CleanShot 2025-09-22 at 14 51 24@2x" src="https://github.com/user-attachments/assets/3d937dfe-cab0-41a4-90b6-0529529d12f1" />
* Try downloading selected files.
  * Ensure the file dump include the selected files.

> [!NOTE]
> There may be some slight styles differences on the buttons, that would be fine to address in another PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
