### PR TITLE
Staging Sites in V2: Update submit button disabled state logic in staging site sync modal

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -364,14 +364,11 @@ function StagingSiteSyncModalInner( {
 
 	const showDomainConfirmation = targetEnvironment === 'production' && ! isLoadingBackupAttempt;
 
-	const isGranularMode = isFileBrowserVisible && ! shouldDisableGranularSync;
-
-	const noGranularSelection =
-		isGranularMode && browserCheckList.totalItems > 0 && browserCheckList.includeList.length === 0;
-
 	const isSubmitDisabled =
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
-		noGranularSelection ||
+		( browserCheckList.totalItems === 0 &&
+			browserCheckList.includeList.length === 0 &&
+			lastKnownBackupAttempt ) ||
 		pullMutation.isPending ||
 		pushMutation.isPending;
 

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -368,7 +368,7 @@ function StagingSiteSyncModalInner( {
 		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
 		( browserCheckList.totalItems === 0 &&
 			browserCheckList.includeList.length === 0 &&
-			lastKnownBackupAttempt ) ||
+			!! lastKnownBackupAttempt ) ||
 		pullMutation.isPending ||
 		pushMutation.isPending;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14681

## Proposed Changes

* update the logic that disables the Sync modal submit button (reuse the logic we have been using in V1) 

| Before | After |
|--------|--------|
| <img width="1804" height="832" alt="Markup on 2025-09-23 at 16:34:40" src="https://github.com/user-attachments/assets/45570d70-49ae-4cba-bb85-ae8cf88f8bad" /> |<img width="1734" height="790" alt="Markup on 2025-09-23 at 16:41:38" src="https://github.com/user-attachments/assets/7030ddaa-8210-4b29-b3d5-de9e61001298" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To address DOTCOM-14681.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn install && yarn start` (or use the Calypso Live link below).
2. Head over to the Overview tab in V2 dashboard of an existing WoA site that has a staging site created.
3. Click the Sync button and select one of the options from the dropdown menu.
4. Ensure that when no of the options is selected, the submit button is disabled.
5. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
