### PR TITLE
Hosting Dashboard: Monitoring - minor UI improvements

### DIFF
--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -57,11 +57,7 @@ export default function MonitoringCard( {
 	};
 
 	const topContent = (
-		<HStack
-			className="dashboard-monitoring-card__content"
-			justify="space-between"
-			alignment="flex-start"
-		>
+		<HStack justify="space-between" alignment="flex-start">
 			<VStack spacing={ 4 } className="dashboard-monitoring-card__header">
 				<HStack justify="space-between">
 					<HStack spacing={ 1 } alignment="center" expanded={ false }>

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -66,4 +66,8 @@
 		/* Prevent the chart from overflowing its container. */
 		max-width: 100%;
 	}
+
+	.dashboard-monitoring-card__content {
+		min-height: 350px;
+	}
 }

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -110,6 +110,7 @@ export default function MonitoringRequestMethodsCard( {
 					gapScale={ 0.02 }
 					size={ 300 }
 					data={ data }
+					showLabels={ false }
 				/>
 			</HStack>
 		</MonitoringCard>

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -112,6 +112,7 @@ export default function MonitoringResponseTypesCard( {
 					gapScale={ 0.02 }
 					size={ 300 }
 					data={ data }
+					showLabels={ false }
 				/>
 			</HStack>
 		</MonitoringCard>


### PR DESCRIPTION
## Proposed Changes
* Hide overlay labels on donut charts.
* Preserve size for the donut charts while loading.

## Why are these changes being made?
https://linear.app/a8c/issue/DOTDASH-156

## Testing Instructions
1. Load the page `/v2/sites/your-site-slug/monitoring`, confirm "HTTP request methods" and "Response types" charts are showing up fine.
2. Confirm those charts have no overlay labels.
3. Try to switch between time spans, confirm those charts' cards preserve their height.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
