### PR TITLE
Hosting Dashboard Emails: Add `Add email forwarder` and `Add mailbox` buttons

### DIFF
--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -35,7 +35,6 @@ function Emails() {
 		<PageLayout
 			header={
 				<PageHeader
-					title={ __( 'Emails' ) }
 					actions={
 						<>
 							<Button className="emails__add-email-forwarder" variant="link" __next40pxDefaultSize>

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -2,16 +2,12 @@ import { Email } from '@automattic/api-core';
 import { emailsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../components/dataviews-card';
-import { OptInWelcome } from '../components/opt-in-welcome';
-import { PageHeader } from '../components/page-header';
-import PageLayout from '../components/page-layout';
-import '../sites/emails/styles.scss';
 import { createEmailActions, DEFAULT_EMAILS_VIEW, emailFields } from './dataviews';
+import { Layout } from './layout';
+import '../sites/emails/styles.scss';
 import type { View } from '@wordpress/dataviews';
 
 import './style.scss';
@@ -32,23 +28,7 @@ function Emails() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( emails, view, emailFields );
 
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					actions={
-						<>
-							<Button className="emails__add-email-forwarder" variant="link" __next40pxDefaultSize>
-								{ __( 'Add email forwarder' ) }
-							</Button>
-							<Button variant="primary" __next40pxDefaultSize>
-								{ __( 'Add mailbox' ) }
-							</Button>
-						</>
-					}
-				/>
-			}
-			notices={ <OptInWelcome tracksContext="emails" /> }
-		>
+		<Layout>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }
@@ -65,7 +45,7 @@ function Emails() {
 					paginationInfo={ paginationInfo }
 				/>
 			</DataViewsCard>
-		</PageLayout>
+		</Layout>
 	);
 }
 

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -2,7 +2,9 @@ import { Email } from '@automattic/api-core';
 import { emailsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../components/dataviews-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
@@ -11,6 +13,8 @@ import PageLayout from '../components/page-layout';
 import '../sites/emails/styles.scss';
 import { createEmailActions, DEFAULT_EMAILS_VIEW, emailFields } from './dataviews';
 import type { View } from '@wordpress/dataviews';
+
+import './style.scss';
 
 function Emails() {
 	const navigate = useNavigate();
@@ -28,7 +32,24 @@ function Emails() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( emails, view, emailFields );
 
 	return (
-		<PageLayout header={ <PageHeader /> } notices={ <OptInWelcome tracksContext="emails" /> }>
+		<PageLayout
+			header={
+				<PageHeader
+					title={ __( 'Emails' ) }
+					actions={
+						<>
+							<Button className="emails__add-email-forwarder" variant="link" __next40pxDefaultSize>
+								{ __( 'Add email forwarder' ) }
+							</Button>
+							<Button variant="primary" __next40pxDefaultSize>
+								{ __( 'Add mailbox' ) }
+							</Button>
+						</>
+					}
+				/>
+			}
+			notices={ <OptInWelcome tracksContext="emails" /> }
+		>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }

--- a/client/dashboard/emails/layout.tsx
+++ b/client/dashboard/emails/layout.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { PropsWithChildren } from 'react';
+import { OptInWelcome } from '../components/opt-in-welcome';
+import { PageHeader } from '../components/page-header';
+import PageLayout from '../components/page-layout';
+
+import './style.scss';
+
+export const Layout = ( { children }: PropsWithChildren ) => {
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					actions={
+						<>
+							<Button className="emails__add-email-forwarder" variant="link" __next40pxDefaultSize>
+								{ __( 'Add email forwarder' ) }
+							</Button>
+							<Button variant="primary" __next40pxDefaultSize>
+								{ __( 'Add mailbox' ) }
+							</Button>
+						</>
+					}
+				/>
+			}
+			notices={ <OptInWelcome tracksContext="emails" /> }
+		>
+			{ children }
+		</PageLayout>
+	);
+};

--- a/client/dashboard/emails/style.scss
+++ b/client/dashboard/emails/style.scss
@@ -1,0 +1,3 @@
+.emails__add-email-forwarder {
+	text-decoration: none !important;
+}

--- a/client/dashboard/sites/emails/index.tsx
+++ b/client/dashboard/sites/emails/index.tsx
@@ -3,14 +3,12 @@ import { emailsQuery, siteBySlugQuery, siteDomainsQuery } from '@automattic/api-
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { siteRoute } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
-import './styles.scss';
 import { createEmailActions, DEFAULT_EMAILS_VIEW, emailFields } from '../../emails/dataviews';
+import { Layout } from '../../emails/layout';
+import './styles.scss';
 import type { View } from '@wordpress/dataviews';
 
 function SiteEmails() {
@@ -41,7 +39,7 @@ function SiteEmails() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( emails, view, emailFields );
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Emails' ) } /> }>
+		<Layout>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }
@@ -58,7 +56,7 @@ function SiteEmails() {
 					paginationInfo={ paginationInfo }
 				/>
 			</DataViewsCard>
-		</PageLayout>
+		</Layout>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-471

## Proposed Changes

* Add the `Add email forwarder` and `Add mailbox` buttons on the header of the emails dashboard. The buttons' actions will be added on a followup PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of or effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/emails`
* Check that you see the mentioned buttons:

<img width="2993" height="1024" alt="image" src="https://github.com/user-attachments/assets/c2eda100-1c85-4482-9411-5af88050835a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
