### PR TITLE
Hosting Dashboard: Try using breadcrumb everywhere.

### DIFF
--- a/client/dashboard/components/page-header/index.stories.tsx
+++ b/client/dashboard/components/page-header/index.stories.tsx
@@ -1,4 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
+import {
+	RouterProvider,
+	createMemoryHistory,
+	createRouter,
+	createRootRoute,
+} from '@tanstack/react-router';
 import { Button, Icon, DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { help, wordpress, moreVertical } from '@wordpress/icons';
 import { PageHeader } from './index';
@@ -10,6 +16,17 @@ const meta = {
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 	},
+	decorators: [
+		( Story ) => (
+			<RouterProvider
+				router={ createRouter( {
+					basepath: '/',
+					routeTree: createRootRoute( { component: Story } ),
+					history: createMemoryHistory(),
+				} ) }
+			/>
+		),
+	],
 } satisfies Meta< typeof PageHeader >;
 
 export default meta;
@@ -91,6 +108,62 @@ export const FullExample: Story = {
 					) }
 				</DropdownMenu>
 			</>
+		),
+	},
+};
+
+export const WithSubNavigation: Story = {
+	args: {
+		title: 'DNS records',
+		description: 'List of DNS records',
+		prefix: (
+			<PageHeader.SubNavigation
+				items={ [
+					{
+						label: 'Overview',
+						href: '/overview',
+					},
+					{
+						label: 'DNS records',
+						href: '/overview/dns-records',
+					},
+				] }
+			/>
+		),
+		actions: (
+			<Button variant="primary" __next40pxDefaultSize>
+				Save Changes
+			</Button>
+		),
+	},
+};
+
+export const WithSubNavigationBreadcrumbs: Story = {
+	args: {
+		title: 'Add new DNS record',
+		description: 'Add a new DNS record to your domain name',
+		prefix: (
+			<PageHeader.SubNavigation
+				items={ [
+					{
+						label: 'Overview',
+						href: '/overview',
+					},
+					{
+						label: 'DNS Records',
+						href: '/overview/dns-records',
+					},
+					{
+						label: 'Add new DNS record',
+						href: '/overview/dns-records/add-new-dns-record',
+					},
+				] }
+			/>
+		),
+		actions: (
+			<Button variant="primary" __next40pxDefaultSize>
+				Save Changes
+			</Button>
 		),
 	},
 };

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -1,4 +1,5 @@
 import { SectionHeader } from '../section-header';
