### PR TITLE
Dashboard: Fix the guided tour may appear behind the footer of the DataView

### DIFF
--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -10,7 +10,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { useState, useContext, useEffect } from 'react';
 import { GuidedTourContext } from '../context';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, CSSProperties } from 'react';
 
 // This hook will return the async element matching the target selector.
 // After timeout has passed, it will return null.
@@ -54,12 +54,14 @@ export function GuidedTourStep( {
 	selector,
 	placement,
 	inline,
+	popoverStyle,
 }: {
 	id: string;
 	target?: HTMLElement | null;
 	selector?: string;
 	placement?: ComponentProps< typeof Popover >[ 'placement' ];
 	inline?: boolean;
+	popoverStyle?: CSSProperties;
 } ) {
 	const {
 		guidedTours,
@@ -109,7 +111,7 @@ export function GuidedTourStep( {
 			resize={ false }
 			focusOnMount={ false }
 			inline={ inline }
-			style={ { padding: '0 16px', zIndex: inline ? 1 : undefined } }
+			style={ { padding: '0 16px', zIndex: inline ? 1 : undefined, ...popoverStyle } }
 		>
 			<CardBody style={ { width: 'min(80vw, 350px)' } }>
 				<VStack spacing={ 6 }>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -251,12 +251,15 @@ export default function Sites() {
 						selector={ `.dataviews__view-actions button[aria-label="${ __( 'Layout' ) }"]` }
 						placement="bottom"
 						inline
+						// The footer in DataViews uses a z-index of 2, so we need to apply the same value to ensure our element does not appear behind it.
+						popoverStyle={ { zIndex: 2 } }
 					/>
 					<GuidedTourStep
 						id="hosting-dashboard-tours-sites-appearance-options"
 						selector={ `.dataviews__view-actions button[aria-label="${ __( 'View options' ) }"]` }
 						placement="bottom"
 						inline
+						popoverStyle={ { zIndex: 2 } }
 					/>
 				</GuidedTourContextProvider>
 			</PageLayout>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-521

## Proposed Changes

* Fix the guided tour may appear behind the footer of the DataView

| Before | After |
| - | - |
<img width="416" height="276" alt="image" src="https://github.com/user-attachments/assets/48e98fb5-439b-49b8-9cbc-f84ce47bc1ef" /> | <img width="414" height="282" alt="image" src="https://github.com/user-attachments/assets/49bb1ab1-3894-4e4f-8519-1bc3d81d718f" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Resize the window until the GuidedTour is overlapping with the footer of the DataViews
* Ensure the GuidedTour appear on the top of the footer of the DataViews

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
