### PR TITLE
Domain Search Rewrite: Submit domain for gravatar flow directly

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -1,8 +1,8 @@
 import { DomainSearch } from '@automattic/domain-search';
-import { MinimalRequestCartProduct, ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps } from 'react';
 import { WPCOMDomainSearchCartProvider } from './domain-search-cart-provider';
 import { useWPCOMShoppingCartForDomainSearch } from './use-wpcom-shopping-cart-for-domain-search';
+import type { MinimalRequestCartProduct, ResponseCartProduct } from '@automattic/shopping-cart';
 
 type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | 'events' > & {
 	currentSiteId?: number;

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -9,10 +9,10 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 	flowName: string;
 	events?: Omit< Required< ComponentProps< typeof DomainSearch > >[ 'events' ], 'onContinue' > & {
 		onContinue?: ( items: ResponseCartProduct[] ) => void;
+		onAddDomainToCart?: ( domain: MinimalRequestCartProduct ) => MinimalRequestCartProduct;
 	};
 	isFirstDomainFreeForFirstYear?: boolean;
 	flowAllowsMultipleDomainsInCart: boolean;
-	onAddDomainToCart?: ( domain: MinimalRequestCartProduct ) => MinimalRequestCartProduct;
 };
 
 const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
@@ -37,11 +37,10 @@ const DomainSearchWithCart = ( {
 	config: externalConfig,
 	isFirstDomainFreeForFirstYear,
 	flowAllowsMultipleDomainsInCart,
-	onAddDomainToCart,
 	...props
 }: DomainSearchProps ) => {
 	const cartKey = currentSiteId ?? 'no-site';
-	const { onContinue } = props.events ?? {};
+	const { onContinue, onAddDomainToCart } = props.events ?? {};
 
 	const { cart, isNextDomainFree, items } = useWPCOMShoppingCartForDomainSearch( {
 		cartKey,

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -1,5 +1,5 @@
 import { DomainSearch } from '@automattic/domain-search';
-import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { MinimalRequestCartProduct, ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps } from 'react';
 import { WPCOMDomainSearchCartProvider } from './domain-search-cart-provider';
 import { useWPCOMShoppingCartForDomainSearch } from './use-wpcom-shopping-cart-for-domain-search';
@@ -12,6 +12,7 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 	};
 	isFirstDomainFreeForFirstYear?: boolean;
 	flowAllowsMultipleDomainsInCart: boolean;
+	onAddDomainToCart?: ( domain: MinimalRequestCartProduct ) => MinimalRequestCartProduct;
 };
 
 const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
@@ -36,6 +37,7 @@ const DomainSearchWithCart = ( {
 	config: externalConfig,
 	isFirstDomainFreeForFirstYear,
 	flowAllowsMultipleDomainsInCart,
+	onAddDomainToCart,
 	...props
 }: DomainSearchProps ) => {
 	const cartKey = currentSiteId ?? 'no-site';
@@ -47,6 +49,7 @@ const DomainSearchWithCart = ( {
 		isFirstDomainFreeForFirstYear: isFirstDomainFreeForFirstYear ?? false,
 		flowAllowsMultipleDomainsInCart,
 		onContinue,
+		onAddDomainToCart,
 	} );
 
 	const initialQuery = useMemo( () => {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-restricted-imports */
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
-import { type CartKey, type ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import {
+	type CartKey,
+	MinimalRequestCartProduct,
+	type ResponseCartProduct,
+	useShoppingCart,
+} from '@automattic/shopping-cart';
 import { ComponentProps, useMemo } from 'react';
 import { getDomainsInCart } from '../../../lib/cart-values/cart-items';
 
@@ -45,6 +50,7 @@ interface UseWPCOMShoppingCartForDomainSearchOptions {
 	flowAllowsMultipleDomainsInCart: boolean;
 	isFirstDomainFreeForFirstYear: boolean;
 	onContinue?( cartItems: ResponseCartProduct[] ): void;
+	onAddDomainToCart?: ( domain: MinimalRequestCartProduct ) => MinimalRequestCartProduct;
 }
 
 export const useWPCOMShoppingCartForDomainSearch = ( {
@@ -53,6 +59,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 	flowAllowsMultipleDomainsInCart,
 	isFirstDomainFreeForFirstYear,
 	onContinue,
+	onAddDomainToCart = ( domain ) => domain,
 }: UseWPCOMShoppingCartForDomainSearchOptions ) => {
 	const { responseCart, addProductsToCart, removeProductFromCart } = useShoppingCart( cartKey );
 
@@ -85,7 +92,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 			hasItem: ( domain ) => !! domainItems.find( ( item ) => item.meta === domain ),
 			onAddItem: async ( { domain_name, product_slug, supports_privacy } ) => {
 				const cartItems = await addProductsToCart( [
-					{
+					onAddDomainToCart( {
 						product_slug,
 						meta: domain_name,
 						extra: {
@@ -95,7 +102,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 							} ),
 							...( flowName && { flow_name: flowName } ),
 						},
-					},
+					} ),
 				] );
 
 				if ( ! flowAllowsMultipleDomainsInCart ) {
@@ -122,5 +129,6 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 		isFirstDomainFreeForFirstYear,
 		flowAllowsMultipleDomainsInCart,
 		onContinue,
+		onAddDomainToCart,
 	] );
 };

--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -3,7 +3,7 @@ import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
 	type CartKey,
-	MinimalRequestCartProduct,
+	type MinimalRequestCartProduct,
 	type ResponseCartProduct,
 	useShoppingCart,
 } from '@automattic/shopping-cart';

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -5,7 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
@@ -64,6 +64,24 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 					},
 					{ domainItem, siteUrl: domainItem.meta, domainCart }
 				);
