### PR TITLE
Dashboard v2: Use Gravatar Quick Editor for avatar updates and fix profile link

### DIFF
--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -1,67 +1,13 @@
-import path from 'path';
+import { GravatarQuickEditorCore } from '@gravatar-com/quick-editor';
 import {
 	Button,
-	Spinner,
-	FormFileUpload,
-	DropZone,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, upload, caution } from '@wordpress/icons';
-import { useState, CSSProperties, KeyboardEvent } from 'react';
-import wpcom from 'calypso/lib/wp';
-
-const ALLOWED_FILE_EXTENSIONS = [ 'jpg', 'jpeg', 'gif', 'png' ];
-
-/**
- * Crops an image file to a square aspect ratio
- * @param file - The image file to crop
- * @returns A promise that resolves to the cropped file blob
- */
-const cropFile = async ( file: File ): Promise< Blob > => {
-	return new Promise( ( resolve, reject ) => {
-		const img = new Image();
-		img.onload = () => {
-			// Get the smallest dimension to make a square
-			const size = Math.min( img.width, img.height );
-
-			// Calculate crop coordinates (center the crop)
-			const left = ( img.width - size ) / 2;
-			const top = ( img.height - size ) / 2;
-
-			// Create canvas for cropping
-			const canvas = document.createElement( 'canvas' );
-			canvas.width = size;
-			canvas.height = size;
-
-			// Draw cropped image on canvas
-			const ctx = canvas.getContext( '2d' );
-			if ( ! ctx ) {
-				reject( new Error( 'Could not get canvas context' ) );
-				return;
-			}
-
-			ctx.drawImage( img, left, top, size, size, 0, 0, size, size );
-
-			// Convert canvas to blob
-			canvas.toBlob( ( blob ) => {
-				if ( ! blob ) {
-					reject( new Error( 'Could not create blob from canvas' ) );
-					return;
-				}
-				resolve( blob );
-			}, file.type );
-		};
-
-		img.onerror = () => {
-			reject( new Error( 'Could not load image for cropping' ) );
-		};
-
-		// Load image from file
-		img.src = URL.createObjectURL( file );
-	} );
-};
+import { addQueryArgs } from '@wordpress/url';
+import { useState, useEffect, useRef, CSSProperties, KeyboardEvent } from 'react';
 
 interface EditGravatarProps {
 	/** URL to the user's avatar image */
@@ -73,7 +19,6 @@ interface EditGravatarProps {
 }
 
 const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGravatarProps ) => {
-	const [ isUploading, setIsUploading ] = useState< boolean >( false );
 	const [ tempImage, setTempImage ] = useState< string | null >( null );
 	const [ showEmailVerificationNotice, setShowEmailVerificationNotice ] =
 		useState< boolean >( false );
@@ -83,77 +28,35 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		? __( 'Change profile photo' )
 		: __( 'Verify your email to change profile photo' );
 
-	const handleUploadError = ( errorMessage: string ): void => {
-		// This could be replaced with a WordPress Notice component in the future
-		// eslint-disable-next-line no-console
-		console.error( errorMessage );
-	};
+	// Initialize the Gravatar Quick Editor to manage avatars in a dedicated Gravatar UI
+	const quickEditorRef = useRef< GravatarQuickEditorCore | null >( null );
 
-	const uploadGravatarFile = async ( file: File ): Promise< void > => {
-		setIsUploading( true );
-		// crop file image to be a square
-		const croppedFile = await cropFile( file );
-		// Upload using wpcom REST API
-		wpcom.req
-			.post( {
-				method: 'POST',
-				path: '/gravatar-upload',
-				body: {},
-				apiNamespace: 'wpcom/v2',
-				formData: [
-					[ 'account', userEmail ],
-					[ 'filedata', croppedFile ],
-				],
-			} )
-			.then( () => {
-				setIsUploading( false );
+	useEffect( () => {
+		quickEditorRef.current = new GravatarQuickEditorCore( {
+			email: userEmail,
+			scope: [ 'avatars' ],
+			utm: 'wpcomme',
+			onProfileUpdated: () => {
+				// Bust cache so the <img> reloads the latest avatar immediately
+				setTempImage( addQueryArgs( avatarUrl, { ver: Date.now() } ) as unknown as string );
+			},
+		} );
 
-				// Create a temporary image preview
-				const fileReader = new FileReader();
-				fileReader.addEventListener( 'load', () => {
-					if ( typeof fileReader.result === 'string' ) {
-						setTempImage( fileReader.result );
-					}
-				} );
-				fileReader.readAsDataURL( file );
-			} )
-			.catch( () => {
-				setIsUploading( false );
-				handleUploadError(
-					__( 'Hmm, your new profile photo was not saved. Please try uploading again.' )
-				);
-			} );
-	};
+		const onPageHide = () => {
+			try {
+				quickEditorRef.current?.close?.();
+			} catch ( _e ) {}
+		};
+		window.addEventListener( 'pagehide', onPageHide );
 
-	const handleReceiveFile = ( event: React.ChangeEvent< HTMLInputElement > ): void => {
-		const files = event.target.files;
-		if ( ! files || ! files.length ) {
-			return;
-		}
-
-		const file = files[ 0 ];
-		const extension = path.extname( file.name ).toLowerCase().substring( 1 );
-
-		if ( ALLOWED_FILE_EXTENSIONS.indexOf( extension ) === -1 ) {
-			let errorMessage = '';
-
-			if ( extension ) {
-				// translators: %s is the file extension that is not supported
-				errorMessage = __(
-					'Sorry, %s files are not supported - please make sure your image is in JPG, GIF, or PNG format.'
-				).replace( '%s', extension );
-			} else {
-				errorMessage = __(
-					'Sorry, images of that filetype are not supported - please make sure your image is in JPG, GIF, or PNG format.'
-				);
-			}
-
-			handleUploadError( errorMessage );
-			return;
-		}
-
-		uploadGravatarFile( file );
-	};
+		return () => {
+			window.removeEventListener( 'pagehide', onPageHide );
+			try {
+				quickEditorRef.current?.close?.();
+			} catch ( _e ) {}
+			quickEditorRef.current = null;
+		};
+	}, [ userEmail, avatarUrl ] );
 
 	const handleUnverifiedUserClick = (): void => {
 		if ( ! isEmailVerified ) {
@@ -205,108 +108,69 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		transition: 'opacity 0.2s',
 	};
 
-	const handleUpdateAvatar = ( openFileDialog: () => void ) => {
+	const openGravatarEditor = () => {
 		handleUnverifiedUserClick();
 		if ( isEmailVerified ) {
-			openFileDialog();
+			quickEditorRef.current?.open?.();
 		}
 	};
 
 	return (
-		<VStack
-			style={ {
-				opacity: isUploading ? 0.7 : 1,
-			} }
-			spacing={ 4 }
-		>
-			<FormFileUpload
-				accept="image/*"
-				onChange={ handleReceiveFile }
-				render={ ( { openFileDialog } ) => (
-					<HStack justify="flex-start">
-						<button
-							type="button"
-							onClick={ () => {
-								handleUpdateAvatar( openFileDialog );
-							} }
-							style={ {
-								border: 'none',
-								padding: 0,
-								background: 'transparent',
-								cursor: isEmailVerified ? 'pointer' : 'default',
-							} }
-							aria-label={ uploadButtonLabel }
-						>
-							<div
-								style={ {
-									position: 'relative',
-									width: 48,
-									height: 48,
-									borderRadius: '50%',
-									overflow: 'hidden',
-								} }
-								onMouseOver={ handleMouseOver }
-								onMouseOut={ handleMouseOut }
-								onFocus={ handleFocus }
-								onBlur={ handleBlur }
-								onKeyDown={ handleKeyDown }
-								tabIndex={ 0 }
-								role="button"
-								aria-label={ uploadButtonLabel }
-							>
-								{ isEmailVerified && (
-									<DropZone
-										label={ __( 'Drop to upload profile photo' ) }
-										onFilesDrop={ ( files: File[] ) => {
-											if ( files.length ) {
-												uploadGravatarFile( files[ 0 ] );
-											}
-										} }
-										style={ {
-											position: 'absolute',
-											top: 0,
-											left: 0,
-											width: '100%',
-											height: '100%',
-											zIndex: 1,
-										} }
-									/>
+		<VStack spacing={ 4 }>
+			<HStack justify="flex-start">
+				<button
+					type="button"
+					onClick={ openGravatarEditor }
+					style={ {
+						border: 'none',
+						padding: 0,
+						background: 'transparent',
+						cursor: isEmailVerified ? 'pointer' : 'default',
+					} }
+					aria-label={ uploadButtonLabel }
+				>
+					<div
+						style={ {
+							position: 'relative',
+							width: 48,
+							height: 48,
+							borderRadius: '50%',
+							overflow: 'hidden',
+						} }
+						onMouseOver={ handleMouseOver }
+						onMouseOut={ handleMouseOut }
+						onFocus={ handleFocus }
+						onBlur={ handleBlur }
+						onKeyDown={ handleKeyDown }
+						tabIndex={ 0 }
+						role="button"
+						aria-label={ uploadButtonLabel }
+					>
+						<img
+							src={ tempImage || avatarUrl }
+							alt={ __( 'Gravatar' ) }
+							width={ 48 }
+							height={ 48 }
+							style={ { objectFit: 'cover' } }
+						/>
+
+						<div className="overlay-hover" style={ overlayStyle }>
+							<div style={ { color: '#fff' } }>
+								{ ! isEmailVerified && (
+									<Icon icon={ caution } size={ 24 } style={ { fill: '#fff' } } />
 								) }
 
-								<img
-									src={ tempImage || avatarUrl }
-									alt={ __( 'Gravatar' ) }
-									width={ 48 }
-									height={ 48 }
-									style={ { objectFit: 'cover' } }
-								/>
-
-								<div className="overlay-hover" style={ overlayStyle }>
-									<div style={ { color: '#fff' } }>
-										{ ! isEmailVerified && (
-											<Icon icon={ caution } size={ 24 } style={ { fill: '#fff' } } />
-										) }
-
-										{ isEmailVerified && ! isUploading && (
-											<Icon icon={ upload } size={ 24 } style={ { fill: '#fff' } } />
-										) }
-
-										{ isEmailVerified && isUploading && <Spinner /> }
-									</div>
-								</div>
+								{ isEmailVerified && (
+									<Icon icon={ upload } size={ 24 } style={ { fill: '#fff' } } />
+								) }
 							</div>
-						</button>
-						<Button
-							variant="tertiary"
-							onClick={ () => {
-								handleUpdateAvatar( openFileDialog );
-							} }
-						>
-							{ __( 'Update avatar' ) }
-						</Button>
-					</HStack>
-				) }
-			/>
+						</div>
+					</div>
+				</button>
+				<Button variant="tertiary" onClick={ openGravatarEditor }>
+					{ __( 'Update avatar' ) }
+				</Button>
+			</HStack>
 
 			{ showEmailVerificationNotice && (
 				<div

--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -3,7 +3,7 @@ import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, upload, caution } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState, useEffect, useRef, useMemo, CSSProperties, KeyboardEvent } from 'react';
+import { useState, useEffect, useRef, CSSProperties, KeyboardEvent } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 
 interface EditGravatarProps {
@@ -27,6 +27,15 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 
 	// Initialize the Gravatar Quick Editor to manage avatars in a dedicated Gravatar UI
 	const quickEditorRef = useRef< GravatarQuickEditorCore | null >( null );
+	const avatarUrlRef = useRef( avatarUrl );
+
+	// Update the avatar URL reference when the prop changes
+	useEffect( () => {
+		avatarUrlRef.current = avatarUrl;
+	}, [ avatarUrl ] );
+
+	// Add a timestamp to the avatar URL to avoid cache since this component needs to show the latest avatar the user has uploaded
+	const displayUrl = addQueryArgs( avatarUrlRef.current, { ver: Date.now() } );
 
 	useEffect( () => {
 		quickEditorRef.current = new GravatarQuickEditorCore( {
@@ -35,7 +44,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 			utm: 'wpcomme',
 			onProfileUpdated: () => {
 				// Bust cache so the <img> reloads the latest avatar immediately
-				setTempImage( addQueryArgs( avatarUrl, { ver: Date.now() } ) as string );
+				setTempImage( addQueryArgs( avatarUrlRef.current, { ver: Date.now() } ) as string );
 			},
 		} );
 
@@ -53,7 +62,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 			} catch ( _e ) {}
 			quickEditorRef.current = null;
 		};
-	}, [ userEmail, avatarUrl ] );
+	}, [ userEmail ] );
 
 	const handleUnverifiedUserClick = (): void => {
 		if ( ! isEmailVerified ) {
@@ -104,12 +113,6 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		opacity: isOverlayVisible ? 1 : 0,
 		transition: 'opacity 0.2s',
 	};
-
-	// Add a timestamp to the avatar URL to avoid cache since this component needs to show the latest avatar the user has uploaded
-	const displayUrl = useMemo(
-		() => addQueryArgs( avatarUrl, { ver: Date.now() } ) as string,
-		[ avatarUrl ]
-	);
 
 	const openGravatarEditor = () => {
 		handleUnverifiedUserClick();

--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -38,7 +38,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 			utm: 'wpcomme',
 			onProfileUpdated: () => {
 				// Bust cache so the <img> reloads the latest avatar immediately
-				setTempImage( addQueryArgs( avatarUrl, { ver: Date.now() } ) as unknown as string );
+				setTempImage( addQueryArgs( avatarUrl, { ver: Date.now() } ) as string );
 			},
 		} );
 
@@ -110,7 +110,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 
 	// Add a timestamp to the avatar URL to avoid cache since this component needs to show the latest avatar the user has uploaded
 	const displayUrl = useMemo(
-		() => addQueryArgs( avatarUrl, { ver: Date.now() } ) as unknown as string,
+		() => addQueryArgs( avatarUrl, { ver: Date.now() } ) as string,
 		[ avatarUrl ]
 	);
 

--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -7,7 +7,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, upload, caution } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState, useEffect, useRef, CSSProperties, KeyboardEvent } from 'react';
+import { useState, useEffect, useRef, useMemo, CSSProperties, KeyboardEvent } from 'react';
 
 interface EditGravatarProps {
 	/** URL to the user's avatar image */
@@ -108,6 +108,12 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 		transition: 'opacity 0.2s',
 	};
 
+	// Add a timestamp to the avatar URL to avoid cache since this component needs to show the latest avatar the user has uploaded
+	const displayUrl = useMemo(
+		() => addQueryArgs( avatarUrl, { ver: Date.now() } ) as unknown as string,
+		[ avatarUrl ]
+	);
+
 	const openGravatarEditor = () => {
 		handleUnverifiedUserClick();
 		if ( isEmailVerified ) {
@@ -147,7 +153,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 						aria-label={ uploadButtonLabel }
 					>
 						<img
-							src={ tempImage || avatarUrl }
+							src={ tempImage || displayUrl }
 							alt={ __( 'Gravatar' ) }
 							width={ 48 }
 							height={ 48 }

--- a/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
+++ b/client/dashboard/me/profile-gravatar/edit-gravatar.tsx
@@ -1,13 +1,10 @@
 import { GravatarQuickEditorCore } from '@gravatar-com/quick-editor';
-import {
-	Button,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, upload, caution } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useState, useEffect, useRef, useMemo, CSSProperties, KeyboardEvent } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 
 interface EditGravatarProps {
 	/** URL to the user's avatar image */
@@ -123,7 +120,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 
 	return (
 		<VStack spacing={ 4 }>
-			<HStack justify="flex-start">
+			<ButtonStack justify="flex-start">
 				<button
 					type="button"
 					onClick={ openGravatarEditor }
@@ -176,7 +173,7 @@ const EditGravatar = ( { isEmailVerified = true, avatarUrl, userEmail }: EditGra
 				<Button variant="tertiary" onClick={ openGravatarEditor }>
 					{ __( 'Update avatar' ) }
 				</Button>
-			</HStack>
+			</ButtonStack>
 
 			{ showEmailVerificationNotice && (
 				<div

--- a/client/dashboard/me/profile-gravatar/index.tsx
+++ b/client/dashboard/me/profile-gravatar/index.tsx
@@ -161,7 +161,7 @@ export default function GravatarProfileSection( {
 								{
 									strong: <strong />,
 									// @ts-expect-error children prop is injected by createInterpolateElement
-									external: <ExternalLink href="https://gravatar.com" />,
+									external: <ExternalLink href="https://gravatar.com/profile" />,
 								}
 							) }
 						/>


### PR DESCRIPTION
This is a follow-up on https://linear.app/a8c/issue/DOTDASH-353/implement-profile-public-gravatar-profile-section

## Proposed Changes
- Open the official Gravatar Quick Editor from the “Update avatar” action (replaces the file uploader)
- Remove instant-upload flow; rely on the widget’s own Save UX
- Bust avatar image cache after save so the thumbnail refreshes immediately
- Update the “Gravatar profile” link to https://gravatar.com/profile

## Why are these changes being made?
Aligns Dashboard v2 with Dashboard v1 behavior for avatars. The widget provides clearer feedback (upload/progress) and an explicit Save button, avoiding the confusing instant‑save pattern.

## Testing Instructions
1. Go to Dashboard → Profile
2. Click “Update avatar”
   - Gravatar editor opens
3. Upload/select an image and click Save Changes in the widget
   - The avatar preview should update immediately
4. Verify the “Gravatar profile” link points to https://gravatar.com/profile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
