### PR TITLE
Dashboard v2: Activity Logs Filtering

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -292,6 +292,13 @@ export const siteLogsServerRoute = createRoute( {
 );
 
 export const siteLogsActivityRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Activity' ),
+			},
+		],
+	} ),
 	getParentRoute: () => siteLogsRoute,
 	path: 'activity',
 	loader: async ( { params: { siteSlug } } ) => {

--- a/client/dashboard/sites/logs-activity/dataviews/filters.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/filters.ts
@@ -1,8 +1,42 @@
-import { Filter } from '@wordpress/dataviews';
+import { decodeSearchParam } from '../../logs/dataviews/url-sync';
+import type { Filter } from '@wordpress/dataviews';
+
 export const ALLOWED_FILTER_FIELDS = [ 'activity_type' ];
 
 export const sanitizeFilters = ( filters?: Filter[] ): Filter[] =>
 	( filters ?? [] ).filter( ( filter ) => ALLOWED_FILTER_FIELDS.includes( filter.field ) );
+
+export const getInitialFiltersFromSearch = ( search: string ): Filter[] => {
+	const params = new URLSearchParams( search );
+	const raw = params.get( 'activity_type' );
+	if ( ! raw ) {
+		return [];
+	}
+	const values = raw
+		.split( ',' )
+		.map( ( token ) => decodeSearchParam( token ).trim() )
+		.filter( Boolean );
+	if ( values.length === 0 ) {
+		return [];
+	}
+	return [
+		{
+			field: 'activity_type',
+			operator: 'isAny',
+			value: Array.from( new Set( values ) ),
+		},
+	];
+};
+
+export const getInitialSearchTermFromSearch = ( search: string ): string | undefined => {
+	const params = new URLSearchParams( search );
+	const raw = params.get( 'search' );
+	if ( ! raw ) {
+		return undefined;
+	}
+	const decoded = decodeSearchParam( raw ).trim();
+	return decoded.length > 0 ? decoded : undefined;
+};
 
 export const extractActivityLogTypeValues = ( filters: Filter[] ): string[] => {
 	const filter = filters.find( ( item ) => item.field === 'activity_type' );

--- a/client/dashboard/sites/logs-activity/dataviews/filters.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/filters.ts
@@ -1,0 +1,22 @@
+import { Filter } from '@wordpress/dataviews';
+export const ALLOWED_FILTER_FIELDS = [ 'activity_type' ];
+
+export const sanitizeFilters = ( filters?: Filter[] ): Filter[] =>
+	( filters ?? [] ).filter( ( filter ) => ALLOWED_FILTER_FIELDS.includes( filter.field ) );
+
+export const extractActivityLogTypeValues = ( filters: Filter[] ): string[] => {
+	const filter = filters.find( ( item ) => item.field === 'activity_type' );
+	if ( ! filter ) {
+		return [];
+	}
+	const { value } = filter;
+	if ( Array.isArray( value ) ) {
+		return value.filter( ( item ): item is string => typeof item === 'string' && item.length > 0 );
+	}
+	if ( typeof value === 'string' && value.length > 0 ) {
+		return [ value ];
+	}
+	return [];
+};
+
+export const getValuesSignature = ( values: string[] ): string => values.slice().sort().join( ',' );

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -1,13 +1,18 @@
 import { SiteActivityLog, ActivityLogParams, LogType } from '@automattic/api-core';
-import { siteActivityLogQuery } from '@automattic/api-queries';
+import { siteActivityLogQuery, siteActivityLogGroupCountsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { DataViews, View, Field } from '@wordpress/dataviews';
+import { DataViews, View, Field, Filter } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 import { useMemo, useEffect } from 'react';
+import { filtersSignature } from '../../logs/dataviews/filters';
 import { buildTimeRangeInSeconds } from '../../logs/utils';
 import { useActivityActions } from './actions';
 import { useActivityFields } from './fields';
+import { extractActivityLogTypeValues, sanitizeFilters, ALLOWED_FILTER_FIELDS } from './filters';
 import { useActivityView } from './views';
 import type { SiteLogsDataViewsProps } from '../../logs/dataviews';
+
+import './style.scss';
 
 function SiteActivityLogsDataViews( {
 	gmtOffset,
@@ -26,6 +31,13 @@ function SiteActivityLogsDataViews( {
 		[ dateRange.start, dateRange.end, gmtOffset, timezoneString ]
 	);
 
+	const activityLogTypeValues = useMemo( () => {
+		const filters = ( view.filters as Filter[] | undefined ) ?? [];
+		return extractActivityLogTypeValues( filters );
+	}, [ view.filters ] );
+
+	const searchTerm = view.search?.trim() ?? '';
+
 	const activityLogQueryParams: ActivityLogParams = {
 		sort_order: view.sort?.direction,
 		number: view.perPage || 20,
@@ -34,19 +46,32 @@ function SiteActivityLogsDataViews( {
 		before: new Date( endSec * 1000 ).toISOString(),
 	};
 
-	const { data: activityLogData, isFetching } = useQuery(
+	if ( searchTerm ) {
+		activityLogQueryParams.text_search = searchTerm;
+	}
+	if ( activityLogTypeValues.length ) {
+		activityLogQueryParams.group = activityLogTypeValues;
+	}
+
+	const { data: activityLogData, isFetching: isFetchingData } = useQuery(
 		siteActivityLogQuery( site.ID, activityLogQueryParams )
 	);
 
-	// Reset pagination when the date range changes
-	useEffect( () => {
-		setView( ( next ) => ( { ...next, page: 1 } ) );
-	}, [ dateRangeVersion, setView ] );
+	/**
+	 * We're not passing the extra params, like text_search, to the query because that would make the group changes and
+	 * we would lose the selected filters descriptions in the UI.
+	 * The downside of this is that the counts might not be 100% accurate when a search term is applied.
+	 */
+	const { data: groupCountsData, isFetching: isFetchingFilters } = useQuery(
+		siteActivityLogGroupCountsQuery( site.ID )
+	);
+	const isFetching = isFetchingData || isFetchingFilters;
 
 	const logs = useMemo( () => {
-		const suffix = `p${ view.page }`;
-
+		const currentPage = view.page ?? 1;
+		const suffix = `p${ currentPage }`;
 		const items = activityLogData?.activityLogs ?? [];
+
 		return items.map( ( activity: SiteActivityLog, index: number ) => ( {
 			...activity,
 			id: `${ activity.activity_id }|${ suffix }|${ String( index ) }`,
@@ -59,17 +84,41 @@ function SiteActivityLogsDataViews( {
 	};
 
 	const fields = useActivityFields(
-		timezoneString ? { gmtOffset, timezoneString } : { gmtOffset }
+		timezoneString
+			? { gmtOffset, timezoneString, activityLogTypes: groupCountsData?.groups }
+			: { gmtOffset, activityLogTypes: groupCountsData?.groups }
 	);
 
 	const actions = useActivityActions( { isLoading: isFetching } );
 
 	const onChangeView = ( next: View ) => {
+		const nextFilters = sanitizeFilters( next.filters as Filter[] | undefined );
+		const nextSearch = next.search?.trim() ?? '';
+
+		const currentPage = view.page ?? 1;
+		const requestedPage = next.page ?? currentPage;
+
+		const perPageChanged = next.perPage !== view.perPage;
+		const sortChanged = next.sort?.direction !== view.sort?.direction;
+		const filtersChanged =
+			filtersSignature( nextFilters, ALLOWED_FILTER_FIELDS ) !==
+			filtersSignature( view.filters, ALLOWED_FILTER_FIELDS );
+
+		const searchChanged = nextSearch !== searchTerm;
+
+		const datasetChanged = perPageChanged || sortChanged || filtersChanged || searchChanged;
+
 		setView( {
 			...next,
-			filters: [],
+			page: datasetChanged ? 1 : requestedPage,
+			filters: nextFilters,
 		} );
 	};
+
+	// Reset pagination when the date range changes
+	useEffect( () => {
+		setView( ( next ) => ( { ...next, page: 1 } ) );
+	}, [ dateRangeVersion, setView ] );
 
 	return (
 		<DataViews< SiteActivityLog >
@@ -79,7 +128,8 @@ function SiteActivityLogsDataViews( {
 			fields={ fields as Field< SiteActivityLog >[] }
 			view={ view }
 			actions={ actions }
-			search={ false }
+			search
+			searchLabel={ __( 'Search posts by ID, title or author' ) }
 			defaultLayouts={ { table: {} } }
 			onChangeView={ onChangeView }
 		/>

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -44,6 +44,10 @@ function SiteActivityLogsDataViews( {
 		[ dateRange.start, dateRange.end, gmtOffset, timezoneString ]
 	);
 
+	// Convert to ISO strings since that's what the API expects.
+	const afterIso = new Date( startSec * 1000 ).toISOString();
+	const beforeIso = new Date( endSec * 1000 ).toISOString();
+
 	const activityLogTypeValues = useMemo( () => {
 		const filters = ( view.filters as Filter[] | undefined ) ?? [];
 		return extractActivityLogTypeValues( filters );
@@ -55,8 +59,8 @@ function SiteActivityLogsDataViews( {
 		sort_order: view.sort?.direction,
 		number: view.perPage || 20,
 		page: view.page,
-		after: new Date( startSec * 1000 ).toISOString(),
-		before: new Date( endSec * 1000 ).toISOString(),
+		after: afterIso,
+		before: beforeIso,
 	};
 
 	if ( searchTerm ) {
@@ -76,7 +80,11 @@ function SiteActivityLogsDataViews( {
 	 * The downside of this is that the counts might not be 100% accurate when a search term is applied.
 	 */
 	const { data: groupCountsData, isFetching: isFetchingFilters } = useQuery(
-		siteActivityLogGroupCountsQuery( site.ID )
+		siteActivityLogGroupCountsQuery( site.ID, {
+			after: afterIso,
+			before: beforeIso,
+			number: 1000,
+		} )
 	);
 	const isFetching = isFetchingData || isFetchingFilters;
 

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -1,14 +1,22 @@
 import { SiteActivityLog, ActivityLogParams, LogType } from '@automattic/api-core';
 import { siteActivityLogQuery, siteActivityLogGroupCountsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { DataViews, View, Field, Filter } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useEffect } from 'react';
 import { filtersSignature } from '../../logs/dataviews/filters';
+import { syncFiltersSearchParams } from '../../logs/dataviews/url-sync';
 import { buildTimeRangeInSeconds } from '../../logs/utils';
 import { useActivityActions } from './actions';
 import { useActivityFields } from './fields';
-import { extractActivityLogTypeValues, sanitizeFilters, ALLOWED_FILTER_FIELDS } from './filters';
+import {
+	extractActivityLogTypeValues,
+	sanitizeFilters,
+	ALLOWED_FILTER_FIELDS,
+	getInitialFiltersFromSearch,
+	getInitialSearchTermFromSearch,
+} from './filters';
 import { useActivityView } from './views';
 import type { SiteLogsDataViewsProps } from '../../logs/dataviews';
 
@@ -23,7 +31,12 @@ function SiteActivityLogsDataViews( {
 }: SiteLogsDataViewsProps & {
 	logType: typeof LogType.ACTIVITY;
 } ) {
-	const [ view, setView ] = useActivityView();
+	const router = useRouter();
+	const locationSearch = router.state.location.search;
+	const [ view, setView ] = useActivityView( {
+		initialFilters: sanitizeFilters( getInitialFiltersFromSearch( locationSearch ) ),
+		initialSearch: getInitialSearchTermFromSearch( locationSearch ),
+	} );
 
 	// buildTimeRangeInSeconds applies the proper timezone offset and normalizes to full-day bounds.
 	const { startSec, endSec } = useMemo(
@@ -94,6 +107,7 @@ function SiteActivityLogsDataViews( {
 	const onChangeView = ( next: View ) => {
 		const nextFilters = sanitizeFilters( next.filters as Filter[] | undefined );
 		const nextSearch = next.search?.trim() ?? '';
+		const nextSearchValue = nextSearch.length > 0 ? nextSearch : undefined;
 
 		const currentPage = view.page ?? 1;
 		const requestedPage = next.page ?? currentPage;
@@ -108,10 +122,20 @@ function SiteActivityLogsDataViews( {
 
 		const datasetChanged = perPageChanged || sortChanged || filtersChanged || searchChanged;
 
+		const url = new URL( window.location.href );
+		syncFiltersSearchParams( url.searchParams, ALLOWED_FILTER_FIELDS, nextFilters );
+		if ( nextSearchValue ) {
+			url.searchParams.set( 'search', nextSearchValue );
+		} else {
+			url.searchParams.delete( 'search' );
+		}
+		window.history.replaceState( null, '', url.pathname + url.search );
+
 		setView( {
 			...next,
 			page: datasetChanged ? 1 : requestedPage,
 			filters: nextFilters,
+			search: nextSearchValue,
 		} );
 	};
 

--- a/client/dashboard/sites/logs-activity/dataviews/style.scss
+++ b/client/dashboard/sites/logs-activity/dataviews/style.scss
@@ -1,0 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+.components-search-control.dataviews-search {
+	@include break-small {
+		min-width: 250px; // makes the placeholder text fully visible on bigger screens
+	}
+}

--- a/client/dashboard/sites/logs-activity/dataviews/test/filters.test.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/test/filters.test.ts
@@ -1,0 +1,59 @@
+import {
+	getInitialFiltersFromSearch,
+	getInitialSearchTermFromSearch,
+	extractActivityLogTypeValues,
+	getValuesSignature,
+} from '../filters';
+import type { Filter } from '@wordpress/dataviews';
+
+describe( 'logs-activity/dataviews/filters', () => {
+	describe( 'getInitialFiltersFromSearch', () => {
+		it( 'returns [] for empty or missing params', () => {
+			expect( getInitialFiltersFromSearch( '' ) ).toEqual( [] );
+			expect( getInitialFiltersFromSearch( '?foo=bar' ) ).toEqual( [] );
+		} );
+
+		it( 'parses activity_type with multiple, deduped values (order-insensitive check)', () => {
+			const out = getInitialFiltersFromSearch( '?activity_type=a,b,a%20c' );
+			expect( out ).toHaveLength( 1 );
+			expect( out[ 0 ] ).toMatchObject( { field: 'activity_type', operator: 'isAny' } );
+			const values = ( out[ 0 ] as Filter ).value as string[];
+			expect( values.sort() ).toEqual( [ 'a', 'a c', 'b' ].sort() );
+		} );
+	} );
+
+	describe( 'getInitialSearchTermFromSearch', () => {
+		it( 'decodes + and percent-encoding and trims whitespace', () => {
+			expect( getInitialSearchTermFromSearch( '?search=John+Doe' ) ).toBe( 'John Doe' );
+			expect( getInitialSearchTermFromSearch( '?search=a%2Bb' ) ).toBe( 'a b' );
+			expect( getInitialSearchTermFromSearch( '?search=%20' ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'extractActivityLogTypeValues', () => {
+		it( 'extracts array values, filtering empties and non-strings', () => {
+			const filters = [
+				{ field: 'activity_type', operator: 'isAny', value: [ 'one', '', 'two' ] },
+			] as unknown as Filter[];
+			expect( extractActivityLogTypeValues( filters ).sort() ).toEqual( [ 'one', 'two' ] );
+		} );
+
+		it( 'extracts single string value', () => {
+			const filters = [
+				{ field: 'activity_type', operator: 'isAny', value: 'single' },
+			] as unknown as Filter[];
+			expect( extractActivityLogTypeValues( filters ) ).toEqual( [ 'single' ] );
+		} );
+
+		it( 'returns [] when no matching filter', () => {
+			expect( extractActivityLogTypeValues( [] ) ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'getValuesSignature', () => {
+		it( 'produces a stable, sorted signature', () => {
+			expect( getValuesSignature( [ 'b', 'a', 'b' ] ) ).toBe( 'a,b,b' );
+			expect( getValuesSignature( [] ) ).toBe( '' );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/logs-activity/dataviews/views.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/views.ts
@@ -3,8 +3,10 @@ import type { View } from '@wordpress/dataviews';
 
 export function useActivityView( {
 	initialFilters,
+	initialSearch,
 }: {
 	initialFilters?: View[ 'filters' ];
+	initialSearch?: string;
 } = {} ) {
 	return useState< View >( () => ( {
 		type: 'table',
@@ -25,5 +27,6 @@ export function useActivityView( {
 				actor: { maxWidth: '150px', minWidth: '75px' },
 			},
 		},
+		search: initialSearch ?? undefined,
 	} ) );
 }

--- a/client/dashboard/sites/logs/dataviews/filters.ts
+++ b/client/dashboard/sites/logs/dataviews/filters.ts
@@ -1,4 +1,5 @@
 import { LogType } from '@automattic/api-core';
+import { decodeSearchParam } from './url-sync';
 import type { Filter } from '@wordpress/dataviews';
 
 export function filtersSignature(
@@ -41,15 +42,6 @@ export function getInitialFiltersFromSearch( logType: LogType, search: string ):
 	const allowed = getAllowedFields( logType );
 	const params = new URLSearchParams( search );
 
-	const decode = ( value: string ): string => {
-		const withSpaces = value.replace( /\+/g, ' ' );
-		try {
-			return decodeURIComponent( withSpaces );
-		} catch {
-			return withSpaces;
-		}
-	};
-
 	const normalizeSeverity = ( values: string[] ): string[] =>
 		Array.from(
 			new Set(
@@ -67,7 +59,7 @@ export function getInitialFiltersFromSearch( logType: LogType, search: string ):
 		}
 		let values = raw
 			.split( ',' )
-			.map( ( rawToken ) => decode( rawToken ).trim() )
+			.map( ( rawToken ) => decodeSearchParam( rawToken ).trim() )
 			.filter( Boolean );
 		if ( field === 'severity' ) {
 			values = normalizeSeverity( values );

--- a/client/dashboard/sites/logs/dataviews/filters.ts
+++ b/client/dashboard/sites/logs/dataviews/filters.ts
@@ -1,6 +1,21 @@
 import { LogType } from '@automattic/api-core';
 import type { Filter } from '@wordpress/dataviews';
 
+export function filtersSignature(
+	filters: Filter[] | undefined,
+	allowed: ReadonlyArray< string >
+): string {
+	return allowed
+		.slice()
+		.sort()
+		.map( ( field ) => {
+			const raw = filters?.find( ( filter ) => filter.field === field )?.value;
+			const values = Array.isArray( raw ) ? ( raw as string[] ).slice().sort() : [];
+			return `${ field }:${ values.slice().sort().join( ',' ) }`;
+		} )
+		.join( '|' );
+}
+
 const SEVERITY_LABELS: Readonly< Record< string, string > > = {
 	user: 'User',
 	warning: 'Warning',

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -13,27 +13,12 @@ import { LogsDownloader } from '../downloader';
 import { buildTimeRangeInSeconds } from '../utils';
 import { useActions } from './actions';
 import { useFields } from './fields';
-import { getInitialFiltersFromSearch, getAllowedFields } from './filters';
+import { getInitialFiltersFromSearch, getAllowedFields, filtersSignature } from './filters';
 import { useView, toFilterParams } from './views';
 import type { Site } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
 import './style.scss';
 import type { Dispatch, SetStateAction } from 'react';
-
-function filtersSignature(
-	filters: Filter[] | undefined,
-	allowed: ReadonlyArray< string >
-): string {
-	return allowed
-		.slice()
-		.sort()
-		.map( ( field ) => {
-			const raw = filters?.find( ( filter ) => filter.field === field )?.value;
-			const values = Array.isArray( raw ) ? ( raw as string[] ).slice().sort() : [];
-			return `${ field }:${ values.slice().sort().join( ',' ) }`;
-		} )
-		.join( '|' );
-}
 
 export type SiteLogsDataViewsProps = {
 	dateRange: { start: Date; end: Date };

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -14,6 +14,7 @@ import { buildTimeRangeInSeconds } from '../utils';
 import { useActions } from './actions';
 import { useFields } from './fields';
 import { getInitialFiltersFromSearch, getAllowedFields, filtersSignature } from './filters';
+import { syncFiltersSearchParams } from './url-sync';
 import { useView, toFilterParams } from './views';
 import type { Site } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -178,18 +179,7 @@ function SiteLogsDataViews( {
 
 		// Sync allowed filters to URL using sourceFilters
 		const url = new URL( window.location.href );
-		const isEmpty = ( value?: string[] ) => ! value || value.length === 0;
-		allowed.forEach( ( field ) => {
-			const value =
-				( sourceFilters.find( ( filter ) => filter.field === field )?.value as
-					| string[]
-					| undefined ) || [];
-			if ( isEmpty( value ) ) {
-				url.searchParams.delete( field );
-			} else {
-				url.searchParams.set( field, value.slice().sort().toString() );
-			}
-		} );
+		syncFiltersSearchParams( url.searchParams, allowed, sourceFilters );
 		window.history.replaceState( null, '', url.pathname + url.search );
 
 		// Apply view with only allowed filters; reset page/cursors if dataset changed

--- a/client/dashboard/sites/logs/dataviews/test/filters.test.ts
+++ b/client/dashboard/sites/logs/dataviews/test/filters.test.ts
@@ -1,0 +1,19 @@
+import { filtersSignature } from '../filters';
+import type { Filter } from '@wordpress/dataviews';
+
+describe( 'logs/dataviews/filters', () => {
+	it( 'filtersSignature generates canonical, field-ordered, value-sorted signature', () => {
+		const filters = [
+			{ field: 'c', operator: 'isAny', value: [ 'x' ] },
+			{ field: 'a', operator: 'isAny', value: [ 'b', 'a' ] },
+		] as unknown as Filter[];
+		const sig = filtersSignature( filters, [ 'c', 'a' ] );
+		expect( sig ).toBe( 'a:a,b|c:x' );
+	} );
+
+	it( 'handles undefined filters and empty values', () => {
+		expect( filtersSignature( undefined, [ 'a' ] ) ).toBe( 'a:' );
+		const filters = [ { field: 'a', operator: 'isAny', value: [] } ] as unknown as Filter[];
+		expect( filtersSignature( filters, [ 'a' ] ) ).toBe( 'a:' );
+	} );
+} );

--- a/client/dashboard/sites/logs/dataviews/test/url-sync.test.ts
+++ b/client/dashboard/sites/logs/dataviews/test/url-sync.test.ts
@@ -1,0 +1,34 @@
+import { syncFiltersSearchParams, decodeSearchParam } from '../url-sync';
+import type { Filter } from '@wordpress/dataviews';
+
+describe( 'logs/dataviews/url-sync', () => {
+	describe( 'decodeSearchParam', () => {
+		it( 'decodes plus-as-space and percent-encoding', () => {
+			expect( decodeSearchParam( 'John+Doe' ) ).toBe( 'John Doe' );
+			expect( decodeSearchParam( 'a%2Bb' ) ).toBe( 'a+b' );
+		} );
+	} );
+
+	describe( 'syncFiltersSearchParams', () => {
+		it( 'sets deduped, trimmed, sorted values for allowed fields', () => {
+			const params = new URLSearchParams( 'foo=bar&activity_type=old' );
+			const allowed = [ 'activity_type', 'other' ] as const;
+			const filters = [
+				{ field: 'activity_type', operator: 'isAny', value: [ ' b ', 'a', 'a' ] },
+				{ field: 'other', operator: 'isAny', value: [] },
+			] as unknown as Filter[];
+			syncFiltersSearchParams( params, allowed, filters );
+			expect( params.get( 'activity_type' ) ).toBe( 'a,b' );
+			// "other" should be deleted because it is empty
+			expect( params.has( 'other' ) ).toBe( false );
+			// unrelated params remain
+			expect( params.get( 'foo' ) ).toBe( 'bar' );
+		} );
+
+		it( 'deletes param when values are empty', () => {
+			const params = new URLSearchParams( 'activity_type=a' );
+			syncFiltersSearchParams( params, [ 'activity_type' ], [] );
+			expect( params.has( 'activity_type' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/logs/dataviews/url-sync.ts
+++ b/client/dashboard/sites/logs/dataviews/url-sync.ts
@@ -1,0 +1,56 @@
+import type { Filter } from '@wordpress/dataviews';
+
+const getFilterValues = ( filters: Filter[], field: string ): string[] => {
+	const raw = filters.find( ( filter ) => filter.field === field )?.value;
+
+	if ( Array.isArray( raw ) ) {
+		return raw
+			.map( ( value ) => ( typeof value === 'string' ? value : String( value ) ) )
+			.filter( ( value ) => value.length > 0 );
+	}
+
+	if ( typeof raw === 'string' && raw.length > 0 ) {
+		return [ raw ];
+	}
+
+	return [];
+};
+
+const setMultiValueParam = ( searchParams: URLSearchParams, key: string, values: string[] ) => {
+	if ( values.length === 0 ) {
+		searchParams.delete( key );
+		return;
+	}
+
+	const uniqueValues = Array.from( new Set( values ) )
+		.map( ( value ) => value.trim() )
+		.filter( Boolean )
+		.sort();
+
+	if ( uniqueValues.length === 0 ) {
+		searchParams.delete( key );
+		return;
+	}
+
+	searchParams.set( key, uniqueValues.join( ',' ) );
+};
+
+export const syncFiltersSearchParams = (
+	searchParams: URLSearchParams,
+	allowedFields: ReadonlyArray< string >,
+	filters: Filter[]
+) => {
+	allowedFields.forEach( ( field ) => {
+		const values = getFilterValues( filters, field );
+		setMultiValueParam( searchParams, field, values );
+	} );
+};
+
+export const decodeSearchParam = ( value: string ): string => {
+	const withSpaces = value.replace( /\+/g, ' ' );
+	try {
+		return decodeURIComponent( withSpaces );
+	} catch {
+		return withSpaces;
+	}
+};

--- a/packages/api-core/src/site-activity-log/fetchers.ts
+++ b/packages/api-core/src/site-activity-log/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { ActivityLogParams, ActivityLogsData } from './types';
+import type { ActivityLogParams, ActivityLogsData, ActivityLogGroupCountResponse } from './types';
 
 export async function fetchSiteActivityLog(
 	siteId: number,
@@ -20,4 +20,19 @@ export async function fetchSiteActivityLog(
 		itemsPerPage: response.itemsPerPage,
 		totalPages: response.totalPages,
 	};
+}
+
+export async function fetchSiteActivityLogGroupCounts(
+	siteId: number,
+	params: ActivityLogParams
+): Promise< ActivityLogGroupCountResponse > {
+	const response = await wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/activity/count/group`,
+			apiNamespace: 'wpcom/v2',
+		},
+		params
+	);
+
+	return response;
 }

--- a/packages/api-core/src/site-activity-log/types.ts
+++ b/packages/api-core/src/site-activity-log/types.ts
@@ -62,6 +62,16 @@ export interface ActivityLogResponse {
 	totalPages: number;
 }
 
+export interface ActivityLogGroupCountResponse {
+	groups: {
+		[ group: string ]: {
+			name: string;
+			count: number;
+		};
+	};
+	totalItems: number;
+}
+
 // Activity Log: shared primitives
 
 export interface ActivityImage {
@@ -103,7 +113,7 @@ export interface ActivityLogParams {
 	date_range?: string;
 	number?: number;
 	not_group?: string;
-	group?: string;
+	group?: string[];
 	name?: string;
 	text_search?: string;
 }

--- a/packages/api-queries/src/site-activity-log.ts
+++ b/packages/api-queries/src/site-activity-log.ts
@@ -20,7 +20,7 @@ export const siteActivityLogQuery = ( siteId: number, activityLogQueryParams: Ac
 
 export const siteActivityLogGroupCountsQuery = (
 	siteId: number,
-	activityLogQueryParams: ActivityLogParams
+	activityLogQueryParams: ActivityLogParams = { number: 1000 } // we're getting the count for the latest 1000 items to list the available groups
 ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'activity-log', 'group-counts', activityLogQueryParams ],

--- a/packages/api-queries/src/site-activity-log.ts
+++ b/packages/api-queries/src/site-activity-log.ts
@@ -1,4 +1,8 @@
-import { fetchSiteActivityLog, ActivityLogParams } from '@automattic/api-core';
+import {
+	fetchSiteActivityLog,
+	ActivityLogParams,
+	fetchSiteActivityLogGroupCounts,
+} from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
 export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
@@ -12,4 +16,13 @@ export const siteActivityLogQuery = ( siteId: number, activityLogQueryParams: Ac
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'activity-log', activityLogQueryParams ],
 		queryFn: () => fetchSiteActivityLog( siteId, activityLogQueryParams ),
+	} );
+
+export const siteActivityLogGroupCountsQuery = (
+	siteId: number,
+	activityLogQueryParams: ActivityLogParams
+) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'activity-log', 'group-counts', activityLogQueryParams ],
+		queryFn: () => fetchSiteActivityLogGroupCounts( siteId, activityLogQueryParams ),
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Implements DOTDASH-434

## Proposed Changes

* Adds support for Activity Type filtering as well as generic post id/author search
* This PR also locks the Activity Event/Actor columns are requested in DOTDASH-399
* Add support for saving the filters in the URL and restoring the filters from the URL (similar to what we already have for Server Logs)
* Add Activity Logs page title

**Notes:** 
Previous logic was to retrieve the activity types and print the amount of available items. For now I've kept it identical, with the number of the available items printed alongside the activity type name. Since this is based on the count from the first 1000 results, it's a good representation, but I do think the number is a little bit misleading since it doesn't update when you search (intentionally, or we'd lose the labels since the labels are available via the count endpoint).

The Activity Type filter is added as a hidden field that's not being shown by default.
The search box placeholder is the same as the previous dashboard.

**TODO**

- [ ] Once #105930 is merged, update this PR by disabling filtering when we're on the free plan. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Porting logic from the previous dashboard to have feature parity.

### Before (previous dashboard)

<img width="1880" height="358" alt="CleanShot 2025-09-23 at 12 43 10@2x" src="https://github.com/user-attachments/assets/3946b303-e720-4503-a769-13fc8bdf139c" />

### After
<img width="2900" height="1988" alt="CleanShot 2025-09-23 at 13 55 30@2x" src="https://github.com/user-attachments/assets/ac16aae9-9b17-4276-aeb4-aaee7bd663cd" />

**Activity Type filter**
<img width="1236" height="1236" alt="CleanShot 2025-09-23 at 13 54 46@2x" src="https://github.com/user-attachments/assets/5fceeb68-83fb-49ef-b454-6fba9a35db94" />


**Table with filters and activity type column**
<img width="2956" height="1254" alt="CleanShot 2025-09-23 at 13 55 04@2x" src="https://github.com/user-attachments/assets/65c3a827-d99c-40a1-82b4-108a823228da" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/v2/sites/<site>/logs/activity` and try to filter by some activity type the url should change and include the filter
* Search for an author name, the URL should change and the table should display both filters.
* If you copy that URL and go there, you will be presented the same filter/search.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
