### PR TITLE
Hosting dashboard: Add opt-out survey notices to preference views

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -6,14 +6,16 @@ import {
 	CardBody,
 	CheckboxControl,
 	__experimentalVStack as VStack,
+	ExternalLink,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useState } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import FlashMessage from '../../components/flash-message';
+import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
 import type { Field } from '@wordpress/dataviews';
 
@@ -126,6 +128,28 @@ export default function PreferencesLanguageForm() {
 							setFormData( ( current ) => ( { ...current, ...edits } ) );
 						} }
 					/>
+					{ ! formData.enabled && ( optIn.value === 'opt-in' || isRedirecting ) && (
+						<Notice title={ __( 'Prefer the previous version?' ) } variant="info">
+							{ createInterpolateElement(
+								__(
+									'<surveyLink>Please complete this short survey</surveyLink> to help us understand what didn’t work and how we can improve.'
+								),
+								{
+									surveyLink: (
+										<ExternalLink
+											href="https://automattic.survey.fm/new-hosting-dashboard-opt-out-survey"
+											onClick={ () =>
+												recordTracksEvent(
+													'calypso_dashboard_me_preferences_new_hosting_dashboard_survey_click'
+												)
+											}
+											children={ null }
+										/>
+									),
+								}
+							) }
+						</Notice>
+					) }
 					<Button
 						variant="primary"
 						type="submit"

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -1,4 +1,4 @@
-import { Card, FormLabel } from '@automattic/components';
+import { Card, FormLabel, NoticeBanner, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
@@ -30,6 +30,10 @@ export default function HostingDashboardOptInForm() {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ enabled, setEnabled ] = useState( savedPreference?.value === 'opt-in' );
 
+	// We do not want the survey NoticeBanner to disappear immediately after opting out
+	// is complete. This state is used to keep it around until the component is unmounted.
+	const [ optedOutThisMount, setOptedOutThisMount ] = useState( false );
+
 	const [ wasFetching, setWasFetching ] = useState( isFetching );
 	if ( isFetching !== wasFetching ) {
 		// Preferences have finished fetching
@@ -38,6 +42,11 @@ export default function HostingDashboardOptInForm() {
 	}
 
 	const isDirty = enabled !== ( savedPreference?.value === 'opt-in' );
+
+	const showOptOutSurvey =
+		( isSaving && savedPreference?.value === 'opt-out' ) ||
+		( ! isSaving && savedPreference?.value === 'opt-out' && optedOutThisMount ) ||
+		( ! isSaving && ! enabled && savedPreference?.value === 'opt-in' );
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -70,6 +79,9 @@ export default function HostingDashboardOptInForm() {
 					duration: 5000,
 				} )
 			);
+			if ( ! enabled ) {
+				setOptedOutThisMount( true );
+			}
 		}
 	};
 
@@ -93,6 +105,34 @@ export default function HostingDashboardOptInForm() {
 							<span>{ translate( 'I want to try the beta version.' ) }</span>
 						</FormLabel>
 					</FormFieldset>
+					{ showOptOutSurvey && (
+						<FormFieldset className="account__hosting-dashboard-notice-banner">
+							<NoticeBanner
+								title={ translate( 'Prefer the previous version?' ) }
+								level="info"
+								hideCloseButton
+							>
+								{ translate(
+									'{{surveyLink}}Please complete this short survey{{/surveyLink}} to help us understand what didn’t work and how we can improve.',
+									{
+										components: {
+											surveyLink: (
+												<ExternalLink
+													href="https://automattic.survey.fm/new-hosting-dashboard-opt-out-survey"
+													icon
+													onClick={ () =>
+														recordTracksEvent(
+															'calypso_account_new_hosting_dashboard_survey_click'
+														)
+													}
+												/>
+											),
+										},
+									}
+								) }
+							</NoticeBanner>
+						</FormFieldset>
+					) }
 					<FormButton
 						isSubmitting={ isSaving }
 						disabled={ isFetching || isSaving || ! isDirty }

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -120,8 +120,10 @@ export default function HostingDashboardOptInForm() {
 													href="https://automattic.survey.fm/new-hosting-dashboard-opt-out-survey"
 													icon
 													onClick={ () =>
-														recordTracksEvent(
-															'calypso_account_new_hosting_dashboard_survey_click'
+														dispatch(
+															recordTracksEvent(
+																'calypso_account_new_hosting_dashboard_survey_click'
+															)
 														)
 													}
 												/>

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -1,6 +1,7 @@
-import { Card, FormLabel, NoticeBanner, ExternalLink } from '@automattic/components';
+import { Card, FormLabel, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import Banner from 'calypso/components/banner';
 import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -30,7 +31,7 @@ export default function HostingDashboardOptInForm() {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ enabled, setEnabled ] = useState( savedPreference?.value === 'opt-in' );
 
-	// We do not want the survey NoticeBanner to disappear immediately after opting out
+	// We do not want the survey banner to disappear immediately after opting out
 	// is complete. This state is used to keep it around until the component is unmounted.
 	const [ optedOutThisMount, setOptedOutThisMount ] = useState( false );
 
@@ -106,13 +107,11 @@ export default function HostingDashboardOptInForm() {
 						</FormLabel>
 					</FormFieldset>
 					{ showOptOutSurvey && (
-						<FormFieldset className="account__hosting-dashboard-notice-banner">
-							<NoticeBanner
+						<FormFieldset>
+							<Banner
 								title={ translate( 'Prefer the previous version?' ) }
-								level="info"
-								hideCloseButton
-							>
-								{ translate(
+								showIcon={ false }
+								description={ translate(
 									'{{surveyLink}}Please complete this short survey{{/surveyLink}} to help us understand what didn’t work and how we can improve.',
 									{
 										components: {
@@ -130,7 +129,7 @@ export default function HostingDashboardOptInForm() {
 										},
 									}
 								) }
-							</NoticeBanner>
+							/>
 						</FormFieldset>
 					) }
 					<FormButton

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -96,6 +96,16 @@
 	font-size: $font-body-small;
 }
 
+.account__hosting-dashboard-notice-banner {
+	.notice-banner {
+		font-size: $font-body-small;
+	}
+
+	.notice-banner__title {
+		font-size: inherit;
+	}
+}
+
 main.account {
 	.email-verification-banner {
 		margin-bottom: 16px;

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -96,16 +96,6 @@
 	font-size: $font-body-small;
 }
 
-.account__hosting-dashboard-notice-banner {
-	.notice-banner {
-		font-size: $font-body-small;
-	}
-
-	.notice-banner__title {
-		font-size: inherit;
-	}
-}
-
 main.account {
 	.email-verification-banner {
 		margin-bottom: 16px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-489

## Proposed Changes

* Add opt-out survey banner to `/v2/me/preferences`
* Add opt-out survey banner to `/me/account`
* Record tracks

**v2**

<img width="1370" height="676" alt="CleanShot 2025-09-26 at 11 29 10@2x" src="https://github.com/user-attachments/assets/aba8bf9d-1931-438d-8518-7b51942f65ac" />


**v1**

<img width="2170" height="816" alt="CleanShot 2025-09-26 at 11 55 16@2x" src="https://github.com/user-attachments/assets/12d0ed9e-33ab-4d06-8b04-f382ff4e12df" />

Surprisingly the "info" style for `<NoticeBanner>` is black 🤷 Doesn't seem like a good idea to customise it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the preference views to opt in and opt out
* Make sure you've tested opting out using both views
* Confirm tracks events for clicking link
* Confirm survey opens in new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
