### PR TITLE
Mailing Lists: Add new category for WordPress Studio notifications

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -112,6 +112,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Scheduled Updates' );
 		} else if ( 'learn' === category ) {
 			return this.props.translate( 'Learn Faster to Grow Faster' );
+		} else if ( 'wp_studio' === category ) {
+			return this.props.translate( 'WordPress Studio' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -172,6 +174,10 @@ class MainComponent extends Component {
 		} else if ( 'learn' === category ) {
 			return this.props.translate(
 				'Take your WordPress.com site to new heights with expert webinars, courses, and community forums.'
+			);
+		} else if ( 'wp_studio' === category ) {
+			return this.props.translate(
+				'WordPress Studio news, announcements, and feature spotlights.'
 			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -177,7 +177,7 @@ class MainComponent extends Component {
 			);
 		} else if ( 'wp_studio' === category ) {
 			return this.props.translate(
-				'WordPress Studio news, announcements, and feature spotlights.'
+				'WordPress Studio news, announcements, tips, and feature spotlights.'
 			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );


### PR DESCRIPTION
This change adds proper Calypso (UI) support for a new mailing list category used for WordPress Studio notifications.

## Testing Instructions

The backend work on adding the new mailing list category for WordPress Studio was completed via 192674.

Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=wp_studio&email=scionet%40samlim.com&hmac=070c8c6dd225b97c3bf7ced6ce0e4ea3). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed.

<img width="2394" height="900" alt="CleanShot 2025-09-24 at 09 20 41@2x" src="https://github.com/user-attachments/assets/8db4d43d-0dee-41f7-9ddc-0f4a90edb7af" />
