### PR TITLE
v2 Plugins - Scheduled Updates: Plugin collision/validation checks when creating new schedule

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/new/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/helpers.ts
@@ -88,3 +88,31 @@ export const runWithConcurrency = async (
 
 	await Promise.allSettled( Array.from( executing ) );
 };
+
+/**
+ * Validate plugins against existing schedules
+ * - Must select at least one plugin
+ * - If existing plugin sets are provided, block identical set
+ */
+export function validatePlugins(
+	plugins: string[],
+	existingPlugins: Array< string[] > = []
+): string {
+	let error = '';
+
+	if ( plugins.length === 0 ) {
+		error = __( 'Please select at least one plugin to update.' );
+	} else if ( existingPlugins.length ) {
+		const normalized = [ ...plugins ].sort();
+		for ( const existing of existingPlugins ) {
+			if ( JSON.stringify( normalized ) === JSON.stringify( [ ...existing ].sort() ) ) {
+				error = __(
+					'Please select a different set of plugins, as this one has already been chosen.'
+				);
+				break;
+			}
+		}
+	}
+
+	return error;
+}

--- a/client/dashboard/plugins/scheduled-updates/new/hooks/use-plugin-collisions.ts
+++ b/client/dashboard/plugins/scheduled-updates/new/hooks/use-plugin-collisions.ts
@@ -1,0 +1,65 @@
+import { hostingUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { validatePlugins } from '../helpers';
+import type { HostingUpdateSchedulesResponse } from '@automattic/api-core';
+
+/**
+ * Build per-site plugin sets from the multisite aggregated response
+ */
+function getPluginSetsBySiteFromMultisite(
+	data: HostingUpdateSchedulesResponse
+): Record< number, string[][] > {
+	const result: Record< number, string[][] > = {};
+	const sites = data?.sites;
+
+	if ( ! sites ) {
+		return result;
+	}
+
+	Object.entries( sites ).forEach( ( [ siteIdStr, schedulesMap ] ) => {
+		const siteId = Number( siteIdStr );
+		const sets: string[][] = [];
+		Object.values( schedulesMap || {} ).forEach( ( sched ) => {
+			if ( Array.isArray( sched.args ) ) {
+				sets.push( sched.args as string[] );
+			}
+		} );
+		result[ siteId ] = sets;
+	} );
+
+	return result;
+}
+
+/**
+ * Given a list of site IDs and a selected plugin set,
+ * return an error message if a site already has an identical plugin set scheduled,
+ * along with the sites that have a collision, if any.
+ */
+export function usePluginCollisionsFromMultisite(
+	siteIds: number[],
+	selectedPlugins: string[]
+): { isLoading: boolean; error: string; collidingSiteIds: number[] } {
+	const { data, isLoading } = useQuery( hostingUpdateSchedulesQuery() );
+
+	if ( isLoading ) {
+		return { isLoading: true, error: '', collidingSiteIds: [] };
+	}
+
+	// Short-circuit if no plugins selected; CTA should already be disabled
+	if ( ! selectedPlugins.length ) {
+		return { isLoading: false, error: '', collidingSiteIds: [] };
+	}
+
+	const bySite = data ? getPluginSetsBySiteFromMultisite( data ) : {};
+
+	let firstError = '';
+	const collidingSiteIds: number[] = siteIds.filter( ( id ) => {
+		const error = validatePlugins( selectedPlugins, bySite[ id ] || [] );
+		if ( error && ! firstError ) {
+			firstError = error;
+		}
+		return !! error;
+	} );
+
+	return { isLoading: false, error: firstError, collidingSiteIds };
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Proposed Changes

This follows up from https://github.com/Automattic/wp-calypso/pull/105808 to bring plugin collision pre-checks when creating new schedules.
- Add client-side plugin validation when creating a new scheduled update. 
  - The backend/endpoints apply plugin validations before creating schedules. The original frontend code (v1) included the same validation pre-checks/client-side on the per-site edit/create logic. 
  - When the user bulk-creates schedules for multiple sites, relying entirely on backend validations may lead to a case where only some of the schedules are created (there is no rollback logic in the backend - bulk-create is a batch process on the frontend). We can either orchestrate a rollback on the client (unlikely) or wire a pre-check in the batch create (as done here).
- Show a notice when a plugin collision exists so users can address and retry the bulk operation.

> [!NOTE]
> As previously mentioned, we may surface the notice at the top and scroll to the top or near the CTA. 
> We may ship something to present the validations and revisit the display on top.

> [!IMPORTANT]
> I am exploring some refactoring on top for performance improvements, as currently the validations happen eagerly (on updates/rerenders), while we only need them when creating the schedule - so on-demand should be explored instead.

## Media

### One option: Show the notice right above the CTA

<img width="600" alt="Screenshot 2025-09-23 at 1 53 15 PM" src="https://github.com/user-attachments/assets/afba3bbf-cae9-4195-be41-5d71eee0ae1f" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/new-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/plugins/scheduled-updates/new`
  - Select a site (must have an atomic site) - ideally multiple sites for testing this
  - Select a plugin (must have a non-managed plugins installed from marketplace)
  - Select a frequency
- Create a new schedule and repeat: 
  - with the same plugin but different time - collision detection
    - confirm a notice is shown and the schedules are not created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
