### PR TITLE
Help Center: New copy and style for introduction message

### DIFF
--- a/packages/odie-client/src/components/message/introduction-message/style.scss
+++ b/packages/odie-client/src/components/message/introduction-message/style.scss
@@ -5,7 +5,7 @@
 .odie-introduction-big-sky-logo {
 	align-items: center;
 	display: flex;
-	justify-content: center;
+	justify-content: left;
 	box-sizing: content-box;
 	color: #3858e9;
 	height: 120px;
@@ -20,6 +20,7 @@
 	flex-direction: column;
 	justify-content: end;
 }
+
 .odie-chatbox-message-introduction {
 	height: 100%;
 	align-items: flex-end;

--- a/packages/odie-client/src/components/message/introduction-message/style.scss
+++ b/packages/odie-client/src/components/message/introduction-message/style.scss
@@ -3,12 +3,13 @@
 }
 
 .odie-introduction-big-sky-logo {
-	align-items: center;
+	align-items: end;
 	display: flex;
 	justify-content: left;
 	box-sizing: content-box;
 	color: #3858e9;
 	height: 120px;
+	padding-bottom: 10px;
 	padding-top: 159px;
 }
 

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -167,7 +167,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				</div>
 				{ ( chat.odieId || chat.provider === 'odie' ) && (
 					<ChatMessage
-						message={ getOdieInitialMessage( botNameSlug ) }
+						message={ getOdieInitialMessage( botNameSlug, currentUser?.display_name ) }
 						key={ 0 }
 						currentUser={ currentUser }
 						displayChatWithSupportLabel={ false }

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -133,14 +133,14 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 
 export const getOdieInitialMessage = (
 	botNameSlug: OdieAllowedBots,
-	display_name: string
+	displayName: string
 ): Message => {
 	return {
 		content: `**${ sprintf(
 			/* translators: %(name)s: the user's display name */
 			__( 'Howdy %(name)s 👋', __i18n_text_domain__ ),
 			{
-				name: display_name,
+				name: displayName || 'there',
 			}
 		) }** \n\n ${ __(
 			"I'm your personal AI assistant. I can help with any questions about your site or account.",

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots } from './types';
 declare const __i18n_text_domain__: string;
 
@@ -131,12 +131,21 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 	}
 };
 
-export const getOdieInitialMessage = ( botNameSlug: OdieAllowedBots ): Message => {
+export const getOdieInitialMessage = (
+	botNameSlug: OdieAllowedBots,
+	display_name: string
+): Message => {
 	return {
-		content: __(
-			'👋 Howdy, I’m WordPress.com’s support assistant. I can help with questions about your site or account.',
+		content: `**${ sprintf(
+			/* translators: %(name)s: the user's display name */
+			__( 'Howdy %(name)s 👋', __i18n_text_domain__ ),
+			{
+				name: display_name,
+			}
+		) }** \n\n ${ __(
+			"I'm your personal AI assistant. I can help with any questions about your site or account.",
 			__i18n_text_domain__
-		),
+		) }`,
 		role: 'bot',
 		type: 'introduction',
 		context: getOdieInitialPromptContext( botNameSlug ),


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-14645/howdy-text-looks-too-small

Before

<img width="317" height="489" alt="image" src="https://github.com/user-attachments/assets/0b5440e0-91ab-49f8-a467-d4ba568326ed" />

After

<img width="421" height="394" alt="image" src="https://github.com/user-attachments/assets/fcc1dd4d-9c9f-4268-8300-7f555495f7e4" />


## Testing steps

1. Open the Help Center
2. Start a chat