### PR TITLE
Backups Dashboard: update backup success notices

### DIFF
--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -113,7 +113,6 @@ function SiteBackupDownload() {
 			case 'success':
 				return downloadUrl ? (
 					<SiteBackupDownloadSuccess
-						site={ site }
 						downloadPointDate={ downloadPointDate }
 						downloadUrl={ downloadUrl }
 						fileSizeBytes={ fileSizeBytes }
@@ -141,8 +140,8 @@ function SiteBackupDownload() {
 			size="small"
 			header={ <PageHeader prefix={ backButton } title={ __( 'Download backup' ) } /> }
 		>
-			<Card>
-				{ currentStep !== 'success' && (
+			{ currentStep !== 'success' ? (
+				<Card>
 					<CardHeader>
 						<SectionHeader
 							title={ __( 'Download point' ) }
@@ -163,11 +162,13 @@ function SiteBackupDownload() {
 							decoration={ <Icon icon={ cloud } /> }
 						/>
 					</CardHeader>
-				) }
-				<CardBody>
-					<VStack spacing={ 4 }>{ renderStep() }</VStack>
-				</CardBody>
-			</Card>
+					<CardBody>
+						<VStack spacing={ 4 }>{ renderStep() }</VStack>
+					</CardBody>
+				</Card>
+			) : (
+				renderStep()
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -1,12 +1,9 @@
-import {
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import Notice from '../../components/notice';
+import { Text } from '../../components/text';
 
 function SiteBackupDownloadSuccess( {
 	downloadPointDate,

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -1,36 +1,23 @@
-import { useRouter } from '@tanstack/react-router';
 import {
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, download, check } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
-import { siteBackupsRoute } from '../../app/router/sites';
-import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
-import type { Site } from '@automattic/api-core';
 
 function SiteBackupDownloadSuccess( {
-	site,
 	downloadPointDate,
 	downloadUrl,
 	fileSizeBytes,
 }: {
-	site: Site;
 	downloadPointDate: string;
 	downloadUrl: string;
 	fileSizeBytes?: string;
 } ) {
 	const { recordTracksEvent } = useAnalytics();
-	const router = useRouter();
-
-	const handleAllBackupsClick = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_download_all_backups' );
-		router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } );
-	};
 
 	const handleDownloadClick = () => {
 		recordTracksEvent( 'calypso_dashboard_backups_download_download_file' );
@@ -38,36 +25,33 @@ function SiteBackupDownloadSuccess( {
 	};
 
 	return (
-		<>
-			<HStack spacing={ 4 }>
-				<HStack justify="flex-start">
-					<Icon icon={ check } />
-					<VStack spacing={ 1 }>
-						<Text size={ 15 }>{ __( 'Backup download file is ready' ) }</Text>
-						<Text size={ 13 } variant="muted">
-							{ downloadPointDate }
-						</Text>
-					</VStack>
-				</HStack>
-				<ButtonStack justify="flex-end">
-					<Button
-						variant="tertiary"
-						text={ __( 'All backups' ) }
-						onClick={ handleAllBackupsClick }
-					/>
-					<Button
-						variant="primary"
-						icon={ download }
-						text={ __( 'Download file' ) + ( fileSizeBytes ? ` (${ fileSizeBytes })` : '' ) }
-						onClick={ handleDownloadClick }
-					/>
-				</ButtonStack>
-			</HStack>
-
-			<Notice variant="info" title={ __( 'Check your email' ) }>
-				{ __( 'For your convenience, we’ve emailed you a link to your downloadable backup file.' ) }
-			</Notice>
-		</>
+		<Notice
+			variant="success"
+			title={ __( 'Backup download file is ready' ) }
+			actions={
+				<Button
+					variant="primary"
+					icon={ download }
+					text={ __( 'Download file' ) + ( fileSizeBytes ? ` (${ fileSizeBytes })` : '' ) }
+					onClick={ handleDownloadClick }
+				/>
+			}
+		>
+			<VStack spacing={ 1 }>
+				<Text>
+					{ sprintf(
+						/* translators: %s is the date of the download point */
+						__( 'We’ve prepared your backup from %s.' ),
+						downloadPointDate
+					) }
+				</Text>
+				<Text>
+					{ __(
+						'For your convenience, we’ve emailed you a link to your downloadable backup file.'
+					) }
+				</Text>
+			</VStack>
+		</Notice>
 	);
 }
 

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -2,7 +2,7 @@ import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
-import Notice from '../../components/notice';
+import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
 
 function SiteBackupDownloadSuccess( {

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -119,8 +119,8 @@ function SiteBackupRestore() {
 			size="small"
 			header={ <PageHeader prefix={ backButton } title={ __( 'Site restore' ) } /> }
 		>
-			<Card>
-				{ currentStep !== 'success' && (
+			{ currentStep !== 'success' ? (
+				<Card>
 					<CardHeader>
 						<SectionHeader
 							title={ __( 'Restore point' ) }
@@ -141,11 +141,13 @@ function SiteBackupRestore() {
 							decoration={ <Icon icon={ cloud } /> }
 						/>
 					</CardHeader>
-				) }
-				<CardBody>
-					<VStack spacing={ 4 }>{ renderStep() }</VStack>
-				</CardBody>
-			</Card>
+					<CardBody>
+						<VStack spacing={ 4 }>{ renderStep() }</VStack>
+					</CardBody>
+				</Card>
+			) : (
+				renderStep()
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/backup-restore/success.tsx
+++ b/client/dashboard/sites/backup-restore/success.tsx
@@ -1,15 +1,7 @@
-import { useRouter } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, check } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
-import { siteBackupsRoute } from '../../app/router/sites';
-import { ButtonStack } from '../../components/button-stack';
+import { Notice } from '../../components/notice';
 import type { Site } from '@automattic/api-core';
 
 const SiteBackupRestoreSuccess = ( {
@@ -20,12 +12,6 @@ const SiteBackupRestoreSuccess = ( {
 	site: Site;
 } ) => {
 	const { recordTracksEvent } = useAnalytics();
-	const router = useRouter();
-
-	const handleAllBackupsClick = () => {
-		recordTracksEvent( 'calypso_dashboard_backups_restore_all_backups' );
-		router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug: site.slug } } );
-	};
 
 	const handleViewWebsiteClick = () => {
 		recordTracksEvent( 'calypso_dashboard_backups_restore_view_website' );
@@ -33,25 +19,23 @@ const SiteBackupRestoreSuccess = ( {
 	};
 
 	return (
-		<HStack spacing={ 4 }>
-			<HStack justify="flex-start">
-				<Icon icon={ check } />
-				<VStack spacing={ 1 }>
-					<Text size={ 15 }>{ __( 'Site successfully restored' ) }</Text>
-					<Text size={ 13 } variant="muted">
-						{ restorePointDate }
-					</Text>
-				</VStack>
-			</HStack>
-			<ButtonStack justify="flex-end">
-				<Button variant="tertiary" text={ __( 'All backups' ) } onClick={ handleAllBackupsClick } />
+		<Notice
+			variant="success"
+			title={ __( 'Site successfully restored' ) }
+			actions={
 				<Button
 					variant="primary"
 					text={ __( 'View website ↗' ) }
 					onClick={ handleViewWebsiteClick }
 				/>
-			</ButtonStack>
-		</HStack>
+			}
+		>
+			{ sprintf(
+				/* translators: %s is the date of the restore point */
+				__( 'We restored the backup from %s.' ),
+				restorePointDate
+			) }
+		</Notice>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-527

## Proposed Changes

* Update backup download and restore success notices

### Screenshots

| Old | New |
|---|---|
| <img width="1112" height="394" alt="image" src="https://github.com/user-attachments/assets/1eb8d104-ab9a-49a8-afc6-d6ecb147b225" /> | <img width="1070" height="412" alt="image" src="https://github.com/user-attachments/assets/3cf852cd-9c28-4230-8ff9-3818c0bf92c8" /> |
| <img width="1242" height="614" alt="image" src="https://github.com/user-attachments/assets/fd6875ea-1fa4-4990-8ab2-233b7554ed5a" /> | <img width="1366" height="584" alt="image" src="https://github.com/user-attachments/assets/e85300d5-ff00-46b9-83b6-09536f6496e9" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Design request

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Calypso Live branch and navigate to `/v2/sites/{site}/backups`
2. Click on a full backup entry (those that refers to "Backup and scan complete")
3. Try a restore and a download and ensure the notices looks as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
