### PR TITLE
MCP: Fix Site Settings Master Toggle Bug and Standardise Boolean Values

### DIFF
--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -4,7 +4,7 @@ import type { SiteMcpAbilities, McpAbilities } from '@automattic/api-core';
 export type McpAbilitiesApiStructure = {
 	account?: Record< string, number >;
 	site?: Record< string | number, Record< string, number > >; // site_id => abilities mapping
-	sites?: Record< string | number, Record< string, number > >; // Custom overrides per site
+	sites?: Record< string | number, Record< string, boolean > >; // Custom overrides per site
 };
 
 /**
@@ -25,8 +25,8 @@ export function getSiteMcpAbilities(
 	// Start with default site abilities
 	const defaultSiteAbilities = mcpData.site || {};
 
-	// Apply site-specific overrides if they exist (now only contains enabled/disabled values: 0 or 1)
-	const siteOverrides: Record< string, number > = mcpData.sites?.[ siteIdStr ] || {};
+	// Apply site-specific overrides if they exist (enabled/disabled values: true/false)
+	const siteOverrides: Record< string, boolean > = mcpData.sites?.[ siteIdStr ] || {};
 
 	// Merge defaults with overrides
 	const mergedAbilities: SiteMcpAbilities = {};
@@ -39,13 +39,13 @@ export function getSiteMcpAbilities(
 		}
 	} );
 
-	// Then, apply any site-specific overrides (only enabled/disabled state)
+	// Then, apply any site-specific overrides (enabled/disabled state)
 	Object.entries( siteOverrides ).forEach( ( [ abilityName, enabledValue ] ) => {
-		// enabledValue is now just 0 or 1, not a full ability object
+		// enabledValue is boolean (true/false)
 		if ( mergedAbilities[ abilityName ] ) {
 			mergedAbilities[ abilityName ] = {
 				...mergedAbilities[ abilityName ],
-				enabled: ( enabledValue as number ) === 1,
+				enabled: enabledValue,
 			};
 		}
 	} );
@@ -178,13 +178,13 @@ export function createSiteSpecificApiPayload(
 	const allAbilitiesEnabled = Object.values( abilities ).every( ( ability ) => ability.enabled );
 
 	// Find only the abilities that differ from defaults
-	const siteOverrides: Record< string, number > = {};
+	const siteOverrides: Record< string, boolean > = {};
 	Object.entries( abilities ).forEach( ( [ abilityName, ability ] ) => {
 		const defaultAbility = defaultSiteAbilities[ abilityName ];
 
 		// Only store if it differs from the default
 		if ( ! defaultAbility || defaultAbility.enabled !== ability.enabled ) {
-			siteOverrides[ abilityName ] = ability.enabled ? 1 : 0;
+			siteOverrides[ abilityName ] = ability.enabled;
 		}
 	} );
 
@@ -195,9 +195,9 @@ export function createSiteSpecificApiPayload(
 	// to ensure the master toggle is properly disabled
 	if ( allAbilitiesDisabled && Object.keys( abilities ).length > 0 ) {
 		// Store all abilities as disabled overrides
-		const allDisabledOverrides: Record< string, number > = {};
+		const allDisabledOverrides: Record< string, boolean > = {};
 		Object.keys( abilities ).forEach( ( abilityName ) => {
-			allDisabledOverrides[ abilityName ] = 0;
+			allDisabledOverrides[ abilityName ] = false;
 		} );
 
 		payload.sites = {
@@ -205,9 +205,9 @@ export function createSiteSpecificApiPayload(
 		};
 	} else if ( allAbilitiesEnabled && Object.keys( abilities ).length > 0 ) {
 		// Special case: If all abilities are enabled, we need to send them to clear any existing disabled overrides
-		const allEnabledOverrides: Record< string, number > = {};
+		const allEnabledOverrides: Record< string, boolean > = {};
 		Object.keys( abilities ).forEach( ( abilityName ) => {
-			allEnabledOverrides[ abilityName ] = 1;
+			allEnabledOverrides[ abilityName ] = true;
 		} );
 
 		payload.sites = {

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -26,7 +26,7 @@ export function getSiteMcpAbilities(
 	const defaultSiteAbilities = mcpData.site || {};
 
 	// Apply site-specific overrides if they exist (enabled/disabled values: true/false)
-	const siteOverrides: Record< string, boolean > = mcpData.sites?.[ siteIdStr ] || {};
+	const siteOverrides: Record< string, boolean > = ( mcpData.sites?.[ siteIdStr ] as any ) || {};
 
 	// Merge defaults with overrides
 	const mergedAbilities: SiteMcpAbilities = {};

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -44,12 +44,12 @@ export function getAccountMcpAbilities( userSettings ) {
  * @returns {Object} The API payload with mcp_abilities.account structure
  */
 export function createAccountApiPayload( userSettings, abilities ) {
-	// Convert abilities to the format expected by the API (1/0 instead of boolean)
+	// Convert abilities to the format expected by the API (boolean values)
 	const accountAbilities = {};
 	Object.entries( abilities ).forEach( ( [ toolId, tool ] ) => {
-		// Handle both old structure (tool.enabled) and new structure (tool is just 1/0)
-		const enabled = typeof tool === 'object' ? tool.enabled : tool === 1;
-		accountAbilities[ toolId ] = enabled ? 1 : 0;
+		// Handle both old structure (tool.enabled) and new structure (tool is just boolean)
+		const enabled = typeof tool === 'object' ? tool.enabled : tool === true;
+		accountAbilities[ toolId ] = enabled;
 	} );
 
 	// For account-level settings, we only send the account section


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/AIINT-183/investigate-bug-with-mcp-site-settings

Master toggle was not working correctly due to data type mismatch between frontend and backend.

### **Root Cause**
- **Backend was sending**: `"sites": { "123": { "tool-name": true } }` (boolean values)
- **Frontend was expecting**: `"sites": { "123": { "tool-name": 1 } }` (numeric values)

## Proposed Changes

* Standardised on boolean values (`true`/`false`) throughout the entire data flow:

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
