### PR TITLE
Discover: do not attempt to dynamically get the tab title

### DIFF
--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, fixMe } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { addQueryArgs } from 'calypso/lib/url';
 import DiscoverNavigation from 'calypso/reader/discover/components/navigation';
@@ -46,7 +46,14 @@ export default function DiscoverHeaderAndNavigation(
 			subHeaderText = translate( 'Follow your favorite subreddits inside the Reader.' );
 			break;
 		case RECOMMENDED_TAB:
-			subHeaderText = translate( 'Explore popular blogs that inspire, educate, and entertain.' );
+			subHeaderText = fixMe( {
+				text: 'Explore popular blogs that inspire, educate, and entertain.',
+				newCopy: translate( 'Explore popular blogs that inspire, educate, and entertain.' ),
+				oldCopy: translate( 'Explore %s blogs that inspire, educate, and entertain.', {
+					args: [ 'popular' ],
+					comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
+				} ),
+			} );
 			break;
 		case FRESHLY_PRESSED_TAB:
 			subHeaderText = translate( "Our team's favorite blog posts." );

--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from 'calypso/lib/url';
 import DiscoverNavigation from 'calypso/reader/discover/components/navigation';
 import DiscoverTagsNavigation from 'calypso/reader/discover/components/tags-navigation';
 import {
-	getSelectedTabTitle,
 	FIRST_POSTS_TAB,
 	ADD_NEW_TAB,
 	REDDIT_TAB,
@@ -17,16 +16,14 @@ import {
 
 export interface DiscoverHeaderAndNavigationProps {
 	selectedTab: string;
-	effectiveTabSelection: string;
 	selectedTag?: string;
 }
 
 export default function DiscoverHeaderAndNavigation(
 	props: DiscoverHeaderAndNavigationProps
 ): JSX.Element {
-	const { selectedTab, effectiveTabSelection, selectedTag } = props;
+	const { selectedTab, selectedTag } = props;
 	const currentLocale = useLocale();
-	const tabTitle = getSelectedTabTitle( effectiveTabSelection );
 	const translate = useTranslate();
 
 	function handleTagSelect( tag: string ): void {
@@ -49,10 +46,7 @@ export default function DiscoverHeaderAndNavigation(
 			subHeaderText = translate( 'Follow your favorite subreddits inside the Reader.' );
 			break;
 		case RECOMMENDED_TAB:
-			subHeaderText = translate( 'Explore %s blogs that inspire, educate, and entertain.', {
-				args: [ tabTitle ],
-				comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
-			} );
+			subHeaderText = translate( 'Explore popular blogs that inspire, educate, and entertain.' );
 			break;
 		case FRESHLY_PRESSED_TAB:
 			subHeaderText = translate( "Our team's favorite blog posts." );

--- a/client/reader/discover/discover-document-head.js
+++ b/client/reader/discover/discover-document-head.js
@@ -1,13 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 
-export const DiscoverDocumentHead = ( { tabTitle } ) => {
+export const DiscoverDocumentHead = () => {
 	const translate = useTranslate();
 
-	const title = translate( 'Browse %s blogs & read articles ‹ Reader', {
-		args: [ tabTitle ],
-		comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
-	} );
+	const title = translate( 'Browse popular blogs & read articles ‹ Reader' );
 
 	const meta = [
 		{

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -28,7 +28,6 @@ const DiscoverStream = ( props ) => {
 	const headerAndNavigationProps = {
 		width: props.width,
 		selectedTab: selectedTab,
-		effectiveTabSelection: effectiveTabSelection,
 		selectedTag: selectedTag,
 	};
 

--- a/client/reader/discover/helper/index.ts
+++ b/client/reader/discover/helper/index.ts
@@ -27,23 +27,6 @@ export function getDiscoverStreamTags( tags: string[] | null, isLoggedIn: boolea
 	return tags;
 }
 
-export function getSelectedTabTitle( selectedTab: string ) {
-	if ( selectedTab === RECOMMENDED_TAB ) {
-		return 'popular';
-	}
-
-	if ( selectedTab === LATEST_TAB ) {
-		return 'new';
-	}
-	if ( selectedTab === FIRST_POSTS_TAB ) {
-		return 'fresh';
-	}
-	if ( selectedTab === FRESHLY_PRESSED_TAB ) {
-		return 'Freshly Pressed';
-	}
-	return decodeURIComponent( selectedTab );
-}
-
 export function getDefaultTab() {
 	return isEnabled( 'reader/discover/freshly-pressed' ) ? FRESHLY_PRESSED_TAB : RECOMMENDED_TAB;
 }

--- a/client/reader/discover/index.node.js
+++ b/client/reader/discover/index.node.js
@@ -4,21 +4,17 @@ import DiscoverHeaderAndNavigation from 'calypso/reader/discover/components/head
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
-import { getSelectedTabTitle, getDefaultTab } from './helper';
+import { getDefaultTab } from './helper';
 import { getLocalizedRoutes, getCurrentTab } from './routes';
 
 const discoverSsr = ( context, next ) => {
 	context.renderHeaderSection = renderHeaderSection;
 	const selectedTab = getCurrentTab( context.path, getDefaultTab() );
-	const tabTitle = getSelectedTabTitle( selectedTab );
 
 	context.primary = (
 		<>
-			<DiscoverDocumentHead tabTitle={ tabTitle } />
-			<DiscoverHeaderAndNavigation
-				selectedTab={ selectedTab }
-				effectiveTabSelection={ selectedTab }
-			/>
+			<DiscoverDocumentHead />
+			<DiscoverHeaderAndNavigation selectedTab={ selectedTab } />
 			<PostPlaceholder />
 		</>
 	);

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -21,7 +21,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
-import { getSelectedTabTitle, getDefaultTab } from './helper';
+import { getDefaultTab } from './helper';
 import { getPrivateRoutes, getDiscoverRoutes, getCurrentTab } from './routes';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
@@ -35,7 +35,6 @@ const discover = ( context, next ) => {
 	const currentRoute = getCurrentRoute( state );
 	const currentQueryArgs = new URLSearchParams( getCurrentQueryArguments( state ) ).toString();
 	const selectedTab = getCurrentTab( context.path, getDefaultTab() );
-	const tabTitle = getSelectedTabTitle( selectedTab );
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack(
@@ -50,7 +49,7 @@ const discover = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<DiscoverDocumentHead tabTitle={ tabTitle } />
+			<DiscoverDocumentHead />
 			<AsyncLoad
 				require="calypso/reader/discover/discover-stream"
 				key="discover-page"


### PR DESCRIPTION
Fixes CML-920

## Proposed Changes, why are these changes being made?

We do not need to get the tab title dynamically anymore, only one discover screen uses that parameter anymore, so it can be hardcoded in the final string and we can get rid of the utility function.

<img width="807" height="195" alt="image" src="https://github.com/user-attachments/assets/7b565f35-1d1e-421e-a37c-5a61242a10e5" />


## Testing Instructions

* Go to http://calypso.localhost:3000/discover/recommended
   * Check the page description
* Switch to other tabs
   * Check the page descriptions
* Go to http://calypso.localhost:3000/reader in an incognito page
   * Check the page description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