+import { SubNavigation } from './sub-navigation';
 import type { PageHeaderProps } from './types';
 
 /**
@@ -13,3 +14,5 @@ import type { PageHeaderProps } from './types';
 export const PageHeader = ( props: PageHeaderProps ) => {
 	return <SectionHeader { ...props } level={ 1 } className="dashboard-page-header" />;
 };
+
+PageHeader.SubNavigation = SubNavigation;

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -1,0 +1,4 @@
+.components-button.sub-navigation__button {
+    padding-left: 0;
+    padding-right: 0;
+}

--- a/client/dashboard/components/page-header/sub-navigation.tsx
+++ b/client/dashboard/components/page-header/sub-navigation.tsx
@@ -7,7 +7,7 @@ import type { SubNavigationProps } from './types';
 import './style.scss';
 
 export const SubNavigation = ( props: SubNavigationProps ) => {
-	if ( props.items.length < 2 ) {
+	if ( props.items.length < 1 ) {
 		return null;
 	}
 

--- a/client/dashboard/components/page-header/sub-navigation.tsx
+++ b/client/dashboard/components/page-header/sub-navigation.tsx
@@ -1,6 +1,4 @@
 import { Breadcrumbs } from '@automattic/components/src/breadcrumbs';
-import { isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
 import RouterLinkButton from '../router-link-button';
 import type { SubNavigationProps } from './types';
 
@@ -11,17 +9,17 @@ export const SubNavigation = ( props: SubNavigationProps ) => {
 		return null;
 	}
 
-	if ( props.items.length === 2 ) {
-		return (
-			<RouterLinkButton
-				className="sub-navigation__button"
-				icon={ isRTL() ? chevronRight : chevronLeft }
-				to={ props.items[ 0 ].href }
-			>
-				{ props.items[ 0 ].label }
-			</RouterLinkButton>
-		);
-	}
+	// if ( props.items.length === 2 ) {
+	// 	return (
+	// 		<RouterLinkButton
+	// 			className="sub-navigation__button"
+	// 			icon={ isRTL() ? chevronRight : chevronLeft }
+	// 			to={ props.items[ 0 ].href }
+	// 		>
+	// 			{ props.items[ 0 ].label }
+	// 		</RouterLinkButton>
+	// 	);
+	// }
 
 	return (
 		<Breadcrumbs

--- a/client/dashboard/components/page-header/sub-navigation.tsx
+++ b/client/dashboard/components/page-header/sub-navigation.tsx
@@ -1,0 +1,36 @@
+import { Breadcrumbs } from '@automattic/components/src/breadcrumbs';
+import { isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import RouterLinkButton from '../router-link-button';
+import type { SubNavigationProps } from './types';
+
+import './style.scss';
+
+export const SubNavigation = ( props: SubNavigationProps ) => {
+	if ( props.items.length < 2 ) {
+		return null;
+	}
+
+	if ( props.items.length === 2 ) {
+		return (
+			<RouterLinkButton
+				className="sub-navigation__button"
+				icon={ isRTL() ? chevronRight : chevronLeft }
+				to={ props.items[ 0 ].href }
+			>
+				{ props.items[ 0 ].label }
+			</RouterLinkButton>
+		);
+	}
+
+	return (
+		<Breadcrumbs
+			items={ props.items }
+			renderItemLink={ ( item ) => (
+				<RouterLinkButton className="sub-navigation__button" to={ item.href }>
+					{ item.label }
+				</RouterLinkButton>
+			) }
+		/>
+	);
+};

--- a/client/dashboard/components/page-header/types.ts
+++ b/client/dashboard/components/page-header/types.ts
@@ -1,3 +1,8 @@
+import { Item } from '@automattic/components/src/breadcrumbs/types';
 import { SectionHeaderProps } from '../section-header/types';
 
 export interface PageHeaderProps extends Omit< SectionHeaderProps, 'level' > {}
+
+export interface SubNavigationProps {
+	items: Item[];
+}

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -1,10 +1,15 @@
 import { domainDnsMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { domainRoute } from '../../app/router/domains';
+import {
+	domainRoute,
+	domainOverviewRoute,
+	domainDnsRoute,
+	domainDnsAddRoute,
+} from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DNSRecordForm from './form';
@@ -48,8 +53,44 @@ export default function DomainAddDNS() {
 		);
 	};
 
+	const router = useRouter();
+
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Add a new DNS record' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={
+						<PageHeader.SubNavigation
+							items={ [
+								{
+									label: __( 'Overview' ),
+									href: router.buildLocation( {
+										to: domainOverviewRoute.fullPath,
+										params: { domainName },
+									} ).href,
+								},
+								{
+									label: __( 'DNS records' ),
+									href: router.buildLocation( {
+										to: domainDnsRoute.fullPath,
+										params: { domainName },
+									} ).href,
+								},
+								{
+									label: __( 'Add a new DNS record' ),
+									href: router.buildLocation( {
+										to: domainDnsAddRoute.fullPath,
+										params: { domainName },
+									} ).href,
+								},
+							] }
+						/>
+					}
+					title={ __( 'Add a new DNS record' ) }
+				/>
+			}
+		>
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -14,7 +14,12 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { domainDnsAddRoute, domainRoute } from '../../app/router/domains';
+import {
+	domainDnsAddRoute,
+	domainRoute,
+	domainOverviewRoute,
+	domainDnsRoute,
+} from '../../app/router/domains';
 import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -285,6 +290,26 @@ export default function DomainDns() {
 				<VStack>
 					<PageHeader
 						title={ __( 'DNS records' ) }
+						prefix={
+							<PageHeader.SubNavigation
+								items={ [
+									{
+										label: __( 'Overview' ),
+										href: router.buildLocation( {
+											to: domainOverviewRoute.fullPath,
+											params: { domainName },
+										} ).href,
+									},
+									{
+										label: __( 'DNS records' ),
+										href: router.buildLocation( {
+											to: domainDnsRoute.fullPath,
+											params: { domainName },
+										} ).href,
+									},
+								] }
+							/>
+						}
 						actions={
 							<>
 								<ImportBindFileButton

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -5,13 +5,14 @@ import {
 	siteByIdQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { Card, CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useCallback } from 'react';
 import { useAuth } from '../../app/auth';
-import { domainRoute } from '../../app/router/domains';
+import { domainRoute, domainOverviewRoute, domainNameServersRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getDomainSiteSlug } from '../../utils/domain';
@@ -52,8 +53,37 @@ export default function NameServers() {
 		[ updateNameServers, createSuccessNotice, createErrorNotice ]
 	);
 
+	const router = useRouter();
+
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Name servers' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={
+						<PageHeader.SubNavigation
+							items={ [
+								{
+									label: __( 'Overview' ),
+									href: router.buildLocation( {
+										to: domainOverviewRoute.fullPath,
+										params: { domainName },
+									} ).href,
+								},
+								{
+									label: __( 'Name servers' ),
+									href: router.buildLocation( {
+										to: domainNameServersRoute.fullPath,
+										params: { domainName },
+									} ).href,
+								},
+							] }
+						/>
+					}
+					title={ __( 'Name servers' ) }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<NameServersForm

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -1,10 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import BillingPageHeader from '../billing-page-header';
 
 function BillingHistory() {
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Billing history' ) } /> }>
+		<PageLayout size="small" header={ <BillingPageHeader title={ __( 'Billing history' ) } /> }>
 			<div>Billing history content will go here</div>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-page-header/index.tsx
+++ b/client/dashboard/me/billing-page-header/index.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { billingIndexRoute } from '../../app/router/me';
+import { PageHeader } from '../../components/page-header';
+import type { PageHeaderProps } from '../../components/page-header/types';
+
+export default function BillingPageHeader( props: PageHeaderProps ) {
+	const router = useRouter();
+
+	return (
+		<PageHeader
+			prefix={
+				<PageHeader.SubNavigation
+					items={ [
+						{
+							label: __( 'Billing' ),
+							href: router.buildLocation( {
+								to: billingIndexRoute.fullPath,
+							} ).href,
+						},
+					] }
+				/>
+			}
+			{ ...props }
+		/>
+	);
+}

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -21,12 +21,12 @@ import { info, warning } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
 import { formatCreditCardExpiry } from '../../utils/datetime';
 import { isCreditCard } from '../../utils/payment-method';
+import BillingPageHeader from '../billing-page-header';
 import { PaymentMethodImage } from '../billing-purchases/payment-method-image';
 import { PaymentMethodDeleteDialog } from './payment-method-delete-dialog';
 import { PaymentMethodDetails } from './payment-method-details';
@@ -170,7 +170,7 @@ export default function PaymentMethods() {
 		<PageLayout
 			size="large"
 			header={
-				<PageHeader
+				<BillingPageHeader
 					title={ __( 'Payment methods' ) }
 					actions={
 						<Button __next40pxDefaultSize variant="primary" href={ addPaymentMethodUrl }>

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -11,9 +11,9 @@ import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { purchasesRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
+import BillingPageHeader from '../billing-page-header';
 import {
 	purchasesWideFields,
 	purchasesDesktopFields,
@@ -151,7 +151,7 @@ export default function PurchasesList() {
 	};
 
 	return (
-		<PageLayout size="large" header={ <PageHeader title={ __( 'Active upgrades' ) } /> }>
+		<PageLayout size="large" header={ <BillingPageHeader title={ __( 'Active upgrades' ) } /> }>
 			<div ref={ ref }>
 				<DataViewsCard>
 					<DataViews

--- a/client/dashboard/me/notifications-comments/index.tsx
+++ b/client/dashboard/me/notifications-comments/index.tsx
@@ -1,13 +1,13 @@
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import NotificationsPageHeader from '../notifications-page-header';
 
 export default function NotificationsComments() {
 	return (
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<NotificationsPageHeader
 					title={ __( 'Comments' ) }
 					description={ __(
 						'Set your notification preferences for activity on comments you’ve made on other sites.'

--- a/client/dashboard/me/notifications-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/index.tsx
@@ -1,8 +1,8 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import NotificationsPageHeader from '../notifications-page-header';
 import { PauseAllEmails } from './pause-all-emails';
 import { SubscriptionSettings } from './subscription-settings';
 
@@ -11,10 +11,10 @@ export default function NotificationsEmails() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<NotificationsPageHeader
 					title={ __( 'Emails' ) }
 					description={ createInterpolateElement(
-						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),
+						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),
 						{
 							link: <a href="/reader/subscriptions" target="_blank" rel="noopener noreferrer" />,
 						}

--- a/client/dashboard/me/notifications-extras/index.tsx
+++ b/client/dashboard/me/notifications-extras/index.tsx
@@ -5,9 +5,9 @@ import {
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
+import NotificationsPageHeader from '../notifications-page-header';
 import {
 	WPCOM_OPTION_KEYS,
 	WPCOM_TITLES,
@@ -33,7 +33,7 @@ export default function NotificationsExtras() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<NotificationsPageHeader
 					title={ __( 'Extras' ) }
 					description={ __(
 						'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'

--- a/client/dashboard/me/notifications-page-header/index.tsx
+++ b/client/dashboard/me/notifications-page-header/index.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { securityIndexRoute } from '../../app/router/me';
+import { notificationsIndexRoute } from '../../app/router/me';
 import { PageHeader } from '../../components/page-header';
 import type { PageHeaderProps } from '../../components/page-header/types';
 
-export default function SecurityPageHeader( props: PageHeaderProps ) {
+export default function NotificationsPageHeader( props: PageHeaderProps ) {
 	const router = useRouter();
 
 	return (
@@ -13,9 +13,9 @@ export default function SecurityPageHeader( props: PageHeaderProps ) {
 				<PageHeader.SubNavigation
 					items={ [
 						{
-							label: __( 'Security' ),
+							label: __( 'Notifications' ),
 							href: router.buildLocation( {
-								to: securityIndexRoute.fullPath,
+								to: notificationsIndexRoute.fullPath,
 							} ).href,
 						},
 					] }

--- a/client/dashboard/me/notifications-sites/index.tsx
+++ b/client/dashboard/me/notifications-sites/index.tsx
@@ -3,8 +3,8 @@ import { notificationPushPermissionStateQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import NotificationsPageHeader from '../notifications-page-header';
 import { BrowserNotificationCard } from './browser-notification-card';
 import { BrowserNotificationNotice } from './browser-notification-notice';
 
@@ -15,7 +15,7 @@ export default function NotificationsSites() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<NotificationsPageHeader
 					title={ __( 'Sites' ) }
 					description={ __(
 						'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'

--- a/client/dashboard/me/tax-details/index.tsx
+++ b/client/dashboard/me/tax-details/index.tsx
@@ -1,7 +1,7 @@
 import { Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import BillingPageHeader from '../billing-page-header';
 import UserTaxForm from './user-tax-form';
 
 export default function UserTaxInfoPage() {
@@ -9,7 +9,7 @@ export default function UserTaxInfoPage() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<BillingPageHeader
 					title={ __( 'Tax details' ) }
 					description={ __( 'Configure tax details (VAT/GST/CT) to be included on all receipts.' ) }
 				/>

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -2,7 +2,6 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
-	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -11,8 +10,8 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
-import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
@@ -107,22 +106,26 @@ function SiteBackupDownload() {
 		}
 	};
 
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug } } );
-			} }
-		>
-			{ __( 'Backups' ) }
-		</Button>
-	);
-
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ backButton } title={ __( 'Download backup' ) } /> }
+			header={
+				<PageHeader
+					prefix={
+						<PageHeader.SubNavigation
+							items={ [
+								{
+									label: __( 'Backups' ),
+									href: router.buildLocation( {
+										to: siteBackupsRoute.fullPath,
+									} ).href,
+								},
+							] }
+						/>
+					}
+					title={ __( 'Download backup' ) }
+				/>
+			}
 		>
 			<Card>
 				{ currentStep !== 'success' && (

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -2,7 +2,6 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
-	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -11,8 +10,8 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
-import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupRestoreRoute, siteBackupsRoute } from '../../app/router/sites';
@@ -91,22 +90,26 @@ function SiteBackupRestore() {
 		}
 	};
 
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug } } );
-			} }
-		>
-			{ __( 'Backups' ) }
-		</Button>
-	);
-
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ backButton } title={ __( 'Site restore' ) } /> }
+			header={
+				<PageHeader
+					prefix={
+						<PageHeader.SubNavigation
+							items={ [
+								{
+									label: __( 'Backups' ),
+									href: router.buildLocation( {
+										to: siteBackupsRoute.fullPath,
+									} ).href,
+								},
+							] }
+						/>
+					}
+					title={ __( 'Site restore' ) }
+				/>
+			}
 		>
 			<Card>
 				{ currentStep !== 'success' && (

--- a/client/dashboard/sites/settings-page-header/index.tsx
+++ b/client/dashboard/sites/settings-page-header/index.tsx
@@ -1,8 +1,6 @@
 import { useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { siteRoute } from '../../app/router/sites';
+import { __ } from '@wordpress/i18n';
+import { siteSettingsRoute } from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import type { PageHeaderProps } from '../../components/page-header/types';
 
@@ -12,24 +10,24 @@ interface SettingsPageHeaderProps extends PageHeaderProps {
 }
 
 export default function SettingsPageHeader( props: SettingsPageHeaderProps ) {
-	const { siteSlug } = siteRoute.useParams();
 	const { backPath, backLabel, ...pageHeaderProps } = props;
 	const router = useRouter();
 
-	const defaultBackPath = `/sites/${ siteSlug }/settings`;
-	const defaultBackLabel = __( 'Settings' );
-
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: backPath || defaultBackPath } );
-			} }
-		>
-			{ backLabel || defaultBackLabel }
-		</Button>
+	return (
+		<PageHeader
+			prefix={
+				<PageHeader.SubNavigation
+					items={ [
+						{
+							label: __( 'Settings' ),
+							href: router.buildLocation( {
+								to: siteSettingsRoute.fullPath,
+							} ).href,
+						},
+					] }
+				/>
+			}
+			{ ...pageHeaderProps }
+		/>
 	);
-
-	return <PageHeader prefix={ backButton } { ...pageHeaderProps } />;
 }

--- a/packages/components/src/breadcrumbs/index.tsx
+++ b/packages/components/src/breadcrumbs/index.tsx
@@ -176,12 +176,11 @@ function UnforwardedBreadcrumbs(
 	} );
 
 	const mergedRefs = useMergeRefs( [ ref, containerRef ] );
-	if ( ! items.length || items.length === 1 ) {
-		return null;
-	}
+	// if ( ! items.length || items.length === 1 ) {
+	// 	return null;
+	// }
 
 	const computedVariant = shouldRenderCompact ? 'compact' : props.variant;
-
 	return (
 		<>
 			<BreadcrumbsNav

--- a/packages/components/src/breadcrumbs/style.scss
+++ b/packages/components/src/breadcrumbs/style.scss
@@ -29,9 +29,13 @@
 		}
 	}
 
+	.a8c-components-breadcrumbs__item-wrapper a {
+		text-decoration: underline;
+	}
+
 	.a8c-components-breadcrumbs__item {
 		color: $gray-700;
-		text-decoration: none;
+
 		height: auto;
 		padding: 0;
 		@include body-medium;
@@ -39,6 +43,7 @@
 		&:hover {
 			color: $gray-900;
 		}
+
 	}
 
 	&.is-offscreen {

--- a/packages/components/src/breadcrumbs/style.scss
+++ b/packages/components/src/breadcrumbs/style.scss
@@ -13,6 +13,7 @@
 	.a8c-components-breadcrumbs__item-wrapper {
 		display: inline-flex;
 		flex-shrink: 0;
+		align-items: center;
 
 		&.is-current {
 			.breadcrumb__item {


### PR DESCRIPTION
> [!WARNING]
> This is a PR to test experience and isn't ready to be merged. For discussions on technical approach, see #105885

## Proposed Changes

This PR utilizes #105885 ❤️ to test what it would _feel_ like to rely solely on a breadcrumb and the back button for dashboard navigation. 

For more context, read:

pgz0xU-f7-p2

## Why are these changes being made?

We don't have a standard for navigating or communication the dashboard IA to our users.

## Screenshots

<img width="773" height="332" alt="Screenshot 2025-09-24 at 11 26 38 AM" src="https://github.com/user-attachments/assets/7cd06fd4-4817-4328-b407-7e6ae815f1e4" />
<img width="735" height="297" alt="Screenshot 2025-09-24 at 11 26 33 AM" src="https://github.com/user-attachments/assets/867b798f-a520-4e58-aeac-5e24967c456f" />
<img width="1385" height="776" alt="Screenshot 2025-09-24 at 11 26 26 AM" src="https://github.com/user-attachments/assets/661653c8-ddf5-4490-9e61-6cb4c6791cd5" />
<img width="711" height="747" alt="Screenshot 2025-09-24 at 11 26 12 AM" src="https://github.com/user-attachments/assets/50fa8da1-c28f-4119-8731-41605b18cfbb" />
<img width="754" height="620" alt="Screenshot 2025-09-24 at 11 26 16 AM" src="https://github.com/user-attachments/assets/095fafe6-061d-4e25-b34b-a93c72cf4c1a" />
<img width="730" height="710" alt="Screenshot 2025-09-24 at 11 25 59 AM" src="https://github.com/user-attachments/assets/fa51c951-fd27-4bad-8305-bd4e6b4b6ab0" />
<img width="726" height="537" alt="Screenshot 2025-09-24 at 11 25 51 AM" src="https://github.com/user-attachments/assets/404c5548-172a-4c95-92f8-71976b0cf148" />


## Testing Instructions

No specific instructions, but click around the dashboard and note how easily you can navigate.

Pages with Breadcrumbs:
- Site Settings
- Backups
- Notifications
- Billing
- Security
- Domains

Try navigations from the  (Site|Domains) Overview pages as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?