### PR TITLE
Scan: add single threat fix

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -15,13 +15,8 @@ export function getActions( siteId: number ): Action< Threat >[] {
 			label: __( 'Fix threat' ),
 			modalHeader: __( 'Fix threat' ),
 			supportsBulk: true,
-			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
-				<FixThreatModal
-					items={ items }
-					closeModal={ closeModal }
-					onActionPerformed={ onActionPerformed }
-					siteId={ siteId }
-				/>
+			RenderModal: ( { items, closeModal } ) => (
+				<FixThreatModal items={ items } closeModal={ closeModal } siteId={ siteId } />
 			),
 			isEligible: ( threat: Threat ) => !! threat.fixable,
 		},
@@ -30,13 +25,8 @@ export function getActions( siteId: number ): Action< Threat >[] {
 			label: __( 'Ignore threat' ),
 			modalHeader: __( 'Ignore threat' ),
 			supportsBulk: false,
-			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
-				<IgnoreThreatModal
-					items={ items }
-					closeModal={ closeModal }
-					onActionPerformed={ onActionPerformed }
-					siteId={ siteId }
-				/>
+			RenderModal: ( { items, closeModal } ) => (
+				<IgnoreThreatModal items={ items } closeModal={ closeModal } siteId={ siteId } />
 			),
 		},
 	];

--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -1,16 +1,9 @@
-import {
-	Button,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Icon,
-} from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
-import { ButtonStack } from '../../../components/button-stack';
+import { FixThreatModal } from '../../scan/components/fix-threat-modal';
 import { IgnoreThreatModal } from '../../scan/components/ignore-threat-modal';
