### PR TITLE
Fix: The Add-Ons page can't scroll to the bottom on iOS 26

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -19,12 +19,10 @@ import type { ReactElement } from 'react';
 const globalOverrides = css`
 	.is-section-add-ons {
 		height: 100%;
+		--color-surface-backdrop: #fdfdfd;
 	}
 	.layout__primary {
 		height: 100%;
-	}
-	body {
-		--color-surface-backdrop: #fdfdfd;
 	}
 `;
 

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -21,7 +21,7 @@ const globalOverrides = css`
 		height: 100%;
 		#content.layout__content {
 			background: #fdfdfd;
-			height: 100%;
+			min-height: 100%;
 		}
 	}
 	.layout__primary {
@@ -36,7 +36,7 @@ const globalOverrides = css`
 const mobileBreakpoint = 660;
 
 const ContainerMain = styled.div`
-	height: 100%;
+	min-height: 100%;
 	.add-ons__main {
 		.add-ons__formatted-header {
 			text-align: center;

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -19,13 +19,12 @@ import type { ReactElement } from 'react';
 const globalOverrides = css`
 	.is-section-add-ons {
 		height: 100%;
-		#content.layout__content {
-			background: #fdfdfd;
-			min-height: 100%;
-		}
 	}
 	.layout__primary {
 		height: 100%;
+	}
+	body {
+		--color-surface-backdrop: #fdfdfd;
 	}
 `;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [CHE-256](https://linear.app/a8c/issue/CHE-256/the-add-ons-page-cant-scroll-to-the-bottom-on-ios-26)

## Proposed Changes

* removes height restriction so that the content can overflow and allow scrolling
* use CSS variable to change the body's background instead of relying on the layout content to fill in that color

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* scrolling on ios 26 doesn't work on the add-ons page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* got to the Upgrade > Add-ons page on an small screen (preferably ios 26)
* you should be able to reach the bottom of the page

| Before | After |
|--------|--------|
| <img width="585" height="1266" alt="D64635F6-1425-41C5-A91F-EF07C2194E7E" src="https://github.com/user-attachments/assets/373a3c8a-1657-4943-99ab-d64ac66056b2" /> | <img width="585" height="1266" alt="7F1A8BBE-28FE-4331-B3DF-5D42ADB3A651" src="https://github.com/user-attachments/assets/8318dc5d-77d0-46f4-994a-47d54b896c31" /> | 





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
