### PR TITLE
Hosting Dashboard Plugin Inspsector: Plugin links to main plugin page

### DIFF
--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -1,5 +1,5 @@
 import { Site } from '@automattic/api-core';
-import { Link } from '@tanstack/react-router';
+import { ExternalLink } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
@@ -36,10 +36,10 @@ export const SitesWithoutThisPlugin = ( { pluginSlug }: { pluginSlug: string } )
 				id: 'link',
 				header: <div />,
 				getValue: ( { item }: { item: Site } ) => item.URL,
-				render: ( { item }: { item: Site } ) => (
-					<Link to={ `/plugins/${ pluginSlug }/${ item.slug }` }>
+				render: () => (
+					<ExternalLink href={ `https://wordpress.com/plugins/${ pluginSlug }` }>
 						{ __( 'Go to plugin page' ) }
-					</Link>
+					</ExternalLink>
 				),
 			},
 		],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DSGCOM-276/hosting-dashboard-plugin-inspector-go-to-plugin-link-should-work

## Proposed Changes

* On the sites without this plugin section of the inspector, the links are now external links that link to the marketplace plugin version.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to /v2/plugins and click on a plugin
* On the sites without this plugin section
   * The links must be external links
   * When clicked should take you to the plugin page (non-site aware)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
