### PR TITLE
Stats: Fix condition check with boolean rather than number for post likes

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -99,7 +99,7 @@ class PostLikes extends PureComponent {
 		// => bypassed the loading state. We can check for likes instead, which is falsy until
 		// loaded as an array. However, for future proofing I am treating this as if it may be
 		// initialized as an empty array and checking its length vs the count.
-		const areLikesLoading = ! likes || ( likeCount && likes?.length === 0 );
+		const areLikesLoading = ! likes || ( !! likeCount && likes?.length === 0 );
 
 		// Prevent loading for postId `0`
 		const isLoading = !! postId && areLikesLoading;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixed STATS-131.

## Proposed Changes

* Fix condition check of `likes` loading with `boolean` rather than `number` for post likes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Odyssey Stats with option 3 of the development guide: PCYsg-Pp7-p2#option-3.
* Navigate to Stats > Traffic.
* Go to a post details page without likes.
* Ensure the redundant `0` is not showing.

|Before|After|
|-|-|
|<img width="1288" height="554" alt="截圖 2025-09-23 中午12 50 09" src="https://github.com/user-attachments/assets/20c4b65c-ab4d-4572-bbe7-9915dcbd32a3" />|<img width="1278" height="540" alt="截圖 2025-09-23 中午12 49 34" src="https://github.com/user-attachments/assets/04de9062-ccd2-4997-afc1-02897e1bfb51" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?