### PR TITLE
Fix monitoring-performance-card type import

### DIFF
--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -1,5 +1,5 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
-import { LineChart, SeriesData } from '@automattic/charts';
+import { type DataPointDate, LineChart, SeriesData } from '@automattic/charts';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -10,7 +10,6 @@ import { Text } from '../../components/text';
 import MonitoringCard from '../monitoring-card';
 import type { PeriodData, TimeRange } from '../monitoring/types';
 import type { Site } from '@automattic/api-core';
-import type { DataPointDate } from '@automattic/charts/dist/types/types';
 
 function convertTimeRangeToUnix( timeRange: number ): TimeRange {
 	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/105965 broke the build by importing a type from a non-existing path. This PR fixes that.

I wonder why the type check passed in the PR, but is failing on `trunk` and subsequent PRs, like https://github.com/Automattic/wp-calypso/pull/105997.

## Testing Instructions

Unit tests should pass.