### PR TITLE
Hosting dashboard: prevent direct @automattic/calypso-analytics imports

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/components/src/logos',
+							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',
 							'!@automattic/generate-password',
@@ -68,6 +69,10 @@ module.exports = {
 					},
 				],
 				paths: [
+					{
+						name: '@automattic/calypso-analytics',
+						message: 'Please import { useAnalytics } from client/dashboard/app/analytics instead.',
+					},
 					{
 						name: '@automattic/components',
 						message:

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -46,7 +46,6 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/components/src/logos',
-							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',
 							'!@automattic/generate-password',

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -1,4 +1,5 @@
 import { queryClient } from '@automattic/api-queries';
+// eslint-disable-next-line no-restricted-imports
 import {
 	initializeAnalytics,
 	recordTracksEvent,

--- a/client/dashboard/sites/actions.tsx
+++ b/client/dashboard/sites/actions.tsx
@@ -1,12 +1,12 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { backup, wordpress } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
+import { useAnalytics } from '../app/analytics';
 import { isP2, isSelfHostedJetpackConnected } from '../utils/site-types';
 import { canManageSite } from './features';
 import type { Site } from '@automattic/api-core';
-import type { AnyRouter } from '@tanstack/react-router';
 import type { Action } from '@wordpress/dataviews';
 
 const SiteLeaveContentInfo = lazy( () => import( './site-leave-modal/content-info' ) );
@@ -14,7 +14,10 @@ const SiteRestoreContentInfo = lazy( () => import( './site-restore-modal/content
 
 const noop = () => undefined;
 
-export function getActions( router: AnyRouter ): Action< Site >[] {
+export function useActions(): Action< Site >[] {
+	const router = useRouter();
+	const { recordTracksEvent } = useAnalytics();
+
 	return [
 		{
 			id: 'admin',

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { WordPressLogo } from '@automattic/components/src/logos/wordpress-logo';
@@ -13,42 +12,45 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
+import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import Column from './column';
 import MenuItem from './menu-item';
 import type { AddNewSiteProps } from './types';
 import './style.scss';
 
-const wordpressClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'wordpress',
-	} );
-};
-const jetpackClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'jetpack',
-	} );
-};
-const migrateClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'migrate',
-	} );
-};
-const importClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'import',
-	} );
-};
-const offerClick = () => {
-	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-		action: 'offer',
-	} );
-};
-
 function AddNewSite( { context }: AddNewSiteProps ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	const wordpressClick = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'wordpress',
+		} );
+	};
+	const jetpackClick = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'jetpack',
+		} );
+	};
+	const migrateClick = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'migrate',
+		} );
+	};
+	const importClick = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'import',
+		} );
+	};
+	const offerClick = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'offer',
+		} );
+	};
+
 	const isDesktop = useViewportMatch( 'medium' );
 	const Wrapper = isDesktop ? HStack : VStack;
 	const offer = sprintf(

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,7 +5,7 @@ import {
 	sitesQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation, keepPreviousData } from '@tanstack/react-query';
-import { useNavigate, useRouter } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
@@ -18,7 +18,7 @@ import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { GuidedTourContextProvider, GuidedTourStep } from '../components/guided-tour';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import { getActions } from './actions';
+import { useActions } from './actions';
 import AddNewSite from './add-new-site';
 import { getFields } from './fields';
 import noSitesIllustration from './no-sites-illustration.svg';
@@ -57,7 +57,6 @@ const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchS
 export default function Sites() {
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
-	const router = useRouter();
 	const currentSearchParams = sitesRoute.useSearch();
 	const viewSearchParams: ViewSearchParams = currentSearchParams.view ?? {};
 	const isRestoringAccount = !! currentSearchParams.restored;
@@ -85,7 +84,7 @@ export default function Sites() {
 	} );
 
 	const fields = getFields( { isAutomattician, viewType: view.type } );
-	const actions = getActions( router );
+	const actions = useActions();
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -1,6 +1,5 @@
 import { HostingFeatures, fetchPhpMyAdminToken } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
@@ -15,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { blockTable } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -26,6 +26,7 @@ import upsellIllustrationUrl from './upsell-illustration.svg';
 
 export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 	const [ isFetchingToken, setIsFetchingToken ] = useState( false );
 	const [ isResetPasswordModalOpen, setIsResetPasswordModalOpen ] = useState( false );

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -3,7 +3,6 @@ import {
 	siteCurrentUserQuery,
 	siteUserDeleteMutation,
 } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -17,6 +16,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
@@ -36,6 +36,8 @@ function isSiteOwner( user: User, site: Site ) {
 }
 
 function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
+	const { recordTracksEvent } = useAnalytics();
+
 	return (
 		<>
 			<VStack spacing={ 0 }>
@@ -64,6 +66,8 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 }
 
 function ContentSiteOwner( { site, onClose }: ContentInfoProps ) {
+	const { recordTracksEvent } = useAnalytics();
+
 	return (
 		<>
 			<VStack spacing={ 0 }>
@@ -93,6 +97,7 @@ function ContentSiteOwner( { site, onClose }: ContentInfoProps ) {
 
 function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 	const router = useRouter();
+	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	// It gets external user ID (ID of user entity from site connected via Jetpack) from provided WPCOM user ID.

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -9,7 +9,6 @@ import {
 	isCreatingStagingSiteQuery,
 	siteBySlugQuery,
 } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -25,6 +24,7 @@ import { useEffect } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, chevronDownSmall, plus } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
 import Environment from '../../components/environment';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
@@ -144,6 +144,7 @@ const EnvironmentSwitcherDropdown = ( {
 };
 
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
+	const { recordTracksEvent } = useAnalytics();
 	const queryClient = useQueryClient();
 
 	const productionSiteId = getProductionSiteId( site );

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -1,5 +1,4 @@
 import { siteByIdQuery, stagingSiteDeleteMutation } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -11,6 +10,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { Site } from '@automattic/api-core';
 
@@ -23,6 +23,7 @@ export default function StagingSiteDeleteModal( {
 } ) {
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
 
 	const productionSiteId = site.options?.wpcom_production_blog_id;
 	const { data: productionSite } = useQuery( {

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -12,10 +12,7 @@ const mockMutate = jest.fn();
 const mockCreateErrorNotice = jest.fn();
 const mockCreateSuccessNotice = jest.fn();
 const mockNavigate = jest.fn();
-
-jest.mock( '@automattic/calypso-analytics', () => ( {
-	recordTracksEvent: jest.fn(),
-} ) );
+const mockRecordTracksEvent = jest.fn();
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
@@ -51,6 +48,12 @@ jest.mock( '@tanstack/react-query', () => ( {
 		mutate: mockMutate,
 		isPending: false,
 		error: null,
+	} ) ),
+} ) );
+
+jest.mock( '../../../app/analytics', () => ( {
+	useAnalytics: jest.fn( () => ( {
+		recordTracksEvent: mockRecordTracksEvent,
 	} ) ),
 } ) );
 
@@ -155,7 +158,6 @@ describe( 'StagingSiteDeleteModal', () => {
 		test( 'shows error notice and tracks failure when deletion fails', async () => {
 			const user = userEvent.setup();
 			const { useMutation } = require( '@tanstack/react-query' );
-			const { recordTracksEvent } = require( '@automattic/calypso-analytics' );
 
 			// Mock mutate to simulate calling onError callback with an error
 			const mockMutateWithError = jest.fn( ( _, options ) => {
@@ -178,7 +180,7 @@ describe( 'StagingSiteDeleteModal', () => {
 				type: 'snackbar',
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_hosting_configuration_staging_site_delete_failure'
 			);
 		} );
@@ -224,7 +226,6 @@ describe( 'StagingSiteDeleteModal', () => {
 		test( 'shows success notice, closes modal, and navigates on successful deletion', async () => {
 			const user = userEvent.setup();
 			const { useMutation } = require( '@tanstack/react-query' );
-			const { recordTracksEvent } = require( '@automattic/calypso-analytics' );
 
 			// Mock mutate to simulate calling onSuccess callback
 			const mockMutateWithSuccess = jest.fn( ( _, options ) => {
@@ -256,7 +257,7 @@ describe( 'StagingSiteDeleteModal', () => {
 				params: { siteSlug: 'production-site' },
 			} );
 
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_hosting_configuration_staging_site_delete_success'
 			);
 		} );

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -3,7 +3,6 @@ import {
 	pushToStagingMutation,
 	pullFromStagingMutation,
 } from '@automattic/api-queries';
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -28,6 +27,7 @@ import {
 	FileBrowserProvider,
 	useFileBrowserContext,
 } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
+import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
 import { ButtonStack } from '../../components/button-stack';
 import Environment, { EnvironmentType } from '../../components/environment';
@@ -166,6 +166,7 @@ function StagingSiteSyncModalInner( {
 	onSyncStart,
 }: StagingSiteSyncModalProps ) {
 	const syncConfig = getSyncConfig( syncType );
+	const { recordTracksEvent } = useAnalytics();
 	const [ domainConfirmation, setDomainConfirmation ] = useState( '' );
 	const [ isFileBrowserVisible, setIsFileBrowserVisible ] = useState( false );
 


### PR DESCRIPTION
## Proposed Changes

This PR cleans up `@automattic/calypso-analytics` imports that should have been forbidden. Devs are supposed to import `{ useAnalytics }` from `app/analytics` instead.

This PR removes the entry from `.eslintrc.js` to prevent further violations.

## Why are these changes being made?

Code hygiene

## Testing Instructions

1. Visually check the changes.
2. Try to smoke-check come changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
