### PR TITLE
e2e tests: Refactor TOTP approval step to use locator handler for button click

### DIFF
--- a/test/e2e/specs/authentication/authentication__totp.spec.ts
+++ b/test/e2e/specs/authentication/authentication__totp.spec.ts
@@ -99,7 +99,12 @@ test.describe(
 			} );
 
 			await test.step( 'And I approve logon to woo.com', async function () {
-				await page.getByRole( 'button', { name: 'Approve' } ).click();
+				await page.addLocatorHandler(
+					page.getByRole( 'button', { name: 'Approve' } ),
+					async ( locator ) => {
+						await locator.click();
+					}
+				);
 			} );
 
 			await test.step( 'Then I am redirected to woo.com', async function () {


### PR DESCRIPTION
## Proposed Changes

Fixes a step in the totp authentication test with woo.com user.

## Testing Instructions

```
CALYPSO_BASE_URL=https://wordpress.com yarn test:pw:authentication --grep "I can use a TOTP to secure my account on Woo"
```
