### PR TITLE
Backups Dashboard: fix dataviews list sorting - i2

### DIFF
--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -39,6 +39,9 @@ export function getFields(): Field< ActivityLogEntry >[] {
 		{
 			id: 'date',
 			label: __( 'Date' ),
+			getValue: ( { item } ) => {
+				return item.published || item.last_published;
+			},
 			render: ( { item } ) => <FormattedTime timestamp={ item.published || item.last_published } />,
 		},
 		{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-463

## Proposed Changes

* Add getValue to date field to fix 500 error when sorting

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We addressed one of the errors in https://github.com/Automattic/wp-calypso/pull/105791, but didn't realize it also fails when filtering by date. In this case, the missing getValue causes the filter to throw the same error:

https://github.com/user-attachments/assets/854a1158-7f70-45e7-b9f1-1ecc1b61017e

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live branch and navigate to /v2/sites/{site}/backups
* Try to sort the dataviews by Date ensure it doesn't throw the error shared above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
