### PR TITLE
Hosting Dashboard: Implement Themes navigation item

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -22,6 +22,7 @@ boot( {
 		},
 		domains: false,
 		emails: false,
+		themes: false,
 		reader: false,
 		help: true,
 		notifications: false,

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -21,6 +21,7 @@ boot( {
 		},
 		domains: true,
 		emails: true,
+		themes: false,
 		reader: false,
 		help: true,
 		notifications: false,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -21,6 +21,7 @@ boot( {
 		},
 		domains: true,
 		emails: true,
+		themes: true,
 		reader: true,
 		help: true,
 		notifications: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -28,6 +28,7 @@ export type AppConfig = {
 		plugins: boolean;
 		domains: boolean;
 		emails: boolean;
+		themes: boolean;
 		reader: boolean;
 		help: boolean;
 		notifications: boolean;
@@ -47,6 +48,7 @@ const AppContext = createContext< AppConfig >( {
 		plugins: false,
 		domains: false,
 		emails: false,
+		themes: false,
 		reader: false,
 		help: false,
 		notifications: false,

--- a/client/dashboard/app/primary-menu-mobile/index.tsx
+++ b/client/dashboard/app/primary-menu-mobile/index.tsx
@@ -1,6 +1,7 @@
 import { DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
+import Menu from '../../components/menu';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAppContext } from '../context';
 
@@ -41,6 +42,11 @@ function PrimaryMenuMobile() {
 						<RouterLinkMenuItem to="/plugins" onClick={ onClose }>
 							{ __( 'Plugins' ) }
 						</RouterLinkMenuItem>
+					) }
+					{ supports.themes && (
+						<Menu.ExternalItem as={ Menu.ItemLink } href="/themes" onClick={ onClose }>
+							{ __( 'Themes' ) }
+						</Menu.ExternalItem>
 					) }
 				</>
 			) }

--- a/client/dashboard/app/primary-menu-mobile/index.tsx
+++ b/client/dashboard/app/primary-menu-mobile/index.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu } from '@wordpress/components';
+import { __experimentalHStack as HStack, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
 import Menu from '../../components/menu';
@@ -44,9 +44,17 @@ function PrimaryMenuMobile() {
 						</RouterLinkMenuItem>
 					) }
 					{ supports.themes && (
-						<Menu.ExternalItem as={ Menu.ItemLink } href="/themes" onClick={ onClose }>
-							{ __( 'Themes' ) }
-						</Menu.ExternalItem>
+						<Menu.ItemLink
+							href="/themes"
+							onClick={ onClose }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<HStack justify="flex-start" spacing={ 1 }>
+								<span>{ __( 'Themes' ) }</span>
+								<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+							</HStack>
+						</Menu.ItemLink>
 					) }
 				</>
 			) }

--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -12,6 +12,11 @@ function PrimaryMenu() {
 			{ supports.domains && <Menu.Item to="/domains">{ __( 'Domains' ) }</Menu.Item> }
 			{ supports.emails && <Menu.Item to="/emails">{ __( 'Emails' ) }</Menu.Item> }
 			{ supports.plugins && <Menu.Item to="/plugins/manage">{ __( 'Plugins' ) }</Menu.Item> }
+			{ supports.themes && (
+				<Menu.ExternalItem href="/themes" className="dashboard-menu__item">
+					{ __( 'Themes' ) }
+				</Menu.ExternalItem>
+			) }
 		</Menu>
 	);
 }

--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -1,3 +1,4 @@
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import Menu from '../../components/menu';
 import { useAppContext } from '../context';
@@ -13,9 +14,18 @@ function PrimaryMenu() {
 			{ supports.emails && <Menu.Item to="/emails">{ __( 'Emails' ) }</Menu.Item> }
 			{ supports.plugins && <Menu.Item to="/plugins/manage">{ __( 'Plugins' ) }</Menu.Item> }
 			{ supports.themes && (
-				<Menu.ExternalItem href="/themes" className="dashboard-menu__item">
-					{ __( 'Themes' ) }
-				</Menu.ExternalItem>
+				<Button
+					href="/themes"
+					className="dashboard-menu__item"
+					variant="tertiary"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<HStack justify="flex-start" spacing={ 1 }>
+						<span>{ __( 'Themes' ) }</span>
+						<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+					</HStack>
+				</Button>
 			) }
 		</Menu>
 	);

