### PR TITLE
STATS-149: Make selected nav color readable on mobile.

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -31,6 +31,11 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	font-family: $font-sf-pro-display;
 }
 
+.stats {
+	--color-link: var(--theme-highlight-color);
+	--color-link-dark: var(--color-accent-dark);
+}
+
 // Module container
 @include breakpoint-deprecated( ">960px" ) {
 	.stats__module-column {
@@ -103,19 +108,6 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	.horizontal-bar-list-item--additional,
 	.stats-card-header__additional {
 		font-weight: 500;
-	}
-}
-
-.stats {
-	a,
-	a:visited  {
-		color: var(--theme-highlight-color);
-	}
-
-	a:hover,
-	a:focus,
-	a:active {
-		color: var(--color-accent-dark);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes of # STATS-149

## Proposed Changes

* Increase the specificity of selected nav style.

## Why are these changes being made?

* The property was being overridden by other unrelated CSS rules with strong specificity. So, used `!important` to overrule that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch calypso and visit the stats page (maybe this: `http://calypso.localhost:3000/stats/day/jetpack.com`)
* In mobile view, the selected nav text is readable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
