### PR TITLE
Backups Dashboard: enable individual restore via Backup FileBrowser

### DIFF
--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -104,7 +104,7 @@ function SiteBackupGranularRestoreForm( {
 						isBusy={ isRestoreMutationPending }
 						disabled={ isRestoreMutationPending }
 					>
-						{ __( 'Restore selected files' ) }
+						{ _n( 'Restore selected file', 'Restore selected files', browserCheckList.totalItems ) }
 					</Button>
 				</ButtonStack>
 			</VStack>

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -2,7 +2,7 @@ import { siteBackupGranularRestoreMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack, Panel } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { rotateLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
@@ -78,7 +78,13 @@ function SiteBackupGranularRestoreForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				<Text>{ __( 'All the following selected items will be restored:' ) }</Text>
+				<Text>
+					{ _n(
+						'The following item will be restored:',
+						'All the following selected items will be restored:',
+						browserCheckList.totalItems
+					) }
+				</Text>
 				<Panel>
 					<FileSectionPanelBody type="theme" selectedItems={ browserSelectedList } />
 					<FileSectionPanelBody type="plugin" selectedItems={ browserSelectedList } />

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -128,6 +128,7 @@ export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; sit
 								siteSlug={ site.slug }
 								isRestoreEnabled
 								onTrackEvent={ recordTracksEvent }
+								onRequestGranularRestore={ handleRestoreClick }
 							/>
 						</div>
 					) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-525

## Proposed Changes

* Enable individual restore via Backup FileBrowser
* Update confirmation page instruction and action button to use pluralization based on the number of selected files

### Demo

https://github.com/user-attachments/assets/47809425-a007-4731-9d1c-967c8e1054a2

### Screenshots

| Selection | Confirmation page |
|---|---|
| <img width="1510" height="496" alt="CleanShot 2025-09-23 at 14 56 45@2x" src="https://github.com/user-attachments/assets/dcc3dc1d-2cc2-4ba5-a9ca-51e91510b7f6" /> | <img width="1402" height="1158" alt="CleanShot 2025-09-23 at 15 07 55@2x" src="https://github.com/user-attachments/assets/87aa5ec4-0f42-4a12-9a4d-77bd328fa434" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up task of DOTDASH-359

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Calypso Live branch and navigate to `/v2/sites/{site}/backups`
2. Click on a full backup entry (those that refers to "Backup and scan complete")
3. Click on a specific file and ensure you see its details
4. Click on `Restore` button on file details
5. Ensure it navigates to the restore page and you see the file you clicked on the confirmation page
6. Try restoring the file and ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
