### PR TITLE
Dashboard v2 - Remove duplicated Date column on Activity logs when local time is equal to UTC

### DIFF
--- a/client/dashboard/sites/logs-activity/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/fields.tsx
@@ -56,6 +56,9 @@ export function useActivityFields( {
 	const isLargeScreen = useViewportMatch( 'huge', '>=' );
 	const dateTimeLabel = getDateTimeLabel( { timezoneString, gmtOffset, isLargeScreen } );
 
+	const localIsUTC =
+		( timezoneString ? timezoneString.toUpperCase().includes( 'UTC' ) : false ) || gmtOffset === 0;
+
 	const activityLogTypeElements = useMemo< ActivityLogTypeOption[] >( () => {
 		if ( ! activityLogTypes ) {
 			return [];
@@ -84,23 +87,33 @@ export function useActivityFields( {
 				},
 				filterBy: { operators: [] },
 			},
-			{
-				id: 'published_utc',
-				type: 'datetime',
-				label: __( 'Date & Time (UTC)' ),
-				enableHiding: true,
-				enableSorting: true,
-				getValue: ( { item } ) => item.published,
-				render: ( { item } ) => {
-					const value = item.published;
-					return (
-						<span>
-							{ formatDateCell( { value, timezoneString, gmtOffset, locale, formatAsUTC: true } ) }
-						</span>
-					);
-				},
-				filterBy: { operators: [] },
-			},
+			...( ! localIsUTC
+				? [
+						{
+							id: 'published_utc',
+							type: 'datetime',
+							label: __( 'Date & time (UTC)' ),
+							enableHiding: true,
+							enableSorting: true,
+							getValue: ( { item } ) => item.published,
+							render: ( { item } ) => {
+								const value = item.published;
+								return (
+									<span>
+										{ formatDateCell( {
+											value,
+											timezoneString,
+											gmtOffset,
+											locale,
+											formatAsUTC: true,
+										} ) }
+									</span>
+								);
+							},
+							filterBy: { operators: [] },
+						} as Field< SiteActivityLog >,
+				  ]
+				: [] ),
 			{
 				id: 'event',
 				type: 'text',
@@ -147,5 +160,6 @@ export function useActivityFields( {
 		dateTimeLabel,
 		activityLogTypeElements,
 		activityLogTypes,
+		localIsUTC,
 	] );
 }

--- a/client/dashboard/sites/logs-activity/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/fields.tsx
@@ -55,9 +55,7 @@ export function useActivityFields( {
 	const locale = useLocale();
 	const isLargeScreen = useViewportMatch( 'huge', '>=' );
 	const dateTimeLabel = getDateTimeLabel( { timezoneString, gmtOffset, isLargeScreen } );
-
-	const localIsUTC =
-		( timezoneString ? timezoneString.toUpperCase().includes( 'UTC' ) : false ) || gmtOffset === 0;
+	const localIsUTC = gmtOffset === 0;
 
 	const activityLogTypeElements = useMemo< ActivityLogTypeOption[] >( () => {
 		if ( ! activityLogTypes ) {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTDASH-399/implement-column-customization-for-activity-log#comment-4bb08743

## Proposed Changes

Removes the duplicated Date column we had before:

<img width="427" height="763" alt="Screenshot 2025-09-25 at 14 17 37" src="https://github.com/user-attachments/assets/23744b61-2cb2-4cfd-8474-43c828fbf646" />

## Why are these changes being made?

* The duplicated date column was confusing when the site GMT offset was equal to UTC

## Testing Instructions

* Open a site’s Activity Log (like http://calypso.localhost:3000/v2/sites/brunobasto.wpcomstaging.com/logs/activity).
* Click the gear icon to see the DataView options
* Make sure there are no duplicated Date columns

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label once new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?