### PR TITLE
Hosting Dashboard: Hide command palette from hosting dashboard

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -30,5 +30,6 @@ boot( {
 			apps: false,
 		},
 		plugins: true,
+		commandPalette: false,
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -29,5 +29,6 @@ boot( {
 			apps: false,
 		},
 		plugins: false,
+		commandPalette: false,
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -29,5 +29,6 @@ boot( {
 			apps: true,
 		},
 		plugins: true,
+		commandPalette: false,
 	},
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -32,6 +32,7 @@ export type AppConfig = {
 		help: boolean;
 		notifications: boolean;
 		me: MeSupports | false;
+		commandPalette: boolean;
 	};
 };
 
@@ -51,6 +52,7 @@ const AppContext = createContext< AppConfig >( {
 		help: false,
 		notifications: false,
 		me: false,
+		commandPalette: false,
 	},
 } );
 

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -23,7 +23,7 @@ const SLOW_THRESHOLD_MS = 100;
 const VERY_SLOW_THRESHOLD_MS = 6000;
 
 function Root() {
-	const { name, LoadingLogo = WordPressLogo } = useAppContext();
+	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isFetching = useIsFetching();
 	const router = useRouter();
 	const { routeMeta, isNavigating, isInitialLoad } = useRouterState( {
@@ -101,7 +101,7 @@ function Root() {
 					</CatchNotFound>
 				</main>
 			) }
-			<CommandPalette />
+			{ supports.commandPalette && <CommandPalette /> }
 			<Snackbars />
 			<PageViewTracker />
 			{ 'development' === process.env.NODE_ENV && (

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -63,6 +63,7 @@ function Help() {
 // User profile dropdown component
 function UserProfile() {
 	const { user } = useAuth();
+	const { supports } = useAppContext();
 	const openCommandPalette = useOpenCommandPalette();
 
 	return (
@@ -99,22 +100,24 @@ function UserProfile() {
 							{ __( 'Account' ) }
 						</RouterLinkMenuItem>
 					</MenuGroup>
-					<MenuGroup>
-						<MenuItem
-							onClick={ () => {
-								// First close the dropdown
-								onClose();
-								// Then open the command palette after a tiny delay
-								// to ensure the dropdown is fully closed
-								requestAnimationFrame( () => {
-									openCommandPalette();
-								} );
-							} }
-							shortcut="⌘K"
-						>
-							{ __( 'Command palette' ) }
-						</MenuItem>
-					</MenuGroup>
+					{ supports.commandPalette && (
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									// First close the dropdown
+									onClose();
+									// Then open the command palette after a tiny delay
+									// to ensure the dropdown is fully closed
+									requestAnimationFrame( () => {
+										openCommandPalette();
+									} );
+								} }
+								shortcut="⌘K"
+							>
+								{ __( 'Command palette' ) }
+							</MenuItem>
+						</MenuGroup>
+					) }
 					<MenuGroup>
 						<MenuItem onClick={ () => {} }>{ __( 'Log out' ) }</MenuItem>
 					</MenuGroup>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

* Adds `supports.commandPalette` to the app config
* Hide command palette in all HD app configs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We shouldn't introduce the command palette until there is a useful number of commands available.

p1758862001255479-slack-C08JZTRS6NA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Press cmd+k; no command palette should open
* Open profile menu; no command palette option should be there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?