### PR TITLE
Hosting Dashboard: Site switcher only refreshes list data if it is opened

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -13,6 +13,9 @@ export default function Switcher< T >( {
 	getItemName,
 	getItemUrl,
 	renderItemIcon,
+	open,
+	onToggle,
+	defaultOpen,
 }: {
 	items?: T[];
 	value: T;
@@ -20,9 +23,17 @@ export default function Switcher< T >( {
 	getItemName: ( item: T ) => string;
 	getItemUrl: ( item: T ) => string;
 	renderItemIcon: RenderItemIcon< T >;
+
+	// For controlled usage of the switcher
+	open?: boolean;
+	onToggle?: ( willOpen: boolean ) => void;
+	defaultOpen?: boolean;
 } ) {
 	return (
 		<Dropdown
+			open={ open }
+			onToggle={ onToggle }
+			defaultOpen={ defaultOpen }
 			renderToggle={ ( { onToggle, isOpen } ) => (
 				<Button
 					className="dashboard-menu__item active"

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,10 +1,20 @@
 import { Dropdown, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import SwitcherContent, { type RenderItemIcon } from './switcher-content';
+import type { ComponentProps } from 'react';
 
 interface RenderCallbackProps {
 	onClose: () => void;
 }
+
+type SwitcherProps< T > = {
+	items?: T[];
+	value: T;
+	children?: ( props: RenderCallbackProps ) => React.ReactNode;
+	getItemName: ( item: T ) => string;
+	getItemUrl: ( item: T ) => string;
+	renderItemIcon: RenderItemIcon< T >;
+} & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >; // For controlled usage of the switcher
 
 export default function Switcher< T >( {
 	items,
@@ -16,19 +26,7 @@ export default function Switcher< T >( {
 	open,
 	onToggle,
 	defaultOpen,
-}: {
-	items?: T[];
-	value: T;
-	children?: ( props: RenderCallbackProps ) => React.ReactNode;
-	getItemName: ( item: T ) => string;
-	getItemUrl: ( item: T ) => string;
-	renderItemIcon: RenderItemIcon< T >;
-
-	// For controlled usage of the switcher
-	open?: boolean;
-	onToggle?: ( willOpen: boolean ) => void;
-	defaultOpen?: boolean;
-} ) {
+}: SwitcherProps< T > ) {
 	return (
 		<Dropdown
 			open={ open }

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -28,7 +28,8 @@ import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
-	const sites = useQuery( sitesQuery() ).data;
+	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
+	const sites = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } ).data;
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -49,6 +50,8 @@ function Site() {
 							getItemName={ getSiteDisplayName }
 							getItemUrl={ ( site ) => `/sites/${ site.slug }` }
 							renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+							open={ isSwitcherOpen }
+							onToggle={ setIsSwitcherOpen }
 						>
 							{ ( { onClose } ) => (
 								<MenuGroup>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -29,7 +29,7 @@ import EnvironmentSwitcher from './environment-switcher';
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
-	const sites = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } ).data;
+	const { data: sites } = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } );
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Site switcher only refreshes potentially stale data if it is opened
* Adds a "controlled" mode to the `<Switcher>` component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The entire site list gets reloaded every single time you land on the site overview page. Seems kinda expensive when we've got other more important things to load.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before this PR**

* Open network tools, filter by `me/sites` in order to just see site list loads
* Navigate to `/v2/sites`
  * Site list is fetched. Fair enough, React Query considers it potentially stale data
* Click an item in the site list
* Notice another call to `me/sites`

**After this PR**

* Redo steps above
* Notice no call to `me/sites` after landing on site overview
* Open site switcher
* Notice the call to refresh potentially stale `me/sites` data

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
