### PR TITLE
Hosting Dashboard: Adding performance page WIP

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -1,30 +1,96 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { siteRoute } from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { getPerformanceCalloutProps } from './performance-callout';
+import { PerformanceFooter } from './performance-footer';
+import { PerformancePageLoadTimelineCard } from './performance-page-load-timeline-card';
+import { PerformancePageSelector } from './performance-page-selector';
+import { PerformanceRecommendationsCard } from './performance-recommendations-card';
+import { PerformanceScoreSection } from './performance-score-section';
+import { PerformanceSubtitle } from './performance-subtitle';
+import { usePerformanceData } from './use-performance-data';
+
+function SitePerformanceBody( { device, data }: { device: string; data: PerformanceData } ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const deviceData = data.performanceData.pagespeed[ device ];
+
+	return (
+		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+			<PerformanceSubtitle timestamp={ deviceData.timestamp } />
+			<PerformanceScoreSection scores={ deviceData } />
+			<PerformancePageLoadTimelineCard screenshots={ deviceData.screenshots } />
+			<PerformanceRecommendationsCard audits={ deviceData.audits } />
+			<PerformanceFooter />
+		</VStack>
+	);
+}
 
 function SitePerformance() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+	const [ device, setDevice ] = useState( 'mobile' );
+	const hasPerformanceFeature = hasHostingFeature( site, HostingFeatures.PERFORMANCE );
+	const data = usePerformanceData( site.ID, site.URL );
 
 	if ( ! site ) {
 		return;
 	}
 
+	const handleDeviceChange = ( value: string | number | undefined ) => {
+		if ( ! value ) {
+			return;
+		}
+
+		setDevice( value.toString() );
+	};
+
+	const actions = (
+		<>
+			<PerformancePageSelector />
+			<ToggleGroupControl
+				value={ device }
+				isBlock
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				onChange={ handleDeviceChange }
+				label={ __( 'Device' ) }
+				hideLabelFromVision
+			>
+				<ToggleGroupControlOption value="mobile" label={ __( 'Mobile' ) } />
+				<ToggleGroupControlOption value="desktop" label={ __( 'Desktop' ) } />
+			</ToggleGroupControl>
+		</>
+	);
+
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Performance' ) } /> }>
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Performance' ) }
+					actions={ hasPerformanceFeature ? actions : undefined }
+				/>
+			}
+		>
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.PERFORMANCE }
 				asOverlay
 				{ ...getPerformanceCalloutProps() }
 			>
-				<></>
+				<SitePerformanceBody device={ device } data={ data } />
 			</HostingFeatureGatedWithCallout>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/performance/performance-footer.tsx
+++ b/client/dashboard/sites/performance/performance-footer.tsx
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+
+export function PerformanceFooter() {
+	return (
+		<>
+			<div>
+				{ __(
+					'The historical performance data and metrics presented in this site are sourced from the Google Chrome User Experience Report (CrUX) dataset, which reflects real-world user experiences and interactions with your site. Realtime data is provided by PageSpeed Insights. This data helps us provide actionable recommendations to improve your site‘s performance.'
+				) }
+			</div>
+			<div>
+				{ __(
+					'While we strive to provide accurate and helpful insights, please note that performance improvements are dependent on various factors, including your current setup and specific use case. Our recommendations aim to guide you towards potential enhancements, but results may vary.'
+				) }
+			</div>
+			<div>
+				<a
+					href="https://developer.wordpress.com/docs/site-performance/speed-test/#accessing-the-speed-test-tool"
+					target="_blank"
+					rel="noreferrer"
+				>
+					{ __( 'Learn more about the Chrome UX Report ↗' ) }
+				</a>
+			</div>
+		</>
+	);
+}

