### PR TITLE
Hosting Dashboard > Security: Implement Enhanced Account Security for Two-step

### DIFF
--- a/client/dashboard/me/security-social-logins/index.tsx
+++ b/client/dashboard/me/security-social-logins/index.tsx
@@ -174,18 +174,6 @@ export default function SecuritySocialLogins() {
 					) }
 				/>
 				<SocialLoginItem
-					service="Google"
-					decoration={ GoogleIcon }
-					renderButton={ ( { isConnected, responseHandler, handleDisconnect, isLoading } ) => (
-						<GoogleLogin
-							isConnected={ isConnected }
-							responseHandler={ responseHandler }
-							handleDisconnect={ handleDisconnect }
-							isLoading={ isLoading }
-						/>
-					) }
-				/>
-				<SocialLoginItem
 					service="Apple"
 					decoration={ AppleIcon }
 					renderButton={ ( { isConnected, responseHandler, handleDisconnect, isLoading } ) => (

--- a/client/dashboard/me/security-two-step-auth-app/index.tsx
+++ b/client/dashboard/me/security-two-step-auth-app/index.tsx
@@ -1,7 +1,10 @@
 import { userSettingsQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import SecurityTwoStepAuthPageLayout from '../security-two-step-auth/common/page-layout';
 import PrintBackupCodes from '../security-two-step-auth/common/print-backup-codes';
@@ -21,12 +24,21 @@ export default function SecurityTwoStepAuthApp() {
 			<VStack spacing={ 8 }>
 				{ ! isTwoStepAppEnabled && (
 					<Notice variant="info" title={ __( 'Before you continue' ) }>
-						{
-							// TODO: Add link to support article
+						{ createInterpolateElement(
 							__(
-								'You‘ll need an authenticator app like Google Authenticator or Authy installed on your device to enable two-step authentication.'
-							)
-						}
+								'You‘ll need an authenticator app like Google Authenticator or Authy installed on your device to enable two-step authentication. <learnMoreLink>Learn more</learnMoreLink>'
+							),
+							{
+								learnMoreLink: (
+									<InlineSupportLink
+										supportPostId={ 58847 }
+										supportLink={ localizeUrl(
+											'https://wordpress.com/support/security/two-step-authentication/#use-an-app'
+										) }
+									/>
+								),
+							}
+						) }
 					</Notice>
 				) }
 

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
@@ -1,3 +1,5 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -7,6 +9,9 @@ import DisableTwoStepDialog from './disable-two-step-dialog';
 
 export default function TwoStepAuthActions() {
 	const router = useRouter();
+
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const { two_step_enhanced_security_forced } = userSettings;
 
 	const [ showDisableDialog, setShowDisableDialog ] = useState( false );
 
@@ -33,9 +38,17 @@ export default function TwoStepAuthActions() {
 							onClick={ () => setShowDisableDialog( true ) }
 							variant="secondary"
 							size="compact"
+							disabled={ two_step_enhanced_security_forced }
 						>
 							{ __( 'Disable' ) }
 						</Button>
+					}
+					description={
+						two_step_enhanced_security_forced
+							? __(
+									'Two-step authentication is currently required by your organization. To make changes, please contact your administrator.'
+							  )
+							: undefined
 					}
 				/>
 			</ActionList>

--- a/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
@@ -1,0 +1,66 @@
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	ToggleControl,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { SectionHeader } from '../../../../components/section-header';
+
+export default function EnhancedSecurity() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const { two_step_enhanced_security_forced, two_step_enhanced_security } = userSettings;
+
+	const { mutate: updateUserSettings, isPending: isUpdatingUserSettings } = useMutation(
+		userSettingsMutation()
+	);
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleChange = ( value: boolean ) => {
+		updateUserSettings(
+			{ two_step_enhanced_security: value },
+			{
+				onSuccess: () => {
+					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+				},
+				onError: () => {
+					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+				},
+			}
+		);
+	};
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<SectionHeader title={ __( 'Enhanced account security' ) } level={ 3 } />
+						<ToggleControl
+							checked={ two_step_enhanced_security }
+							onChange={ handleChange }
+							disabled={ two_step_enhanced_security_forced || isUpdatingUserSettings }
+							label={
+								two_step_enhanced_security_forced
+									? __(
+											'Your account is currently required to use security keys (passkeys) as a second factor.'
+									  )
+									: __(
+											'Secure your account by requiring the use of security keys (passkeys) as second factor.'
+									  )
+							}
+							help={ __(
+								'Security keys (or passkeys) offer a more secure way to access your account. Whether it’s a physical device or another secure method, they make it significantly harder for unauthorised users to gain access.'
+							) }
+						/>
+					</VStack>
+				</CardBody>
+			</Card>
+		</>
+	);
+}

--- a/client/dashboard/me/security-two-step-auth/main-page/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/index.tsx
@@ -1,4 +1,5 @@
 import { smsCountryCodesQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -82,7 +83,7 @@ export default function SecurityTwoStepAuthMainPage( {
 								}
 						  ) ) }
 			</Notice>
-			<EnhancedSecurity />
+			{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
 			<SecurityKeys />
 			<ApplicationPasswords />
 			<BackupCodes />

--- a/client/dashboard/me/security-two-step-auth/main-page/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/index.tsx
@@ -9,6 +9,7 @@ import Notice from '../../../components/notice';
 import TwoStepAuthActions from './actions';
 import ApplicationPasswords from './application-passwords';
 import BackupCodes from './backup-codes';
+import EnhancedSecurity from './enhanced-security';
 import SecurityKeys from './security-keys';
 import type { UserSettings } from '@automattic/api-core';
 
@@ -26,6 +27,7 @@ export default function SecurityTwoStepAuthMainPage( {
 		two_step_sms_enabled,
 		two_step_sms_phone_number,
 		two_step_sms_country,
+		two_step_enhanced_security_forced,
 	} = userSettings;
 
 	const initialCountryCode = two_step_sms_country;
@@ -37,35 +39,50 @@ export default function SecurityTwoStepAuthMainPage( {
 			? `${ countryCode.numeric_code } ${ two_step_sms_phone_number }`
 			: two_step_sms_phone_number;
 
+	const enforcedByOrganizationText = __(
+		'Two-step authentication is required by your organization and can’t be disabled. For any changes, please contact your administrator.'
+	);
+
 	return (
 		<VStack className="security-two-step-auth-main-page" spacing={ 8 }>
 			<Notice variant="info" title={ __( 'Two-step authentication is enabled' ) }>
-				{ two_step_sms_enabled &&
-					sprintf(
-						/* translators: %s is the phone number */
-						__(
-							'You‘re all set to receive authentication codes at %s. Want to use a different number? Just disable two-step authentication and set it up again using the new number.'
-						),
-						phoneNumber
-					) }
+				{ two_step_sms_enabled && (
+					<>
+						{ sprintf(
+							/* translators: %s is the phone number */
+							__( 'You‘re all set to receive authentication codes at %s.' ),
+							phoneNumber
+						) }
+						&nbsp;
+						{ two_step_enhanced_security_forced
+							? enforcedByOrganizationText
+							: __(
+									'Want to use a different number? Just disable two-step authentication and set it up again using the new number.'
+							  ) }
+					</>
+				) }
+
 				{ two_step_app_enabled &&
-					createInterpolateElement(
-						__(
-							/* translators: followStepsLink is a link to the support article */
-							'Switching to a new device? <followStepsLink>Follow these steps</followStepsLink> to avoid losing access to your account.'
-						),
-						{
-							followStepsLink: (
-								<InlineSupportLink
-									supportPostId={ 39178 }
-									supportLink={ localizeUrl(
-										'https://wordpress.com/support/security/two-step-authentication/#moving-to-a-new-device'
-									) }
-								/>
-							),
-						}
-					) }
+					( two_step_enhanced_security_forced
+						? enforcedByOrganizationText
+						: createInterpolateElement(
+								__(
+									/* translators: followStepsLink is a link to the support article */
+									'Switching to a new device? <followStepsLink>Follow these steps</followStepsLink> to avoid losing access to your account.'
+								),
+								{
+									followStepsLink: (
+										<InlineSupportLink
+											supportPostId={ 39178 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/security/two-step-authentication/#moving-to-a-new-device'
+											) }
+										/>
+									),
+								}
+						  ) ) }
 			</Notice>
+			<EnhancedSecurity />
 			<SecurityKeys />
 			<ApplicationPasswords />
 			<BackupCodes />

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -29,6 +29,7 @@ export async function updateUserSettings(
 		'p2_disable_autofollow_on_comment',
 		'two_step_sms_country',
 		'two_step_sms_phone_number',
+		'two_step_enhanced_security',
 		'primary_site_ID',
 		'mcp_abilities',
 	];


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-462/update-the-two-step-authentication-screen-to-indicate-organization

## Proposed Changes

This PR:

- Implements "Enhanced Account Security" for Two-step authentication
- Updates UI when the Two-step is enforced at the org level
- Update link for Two-step authentication using an app

## Why are these changes being made?

* To allow users to update the "Enhanced Account Security" settings and indicate when the Two-step is enforced

## Testing Instructions

* Open the Calypso live link > Go to /v2/me/security/two-step-auth when enabled > Verify the "Enhanced Account Security" section is shown as displayed below

<img width="1920" height="640" alt="Screenshot 2025-09-23 at 8 56 46 AM" src="https://github.com/user-attachments/assets/03738cfb-6e80-4a0d-9334-d47aa6bea0e0" />

* Update the "Enhanced Account Security" toggle and verify it gets saved

<img width="162" height="65" alt="Screenshot 2025-09-23 at 8 57 55 AM" src="https://github.com/user-attachments/assets/91fcbf34-370e-469e-9359-6450145b0ade" />

* Verify the UI looks like below for different scenarios:

1) When Two-step is enabled using an app and is not enforced

<img width="1920" height="640" alt="Screenshot 2025-09-23 at 8 56 46 AM" src="https://github.com/user-attachments/assets/03738cfb-6e80-4a0d-9334-d47aa6bea0e0" />

2) When Two-step is enabled using an app and is enforced

<img width="1920" height="660" alt="Screenshot 2025-09-23 at 8 57 29 AM" src="https://github.com/user-attachments/assets/2d72ec51-588a-4c96-9505-5117dea61eaf" />

3) When Two-step is enabled using SMS and is not enforced

<img width="1920" height="655" alt="Screenshot 2025-09-23 at 9 29 27 AM" src="https://github.com/user-attachments/assets/d07a69ab-3b7f-4111-ba42-e5a93ac49940" />

4) When Two-step is enabled using SMS and is enforced

<img width="1920" height="655" alt="Screenshot 2025-09-23 at 9 30 06 AM" src="https://github.com/user-attachments/assets/ccde554f-52fd-474b-a138-ca5d3b537335" />

5) When Two-step is enabled using an app or SMS, and is not enforced

<img width="685" height="159" alt="Screenshot 2025-09-23 at 8 56 33 AM" src="https://github.com/user-attachments/assets/a72be763-468b-4da2-9b93-fccabcd47898" />

6) When Two-step is enabled using an app or SMS, and is enforced

<img width="697" height="190" alt="Screenshot 2025-09-23 at 8 56 25 AM" src="https://github.com/user-attachments/assets/71ff2c0a-ec84-4dbe-b381-5d4f512688ca" />

Learn more link for Two-step using an app:

<img width="686" height="252" alt="Screenshot 2025-09-25 at 12 45 46 PM" src="https://github.com/user-attachments/assets/4d7786f2-a785-498b-8581-298ecd68f958" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
