### PR TITLE
Dashboard v2: don't wrap long site URL in overview header

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -23,7 +23,6 @@
 	--dashboard__foreground-color-warning: #b36100;
 	--dashboard__foreground-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
-	--dashboard__text-max-width: 660px;
 
 	// Header bar
 	--dashboard-header__background-color: #021A23;

--- a/client/dashboard/app-ciab/style.scss
+++ b/client/dashboard/app-ciab/style.scss
@@ -23,7 +23,6 @@
 	--dashboard__foreground-color-warning: #b36100;
 	--dashboard__foreground-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
-	--dashboard__text-max-width: 660px;
 
 	// Header bar
 	--dashboard-header__background-color: rgba(252, 252, 252, 0.90);

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -23,7 +23,6 @@
 	--dashboard__foreground-color-warning: #b36100;
 	--dashboard__foreground-color-error: #{$alert-red};
 	--dashboard__text-color: #{$gray-900};
-	--dashboard__text-max-width: 660px;
 
 	// Header bar
 	--dashboard-header__background-color: rgba(252, 252, 252, 0.90);

--- a/client/dashboard/sites/overview-site-fields/style.scss
+++ b/client/dashboard/sites/overview-site-fields/style.scss
@@ -1,6 +1,5 @@
 .site-overview-fields {
 	flex-wrap: wrap;
-	max-width: var(--dashboard__text-max-width);
 }
 
 .site-overview-field:not(:last-child) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR prevents wrapping the site header description into two lines even though we still have enough space:

### Before

<img width="1358" height="145" alt="image" src="https://github.com/user-attachments/assets/6a0dc834-159a-4250-8b8e-98306f3e81a5" />

### After

<img width="1360" height="128" alt="image" src="https://github.com/user-attachments/assets/3e720c60-e4f3-45ee-988c-b7b1be4552c9" />

### Note

The `--dashboard__text-max-width` was added in https://github.com/Automattic/wp-calypso/pull/104748. @arthur791004 please check whether I break anything. I tested on responsive widths, but I don't see any regressions. 🤔 


## Testing Instructions

1. Go to `/v2/sites/:slug` of a site with a long URL (e.g. staging sites)
2. Verify the header is not cut into two lines as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [X] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
