### PR TITLE
GitHub Deployments: Remove the warning from the SelectControl in trigger deployment modal

### DIFF
--- a/client/dashboard/sites/deployments-list/trigger-deployment-modal.tsx
+++ b/client/dashboard/sites/deployments-list/trigger-deployment-modal.tsx
@@ -43,6 +43,7 @@ function DeploymentSelectControl( { data, field, onChange }: DeploymentSelectCon
 	return (
 		<SelectControl
 			__next40pxDefaultSize
+			__nextHasNoMarginBottom
 			label={ label }
 			onChange={ ( value ) => onChange( { [ id ]: value } ) }
 			options={ options }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/105782

## Proposed Changes

* The `SelectControl` is throwing a warning in dev mode, I propose adding the prop `__nextHasNoMarginBottom`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remove the warning, and avoid future visual changes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/v2/sites/<SITENAME>/deployments`
* Connect a repository
* Open the chrome dev tools
* Click on "Trigger deployment" on the top right
* Observe that the modal opens
* Observe that no warning appears.

| Before | After |
|--------|--------|
|  <img width="2746" height="2156" alt="Screenshot 2025-09-24 at 15 39 43" src="https://github.com/user-attachments/assets/ed6a9d88-bc55-4247-8be0-7a12910c3280" /> | <img width="2746" height="2156" alt="Screenshot 2025-09-24 at 15 40 57" src="https://github.com/user-attachments/assets/339de5d7-e744-401e-a3ae-abc177efc316" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