+
+				if ( isDomainForGravatarFlow( flowName ) ) {
+					submitSignupStep(
+						{
+							stepName: 'site-or-domain',
+							domainItem,
+							designType: 'domain',
+							siteSlug: domainItem.meta,
+							siteUrl: domainItem.meta,
+							isPurchasingItem: true,
+						},
+						{ designType: 'domain', domainItem, siteUrl: domainItem.meta }
+					);
+					submitSignupStep(
+						{ stepName: 'site-picker', wasSkipped: true },
+						{ themeSlugWithRepo: 'pub/twentysixteen' }
+					);
+				}
 
 				goToNextStep();
 			},
@@ -148,6 +166,23 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
 	}, [ flowName ] );
 
+	const addGravatarDomainExtra = useCallback(
+		( product: MinimalRequestCartProduct ) => {
+			if ( isDomainForGravatarFlow( flowName ) ) {
+				return {
+					...product,
+					extra: {
+						...product.extra,
+						is_gravatar_domain: true,
+					},
+				};
+			}
+
+			return product;
+		},
+		[ flowName ]
+	);
+
 	return (
 		<StepWrapper
 			{ ...props }
@@ -164,6 +199,7 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }
 					slots={ slots }
+					onAddDomainToCart={ addGravatarDomainExtra }
 				/>
 			}
 		/>

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -5,7 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
@@ -30,6 +30,19 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 
 	const events = useMemo( () => {
 		return {
+			onAddDomainToCart: ( product: MinimalRequestCartProduct ) => {
+				if ( isDomainForGravatarFlow( flowName ) ) {
+					return {
+						...product,
+						extra: {
+							...product.extra,
+							is_gravatar_domain: true,
+						},
+					};
+				}
+
+				return product;
+			},
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
 			},
@@ -166,23 +179,6 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
 	}, [ flowName ] );
 
-	const addGravatarDomainExtra = useCallback(
-		( product: MinimalRequestCartProduct ) => {
-			if ( isDomainForGravatarFlow( flowName ) ) {
-				return {
-					...product,
-					extra: {
-						...product.extra,
-						is_gravatar_domain: true,
-					},
-				};
-			}
-
-			return product;
-		},
-		[ flowName ]
-	);
-
 	return (
 		<StepWrapper
 			{ ...props }
@@ -199,7 +195,6 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }
 					slots={ slots }
-					onAddDomainToCart={ addGravatarDomainExtra }
 				/>
 			}
 		/>


### PR DESCRIPTION
Part of DOMAINS-1668.

## Proposed Changes

`/start/domain-for-gravatar` is a bit peculiar. It goes directly to checkout after the user selects a domain.

The production version does that already, but the rewritten step wasn't doing it.

## Testing Instructions

Enter `/start/domain-for-gravatar` with the `domain-search-rewrite` feature flag turned ON and verify you can add a domain and see it at checkout. It should also have the `is_gravatar_domain` flag as part of the `extra` object of the domain registration product in the cart.