### PR TITLE
Dashboard v2: use DataViews loading state instead of blocking /v2/domains

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -43,11 +43,10 @@ export const domainsRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'domains',
-	loader: () =>
-		Promise.all( [
-			queryClient.ensureQueryData( domainsQuery() ),
-			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-		] ),
+	loader: async () => {
+		queryClient.ensureQueryData( domainsQuery() );
+		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+	},
 } ).lazy( () =>
 	import( '../../domains' ).then( ( d ) =>
 		createLazyRoute( 'domains' )( {


### PR DESCRIPTION
## Proposed Changes

This PR updates the `/v2/domains` screen so that we we're still fetching the domains data, we show the domains table in a loading state, rather than completely blocking navigation.

This is because for users with large number of domains, the endpoint will be 

See also this discussion:  p1758532569906719/1758523535.889949-slack-C08JZTRS6NA

### Before

<img width="712" height="114" alt="image" src="https://github.com/user-attachments/assets/9312965b-c421-4a47-adcc-7f9d6690bffe" />

### After

<img width="761" height="343" alt="image" src="https://github.com/user-attachments/assets/c8a8ad50-2468-4811-a052-82c261d95843" />

## Why are these changes being made?

Performance audit

## Testing Instructions

1. Clear your REACT_QUERY_OFFLINE_CACHE in the browser local storage
2. Go to /v2/sites
3. Then click the Domains tab
4. Verify you see the page immediately with loading state in the domains table

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?