### PR TITLE
Hosting Dashboard: Always link to Stepper domain flow within domains pages

### DIFF
--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,5 +1,4 @@
 import { domainsQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -40,11 +39,7 @@ function Domains() {
 				<PageHeader
 					title={ __( 'Domains' ) }
 					actions={
-						<Button
-							variant="primary"
-							__next40pxDefaultSize
-							href={ isEnabled( 'domain-search-rewrite' ) ? '/setup/domain' : '/start/domain' }
-						>
+						<Button variant="primary" __next40pxDefaultSize href="/setup/domain">
 							{ __( 'Add New Domain' ) }
 						</Button>
 					}

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,5 +1,4 @@
 import { siteDomainsQuery, siteBySlugQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -48,11 +47,7 @@ function SiteDomains() {
 					title={ __( 'Domains' ) }
 					actions={
 						<Button
-							href={
-								isEnabled( 'domain-search-rewrite' )
-									? addQueryArgs( '/setup/domain', { siteSlug: site.slug } )
-									: `/domains/add/${ site.slug }`
-							}
+							href={ addQueryArgs( '/setup/domain', { siteSlug: site.slug } ) }
 							variant="primary"
 							__next40pxDefaultSize
 						>


### PR DESCRIPTION
## Proposed Changes

Removes the `domain-search-rewrite` feature flag when deciding whether to redirect to the new Stepper domain flow within the Hosting Dashboard.

The flow is ready, there's no need to keep the feature flag.

## Testing Instructions

Enter `/v2/sites/%s/domains` and click the "Add New Domain" button. You should be redirected to  `/setup/domain?siteSlug=%s`. Finish the flow and you should be sent back to `/v2/sites/%s/domains`.

Enter `/v2/domains` and click the "Add New Domain" button. Perform a domain-only purchase and you should be redirected to `/v2/domains` again.

Enter `/setup/domain` and create a new site for the domain you want to purchase. You should redirected to `/v2/sites/%s/domains`.