### PR TITLE
Domain Search Rewrite: Make sure badges dont wrap with suggestion name

### DIFF
--- a/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.skeleton.tsx
@@ -36,9 +36,9 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 		if ( activeQuery === 'large' ) {
 			if ( matchReasonsList ) {
 				return (
-					<HStack spacing={ 6 } className="domain-suggestion-featured__content">
-						<VStack spacing={ 3 } style={ { justifyContent: 'flex-start', height: '100%' } }>
-							{ badges }
+					<VStack spacing={ 3 } className="domain-suggestion-featured__content">
+						{ badges }
+						<HStack spacing={ 6 } style={ { flex: 1 } }>
 							<VStack
 								spacing={ 3 }
 								alignment="left"
@@ -47,16 +47,16 @@ export const FeaturedSkeleton = forwardRef< HTMLDivElement, SkeletonProps >( ( p
 								{ title }
 								{ matchReasonsList }
 							</VStack>
-						</VStack>
-						<VStack
-							spacing={ 6 }
-							alignment="right"
-							className="domain-suggestion-featured__price-info"
-						>
-							{ price }
-							{ cta }
-						</VStack>
-					</HStack>
+							<VStack
+								spacing={ 6 }
+								alignment="right"
+								className="domain-suggestion-featured__price-info"
+							>
+								{ price }
+								{ cta }
+							</VStack>
+						</HStack>
+					</VStack>
 				);
 			}
 


### PR DESCRIPTION
Closes DOMAINS-1643.

## Proposed Changes

### Before

In the large viewport version of the feature domain suggestion the badges were wrapping along with the domain name, and that's not what we wanted since there was plenty of space for them.

<img width="1145" height="267" alt="image" src="https://github.com/user-attachments/assets/572f8320-9d48-4758-ba45-e5f9f2618859" />

### After

<img width="1147" height="234" alt="image" src="https://github.com/user-attachments/assets/7a8964b6-5e67-4862-a164-1ff196206953" />


## Testing Instructions

Enter `/setup/domain` and search for "work". You should see the badges taking the available space instead of wrapping early.