### PR TITLE
Dashboard v2: prefetch pluginsQuery() when hovering Plugins top nav

### DIFF
--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -11,7 +11,7 @@ function PrimaryMenu() {
 			{ supports.sites && <Menu.Item to="/sites">{ __( 'Sites' ) }</Menu.Item> }
 			{ supports.domains && <Menu.Item to="/domains">{ __( 'Domains' ) }</Menu.Item> }
 			{ supports.emails && <Menu.Item to="/emails">{ __( 'Emails' ) }</Menu.Item> }
-			{ supports.plugins && <Menu.Item to="/plugins">{ __( 'Plugins' ) }</Menu.Item> }
+			{ supports.plugins && <Menu.Item to="/plugins/manage">{ __( 'Plugins' ) }</Menu.Item> }
 		</Menu>
 	);
 }

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -1,4 +1,9 @@
-import { sitesQuery, queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
+import {
+	pluginsQuery,
+	sitesQuery,
+	queryClient,
+	rawUserPreferencesQuery,
+} from '@automattic/api-queries';
 import { createRoute, createLazyRoute, redirect } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { rootRoute } from './root';
@@ -65,7 +70,10 @@ export const pluginsManageRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: 'manage',
-	loader: () => queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+	loader: async () => {
+		queryClient.ensureQueryData( pluginsQuery() );
+		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+	},
 } ).lazy( () =>
 	import( '../../plugins/manage' ).then( ( d ) =>
 		createLazyRoute( 'plugins-manage' )( {


### PR DESCRIPTION

## Proposed Changes

This PR preload the `pluginsQuery()` API call when the user hovers over the Plugins nav as follows:

<img width="773" height="522" alt="image" src="https://github.com/user-attachments/assets/be5b3cb9-8ffe-4cae-9aeb-031ab9f29775" />

With this, the API call will have already run when the user finally lands in the Plugins page, improving the load time.

## Why are these changes being made?

Performance audit.

## Testing Instructions

1. Open your dev console
1. Clear your REACT_QUERY_OFFLINE_CACHE on your local storage
2. Go to /v2/sites
3. Open the network tab
4. Hover the `Plugins` top nav
5. Verify you see the plugins endpoint call as shown in the screenshot above
6. Wait a few seconds
7. Click the Plugins top nav, and see that the data is already available instantly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
