### PR TITLE
Staging Sites in V2: Replace `InputControl` with `DataForm` for domain confirmation in staging sync modal

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -377,11 +377,11 @@ function StagingSiteSyncModalInner( {
 	const fields: Field< StagingSiteSyncFormData >[] = [
 		{
 			id: 'domain',
-			label: __( "Enter your site's name to confirm" ),
+			label: __( 'Type the site domain to confirm' ),
 			type: 'text' as const,
 			description: sprintf(
 				/* translators: %s: site domain */
-				__( "The site's name is: %s" ),
+				__( 'The site domain is: %s' ),
 				productionSiteSlug || ''
 			),
 		},

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -382,7 +382,7 @@ function StagingSiteSyncModalInner( {
 			description: sprintf(
 				/* translators: %s: site domain */
 				__( 'The site domain is: %s' ),
-				productionSiteSlug || ''
+				productionSiteSlug
 			),
 		},
 	];

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -524,7 +524,7 @@ function StagingSiteSyncModalInner( {
 							data={ formData }
 							fields={ fields }
 							form={ { layout: { type: 'regular' as const }, fields } }
-							onChange={ ( edits: { domain?: string } ) => {
+							onChange={ ( edits: Partial< StagingSiteSyncFormData > ) => {
 								setFormData( ( data ) => ( {
 									...data,
 									...edits,

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -13,12 +13,12 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalInputControl as InputControl,
 	CheckboxControl,
 	SelectControl,
 } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement, useState, useCallback, useMemo } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import useRewindableActivityLogQuery from '../../../data/activity-log/use-rewindable-activity-log-query';
 import { SUCCESSFUL_BACKUP_ACTIVITIES } from '../../../lib/jetpack/backup-utils';
@@ -34,6 +34,7 @@ import Environment, { EnvironmentType } from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import type { FileBrowserConfig } from '../../../my-sites/backup/backup-contents-page/file-browser';
+import type { Field } from '@wordpress/dataviews';
 
 // File browser config used for granular selection
 const fileBrowserConfig: FileBrowserConfig = {
@@ -49,6 +50,10 @@ const fileBrowserConfig: FileBrowserConfig = {
 };
 
 type BackupActivity = { rewindId: number; activityTs: number };
+
+type StagingSiteSyncFormData = {
+	domain: string;
+};
 
 const DirectionArrow = () => {
 	return (
@@ -167,7 +172,9 @@ function StagingSiteSyncModalInner( {
 }: StagingSiteSyncModalProps ) {
 	const syncConfig = getSyncConfig( syncType );
 	const { recordTracksEvent } = useAnalytics();
-	const [ domainConfirmation, setDomainConfirmation ] = useState( '' );
+	const [ formData, setFormData ] = useState< StagingSiteSyncFormData >( {
+		domain: '',
+	} );
 	const [ isFileBrowserVisible, setIsFileBrowserVisible ] = useState( false );
 
 	const targetEnvironment = syncConfig[ environment ].syncTo;
@@ -357,20 +364,28 @@ function StagingSiteSyncModalInner( {
 		}
 	};
 
-	const handleDomainConfirmation = useCallback(
-		( value: string | undefined ) => setDomainConfirmation( value || '' ),
-		[]
-	);
-
 	const showDomainConfirmation = targetEnvironment === 'production' && ! isLoadingBackupAttempt;
 
 	const isSubmitDisabled =
-		( showDomainConfirmation && domainConfirmation !== productionSiteSlug ) ||
+		( showDomainConfirmation && formData.domain !== productionSiteSlug ) ||
 		( browserCheckList.totalItems === 0 &&
 			browserCheckList.includeList.length === 0 &&
 			!! lastKnownBackupAttempt ) ||
 		pullMutation.isPending ||
 		pushMutation.isPending;
+
+	const fields: Field< StagingSiteSyncFormData >[] = [
+		{
+			id: 'domain',
+			label: __( "Enter your site's name to confirm" ),
+			type: 'text' as const,
+			description: sprintf(
+				/* translators: %s: site domain */
+				__( "The site's name is: %s" ),
+				productionSiteSlug || ''
+			),
+		},
+	];
 
 	return (
 		<Modal title={ syncConfig[ environment ].title } onRequestClose={ handleClose } size="large">
@@ -505,21 +520,17 @@ function StagingSiteSyncModalInner( {
 					</VStack>
 
 					{ showDomainConfirmation && (
-						<InputControl
-							__next40pxDefaultSize
-							label={
-								<HStack style={ { textTransform: 'none' } } alignment="left" spacing={ 1 }>
-									<Text>
-										{ __( 'Enter your site‘s name' ) }{ ' ' }
-										<Text color="var(--dashboard__foreground-color-error)">
-											{ productionSiteSlug }
-										</Text>{ ' ' }
-										{ __( 'to confirm.' ) }
-									</Text>
-								</HStack>
-							}
-							onChange={ handleDomainConfirmation }
-							value={ domainConfirmation }
+						<DataForm< StagingSiteSyncFormData >
+							data={ formData }
+							fields={ fields }
+							form={ { layout: { type: 'regular' as const }, fields } }
+							onChange={ ( edits: { domain?: string } ) => {
+								setFormData( ( data ) => ( {
+									...data,
+									...edits,
+									domain: edits.domain?.trim() ?? data.domain,
+								} ) );
+							} }
 						/>
 					) }
 					<HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14668

## Proposed Changes

* replace `InputControl` with `DataForm` for domain confirmation in staging sync modal

| Before | After |
|--------|--------|
| <img width="1730" height="958" alt="Markup on 2025-09-23 at 17:02:25" src="https://github.com/user-attachments/assets/2273b309-ccbe-4568-a720-1ab932920795" /> | <img width="1736" height="1016" alt="Markup on 2025-09-24 at 11:08:59" src="https://github.com/user-attachments/assets/72f57a3e-082b-4424-be15-672143d63dc6" /> | 




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To resolve DOTCOM-14668 and use the same domain confirmation that has been used in the V2 dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `yarn install && yarn start` (or use the Calypso Live link below).
2. Head over to the Overview tab in V2 dashboard of an existing WoA site that has a staging site created.
3. Click the Sync button and select `Push to production` or `Pull from staging` option from the dropdown menu (depending on whether you are on the production or staging site). The goal is to open the modal that is syncing from staging to production.
4. Tick one or more checkboxes in the modal.
5. Ensure that the domain confirmation text field is working correctly (i.e. the submit button should be disabled until the text field includes the exact production site address).
6. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
