### PR TITLE
Stepper: Make use my domain step easier to work with

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -57,6 +57,7 @@ const domain: FlowV2< typeof initialize > = {
 			setPlanCartItem,
 			setProductCartItems,
 			setPendingAction,
+			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 
 		const { siteSlug, site } = useSiteData();
@@ -121,7 +122,6 @@ const domain: FlowV2< typeof initialize > = {
 						} )
 					);
 				case STEPS.USE_MY_DOMAIN.slug:
-					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 					if (
 						providedDependencies &&
 						'mode' in providedDependencies &&
@@ -137,6 +137,8 @@ const domain: FlowV2< typeof initialize > = {
 					}
 
 					if ( siteSlug && providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setHideFreePlan( true );
 						setSignupCompleteFlowName( this.name );
 						setSignupCompleteSlug( siteSlug );
 
@@ -153,6 +155,12 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 
 						return navigate( STEPS.PROCESSING.slug );
+					}
+
+					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setHideFreePlan( true );
+						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
 					}
 
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -2,8 +2,8 @@ import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { DOMAIN_FLOW, addProductsToCart, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useEffect } from 'react';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import {
@@ -17,26 +17,12 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useSiteData } from '../../../hooks/use-site-data';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
-import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type SubmitHandler } from '../../internals/types';
-
-const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
-	const isDomainsStep = currentStepSlug === 'domains';
-	const isPlansStepWithQuery =
-		currentStepSlug === 'plans' && getQueryArg( window.location.href, 'step' );
-
-	if ( isDomainsStep || isPlansStepWithQuery ) {
-		const { pathname, search } = window.location;
-		const newURL = removeQueryArgs( pathname + search, 'step', 'initialQuery', 'lastQuery' );
-		window.history.replaceState( {}, document.title, newURL );
-	}
-};
 
 function initialize() {
 	const steps = [
@@ -83,10 +69,6 @@ const domain: FlowV2< typeof initialize > = {
 			[]
 		);
 
-		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
-
-		clearUseMyDomainsQueryParams( currentStepSlug );
-
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -108,11 +90,6 @@ const domain: FlowV2< typeof initialize > = {
 							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
 						}
 
-						setUseMyDomainTracksEventProps( {
-							site_url: providedDependencies.siteUrl,
-							signup_domain_origin: signupDomainOrigin,
-							domain_item: providedDependencies.domainItem,
-						} );
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}
 
@@ -151,11 +128,6 @@ const domain: FlowV2< typeof initialize > = {
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						setUseMyDomainTracksEventProps( {
-							...useMyDomainTracksEventProps,
-							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
-							site_url: providedDependencies.domain,
-						} );
 						const destination = addQueryArgs( '/use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
@@ -163,16 +135,6 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 						return navigate( destination as typeof currentStepSlug );
 					}
-
-					// We trigger the event here, because we skip it in the domains step if
-					// the user chose use-my-domain
-					recordStepNavigation( {
-						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-						flow: this.name,
-						intent: '',
-						step: 'domains',
-						providedDependencies: useMyDomainTracksEventProps,
-					} );
 
 					if ( siteSlug && providedDependencies && 'domainCartItem' in providedDependencies ) {
 						setSignupCompleteFlowName( this.name );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -3,8 +3,8 @@ import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useEffect } from 'react';
+import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
@@ -22,29 +22,15 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
-import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import type { DomainSuggestion } from '@automattic/api-core';
-
-const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
-	const isDomainsStep = currentStepSlug === 'domains';
-	const isPlansStepWithQuery =
-		currentStepSlug === 'plans' && getQueryArg( window.location.href, 'step' );
-
-	if ( isDomainsStep || isPlansStepWithQuery ) {
-		const { pathname, search } = window.location;
-		const newURL = removeQueryArgs( pathname + search, 'step', 'initialQuery', 'lastQuery' );
-		window.history.replaceState( {}, document.title, newURL );
-	}
-};
 
 const withLocale = ( url: string, locale: string ) => {
 	return locale && locale !== 'en' ? `${ url }/${ locale }` : url;
@@ -90,7 +76,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		);
 		const coupon = useQuery().get( 'coupon' );
 
-		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		const playgroundId = useQuery().get( 'playground' );
@@ -147,8 +132,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			return [ destination, addQueryArgs( destination, { skippedCheckout: 1 } ) ];
 		};
 
