### PR TITLE
Domain Search Rewrite: Add submit step props to Start variation

### DIFF
--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
@@ -20,13 +21,36 @@ import type { StepProps } from './types';
 
 import './style.scss';
 
-const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
-	const { flowName, stepName, submitSignupStep, goToNextStep, locale, queryObject } = props;
+const getThemeSlugWithRepo = ( themeSlug: string | undefined, isPurchasingTheme: boolean ) => {
+	if ( ! themeSlug ) {
+		return undefined;
+	}
+
+	const repo = isPurchasingTheme ? 'premium' : 'pub';
+
+	return `${ repo }/${ themeSlug }`;
+};
+
+const DomainSearchUI = (
+	props: StepProps & {
+		locale: string;
+		baseSubmitStepProps: Record< string, unknown >;
+		baseSubmitProvidedDependencies: Record< string, unknown >;
+	}
+) => {
+	const {
+		flowName,
+		stepName,
+		submitSignupStep,
+		goToNextStep,
+		locale,
+		queryObject,
+		baseSubmitStepProps,
+		baseSubmitProvidedDependencies,
+	} = props;
 
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
-
-	const allowedTldParam = queryObject.tld;
 
 	const events = useMemo( () => {
 		return {
@@ -55,14 +79,20 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 
 				submitSignupStep(
 					{
-						stepName,
+						...baseSubmitStepProps,
+						stepSectionName: '',
 						domainItem,
 						isPurchasingItem: true,
 						siteUrl: domainItem.meta,
-						stepSectionName: '',
 						domainCart,
 					},
-					{ domainItem, siteUrl: domainItem.meta, domainCart }
+					{
+						...baseSubmitProvidedDependencies,
+						signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.CUSTOM,
+						domainItem,
+						siteUrl: domainItem.meta,
+						domainCart,
+					}
 				);
 
 				goToNextStep();
@@ -72,19 +102,38 @@ const DomainSearchUI = ( props: StepProps & { locale: string } ) => {
 
 				submitSignupStep(
 					{
-						stepName,
+						...baseSubmitStepProps,
+						stepSectionName: '',
 						domainItem: undefined,
 						isPurchasingItem: false,
 						domainCart: [],
 						siteUrl,
 					},
-					{ domainCart: [], siteUrl }
+					{
+						...baseSubmitProvidedDependencies,
+						signupDomainOrigin: suggestion
+							? SIGNUP_DOMAIN_ORIGIN.FREE
+							: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
+						domainCart: [],
+						siteUrl,
+					}
 				);
 
 				goToNextStep();
 			},
 		};
-	}, [ flowName, stepName, submitSignupStep, goToNextStep, locale, isDomainOnlyFlow ] );
+	}, [
+		flowName,
+		stepName,
+		submitSignupStep,
+		goToNextStep,
+		locale,
+		isDomainOnlyFlow,
+		baseSubmitStepProps,
+		baseSubmitProvidedDependencies,
+	] );
+
+	const allowedTldParam = queryObject.tld;
 
 	const config = useMemo( () => {
 		const allowedTlds = Array.isArray( allowedTldParam )
@@ -177,23 +226,55 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 		submitSignupStep,
 		goToNextStep,
 		stepSectionName,
+		queryObject,
 	} = props;
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const locale = ! isLoggedIn ? externalLocale : '';
+	const themeSlug = queryObject.theme;
+
+	const baseSubmitStepProps = useMemo( () => {
+		const themeStyleVariation = queryObject.style_variation;
+
+		const isPurchasingTheme = !! queryObject.premium;
+		const themeSlugWithRepo = getThemeSlugWithRepo( themeSlug, isPurchasingTheme );
+
+		return {
+			stepName,
+			themeSlug,
+			themeSlugWithRepo,
+			themeStyleVariation,
+		};
+	}, [ stepName, themeSlug, queryObject ] );
+
+	const baseSubmitProvidedDependencies = useMemo( () => {
+		if ( themeSlug ) {
+			return {
+				useThemeHeadstartItem: true,
+			};
+		}
+
+		return {};
+	}, [ themeSlug ] );
 
 	if ( stepSectionName === USE_MY_DOMAIN_SECTION_NAME ) {
 		const handleUseMyDomainSubmit = ( domainItem: MinimalRequestCartProduct ) => {
 			submitSignupStep(
 				{
-					stepName: stepName,
+					...baseSubmitStepProps,
+					stepSectionName,
 					domainItem,
 					isPurchasingItem: true,
 					siteUrl: domainItem.meta,
-					stepSectionName: stepSectionName,
 					domainCart: [],
 				},
-				{ domainItem, siteUrl: domainItem.meta, domainCart: [] }
+				{
+					...baseSubmitProvidedDependencies,
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
+					domainItem,
+					siteUrl: domainItem.meta,
+					domainCart: [],
+				}
 			);
 
 			goToNextStep();
@@ -201,8 +282,21 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 
 		const handleSkip = () => {
 			submitSignupStep(
-				{ stepName, suggestion: undefined, isPurchasingItem: false, domainCart: [], siteUrl: '' },
-				{ suggestion: undefined, domainCart: [], siteUrl: '' }
+				{
+					...baseSubmitStepProps,
+					stepSectionName,
+					suggestion: undefined,
+					isPurchasingItem: false,
+					domainCart: [],
+					siteUrl: '',
+				},
+				{
+					...baseSubmitProvidedDependencies,
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
+					suggestion: undefined,
+					domainCart: [],
+					siteUrl: '',
+				}
 			);
 
 			goToNextStep();
@@ -218,7 +312,14 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 		);
 	}
 
-	return <DomainSearchUI { ...props } locale={ locale } />;
+	return (
+		<DomainSearchUI
+			{ ...props }
+			locale={ locale }
+			baseSubmitStepProps={ baseSubmitStepProps }
+			baseSubmitProvidedDependencies={ baseSubmitProvidedDependencies }
+		/>
+	);
 }
 
 export default localize( DomainSearchStep );


### PR DESCRIPTION
Closes DOMAINS-1668.

## Proposed Changes

Adds missing props to submit step callback, as well as the missing provided dependencies.

## Testing Instructions

Install the [Redux DevTools extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd).

Open each of the flows below side by side (this PR in one window, production in the other) and go to the Redux tab in the devtools (1), then type `SIGNUP_PROGRESS_SUBMIT_STEP` in the filter box (2) so you can inspect the submission as it enter the Redux store.

<img width="570" height="271" alt="image" src="https://github.com/user-attachments/assets/18af9dbe-0add-41be-9506-c60d6ff8fd01" />

This PR should have the `domain-search-rewrite` feature flag on, while production has it turned off. You should see the same properties in both environments. Test the following flows:

- `/start/launch-site?siteSlug=%s`
- `/start/onboarding-pm`
- `/start/domain`
- `/start/free` or `/personal`, `/business` or any product plan
- `/start/with-theme?ref=calypshowcase&theme=retrospect&theme_type=free&intervaltype=yearly`
- `/start/with-plugin?ref=plugins-lp&plugin=jetpack`
- `/start/domain-for-gravatar`
- `/start/onboarding-with-email`
- `/start/onboarding-affiliate`
- `/start/import`