### PR TITLE
Backups: show dates in the site timezone

### DIFF
--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -1,26 +1,62 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
-import { formatDate } from '../../utils/datetime';
+import { formatDate, formatDateWithOffset, formatYmd, parseYmdLocal } from '../../utils/datetime';
 
-export function useFormattedTime( timestamp: string, formatOptions?: Intl.DateTimeFormatOptions ) {
+export function useFormattedTime(
+	timestamp: string,
+	formatOptions?: Intl.DateTimeFormatOptions,
+	timezoneString?: string,
+	gmtOffset?: number
+) {
 	const locale = useLocale();
 
 	const date = new Date( timestamp );
-	const formatted = formatDate( date, locale, formatOptions );
+
+	// Use timezone-aware formatting when timezone info is provided
+	let formatted = formatDate( date, locale, formatOptions );
+	if ( timezoneString ) {
+		formatted = formatDate( date, locale, { ...formatOptions, timeZone: timezoneString } );
+	} else if ( gmtOffset !== undefined ) {
+		formatted = formatDateWithOffset( date, gmtOffset, locale, formatOptions );
+	}
 
 	if ( ! formatOptions?.dateStyle ) {
-		const now = new Date();
+		// Determine "today" in the site's timezone, not browser's timezone
+		let siteToday = new Date();
+		if ( timezoneString || gmtOffset !== undefined ) {
+			siteToday = parseYmdLocal( formatYmd( new Date(), timezoneString, gmtOffset ) ) || new Date();
+		}
+
+		let dateInSiteTimezone = date;
+		if ( timezoneString || gmtOffset !== undefined ) {
+			dateInSiteTimezone = parseYmdLocal( formatYmd( date, timezoneString, gmtOffset ) ) || date;
+		}
 
 		const isToday =
-			date.getDate() === now.getDate() &&
-			date.getMonth() === now.getMonth() &&
-			date.getFullYear() === now.getFullYear();
+			dateInSiteTimezone.getDate() === siteToday.getDate() &&
+			dateInSiteTimezone.getMonth() === siteToday.getMonth() &&
+			dateInSiteTimezone.getFullYear() === siteToday.getFullYear();
 
 		if ( isToday ) {
 			// translators: time today
 			return sprintf( __( 'Today at %s' ), formatted );
+		} else if ( timezoneString ) {
+			return formatDate( date, locale, {
+				...formatOptions,
+				dateStyle: 'long',
+				timeZone: timezoneString,
+			} );
+		} else if ( gmtOffset !== undefined ) {
+			return formatDateWithOffset( date, gmtOffset, locale, {
+				...formatOptions,
+				dateStyle: 'long',
+			} );
 		}
-		return formatDate( date, locale, { ...formatOptions, dateStyle: 'long' } );
+
+		return formatDate( date, locale, {
+			...formatOptions,
+			dateStyle: 'long',
+		} );
 	}
 
 	return formatted;

--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -38,8 +38,11 @@ export function useFormattedTime(
 			dateInSiteTimezone.getFullYear() === siteToday.getFullYear();
 
 		if ( isToday ) {
-			// translators: time today
-			return sprintf( __( 'Today at %s' ), formatted );
+			if ( formatOptions?.timeStyle ) {
+				// translators: time today
+				return sprintf( __( 'Today at %s' ), formatted );
+			}
+			return __( 'Today' );
 		} else if ( timezoneString ) {
 			return formatDate( date, locale, {
 				...formatOptions,

--- a/client/dashboard/components/formatted-time/test/index.tsx
+++ b/client/dashboard/components/formatted-time/test/index.tsx
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import MockDate from 'mockdate';
+import { useFormattedTime } from '../index';
+
+// Mock the useLocale hook to return a consistent locale
+jest.mock( '../../../app/locale', () => ( {
+	useLocale: () => 'en-US',
+} ) );
+
+function TestFormattedTime( {
+	timestamp,
+	formatOptions,
+	timezoneString,
+	gmtOffset,
+}: {
+	timestamp: string;
+	formatOptions?: Intl.DateTimeFormatOptions;
+	timezoneString?: string;
+	gmtOffset?: number;
+} ) {
+	const formatted = useFormattedTime( timestamp, formatOptions, timezoneString, gmtOffset );
+	return <span data-testid="formatted-time">{ formatted }</span>;
+}
+
+describe( 'useFormattedTime', () => {
+	beforeEach( () => {
+		// Freeze time at a known date for consistent testing
+		MockDate.set( '2025-09-26T12:00:00Z' );
+	} );
+
+	afterEach( () => {
+		MockDate.reset();
+	} );
+
+	test( 'formats date when dateStyle option is provided', () => {
+		const timestamp = '2025-09-15T10:30:00Z';
+		const formatOptions = { dateStyle: 'long' as const };
+
+		render( <TestFormattedTime timestamp={ timestamp } formatOptions={ formatOptions } /> );
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+	} );
+
+	test( 'formats as "Today" when timestamp is same day as current date and no time style is provided', () => {
+		// Use same date as MockDate (2025-09-26) but different time
+		const timestamp = '2025-09-26T10:30:00Z';
+
+		render( <TestFormattedTime timestamp={ timestamp } /> );
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /Today/ );
+		expect( formattedElement ).not.toHaveTextContent( /Today at/ );
+	} );
+
+	test( 'formats as "Today" when timestamp is same day in site timezone without time style', () => {
+		// Use same date as MockDate (2025-09-26) but different time
+		const timestamp = '2025-09-26T20:00:00Z';
+		const timezoneString = 'America/Los_Angeles';
+
+		render( <TestFormattedTime timestamp={ timestamp } timezoneString={ timezoneString } /> );
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /Today/ );
+		expect( formattedElement ).not.toHaveTextContent( /Today at/ );
+	} );
+
+	test( 'formats as "Today at" when timestamp is same day in site timezone and time style is provided', () => {
+		// Use same date as MockDate (2025-09-26) but different time
+		const timestamp = '2025-09-26T20:00:00Z';
+		const timezoneString = 'America/Los_Angeles';
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /Today at 1:00 PM/ );
+	} );
+
+	test( 'formats as "Today at" when timestamp is same day using GMT offset', () => {
+		// Use same date as MockDate (2025-09-26) but different time
+		const timestamp = '2025-09-26T20:00:00Z';
+		const gmtOffset = -3;
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				gmtOffset={ gmtOffset }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /Today at 5:00 PM/ );
+	} );
+
+	test( 'formats date with timezone string using long date style', () => {
+		const timestamp = '2025-09-15T14:30:00Z';
+		const timezoneString = 'America/New_York'; // Should be 10:30 AM EDT (UTC-4 in August)
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+		expect( formattedElement ).toHaveTextContent( /10:30 AM/ );
+	} );
+
+	test( 'formats date with positive timezone offset', () => {
+		const timestamp = '2025-09-15T10:30:00Z';
+		const timezoneString = 'Europe/Berlin'; // Should be 12:30 PM CEST (UTC+2 in September)
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+		expect( formattedElement ).toHaveTextContent( /12:30 PM/ );
+	} );
+
+	test( 'formats date with negative GMT offset', () => {
+		const timestamp = '2025-09-15T14:30:00Z';
+		const gmtOffset = -5; // Should be 9:30 AM (UTC-5)
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				gmtOffset={ gmtOffset }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+		expect( formattedElement ).toHaveTextContent( /9:30 AM/ );
+	} );
+
+	test( 'formats date with positive GMT offset', () => {
+		const timestamp = '2025-09-15T10:30:00Z';
+		const gmtOffset = 3; // Should be 1:30 PM (UTC+3)
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				gmtOffset={ gmtOffset }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+		expect( formattedElement ).toHaveTextContent( /1:30 PM/ );
+	} );
+
+	test( 'prioritizes timezoneString over gmtOffset when both are provided', () => {
+		const timestamp = '2025-09-15T14:30:00Z';
+		const timezoneString = 'America/New_York'; // UTC-4 in September
+		const gmtOffset = -8;
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				gmtOffset={ gmtOffset }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 15, 2025/ );
+		// Should use timezoneString (New York time: 10:30 AM), not gmtOffset (6:30 AM)
+		expect( formattedElement ).toHaveTextContent( /10:30 AM/ );
+		expect( formattedElement ).not.toHaveTextContent( /6:30 AM/ );
+	} );
+
+	test( 'does not format as "Today" when timestamp is different day in site timezone', () => {
+		const timestamp = '2025-09-26T01:00:00Z';
+		const timezoneString = 'America/New_York';
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				formatOptions={ formatOptions }
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /September 25, 2025/ );
+		expect( formattedElement ).toHaveTextContent( /9:00 PM/ );
+		expect( formattedElement ).not.toHaveTextContent( /Today/ );
+	} );
+} );

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,4 +1,4 @@
-import { siteBySlugQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -31,6 +31,16 @@ function SiteBackupDownload() {
 	const { siteSlug, rewindId } = siteBackupDownloadRoute.useParams();
 	const { downloadId: searchDownloadId } = siteBackupDownloadRoute.useSearch();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+
+	const { data: siteSettings } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: ( s ) => ( {
+			gmtOffset: typeof s?.gmt_offset === 'number' ? s.gmt_offset : 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} );
+
+	const { gmtOffset, timezoneString } = siteSettings;
 
 	// Initialize step based on whether downloadId is provided in search params
 	const initialStep: DownloadStep = searchDownloadId ? 'progress' : 'form';
@@ -89,7 +99,9 @@ function SiteBackupDownload() {
 		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
 		{
 			timeStyle: 'short',
-		}
+		},
+		timezoneString,
+		gmtOffset
 	);
 
 	const renderStep = () => {

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -27,14 +27,26 @@ import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { ImagePreview } from './image-preview';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
 
-export function BackupDetails( { backup, site }: { backup: ActivityLogEntry; site: Site } ) {
+interface BackupDetailsProps {
+	backup: ActivityLogEntry;
+	site: Site;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
+
+export function BackupDetails( { backup, site, timezoneString, gmtOffset }: BackupDetailsProps ) {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
 	const publishedTimestamp = backup.published || backup.last_published;
-	const formattedTime = useFormattedTime( publishedTimestamp, {
-		dateStyle: 'medium',
-		timeStyle: 'short',
-	} );
+	const formattedTime = useFormattedTime(
+		publishedTimestamp,
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
 	const { fileBrowserState } = useFileBrowserContext();
 	const { totalItems: selectedFilesCount } = fileBrowserState.getCheckList(
 		Number( backup.rewind_id )

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -7,14 +7,25 @@ import { Notice } from '../../components/notice';
 import { useBackupState } from './use-backup-state';
 import type { Site } from '@automattic/api-core';
 
+interface BackupNoticesProps {
+	site: Site;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
+
 /**
  * Renders a contextual Notice based on the site's backup status
  */
-export function BackupNotices( { site }: { site: Site } ) {
+export function BackupNotices( { site, timezoneString, gmtOffset }: BackupNoticesProps ) {
 	const { status, backup } = useBackupState( site.ID );
-	const backupDate = useFormattedTime( backup?.started ?? '', {
-		timeStyle: 'short',
-	} );
+	const backupDate = useFormattedTime(
+		backup?.started ?? '',
+		{
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
 	const handleDismiss = () => {

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -71,7 +71,7 @@ export function BackupsList( {
 		},
 	} );
 
-	const fields = getFields();
+	const fields = getFields( timezoneString, gmtOffset );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( activityLog, view, fields );
 
 	useEffect( () => {

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -5,15 +5,28 @@ import { gridiconToWordPressIcon } from '../../../utils/gridicons';
 import type { ActivityLogEntry } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
-const FormattedTime = ( { timestamp }: { timestamp: string } ) => {
-	const formattedTime = useFormattedTime( timestamp, {
-		dateStyle: 'medium',
-		timeStyle: 'short',
-	} );
-	return <>{ formattedTime }</>;
-};
+interface FormattedTimeProps {
+	timestamp: string;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
 
-export function getFields(): Field< ActivityLogEntry >[] {
+function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
+	return useFormattedTime(
+		timestamp,
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
+}
+
+export function getFields(
+	timezoneString?: string,
+	gmtOffset?: number
+): Field< ActivityLogEntry >[] {
 	return [
 		{
 			id: 'icon',
@@ -42,7 +55,13 @@ export function getFields(): Field< ActivityLogEntry >[] {
 			getValue: ( { item } ) => {
 				return item.published || item.last_published;
 			},
-			render: ( { item } ) => <FormattedTime timestamp={ item.published || item.last_published } />,
+			render: ( { item } ) => (
+				<FormattedTime
+					timestamp={ item.published || item.last_published }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+				/>
+			),
 		},
 		{
 			id: 'content_text',

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -82,7 +82,14 @@ export function BackupsListPage() {
 
 	const renderMobileView = () => {
 		if ( showDetails && selectedBackup ) {
-			return <BackupDetails backup={ selectedBackup } site={ site } />;
+			return (
+				<BackupDetails
+					backup={ selectedBackup }
+					site={ site }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+				/>
+			);
 		}
 
 		return (
@@ -128,7 +135,11 @@ export function BackupsListPage() {
 					actions={ shouldShowActions ? actions : undefined }
 				/>
 			}
-			notices={ shouldShowNotices ? <BackupNotices site={ site } /> : undefined }
+			notices={
+				shouldShowNotices ? (
+					<BackupNotices site={ site } timezoneString={ timezoneString } gmtOffset={ gmtOffset } />
+				) : undefined
+			}
 		>
 			{ hasBackups && (
 				<>
@@ -145,7 +156,14 @@ export function BackupsListPage() {
 								gmtOffset={ gmtOffset }
 							/>
 
-							{ selectedBackup && <BackupDetails backup={ selectedBackup } site={ site } /> }
+							{ selectedBackup && (
+								<BackupDetails
+									backup={ selectedBackup }
+									site={ site }
+									timezoneString={ timezoneString }
+									gmtOffset={ gmtOffset }
+								/>
+							) }
 						</Grid>
 					) }
 				</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-543][1].

This PR is related to #105954, but doesn't depend on it.

## Proposed Changes

- Add timezone support to the `useFormattedTime` hook.
- Make use of timezones on all backup pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When the `DateRangePicker` component is fixed, we'll use the site timezone to filter dates. We need to display them in the same timezone to avoid inconsistencies, like an entry being displayed the day before/after the filtering.

This is also in line with the way Jetpack Cloud handles timezones:

<img width="707" height="87" alt="image" src="https://github.com/user-attachments/assets/0105f1a6-e464-4965-b17e-b4ae9edd7666" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/:slug/backups`
- Check the dates for backup list, details and download/restore pages.
- Confirm they match the dates in Jetpack Cloud.

| Before | After |
| - | - |
| <img width="1279" height="751" alt="image" src="https://github.com/user-attachments/assets/9a203c6a-e6f4-4e79-94d9-3760454eeb20" /> | <img width="1279" height="755" alt="image" src="https://github.com/user-attachments/assets/d21ce2e4-6e8e-4d7b-b557-438c3b116a49" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-543