### PR TITLE
Experimenting with chevrons and spacing

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -334,15 +334,16 @@ function FileBrowserNode( {
 		return (
 			<Button
 				onClick={ handleExpandButtonClick }
-				icon={ isOpen ? chevronDown : expandIcon }
 				className="file-browser-node__separate-expand-button"
 				variant="tertiary"
 				// translators: %s is a directory name
 				aria-label={ sprintf( __( 'Expand contents of %s' ), item.name ) }
 				aria-expanded={ isOpen }
 				size="compact"
-				style={ { color: 'inherit' } }
-			/>
+				style={ { color: 'inherit', paddingLeft: '0', paddingRight: '0' } }
+			>
+				<Icon icon={ isOpen ? chevronDown : expandIcon } size={ 18 } />
+			</Button>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14655/

## Proposed Changes

TBD - Just experimenting whether this is worth pursuing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

**New modal and new modal look identical**: 

<img width="841" height="550" alt="Screenshot 2025-09-24 at 10 02 32 AM" src="https://github.com/user-attachments/assets/b3418cb7-f205-4f5d-a47d-083f5c81cb9f" />

For comparison, this is the current look:

<img width="647" height="388" alt="Screenshot 2025-09-24 at 10 12 43 AM" src="https://github.com/user-attachments/assets/a1e022f5-d2f2-4825-99e6-aa439331b008" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
