### PR TITLE
Hosting Dashboard > Security: Display overall security status badges

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -233,6 +233,14 @@ export const securityRoute = createRoute( {
 			},
 		],
 	} ),
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( accountRecoveryQuery() ),
+			queryClient.ensureQueryData( connectedApplicationsQuery() ),
+			queryClient.ensureQueryData( sshKeysQuery() ),
+		] );
+	},
 	getParentRoute: () => meRoute,
 	path: 'security',
 } );

--- a/client/dashboard/me/profile-gravatar/test/__mocks__/user-settings.ts
+++ b/client/dashboard/me/profile-gravatar/test/__mocks__/user-settings.ts
@@ -7,6 +7,7 @@ export const mockUserSettings: UserSettings = {
 	display_name: 'Test User',
 	is_dev_account: false,
 	password: 'password',
+	is_passwordless_user: false,
 	tracks_opt_out: false,
 	user_email: 'test@example.com',
 	user_login: 'testuser',

--- a/client/dashboard/me/security-account-recovery/summary.tsx
+++ b/client/dashboard/me/security-account-recovery/summary.tsx
@@ -1,15 +1,49 @@
+import { accountRecoveryQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lifesaver } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
 export default function SecurityAccountRecoverySummary() {
+	const { data: accountRecovery } = useSuspenseQuery( accountRecoveryQuery() );
+
+	const { email, email_validated, phone, phone_validated } = accountRecovery;
+
+	const badges: SummaryButtonBadgeProps[] = [];
+
+	if ( email ) {
+		badges.push( {
+			text: email_validated ? __( 'Email added' ) : __( 'Email not validated' ),
+			intent: email_validated ? 'success' : 'warning',
+		} );
+	} else {
+		badges.push( {
+			text: __( 'No recovery email' ),
+			intent: 'warning',
+		} );
+	}
+
+	if ( phone ) {
+		badges.push( {
+			text: phone_validated ? __( 'SMS number added' ) : __( 'SMS number not validated' ),
+			intent: phone_validated ? 'success' : 'warning',
+		} );
+	} else {
+		badges.push( {
+			text: __( 'No recovery SMS number' ),
+			intent: 'warning',
+		} );
+	}
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/account-recovery"
 			title={ __( 'Account recovery' ) }
 			description={ __( 'Set up recovery email & SMS number' ) }
 			decoration={ <Icon icon={ lifesaver } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-connected-apps/summary.tsx
+++ b/client/dashboard/me/security-connected-apps/summary.tsx
@@ -1,15 +1,40 @@
+import { connectedApplicationsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { connection } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
-export default function SecurityAccountRecoverySummary() {
+export default function SecurityConnectedAppsSummary() {
+	const { data: connectedApplications } = useSuspenseQuery( connectedApplicationsQuery() );
+
+	const connectedApplicationsCount = connectedApplications.length;
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: connectedApplicationsCount
+				? sprintf(
+						/* translators: %d is the number of connected applications */
+						_n(
+							'%d connected application',
+							'%d connected applications',
+							connectedApplicationsCount
+						),
+						connectedApplicationsCount
+				  )
+				: __( 'No connected applications' ),
+			intent: connectedApplicationsCount ? 'info' : 'default',
+		},
+	];
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/connected-apps"
 			title={ __( 'Connected applications' ) }
 			description={ __( 'Manage applications connected to your WordPress.com account.' ) }
 			decoration={ <Icon icon={ connection } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-password/summary.tsx
+++ b/client/dashboard/me/security-password/summary.tsx
@@ -11,12 +11,15 @@ export default function SecurityAccountRecoverySummary() {
 
 	const { is_passwordless_user } = userSettings;
 
-	const badges: SummaryButtonBadgeProps[] = [
-		{
-			text: is_passwordless_user ? __( 'Password not set' ) : __( 'Password set' ),
-			intent: is_passwordless_user ? 'warning' : 'success',
-		},
-	];
+	const badges: SummaryButtonBadgeProps[] = [];
+
+	if ( is_passwordless_user ) {
+		badges.push( {
+			text: __( 'Password not set' ),
+			intent: 'warning',
+		} );
+	}
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/password"

--- a/client/dashboard/me/security-password/summary.tsx
+++ b/client/dashboard/me/security-password/summary.tsx
@@ -1,15 +1,29 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lockOutline } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
 export default function SecurityAccountRecoverySummary() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	const { is_passwordless_user } = userSettings;
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: is_passwordless_user ? __( 'Password not set' ) : __( 'Password set' ),
+			intent: is_passwordless_user ? 'warning' : 'success',
+		},
+	];
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/password"
 			title={ __( 'Password' ) }
 			description={ __( 'Strengthen your account by ensuring your password is strong.' ) }
 			decoration={ <Icon icon={ lockOutline } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-social-logins/summary.tsx
+++ b/client/dashboard/me/security-social-logins/summary.tsx
@@ -1,15 +1,35 @@
 import { Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { commentAuthorAvatar } from '@wordpress/icons';
+import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
 export default function SecuritySocialLoginsSummary() {
+	const { user } = useAuth();
+
+	const socialLoginCount = user.social_login_connections?.length ?? 0;
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: socialLoginCount
+				? sprintf(
+						/* translators: %d is the number of social logins */
+						_n( '%d social login', '%d social logins', socialLoginCount ),
+						socialLoginCount
+				  )
+				: __( 'No social logins added' ),
+			intent: socialLoginCount ? 'info' : 'default',
+		},
+	];
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/social-logins"
 			title={ __( 'Social logins' ) }
 			description={ __( 'Log in faster with the accounts you already use.' ) }
 			decoration={ <Icon icon={ commentAuthorAvatar } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-ssh-key/summary.tsx
+++ b/client/dashboard/me/security-ssh-key/summary.tsx
@@ -1,9 +1,21 @@
+import { sshKeysQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { key } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
 export default function SecuritySshKeySummary() {
+	const { data: sshKeys } = useSuspenseQuery( sshKeysQuery() );
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: sshKeys.length ? __( 'SSH key added' ) : __( 'No SSH key added' ),
+			intent: sshKeys.length ? 'success' : 'default',
+		},
+	];
+
 	return (
 		<RouterLinkSummaryButton
 			to="/me/security/ssh-key"
@@ -12,6 +24,7 @@ export default function SecuritySshKeySummary() {
 				'Add a SSH key to your WordPress.com account to make it available for SFTP and SSH authentication.'
 			) }
 			decoration={ <Icon icon={ key } /> }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -1,15 +1,46 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { mobile } from '@wordpress/icons';
+import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
 export default function SecurityTwoStepAuthSummary() {
+	const { user } = useAuth();
+	const isEmailVerified = user?.email_verified;
+
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	const { two_step_enabled, two_step_backup_codes_printed } = userSettings;
+
+	const badges: SummaryButtonBadgeProps[] = [
+		{
+			text: two_step_enabled ? __( 'Enabled' ) : __( 'Not enabled' ),
+			intent: two_step_enabled ? 'success' : 'warning',
+		},
+	];
+
+	if ( two_step_enabled && ! two_step_backup_codes_printed ) {
+		badges.push( {
+			text: __( 'Backup codes not printed' ),
+			intent: 'warning',
+		} );
+	}
+
 	return (
 		<RouterLinkSummaryButton
+			disabled={ ! isEmailVerified }
 			to="/me/security/two-step-auth"
 			title={ __( 'Two-step authentication' ) }
-			description={ __( 'Manage two-step authentication and security keys and backup codes.' ) }
+			description={
+				isEmailVerified
+					? __( 'Manage two-step authentication and security keys and backup codes.' )
+					: __( 'Please verify your email address to enable two-step authentication.' )
+			}
 			decoration={ <Icon icon={ mobile } /> }
+			badges={ isEmailVerified ? badges : [] }
 		/>
 	);
 }

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -22,6 +22,7 @@ export interface UserSettings {
 	display_name: string;
 	is_dev_account: boolean;
 	password: string;
+	is_passwordless_user: boolean;
 	tracks_opt_out: boolean;
 	user_email: string;
 	user_login: string;

--- a/packages/api-core/src/me/types.ts
+++ b/packages/api-core/src/me/types.ts
@@ -1,5 +1,11 @@
 export type UserFlags = 'calypso_allow_nonprimary_domains_without_plan';
 
+export interface SocialLoginConnection {
+	service: string;
+	service_user_email: string;
+	service_user_id: string;
+}
+
 export interface User {
 	ID: number;
 	username: string;
@@ -8,6 +14,7 @@ export interface User {
 	language: string;
 	locale_variant: string;
 	email: string;
+	email_verified: boolean;
 	has_unseen_notes: boolean;
 	site_count: number;
 	meta: {
@@ -17,6 +24,7 @@ export interface User {
 			};
 		};
 	};
+	social_login_connections: SocialLoginConnection[];
 }
 
 export interface TwoStep {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/DOTDASH-162/implement-account-security-to-the-hosting-dashboard

<img width="708" height="833" alt="Screenshot 2025-09-24 at 2 50 59 PM" src="https://github.com/user-attachments/assets/340e82e3-abf6-4fd9-af65-1e01573f28c6" />


## Proposed Changes

This PR implements status badges on the main security page to indicate overall security statuses. 

## Why are these changes being made?

* To indicate overall security statuses. 

## Testing Instructions

* Open the Calypso live link
* Go to /v2/me/security > Verify the status badges are displayed for different scenarios as shown below:

----

### Security > Password

Password is set:

<img width="708" height="136" alt="Screenshot 2025-09-24 at 2 51 07 PM" src="https://github.com/user-attachments/assets/655e4d47-0782-4df6-9d10-c47f04d6bc1c" />

Password is not set:

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 48 00 AM" src="https://github.com/user-attachments/assets/fd95e3e0-a064-4fcf-9f34-0b0b80de912c" />

----

### Security > Account Recovery

No email/SMS added:

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 49 15 AM" src="https://github.com/user-attachments/assets/67e678f2-4696-48f7-96b8-fb0de3c815a8" />

Email/SMS added, but not validated:

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 49 59 AM" src="https://github.com/user-attachments/assets/5d4a2e35-f923-474d-b464-15e269cdeed2" />

Email/SMS added and validated:

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 51 52 AM" src="https://github.com/user-attachments/assets/8263b891-e163-44f8-b42e-33de0f4754fa" />

----

### Security > Two-step Authentication

Not enabled:

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 52 15 AM" src="https://github.com/user-attachments/assets/880708ba-4a45-4f3c-88e8-c70cad9a5cff" />

Enabled: 

<img width="720" height="168" alt="Screenshot 2025-09-24 at 11 52 25 AM" src="https://github.com/user-attachments/assets/57262bf2-3027-42a5-a0a3-135b1699d583" />

When email is not verified:
 
<img width="708" height="129" alt="Screenshot 2025-09-24 at 11 53 40 AM" src="https://github.com/user-attachments/assets/2609a184-0a67-4a45-97c2-8a4112254fcd" />


----

### Security > SSH Key

Added:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 52 35 AM" src="https://github.com/user-attachments/assets/a6db16f7-ac9b-4b37-a1f2-2fc874f466fd" />

Not added:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 52 40 AM" src="https://github.com/user-attachments/assets/b04ff9d6-c9fe-4670-97df-05d1ee095d05" />

----

### Security > Connected Applications

No connected applications:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 52 45 AM" src="https://github.com/user-attachments/assets/c60e19b6-69d1-44b2-90be-22e642d3ec55" />

Connected applications:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 52 51 AM" src="https://github.com/user-attachments/assets/5ddd6188-b62f-4bea-89d8-159dac65f643" />

### Security > Social logins

Social logins:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 52 56 AM" src="https://github.com/user-attachments/assets/1a548bfa-385d-4fc3-8cd3-b900a96f9abc" />

No social logins:

<img width="720" height="174" alt="Screenshot 2025-09-24 at 11 53 00 AM" src="https://github.com/user-attachments/assets/4e4ff48f-4b15-40af-bc20-0a8ad7fa0367" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
