### PR TITLE
Stepper: Even more liberal back button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -40,17 +40,9 @@ export const useStepNavigationWithTracking = ( { flow, currentStepRoute, navigat
 	);
 
 	/**
-	 * If the previous step is defined in the store, and the current step is not the first step, we can go back.
-	 * We need to make sure we're not at the first step because `previousStep` is persisted and can be a step from another flow or another run of the current flow.
-	 * We include a check for whether the previous step is the same sort of step as the current step. This can happen briefly while transitioning from one step to
-	 * the next where the onboard store data has updated, but `currentStepRoute` hasn't yet because the step hasn't been rendered yet. This would cause the back button
-	 * to flash briefly while navigating.
+	 * If the previous step is defined in the store, it means we've navigated at least once, we can go back.
 	 */
-	const canUserGoBack =
-		( stepData?.previousStep &&
-			history.length > 1 &&
-			stepData.previousStep !== currentStepRoute ) ||
-		canUseAutomaticGoBack();
+	const canUserGoBack = ( stepData?.previousStep && history.length > 1 ) || canUseAutomaticGoBack();
 
 	const tracksEventPropsFromFlow = flow.useTracksEventProps?.();
 	const handleRecordStepNavigation = useCallback(


### PR DESCRIPTION
Fixes DOMAINS-1650

## Proposed Changes

This makes the conditions around rendering the back button, when the flow doesn't implement back handlers, more relaxed.

The final goal is to make it identical to the browsers back button, something we have no control over.

This reverts #102022 because it's no longer needed. The flicker happened because the domain step didn't have a back button, whereas the user step before it did. This made the back button appear for a few milliseconds after auth until the user is finally redirected to the domains step. But now the domain step has a back button, so if that of the user step appears, it's fine.


## Why are these changes being made?
Bug fix.

## Testing Instructions
1. Go to /setup/domain
2. Pick "Already have a domain?". 
3. Type anything and click Continue.
4. Click Back all the way to domain step.
5. It should work.