### PR TITLE
Hosting Dashboard: Add preferences helper

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -9,6 +9,7 @@ import '@wordpress/components/build-style/style.css';
 import '@wordpress/commands/build-style/style.css';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
+import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
 import type { AppConfig } from './context';
 
@@ -21,6 +22,7 @@ function boot( config: AppConfig ) {
 
 	maybeInitializeSupportSession( wpcom );
 	loadDevHelpers();
+	loadPreferencesHelper();
 
 	const rootElement = document.getElementById( 'wpcom' );
 	if ( rootElement === null ) {

--- a/client/dashboard/app/dev-tools/preferences.scss
+++ b/client/dashboard/app/dev-tools/preferences.scss
@@ -11,10 +11,10 @@
 
 .environment.is-prefs:hover .preferences-helper__current-preferences {
 	display: block;
+	inset-inline-end: 0;
 	max-height: 80vh;
 	overflow-y: scroll;
 	position: absolute;
 	bottom: 100%;
-	right: 0;
 	margin: 0;
 }

--- a/client/dashboard/app/dev-tools/preferences.scss
+++ b/client/dashboard/app/dev-tools/preferences.scss
@@ -1,0 +1,20 @@
+@import '@wordpress/base-styles/variables';
+
+.preferences-helper__current-preferences {
+	font-size: $font-size-small;
+	text-transform: none;
+}
+
+.environment.is-prefs:not(:hover) .preferences-helper__current-preferences {
+	display: none;
+}
+
+.environment.is-prefs:hover .preferences-helper__current-preferences {
+	display: block;
+	max-height: 80vh;
+	overflow-y: scroll;
+	position: absolute;
+	bottom: 100%;
+	right: 0;
+	margin: 0;
+}

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -1,0 +1,82 @@
+import {
+	queryClient,
+	rawUserPreferencesQuery,
+	userPreferenceMutation,
+} from '@automattic/api-queries';
+import { QueryClientProvider, useMutation, useQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	Card,
+	CardBody,
+	CardDivider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import { Fragment } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Text } from '../../components/text';
+import type { UserPreferences } from '@automattic/api-core';
+import './preferences.scss';
+
+function Preference( { name }: { name: string } ) {
+	const { mutate: unsetPreference } = useMutation(
+		userPreferenceMutation( name as keyof UserPreferences )
+	);
+
+	const handleClick = () => {
+		unsetPreference( null as unknown as UserPreferences[ keyof UserPreferences ] );
+	};
+
+	return (
+		<div>
+			<HStack justify="flex-start" spacing={ 1 }>
+				<Button
+					icon={ closeSmall }
+					size="compact"
+					title={ __( 'Unset preference' ) }
+					onClick={ handleClick }
+				/>
+				<Text>{ name }</Text>
+			</HStack>
+		</div>
+	);
+}
+
+function PreferenceList() {
+	const { data: preferences } = useQuery( rawUserPreferencesQuery() );
+	const entries = Object.entries( preferences ?? {} );
+
+	return (
+		<div>
+			<div>{ __( 'Preferences' ) }</div>
+			<Card size="xSmall" className="preferences-helper__current-preferences">
+				{ entries.length > 0 ? (
+					entries.map( ( [ name ], index ) => (
+						<Fragment key={ name }>
+							<CardBody>
+								<Preference name={ name } />
+							</CardBody>
+							{ index < entries.length - 1 && <CardDivider /> }
+						</Fragment>
+					) )
+				) : (
+					<CardBody>
+						<Text>{ __( 'No preferences' ) }</Text>
+					</CardBody>
+				) }
+			</Card>
+		</div>
+	);
+}
+
+export function loadPreferencesHelper() {
+	const element = document.querySelector( '.environment.is-prefs' );
+	if ( element ) {
+		createRoot( element ).render(
+			<QueryClientProvider client={ queryClient }>
+				<PreferenceList />
+			</QueryClientProvider>
+		);
+	}
+}

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-import { Fragment } from 'react';
+import { Fragment, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Text } from '../../components/text';
 import type { UserPreferences } from '@automattic/api-core';
@@ -45,7 +45,10 @@ function Preference( { name }: { name: string } ) {
 
 function PreferenceList() {
 	const { data: preferences } = useQuery( rawUserPreferencesQuery() );
-	const entries = Object.entries( preferences ?? {} );
+	const entries = useMemo(
+		() => Object.entries( preferences ?? {} ).sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) ),
+		[ preferences ]
+	);
 
 	return (
 		<div>

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -46,8 +46,19 @@ export const userPreferenceMutation = < P extends keyof UserPreferences >( prefe
 				[ preferenceName ]: data,
 			} as Partial< UserPreferences > ),
 		onSuccess: ( newData ) => {
-			queryClient.setQueryData( rawUserPreferencesQuery().queryKey, ( oldData ) =>
-				oldData ? { ...oldData, ...newData } : newData
-			);
+			queryClient.setQueryData( rawUserPreferencesQuery().queryKey, ( oldData ) => {
+				if ( ! oldData ) {
+					return newData;
+				}
+
+				// If newData doesn't contain the preference key, it means it was unset.
+				// We need to remove it from oldData.
+				if ( ! ( preferenceName in newData ) ) {
+					const { [ preferenceName ]: _, ...rest } = oldData;
+					return rest;
+				}
+
+				return { ...oldData, ...newData };
+			} );
 		},
 	} );

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -55,7 +55,7 @@ export const userPreferenceMutation = < P extends keyof UserPreferences >( prefe
 				// We need to remove it from oldData.
 				if ( ! ( preferenceName in newData ) ) {
 					const { [ preferenceName ]: _, ...rest } = oldData;
-					return rest;
+					return { ...rest, ...newData };
 				}
 
 				return { ...oldData, ...newData };


### PR DESCRIPTION
## Proposed Changes

This is the initial implementation for the environment badge preferences helper. This PR will only handle unsetting the preference entirely.

<img width="789" height="997" alt="SCR-20250925-lywy" src="https://github.com/user-attachments/assets/1f9a781e-f7ed-44e0-952b-996552907e3f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure you see "Preferences" in the dev helpers tool
* Try an action that adds a new preference, like dismissing a product tour or notice
* Ensure that the preferences list is updated accordingly
* Click on the close button next of the preference name
* Ensure that the preference is unset and the list is updated accordingly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
