### PR TITLE
Dashboard v2 - Enable date filtering on the Activity Logs

### DIFF
--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -72,16 +72,14 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 				{ ...getLogsCalloutProps() }
 			>
 				<>
-					{ logType !== LogType.ACTIVITY && (
-						<DateRangePicker
-							start={ dateRange.start }
-							end={ dateRange.end }
-							gmtOffset={ gmtOffset }
-							timezoneString={ timezoneString }
-							locale={ locale }
-							onChange={ handleDateRangeChangeWrapper }
-						/>
-					) }
+					<DateRangePicker
+						start={ dateRange.start }
+						end={ dateRange.end }
+						gmtOffset={ gmtOffset }
+						timezoneString={ timezoneString }
+						locale={ locale }
+						onChange={ handleDateRangeChangeWrapper }
+					/>
 					<Card className={ `site-logs-card site-logs-card--${ logType }` }>
 						<CardHeader style={ { paddingBottom: '0' } }>
 							<TabPanel

--- a/packages/api-core/src/site-activity-log/types.ts
+++ b/packages/api-core/src/site-activity-log/types.ts
@@ -93,8 +93,8 @@ export type ActivityActor = {
 };
 
 export interface ActivityLogParams {
-	after?: number;
-	before?: number;
+	after?: string;
+	before?: string;
 	sort_order?: 'asc' | 'desc';
 	page?: number;
 	aggregate?: boolean;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-446/add-date-picker-for-activity-logs

## Proposed Changes

- Dashboard v2 Logs > Activity tab: add DateRangePicker consistent with PHP and Web tabs.
- Normalize selected dates to site-local calendar-day bounds (00:00:00 to 23:59:59) using existing timezone-aware utility, then serialize to UTC ISO (`after`/`before`) for the API.
- Wire the normalized range into siteActivityLogQuery via `ActivityLogParams`.
- Reset pagination to page 1 when the date range changes to prevent stale cursors/pages.

Touched files (user-facing logic):
- `client/dashboard/sites/logs/index.tsx` – always render DateRangePicker (including Activity).
- `client/dashboard/sites/logs-activity/dataviews/index.tsx` – compute and pass `after`/`before` to the query; reset pagination on range change.

## Why are these changes being made?

- Feature parity across Logs tabs: PHP and Web already expose a date range; Activity lacked it.
- Aligns with legacy Activity Log (v1) behavior that filtered by date range and with the API’s expected timestamp format.

## Testing Instructions

Preconditions
- Have a site with Activity log data and access to Dashboard v2.
- Know the site slug (e.g., `example.wordpress.com`).

Steps
1. Navigate to `/v2/sites/<siteSlug>/logs/activity`.
2. Verify a DateRangePicker is visible in the page header (same placement as other tabs).
3. Select a short recent range (e.g., the last 3 days).
   - Expected: The list reloads; only items within the selected range appear.
4. Select an older range with no recent events.
   - Expected: Empty state or only historical items in range.
5. Pagination behavior
   - Move to a later page; change the date range; ensure pagination resets to page 1 automatically.
6. Boundary checks
   - Pick the same day for start and end; events from that local day (site timezone) should appear.
   - If the site timezone differs from your browser, verify items are calculated using the site’s timezone.
7. Switch to the PHP/Web tabs
   - Confirm the DateRangePicker remains and that changing the range there also filters as before (no regressions).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests where appropriate? (No logic branched on new conditions; relies on existing query + dataviews plumbing.)
- [ ] Have you tested in Simple, Atomic, and self-hosted Jetpack sites as applicable?
- [ ] Checked browser console for TS/React errors while interacting with the date picker and switching tabs?
- [ ] Accessibility: date picker keyboard/focus behavior verified; list remains navigable.
- [ ] Strings: no new translatable strings introduced by this change.
- [ ] Privacy: no new data collection; params are standard `after`/`before` filters.

## Notes for Reviewers

- `after`/`before` are sent as UTC ISO strings, after normalizing local-day boundaries in the site’s timezone/gmt offset. This mirrors v1 behavior and conforms to the API.
- If preferred, we can factor a small helper to emit ISO directly from the normalized seconds to make the intent even clearer.
- Figma spec: GzuR02sJZldvmRnbFsL04l-fi-5605_65148
- Context P2: pgz0xU-ct-p2