### PR TITLE
Backups Dashboard: Implement granular download

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -427,6 +427,12 @@ export const siteBackupDownloadRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteBackupsRoute,
 	path: '$rewindId/download',
+	validateSearch: ( search ) => {
+		const downloadId = Number( search.downloadId );
+		return {
+			downloadId: downloadId > 0 ? downloadId : undefined,
+		};
+	},
 } ).lazy( () =>
 	import( '../../sites/backup-download' ).then( ( d ) =>
 		createLazyRoute( 'site-backup-download' )( {

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -34,6 +34,7 @@ function SiteBackupDownload() {
 
 	// Initialize step based on whether downloadId is provided in search params
 	const initialStep: DownloadStep = searchDownloadId ? 'progress' : 'form';
+
 	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( initialStep );
 	const [ downloadId, setDownloadId ] = useState< number | null >( searchDownloadId || null );
 	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -29,15 +29,31 @@ type DownloadStep = 'form' | 'progress' | 'success' | 'error';
 
 function SiteBackupDownload() {
 	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
+	const { downloadId: searchDownloadId } = siteBackupDownloadRoute.useSearch();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( 'form' );
-	const [ downloadId, setDownloadId ] = useState< number | null >( null );
+
+	// Initialize step based on whether downloadId is provided in search params
+	const initialStep: DownloadStep = searchDownloadId ? 'progress' : 'form';
+	const [ currentStep, setCurrentStep ] = useState< DownloadStep >( initialStep );
+	const [ downloadId, setDownloadId ] = useState< number | null >( searchDownloadId || null );
 	const [ downloadUrl, setDownloadUrl ] = useState< string | null >( null );
 	const [ fileSizeBytes, setFileSizeBytes ] = useState< string | undefined >();
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	const router = useRouter();
+
+	// Clean up the downloadId query param once we've captured it
+	useEffect( () => {
+		if ( searchDownloadId ) {
+			router.navigate( {
+				to: siteBackupDownloadRoute.fullPath,
+				params: { siteSlug, rewindId },
+				search: {},
+				replace: true,
+			} );
+		}
+	}, [ router, siteSlug, rewindId, searchDownloadId ] );
 
 	const handleDownloadInitiate = ( newDownloadId: number ) => {
 		recordTracksEvent( 'calypso_dashboard_backups_download_started' );

--- a/packages/api-core/src/site-backup-download/mutators.ts
+++ b/packages/api-core/src/site-backup-download/mutators.ts
@@ -58,3 +58,31 @@ export function prepareBackupDownload(
 		}
 	);
 }
+
+/**
+ * Initiate a granular backup download with specific paths to include/exclude.
+ * @param siteId - The ID of the site to download backup for.
+ * @param rewindId - The backup/rewind ID to download from.
+ * @param includePaths - Comma-separated list of paths to include.
+ * @param excludePaths - Comma-separated list of paths to exclude.
+ * @returns A promise that resolves to the download ID.
+ */
+export async function initiateGranularBackupDownload(
+	siteId: number,
+	rewindId: string,
+	includePaths: string,
+	excludePaths: string = ''
+): Promise< number > {
+	const data: DownloadStatusResponse = await wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/rewind/downloads`,
+		body: {
+			rewindId,
+			types: { paths: true },
+			include_path_list: includePaths,
+			exclude_path_list: excludePaths,
+		},
+	} );
+
+	return data.downloadId;
+}

--- a/packages/api-queries/src/site-backup-download.ts
+++ b/packages/api-queries/src/site-backup-download.ts
@@ -1,6 +1,7 @@
 import {
 	fetchSiteBackupDownloadProgress,
 	initiateSiteBackupDownload,
+	initiateGranularBackupDownload,
 	prepareBackupDownload,
 	getBackupDownloadStatus,
 	type DownloadConfig,
@@ -64,4 +65,25 @@ export const siteBackupFilteredDownloadPrepareMutation = () =>
 			manifestFilter: string;
 			dataType: number;
 		} ) => prepareBackupDownload( siteId, rewindId, manifestFilter, dataType ),
+	} );
+
+/**
+ * Initiate a granular backup download with selected paths.
+ * @param siteId - The ID of the site to initiate a granular download for.
+ * @returns A promise that resolves to the download ID.
+ */
+export const siteGranularBackupDownloadInitiateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( {
+			rewindId,
+			includePaths,
+			excludePaths,
+		}: {
+			rewindId: string;
+			includePaths: string;
+			excludePaths?: string;
+		} ) => initiateGranularBackupDownload( siteId, rewindId, includePaths, excludePaths ),
+		onSuccess: ( downloadId ) => {
+			queryClient.prefetchQuery( siteBackupDownloadProgressQuery( siteId, downloadId ) );
+		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-390

## Proposed Changes

* Add granular backup download functionality to the Hosting Dashboard's backup details page
* Enable `Download selected files` button when users select specific files in the file browser
* Add data layer (core API and mutation)
* Add seamless navigation that skips confirmation form for granular downloads
* Add error handling for invalid download IDs

### Demo

https://github.com/user-attachments/assets/9b4fabfb-beb9-4d8f-b190-43775769105a

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up task of DOTDASH-359

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Calypso Live branch and navigate to `/v2/sites/{site}/backups`
2. Click on a full backup entry (those that refers to "Backup and scan complete")
3. Select some files or directories (click on the checkboxes)
4. Ensure the download button now say `Download selected files` and is enabled
5. Click the download selected files button
6. Ensure it goes directly to the download progress page and the downloadId parameter is no longer visible in the URL
7. Ensure it finishes properly

Bonus:
1. Try passing a random downloadId on the URL, like: `/download?downloadId`.
2. It will try to get any download in progress and then fail.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
