### PR TITLE
Domain Search Rewrite: Retire domainAndPlanPackage flow

### DIFF
--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -39,7 +39,7 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 		recordTracksEvent( trackEventClick );
 
 		if ( shouldRenderRewrittenDomainSearch() ) {
-			return window.location.assign( `/setup/domain-upsell?siteSlug=${ site?.slug }` );
+			return window.location.assign( `/setup/domain-and-plan?siteSlug=${ site?.slug }` );
 		}
 
 		page( `/domains/add/${ site?.domain }?domainAndPlanPackage=true` );

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
@@ -42,11 +43,13 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 
 		recordTracksEvent( trackEventClick );
 
+		const domainUpsellUrl = getDomainAndPlanUpsellUrl( { siteSlug: site.slug } );
+
 		if ( shouldRenderRewrittenDomainSearch() ) {
-			return window.location.assign( `/setup/domain-and-plan?siteSlug=${ site.slug }` );
+			return window.location.assign( domainUpsellUrl );
 		}
 
-		page( `/domains/add/${ site.domain }?domainAndPlanPackage=true` );
+		page( domainUpsellUrl );
 	}, [ trackEventClick, site ] );
 
 	const getDismissClickHandler = () => {

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -36,8 +37,13 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 
 	const getCtaClickHandler = useCallback( () => {
 		recordTracksEvent( trackEventClick );
+
+		if ( shouldRenderRewrittenDomainSearch() ) {
+			return window.location.assign( `/setup/domain-upsell?siteSlug=${ site?.slug }` );
+		}
+
 		page( `/domains/add/${ site?.domain }?domainAndPlanPackage=true` );
-	}, [ trackEventClick, site?.domain ] );
+	}, [ trackEventClick, site?.domain, site?.slug ] );
 
 	const getDismissClickHandler = () => {
 		recordTracksEvent( trackEventDismiss );

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -36,14 +36,18 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 	const { __ } = useI18n();
 
 	const getCtaClickHandler = useCallback( () => {
+		if ( ! site ) {
+			return;
+		}
+
 		recordTracksEvent( trackEventClick );
 
 		if ( shouldRenderRewrittenDomainSearch() ) {
-			return window.location.assign( `/setup/domain-and-plan?siteSlug=${ site?.slug }` );
+			return window.location.assign( `/setup/domain-and-plan?siteSlug=${ site.slug }` );
 		}
 
-		page( `/domains/add/${ site?.domain }?domainAndPlanPackage=true` );
-	}, [ trackEventClick, site?.domain, site?.slug ] );
+		page( `/domains/add/${ site.domain }?domainAndPlanPackage=true` );
+	}, [ trackEventClick, site ] );
 
 	const getDismissClickHandler = () => {
 		recordTracksEvent( trackEventDismiss );

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -5,7 +5,6 @@ import { Gridicon } from '@automattic/components';
 import { useMemo } from '@wordpress/element';
 import { globe, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
@@ -36,22 +35,6 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 	const { __ } = useI18n();
 
-	const getCtaClickHandler = useCallback( () => {
-		if ( ! site ) {
-			return;
-		}
-
-		recordTracksEvent( trackEventClick );
-
-		const domainUpsellUrl = getDomainAndPlanUpsellUrl( { siteSlug: site.slug } );
-
-		if ( shouldRenderRewrittenDomainSearch() ) {
-			return window.location.assign( domainUpsellUrl );
-		}
-
-		page( domainUpsellUrl );
-	}, [ trackEventClick, site ] );
-
 	const getDismissClickHandler = () => {
 		recordTracksEvent( trackEventDismiss );
 		dispatch( savePreference( dismissPreference, 1 ) );
@@ -68,6 +51,18 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 	) {
 		return null;
 	}
+
+	const getCtaClickHandler = () => {
+		recordTracksEvent( trackEventClick );
+
+		const domainUpsellUrl = getDomainAndPlanUpsellUrl( { siteSlug: site.slug } );
+
+		if ( shouldRenderRewrittenDomainSearch() ) {
+			return window.location.assign( domainUpsellUrl );
+		}
+
+		page( domainUpsellUrl );
+	};
 
 	return (
 		<>

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -6,9 +6,8 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
-// This imports the feature flag decider and will be removed soon.
 // eslint-disable-next-line no-restricted-imports
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
@@ -73,18 +72,11 @@ const DomainUpsellCardContent = ( {
 		}
 
 		if ( site.plan?.is_free || site.plan?.billing_period === 'Monthly' ) {
-			if ( shouldRenderRewrittenDomainSearch() ) {
-				window.location.href = addQueryArgs( '/setup/domain-and-plan/plans', {
-					siteSlug: site.slug,
-					back_to: backUrl,
-				} );
-			} else {
-				window.location.href = addQueryArgs( `/plans/yearly/${ site.slug }`, {
-					domain: true,
-					domainAndPlanPackage: true,
-					back_to: backUrl,
-				} );
-			}
+			window.location.href = getDomainAndPlanUpsellUrl( {
+				siteSlug: site.slug,
+				backUrl,
+				step: 'plans',
+			} );
 		} else {
 			window.location.href = addQueryArgs( `/checkout/${ site.slug }`, {
 				cancel_to: backUrl,
@@ -93,16 +85,10 @@ const DomainUpsellCardContent = ( {
 		}
 	};
 
-	const chooseYourOwnUrl = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs( `${ window.location.origin }/setup/domain-and-plan`, {
-				siteSlug: site.slug,
-				back_to: backUrl,
-		  } )
-		: addQueryArgs( `${ window.location.origin }/domains/add/${ site.slug }`, {
-				domainAndPlanPackage: true,
-				domain: true,
-				back_to: backUrl,
-		  } );
+	const chooseYourOwnUrl = getDomainAndPlanUpsellUrl( {
+		siteSlug: site.slug,
+		backUrl,
+	} );
 
 	return (
 		<Callout

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -6,6 +6,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
+// This imports the feature flag decider and will be removed soon.
+// eslint-disable-next-line no-restricted-imports
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
@@ -70,11 +73,18 @@ const DomainUpsellCardContent = ( {
 		}
 
 		if ( site.plan?.is_free || site.plan?.billing_period === 'Monthly' ) {
-			window.location.href = addQueryArgs( `/plans/yearly/${ site.slug }`, {
-				domain: true,
-				domainAndPlanPackage: true,
-				back_to: backUrl,
-			} );
+			if ( shouldRenderRewrittenDomainSearch() ) {
+				window.location.href = addQueryArgs( '/setup/domain-upsell/plans', {
+					siteSlug: site.slug,
+					back_to: backUrl,
+				} );
+			} else {
+				window.location.href = addQueryArgs( `/plans/yearly/${ site.slug }`, {
+					domain: true,
+					domainAndPlanPackage: true,
+					back_to: backUrl,
+				} );
+			}
 		} else {
 			window.location.href = addQueryArgs( `/checkout/${ site.slug }`, {
 				cancel_to: backUrl,
@@ -82,6 +92,17 @@ const DomainUpsellCardContent = ( {
 			} );
 		}
 	};
+
+	const chooseYourOwnUrl = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs( `${ window.location.origin }/setup/domain-upsell`, {
+				siteSlug: site.slug,
+				back_to: backUrl,
+		  } )
+		: addQueryArgs( `${ window.location.origin }/domains/add/${ site.slug }`, {
+				domainAndPlanPackage: true,
+				domain: true,
+				back_to: backUrl,
+		  } );
 
 	return (
 		<Callout
@@ -95,16 +116,7 @@ const DomainUpsellCardContent = ( {
 						) : (
 							<TextBlur>{ search }</TextBlur>
 						),
-						link: (
-							<Link
-								to={ addQueryArgs( `${ window.location.origin }/domains/add/${ site.slug }`, {
-									domainAndPlanPackage: true,
-									domain: true,
-									back_to: backUrl,
-								} ) }
-								onClick={ handleChooseYourOwn }
-							/>
-						),
+						link: <Link to={ chooseYourOwnUrl } onClick={ handleChooseYourOwn } />,
 					} ) }
 				</Text>
 			}

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -74,7 +74,7 @@ const DomainUpsellCardContent = ( {
 
 		if ( site.plan?.is_free || site.plan?.billing_period === 'Monthly' ) {
 			if ( shouldRenderRewrittenDomainSearch() ) {
-				window.location.href = addQueryArgs( '/setup/domain-upsell/plans', {
+				window.location.href = addQueryArgs( '/setup/domain-and-plan/plans', {
 					siteSlug: site.slug,
 					back_to: backUrl,
 				} );
@@ -94,7 +94,7 @@ const DomainUpsellCardContent = ( {
 	};
 
 	const chooseYourOwnUrl = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs( `${ window.location.origin }/setup/domain-upsell`, {
+		? addQueryArgs( `${ window.location.origin }/setup/domain-and-plan`, {
 				siteSlug: site.slug,
 				back_to: backUrl,
 		  } )

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -76,6 +76,7 @@ const DomainUpsellCardContent = ( {
 				siteSlug: site.slug,
 				backUrl,
 				step: 'plans',
+				domain: true,
 			} );
 		} else {
 			window.location.href = addQueryArgs( `/checkout/${ site.slug }`, {
@@ -88,6 +89,7 @@ const DomainUpsellCardContent = ( {
 	const chooseYourOwnUrl = getDomainAndPlanUpsellUrl( {
 		siteSlug: site.slug,
 		backUrl,
+		domain: true,
 	} );
 
 	return (

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/README.md
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/README.md
@@ -1,10 +1,10 @@
-# domain-upsell flow
+# domain-and-plan flow
 
 ## Testing instructions
 
 Please improve the instructions on how to test this flow.
 
-1. Go to /setup/domain-upsell.
+1. Go to /setup/domain-and-plan.
 
 ## Owned by
 

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -11,11 +11,10 @@ import { useEffect, useRef } from 'react';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
-import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
-import { ProvidedDependencies } from '../../internals/types';
+import { AssertConditionState, ProvidedDependencies } from '../../internals/types';
 import type { Flow } from '../../internals/types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
@@ -38,8 +37,7 @@ const domainUpsell: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const backTo = useQuery().get( 'back_to' );
 		const flowName = this.name;
-		const siteSlug = useSiteSlug();
-		const siteId = useSiteIdParam();
+		const siteSlug = useSiteSlug()!;
 		const { getDomainCartItem, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
@@ -54,7 +52,6 @@ const domainUpsell: Flow = {
 
 		const returnUrl =
 			launchpadScreenOption === 'skipped' || ! backTo ? `/home/${ siteSlug }` : backTo;
-		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		const submittedDomains = useRef( false );
 
@@ -81,9 +78,8 @@ const domainUpsell: Flow = {
 					if ( ! isUsingRewrittenDomainSearch ) {
 						if ( providedDependencies?.deferDomainSelection ) {
 							try {
-								const siteIdentifier = siteSlug || siteId;
-								if ( siteIdentifier ) {
-									await updateLaunchpadSettings( siteIdentifier, {
+								if ( siteSlug ) {
+									await updateLaunchpadSettings( siteSlug, {
 										checklist_statuses: { domain_upsell_deferred: true },
 									} );
 								}
@@ -147,24 +143,34 @@ const domainUpsell: Flow = {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
 
-						if ( planCartItem && siteSlug ) {
+						if ( planCartItem ) {
 							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
 						}
 
-						if ( domainCartItem && siteSlug ) {
+						if ( domainCartItem ) {
 							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
 						}
 
 						return window.location.assign(
-							`/checkout/${ encodeURIComponent(
-								siteSlug ?? ''
-							) }?redirect_to=${ encodedReturnUrl }`
+							`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent( returnUrl ) }`
 						);
 					}
+
+					return window.location.assign( returnUrl );
 			}
 		}
 
 		return { submit, goBack };
+	},
+	useAssertConditions() {
+		const siteSlug = useSiteSlug();
+
+		if ( ! siteSlug ) {
+			window.location.assign( '/sites' );
+			return { state: AssertConditionState.FAILURE, message: 'siteSlug is required' };
+		}
+
+		return { state: AssertConditionState.SUCCESS };
 	},
 	useSideEffect() {
 		const { setHideFreePlan } = useDispatch( ONBOARD_STORE ) as OnboardActions;

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -139,6 +139,10 @@ const domainUpsell: Flow = {
 					return navigate( STEPS.PLANS.slug );
 				}
 				case STEPS.PLANS.slug:
+					await updateLaunchpadSettings( siteSlug, {
+						checklist_statuses: { plan_completed: true },
+					} );
+
 					if ( providedDependencies?.goToCheckout ) {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -56,20 +56,22 @@ const domainUpsell: Flow = {
 		const submittedDomains = useRef( false );
 
 		function goBack() {
-			if ( currentStep === 'domains' ) {
+			if ( currentStep === STEPS.DOMAINS.slug ) {
 				return window.location.assign( returnUrl );
 			}
-			if ( currentStep === 'plans' ) {
+			if ( currentStep === STEPS.PLANS.slug ) {
 				if ( ! submittedDomains.current ) {
 					return window.location.assign( returnUrl );
 				}
 
-				return navigate( 'domains' );
+				return navigate( STEPS.DOMAINS.slug );
 			}
 
-			if ( currentStep === 'use-my-domain' ) {
-				return navigate( 'domains' );
+			if ( currentStep === STEPS.USE_MY_DOMAIN.slug ) {
+				return navigate( STEPS.DOMAINS.slug );
 			}
+
+			throw new Error( `Step back button not handled: ${ currentStep }` );
 		}
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -4,7 +4,7 @@ import {
 	updateLaunchpadSettings,
 	useLaunchpad,
 } from '@automattic/data-stores';
-import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
+import { addPlanToCart, addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
@@ -28,7 +28,7 @@ const DOMAIN_UPSELL_STEPS = [
 ];
 
 const domainUpsell: Flow = {
-	name: DOMAIN_UPSELL_FLOW,
+	name: DOMAIN_AND_PLAN_FLOW,
 	isSignupFlow: false,
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
@@ -7,7 +7,7 @@ import {
 import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
@@ -47,8 +47,9 @@ const domainUpsell: Flow = {
 			} ),
 			[]
 		);
-		const { setDomainCartItem, setDomainCartItems, setSignupDomainOrigin, setHideFreePlan } =
-			useDispatch( ONBOARD_STORE ) as OnboardActions;
+		const { setDomainCartItem, setDomainCartItems, setSignupDomainOrigin } = useDispatch(
+			ONBOARD_STORE
+		) as OnboardActions;
 		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
 
 		const returnUrl =
@@ -87,7 +88,6 @@ const domainUpsell: Flow = {
 							return window.location.assign( returnUrl );
 						}
 
-						setHideFreePlan( true );
 						submittedDomains.current = true;
 						navigate( STEPS.PLANS.slug );
 						return;
@@ -110,8 +110,6 @@ const domainUpsell: Flow = {
 					}
 
 					submittedDomains.current = true;
-
-					setHideFreePlan( true );
 
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
@@ -163,6 +161,13 @@ const domainUpsell: Flow = {
 		}
 
 		return { submit, goBack };
+	},
+	useSideEffect() {
+		const { setHideFreePlan } = useDispatch( ONBOARD_STORE ) as OnboardActions;
+
+		useEffect( () => {
+			setHideFreePlan( true );
+		}, [ setHideFreePlan ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
@@ -67,7 +67,11 @@ const domainUpsell: Flow = {
 					return window.location.assign( returnUrl );
 				}
 
-				navigate( 'domains' );
+				return navigate( 'domains' );
+			}
+
+			if ( currentStep === 'use-my-domain' ) {
+				return navigate( 'domains' );
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
@@ -1,8 +1,14 @@
-import { OnboardSelect, updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
+import {
+	OnboardActions,
+	OnboardSelect,
+	updateLaunchpadSettings,
+	useLaunchpad,
+} from '@automattic/data-stores';
 import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
+import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
 import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
@@ -10,17 +16,18 @@ import { ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
 import { ProvidedDependencies } from '../../internals/types';
 import type { Flow } from '../../internals/types';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+
+const isUsingRewrittenDomainSearch = shouldRenderRewrittenDomainSearch();
 
 const DOMAIN_UPSELL_STEPS = [
-	shouldRenderRewrittenDomainSearch() ? STEPS.DOMAIN_SEARCH : STEPS.DOMAINS,
+	isUsingRewrittenDomainSearch ? STEPS.DOMAIN_SEARCH : STEPS.DOMAINS,
+	STEPS.USE_MY_DOMAIN,
 	STEPS.PLANS,
 ];
 
 const domainUpsell: Flow = {
 	name: DOMAIN_UPSELL_FLOW,
-	get title() {
-		return translate( 'Domain Upsell' );
-	},
 	isSignupFlow: false,
 
 	useSteps() {
@@ -38,13 +45,14 @@ const domainUpsell: Flow = {
 			} ),
 			[]
 		);
-		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
+		const { setDomainCartItem, setDomainCartItems, setSignupDomainOrigin, setHideFreePlan } =
+			useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
 
 		const returnUrl =
-			launchpadScreenOption === 'skipped'
+			launchpadScreenOption === 'skipped' || ! flowName
 				? `/home/${ siteSlug }`
-				: `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
+				: `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		function goBack() {
@@ -58,32 +66,80 @@ const domainUpsell: Flow = {
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
-				case 'domains':
-					if ( providedDependencies?.deferDomainSelection ) {
-						try {
-							const siteIdentifier = siteSlug || siteId;
-							if ( siteIdentifier ) {
-								await updateLaunchpadSettings( siteIdentifier, {
-									checklist_statuses: { domain_upsell_deferred: true },
-								} );
-							}
-						} catch ( error ) {}
+				case STEPS.DOMAINS.slug: {
+					if ( ! isUsingRewrittenDomainSearch ) {
+						if ( providedDependencies?.deferDomainSelection ) {
+							try {
+								const siteIdentifier = siteSlug || siteId;
+								if ( siteIdentifier ) {
+									await updateLaunchpadSettings( siteIdentifier, {
+										checklist_statuses: { domain_upsell_deferred: true },
+									} );
+								}
+							} catch ( error ) {}
 
-						return window.location.assign( returnUrl );
+							return window.location.assign( returnUrl );
+						}
+
+						setHideFreePlan( true );
+						navigate( STEPS.PLANS.slug );
+						return;
 					}
-					setHideFreePlan( true );
-					navigate( 'plans' );
 
-				case 'plans':
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						return navigate( useMyDomainURL as typeof currentStep );
+					}
+
+					setHideFreePlan( true );
+
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
+					return navigate( STEPS.PLANS.slug );
+				}
+				case STEPS.USE_MY_DOMAIN.slug: {
+					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
+						const destination = addQueryArgs( '/use-my-domain', {
+							...getQueryArgs( window.location.href ),
+							step: providedDependencies.mode,
+							initialQuery: providedDependencies.domain,
+						} );
+						return navigate( destination as typeof currentStep );
+					}
+
+					return navigate( STEPS.PLANS.slug );
+				}
+				case STEPS.PLANS.slug:
 					if ( providedDependencies?.goToCheckout ) {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
-						if ( planCartItem && siteSlug && flowName ) {
-							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
+
+						if ( planCartItem && siteSlug ) {
+							await addPlanToCart( siteSlug, flowName as string, true, '', planCartItem );
 						}
 
-						if ( domainCartItem && siteSlug && flowName ) {
-							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
+						if ( domainCartItem && siteSlug ) {
+							await addProductsToCart( siteSlug, flowName as string, [ domainCartItem ] );
 						}
 
 						return window.location.assign(

--- a/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
@@ -35,7 +35,8 @@ const domainUpsell: Flow = {
 	},
 
 	useStepNavigation( currentStep, navigate ) {
-		const flowName = useQuery().get( 'flowToReturnTo' );
+		const backTo = useQuery().get( 'back_to' );
+		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 		const siteId = useSiteIdParam();
 		const { getDomainCartItem, getPlanCartItem } = useSelect(
@@ -50,9 +51,7 @@ const domainUpsell: Flow = {
 		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
 
 		const returnUrl =
-			launchpadScreenOption === 'skipped' || ! flowName
-				? `/home/${ siteSlug }`
-				: `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
+			launchpadScreenOption === 'skipped' || ! backTo ? `/home/${ siteSlug }` : backTo;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		function goBack() {
@@ -135,11 +134,11 @@ const domainUpsell: Flow = {
 						const domainCartItem = getDomainCartItem();
 
 						if ( planCartItem && siteSlug ) {
-							await addPlanToCart( siteSlug, flowName as string, true, '', planCartItem );
+							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
 						}
 
 						if ( domainCartItem && siteSlug ) {
-							await addProductsToCart( siteSlug, flowName as string, [ domainCartItem ] );
+							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
 						}
 
 						return window.location.assign(

--- a/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-upsell/domain-upsell.ts
@@ -7,6 +7,7 @@ import {
 import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+import { useRef } from 'react';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
@@ -54,11 +55,17 @@ const domainUpsell: Flow = {
 			launchpadScreenOption === 'skipped' || ! backTo ? `/home/${ siteSlug }` : backTo;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
+		const submittedDomains = useRef( false );
+
 		function goBack() {
 			if ( currentStep === 'domains' ) {
 				return window.location.assign( returnUrl );
 			}
 			if ( currentStep === 'plans' ) {
+				if ( ! submittedDomains.current ) {
+					return window.location.assign( returnUrl );
+				}
+
 				navigate( 'domains' );
 			}
 		}
@@ -81,6 +88,7 @@ const domainUpsell: Flow = {
 						}
 
 						setHideFreePlan( true );
+						submittedDomains.current = true;
 						navigate( STEPS.PLANS.slug );
 						return;
 					}
@@ -100,6 +108,8 @@ const domainUpsell: Flow = {
 
 						return navigate( useMyDomainURL as typeof currentStep );
 					}
+
+					submittedDomains.current = true;
 
 					setHideFreePlan( true );
 
@@ -125,6 +135,8 @@ const domainUpsell: Flow = {
 						} );
 						return navigate( destination as typeof currentStep );
 					}
+
+					submittedDomains.current = true;
 
 					return navigate( STEPS.PLANS.slug );
 				}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -189,7 +189,7 @@ button {
 		}
 	}
 
-	&:not(:has(.wpcom-domain-search-v2)) {
+	&:not(:has(.wpcom-domain-search-v2)):not(:has(.domain-search--step-container)):not(:has(.domain-search--step-container-v2)) {
 		// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
 		.components-button.is-primary {
 			border-radius: 4px;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -120,7 +120,7 @@ button {
 			&.courses,
 			&.site-picker,
 			&.new-or-existing-site,
-			&.domains:not(.copy-site):not(.ai-site-builder):not(.domain-upsell):not(.onboarding):not(.newsletter):not(.readymade-template):not(.reblogging):not(.start-writing) {
+			&.domains:not(.copy-site):not(.ai-site-builder):not(.domain-and-plan):not(.onboarding):not(.newsletter):not(.readymade-template):not(.reblogging):not(.start-writing) {
 				margin-top: -60px;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -2,7 +2,7 @@ import {
 	isAIBuilderFlow,
 	isCopySiteFlow,
 	isDomainFlow,
-	isDomainUpsellFlow,
+	isDomainAndPlanFlow,
 	isHundredYearDomainFlow,
 	isHundredYearPlanFlow,
 	isNewHostedSiteCreationFlow,
@@ -75,7 +75,7 @@ const DomainSearchStep: StepType< {
 		return {
 			vendor: getSuggestionsVendor( {
 				isSignup:
-					! isDomainUpsellFlow( flow ) && ! isCopySiteFlow( flow ) && ! isDomainFlow( flow ),
+					! isDomainAndPlanFlow( flow ) && ! isCopySiteFlow( flow ) && ! isDomainFlow( flow ),
 				isDomainOnly: isDomainFlow( flow ),
 				flowName: flow,
 			} ),
@@ -88,7 +88,7 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&
 				! isDomainFlow( flow ) &&
-				! isDomainUpsellFlow( flow ),
+				! isDomainAndPlanFlow( flow ),
 			allowedTlds,
 			allowsUsingOwnDomain: ! isAIBuilderFlow( flow ) && ! isNewHostedSiteCreationFlow( flow ),
 		};
@@ -186,14 +186,14 @@ const DomainSearchStep: StepType< {
 			config={ config }
 			query={ query }
 			isFirstDomainFreeForFirstYear={
-				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isDomainUpsellFlow( flow )
+				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isDomainAndPlanFlow( flow )
 			}
 			events={ events }
 			flowAllowsMultipleDomainsInCart={
 				isOnboardingFlow( flow ) ||
 				isDomainFlow( flow ) ||
 				isNewHostedSiteCreationFlow( flow ) ||
-				isDomainUpsellFlow( flow )
+				isDomainAndPlanFlow( flow )
 			}
 			slots={ slots }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -187,7 +187,10 @@ const DomainSearchStep: StepType< {
 			isFirstDomainFreeForFirstYear={ isOnboardingFlow( flow ) || isDomainFlow( flow ) }
 			events={ events }
 			flowAllowsMultipleDomainsInCart={
-				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isNewHostedSiteCreationFlow( flow )
+				isOnboardingFlow( flow ) ||
+				isDomainFlow( flow ) ||
+				isNewHostedSiteCreationFlow( flow ) ||
+				isDomainUpsellFlow( flow )
 			}
 			slots={ slots }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -2,6 +2,7 @@ import {
 	isAIBuilderFlow,
 	isCopySiteFlow,
 	isDomainFlow,
+	isDomainUpsellFlow,
 	isHundredYearDomainFlow,
 	isHundredYearPlanFlow,
 	isNewHostedSiteCreationFlow,
@@ -73,7 +74,8 @@ const DomainSearchStep: StepType< {
 
 		return {
 			vendor: getSuggestionsVendor( {
-				isSignup: true,
+				isSignup:
+					! isDomainUpsellFlow( flow ) && ! isCopySiteFlow( flow ) && ! isDomainFlow( flow ),
 				isDomainOnly: isDomainFlow( flow ),
 				flowName: flow,
 			} ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -87,7 +87,8 @@ const DomainSearchStep: StepType< {
 			skippable:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&
-				! isDomainFlow( flow ),
+				! isDomainFlow( flow ) &&
+				! isDomainUpsellFlow( flow ),
 			allowedTlds,
 			allowsUsingOwnDomain: ! isAIBuilderFlow( flow ) && ! isNewHostedSiteCreationFlow( flow ),
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -227,6 +227,7 @@ const DomainSearchStep: StepType< {
 			stepName="step-container--domain-search"
 			isWideLayout
 			flowName={ flow }
+			goBack={ navigation.goBack }
 			formattedHeader={
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -73,7 +73,7 @@ const DomainSearchStep: StepType< {
 
 		return {
 			vendor: getSuggestionsVendor( {
-				isSignup: false,
+				isSignup: true,
 				isDomainOnly: isDomainFlow( flow ),
 				flowName: flow,
 			} ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -185,7 +185,9 @@ const DomainSearchStep: StepType< {
 			flowName={ flow }
 			config={ config }
 			query={ query }
-			isFirstDomainFreeForFirstYear={ isOnboardingFlow( flow ) || isDomainFlow( flow ) }
+			isFirstDomainFreeForFirstYear={
+				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isDomainUpsellFlow( flow )
+			}
 			events={ events }
 			flowAllowsMultipleDomainsInCart={
 				isOnboardingFlow( flow ) ||

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -1,6 +1,6 @@
 import {
 	COPY_SITE_FLOW,
-	DOMAIN_UPSELL_FLOW,
+	DOMAIN_AND_PLAN_FLOW,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	NEWSLETTER_FLOW,
@@ -96,7 +96,7 @@ export function DomainFormControl( {
 		showSkipButton = true;
 	}
 
-	if ( flow === DOMAIN_UPSELL_FLOW ) {
+	if ( flow === DOMAIN_AND_PLAN_FLOW ) {
 		includeWordPressDotCom = false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -4,9 +4,8 @@ import {
 	COPY_SITE_FLOW,
 	isCopySiteFlow,
 	NEWSLETTER_FLOW,
-	DOMAIN_UPSELL_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
-	isDomainUpsellFlow,
+	isDomainAndPlanFlow,
 	isHundredYearDomainFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
@@ -162,7 +161,7 @@ const DomainsStep: Step< {
 
 		dispatch( recordTracksEvent( 'calypso_signup_skip_step', tracksProperties ) );
 
-		if ( flow === DOMAIN_UPSELL_FLOW ) {
+		if ( isDomainAndPlanFlow( flow ) ) {
 			return submit?.( { deferDomainSelection: true } );
 		}
 
@@ -295,21 +294,21 @@ const DomainsStep: Step< {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( isDomainUpsellFlow( flow ) ) {
+		if ( isDomainAndPlanFlow( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( isDomainUpsellFlow( flow ) ) {
+		if ( isDomainAndPlanFlow( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );
 	};
 
 	const shouldHideBackButton = () => {
-		if ( isDomainUpsellFlow( flow ) ) {
+		if ( isDomainAndPlanFlow( flow ) ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -7,7 +7,7 @@
 .readymade-template,
 .reblogging,
 .start-writing,
-.domain-upsell {
+.domain-and-plan {
 	&.domains.step-container {
 		&:has( .wpcom-domain-search-v2 ) {
 			padding: 0 16px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -19,7 +19,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { type NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { type ResponseDomain } from 'calypso/lib/domains/types';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { TYPE_TIER } from 'calypso/my-sites/earn/memberships/constants';
@@ -171,15 +171,14 @@ const Sidebar = ( {
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 
 	function getDomainUpgradeBadgeUrl() {
-		if ( shouldRenderRewrittenDomainSearch() ) {
-			return `/setup/domain-and-plan?siteSlug=${ siteSlug }`;
+		if ( ! siteSlug ) {
+			return '';
 		}
-		if ( isStartWritingFlow( siteIntentOption ) ) {
-			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;
+
+		if ( ! site?.plan?.is_free ) {
+			return `/domains/manage/${ siteSlug }`;
 		}
-		return ! site?.plan?.is_free
-			? `/domains/manage/${ siteSlug }`
-			: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+		return getDomainAndPlanUpsellUrl( { siteSlug } );
 	}
 
 	function showDomainUpgradeBadge() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -19,6 +19,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { type NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { type ResponseDomain } from 'calypso/lib/domains/types';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { TYPE_TIER } from 'calypso/my-sites/earn/memberships/constants';
@@ -170,6 +171,9 @@ const Sidebar = ( {
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 
 	function getDomainUpgradeBadgeUrl() {
+		if ( shouldRenderRewrittenDomainSearch() ) {
+			return `/setup/domain-upsell?siteSlug=${ siteSlug }`;
+		}
 		if ( isStartWritingFlow( siteIntentOption ) ) {
 			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -172,7 +172,7 @@ const Sidebar = ( {
 
 	function getDomainUpgradeBadgeUrl() {
 		if ( shouldRenderRewrittenDomainSearch() ) {
-			return `/setup/domain-upsell?siteSlug=${ siteSlug }`;
+			return `/setup/domain-and-plan?siteSlug=${ siteSlug }`;
 		}
 		if ( isStartWritingFlow( siteIntentOption ) ) {
 			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -175,9 +175,14 @@ const Sidebar = ( {
 			return '';
 		}
 
+		if ( isStartWritingFlow( siteIntentOption ) ) {
+			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;
+		}
+
 		if ( ! site?.plan?.is_free ) {
 			return `/domains/manage/${ siteSlug }`;
 		}
+
 		return getDomainAndPlanUpsellUrl( { siteSlug } );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,7 +1,7 @@
 import { Task } from '@automattic/launchpad';
 import { isStartWritingFlow } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
@@ -10,10 +10,16 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
 
 	const getDestionationUrl = () => {
-		const purchaseDomainUrl = addQueryArgs( '/setup/domain-and-plan', {
+		if ( ! siteSlug ) {
+			return '';
+		}
+
+		const backUrl = `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;
+
+		const purchaseDomainUrl = getDomainAndPlanUpsellUrl( {
 			siteSlug,
-			back_to: `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`,
-			new: site?.name,
+			backUrl,
+			suggestion: site?.name,
 		} );
 
 		return domainUpsellCompleted ? `/domains/manage/${ siteSlug }` : purchaseDomainUrl;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -30,6 +30,7 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 			siteSlug,
 			backUrl,
 			suggestion: site?.name,
+			forceStepperFlow: true,
 		} );
 
 		return domainUpsellCompleted ? `/domains/manage/${ siteSlug }` : purchaseDomainUrl;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -10,7 +10,7 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
 
 	const getDestionationUrl = () => {
-		const purchaseDomainUrl = addQueryArgs( '/setup/domain-upsell', {
+		const purchaseDomainUrl = addQueryArgs( '/setup/domain-and-plan', {
 			siteSlug,
 			back_to: `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`,
 			new: site?.name,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,8 +1,8 @@
 import { Task } from '@automattic/launchpad';
-import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { isStartWritingFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { isDomainUpsellCompleted, getSiteIdOrSlug } from '../../task-helper';
+import { isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -10,22 +10,13 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
 
 	const getDestionationUrl = () => {
-		if ( isStartWritingFlow( flow ) || isReadymadeFlow( flow ) ) {
-			return addQueryArgs( `/setup/${ flow }/domains`, {
-				...getSiteIdOrSlug( flow, site, siteSlug ),
-				flowToReturnTo: flow,
-				new: site?.name,
-				domainAndPlanPackage: true,
-			} );
-		}
+		const purchaseDomainUrl = addQueryArgs( '/setup/domain-upsell', {
+			siteSlug,
+			back_to: `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`,
+			new: site?.name,
+		} );
 
-		return domainUpsellCompleted
-			? `/domains/manage/${ siteSlug }`
-			: addQueryArgs( '/setup/domain-upsell/domains', {
-					...getSiteIdOrSlug( flow, site, siteSlug ),
-					flowToReturnTo: flow,
-					new: site?.name,
-			  } );
+		return domainUpsellCompleted ? `/domains/manage/${ siteSlug }` : purchaseDomainUrl;
 	};
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,8 +1,9 @@
 import { Task } from '@automattic/launchpad';
-import { isStartWritingFlow } from '@automattic/onboarding';
+import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
-import { isDomainUpsellCompleted } from '../../task-helper';
+import { getSiteIdOrSlug, isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -12,6 +13,15 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const getDestionationUrl = () => {
 		if ( ! siteSlug ) {
 			return '';
+		}
+
+		if ( isStartWritingFlow( flow ) || isReadymadeFlow( flow ) ) {
+			return addQueryArgs( `/setup/${ flow }/domains`, {
+				...getSiteIdOrSlug( flow, site, siteSlug ),
+				flowToReturnTo: flow,
+				new: site?.name,
+				domainAndPlanPackage: true,
+			} );
 		}
 
 		const backUrl = `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -29,7 +29,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/start-writing/domains?siteId=211078228&flowToReturnTo=start-writing&new=site.wordpress.com&domainAndPlanPackage=true',
+				'/setup/domain-and-plan?siteSlug=site.wordpress.com&back_to=%2Fsetup%2Fstart-writing%2Flaunchpad%3FsiteSlug%3Dsite.wordpress.com&new=site.wordpress.com',
 		} );
 	} );
 
@@ -45,7 +45,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, 'flow', context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/domain-and-plan/domains?siteSlug=site.wordpress.com&flowToReturnTo=flow&new=paid-site',
+				'/setup/domain-and-plan?siteSlug=site.wordpress.com&back_to=%2Fsetup%2Fflow%2Flaunchpad%3FsiteSlug%3Dsite.wordpress.com&new=paid-site',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -45,7 +45,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, 'flow', context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/domain-upsell/domains?siteSlug=site.wordpress.com&flowToReturnTo=flow&new=paid-site',
+				'/setup/domain-and-plan/domains?siteSlug=site.wordpress.com&flowToReturnTo=flow&new=paid-site',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -29,7 +29,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/domain-and-plan?siteSlug=site.wordpress.com&back_to=%2Fsetup%2Fstart-writing%2Flaunchpad%3FsiteSlug%3Dsite.wordpress.com&new=site.wordpress.com',
+				'/setup/start-writing/domains?siteId=211078228&flowToReturnTo=start-writing&new=site.wordpress.com&domainAndPlanPackage=true',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,4 +1,4 @@
-import { isDomainUpsellFlow, isStartWritingFlow, StepContainer } from '@automattic/onboarding';
+import { isDomainAndPlanFlow, isStartWritingFlow, StepContainer } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
@@ -24,7 +24,7 @@ const plans: Step< {
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies = {
 			plan,
-			goToCheckout: isDomainUpsellFlow( flow ) || isStartWritingFlow( flow ),
+			goToCheckout: isDomainAndPlanFlow( flow ) || isStartWritingFlow( flow ),
 		};
 
 		submit?.( providedDependencies );
@@ -36,7 +36,7 @@ const plans: Step< {
 		return null;
 	}
 
-	const isAllowedToGoBack = isDomainUpsellFlow( flow );
+	const isAllowedToGoBack = isDomainAndPlanFlow( flow );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -6,7 +6,7 @@ import {
 	isNewsletterFlow,
 	NEWSLETTER_FLOW,
 	NEW_HOSTED_SITE_FLOW,
-	isDomainUpsellFlow,
+	isDomainAndPlanFlow,
 	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -91,7 +91,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const stepName = 'plans';
 	const customerType = 'personal';
 	const headerText = __( 'Choose a plan' );
-	const isInSignup = isDomainUpsellFlow( flowName ) ? false : true;
+	const isInSignup = isDomainAndPlanFlow( flowName ) ? false : true;
 	/**
 	 * isWordCampPromo is temporary
 	 */
@@ -191,7 +191,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const getHeaderText = () => {
-		if ( isDomainUpsellFlow( flowName ) ) {
+		if ( isDomainAndPlanFlow( flowName ) ) {
 			return __( 'Choose the perfect plan' );
 		}
 
@@ -215,7 +215,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return;
 		}
 
-		if ( isDomainUpsellFlow( flowName ) && domainCartItem?.meta ) {
+		if ( isDomainAndPlanFlow( flowName ) && domainCartItem?.meta ) {
 			return (
 				<>
 					<p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -192,7 +192,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	const getHeaderText = () => {
 		if ( isDomainUpsellFlow( flowName ) ) {
-			return __( 'There’s a plan for you' );
+			return __( 'Choose the perfect plan' );
 		}
 
 		if ( isNewsletterFlow( flowName ) || isStartWritingFlow( flowName ) ) {
@@ -211,12 +211,33 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
 
-		if (
-			isStartWritingFlow( flowName ) ||
-			isNewsletterFlow( flowName ) ||
-			isDomainUpsellFlow( flowName )
-		) {
+		if ( isStartWritingFlow( flowName ) || isNewsletterFlow( flowName ) ) {
 			return;
+		}
+
+		if ( isDomainUpsellFlow( flowName ) && domainCartItem?.meta ) {
+			return (
+				<>
+					<p>
+						{ translate(
+							'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}.',
+							{
+								args: {
+									domainName: domainCartItem.meta,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'You’ll also unlock advanced features that make it easy to build and grow your site.'
+						) }
+					</p>
+				</>
+			);
 		}
 
 		if ( ! hideFreePlan ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -182,7 +182,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					removePaidDomain={ removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
 					showPlanTypeSelectorDropdown={ config.isEnabled( 'onboarding/interval-dropdown' ) }
-					hidePlanTypeSelector={ isWordCampPromo }
+					hidePlanTypeSelector={ isWordCampPromo || isDomainAndPlanFlow( flowName ) }
 					onPlanIntervalUpdate={ onPlanIntervalUpdate }
 					coupon={ couponCode }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -134,7 +134,7 @@
 	}
 }
 
-.domain-upsell.plans {
+.domain-and-plan.plans {
 	.signup-header h1 {
 		display: none;
 	}
@@ -169,7 +169,7 @@
 
 // Override styles for newsletter flow
 .newsletter.plans,
-.domain-upsell.plans {
+.domain-and-plan.plans {
 	.step-container {
 		.step-wrapper__header {
 			.formatted-header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -1,12 +1,11 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@automattic/onboarding/styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@automattic/onboarding/styles/mixins';
 
 .plans {
 	.step-container {
 		padding: 0;
 
 		.step-wrapper__header {
-
 			.formatted-header {
 				margin: 20px 0 40px 0;
 				@include break-small {
@@ -14,7 +13,7 @@
 				}
 
 				h1.formatted-header__title {
-					font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+					font-family: Recoleta, 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
 					font-size: 2.25rem;
 					font-weight: 500;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -89,14 +88,14 @@
 					line-height: 1.25rem;
 					padding: 0 8px;
 					right: 50%;
-					transform: translate(50%);
+					transform: translate( 50% );
 					border-radius: 4px;
-					background-color: var(--studio-green-5);
-					color: var(--studio-gray-80);
+					background-color: var( --studio-green-5 );
+					color: var( --studio-gray-80 );
 				}
 
 				.plan-features-comparison__item-annual-plan {
-					color: var(--studio-orange-40) !important;
+					color: var( --studio-orange-40 ) !important;
 				}
 
 				.plan-features-comparison__header {
@@ -115,7 +114,7 @@
 		}
 
 		button.is-borderless {
-			color: var(--studio-gray-90);
+			color: var( --studio-gray-90 );
 			font-weight: 500;
 			border: 0;
 			box-shadow: none;
@@ -140,10 +139,16 @@
 		display: none;
 	}
 
+	.step-wrapper__header,
+	#step-header {
+		margin-top: 0;
+		margin-bottom: 24px;
+	}
+
 	button.button.navigation-link.is-borderless {
 		background: none;
 		border: none;
-		color: var(--studio-gray-100);
+		color: var( --studio-gray-100 );
 		font-size: 0.875rem;
 		font-weight: 600;
 		padding: 0;
@@ -163,22 +168,23 @@
 }
 
 // Override styles for newsletter flow
-.newsletter.plans {
+.newsletter.plans,
+.domain-upsell.plans {
 	.step-container {
 		.step-wrapper__header {
 			.formatted-header {
 				h1.formatted-header__title {
-					font-size: rem(32px); //typography-exception
-					line-height: rem(40px); //typography-exception
+					font-size: rem( 32px ); //typography-exception
+					line-height: rem( 40px ); //typography-exception
 
 					@include break-medium {
-						font-size: rem(44px); //typography-exception
-						line-height: rem(52px); //typography-exception
+						font-size: rem( 44px ); //typography-exception
+						line-height: rem( 52px ); //typography-exception
 					}
 				}
 				.formatted-header__subtitle {
-					font-size: rem(16px);
-					line-height: rem(24px);
+					font-size: rem( 16px );
+					line-height: rem( 24px );
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -17,6 +17,7 @@ import {
 	AI_SITE_BUILDER_FLOW,
 	AI_SITE_BUILDER_SPEC_FLOW,
 	ONBOARDING_UNIFIED_FLOW,
+	DOMAIN_AND_PLAN_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
 
@@ -79,8 +80,10 @@ export const deprecatedV1Flows: Record< string, () => Promise< { default: Flow }
 	'update-options': () =>
 		import( /* webpackChunkName: "update-options-flow" */ './flows/update-options/update-options' ),
 
-	'domain-upsell': () =>
-		import( /* webpackChunkName: "update-design-flow" */ './flows/domain-upsell/domain-upsell' ),
+	[ DOMAIN_AND_PLAN_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "domain-and-plan-flow" */ './flows/domain-and-plan/domain-and-plan'
+		),
 
 	build: () => import( /* webpackChunkName: "build-flow" */ './flows/build/build' ),
 

--- a/client/landing/stepper/declarative-flow/test/deprecated-flows.tsx
+++ b/client/landing/stepper/declarative-flow/test/deprecated-flows.tsx
@@ -8,7 +8,7 @@ const frozenDeprecatedV1Flows = [
 	'readymade-template',
 	'update-design',
 	'update-options',
-	'domain-upsell',
+	'domain-and-plan',
 	'build',
 	'write',
 	'start-writing',

--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -15,6 +15,7 @@ const REMOVED_TAILORED_FLOWS = [
 	{ flow: 'site-setup-wg', to: '/setup/site-setup' },
 	{ flow: 'migration-signup', to: '/setup/site-migration' },
 	{ flow: 'hosted-site-migration', to: '/setup/site-migration' },
+	{ flow: 'domain-upsell', to: '/setup/domain-and-plan' },
 ];
 
 export const isRemovedFlow = ( flowToCheck: string ) =>

--- a/client/lib/domains/get-domain-and-plan-upsell-url.ts
+++ b/client/lib/domains/get-domain-and-plan-upsell-url.ts
@@ -1,0 +1,45 @@
+import { addQueryArgs } from '@wordpress/url';
+import { shouldRenderRewrittenDomainSearch } from './should-render-rewritten-domain-search';
+
+interface GetDomainUpsellUrlParams {
+	siteSlug: string;
+	step?: 'domains' | 'plans';
+	suggestion?: string;
+	backUrl?: string;
+}
+
+export const getDomainAndPlanUpsellUrl = ( {
+	siteSlug,
+	backUrl,
+	step = 'domains',
+	suggestion,
+}: GetDomainUpsellUrlParams ) => {
+	if ( step === 'domains' ) {
+		if ( shouldRenderRewrittenDomainSearch() ) {
+			return addQueryArgs( '/setup/domain-and-plan', {
+				siteSlug,
+				back_to: backUrl,
+				new: suggestion,
+			} );
+		}
+
+		return addQueryArgs( `/domains/add/${ siteSlug }`, {
+			domainAndPlanPackage: true,
+			domain: true,
+			back_to: backUrl,
+		} );
+	}
+
+	if ( shouldRenderRewrittenDomainSearch() ) {
+		return addQueryArgs( '/setup/domain-and-plan/plans', {
+			siteSlug,
+			back_to: backUrl,
+		} );
+	}
+
+	return addQueryArgs( `/plans/yearly/${ siteSlug }`, {
+		domain: true,
+		domainAndPlanPackage: true,
+		back_to: backUrl,
+	} );
+};

--- a/client/lib/domains/get-domain-and-plan-upsell-url.ts
+++ b/client/lib/domains/get-domain-and-plan-upsell-url.ts
@@ -6,6 +6,12 @@ interface GetDomainUpsellUrlParams {
 	step?: 'domains' | 'plans';
 	suggestion?: string;
 	backUrl?: string;
+	domain?: boolean;
+	/**
+	 * This is necessary while we don't remove the feature flag and ?domainAndPlanPackage=true entirely.
+	 * Some entrypoints currently link to the domain and package plan flow instead of the domains/add page.
+	 */
+	forceStepperFlow?: boolean;
 }
 
 export const getDomainAndPlanUpsellUrl = ( {
@@ -13,9 +19,11 @@ export const getDomainAndPlanUpsellUrl = ( {
 	backUrl,
 	step = 'domains',
 	suggestion,
+	domain,
+	forceStepperFlow,
 }: GetDomainUpsellUrlParams ) => {
 	if ( step === 'domains' ) {
-		if ( shouldRenderRewrittenDomainSearch() ) {
+		if ( shouldRenderRewrittenDomainSearch() || forceStepperFlow ) {
 			return addQueryArgs( '/setup/domain-and-plan', {
 				siteSlug,
 				back_to: backUrl,
@@ -25,12 +33,12 @@ export const getDomainAndPlanUpsellUrl = ( {
 
 		return addQueryArgs( `/domains/add/${ siteSlug }`, {
 			domainAndPlanPackage: true,
-			domain: true,
+			domain,
 			back_to: backUrl,
 		} );
 	}
 
-	if ( shouldRenderRewrittenDomainSearch() ) {
+	if ( shouldRenderRewrittenDomainSearch() || forceStepperFlow ) {
 		return addQueryArgs( '/setup/domain-and-plan/plans', {
 			siteSlug,
 			back_to: backUrl,
@@ -38,7 +46,7 @@ export const getDomainAndPlanUpsellUrl = ( {
 	}
 
 	return addQueryArgs( `/plans/yearly/${ siteSlug }`, {
-		domain: true,
+		domain,
 		domainAndPlanPackage: true,
 		back_to: backUrl,
 	} );

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -34,3 +34,4 @@ export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';
 export { getTransferredInDomains, isTransferredInDomain } from './transferred-domains';
 export { extractDomainFromInput } from './get-domain-from-input';
+export { getDomainAndPlanUpsellUrl } from './get-domain-and-plan-upsell-url';

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -12,8 +12,7 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
-import { addQueryArgs } from 'calypso/lib/url';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isNotAtomicJetpack, isP2Site, isStagingSite } from 'calypso/sites-dashboard/utils';
@@ -124,21 +123,8 @@ export function RenderDomainUpsell( {
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs(
-				{
-					siteSlug,
-					back_to: backUrl,
-				},
-				`/setup/domain-and-plan`
-		  )
-		: addQueryArgs(
-				{
-					domainAndPlanPackage: true,
-					domain: true,
-				},
-				`/domains/add/${ siteSlug }`
-		  );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_profile_domain_upsell_search_click', {
 			button_url: searchLink,
@@ -147,18 +133,7 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const plansPageLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs( '/setup/domain-and-plan/plans', {
-				siteSlug,
-				back_to: backUrl,
-		  } )
-		: addQueryArgs(
-				{
-					domain: true,
-					domainAndPlanPackage: true,
-				},
-				`/plans/yearly/${ siteSlug }`
-		  );
+	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -121,13 +122,23 @@ export function RenderDomainUpsell( {
 
 	const domainSuggestionProductSlug = domainSuggestion?.product_slug;
 
-	const searchLink = addQueryArgs(
-		{
-			domainAndPlanPackage: true,
-			domain: true,
-		},
-		`/domains/add/${ siteSlug }`
-	);
+	const backUrl = window.location.href.replace( window.location.origin, '' );
+
+	const searchLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs(
+				{
+					siteSlug,
+					back_to: backUrl,
+				},
+				`/setup/domain-upsell`
+		  )
+		: addQueryArgs(
+				{
+					domainAndPlanPackage: true,
+					domain: true,
+				},
+				`/domains/add/${ siteSlug }`
+		  );
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_profile_domain_upsell_search_click', {
 			button_url: searchLink,
@@ -136,16 +147,20 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const purchaseLink =
-		! isFreePlan && ! isMonthlyPlan
-			? `/checkout/${ siteSlug }`
-			: addQueryArgs(
-					{
-						domain: true,
-						domainAndPlanPackage: true,
-					},
-					`/plans/yearly/${ siteSlug }`
-			  );
+	const plansPageLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs( '/setup/domain-upsell/plans', {
+				siteSlug,
+				back_to: backUrl,
+		  } )
+		: addQueryArgs(
+				{
+					domain: true,
+					domainAndPlanPackage: true,
+				},
+				`/plans/yearly/${ siteSlug }`
+		  );
+
+	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 
 	const getDismissClickHandler = () => {
 		recordTracksEvent( 'calypso_profile_domain_upsell_dismiss_click' );

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -123,7 +123,7 @@ export function RenderDomainUpsell( {
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_profile_domain_upsell_search_click', {
@@ -133,7 +133,12 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
+	const plansPageLink = getDomainAndPlanUpsellUrl( {
+		siteSlug,
+		backUrl,
+		step: 'plans',
+		domain: true,
+	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -130,7 +130,7 @@ export function RenderDomainUpsell( {
 					siteSlug,
 					back_to: backUrl,
 				},
-				`/setup/domain-upsell`
+				`/setup/domain-and-plan`
 		  )
 		: addQueryArgs(
 				{
@@ -148,7 +148,7 @@ export function RenderDomainUpsell( {
 	};
 
 	const plansPageLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs( '/setup/domain-upsell/plans', {
+		? addQueryArgs( '/setup/domain-and-plan/plans', {
 				siteSlug,
 				back_to: backUrl,
 		  } )
@@ -181,7 +181,7 @@ export function RenderDomainUpsell( {
 					productSlug: domainSuggestionProductSlug,
 					domain: domainSuggestionName,
 					extra: {
-						flow_name: 'domain-upsell',
+						flow_name: 'domain-and-plan',
 					},
 				} ),
 			] );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -127,7 +127,7 @@ export function RenderDomainUpsell( {
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_my_home_domain_upsell_search_click', {
@@ -137,7 +137,12 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
+	const plansPageLink = getDomainAndPlanUpsellUrl( {
+		siteSlug,
+		backUrl,
+		step: 'plans',
+		domain: true,
+	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -132,7 +132,7 @@ export function RenderDomainUpsell( {
 					siteSlug,
 					back_to: window.location.href.replace( window.location.origin, '' ),
 				},
-				'/setup/domain-upsell'
+				'/setup/domain-and-plan'
 		  )
 		: addQueryArgs(
 				{
@@ -156,7 +156,7 @@ export function RenderDomainUpsell( {
 					siteSlug,
 					back_to: window.location.href.replace( window.location.origin, '' ),
 				},
-				'/setup/domain-upsell/plans'
+				'/setup/domain-and-plan/plans'
 		  )
 		: addQueryArgs(
 				{

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -21,6 +21,7 @@ import domainUpsellIllustration from 'calypso/assets/images/customer-home/illust
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -125,14 +126,22 @@ export function RenderDomainUpsell( {
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
-	const searchLink = addQueryArgs(
-		{
-			domainAndPlanPackage: true,
-			domain: true,
-			back_to: window.location.href.replace( window.location.origin, '' ),
-		},
-		`/domains/add/${ siteSlug }`
-	);
+	const searchLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs(
+				{
+					siteSlug,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				'/setup/domain-upsell'
+		  )
+		: addQueryArgs(
+				{
+					domainAndPlanPackage: true,
+					domain: true,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				`/domains/add/${ siteSlug }`
+		  );
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_my_home_domain_upsell_search_click', {
 			button_url: searchLink,
@@ -141,16 +150,23 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const purchaseLink =
-		! isFreePlan && ! isMonthlyPlan
-			? `/checkout/${ siteSlug }`
-			: addQueryArgs(
-					{
-						domain: true,
-						domainAndPlanPackage: true,
-					},
-					`/plans/yearly/${ siteSlug }`
-			  );
+	const plansPageLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs(
+				{
+					siteSlug,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				'/setup/domain-upsell/plans'
+		  )
+		: addQueryArgs(
+				{
+					domain: true,
+					domainAndPlanPackage: true,
+				},
+				`/plans/yearly/${ siteSlug }`
+		  );
+
+	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 
 	const getDismissClickHandler = () => {
 		recordTracksEvent( 'calypso_my_home_domain_upsell_dismiss_click' );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -21,8 +21,7 @@ import domainUpsellIllustration from 'calypso/assets/images/customer-home/illust
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
-import { addQueryArgs } from 'calypso/lib/url';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
@@ -126,22 +125,10 @@ export function RenderDomainUpsell( {
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
-	const searchLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs(
-				{
-					siteSlug,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				'/setup/domain-and-plan'
-		  )
-		: addQueryArgs(
-				{
-					domainAndPlanPackage: true,
-					domain: true,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				`/domains/add/${ siteSlug }`
-		  );
+	const backUrl = window.location.href.replace( window.location.origin, '' );
+
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_my_home_domain_upsell_search_click', {
 			button_url: searchLink,
@@ -150,21 +137,7 @@ export function RenderDomainUpsell( {
 		} );
 	};
 
-	const plansPageLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs(
-				{
-					siteSlug,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				'/setup/domain-and-plan/plans'
-		  )
-		: addQueryArgs(
-				{
-					domain: true,
-					domainAndPlanPackage: true,
-				},
-				`/plans/yearly/${ siteSlug }`
-		  );
+	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -133,8 +133,8 @@ describe( 'index', () => {
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
 		await waitFor( () => {
-			expect( pageLink ).toBe(
-				'/plans/yearly/example.wordpress.com?domain=true&domainAndPlanPackage=true'
+			expect( pageLink ).toMatch(
+				/\/plans\/yearly\/example\.wordpress\.com\?domain=true&domainAndPlanPackage=true/
 			);
 		} );
 	} );

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -115,7 +115,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 					siteSlug,
 					back_to: window.location.href.replace( window.location.origin, '' ),
 				},
-				'/setup/domain-upsell'
+				'/setup/domain-and-plan'
 		  )
 		: addQueryArgs(
 				{
@@ -132,7 +132,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 					siteSlug,
 					back_to: window.location.href.replace( window.location.origin, '' ),
 				},
-				'/setup/domain-upsell/plans'
+				'/setup/domain-and-plan/plans'
 		  )
 		: addQueryArgs(
 				{
@@ -154,7 +154,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 					productSlug: domainSuggestionProductSlug,
 					domain: domainSuggestionName,
 					extra: {
-						flow_name: 'domain-upsell',
+						flow_name: 'domain-and-plan',
 					},
 				} ),
 			] );

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -19,6 +19,7 @@ import editorPreviewIllustration from 'calypso/assets/images/customer-home/illus
 import sitePreviewIllustration from 'calypso/assets/images/customer-home/illustration--preview-site.png';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -108,25 +109,40 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
-	const searchLink = addQueryArgs(
-		{
-			domainAndPlanPackage: true,
-			domain: true,
-			back_to: window.location.href.replace( window.location.origin, '' ),
-		},
-		`/domains/add/${ siteSlug }`
-	);
+	const searchLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs(
+				{
+					siteSlug,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				'/setup/domain-upsell'
+		  )
+		: addQueryArgs(
+				{
+					domainAndPlanPackage: true,
+					domain: true,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				`/domains/add/${ siteSlug }`
+		  );
 
-	const purchaseLink =
-		! isFreePlan && ! isMonthlyPlan
-			? `/checkout/${ siteSlug }`
-			: addQueryArgs(
-					{
-						domain: true,
-						domainAndPlanPackage: true,
-					},
-					`/plans/yearly/${ siteSlug }`
-			  );
+	const plansPageLink = shouldRenderRewrittenDomainSearch()
+		? addQueryArgs(
+				{
+					siteSlug,
+					back_to: window.location.href.replace( window.location.origin, '' ),
+				},
+				'/setup/domain-upsell/plans'
+		  )
+		: addQueryArgs(
+				{
+					domain: true,
+					domainAndPlanPackage: true,
+				},
+				`/plans/yearly/${ siteSlug }`
+		  );
+
+	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 
 	const [ ctaIsBusy, setCtaIsBusy ] = useState( false );
 	const getCtaClickHandler = async () => {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -110,9 +110,14 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
-	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
+	const plansPageLink = getDomainAndPlanUpsellUrl( {
+		siteSlug,
+		backUrl,
+		step: 'plans',
+		domain: true,
+	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -19,9 +19,8 @@ import editorPreviewIllustration from 'calypso/assets/images/customer-home/illus
 import sitePreviewIllustration from 'calypso/assets/images/customer-home/illustration--preview-site.png';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { preventWidows } from 'calypso/lib/formatting';
-import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { TASK_DOMAIN_UPSELL } from 'calypso/my-sites/customer-home/cards/constants';
@@ -109,38 +108,11 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
-	const searchLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs(
-				{
-					siteSlug,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				'/setup/domain-and-plan'
-		  )
-		: addQueryArgs(
-				{
-					domainAndPlanPackage: true,
-					domain: true,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				`/domains/add/${ siteSlug }`
-		  );
+	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const plansPageLink = shouldRenderRewrittenDomainSearch()
-		? addQueryArgs(
-				{
-					siteSlug,
-					back_to: window.location.href.replace( window.location.origin, '' ),
-				},
-				'/setup/domain-and-plan/plans'
-		  )
-		: addQueryArgs(
-				{
-					domain: true,
-					domainAndPlanPackage: true,
-				},
-				`/plans/yearly/${ siteSlug }`
-		  );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+
+	const plansPageLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, step: 'plans' } );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;
 

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
@@ -136,8 +136,8 @@ describe( 'index', () => {
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
 		await waitFor( () => {
-			expect( pageLink ).toBe(
-				'/plans/yearly/example.wordpress.com?domain=true&domainAndPlanPackage=true'
+			expect( pageLink ).toMatch(
+				/\/plans\/yearly\/example\.wordpress\.com\?domain=true&domainAndPlanPackage=true/
 			);
 		} );
 	} );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -118,7 +118,7 @@ const redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled = ( context, ne
 
 	if ( shouldRenderRewrittenDomainSearch() && isBrowsingDomainAndPlanPackageFlow ) {
 		return window.location.replace(
-			addQueryArgs( '/setup/domain-upsell', { siteSlug: context.params.domain } )
+			addQueryArgs( '/setup/domain-and-plan', { siteSlug: context.params.domain } )
 		);
 	}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { get, includes, map } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -98,6 +99,29 @@ const domainSearch = ( context, next ) => {
 			{ getContent() }
 		</Main>
 	);
+	next();
+};
+
+/**
+ * If the user enters /domains/add/:domain?domainAndPlanPackage=true,
+ * we redirect them to the domain upsell flow.
+ *
+ * This is necessary because we have some back-end logic that sends the user directly,
+ * and the concept of feature flags don't exist there. So we need to redirect here.
+ *
+ * Once the feature flag is removed and the back-end logic is updated, this can be removed.
+ *
+ * Remove this when working on DOMAINS-1590.
+ */
+const redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled = ( context, next ) => {
+	const isBrowsingDomainAndPlanPackageFlow = context.query.domainAndPlanPackage === 'true';
+
+	if ( shouldRenderRewrittenDomainSearch() && isBrowsingDomainAndPlanPackageFlow ) {
+		return window.location.replace(
+			addQueryArgs( '/setup/domain-upsell', { siteSlug: context.params.domain } )
+		);
+	}
+
 	next();
 };
 
@@ -349,6 +373,7 @@ export default {
 	siteRedirect,
 	mapDomain,
 	mapDomainSetup,
+	redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled,
 	redirectToDomainSearchSuggestion,
 	redirectIfNoSite,
 	redirectToUseYourDomainIfVipSite,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -294,6 +294,7 @@ export default function () {
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		domainsController.redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled,
 		domainsController.domainSearch,
 		makeLayout,
 		clientRender

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -531,12 +531,12 @@ const PlansFeaturesMain = ( {
 		};
 
 		const handlePlanIntervalUpdate = ( interval: SupportedUrlFriendlyTermType ) => {
-			let isDomainUpsellFlow: string | null = '';
+			let isDomainAndPlanFlow: string | null = '';
 			let isDomainAndPlanPackageFlow: string | null = '';
 			let isJetpackAppFlow: string | null = '';
 
 			if ( typeof window !== 'undefined' ) {
-				isDomainUpsellFlow = new URLSearchParams( window.location.search ).get( 'domain' );
+				isDomainAndPlanFlow = new URLSearchParams( window.location.search ).get( 'domain' );
 				isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
 					'domainAndPlanPackage'
 				);
@@ -545,7 +545,7 @@ const PlansFeaturesMain = ( {
 
 			const pathOrQueryParam = getPlanTypeDestination( props, {
 				intervalType: interval,
-				domain: isDomainUpsellFlow,
+				domain: isDomainAndPlanFlow,
 				domainAndPlanPackage: isDomainAndPlanPackageFlow,
 				jetpackAppPlans: isJetpackAppFlow,
 			} );

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -15,7 +15,7 @@ const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
 	const href = shouldRenderRewrittenDomainSearch()
-		? `/setup/domain-upsell?siteSlug=${ siteSlug }`
+		? `/setup/domain-and-plan?siteSlug=${ siteSlug }`
 		: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
 
 	return (

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -4,7 +4,7 @@ import { Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { clickUpgradeNudge } from 'calypso/state/marketing/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
@@ -14,9 +14,7 @@ import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-f
 const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
-	const href = shouldRenderRewrittenDomainSearch()
-		? `/setup/domain-and-plan?siteSlug=${ siteSlug }`
-		: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+	const href = getDomainAndPlanUpsellUrl( { siteSlug } );
 
 	return (
 		<UpsellNudge

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { clickUpgradeNudge } from 'calypso/state/marketing/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
@@ -13,13 +14,17 @@ import isEligibleForFreeToPaidUpsell from 'calypso/state/selectors/is-eligible-f
 const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
+	const href = shouldRenderRewrittenDomainSearch()
+		? `/setup/domain-upsell?siteSlug=${ siteSlug }`
+		: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+
 	return (
 		<UpsellNudge
 			event="free-to-paid-sidebar-reader"
 			forceHref
 			callToAction={ translate( 'Upgrade' ) }
 			compact
-			href={ '/domains/add/' + siteSlug + '?domainAndPlanPackage=true' }
+			href={ href }
 			title={ translate( 'Free domain with an annual plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
 			tracksClickName="calypso_upgrade_nudge_cta_click"

--- a/packages/launchpad/src/msw/setup-free.ts
+++ b/packages/launchpad/src/msw/setup-free.ts
@@ -46,7 +46,7 @@ export default {
 			subtitle: '',
 			badge_text: 'Upgrade plan',
 			isLaunchTask: false,
-			calypso_path: '/setup/domain-upsell/domains?siteSlug=site62798.wordpress.com',
+			calypso_path: '/setup/domain-and-plan/domains?siteSlug=site62798.wordpress.com',
 		},
 		{
 			id: 'first_post_published',

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -20,7 +20,7 @@ export const ECOMMERCE_MONTHLY_FLOW = 'ecommerce-monthly';
 export const READYMADE_TEMPLATE_FLOW = 'readymade-template';
 
 export const UPDATE_DESIGN_FLOW = 'update-design';
-export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
+export const DOMAIN_AND_PLAN_FLOW = 'domain-and-plan';
 export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
 export const HUNDRED_YEAR_DOMAIN_TRANSFER = 'hundred-year-domain-transfer';
@@ -106,8 +106,8 @@ export const isOnboardingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ ONBOARDING_FLOW ].includes( flowName ) );
 };
 
-export const isDomainUpsellFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && [ DOMAIN_UPSELL_FLOW ].includes( flowName ) );
+export const isDomainAndPlanFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ DOMAIN_AND_PLAN_FLOW ].includes( flowName ) );
 };
 
 export const isReadymadeFlow = ( flowName: string | null ) => flowName === READYMADE_TEMPLATE_FLOW;


### PR DESCRIPTION
Part of DOMAINS-1633.

## Proposed Changes

Currently, some domain upsell links and buttons point to `/domains/add/%s?domainAndPlanPackage=true`:

| Domains | Plans |
| ---- | ---- |
| <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/961c5f77-daa5-4cf7-bd49-4c83a30fd061" /> |  <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/1b353e13-eb3f-475b-9d00-8a1b731e0807" /> |

This page looks and behaves like a Stepper flow, but it's actually the in-Calypso version of `/domains/add/%s` and `/plans/yearly/%s`, just with new clothes. That's bad from a maintenance perspective because we're trying to emulate Stepper, but we don't need that because we already have the framework... which was designed specifically for that use case. :)

| Domains | Plans |
| ----- | ----- |
| <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/c3f91831-24a3-42a4-9f21-fcc053a0fa73" /> | <img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/d6866fc3-73df-41bb-bc80-bbbea125c1ed" /> |

This PR repurposes `/setup/domain-upsell?siteSlug=%s` and renames it to `/setup/domain-and-plan`, which is a flow that has similar steps, so we can officially retire the `?domainAndPlanPackage=true` madness once it's time to remove the `domain-search-rewrite` feature flag.

The only difference between the in-Calypso version and the Stepper flow is that the latter doesn't have the "quick filters" area below the search bar, but that's intentional as that isn't envisioned in the designs.

## Why are these changes being made?

Product consistency and simplicity.

## Testing Instructions

Enter `/setup/domain-upsell?siteSlug=%s` directly, verify you're redirected to `/setup/domain-and-plan`, and check you can do the same operations as in `/domains/add/%s?domainAndPlanPackage=true`. Links to it:

### Domain upsell nudge in select free sites

Location: Calypso sidebar

Expected behavior:
- Clicking it opens the domain search step

<img width="455" height="143" alt="image" src="https://github.com/user-attachments/assets/4123aaee-79ff-40a2-9c5d-e0e63dc2d3b6" />

### Dashboard domain upsell

Location: `/home/%s`

Expected behavior:
- Clicking "Get this domain" opens the plans step
- Clicking search opens the domains step

<img width="764" height="419" alt="image" src="https://github.com/user-attachments/assets/8abfbb2a-0bac-45bf-a2da-57724e232a82" />

### V2 Dashboard domain upsell

Location: `/v2/sites/%s`

Expected behavior:
- Clicking the link opens the domain search step
- Clicking the CTA opens the plans step

<img width="800" height="660" alt="image" src="https://github.com/user-attachments/assets/5d511468-b9ac-43f2-b809-30a87c44a84b" />

### Profile settings domain upsell

To visually this upsell you need to have a verified account with only one free site.

Location: `/me`

Expected behavior:
- Clicking "Search for another domain" opens the domain search step
- Clicking "Buy this domain" opens the plans step

<img width="1096" height="356" alt="image" src="https://github.com/user-attachments/assets/e573a248-f2e7-4867-ab63-3eae58d7971f" />

---

There are some Launchpad tasks and checklists in home that I didn't manage to see, but all changes are following the same pattern so it should still work. Let me know if you know how to trigger the,.