-		clearUseMyDomainsQueryParams( currentStepSlug );
-
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -188,20 +171,13 @@ const onboarding: FlowV2< typeof initialize > = {
 					return navigate( 'plans' );
 				case 'use-my-domain': {
 					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
-					let newUseMyDomainTracksEventProps = useMyDomainTracksEventProps;
+
 					if (
 						providedDependencies &&
 						'mode' in providedDependencies &&
 						providedDependencies.mode &&
 						providedDependencies.domain
 					) {
-						newUseMyDomainTracksEventProps = {
-							...useMyDomainTracksEventProps,
-							signup_domain_origin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
-							site_url: providedDependencies.domain,
-						};
-
-						setUseMyDomainTracksEventProps( newUseMyDomainTracksEventProps );
 						const destination = addQueryArgs( '/use-my-domain', {
 							...getQueryArgs( window.location.href ),
 							step: providedDependencies.mode,
@@ -209,16 +185,6 @@ const onboarding: FlowV2< typeof initialize > = {
 						} );
 						return navigate( destination as typeof currentStepSlug );
 					}
-
-					// We trigger the event here, because we skip it in the domains step if
-					// the user chose use-my-domain
-					recordStepNavigation( {
-						event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-						flow: this.name,
-						intent: '',
-						step: 'domains',
-						providedDependencies: useMyDomainTracksEventProps,
-					} );
 
 					return navigate( 'plans' );
 				}

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -65,6 +65,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			setProductCartItems,
 			setSiteUrl,
 			setSignupDomainOrigin,
+			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
 
@@ -170,8 +171,6 @@ const onboarding: FlowV2< typeof initialize > = {
 
 					return navigate( 'plans' );
 				case 'use-my-domain': {
-					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
-
 					if (
 						providedDependencies &&
 						'mode' in providedDependencies &&
@@ -184,6 +183,12 @@ const onboarding: FlowV2< typeof initialize > = {
 							initialQuery: providedDependencies.domain,
 						} );
 						return navigate( destination as typeof currentStepSlug );
+					}
+
+					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setHideFreePlan( true );
+						setDomainCartItem( providedDependencies.domainCartItem );
 					}
 
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -65,7 +65,9 @@ export function recordStepNavigation( {
 			}
 
 			if (
-				[ 'cart_items', 'domain_item', 'email_item', 'domain_cart' ].includes( propName ) &&
+				[ 'cart_items', 'domain_item', 'domain_cart_item', 'email_item', 'domain_cart' ].includes(
+					propName
+				) &&
 				typeof propValue !== 'string'
 			) {
 				propValue = Object.entries( propValue || {} )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -15,6 +15,7 @@ import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
@@ -91,6 +92,7 @@ const DomainSearchStep: StepType< {
 				submit( {
 					navigateToUseMyDomain: true,
 					lastQuery: domainName,
+					shouldSkipSubmitTracking: true,
 				} );
 			},
 			onContinue: ( domainCart: MinimalRequestCartProduct[] ) => {
@@ -104,6 +106,7 @@ const DomainSearchStep: StepType< {
 						domain_name: domainItem.meta!,
 						is_free: false,
 					},
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.CUSTOM,
 				} );
 			},
 			onSkip: ( suggestion?: FreeDomainSuggestion ) => {
@@ -112,6 +115,9 @@ const DomainSearchStep: StepType< {
 					domainItem: undefined,
 					domainCart: [],
 					suggestion,
+					signupDomainOrigin: suggestion
+						? SIGNUP_DOMAIN_ORIGIN.FREE
+						: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
 				} );
 			},
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -11,7 +11,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useLocation } from 'react-router';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import {
@@ -55,6 +55,12 @@ const UseMyDomain: StepType< {
 		goBack?.();
 	};
 
+	const clearQueryParams = () => {
+		const { pathname, search } = window.location;
+		const newURL = removeQueryArgs( pathname + search, 'step', 'initialQuery', 'lastQuery' );
+		window.history.replaceState( {}, document.title, newURL );
+	};
+
 	const handleOnTransfer = async ( { domain, authCode }: { domain: string; authCode: string } ) => {
 		const domainCartItem = domainTransfer( {
 			domain: domain,
@@ -66,6 +72,7 @@ const UseMyDomain: StepType< {
 		setHideFreePlan( true );
 		setDomainCartItem( domainCartItem );
 
+		clearQueryParams();
 		submit?.( { domainCartItem } );
 	};
 
@@ -74,6 +81,7 @@ const UseMyDomain: StepType< {
 		setHideFreePlan( true );
 		setDomainCartItem( domainCartItem );
 
+		clearQueryParams();
 		submit?.( { domainCartItem } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,14 +1,5 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-import {
-	START_WRITING_FLOW,
-	ONBOARDING_FLOW,
-	StepContainer,
-	isStartWritingFlow,
-	Step,
-	DOMAIN_FLOW,
-} from '@automattic/onboarding';
+import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
@@ -19,7 +10,6 @@ import {
 	UseMyDomainInputMode,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -38,9 +28,7 @@ const UseMyDomain: StepType< {
 		| undefined;
 } > = function UseMyDomain( { navigation, flow } ) {
 	const { __ } = useI18n();
-	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 	const { goNext, goBack, submit } = navigation;
-	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 	const location = useLocation();
 
 	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
@@ -69,8 +57,6 @@ const UseMyDomain: StepType< {
 				signup: true,
 			},
 		} );
-		setHideFreePlan( true );
-		setDomainCartItem( domainCartItem );
 
 		clearQueryParams();
 		submit?.( { domainCartItem } );
@@ -78,8 +64,6 @@ const UseMyDomain: StepType< {
 
 	const handleOnConnect = async ( domain: string ) => {
 		const domainCartItem = domainMapping( { domain } );
-		setHideFreePlan( true );
-		setDomainCartItem( domainCartItem );
 
 		clearQueryParams();
 		submit?.( { domainCartItem } );
@@ -125,17 +109,6 @@ const UseMyDomain: StepType< {
 		);
 	};
 
-	const getStepContent = () => {
-		switch ( flow ) {
-			case START_WRITING_FLOW:
-			case ONBOARDING_FLOW:
-			case DOMAIN_FLOW:
-				return getBlogOnboardingFlowStepContent();
-			default:
-				return getDefaultStepContent();
-		}
-	};
-
 	const shouldHideButtons = isStartWritingFlow( flow );
 
 	if ( shouldUseStepContainerV2( flow ) ) {
@@ -165,7 +138,7 @@ const UseMyDomain: StepType< {
 					columnWidth={ columnWidth }
 					heading={ <Step.Heading text={ headingText } /> }
 				>
-					{ getStepContent() }
+					{ getBlogOnboardingFlowStepContent() }
 				</Step.CenteredColumnLayout>
 			</>
 		);
@@ -182,7 +155,7 @@ const UseMyDomain: StepType< {
 				isHorizontalLayout={ false }
 				isWideLayout
 				isLargeSkipLayout={ false }
-				stepContent={ getStepContent() }
+				stepContent={ getBlogOnboardingFlowStepContent() }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -56,8 +56,8 @@ const UseMyDomain: StepType< {
 	};
 
 	const clearQueryParams = () => {
-		const { pathname, search } = window.location;
-		const newURL = removeQueryArgs( pathname + search, 'step', 'initialQuery', 'lastQuery' );
+		const { pathname, search, hash } = window.location;
+		const newURL = removeQueryArgs( pathname + search + hash, 'step', 'initialQuery', 'lastQuery' );
 		window.history.replaceState( {}, document.title, newURL );
 	};
 


### PR DESCRIPTION
Part of DOMAINS-1674.

## Proposed Changes

We have some code in the use my domain step handling in Stepper that's not needed anymore, or badly placed.

Use my domain query parameter cleaning after submission: that's a concern of the use my domain step, not Stepper (badly placed.)

Manual submission of use my domain step isn't needed anymore as `calypso_signup_start` isn't firing twice. This was introduced in https://github.com/Automattic/wp-calypso/pull/95263.

I'm planning to use that step in more flows and it was cumbersome to add it due to all seemingly unnecessary parts that I needed to add for it to work properly.

## Testing Instructions

Follow the instructions from https://github.com/Automattic/wp-calypso/pull/95263.

Verify that the use my domain step query parameters are removed after submitting the use my domain step.

Finally, verify that upon submitting the use my domain step (picking transfer of connect), you see the step submission event dispatched correctly:

<img width="631" height="210" alt="image" src="https://github.com/user-attachments/assets/b4192d10-d5b2-4d40-8466-fda524cf1128" />
