### PR TITLE
Empty Content: always wrap line content

### DIFF
--- a/client/components/empty-content/index.tsx
+++ b/client/components/empty-content/index.tsx
@@ -73,9 +73,20 @@ export default function EmptyContent( props: EmptyContentProps ): JSX.Element {
 		}
 	}
 
-	const { line, illustration, isCompact = false } = props;
+	function renderLine(): React.ReactNode {
+		if ( typeof props.line === 'string' ) {
+			return <h3 className="empty-content__line">{ props.line }</h3>;
+		}
+		if ( React.isValidElement( props.line ) && props.line.type === React.Fragment ) {
+			return <div className="empty-content__line">{ props.line }</div>;
+		}
+		return props.line ?? null;
+	}
+
+	const { illustration, isCompact = false } = props;
 	const translate = useTranslate();
 	const action = props.action && primaryAction();
+	const line = props.line && renderLine();
 	const secondaryActionEl = props.secondaryAction && secondaryAction();
 	const title =
 		props.title !== undefined ? props.title : translate( "You haven't created any content yet." );
@@ -103,11 +114,7 @@ export default function EmptyContent( props: EmptyContentProps ): JSX.Element {
 			) : (
 				title ?? null
 			) }
-			{ typeof line === 'string' ? (
-				<h3 className="empty-content__line">{ props.line }</h3>
-			) : (
-				line ?? null
-			) }
+			{ line }
 			{ action }
 			{ secondaryActionEl }
 			{ props.children }


### PR DESCRIPTION
Fixes CML-917

## Proposed Changes, why are these changes being made?

Always wrapping the explanation should ensure we always display the component without any issues.

**Before**

<img width="852" height="278" alt="Screenshot 2025-09-24 at 12 23 02" src="https://github.com/user-attachments/assets/1bdd66d2-70c8-4693-9cdc-46e1730a10c9" />
<img width="735" height="193" alt="Screenshot 2025-09-24 at 12 22 58" src="https://github.com/user-attachments/assets/e2a9f749-967f-4bae-9bbd-20c18e837f08" />
<img width="792" height="212" alt="image" src="https://github.com/user-attachments/assets/2a47a576-9852-455e-b17f-a0f6102113f0" />

**After**

<img width="838" height="277" alt="Screenshot 2025-09-24 at 12 23 05" src="https://github.com/user-attachments/assets/6e78d256-5428-47cc-b78b-8e5827561a17" />
<img width="775" height="242" alt="Screenshot 2025-09-24 at 12 22 55" src="https://github.com/user-attachments/assets/abf7fbb5-0e4a-4b82-9428-ca734484be6f" />
<img width="792" height="212" alt="image" src="https://github.com/user-attachments/assets/2a47a576-9852-455e-b17f-a0f6102113f0" />

## Testing Instructions

> [!NOTE]
> Test this with a non-a11n account

* Go to http://calypso.localhost:3000/reader/feeds/165951787
* Use the kebab menu to block the site
* Check the blocked message (see screenshot above)
* Go to http://calypso.localhost:3000/jetpack/sso/jeherve.com
* Check the message (see screenshot above)
* Go to http://calypso.localhost:3000/purchases/subscriptions/
* Pick a free site
* Check the message (see screenshot above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
