### PR TITLE
HD Opt-in: Fix various tracks events for the opt-in welcome notice

### DIFF
--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -18,13 +18,20 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	);
 	const { recordTracksEvent } = useAnalytics();
 
+	const handleClose = () => {
+		dismiss( new Date().toISOString() );
+		recordTracksEvent( 'calypso_dashboard_welcome_banner_dismiss_click', {
+			context: tracksContext,
+		} );
+	};
+
 	// Optimistically hide the banner assuming the preference will get saved.
 	if ( isDismissing || isDismissedPersisted ) {
 		return null;
 	}
 
 	return (
-		<Notice onClose={ () => dismiss( new Date().toISOString() ) } variant="info" icon={ starEmpty }>
+		<Notice onClose={ handleClose } variant="info" icon={ starEmpty }>
 			<ComponentViewTracker
 				eventName="calypso_hosting_dashboard_welcome_banner_impression"
 				properties={ { context: tracksContext } }
@@ -38,7 +45,7 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 						<Link
 							to="/me/preferences"
 							onClick={ () => {
-								recordTracksEvent( 'calypso_hosting_dashboard_welcome_banner_preferences_click', {
+								recordTracksEvent( 'calypso_dashboard_welcome_banner_preferences_click', {
 									context: tracksContext,
 								} );
 							} }
@@ -48,7 +55,7 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 						<ExternalLink
 							href="https://automattic.survey.fm/new-hosting-dashboard-opt-in-survey"
 							onClick={ () =>
-								recordTracksEvent( 'calypso_hosting_dashboard_welcome_banner_survey_click', {
+								recordTracksEvent( 'calypso_dashboard_welcome_banner_survey_click', {
 									context: tracksContext,
 								} )
 							}

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -33,7 +33,7 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	return (
 		<Notice onClose={ handleClose } variant="info" icon={ starEmpty }>
 			<ComponentViewTracker
-				eventName="calypso_hosting_dashboard_welcome_banner_impression"
+				eventName="calypso_dashboard_welcome_banner_impression"
 				properties={ { context: tracksContext } }
 			/>
 			{ createInterpolateElement(

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -3,7 +3,6 @@ import { emailsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../components/dataviews-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
@@ -29,10 +28,7 @@ function Emails() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( emails, view, emailFields );
 
 	return (
-		<PageLayout
-			header={ <PageHeader title={ __( 'Emails' ) } /> }
-			notices={ <OptInWelcome tracksContext="emails" /> }
-		>
+		<PageLayout header={ <PageHeader /> } notices={ <OptInWelcome tracksContext="emails" /> }>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -6,6 +6,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../components/dataviews-card';
+import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import '../sites/emails/styles.scss';
@@ -28,7 +29,10 @@ function Emails() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( emails, view, emailFields );
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Emails' ) } /> }>
+		<PageLayout
+			header={ <PageHeader title={ __( 'Emails' ) } /> }
+			notices={ <OptInWelcome tracksContext="emails" /> }
+		>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Re-add `<OptInWelcome>` to the top-level emails view
  * Was removed in https://github.com/Automattic/wp-calypso/pull/106038
* Add tracks for notice dismissal
* Fix tracks name prefix
  * Should be `calypso_dashboard_` not `calypso_hosting_dashboard_`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You may need to clear your `hosting-dashboard-welcome-notice-dismissed` calypso preference in order to get the message to re-appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
