### PR TITLE
Domain Search Rewrite: Make sure Start flows behave correctly

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -9,7 +9,7 @@
 	flex-direction: column;
 	padding: 36px 24px;
 	background-color: inherit;
-	& .card {
+	& .card, &.card {
 		box-shadow: none;
 	}
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -15,6 +15,7 @@
 		// Specificity increase to override Card background color loaded later in the cascade.
 		&.domain-transfer-or-connect__content {
 			background-color: transparent;
+			box-shadow: none;
 		}
 
 		.option-content {

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -30,7 +30,7 @@ const DomainSearchWithCart = ( {
 	const { cart, isNextDomainFree, items } = useWPCOMShoppingCartForDomainSearch( {
 		cartKey,
 		flowName,
-		isFirstDomainFreeForFirstYear: isFirstDomainFreeForFirstYear ?? false,
+		isFirstDomainFreeForFirstYear: isFirstDomainFreeForFirstYear || false,
 		flowAllowsMultipleDomainsInCart,
 		onContinue,
 		onAddDomainToCart,

--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -15,25 +15,10 @@ type DomainSearchProps = Omit< ComponentProps< typeof DomainSearch >, 'cart' | '
 	flowAllowsMultipleDomainsInCart: boolean;
 };
 
-const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
-
-const getSessionStorageQuery = () => {
-	try {
-		return sessionStorage.getItem( SESSION_STORAGE_QUERY_KEY ) ?? '';
-	} catch {
-		return '';
-	}
-};
-
-const setSessionStorageQuery = ( query: string ) => {
-	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
-};
-
 const DomainSearchWithCart = ( {
 	currentSiteId,
 	currentSiteUrl,
 	flowName,
-	initialQuery: externalInitialQuery,
 	config: externalConfig,
 	isFirstDomainFreeForFirstYear,
 	flowAllowsMultipleDomainsInCart,
@@ -50,18 +35,6 @@ const DomainSearchWithCart = ( {
 		onContinue,
 		onAddDomainToCart,
 	} );
-
-	const initialQuery = useMemo( () => {
-		if ( externalInitialQuery ) {
-			return externalInitialQuery;
-		}
-
-		if ( currentSiteUrl ) {
-			return new URL( currentSiteUrl ).host.replace( /\.(wordpress|wpcomstaging)\.com$/, '' );
-		}
-
-		return getSessionStorageQuery();
-	}, [ externalInitialQuery, currentSiteUrl ] );
 
 	const cartItemsLength = cart.items.length;
 
@@ -80,7 +53,7 @@ const DomainSearchWithCart = ( {
 		return {
 			...props.events,
 			onQueryChange: ( query: string ) => {
-				setSessionStorageQuery( query );
+				props.events?.onQueryChange?.( query );
 			},
 			onContinue: () => {
 				props.events?.onContinue?.( items );
@@ -95,7 +68,6 @@ const DomainSearchWithCart = ( {
 			config={ config }
 			cart={ cart }
 			events={ events }
-			initialQuery={ initialQuery }
 		/>
 	);
 };

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+const SESSION_STORAGE_QUERY_KEY = 'domain-search-query';
+
+const getSessionStorageQuery = () => {
+	try {
+		return sessionStorage.getItem( SESSION_STORAGE_QUERY_KEY ) ?? undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+const setSessionStorageQuery = ( query: string ) => {
+	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
+};
+
+export const useQueryHandler = ( {
+	initialQuery: externalInitialQuery,
+	currentSiteUrl,
+}: {
+	initialQuery?: string;
+	currentSiteUrl?: string;
+} ) => {
+	const [ localQuery, setLocalQuery ] = useState< string | undefined >( () => {
+		if ( externalInitialQuery ) {
+			return externalInitialQuery;
+		}
+
+		if ( currentSiteUrl ) {
+			return new URL( currentSiteUrl ).host.replace( /\.(wordpress|wpcomstaging)\.com$/, '' );
+		}
+
+		return getSessionStorageQuery();
+	} );
+
+	return {
+		query: localQuery,
+		setQuery: ( query: string ) => {
+			setLocalQuery( query );
+			setSessionStorageQuery( query );
+		},
+	};
+};

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -5,6 +5,7 @@ import { type ResponseCartProduct, useShoppingCart } from '@automattic/shopping-
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -56,8 +57,17 @@ export default function DomainSearch() {
 
 	const selectedSiteSlug = selectedSite?.slug;
 
+	const initialQuery = queryArguments?.suggestion?.toString() ?? '';
+	const currentSiteUrl = selectedSite?.URL;
+
+	const { query, setQuery } = useQueryHandler( {
+		initialQuery,
+		currentSiteUrl,
+	} );
+
 	const events = useMemo( () => {
 		return {
+			onQueryChange: setQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
 			},
@@ -81,19 +91,18 @@ export default function DomainSearch() {
 				}
 			},
 		};
-	}, [ selectedSiteSlug ] );
+	}, [ selectedSiteSlug, setQuery ] );
 
 	const currentRoute = useSelector( getCurrentRoute );
-	const query = useSelector( getCurrentQueryArguments );
 
-	const isFromMyHome = query?.from === 'my-home';
+	const isFromMyHome = queryArguments?.from === 'my-home';
 
 	const getBackButtonHref = () => {
 		// If we have the from query param, we should use that as the back button href
 		if ( isFromMyHome ) {
 			return `/home/${ selectedSiteSlug }`;
-		} else if ( query?.redirect_to ) {
-			return query.redirect_to.toString();
+		} else if ( queryArguments?.redirect_to ) {
+			return queryArguments.redirect_to.toString();
 		}
 
 		return domainManagementList( selectedSiteSlug ?? undefined, currentRoute );
@@ -112,10 +121,10 @@ export default function DomainSearch() {
 			<WPCOMDomainSearch
 				className="domain-search--calypso"
 				currentSiteId={ selectedSite?.ID }
-				currentSiteUrl={ selectedSite?.URL }
+				currentSiteUrl={ currentSiteUrl }
 				flowName={ FLOW_NAME }
-				initialQuery={ queryArguments?.suggestion?.toString() ?? '' }
 				config={ config }
+				query={ query }
 				events={ events }
 				flowAllowsMultipleDomainsInCart
 			/>

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -201,7 +201,8 @@ const DomainSearchUI = (
 			},
 			allowedTlds,
 			deemphasizedTlds: isEcommerceFlow( flowName ) ? [ 'blog' ] : [],
-			skippable: ! isDomainOnlyFlow && ! isDomainForGravatarFlow( flowName ),
+			skippable:
+				! isDomainOnlyFlow && ! isDomainForGravatarFlow( flowName ) && ! isOnboardingWithEmailFlow,
 			includeOwnedDomainInSuggestions: ! isDomainOnlyFlow,
 			allowsUsingOwnDomain: ! isDomainForGravatarFlow( flowName ) && ! isOnboardingWithEmailFlow,
 		};

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -333,7 +333,7 @@ function DomainSearchStep( props: StepProps & { locale: string } ) {
 	const baseSubmitProvidedDependencies = useMemo( () => {
 		if ( themeSlug ) {
 			return {
-				useThemeHeadstartItem: true,
+				useThemeHeadstart: true,
 			};
 		}
 

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -328,7 +328,7 @@ const DomainSearchUI = (
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }
 					slots={ slots }
-					isFirstDomainFreeForFirstYear={ ! isOnboardingWithEmailFlow }
+					isFirstDomainFreeForFirstYear={ ! isFreeFlow( flowName ) }
 				/>
 			}
 		/>

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -212,6 +212,7 @@ const DomainSearchUI = (
 		return {
 			BeforeResults: () => {
 				if (
+					isDomainOnlyFlow ||
 					isDomainForGravatarFlow( flowName ) ||
 					isFreeFlow( flowName ) ||
 					isOnboardingWithEmailFlow
@@ -223,6 +224,7 @@ const DomainSearchUI = (
 			},
 			BeforeFullCartItems: () => {
 				if (
+					isDomainOnlyFlow ||
 					isDomainForGravatarFlow( flowName ) ||
 					isFreeFlow( flowName ) ||
 					isOnboardingWithEmailFlow
@@ -233,7 +235,7 @@ const DomainSearchUI = (
 				return <FreeDomainForAYearPromo textOnly />;
 			},
 		};
-	}, [ flowName, isOnboardingWithEmailFlow ] );
+	}, [ flowName, isOnboardingWithEmailFlow, isDomainOnlyFlow ] );
 
 	const flowAllowsMultipleDomainsInCart = isDomainOnlyFlow;
 

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -1,13 +1,19 @@
 import { FreeDomainSuggestion, useMyDomainInputMode } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
-import { isDomainForGravatarFlow, isEcommerceFlow, isFreeFlow } from '@automattic/onboarding';
+import {
+	isDomainForGravatarFlow,
+	isEcommerceFlow,
+	isFreeFlow,
+	isWithThemeFlow,
+} from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import { localize } from 'i18n-calypso';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { localize, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
+import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
@@ -15,7 +21,7 @@ import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/pa
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USE_MY_DOMAIN_SECTION_NAME, UseMyDomain } from './use-my-domain';
 import type { StepProps } from './types';
 
@@ -47,6 +53,8 @@ const DomainSearchUI = (
 		queryObject,
 		baseSubmitStepProps,
 		baseSubmitProvidedDependencies,
+		previousStepName,
+		goBack,
 	} = props;
 
 	const isDomainOnlyFlow = flowName === 'domain';
@@ -223,6 +231,51 @@ const DomainSearchUI = (
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
 	}, [ flowName ] );
 
+	const translate = useTranslate();
+	const userSiteCount = useSelector( getCurrentUserSiteCount );
+
+	const { hideBack, backUrl, backLabelText } = useMemo( () => {
+		let backUrl;
+		let backLabelText;
+
+		const shouldHideBack = ! userSiteCount && previousStepName?.startsWith( 'user' ) && ! goBack;
+
+		const hideBack = flowName === 'domain' || shouldHideBack;
+
+		const [ sitesBackLabelText, defaultBackUrl ] =
+			userSiteCount && userSiteCount === 1
+				? [ translate( 'Back to My Home' ), '/home' ]
+				: [ translate( 'Back to sites' ), '/sites' ];
+
+		if ( isDomainForGravatarFlow( flowName ) ) {
+			backUrl = null;
+			backLabelText = null;
+		} else if ( 'with-plugin' === flowName ) {
+			backUrl = '/plugins';
+			backLabelText = translate( 'Back to plugins' );
+		} else if ( isWithThemeFlow( flowName ) ) {
+			backUrl = '/themes';
+			backLabelText = translate( 'Back to themes' );
+		} else if ( 'plans-first' === flowName ) {
+			backUrl = getStepUrl( flowName, previousStepName );
+		} else {
+			backUrl = defaultBackUrl;
+			backLabelText = sitesBackLabelText;
+
+			const backTo = getQueryArg( window.location.href, 'back_to' )?.toString();
+			if ( backTo && isRelativeUrl( backTo ) ) {
+				backUrl = backTo;
+				backLabelText = translate( 'Back' );
+			}
+		}
+
+		return {
+			hideBack,
+			backUrl,
+			backLabelText,
+		};
+	}, [ flowName, previousStepName, goBack, userSiteCount, translate ] );
+
 	return (
 		<StepWrapper
 			{ ...props }
@@ -230,6 +283,9 @@ const DomainSearchUI = (
 			hideSkip
 			headerText={ headerText }
 			subHeaderText={ subHeaderText }
+			hideBack={ hideBack }
+			backUrl={ backUrl }
+			backLabelText={ backLabelText }
 			isWideLayout
 			stepContent={
 				<WPCOMDomainSearch

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -13,6 +13,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
+import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
@@ -60,8 +61,17 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
+	const siteSlug = queryObject.siteSlug;
+	const currentSiteUrl = siteSlug ? `https://${ siteSlug }` : undefined;
+
+	const { query, setQuery } = useQueryHandler( {
+		initialQuery: queryObject.new,
+		currentSiteUrl,
+	} );
+
 	const events = useMemo( () => {
 		return {
+			onQueryChange: setQuery,
 			onAddDomainToCart: ( product: MinimalRequestCartProduct ) => {
 				if ( isDomainForGravatarFlow( flowName ) ) {
 					return {
@@ -92,6 +102,7 @@ const DomainSearchUI = (
 					getStepUrl( flowName, stepName, USE_MY_DOMAIN_SECTION_NAME, locale, {
 						step: useMyDomainInputMode.domainInput,
 						initialQuery: initialQuery,
+						siteSlug,
 					} )
 				);
 			},
@@ -162,6 +173,8 @@ const DomainSearchUI = (
 	}, [
 		flowName,
 		stepName,
+		siteSlug,
+		setQuery,
 		submitSignupStep,
 		goToNextStep,
 		locale,
@@ -288,7 +301,10 @@ const DomainSearchUI = (
 		<StepWrapper
 			{ ...props }
 			className="step-wrapper--domain-search"
-			hideSkip
+			hideSkip={ ! query || ! config.allowsUsingOwnDomain }
+			skipButtonAlign="top"
+			goToNextStep={ () => events.onExternalDomainClick( query ) }
+			skipLabelText={ __( 'Use a domain I already own' ) }
 			headerText={ headerText }
 			subHeaderText={ subHeaderText }
 			hideBack={ hideBack }
@@ -299,8 +315,8 @@ const DomainSearchUI = (
 				<WPCOMDomainSearch
 					className="domain-search--step-wrapper"
 					flowName={ flowName }
-					initialQuery={ queryObject.new }
-					currentSiteUrl={ queryObject.siteSlug ? `https://${ queryObject.siteSlug }` : undefined }
+					query={ query }
+					currentSiteUrl={ currentSiteUrl }
 					events={ events }
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -197,21 +197,29 @@ const DomainSearchUI = (
 	const slots = useMemo( () => {
 		return {
 			BeforeResults: () => {
-				if ( isDomainForGravatarFlow( flowName ) || isFreeFlow( flowName ) ) {
+				if (
+					isDomainForGravatarFlow( flowName ) ||
+					isFreeFlow( flowName ) ||
+					isOnboardingWithEmailFlow
+				) {
 					return null;
 				}
 
 				return <FreeDomainForAYearPromo />;
 			},
 			BeforeFullCartItems: () => {
-				if ( isDomainForGravatarFlow( flowName ) || isFreeFlow( flowName ) ) {
+				if (
+					isDomainForGravatarFlow( flowName ) ||
+					isFreeFlow( flowName ) ||
+					isOnboardingWithEmailFlow
+				) {
 					return null;
 				}
 
 				return <FreeDomainForAYearPromo textOnly />;
 			},
 		};
-	}, [ flowName ] );
+	}, [ flowName, isOnboardingWithEmailFlow ] );
 
 	const flowAllowsMultipleDomainsInCart = isDomainOnlyFlow;
 
@@ -297,6 +305,7 @@ const DomainSearchUI = (
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }
 					slots={ slots }
+					isFirstDomainFreeForFirstYear={ ! isOnboardingWithEmailFlow }
 				/>
 			}
 		/>

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -292,6 +292,7 @@ const DomainSearchUI = (
 					className="domain-search--step-wrapper"
 					flowName={ flowName }
 					initialQuery={ queryObject.new }
+					currentSiteUrl={ queryObject.siteSlug ? `https://${ queryObject.siteSlug }` : undefined }
 					events={ events }
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -129,8 +129,6 @@ const DomainSearchUI = (
 				goToNextStep();
 			},
 			onSkip( suggestion?: FreeDomainSuggestion ) {
-				const siteUrl = suggestion?.domain_name.replace( '.wordpress.com', '' );
-
 				submitSignupStep(
 					{
 						...baseSubmitStepProps,
@@ -138,7 +136,7 @@ const DomainSearchUI = (
 						domainItem: undefined,
 						isPurchasingItem: false,
 						domainCart: [],
-						siteUrl,
+						siteUrl: suggestion?.domain_name.replace( '.wordpress.com', '' ),
 					},
 					{
 						...baseSubmitProvidedDependencies,
@@ -146,7 +144,7 @@ const DomainSearchUI = (
 							? SIGNUP_DOMAIN_ORIGIN.FREE
 							: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
 						domainCart: [],
-						siteUrl,
+						siteUrl: suggestion?.domain_name,
 					}
 				);
 

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -7,6 +7,7 @@ import {
 	isWithThemeFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -304,14 +305,28 @@ const DomainSearchUI = (
 		};
 	}, [ flowName, previousStepName, goBack, userSiteCount, translate ] );
 
+	const getUseDomainIOwnLink = () => {
+		if ( ! query || ! config.allowsUsingOwnDomain ) {
+			return null;
+		}
+
+		return (
+			<Button
+				className="step-wrapper__navigation-link forward"
+				onClick={ () => events.onExternalDomainClick( query ) }
+				variant="link"
+			>
+				<span>{ __( 'Use a domain I already own' ) }</span>
+			</Button>
+		);
+	};
+
 	return (
 		<StepWrapper
 			{ ...props }
 			className="step-wrapper--domain-search"
-			hideSkip={ ! query || ! config.allowsUsingOwnDomain }
-			skipButtonAlign="top"
-			goToNextStep={ () => events.onExternalDomainClick( query ) }
-			skipLabelText={ __( 'Use a domain I already own' ) }
+			hideSkip
+			customizedActionButtons={ getUseDomainIOwnLink() }
 			headerText={ headerText }
 			subHeaderText={ subHeaderText }
 			hideBack={ hideBack }

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -184,10 +184,7 @@ const DomainSearchUI = (
 			deemphasizedTlds: isEcommerceFlow( flowName ) ? [ 'blog' ] : [],
 			skippable: ! isDomainOnlyFlow && ! isDomainForGravatarFlow( flowName ),
 			includeOwnedDomainInSuggestions: ! isDomainOnlyFlow,
-			allowsUsingOwnDomain:
-				! isDomainForGravatarFlow( flowName ) &&
-				! isOnboardingWithEmailFlow &&
-				! isFreeFlow( flowName ),
+			allowsUsingOwnDomain: ! isDomainForGravatarFlow( flowName ) && ! isOnboardingWithEmailFlow,
 		};
 	}, [ flowName, isDomainOnlyFlow, isOnboardingWithEmailFlow, allowedTldParam ] );
 

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -237,12 +237,16 @@ const DomainSearchUI = (
 	const flowAllowsMultipleDomainsInCart = isDomainOnlyFlow;
 
 	const headerText = useMemo( () => {
+		if ( isOnboardingWithEmailFlow ) {
+			return __( 'Choose a domain for your Professional Email' );
+		}
+
 		if ( isDomainForGravatarFlow( flowName ) ) {
 			return __( 'Choose a domain' );
 		}
 
 		return __( 'Claim your space on the web' );
-	}, [ flowName ] );
+	}, [ flowName, isOnboardingWithEmailFlow ] );
 
 	const subHeaderText = useMemo( () => {
 		if ( isDomainForGravatarFlow( flowName ) ) {

--- a/client/signup/steps/domains/rewritten/style.scss
+++ b/client/signup/steps/domains/rewritten/style.scss
@@ -26,4 +26,8 @@
 			padding-inline: 24px;
 		}
 	}
+
+	.step-wrapper__navigation-link {
+		color: #1d2327;
+	}
 }

--- a/client/signup/steps/domains/rewritten/types.ts
+++ b/client/signup/steps/domains/rewritten/types.ts
@@ -7,4 +7,6 @@ export type StepProps = {
 	submitSignupStep: ( step: unknown, dependencies: unknown ) => void;
 	queryObject: Record< string, string | undefined >;
 	locale: string;
+	previousStepName: string | null;
+	goBack?: () => void;
 };

--- a/packages/domain-search/src/components/search-bar/input.tsx
+++ b/packages/domain-search/src/components/search-bar/input.tsx
@@ -1,5 +1,6 @@
+import { useDebounce } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchControls } from '../../ui';
 
@@ -10,13 +11,8 @@ export const Input = () => {
 	const { query, setQuery } = useDomainSearch();
 	const [ localQuery, setLocalQuery ] = useState( query );
 
-	useEffect( () => {
-		const timeout = setTimeout( () => {
-			setQuery( localQuery );
-		}, DELAY_TIMEOUT );
+	const debouncedPropagateQuery = useDebounce( setQuery, DELAY_TIMEOUT );
 
-		return () => clearTimeout( timeout );
-	}, [ localQuery, setQuery ] );
 	return (
 		<DomainSearchControls.Input
 			value={ localQuery }
@@ -25,6 +21,7 @@ export const Input = () => {
 
 				if ( trimmedValue ) {
 					setLocalQuery( trimmedValue );
+					debouncedPropagateQuery( trimmedValue );
 				}
 			} }
 			label={ __( 'Search for a domain' ) }

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -12,7 +12,7 @@ const SkipSuggestion = () => {
 	if ( currentSiteUrl ) {
 		return (
 			<DomainSearchSkipSuggestion
-				existingSiteUrl={ currentSiteUrl }
+				existingSiteUrl={ currentSiteUrl.replace( /^https?:\/\//, '' ) }
 				onSkip={ () => events.onSkip() }
 				disabled={ !! isMutating }
 			/>

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -79,10 +79,9 @@ export const useDomainSearch = () => {
 export const useDomainSearchContextValue = (
 	props: DomainSearchProps
 ): typeof DEFAULT_CONTEXT_VALUE => {
-	const { currentSiteUrl, initialQuery, cart, events, slots, config } = props;
+	const { currentSiteUrl, query: externalQuery, cart, events, slots, config } = props;
 
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
-	const [ query, setQuery ] = useState( initialQuery ?? '' );
 	const [ filter, setFilter ] = useState( {
 		exactSldMatchesOnly: false,
 		tlds: [],
@@ -158,9 +157,8 @@ export const useDomainSearchContextValue = (
 			isFullCartOpen,
 			closeFullCart,
 			openFullCart,
-			query,
+			query: externalQuery ?? '',
 			setQuery: ( query ) => {
-				setQuery( query );
 				normalizedEvents.onQueryChange( query );
 			},
 			slots,
@@ -172,8 +170,7 @@ export const useDomainSearchContextValue = (
 		isFullCartOpen,
 		closeFullCart,
 		openFullCart,
-		query,
-		setQuery,
+		externalQuery,
 		cart,
 		normalizedEvents,
 		slots,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -60,7 +60,7 @@ export interface DomainSearchProps {
 	};
 	cart: DomainSearchCart;
 	className?: string;
-	initialQuery?: string;
+	query?: string;
 	events?: Partial< DomainSearchEvents >;
 	currentSiteUrl?: string;
 	config?: Partial< DomainSearchConfig >;
@@ -69,7 +69,7 @@ export interface DomainSearchProps {
 export interface DomainSearchContextType
 	extends Omit<
 		DomainSearchProps,
-		'className' | 'initialQuery' | 'events' | 'config' | 'getPriceRuleForSuggestion'
+		'className' | 'events' | 'config' | 'getPriceRuleForSuggestion'
 	> {
 	events: DomainSearchEvents;
 	isFullCartOpen: boolean;

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -21,6 +21,7 @@
 		margin-left: 20px;
 		position: static;
 		border: none;
+		z-index: initial;
 
 		.action_buttons__button {
 			margin-left: 20px;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -146,7 +146,6 @@
 		justify-content: space-between;
 		display: flex;
 		font-size: 0.875rem;
-		z-index: 30;
 		bottom: 0;
 		margin: 0;
 		border-top: none;


### PR DESCRIPTION
Part of DOMAINS-1674.

## Proposed Changes

Adds feature parity with production in all eligible `/start` flows, in order of importance:

1. `/start/launch-site?siteSlug=%s`
2. `/start/domain`
3. product flows (`/start/free`, `/start/premium`, `/start/business` etc.)
4. `/start/with-theme?theme=retrospect&theme_type=free&intervalType=yearly`
5. `/start/with-plugin?plugin=dokan-lite&billing_period=`
6. `/start/domain-for-gravatar`
7. `/start/onboarding-with-email`
8. `/start/onboarding-affiliate`

## Testing Instructions

Turn the `domain-search-rewrite` feature flag on and verify all of the flows behave like production: the ability to skip, to use an existing domain, the free domain discount, etc.

Don't worry about Tracks events as they'll be introduced in https://github.com/Automattic/wp-calypso/pull/105944.