### PR TITLE
Dashboard v2: Apply Callout to every route under Backups, Scan, Logs, Monitoring and Performance

### DIFF
--- a/client/dashboard/components/callout-overlay/index.tsx
+++ b/client/dashboard/components/callout-overlay/index.tsx
@@ -9,12 +9,12 @@ interface CalloutOverlayProps {
 
 export function CalloutOverlay( { callout, main }: CalloutOverlayProps ) {
 	return (
-		<>
+		<div style={ { position: 'relative' } }>
 			{ /* The inert attribute is too new for our version of React to understand */ }
 			<div ref={ ( el ) => el?.setAttribute( 'inert', '' ) }>{ main }</div>
 			<VStack className="dashboard-callout-overlay" alignment="center">
 				{ callout }
 			</VStack>
-		</>
+		</div>
 	);
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -165,21 +165,13 @@ function SiteBackups() {
 		showSuccess: ( message: string ) => createSuccessNotice( message, { type: 'snackbar' } ),
 	};
 
-	if ( hasHostingFeature( site, HostingFeatures.BACKUPS ) ) {
-		return (
-			<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
-				<Outlet />
-			</FileBrowserProvider>
-		);
-	}
-
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> }>
+		<div style={ { position: 'relative' } }>
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.BACKUPS }
 				tracksFeatureId="backups"
-				asOverlay
+				overlay={ <PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> } /> }
 				upsellIcon={ backup }
 				upsellTitle={ __( 'Secure your content with Jetpack Backups' ) }
 				upsellImage={ illustrationUrl }
@@ -191,9 +183,11 @@ function SiteBackups() {
 					</Text>
 				}
 			>
-				<></>
+				<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
+					<Outlet />
+				</FileBrowserProvider>
 			</HostingFeatureGatedWithCallout>
-		</PageLayout>
+		</div>
 	);
 }
 

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -166,28 +166,26 @@ function SiteBackups() {
 	};
 
 	return (
-		<div style={ { position: 'relative' } }>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.BACKUPS }
-				tracksFeatureId="backups"
-				overlay={ <PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> } /> }
-				upsellIcon={ backup }
-				upsellTitle={ __( 'Secure your content with Jetpack Backups' ) }
-				upsellImage={ illustrationUrl }
-				upsellDescription={
-					<Text as="p" variant="muted">
-						{ __(
-							'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
-						) }
-					</Text>
-				}
-			>
-				<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
-					<Outlet />
-				</FileBrowserProvider>
-			</HostingFeatureGatedWithCallout>
-		</div>
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.BACKUPS }
+			tracksFeatureId="backups"
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> } /> }
+			upsellIcon={ backup }
+			upsellTitle={ __( 'Secure your content with Jetpack Backups' ) }
+			upsellImage={ illustrationUrl }
+			upsellDescription={
+				<Text as="p" variant="muted">
+					{ __(
+						'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
+					) }
+				</Text>
+			}
+		>
+			<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
+				<Outlet />
+			</FileBrowserProvider>
+		</HostingFeatureGatedWithCallout>
 	);
 }
 

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -18,16 +18,14 @@ function SiteDeployments() {
 	}
 
 	return (
-		<div style={ { position: 'relative' } }>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.DEPLOYMENT }
-				overlay={ <PageLayout header={ <PageHeader title={ __( 'Deployments' ) } /> } /> }
-				{ ...getDeploymentsCalloutProps() }
-			>
-				<Outlet />
-			</HostingFeatureGatedWithCallout>
-		</div>
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.DEPLOYMENT }
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Deployments' ) } /> } /> }
+			{ ...getDeploymentsCalloutProps() }
+		>
+			<Outlet />
+		</HostingFeatureGatedWithCallout>
 	);
 }
 

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -92,13 +92,13 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	};
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Logs' ) } /> }>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.LOGS }
-				asOverlay
-				{ ...getLogsCalloutProps() }
-			>
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.LOGS }
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Logs' ) } /> } /> }
+			{ ...getLogsCalloutProps() }
+		>
+			<PageLayout header={ <PageHeader title={ __( 'Logs' ) } /> }>
 				<VStack as="div" spacing={ 3 }>
 					{ autoRefreshDisabledReason && (
 						<Notice variant="warning">{ autoRefreshDisabledReason }</Notice>
@@ -160,8 +160,8 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 						</CardBody>
 					</Card>
 				</VStack>
-			</HostingFeatureGatedWithCallout>
-		</PageLayout>
+			</PageLayout>
+		</HostingFeatureGatedWithCallout>
 	);
 }
 

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -114,43 +114,43 @@ function SiteMonitoring() {
 	};
 
 	return (
-		<PageLayout
-			header={
-				<HStack
-					justify="space-between"
-					alignment="stretch"
-					wrap
-					spacing={ isSmallViewport ? 5 : 10 }
-				>
-					<PageHeader title={ __( 'Monitoring' ) } />
-					<div>
-						<ToggleGroupControl
-							value={ timeRange }
-							isBlock
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							onChange={ handleTimeRangeChange }
-							label={ __( 'Time period' ) }
-							hideLabelFromVision
-						>
-							<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
-							<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
-							<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
-							<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
-						</ToggleGroupControl>
-					</div>
-				</HStack>
-			}
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.MONITOR }
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Monitoring' ) } /> } /> }
+			{ ...getMonitoringCalloutProps() }
 		>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.MONITOR }
