### PR TITLE
Stepper Domain Flow: Redirect to Hosting Dashboard

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -135,8 +135,8 @@ const domain: FlowV2< typeof initialize > = {
 					// replace the location to delete processing step from history.
 					return window.location.assign(
 						addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-							redirect_to: `/domains/manage/${ siteSlug }`,
-							signup: 1,
+							redirect_to: `/v2/sites/${ siteSlug }/domains`,
+							signup: 0,
 							cancel_to: new URL(
 								addQueryArgs( '/setup/domain', { siteSlug } ),
 								window.location.href
@@ -199,7 +199,7 @@ const domain: FlowV2< typeof initialize > = {
 					if ( providedDependencies.newExistingSiteChoice === 'domain' ) {
 						return window.location.assign(
 							addQueryArgs( '/checkout/no-site', {
-								redirect_to: '/domains/manage',
+								redirect_to: '/v2/domains',
 								signup: 0,
 								isDomainOnly: 1,
 								cancel_to: new URL(
@@ -268,7 +268,7 @@ const domain: FlowV2< typeof initialize > = {
 					return navigate( STEPS.PROCESSING.slug, undefined, true );
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
-						const destination = `/domains/manage/${ providedDependencies.siteSlug }`;
+						const destination = `/v2/sites/${ providedDependencies.siteSlug }/domains`;
 
 						persistSignupDestination( destination );
 						setSignupCompleteFlowName( this.name );


### PR DESCRIPTION
Closes DOMAINS-1653.

## Proposed Changes

The `/setup/domain` flow is linked from the Hosting Dashboard and should link back to it upon completion.

## Testing Instructions

Enter `/setup/domain?siteSlug=%s` and purchase a domain. You should be redirected to `/v2/sites/%s/domains`.

Enter `/setup/domain` and perform a domain-only purchase. You should be redirected to `/v2/domains`.

Enter `/setup/domain` and create a new site for the domain you want to purchase. You should redirected to `/v2/sites/%s/domains`.