--- a/client/dashboard/sites/performance/performance-page-load-timeline-card.tsx
+++ b/client/dashboard/sites/performance/performance-page-load-timeline-card.tsx
@@ -1,0 +1,29 @@
+import { Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+interface PerformancePageLoadTimelineCardProps {
+	screenshots: any[];
+}
+
+export function PerformancePageLoadTimelineCard( {
+	screenshots,
+}: PerformancePageLoadTimelineCardProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<div>{ __( 'Page load timeline' ) }</div>
+				<div>
+					{ screenshots.map( ( screenshot, index ) => {
+						const timing = `${ ( screenshot.timing / 1000 ).toFixed( 1 ) }s`;
+						return (
+							<div key={ index } style={ { float: 'left' } }>
+								<img alt={ timing } src={ screenshot.data } />
+								<div>{ timing }</div>
+							</div>
+						);
+					} ) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/performance-page-selector.tsx
+++ b/client/dashboard/sites/performance/performance-page-selector.tsx
@@ -1,0 +1,37 @@
+import { ComboboxControl } from '@wordpress/components';
+
+export function PerformancePageSelector() {
+	const renderItem = ( { item }: ComboboxControlOption ) => {
+		return (
+			<>
+				<div>{ item.value }</div>
+				<div>{ item.location }</div>
+			</>
+		);
+	};
+
+	return (
+		<ComboboxControl
+			__experimentalRenderItem={ renderItem }
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label=""
+			allowReset={ false }
+			onChange={ () => {} }
+			onFilterValueChange={ () => {} }
+			options={ [
+				{
+					location: '/',
+					value: 'Home',
+					label: 'Home',
+				},
+				{
+					location: '/',
+					value: 'Home',
+					label: 'Home',
+				},
+			] }
+			value="Home"
+		/>
+	);
+}

--- a/client/dashboard/sites/performance/performance-recommendations-card.tsx
+++ b/client/dashboard/sites/performance/performance-recommendations-card.tsx
@@ -1,0 +1,28 @@
+import { Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+interface PerformanceRecommendationsCardProps {
+	audits: any[];
+}
+
+export function PerformanceRecommendationsCard( { audits }: PerformanceRecommendationsCardProps ) {
+	const filteredAudits = Object.keys( audits );
+
+	return (
+		<Card>
+			<CardBody>
+				<div>{ __( 'Recommendations' ) }</div>
+
+				<div>
+					{ filteredAudits.map( ( audit ) => {
+						return (
+							<div>
+								{ audits[ audit ].title } - { audits[ audit ].displayValue }
+							</div>
+						);
+					} ) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/performance-recommendations-filter.tsx
+++ b/client/dashboard/sites/performance/performance-recommendations-filter.tsx
@@ -1,0 +1,53 @@
+import { Card, CardBody, SelectDropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+interface PerformancePageLoadTimelineCardProps {
+	recommendations: any[];
+}
+
+export function PerformancePageLoadTimelineCard( {
+	screenshots,
+}: PerformancePageLoadTimelineCardProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<div>{ __( 'Recommendations' ) }</div>
+				<SelectDropdown
+					value={ selectedFilter }
+					initialSelected={ selectedFilter }
+					onSelect={ onFilter }
+					selectedText={
+						selectedFilter === 'all'
+							? translate( 'All recommendations' )
+							: metricsNames[ selectedFilter as keyof typeof metricsNames ]?.name
+					}
+					selectedCount={ filteredAudits.length }
+					options={ [
+						{ label: 'All recommendations', value: 'all', count: Object.keys( audits ).length },
+					].concat(
+						Object.keys( metricsNames ).map( ( key ) => ( {
+							label: metricsNames[ key as keyof typeof metricsNames ]?.name,
+							value: key,
+							count: Object.keys( audits ).filter( ( auditKey ) =>
+								filterRecommendations( key, audits[ auditKey ] )
+							).length,
+						} ) )
+					) }
+					compact
+				/>
+
+				<div>
+					{ screenshots.map( ( screenshot, index ) => {
+						const timing = `${ ( screenshot.timing / 1000 ).toFixed( 1 ) }s`;
+						return (
+							<div key={ index } style={ { float: 'left' } }>
+								<img alt={ timing } src={ screenshot.data } />
+								<div>{ timing }</div>
+							</div>
+						);
+					} ) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/performance-score-card.tsx
+++ b/client/dashboard/sites/performance/performance-score-card.tsx
@@ -1,0 +1,30 @@
+import { Badge } from '@automattic/ui';
+import { Button, Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { PerformanceScoreExplanation } from './performance-score-explanation';
+
+interface PerformanceScoreCardProps {
+	scores: any[];
+}
+
+export function PerformanceScoreCard( { scores }: PerformanceScoreCardProps ) {
+	const needsImprovement = scores.audits ? (
+		<Badge intent="warning">{ __( 'Needs improvement' ) }</Badge>
+	) : (
+		''
+	);
+
+	return (
+		<Card>
+			<CardBody>
+				<h3>{ __( 'Performance score' ) }</h3>
+				<div>{ needsImprovement }</div>
+				<Button variant="secondary">{ __( 'View all recommendations' ) }</Button>
+
+				<div>{ Math.round( scores.overall_score * 100 ) } / 100</div>
+
+				<PerformanceScoreExplanation />
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/performance-score-explanation.tsx
+++ b/client/dashboard/sites/performance/performance-score-explanation.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+
+export function PerformanceScoreExplanation() {
+	const explanation = translate(
+		"The performance score is a combined representation of your page's individual speed metrics. {{button}}See calculator{{/button}} ↗",
+		{
+			components: {
+				button: (
+					<Button
+						css={ {
+							textDecoration: 'none !important',
+							':hover': {
+								textDecoration: 'underline !important',
+							},
+							fontSize: 'inherit',
+							whiteSpace: 'nowrap',
+						} }
+						variant="link"
+					/>
+				),
+				span: (
+					<span
+						style={ {
+							fontVariantNumeric: 'tabular-nums',
+						} }
+					/>
+				),
+			},
+		}
+	);
+
+	return <div>{ explanation }</div>;
+}

--- a/client/dashboard/sites/performance/performance-score-section.tsx
+++ b/client/dashboard/sites/performance/performance-score-section.tsx
@@ -1,0 +1,26 @@
+import { __experimentalGrid as Grid } from '@wordpress/components';
+import { PerformanceScoreCard } from './performance-score-card';
+import { PerformanceScoreSummaryCard } from './performance-score-summary-card';
+import { PerformanceTimesSummaryCard } from './performance-times-summary-card';
+
+interface PerformanceScoreSectionProps {
+	scores: any[];
+}
+
+export function PerformanceScoreSection( { scores }: PerformanceScoreSectionProps ) {
+	return (
+		<Grid columns={ 2 } templateColumns="15em 1fr">
+			<Grid columns={ 1 } rows={ 2 } templateRows="6em 25em">
+				<PerformanceScoreSummaryCard score={ scores.overall_score } />
+				<PerformanceTimesSummaryCard
+					fcp={ scores.fcp }
+					lcp={ scores.lcp }
+					cls={ scores.cls }
+					inp={ scores.inp }
+					ttfb={ scores.ttfb }
+				/>
+			</Grid>
+			<PerformanceScoreCard scores={ scores } />
+		</Grid>
+	);
+}

--- a/client/dashboard/sites/performance/performance-score-summary-card.tsx
+++ b/client/dashboard/sites/performance/performance-score-summary-card.tsx
@@ -1,0 +1,17 @@
+import { Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+interface PerformanceScoreSummaryCardProps {
+	score: string;
+}
+
+export function PerformanceScoreSummaryCard( { score }: PerformanceScoreSummaryCardProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<div>{ __( 'Performance Score' ) }</div>
+				<div>{ Math.round( score * 100 ) } / 100</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/performance-subtitle.tsx
+++ b/client/dashboard/sites/performance/performance-subtitle.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { useLocale } from '../../app/locale';
+
+interface PerformanceSubtitleProps {
+	timestamp: string;
+}
+
+export function PerformanceSubtitle( { timestamp }: PerformanceSubtitleProps ) {
+	const locale = useLocale();
+	const subtitle = timestamp
+		? translate( 'Tested on {{span}}%(testedDate)s{{/span}}. {{button}}Test again{{/button}}', {
+				args: {
+					testedDate: new Date( timestamp ).toLocaleString( locale, {
+						dateStyle: 'long',
+						timeStyle: 'medium',
+					} ),
+				},
+				components: {
+					button: (
+						<Button
+							css={ {
+								textDecoration: 'none !important',
+								':hover': {
+									textDecoration: 'underline !important',
+								},
+								fontSize: 'inherit',
+								whiteSpace: 'nowrap',
+							} }
+							variant="link"
+						/>
+					),
+					span: (
+						<span
+							style={ {
+								fontVariantNumeric: 'tabular-nums',
+							} }
+						/>
+					),
+				},
+		  } )
+		: __( 'Optimize your site for lightning-fast performance. {{link}}Learn more.{{/link}}' );
+
+	return <div>{ subtitle }</div>;
+}

--- a/client/dashboard/sites/performance/performance-times-summary-card.tsx
+++ b/client/dashboard/sites/performance/performance-times-summary-card.tsx
@@ -1,0 +1,62 @@
+import { Card, CardBody } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+interface PerformanceTimesSummaryCardProps {
+	fcp: number;
+	lcp: number;
+	cls: number;
+	inp: number;
+	ttfb: number;
+}
+
+export function PerformanceTimesSummaryCard( scores: PerformanceTimesSummaryCardProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<div>{ __( 'First Contentful Paint' ) }</div>
+				<div>
+					{
+						/* translators: %s is the calculated First Contentful Paint value. */
+						sprintf( __( '%s s' ), ( scores.fcp / 1000 ).toFixed( 1 ) )
+					}
+				</div>
+				<br />
+
+				<div>{ __( 'Largest Contentful Paint' ) }</div>
+				<div>
+					{
+						/* translators: %s is the calculated Largest Contentful Paint value. */
+						sprintf( __( '%s s' ), ( scores.lcp / 1000 ).toFixed( 1 ) )
+					}
+				</div>
+				<br />
+
+				<div>{ __( 'Cumulative Layout Shift' ) }</div>
+				<div>
+					{
+						/* translators: %s is the calculated Cumulative Layout Shift value. */
+						scores.cls.toFixed( 2 )
+					}
+				</div>
+				<br />
+
+				<div>{ __( 'Interaction to Next Paint' ) }</div>
+				<div>
+					{
+						/* translators: %s is the calculated Interaction to Next Paint value. */
+						sprintf( __( '%s ms' ), Math.round( scores.inp ) )
+					}
+				</div>
+				<br />
+
+				<div>{ __( 'Time to First Byte' ) }</div>
+				<div>
+					{
+						/* translators: %s is the calculated Time to First Byte value. */
+						sprintf( __( '%s s' ), ( scores.ttfb / 1000 ).toFixed( 1 ) )
+					}
+				</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/use-performance-data.ts
+++ b/client/dashboard/sites/performance/use-performance-data.ts
@@ -1,0 +1,64 @@
+import {
+	basicMetricsQuery,
+	performanceInsightsQuery,
+	siteSettingsQuery,
+} from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import type { UrlPerformanceInsights } from '@automattic/api-core';
+
+interface PerformanceData {
+	performanceData: UrlPerformanceInsights | undefined;
+	desktopScore: number | undefined;
+	mobileScore: number | undefined;
+	desktopLoaded: boolean;
+	mobileLoaded: boolean;
+	isLoading: boolean;
+}
+
+export function usePerformanceData( siteId: number, url: string ): PerformanceData {
+	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery( {
+		...siteSettingsQuery( siteId ),
+		refetchOnWindowFocus: false,
+		retry: false,
+		enabled: !! siteId,
+	} );
+
+	const wpcomPerformanceReportUrl: string = siteSettings?.wpcom_performance_report_url || '';
+	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
+
+	const { data: basicMetricsData, isLoading: isLoadingBasicMetrics } = useQuery( {
+		...basicMetricsQuery( url ),
+		refetchOnWindowFocus: false,
+		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
+	} );
+
+	const token = cachedHash || basicMetricsData?.token;
+
+	const { data: performanceData, isLoading: isLoadingPerformanceInsights } = useQuery( {
+		...performanceInsightsQuery( url, token || '' ),
+		refetchOnWindowFocus: false,
+		enabled: !! url && !! token,
+	} );
+
+	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
+	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';
+
+	const desktopScore =
+		desktopLoaded && typeof performanceData?.pagespeed.desktop === 'object'
+			? Math.round( performanceData.pagespeed.desktop.overall_score * 100 )
+			: undefined;
+
+	const mobileScore =
+		mobileLoaded && typeof performanceData?.pagespeed.mobile === 'object'
+			? Math.round( performanceData.pagespeed.mobile.overall_score * 100 )
+			: undefined;
+
+	return {
+		performanceData,
+		desktopScore,
+		mobileScore,
+		desktopLoaded,
+		mobileLoaded,
+		isLoading: isLoadingSiteSettings || isLoadingBasicMetrics || isLoadingPerformanceInsights,
+	};
+}

--- a/client/dashboard/sites/performance/utils.tsx
+++ b/client/dashboard/sites/performance/utils.tsx
@@ -1,0 +1,13 @@
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+
+// Returns props for the support link based on the current environment
+export function getSupportLinkProps() {
+	return {
+		showIcon: false,
+		supportContext: isA8CForAgencies() ? 'a4a-site-performance' : 'site-performance',
+		showSupportModal: ! isA8CForAgencies(),
+		supportLink:
+			isA8CForAgencies() &&
+			'https://agencieshelp.automattic.com/knowledge-base/check-your-sites-performance',
+	};
+}


### PR DESCRIPTION
Part of DOTCOM-14735

I'm adding my progress that I currently have.

Much of the advanced functionality (such filtering by specific metric and recommendation type) is only placeholder at the moment.

Regarding components: I was unable to find a satisfactory search component to use, and I'm not sure that the ComboboxControl component is flexible to meet the design. I hoped to use the Tabs WP component to implement the selection tabs left of the graph card, but it is not available yet, so an alternative will be needed. The FoldingCard component is also unavailable. I wasn't sure if there is an existing good solution to use for the collapsing recommendations. If needed, I can just manually code up a toggle.

## Proposed Changes
* Updated the existing v2 performance page to have most of the cards and base components present.
* Uses `basicMetricsQuery`, `performanceInsightsQuery`, and `siteSettingsQuery` from `@automattic/api-queries` to gather data.
* Uses WP core components as much as possible.

## Testing Instructions
* Run a [Calypso dev environment](https://github.com/Automattic/wp-calypso/blob/trunk/docs/install.md).
* Check out this `add/hosting-dashboard-performance` branch.
* Go to http://calypso.localhost:3000/v2/sites/example.com/performance, replacing `example.com` with your test site's hostname.
* Test the controls and verify that the data looks as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