--- a/client/dashboard/components/menu/index.tsx
+++ b/client/dashboard/components/menu/index.tsx
@@ -1,7 +1,22 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	MenuItem as WPMenuItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ComponentProps, ComponentType } from 'react';
 import RouterLinkButton from '../router-link-button';
 import type { ActiveOptions } from '@tanstack/react-router';
 import './style.scss';
+
+interface MenuItemLinkProps
+	extends Omit< ComponentProps< typeof WPMenuItem >, 'href' | 'target' | 'rel' > {
+	href?: string;
+	target?: string;
+	rel?: string;
+}
+
+const MenuItemLink = WPMenuItem as ComponentType< MenuItemLinkProps >;
 
 function MenuItem( {
 	to,
@@ -25,6 +40,35 @@ function MenuItem( {
 	);
 }
 
+type MenuExternalItemComponent = typeof Button | typeof MenuItemLink;
+type MenuExternalItemProps = {
+	as?: MenuExternalItemComponent;
+	className?: string;
+	href: string;
+	children: React.ReactNode;
+	onClick?: () => void;
+};
+
+function MenuExternalItem( { as, className, href, children, onClick }: MenuExternalItemProps ) {
+	const Component = as ?? Button;
+
+	return (
+		<Component
+			__next40pxDefaultSize
+			className={ className }
+			href={ href }
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ onClick }
+		>
+			<HStack justify="flex-start">
+				<span>{ children }</span>
+				<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
+			</HStack>
+		</Component>
+	);
+}
+
 function Menu( { children }: { children: React.ReactNode } ) {
 	return (
 		<HStack className="dashboard-menu" spacing={ 0 } justify="flex-start">
@@ -34,5 +78,7 @@ function Menu( { children }: { children: React.ReactNode } ) {
 }
 
 Menu.Item = MenuItem;
+Menu.ItemLink = MenuItemLink;
+Menu.ExternalItem = MenuExternalItem;
 
 export default Menu;

--- a/client/dashboard/components/menu/index.tsx
+++ b/client/dashboard/components/menu/index.tsx
@@ -1,9 +1,4 @@
-import {
-	__experimentalHStack as HStack,
-	Button,
-	MenuItem as WPMenuItem,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __experimentalHStack as HStack, MenuItem as WPMenuItem } from '@wordpress/components';
 import { ComponentProps, ComponentType } from 'react';
 import RouterLinkButton from '../router-link-button';
 import type { ActiveOptions } from '@tanstack/react-router';
@@ -40,35 +35,6 @@ function MenuItem( {
 	);
 }
 
-type MenuExternalItemComponent = typeof Button | typeof MenuItemLink;
-type MenuExternalItemProps = {
-	as?: MenuExternalItemComponent;
-	className?: string;
-	href: string;
-	children: React.ReactNode;
-	onClick?: () => void;
-};
-
-function MenuExternalItem( { as, className, href, children, onClick }: MenuExternalItemProps ) {
-	const Component = as ?? Button;
-
-	return (
-		<Component
-			__next40pxDefaultSize
-			className={ className }
-			href={ href }
-			target="_blank"
-			rel="noopener noreferrer"
-			onClick={ onClick }
-		>
-			<HStack justify="flex-start">
-				<span>{ children }</span>
-				<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
-			</HStack>
-		</Component>
-	);
-}
-
 function Menu( { children }: { children: React.ReactNode } ) {
 	return (
 		<HStack className="dashboard-menu" spacing={ 0 } justify="flex-start">
@@ -79,6 +45,5 @@ function Menu( { children }: { children: React.ReactNode } ) {
 
 Menu.Item = MenuItem;
 Menu.ItemLink = MenuItemLink;
-Menu.ExternalItem = MenuExternalItem;
 
 export default Menu;

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,7 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/universal-header": false,
+		"themes/universal-header": true,
 		"plugins/universal-header": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -154,7 +154,7 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/universal-header": false,
+		"themes/universal-header": true,
 		"plugins/universal-header": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
## Proposed Changes

This PR implements the Menu.ExternalItem component so that the button opens the external link in a new window.

| Desktop | Mobile |
| --- | --- |
| <img width="552" height="64" alt="SCR-20250926-oarn" src="https://github.com/user-attachments/assets/bd7669b6-df86-449d-a82c-aa5979ca3ebf" /> |  <img width="214" height="281" alt="SCR-20250926-oatf" src="https://github.com/user-attachments/assets/4b751782-d20a-4ccf-b720-02d7f8aa66b1" /> |

Plugins Marketplace will be handled separately. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the Themes navigation item opens a new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
