### PR TITLE
Site Overview: Add product tour for the WP Admin button

### DIFF
--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -9,6 +9,7 @@ import {
 import { sprintf, __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { useState, useContext, useEffect } from 'react';
+import { SectionHeader } from '../../section-header';
 import { GuidedTourContext } from '../context';
 import type { ComponentProps, CSSProperties } from 'react';
 
@@ -117,9 +118,7 @@ export function GuidedTourStep( {
 				<VStack spacing={ 6 }>
 					<VStack spacing={ 2 }>
 						<HStack justify="space-between">
-							<Text as="h2" size={ 15 } weight={ 500 } lineHeight="20px">
-								{ currentTour.title }
-							</Text>
+							<SectionHeader title={ currentTour.title } level={ 3 } />
 							{ totalSteps > 1 && currentStep + 1 < totalSteps && isSkippable && (
 								<Button icon={ closeSmall } iconSize={ 24 } onClick={ endTour } />
 							) }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -11,6 +11,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
+import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getSiteDisplayName } from '../../utils/site-name';
@@ -105,6 +106,7 @@ function SiteOverview( {
 										variant="primary"
 										href={ site.options.admin_url }
 										icon={ wordpress }
+										label={ __( 'WP Admin' ) }
 									>
 										{ __( 'WP Admin' ) }
 									</Button>
@@ -162,6 +164,27 @@ function SiteOverview( {
 					) }
 				</HStack>
 			</VStack>
+			<GuidedTourContextProvider
+				tourId="hosting-dashboard-tours-site-overview"
+				isSkippable
+				guidedTours={ [
+					{
+						id: 'hosting-dashboard-tours-site-overview-wp-admin',
+						title: __( 'Go to WP Admin' ),
+						description: __(
+							'Use this button to quickly switch from the Hosting Dashboard to your WP Admin.'
+						),
+					},
+				] }
+			>
+				<GuidedTourStep
+					id="hosting-dashboard-tours-site-overview-wp-admin"
+					selector={ `.dashboard-section-header__actions a[aria-label="${ __( 'WP Admin' ) }"]` }
+					placement="bottom"
+					inline
+					popoverStyle={ { zIndex: 2 } }
+				/>
+			</GuidedTourContextProvider>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -11,6 +11,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useRef } from 'react';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -89,6 +90,8 @@ function SiteOverview( {
 		isSmallViewport,
 	} );
 
+	const wpAdminButtonRef = useRef( null );
+
 	const isSelfHostedJetpackConnectedSite = isSelfHostedJetpackConnected( site );
 
 	return (
@@ -102,11 +105,11 @@ function SiteOverview( {
 								<>
 									<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 									<Button
+										ref={ wpAdminButtonRef }
 										__next40pxDefaultSize
 										variant="primary"
 										href={ site.options.admin_url }
 										icon={ wordpress }
-										label={ __( 'WP Admin' ) }
 									>
 										{ __( 'WP Admin' ) }
 									</Button>
@@ -166,7 +169,6 @@ function SiteOverview( {
 			</VStack>
 			<GuidedTourContextProvider
 				tourId="hosting-dashboard-tours-site-overview"
-				isSkippable
 				guidedTours={ [
 					{
 						id: 'hosting-dashboard-tours-site-overview-wp-admin',
@@ -177,13 +179,14 @@ function SiteOverview( {
 					},
 				] }
 			>
-				<GuidedTourStep
-					id="hosting-dashboard-tours-site-overview-wp-admin"
-					selector={ `.dashboard-section-header__actions a[aria-label="${ __( 'WP Admin' ) }"]` }
-					placement="bottom"
-					inline
-					popoverStyle={ { zIndex: 2 } }
-				/>
+				{ wpAdminButtonRef.current && (
+					<GuidedTourStep
+						id="hosting-dashboard-tours-site-overview-wp-admin"
+						target={ wpAdminButtonRef.current }
+						placement="bottom"
+						inline
+					/>
+				) }
 			</GuidedTourContextProvider>
 		</PageLayout>
 	);


### PR DESCRIPTION
Fixes DOTDASH-488

## Proposed Changes

This PR adds a guided tour for the WP Admin button:

<img width="922" height="275" alt="image" src="https://github.com/user-attachments/assets/e109a787-f53b-41b6-bf3e-c77bd9888de6" />


## Testing Instructions

1. Go to /v2/sites/:siteSlug
2. Verify you see the tour as above
3. Dismiss it
4. Refresh the page, verify you can no longer see it
5. You can reset the experience by clearing the `hosting-dashboard-tours-site-overview` user preferences.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
