### PR TITLE
Conditionally undo the transfer language in the free plan paid domain modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -518,6 +518,7 @@ function UnifiedPlansStep( {
 				siteTitle={ siteTitle ?? undefined }
 				signupFlowUserName={ username ?? undefined }
 				siteId={ selectedSite?.ID }
+				domainCartItem={ domainItem }
 				isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 				isInSignup
 				isLaunchPage={ isLaunchPage }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { UrlFriendlyTermType } from '@automattic/calypso-products';
+import { UrlFriendlyTermType, isDomainTransfer } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
@@ -14,7 +14,7 @@ import {
 import { PlansIntent } from '@automattic/plans-grid-next';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { isDesktop as isDesktopViewport, subscribeIsDesktop } from '@automattic/viewport';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -47,7 +47,7 @@ import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-sit
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import { getIntervalType } from './util';
-import type { SiteDetails } from '@automattic/data-stores';
+import type { OnboardSelect, SiteDetails } from '@automattic/data-stores';
 import type { StepState } from 'calypso/state/signup/progress/schema';
 import './unified-plans-step-styles.scss';
 
@@ -258,6 +258,13 @@ function UnifiedPlansStep( {
 
 	const { siteUrl, domainItem, siteTitle, username, coupon, selectedThemeType } =
 		signupDependencies;
+
+	const { domainCartItem } = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
+		const { getDomainCartItem } = select( ONBOARD_STORE );
+		return {
+			domainCartItem: getDomainCartItem(),
+		};
+	}, [] );
 
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 
@@ -518,7 +525,7 @@ function UnifiedPlansStep( {
 				siteTitle={ siteTitle ?? undefined }
 				signupFlowUserName={ username ?? undefined }
 				siteId={ selectedSite?.ID }
-				domainCartItem={ domainItem }
+				isDomainTransfer={ domainCartItem ? isDomainTransfer( domainCartItem ) : false }
 				isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 				isInSignup
 				isLaunchPage={ isLaunchPage }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -27,6 +27,7 @@ export type DomainPlanDialogProps = {
 	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
+	isDomainTransfer?: boolean;
 };
 
 type ModalContainerProps = {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -20,6 +20,7 @@ export function PaidPlanPaidDomainDialog( {
 	generatedWPComSubdomain,
 	onFreePlanSelected,
 	onPlanSelected,
+	isDomainTransfer,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
@@ -35,16 +36,23 @@ export function PaidPlanPaidDomainDialog( {
 		onFreePlanSelected();
 	}
 
+	const getSubHeadingText = () => {
+		if ( isDomainTransfer ) {
+			return translate(
+				"To transfer your domain, you'll need a paid plan. Choose annual billing and get the domain free for a year."
+			);
+		}
+		return translate(
+			"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+		);
+	};
+
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
 				{ translate( 'Paid plan required' ) }
 			</Heading>
-			<SubHeading id="plan-upsell-modal-description">
-				{ translate(
-					'To transfer your domain, you’ll need a paid plan. Choose annual billing and get the domain free for a year.'
-				) }
-			</SubHeading>
+			<SubHeading id="plan-upsell-modal-description">{ getSubHeadingText() }</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<PaidDomainSuggestedPlanSection

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -17,7 +17,6 @@ import {
 	getWooExpressFeaturesGroupedForFeaturesGrid,
 	getSimplifiedPlanFeaturesGroupedForFeaturesGrid,
 	getWordPressHostingFeaturesGroupedForFeaturesGrid,
-	isDomainTransfer,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -126,7 +125,7 @@ export interface PlansFeaturesMainProps {
 	flowName?: string | null;
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
-	domainCartItem?: MinimalRequestCartProduct;
+	isDomainTransfer?: boolean;
 	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
 	/**
 	 * An array of intervals to be displayed in the plan type selector. Defaults to [ 'yearly', '2yearly', '3yearly', 'monthly' ]
@@ -197,7 +196,7 @@ const PlansFeaturesMain = ( {
 	flowName,
 	removePaidDomain,
 	setSiteUrlAsFreeDomainSuggestion,
-	domainCartItem,
+	isDomainTransfer,
 	onUpgradeClick,
 	hidePlanTypeSelector,
 	redirectToAddDomainFlow,
@@ -796,7 +795,7 @@ const PlansFeaturesMain = ( {
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
 					selectedThemeType={ selectedThemeType }
-					isDomainTransfer={ domainCartItem ? isDomainTransfer( domainCartItem ) : false }
+					isDomainTransfer={ isDomainTransfer || false }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -17,6 +17,7 @@ import {
 	getWooExpressFeaturesGroupedForFeaturesGrid,
 	getSimplifiedPlanFeaturesGroupedForFeaturesGrid,
 	getWordPressHostingFeaturesGroupedForFeaturesGrid,
+	isDomainTransfer,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -125,6 +126,7 @@ export interface PlansFeaturesMainProps {
 	flowName?: string | null;
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
+	domainCartItem?: MinimalRequestCartProduct;
 	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
 	/**
 	 * An array of intervals to be displayed in the plan type selector. Defaults to [ 'yearly', '2yearly', '3yearly', 'monthly' ]
@@ -195,6 +197,7 @@ const PlansFeaturesMain = ( {
 	flowName,
 	removePaidDomain,
 	setSiteUrlAsFreeDomainSuggestion,
+	domainCartItem,
 	onUpgradeClick,
 	hidePlanTypeSelector,
 	redirectToAddDomainFlow,
@@ -793,6 +796,7 @@ const PlansFeaturesMain = ( {
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
 					selectedThemeType={ selectedThemeType }
+					isDomainTransfer={ domainCartItem ? isDomainTransfer( domainCartItem ) : false }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-13

## Proposed Changes

* Bring back the language that doesn't mention transfers if a user attempts to get a free plan with a paid domain during the onboarding signup flow

## Why are these changes being made?

* Fixes a bug, the transfer language is incorrect

## Testing Instructions

1. Get a domain
* With a clean state, start /setup/onboarding
* Search for a domain and proceed
* Attempt to get the free plan
* Transfer copy should not be visible

2. Try to transfer a domain
* Go to /setup/onboarding
* Use a domain I already own
* Enter an existing domain from the internet
* Attempt to get a free plan
* transfer copy should be visible
<img width="1312" height="658" alt="Screenshot 2025-09-23 at 10 34 01" src="https://github.com/user-attachments/assets/ee8996c0-625d-479b-834e-59ce2df9e23d" />
<img width="1312" height="658" alt="Screenshot 2025-09-23 at 10 33 31" src="https://github.com/user-attachments/assets/d2f256bb-1fac-4034-913a-470c217c0360" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
