### PR TITLE
Hosting Dashboard Plugins: Improve icon handling

### DIFF
--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -3,6 +3,7 @@ import {
 	sitesQuery,
 	queryClient,
 	rawUserPreferencesQuery,
+	marketplacePluginsQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, redirect } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
@@ -52,6 +53,10 @@ export const pluginRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: '$pluginId',
+	loader: async () => {
+		queryClient.ensureQueryData( marketplacePluginsQuery() );
+		await queryClient.ensureQueryData( pluginsQuery() );
+	},
 } ).lazy( () =>
 	import( '../../plugins/plugin' ).then( ( d ) =>
 		createLazyRoute( 'plugin' )( {
@@ -71,6 +76,7 @@ export const pluginsManageRoute = createRoute( {
 	getParentRoute: () => pluginsRoute,
 	path: 'manage',
 	loader: async () => {
+		queryClient.ensureQueryData( marketplacePluginsQuery() );
 		queryClient.ensureQueryData( pluginsQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},

--- a/client/dashboard/plugins/manage/fields/name.tsx
+++ b/client/dashboard/plugins/manage/fields/name.tsx
@@ -17,17 +17,15 @@ export const nameField: Field< PluginListRow > = {
 	enableSorting: true,
 	getValue: ( { item } ) => item.name,
 	render: ( { item, field } ) => {
-		const src = typeof item.icons === 'string' ? item.icons : item.icons?.[ '1x' ];
-
-		const icon = src ? (
-			<img src={ src } alt={ item.name } width={ ICON_SIZE } height={ ICON_SIZE } />
+		const icon = item.icon ? (
+			<img src={ item.icon } alt={ item.name } width={ ICON_SIZE } height={ ICON_SIZE } />
 		) : (
 			<Icon icon={ plugins } size={ FALLBACK_ICON_SIZE } className="plugin-icon-fallback" />
 		);
 
 		return (
 			<HStack spacing={ 2 } justify="flex-start">
-				<div className={ clsx( 'plugin-icon-wrapper', { 'is-fallback': ! item.icons } ) }>
+				<div className={ clsx( 'plugin-icon-wrapper', { 'is-fallback': ! item.icon } ) }>
 					{ icon }
 				</div>
 				<Link

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -44,7 +44,7 @@ export default function PluginsList() {
 		} )
 	);
 
-	const iconsBySlug = useMemo( () => {
+	const iconBySlug = useMemo( () => {
 		const marketplacePluginsBySlug = new Map( Object.entries( marketplacePlugins?.results || {} ) );
 
 		const marketplaceSearchBySlug = ( marketplaceSearch?.data.results || [] ).reduce(
@@ -56,24 +56,27 @@ export default function PluginsList() {
 		);
 
 		return filteredPlugins.reduce( ( acc, { slug } ) => {
-			acc.set(
-				slug,
-				marketplacePluginsBySlug.get( slug )?.icons ||
-					marketplaceSearchBySlug.get( slug )?.plugin?.icons ||
-					null
-			);
+			let icon;
+			if ( marketplacePluginsBySlug.has( slug ) ) {
+				icon = marketplacePluginsBySlug.get( slug )?.icons;
+			} else if ( marketplaceSearchBySlug.has( slug ) ) {
+				icon = marketplaceSearchBySlug.get( slug )?.plugin?.icons;
+			}
+
+			acc.set( slug, icon );
+
 			return acc;
-		}, new Map< string, PluginListRow[ 'icons' ] >() );
+		}, new Map< string, PluginListRow[ 'icon' ] >() );
 	}, [ filteredPlugins, marketplacePlugins, marketplaceSearch ] );
 
-	const filteredPluginsWithIcons = useMemo( () => {
+	const filteredPluginsWithIcon = useMemo( () => {
 		return filteredPlugins.map( ( plugin ) => {
 			return {
 				...plugin,
-				icons: iconsBySlug?.get( plugin.slug ) || null,
+				icon: iconBySlug?.get( plugin.slug ),
 			};
 		} );
-	}, [ filteredPlugins, iconsBySlug ] );
+	}, [ filteredPlugins, iconBySlug ] );
 
 	return (
 		<PageLayout
@@ -89,7 +92,7 @@ export default function PluginsList() {
 						isLoadingMarketplaceSearch ||
 						isLoadingSites
 					}
-					data={ filteredPluginsWithIcons ?? [] }
+					data={ filteredPluginsWithIcon ?? [] }
 					fields={ fields }
 					view={ view }
 					onChangeView={ setView }

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -1,4 +1,10 @@
-import { marketplaceSearchQuery, pluginsQuery, sitesQuery } from '@automattic/api-queries';
+import { MarketplaceSearchResult } from '@automattic/api-core';
+import {
+	marketplacePluginsQuery,
+	marketplaceSearchQuery,
+	pluginsQuery,
+	sitesQuery,
+} from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -28,20 +34,37 @@ export default function PluginsList() {
 	const { data: filteredPlugins, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ data, view ] );
-
-	const { data: marketplacePlugins, isLoading: isLoadingMarketplace } = useQuery(
+	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
+		marketplacePluginsQuery()
+	);
+	const { data: marketplaceSearch, isLoading: isLoadingMarketplaceSearch } = useQuery(
 		marketplaceSearchQuery( {
 			perPage: Number( view.perPage ),
 			slugs: filteredPlugins.map( ( plugin ) => plugin.slug ),
 		} )
 	);
-	const plugins = ( marketplacePlugins?.data.results || [] ).flat();
+
 	const iconsBySlug = useMemo( () => {
-		return plugins.reduce( ( acc, result ) => {
-			acc.set( result.fields.slug, result.fields.plugin.icons );
+		const marketplacePluginsBySlug = new Map( Object.entries( marketplacePlugins?.results || {} ) );
+
+		const marketplaceSearchBySlug = ( marketplaceSearch?.data.results || [] ).reduce(
+			( acc, { fields } ) => {
+				acc.set( fields.slug, fields );
+				return acc;
+			},
+			new Map< string, MarketplaceSearchResult[ 'fields' ] >()
+		);
+
+		return filteredPlugins.reduce( ( acc, { slug } ) => {
+			acc.set(
+				slug,
+				marketplacePluginsBySlug.get( slug )?.icons ||
+					marketplaceSearchBySlug.get( slug )?.plugin?.icons ||
+					null
+			);
 			return acc;
 		}, new Map< string, PluginListRow[ 'icons' ] >() );
-	}, [ plugins ] );
+	}, [ filteredPlugins, marketplacePlugins, marketplaceSearch ] );
 
 	const filteredPluginsWithIcons = useMemo( () => {
 		return filteredPlugins.map( ( plugin ) => {
@@ -60,7 +83,12 @@ export default function PluginsList() {
 		>
 			<DataViewsCard>
 				<DataViews
-					isLoading={ isLoadingPlugins || isLoadingMarketplace || isLoadingSites }
+					isLoading={
+						isLoadingPlugins ||
+						isLoadingMarketplacePlugins ||
+						isLoadingMarketplaceSearch ||
+						isLoadingSites
+					}
 					data={ filteredPluginsWithIcons ?? [] }
 					fields={ fields }
 					view={ view }

--- a/client/dashboard/plugins/manage/types.ts
+++ b/client/dashboard/plugins/manage/types.ts
@@ -1,12 +1,10 @@
 // Centralized types for the dashboard plugins package
 
-import { MarketplacePlugin, WpOrgPlugin } from '@automattic/api-core';
-
 export type PluginListRow = {
 	id: string;
 	slug: string;
 	name: string;
-	icons: MarketplacePlugin[ 'icons' ] | WpOrgPlugin[ 'icons' ];
+	icon?: string;
 	sitesCount: number;
 	isActive: 'all' | 'some' | 'none';
 	hasUpdate: 'all' | 'some' | 'none';

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -13,7 +13,7 @@ import { usePlugin } from './use-plugin';
 
 export default function Plugin() {
 	const { pluginId: pluginSlug } = pluginRoute.useParams();
-	const { icons, isLoading, sitesWithThisPlugin, plugin } = usePlugin( pluginSlug );
+	const { icon, isLoading, sitesWithThisPlugin, plugin } = usePlugin( pluginSlug );
 
 	if ( ! isLoading && ! plugin ) {
 		return (
@@ -33,13 +33,7 @@ export default function Plugin() {
 					</Text>
 
 					<PageHeader
-						decoration={
-							typeof icons === 'string' ? (
-								<img src={ icons } alt={ plugin?.name } />
-							) : (
-								icons?.[ '1x' ] && <img src={ icons[ '1x' ] } alt={ plugin?.name } />
-							)
-						}
+						decoration={ icon && <img src={ icon } alt={ plugin?.name } /> }
 						title={
 							plugin ? (
 								// @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`.

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -86,6 +86,17 @@ export const usePlugin = ( pluginSlug: string ) => {
 		  )
 		: [ [], [] ];
 
+	let icon;
+	if ( isMarketplacePlugin ) {
+		icon = marketplacePlugins?.results[ pluginSlug ]?.icons;
+	} else if ( wpOrgPlugin?.icons ) {
+		if ( '1x' in wpOrgPlugin.icons ) {
+			icon = wpOrgPlugin.icons[ '1x' ];
+		} else if ( 'default' in wpOrgPlugin.icons ) {
+			icon = wpOrgPlugin.icons.default;
+		}
+	}
+
 	return {
 		isLoading:
 			isLoadingSitesPlugins ||
@@ -98,8 +109,6 @@ export const usePlugin = ( pluginSlug: string ) => {
 		sitesWithThisPlugin,
 		sitesWithoutThisPlugin,
 		plugin: pluginData,
-		icons: isMarketplacePlugin
-			? marketplacePlugins?.results[ pluginSlug ]?.icons
-			: wpOrgPlugin?.icons,
+		icon,
 	};
 };

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -2,9 +2,9 @@ import { PluginItem, Site, SitePlugin } from '@automattic/api-core';
 import {
 	pluginsQuery,
 	sitesQuery,
-	marketplacePluginQuery,
 	wpOrgPluginQuery,
 	sitePluginQuery,
+	marketplacePluginsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -24,9 +24,10 @@ export const usePlugin = ( pluginSlug: string ) => {
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( pluginsQuery() );
 	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
-	const { data: marketplacePlugin, isLoading: isLoadingMarketplacePlugin } = useQuery(
-		marketplacePluginQuery( pluginSlug )
+	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
+		marketplacePluginsQuery()
 	);
+	const isMarketplacePlugin = !! marketplacePlugins?.results[ pluginSlug ];
 	const { data: wpOrgPlugin, isLoading: isLoadingWpOrgPlugin } = useQuery(
 		wpOrgPluginQuery( pluginSlug, locale )
 	);
@@ -90,13 +91,15 @@ export const usePlugin = ( pluginSlug: string ) => {
 			isLoadingSitesPlugins ||
 			isLoadingSites ||
 			isLoadingWpOrgPlugin ||
-			isLoadingMarketplacePlugin ||
+			isLoadingMarketplacePlugins ||
 			isLoadingSitePlugins,
 		isFetching: isFetchingSitePlugins,
 		pluginBySiteId,
 		sitesWithThisPlugin,
 		sitesWithoutThisPlugin,
 		plugin: pluginData,
-		icons: wpOrgPlugin?.icons || marketplacePlugin?.icons,
+		icons: isMarketplacePlugin
+			? marketplacePlugins?.results[ pluginSlug ]?.icons
+			: wpOrgPlugin?.icons,
 	};
 };

--- a/packages/api-core/src/marketplace-products/fetchers.ts
+++ b/packages/api-core/src/marketplace-products/fetchers.ts
@@ -7,3 +7,10 @@ export function fetchMarketplacePlugin( slug: string ): Promise< MarketplacePlug
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+export function fetchMarketplacePlugins(): Promise< MarketplacePlugin[] > {
+	return wpcom.req.get( {
+		path: '/marketplace/products',
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/marketplace-products/fetchers.ts
+++ b/packages/api-core/src/marketplace-products/fetchers.ts
@@ -8,7 +8,9 @@ export function fetchMarketplacePlugin( slug: string ): Promise< MarketplacePlug
 	} );
 }
 
-export function fetchMarketplacePlugins(): Promise< MarketplacePlugin[] > {
+export function fetchMarketplacePlugins(): Promise< {
+	results: Record< string, MarketplacePlugin >;
+} > {
 	return wpcom.req.get( {
 		path: '/marketplace/products',
 		apiNamespace: 'wpcom/v2',

--- a/packages/api-core/src/plugins/types.ts
+++ b/packages/api-core/src/plugins/types.ts
@@ -20,7 +20,11 @@ interface Banners {
 	high: string;
 }
 
-export type Icons = { '1x': string; '2x'?: string } | { '1x': string; svg?: string } | null;
+export type Icons =
+	| { '1x': string; '2x'?: string }
+	| { '1x': string; svg?: string }
+	| { default: string }
+	| null;
 
 export interface WpOrgPlugin {
 	name: string;

--- a/packages/api-queries/src/plugin.ts
+++ b/packages/api-queries/src/plugin.ts
@@ -1,10 +1,20 @@
-import { fetchWpOrgPlugin, fetchMarketplacePlugin } from '@automattic/api-core';
+import {
+	fetchWpOrgPlugin,
+	fetchMarketplacePlugin,
+	fetchMarketplacePlugins,
+} from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
 export const marketplacePluginQuery = ( slug: string ) =>
 	queryOptions( {
 		queryKey: [ 'marketplace-plugin', slug ],
 		queryFn: () => fetchMarketplacePlugin( slug ),
+	} );
+
+export const marketplacePluginsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'marketplace-plugins' ],
+		queryFn: () => fetchMarketplacePlugins(),
 	} );
 
 export const wpOrgPluginQuery = ( slug: string, locale: string ) =>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-209

## Proposed Changes

* Use the `/marketplace/products` endpoint on both the dashboard and the inspector so we can show the icon for some woocommerce products that were showing up without it.
* Provide the `icon` as a string to the consumer components so they don't have to guess where to get it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The icon was not being shown for all plugins.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `/v2/plugins`
* Check that the `WooCommerce Additional Variation Images` and `WooCommerce Back In Stock Notifications` plugins show up with an icon:

<img width="2257" height="456" alt="image" src="https://github.com/user-attachments/assets/5c2b19f7-3708-4b43-9bc9-821360a4c539" />

In order to have them installed, you'll need to use an account with the `a8c.com` email address and this coupon: PCYsg-65X-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?