### PR TITLE
Hosting Dashboard Plugins: Show whether updates are managed when that's the case for all sites with the plugin

### DIFF
--- a/client/dashboard/plugins/manage/fields/update-available.ts
+++ b/client/dashboard/plugins/manage/fields/update-available.ts
@@ -5,7 +5,13 @@ import type { Field } from '@wordpress/dataviews';
 export const updateAvailableField: Field< PluginListRow > = {
 	id: 'updateAvailable',
 	label: __( 'Update Available' ),
-	getValue: ( { item } ) => ( [ 'some', 'all' ].includes( item.hasUpdate ) ? 1 : 0 ),
+	getValue: ( { item } ) => {
+		if ( item.areAutoUpdatesAllowed === 'none' ) {
+			return 0;
+		}
+
+		return [ 'some', 'all' ].includes( item.hasUpdate ) ? 2 : 1;
+	},
 	enableHiding: false,
 	enableSorting: true,
 	elements: [

--- a/client/dashboard/plugins/manage/fields/update-available.ts
+++ b/client/dashboard/plugins/manage/fields/update-available.ts
@@ -14,7 +14,7 @@ export const updateAvailableField: Field< PluginListRow > = {
 	],
 	render: ( { item } ) => {
 		if ( item.areAutoUpdatesAllowed === 'none' ) {
-			return __( 'Auto-managed on this site' );
+			return __( 'Updates auto-managed' );
 		}
 
 		return [ 'some', 'all' ].includes( item.hasUpdate ) ? __( 'Yes' ) : __( 'No' );

--- a/client/dashboard/plugins/manage/fields/update-available.ts
+++ b/client/dashboard/plugins/manage/fields/update-available.ts
@@ -15,8 +15,9 @@ export const updateAvailableField: Field< PluginListRow > = {
 	enableHiding: false,
 	enableSorting: true,
 	elements: [
-		{ value: 1, label: __( 'Yes' ) },
-		{ value: 0, label: __( 'No' ) },
+		{ value: 2, label: __( 'Yes' ) },
+		{ value: 1, label: __( 'No' ) },
+		{ value: 0, label: __( 'Updates auto-managed' ) },
 	],
 	render: ( { item } ) => {
 		if ( item.areAutoUpdatesAllowed === 'none' ) {

--- a/client/dashboard/plugins/manage/fields/update-available.ts
+++ b/client/dashboard/plugins/manage/fields/update-available.ts
@@ -12,6 +12,11 @@ export const updateAvailableField: Field< PluginListRow > = {
 		{ value: 1, label: __( 'Yes' ) },
 		{ value: 0, label: __( 'No' ) },
 	],
-	render: ( { item } ) =>
-		[ 'some', 'all' ].includes( item.hasUpdate ) ? __( 'Yes' ) : __( 'No' ),
+	render: ( { item } ) => {
+		if ( item.areAutoUpdatesAllowed === 'none' ) {
+			return __( 'Auto-managed on this site' );
+		}
+
+		return [ 'some', 'all' ].includes( item.hasUpdate ) ? __( 'Yes' ) : __( 'No' );
+	},
 };

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -1,4 +1,4 @@
-import { marketplaceSearchQuery, pluginsQuery } from '@automattic/api-queries';
+import { marketplaceSearchQuery, pluginsQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -17,9 +17,13 @@ import './style.scss';
 
 export default function PluginsList() {
 	const { data: sitesPlugins, isLoading: isLoadingPlugins } = useQuery( pluginsQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
 	const actions = getActions();
 	const [ view, setView ] = useState( defaultView );
-	const data = useMemo( () => mapApiPluginsToDataViewPlugins( sitesPlugins ), [ sitesPlugins ] );
+	const data = useMemo(
+		() => mapApiPluginsToDataViewPlugins( sites, sitesPlugins ),
+		[ sites, sitesPlugins ]
+	);
 
 	const { data: filteredPlugins, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
@@ -56,7 +60,7 @@ export default function PluginsList() {
 		>
 			<DataViewsCard>
 				<DataViews
-					isLoading={ isLoadingPlugins || isLoadingMarketplace }
+					isLoading={ isLoadingPlugins || isLoadingMarketplace || isLoadingSites }
 					data={ filteredPluginsWithIcons ?? [] }
 					fields={ fields }
 					view={ view }

--- a/client/dashboard/plugins/manage/types.ts
+++ b/client/dashboard/plugins/manage/types.ts
@@ -10,6 +10,7 @@ export type PluginListRow = {
 	sitesCount: number;
 	isActive: 'all' | 'some' | 'none';
 	hasUpdate: 'all' | 'some' | 'none';
+	areAutoUpdatesAllowed: 'all' | 'some' | 'none';
 	areAutoUpdatesEnabled: 'all' | 'some' | 'none';
 	siteIds: number[]; // list of site IDs where this plugin exists
 };

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -206,14 +206,15 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			isActivating,
 			isDeactivating,
 			isFetching,
-			activateMutate,
+			plugin?.name,
 			plugin?.id,
 			deactivateMutate,
+			activateMutate,
 			isEnablingAutoupdate,
 			isDisablingAutoupdate,
-			enableAutoupdateMutate,
-			disableAutoupdateMutate,
 			pluginSlug,
+			disableAutoupdateMutate,
+			enableAutoupdateMutate,
 		]
 	);
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-274/hosting-dashboard-plugins-update-field-should-show-managed-even-when

## Proposed Changes

* On the plugins dashboard, if the plugin is auto-managed for all sites that have it installed, say so to the user.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See [this comment](https://linear.app/a8c/project/hosting-dashboard-plugins-e31435ab03dc/updates#projectUpdate-1db34223&comment-8c18f8ab).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `/v2/plugins`
* Check that you see the `Updates auto-managed` message on the `Update Available` column

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
