### PR TITLE
Prevent running performance test more than once at a time

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -242,7 +242,9 @@ const SitePerformanceContent = () => {
 	);
 
 	const subtitle =
-		! performanceReport.isLoading && performanceReport.performanceReport
+		! performanceReport.isLoading &&
+		! performanceReport.isRetesting &&
+		performanceReport.performanceReport
 			? translate( 'Tested on {{span}}%(testedDate)s{{/span}}. {{button}}Test again{{/button}}', {
 					args: {
 						testedDate: moment( performanceReport.performanceReport.timestamp ).format(


### PR DESCRIPTION
Fixes STU-819
## Why are these changes being made?
I noticed that some users run a lot of tests at teh same time and tried to reproduce it - we indeed don't hide the button to rerun the test immediately. This PR fixes it.

<img width="736" height="560" alt="Screenshot 2025-09-25 at 16 14 24" src="https://github.com/user-attachments/assets/9ada7e92-6421-4688-afbf-3f67311b8a96" />

## Testing Instructions
1. Open `/sites` -> select site -> select "Performance" tab
2. Try to click om "test again" button a few times in a row:<br /><img width="421" height="80" alt="Screenshot 2025-09-25 at 16 15 14" src="https://github.com/user-attachments/assets/32ec5d46-7649-446b-99e5-98199aba0cff" />
3. Assert that you can click on it only once. Previously we coudl click a lot of times and run manu tests at teh same time.
