### PR TITLE
Add commit status publisher configuration for GitHub integration

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -36,6 +36,16 @@ object CalypsoE2ETestsBuildTemplate : Template({
       		rules = "+:test/e2e/output/results.xml"
 			verbose = true
     	}
+
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
 	}
 
   	steps {


### PR DESCRIPTION
Fixes QAO-100

## Proposed Changes

Add commit status publisher for builds using the e2e build template, so that the status is reported in Github checks UI.

## Testing Instructions

* e2e tests pass in TeamCity
* The build `E2E Tests (Playwright Test) (Web app)` is displayed in this PR's checks list
