### PR TITLE
Domain Search Rewrite: Make sure variants have correct styles 

### DIFF
--- a/client/components/domain-search-v2/__legacy/domain-search/index.tsx
+++ b/client/components/domain-search-v2/__legacy/domain-search/index.tsx
@@ -62,7 +62,7 @@ export const DomainSearch = ( {
 
 	return (
 		<DomainSearchContext.Provider value={ contextValue }>
-			<div className={ clsx( 'domain-search', className ) }>{ children }</div>
+			<div className={ clsx( 'domain-search-legacy', className ) }>{ children }</div>
 		</DomainSearchContext.Provider>
 	);
 };

--- a/client/components/domain-search-v2/__legacy/domain-search/style.scss
+++ b/client/components/domain-search-v2/__legacy/domain-search/style.scss
@@ -1,18 +1,22 @@
 @import '@wordpress/base-styles/colors';
 
-.domain-search {
-	--domain-search-v2-background-color: #fcfcfc;
-	--domain-search-secondary-action-color: #{$gray-900};
-	--domain-search-secondary-action-box-shadow-color: #{$gray-400};
-	--domain-search-border-color: #{$gray-400};
-	--domain-search-input-size: 56px;
-	--domain-search-input-border-radius: 4px;
-	--domain-search-promotional-price-color: #048015;
-	--domain-search-warning-badge-border-color: #f4df7b;
-	--domain-search-warning-badge-background-color: #f9edb4;
-	--domain-search-success-badge-border-color: #b8e5be;
-	--domain-search-success-badge-background-color: #d1eed5;
-	--domain-search-mini-cart-height: 80px;
-	--domain-search-mini-cart-inline-padding: 1rem;
-	--domain-search-content-max-width: 64rem;
+@layer module-legacy, consumer-styles-legacy;
+
+@layer module-legacy {
+	.domain-search {
+		--domain-search-v2-background-color: #fcfcfc;
+		--domain-search-secondary-action-color: #{$gray-900};
+		--domain-search-secondary-action-box-shadow-color: #{$gray-400};
+		--domain-search-border-color: #{$gray-400};
+		--domain-search-input-size: 56px;
+		--domain-search-input-border-radius: 4px;
+		--domain-search-promotional-price-color: #048015;
+		--domain-search-warning-badge-border-color: #f4df7b;
+		--domain-search-warning-badge-background-color: #f9edb4;
+		--domain-search-success-badge-border-color: #b8e5be;
+		--domain-search-success-badge-background-color: #d1eed5;
+		--domain-search-mini-cart-height: 80px;
+		--domain-search-mini-cart-inline-padding: 1rem;
+		--domain-search-content-max-width: 64rem;
+	}
 }

--- a/client/components/domain-search-v2/__legacy/domain-search/style.scss
+++ b/client/components/domain-search-v2/__legacy/domain-search/style.scss
@@ -1,22 +1,18 @@
 @import '@wordpress/base-styles/colors';
 
-@layer module-legacy, consumer-styles-legacy;
-
-@layer module-legacy {
-	.domain-search {
-		--domain-search-v2-background-color: #fcfcfc;
-		--domain-search-secondary-action-color: #{$gray-900};
-		--domain-search-secondary-action-box-shadow-color: #{$gray-400};
-		--domain-search-border-color: #{$gray-400};
-		--domain-search-input-size: 56px;
-		--domain-search-input-border-radius: 4px;
-		--domain-search-promotional-price-color: #048015;
-		--domain-search-warning-badge-border-color: #f4df7b;
-		--domain-search-warning-badge-background-color: #f9edb4;
-		--domain-search-success-badge-border-color: #b8e5be;
-		--domain-search-success-badge-background-color: #d1eed5;
-		--domain-search-mini-cart-height: 80px;
-		--domain-search-mini-cart-inline-padding: 1rem;
-		--domain-search-content-max-width: 64rem;
-	}
+.domain-search-legacy {
+	--domain-search-v2-background-color: #fcfcfc;
+	--domain-search-secondary-action-color: #{$gray-900};
+	--domain-search-secondary-action-box-shadow-color: #{$gray-400};
+	--domain-search-border-color: #{$gray-400};
+	--domain-search-input-size: 56px;
+	--domain-search-input-border-radius: 4px;
+	--domain-search-promotional-price-color: #048015;
+	--domain-search-warning-badge-border-color: #f4df7b;
+	--domain-search-warning-badge-background-color: #f9edb4;
+	--domain-search-success-badge-border-color: #b8e5be;
+	--domain-search-success-badge-background-color: #d1eed5;
+	--domain-search-mini-cart-height: 80px;
+	--domain-search-mini-cart-inline-padding: 1rem;
+	--domain-search-content-max-width: 64rem;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -153,7 +153,11 @@ const DomainSearchStep: StepType< {
 
 	const domainSearchElement = (
 		<WPCOMDomainSearch
-			className={ shouldUseStepContainerV2( flow ) ? 'domain-search--step-container-v2' : '' }
+			className={
+				shouldUseStepContainerV2( flow )
+					? 'domain-search--step-container-v2'
+					: 'domain-search--step-container'
+			}
 			currentSiteId={ site?.ID }
 			// eslint-disable-next-line no-nested-ternary
 			currentSiteUrl={ site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined }
@@ -190,7 +194,7 @@ const DomainSearchStep: StepType< {
 
 	return (
 		<StepContainer
-			stepName="domain-search"
+			stepName="step-container--domain-search"
 			isWideLayout
 			flowName={ flow }
 			formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -1,34 +1,9 @@
-@layer module, consumer-styles;
-
-@layer consumer-styles {
-	.domain-search--step-container {
-		--domain-search-content-max-width: 1040px;
-		--domain-search-mini-cart-inline-padding: 16px;
-
-		@include break-small {
-			--domain-search-mini-cart-inline-padding: 24px;
-		}
-
-		height: 100%;
-	}
-
-	.domain-search--step-container-v2 {
-		--domain-search-mini-cart-inline-padding: var( --step-container-v2-content-inline-padding );
-		--domain-search-content-max-width: var( --step-container-v2-content-row-max-width );
-	}
-}
-
-.step-container-v2--domain-search {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-}
-
-.step-container--domain-search {
-	padding-inline: 16px;
+.domain-search--step-container {
+	--domain-search-content-max-width: 1040px;
+	--domain-search-mini-cart-inline-padding: 16px;
 
 	@include break-small {
-		padding-inline: 24px;
+		--domain-search-mini-cart-inline-padding: 24px;
 	}
 
 	.domain-search--initial-state__already-own-domain-cta {
@@ -40,4 +15,24 @@
 		bottom: 36px;
 		padding-inline: var( --domain-search-mini-cart-inline-padding );
 	}
+}
+
+.domain-search--step-container-v2 {
+	--domain-search-mini-cart-inline-padding: var( --step-container-v2-content-inline-padding );
+	--domain-search-content-max-width: var( --step-container-v2-content-row-max-width );
+}
+
+.step-container--domain-search {
+	box-sizing: content-box;
+	padding-inline: 16px;
+
+	@include break-small {
+		padding-inline: 24px;
+	}
+}
+
+.step-container-v2--domain-search {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -1,10 +1,20 @@
 @layer module, consumer-styles;
 
 @layer consumer-styles {
+	.domain-search--step-container {
+		--domain-search-content-max-width: 1040px;
+		--domain-search-mini-cart-inline-padding: 16px;
+
+		@include break-small {
+			--domain-search-mini-cart-inline-padding: 24px;
+		}
+
+		height: 100%;
+	}
+
 	.domain-search--step-container-v2 {
 		--domain-search-mini-cart-inline-padding: var( --step-container-v2-content-inline-padding );
 		--domain-search-content-max-width: var( --step-container-v2-content-row-max-width );
-		--domain-search-full-cart-z-index: 3;
 	}
 }
 
@@ -14,8 +24,20 @@
 	flex-direction: column;
 }
 
-.step-container.domain-search {
-	.step-container__content {
+.step-container--domain-search {
+	padding-inline: 16px;
+
+	@include break-small {
+		padding-inline: 24px;
+	}
+
+	.domain-search--initial-state__already-own-domain-cta {
+		box-sizing: border-box;
+		position: fixed;
 		width: 100%;
+		left: 0;
+		right: 0;
+		bottom: 36px;
+		padding-inline: var( --domain-search-mini-cart-inline-padding );
 	}
 }

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -68,7 +68,11 @@ const domainSearch = ( context, next ) => {
 
 	const getContent = () => {
 		if ( shouldRenderRewrittenDomainSearch() ) {
-			return <DomainSearch />;
+			return (
+				<CalypsoShoppingCartProvider>
+					<DomainSearch />
+				</CalypsoShoppingCartProvider>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -1,21 +1,40 @@
 import page from '@automattic/calypso-router';
-import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { Gridicon } from '@automattic/components';
+import { BackButton } from '@automattic/onboarding';
+import { type ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import QueryProductsList from '../../../components/data/query-products-list';
+import QuerySiteDomains from '../../../components/data/query-site-domains';
 import { useMyDomainInputMode } from '../../../components/domains/connect-domain-step/constants';
+import { hasPlan } from '../../../lib/cart-values/cart-items';
 import { useSelector } from '../../../state';
 import getCurrentQueryArguments from '../../../state/selectors/get-current-query-arguments';
+import getCurrentRoute from '../../../state/selectors/get-current-route';
+import useCartKey from '../../checkout/use-cart-key';
+import NewDomainsRedirectionNoticeUpsell from '../domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
+	domainManagementList,
 	domainManagementTransferToOtherSite,
 	domainUseMyDomain,
 } from '../paths';
 
+import './style.scss';
+
 const FLOW_NAME = 'domains';
 
 export default function DomainSearch() {
+	const translate = useTranslate();
+	const cartKey = useCartKey();
+	const cart = useShoppingCart( cartKey );
+
 	const queryArguments = useSelector( getCurrentQueryArguments );
 	const selectedSite = useSelector( getSelectedSite );
 
@@ -64,15 +83,45 @@ export default function DomainSearch() {
 		};
 	}, [ selectedSiteSlug ] );
 
+	const currentRoute = useSelector( getCurrentRoute );
+	const query = useSelector( getCurrentQueryArguments );
+
+	const isFromMyHome = query?.from === 'my-home';
+
+	const getBackButtonHref = () => {
+		// If we have the from query param, we should use that as the back button href
+		if ( isFromMyHome ) {
+			return `/home/${ selectedSiteSlug }`;
+		} else if ( query?.redirect_to ) {
+			return query.redirect_to.toString();
+		}
+
+		return domainManagementList( selectedSiteSlug ?? undefined, currentRoute );
+	};
+
 	return (
-		<WPCOMDomainSearch
-			currentSiteId={ selectedSite?.ID }
-			currentSiteUrl={ selectedSite?.URL }
-			flowName={ FLOW_NAME }
-			initialQuery={ queryArguments?.suggestion.toString() ?? '' }
-			config={ config }
-			events={ events }
-			flowAllowsMultipleDomainsInCart
-		/>
+		<Main className="main-column calypso-domain-search" wideLayout>
+			<div>
+				<BackButton className="domain-search__go-back" href={ getBackButtonHref() }>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ translate( 'Back' ) }
+				</BackButton>
+				<FormattedHeader brandFont headerText={ translate( 'Search for a domain' ) } align="left" />
+			</div>
+			{ ! hasPlan( cart.responseCart ) && <NewDomainsRedirectionNoticeUpsell /> }
+			<WPCOMDomainSearch
+				className="domain-search--calypso"
+				currentSiteId={ selectedSite?.ID }
+				currentSiteUrl={ selectedSite?.URL }
+				flowName={ FLOW_NAME }
+				initialQuery={ queryArguments?.suggestion?.toString() ?? '' }
+				config={ config }
+				events={ events }
+				flowAllowsMultipleDomainsInCart
+			/>
+			<QueryProductsList />
+			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			{ selectedSite?.ID && <QuerySiteDomains siteId={ selectedSite?.ID } /> }
+		</Main>
 	);
 }

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -1,0 +1,48 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.domain-search--calypso {
+	--domain-search-content-max-width: 1040px;
+
+	@include break-small {
+		--domain-search-mini-cart-inline-padding: 24px;
+	}
+
+	@include break-large {
+		--domain-search-mini-cart-inline-padding: 32px;
+	}
+
+	.domains-mini-cart__container {
+		@include break-medium {
+			width: calc( 100% - var( --sidebar-width-min ) );
+			left: var( --sidebar-width-min );
+		}
+	}
+}
+
+body:has( .calypso-domain-search ) {
+	.domain-search__go-back {
+		color: var( --studio-gray-50 );
+		font-size: 0.875rem;
+		line-height: 17px;
+		text-decoration: none;
+		margin-bottom: 18px;
+	}
+
+	@media ( max-width: #{$break-small} ) {
+		.layout__content {
+			padding-inline: 16px !important;
+		}
+
+		.new-domains-redirection-notice-upsell__banner {
+			margin-bottom: 24px;
+		}
+	}
+
+	@media ( max-width: #{$break-medium} ) {
+		.formatted-header {
+			margin-top: 0;
+			margin-left: 0;
+		}
+	}
+}

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -235,6 +235,7 @@ const DomainSearchUI = (
 			hideSkip
 			headerText={ headerText }
 			subHeaderText={ subHeaderText }
+			isWideLayout
 			stepContent={
 				<WPCOMDomainSearch
 					className="domain-search--step-wrapper"

--- a/client/signup/steps/domains/rewritten/style.scss
+++ b/client/signup/steps/domains/rewritten/style.scss
@@ -1,24 +1,10 @@
-@layer module, consumer-styles;
+.domain-search--step-wrapper {
+	--domain-search-content-max-width: 1040px;
 
-@layer consumer-styles {
-	.domain-search--step-wrapper {
-		--domain-search-content-max-width: 1040px;
+	--domain-search-mini-cart-inline-padding: 16px;
 
-		--domain-search-mini-cart-inline-padding: 16px;
-
-		@include break-small {
-			--domain-search-mini-cart-inline-padding: 24px;
-		}
-	}
-}
-
-.signup__step:has( .step-wrapper--domain-search ) {
-	.step-wrapper {
-		padding-inline: 16px;
-
-		@include break-small {
-			padding-inline: 24px;
-		}
+	@include break-small {
+		--domain-search-mini-cart-inline-padding: 24px;
 	}
 
 	.domain-search--initial-state__already-own-domain-cta {
@@ -29,5 +15,15 @@
 		right: 0;
 		bottom: 36px;
 		padding-inline: var( --domain-search-mini-cart-inline-padding );
+	}
+}
+
+.signup__step:has( .step-wrapper--domain-search ) {
+	.step-wrapper {
+		padding-inline: 16px;
+
+		@include break-small {
+			padding-inline: 24px;
+		}
 	}
 }

--- a/client/signup/steps/domains/rewritten/style.scss
+++ b/client/signup/steps/domains/rewritten/style.scss
@@ -1,31 +1,33 @@
-.signup__step.is-domain-search:has( .step-wrapper--domain-search ) {
-	height: 100vh;
-	box-sizing: border-box;
+@layer module, consumer-styles;
 
-	.step-wrapper {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-	}
+@layer consumer-styles {
+	.domain-search--step-wrapper {
+		--domain-search-content-max-width: 1040px;
 
-	.step-wrapper__header {
-		margin-top: 0 !important;
-		padding-top: 24px;
+		--domain-search-mini-cart-inline-padding: 16px;
 
-		@include break-large {
-			padding-top: 48px;
+		@include break-small {
+			--domain-search-mini-cart-inline-padding: 24px;
 		}
-	}
-
-	.step-wrapper__content {
-		display: flex;
-		flex: 1;
-		padding-bottom: 36px;
 	}
 }
 
-.domain-search--step-wrapper {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
+.signup__step:has( .step-wrapper--domain-search ) {
+	.step-wrapper {
+		padding-inline: 16px;
+
+		@include break-small {
+			padding-inline: 24px;
+		}
+	}
+
+	.domain-search--initial-state__already-own-domain-cta {
+		box-sizing: border-box;
+		position: fixed;
+		width: 100%;
+		left: 0;
+		right: 0;
+		bottom: 36px;
+		padding-inline: var( --domain-search-mini-cart-inline-padding );
+	}
 }

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -1,49 +1,45 @@
 @import '@wordpress/base-styles/colors';
 
-@layer module, consumer-styles;
+.domain-search {
+	// Used by the loading placeholder component
+	--color-neutral-0: #f6f7f7;
+	--color-neutral-10: #c3c4c7;
 
-@layer module {
-	.domain-search {
-		// Used by the loading placeholder component
-		--color-neutral-0: #f6f7f7;
-		--color-neutral-10: #c3c4c7;
+	--domain-search-v2-background-color: #fcfcfc;
+	--domain-search-secondary-action-color: #{$gray-900};
+	--domain-search-secondary-action-box-shadow-color: #{$gray-400};
+	--domain-search-border-color: #{$gray-400};
+	--domain-search-input-size: 56px;
+	--domain-search-input-border-radius: 4px;
+	--domain-search-promotional-price-color: #048015;
+	--domain-search-warning-badge-border-color: #f4df7b;
+	--domain-search-warning-badge-background-color: #f9edb4;
+	--domain-search-success-badge-border-color: #b8e5be;
+	--domain-search-success-badge-background-color: #d1eed5;
+	--domain-search-mini-cart-height: 80px;
+	--domain-search-mini-cart-inline-padding: 1rem;
+	--domain-search-content-max-width: 64rem;
+	--domain-search-initial-state-max-width: 50rem;
 
-		--domain-search-v2-background-color: #fcfcfc;
-		--domain-search-secondary-action-color: #{$gray-900};
-		--domain-search-secondary-action-box-shadow-color: #{$gray-400};
-		--domain-search-border-color: #{$gray-400};
-		--domain-search-input-size: 56px;
-		--domain-search-input-border-radius: 4px;
-		--domain-search-promotional-price-color: #048015;
-		--domain-search-warning-badge-border-color: #f4df7b;
-		--domain-search-warning-badge-background-color: #f9edb4;
-		--domain-search-success-badge-border-color: #b8e5be;
-		--domain-search-success-badge-background-color: #d1eed5;
-		--domain-search-mini-cart-height: 80px;
-		--domain-search-mini-cart-inline-padding: 1rem;
-		--domain-search-content-max-width: 64rem;
-		--domain-search-initial-state-max-width: 50rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	flex: 1;
+}
 
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		flex: 1;
-	}
+.domain-search--initial-state {
+	width: 100%;
+	max-width: var( --domain-search-initial-state-max-width );
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
 
-	.domain-search--initial-state {
-		width: 100%;
-		max-width: var( --domain-search-initial-state-max-width );
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-	}
+.domain-search--initial-state__already-own-domain-cta {
+	margin-top: auto !important;
+}
 
-	.domain-search--initial-state__already-own-domain-cta {
-		margin-top: auto !important;
-	}
-
-	.domain-search--results {
-		width: 100%;
-		max-width: var( --domain-search-content-max-width );
-	}
+.domain-search--results {
+	width: 100%;
+	max-width: var( --domain-search-content-max-width );
 }


### PR DESCRIPTION
Closes DOMAINS-1679.

## Proposed Changes

Matches the styles from the production version in Start (StepWrapper), Stepper (StepContainer and StepContainerV2) and the in-Calypso experience. The domain search results have the proper margin (as in production) and the "Already own a domain?" CTA is pushed to the bottom of the page.

## Testing Instructions

Enter the following pages and compare them to production vs. your environment with the `domain-search-rewrite` feature flag on:
- `/start/domain` (StepWrapper)
- `/setup/onboarding` (StepContainerV2)
- `/setup/copy-site?sourceSlug=%s` (StepContainer)
- `/domains/add/%s` (wrapper class)

