### PR TITLE
Domain Search Rewrite: Show match reasons only in FQDN searches

### DIFF
--- a/packages/domain-search/src/components/featured-search-results/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/item.tsx
@@ -5,6 +5,7 @@ import { type FeaturedSuggestionReason } from '../../helpers/partition-suggestio
 import { usePolicyBadges } from '../../hooks/use-policy-badges';
 import { DomainPriceRule, useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSuggestionBadges } from '../../hooks/use-suggestion-badges';
+import { useDomainSearch } from '../../page/context';
 import { DomainSuggestion, DomainSuggestionBadge } from '../../ui';
 import { DomainSuggestionCTA } from '../suggestion-cta';
 import { DomainSuggestionPrice } from '../suggestion-price';
@@ -20,17 +21,18 @@ export const FeaturedSearchResultsItem = ( {
 	domainName,
 	isSingleFeaturedSuggestion,
 }: FeaturedSearchResultsItemProps ) => {
+	const { query } = useDomainSearch();
 	const [ domain, ...tlds ] = domainName.split( '.' );
 
 	const suggestion = useSuggestion( domainName );
 
 	const matchReasons = useMemo( () => {
-		if ( ! suggestion.match_reasons ) {
+		if ( ! suggestion.match_reasons || query !== domainName ) {
 			return;
 		}
 
 		return parseMatchReasons( domainName, suggestion.match_reasons );
-	}, [ domainName, suggestion.match_reasons ] );
+	}, [ domainName, suggestion.match_reasons, query ] );
 
 	const suggestionBadges = useDomainSuggestionBadges( domainName );
 	const policyBadges = usePolicyBadges( domainName );


### PR DESCRIPTION
Related to p1758840168610899/1758834946.367279-slack-C04H4NY6STW.

## Proposed Changes

I mistakenly thought we wanted to show match reasons for all featured suggestions in the rewritten version, but that's not true. We only want to show them for fully qualified domain name searches.

| Before | After |
| ----- | ------ |
| <img width="1150" height="476" alt="image" src="https://github.com/user-attachments/assets/aa4b4295-de0f-4620-9754-2c533ab7b6e6" /> | <img width="1178" height="487" alt="image" src="https://github.com/user-attachments/assets/0743e958-0111-424d-ba06-21ed81e5f25b" /> |

## Testing Instructions

Turn the `domain-search-rewrite` feature flag on and enter `/setup`.

Search for something without a TLD and you shouldn't see the match reasons in the featured suggestions.

Search for a FQDN and you should see them in the featured suggestion.