-				asOverlay
-				{ ...getMonitoringCalloutProps() }
+			<PageLayout
+				header={
+					<HStack
+						justify="space-between"
+						alignment="stretch"
+						wrap
+						spacing={ isSmallViewport ? 5 : 10 }
+					>
+						<PageHeader title={ __( 'Monitoring' ) } />
+						<div>
+							<ToggleGroupControl
+								value={ timeRange }
+								isBlock
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								onChange={ handleTimeRangeChange }
+								label={ __( 'Time period' ) }
+								hideLabelFromVision
+							>
+								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
+								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />
+								<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
+								<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
+							</ToggleGroupControl>
+						</div>
+					</HStack>
+				}
 			>
 				<SiteMonitoringBody timeRange={ timeRange } site={ site } locale={ locale } />
-			</HostingFeatureGatedWithCallout>
-		</PageLayout>
+			</PageLayout>
+		</HostingFeatureGatedWithCallout>
 	);
 }
 

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -17,16 +17,16 @@ function SitePerformance() {
 	}
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Performance' ) } /> }>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.PERFORMANCE }
-				asOverlay
-				{ ...getPerformanceCalloutProps() }
-			>
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.PERFORMANCE }
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Performance' ) } /> } /> }
+			{ ...getPerformanceCalloutProps() }
+		>
+			<PageLayout header={ <PageHeader title={ __( 'Performance' ) } /> }>
 				<></>
-			</HostingFeatureGatedWithCallout>
-		</PageLayout>
+			</PageLayout>
+		</HostingFeatureGatedWithCallout>
 	);
 }
 

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -75,45 +75,46 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	};
 
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					title={ __( 'Scan' ) }
-					description={ getPageDescription() }
-					actions={
-						<ButtonStack>
-							<ScanNowButton site={ site } scanState={ scanState } />
-							{ /* @TODO: Hide this button if there are no fixable threats */ }
-							<Button variant="primary">
-								{ sprintf(
-									/* translators: %d: number of threats */
-									__( 'Auto-fix %(threatsCount)d threats' ),
-									{
-										// @TODO: replace with the actual number of active fixable threats
-										threatsCount: 4,
-									}
-								) }
-							</Button>
-						</ButtonStack>
-					}
-				/>
+		<HostingFeatureGatedWithCallout
+			site={ site }
+			feature={ HostingFeatures.SCAN }
+			tracksFeatureId="scan"
+			overlay={ <PageLayout header={ <PageHeader title={ __( 'Scan' ) } /> } /> }
+			upsellIcon={ shield }
+			upsellTitle={ __( 'Scan for security threats' ) }
+			upsellImage={ illustrationUrl }
+			upsellDescription={
+				<Text as="p" variant="muted">
+					{ __(
+						'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
+					) }
+				</Text>
 			}
-			notices={ <ScanNotices status={ status } threatCount={ threatCount } /> }
 		>
-			<HostingFeatureGatedWithCallout
-				site={ site }
-				feature={ HostingFeatures.SCAN }
-				tracksFeatureId="scan"
-				asOverlay
-				upsellIcon={ shield }
-				upsellTitle={ __( 'Scan for security threats' ) }
-				upsellImage={ illustrationUrl }
-				upsellDescription={
-					<Text as="p" variant="muted">
-						Automated daily scans check for malware and security vulnerabilities, with automated
-						fixes for most issues.
-					</Text>
+			<PageLayout
+				header={
+					<PageHeader
+						title={ __( 'Scan' ) }
+						description={ getPageDescription() }
+						actions={
+							<ButtonStack>
+								<ScanNowButton site={ site } scanState={ scanState } />
+								{ /* @TODO: Hide this button if there are no fixable threats */ }
+								<Button variant="primary">
+									{ sprintf(
+										/* translators: %d: number of threats */
+										__( 'Auto-fix %(threatsCount)d threats' ),
+										{
+											// @TODO: replace with the actual number of active fixable threats
+											threatsCount: 4,
+										}
+									) }
+								</Button>
+							</ButtonStack>
+						}
+					/>
 				}
+				notices={ <ScanNotices status={ status } threatCount={ threatCount } /> }
 			>
 				<Card>
 					<CardHeader style={ { paddingBottom: '0' } }>
@@ -135,8 +136,8 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 						{ scanTab === 'history' && <ScanHistoryDataViews site={ site } /> }
 					</CardBody>
 				</Card>
-			</HostingFeatureGatedWithCallout>
-		</PageLayout>
+			</PageLayout>
+		</HostingFeatureGatedWithCallout>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Display overlay on every route under Backups, Scan, Logs, Monitoring and Performance
* Move `<div style={ { position: 'relative' } }>...</div>` into `<CalloutOverlay />`

Scan Callout
<img width="630" height="308" alt="image" src="https://github.com/user-attachments/assets/7efbd7a0-b3df-4fa9-a365-78405f5555b4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select a simple site and navigate to Backups
* Ensure you can see the CalloutOverlay with the blurred backups title

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