-import { ThreatDescription } from '../../scan/components/threat-description';
-import { ThreatsDetailCard } from '../../scan/components/threats-detail-card';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions( siteId: number ): Action< Threat >[] {
@@ -22,30 +15,14 @@ export function getActions( siteId: number ): Action< Threat >[] {
 			label: __( 'Fix threat' ),
 			modalHeader: __( 'Fix threat' ),
 			supportsBulk: true,
-			RenderModal: ( { items, closeModal } ) => {
-				const fixButtonLabel = items.length === 1 ? __( 'Fix threat' ) : __( 'Fix all threats' );
-				const description =
-					items.length === 1
-						? __( 'Jetpack will be fixing the following threat:' )
-						: __( 'Jetpack will be fixing the following threats:' );
-
-				return (
-					<VStack spacing={ 4 }>
-						<Text variant="muted">{ description }</Text>
-						<ThreatsDetailCard threats={ items } />
-						<ThreatDescription threat={ items[ 0 ] } />
-						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ closeModal }>
-								{ __( 'Cancel' ) }
-							</Button>
-							{ /* @TODO: implement the auto-fix threat action and remove the disabled prop */ }
-							<Button variant="primary" disabled>
-								{ fixButtonLabel }
-							</Button>
-						</ButtonStack>
-					</VStack>
-				);
-			},
+			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+				<FixThreatModal
+					items={ items }
+					closeModal={ closeModal }
+					onActionPerformed={ onActionPerformed }
+					siteId={ siteId }
+				/>
+			),
 			isEligible: ( threat: Threat ) => !! threat.fixable,
 		},
 		{

--- a/client/dashboard/sites/scan-history/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/actions.tsx
@@ -14,13 +14,8 @@ export function getActions( siteId: number ): Action< Threat >[] {
 			label: __( 'Unignore threat' ),
 			modalHeader: __( 'Unignore threat' ),
 			supportsBulk: false,
-			RenderModal: ( { items, closeModal, onActionPerformed } ) => (
-				<UnignoreThreatModal
-					items={ items }
-					closeModal={ closeModal }
-					onActionPerformed={ onActionPerformed }
-					siteId={ siteId }
-				/>
+			RenderModal: ( { items, closeModal } ) => (
+				<UnignoreThreatModal items={ items } closeModal={ closeModal } siteId={ siteId } />
 			),
 		},
 		{

--- a/client/dashboard/sites/scan/components/fix-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/fix-threat-modal.tsx
@@ -15,12 +15,7 @@ interface FixThreatModalProps extends RenderModalProps< Threat > {
 	siteId: number;
 }
 
-export function FixThreatModal( {
-	items,
-	closeModal,
-	onActionPerformed,
-	siteId,
-}: FixThreatModalProps ) {
+export function FixThreatModal( { items, closeModal, siteId }: FixThreatModalProps ) {
 	const threat = items[ 0 ];
 
 	const fixThreat = useMutation( fixThreatMutation( siteId ) );
@@ -30,7 +25,6 @@ export function FixThreatModal( {
 		fixThreat.mutate( threat.id, {
 			onSuccess: () => {
 				closeModal?.();
-				onActionPerformed?.( [ threat ] );
 				createSuccessNotice( __( 'Threat fixed.' ), { type: 'snackbar' } );
 			},
 			onError: () => {

--- a/client/dashboard/sites/scan/components/fix-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/fix-threat-modal.tsx
@@ -1,0 +1,71 @@
+import { fixThreatMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { ButtonStack } from '../../../components/button-stack';
+import { Text } from '../../../components/text';
+import { ThreatDescription } from './threat-description';
+import { ThreatsDetailCard } from './threats-detail-card';
+import type { Threat } from '@automattic/api-core';
+import type { RenderModalProps } from '@wordpress/dataviews';
+
+interface FixThreatModalProps extends RenderModalProps< Threat > {
+	siteId: number;
+}
+
+export function FixThreatModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+	siteId,
+}: FixThreatModalProps ) {
+	const threat = items[ 0 ];
+
+	const fixThreat = useMutation( fixThreatMutation( siteId ) );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const handleFixThreat = () => {
+		fixThreat.mutate( threat.id, {
+			onSuccess: () => {
+				closeModal?.();
+				onActionPerformed?.( [ threat ] );
+				createSuccessNotice( __( 'Threat fixed.' ), { type: 'snackbar' } );
+			},
+			onError: () => {
+				closeModal?.();
+				createErrorNotice( __( 'Failed to fix threat. Please try again.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
+	const fixButtonLabel = items.length === 1 ? __( 'Fix threat' ) : __( 'Fix all threats' );
+	const description =
+		items.length === 1
+			? __( 'Jetpack will be fixing the following threat:' )
+			: __( 'Jetpack will be fixing the following threats:' );
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text variant="muted">{ description }</Text>
+			<ThreatsDetailCard threats={ items } />
+			<ThreatDescription threat={ items[ 0 ] } />
+			<ButtonStack justify="flex-end">
+				<Button variant="tertiary" onClick={ closeModal }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleFixThreat }
+					isBusy={ fixThreat.isPending }
+					disabled={ fixThreat.isPending }
+				>
+					{ fixButtonLabel }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/scan/components/fix-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/fix-threat-modal.tsx
@@ -25,11 +25,16 @@ export function FixThreatModal( { items, closeModal, siteId }: FixThreatModalPro
 		fixThreat.mutate( threat.id, {
 			onSuccess: () => {
 				closeModal?.();
-				createSuccessNotice( __( 'Threat fixed.' ), { type: 'snackbar' } );
+				createSuccessNotice(
+					__(
+						'We’re hard at work fixing this threat in the background. Please check back shortly.'
+					),
+					{ type: 'snackbar' }
+				);
 			},
 			onError: () => {
 				closeModal?.();
-				createErrorNotice( __( 'Failed to fix threat. Please try again.' ), {
+				createErrorNotice( __( 'Error fixing threat. Please contact support.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/ignore-threat-modal.tsx
@@ -22,12 +22,7 @@ interface IgnoreThreatModalProps extends RenderModalProps< Threat > {
 	siteId: number;
 }
 
-export function IgnoreThreatModal( {
-	items,
-	closeModal,
-	onActionPerformed,
-	siteId,
-}: IgnoreThreatModalProps ) {
+export function IgnoreThreatModal( { items, closeModal, siteId }: IgnoreThreatModalProps ) {
 	const threat = items[ 0 ];
 
 	const ignoreThreat = useMutation( ignoreThreatMutation( siteId ) );
@@ -37,7 +32,6 @@ export function IgnoreThreatModal( {
 		ignoreThreat.mutate( threat.id, {
 			onSuccess: () => {
 				closeModal?.();
-				onActionPerformed?.( [ threat ] );
 				createSuccessNotice( __( 'Threat ignored.' ), { type: 'snackbar' } );
 			},
 			onError: () => {

--- a/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
+++ b/client/dashboard/sites/scan/components/unignore-threat-modal.tsx
@@ -22,12 +22,7 @@ interface UnignoreThreatModalProps extends RenderModalProps< Threat > {
 	siteId: number;
 }
 
-export function UnignoreThreatModal( {
-	items,
-	closeModal,
-	onActionPerformed,
-	siteId,
-}: UnignoreThreatModalProps ) {
+export function UnignoreThreatModal( { items, closeModal, siteId }: UnignoreThreatModalProps ) {
 	const threat = items[ 0 ];
 	const unignoreThreat = useMutation( unignoreThreatMutation( siteId ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
@@ -36,7 +31,6 @@ export function UnignoreThreatModal( {
 		unignoreThreat.mutate( threat.id, {
 			onSuccess: () => {
 				closeModal?.();
-				onActionPerformed?.( [ threat ] );
 				createSuccessNotice( __( 'Threat unignored.' ), { type: 'snackbar' } );
 			},
 			onError: () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-414][1].

## Proposed Changes

This PR implements the action for the `Fix threat` button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The button is currently there, but disabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/:slug/scan`
- Click on `Fix threat` action shortcut.
- In the modal with the threat details, the `Fix threat` button should actually fix it.

| Actions |
| - |
| <img width="265" height="215" alt="image" src="https://github.com/user-attachments/assets/490084dc-fdf3-42d4-bce8-628a475c3825" /> |

| Modal |
| - |
| <img width="534" height="583" alt="image" src="https://github.com/user-attachments/assets/47326a63-5b70-47e7-9b31-db13cc5b848b" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-414