### PR TITLE
v2 Plugins - Scheduled Updates: Edit-schedule route and screen skeleton. placeholder data.

### DIFF
--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -119,6 +119,25 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 	)
 );
 
+export const pluginsScheduledUpdatesEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit schedule' ),
+			},
+		],
+	} ),
+	getParentRoute: () => pluginsRoute,
+	path: 'scheduled-updates/edit/$scheduleId',
+	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+} ).lazy( () =>
+	import( '../../plugins/scheduled-updates/edit' ).then( ( d ) =>
+		createLazyRoute( 'plugins-scheduled-updates-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createPluginsRoutes = () => {
 	const childRoutes: AnyRoute[] = [
 		pluginsIndexRoute,
@@ -126,6 +145,7 @@ export const createPluginsRoutes = () => {
 		pluginsManageRoute,
 		pluginsScheduledUpdatesRoute,
 		pluginsScheduledUpdatesNewRoute,
+		pluginsScheduledUpdatesEditRoute,
 	];
 	return [ pluginsRoute.addChildren( childRoutes ) ];
 };

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -110,7 +110,9 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: 'scheduled-updates/new',
-	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+	loader: () => {
+		queryClient.ensureQueryData( sitesQuery() );
+	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/new' ).then( ( d ) =>
 		createLazyRoute( 'plugins-scheduled-updates-new' )( {
@@ -129,7 +131,9 @@ export const pluginsScheduledUpdatesEditRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: 'scheduled-updates/edit/$scheduleId',
-	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+	loader: () => {
+		queryClient.ensureQueryData( sitesQuery() );
+	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/edit' ).then( ( d ) =>
 		createLazyRoute( 'plugins-scheduled-updates-edit' )( {

--- a/client/dashboard/plugins/scheduled-updates/components/frequency-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/frequency-selection.tsx
@@ -7,7 +7,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import type { Frequency, Weekday } from '../../types';
+import type { Frequency, Weekday } from '../types';
 
 type Props = {
 	frequency: Frequency;

--- a/client/dashboard/plugins/scheduled-updates/components/plugins-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/plugins-selection.tsx
@@ -1,8 +1,8 @@
 import { DataViews, Field, View, filterSortAndPaginate, type Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
-import { DataViewsCard } from '../../../../components/dataviews-card';
-import { useEligiblePlugins } from '../../hooks/use-eligible-plugins';
+import { DataViewsCard } from '../../../components/dataviews-card';
+import { useEligiblePlugins } from '../hooks/use-eligible-plugins';
 import type { CorePlugin } from '@automattic/api-core';
 
 const pluginFields: Field< CorePlugin >[] = [

--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -21,6 +21,8 @@ import PluginsSelection from './plugins-selection';
 import SitesSelection from './sites-selection';
 import type { Frequency, Weekday } from '../types';
 
+const BLOCK_CREATE = true;
+
 type Inputs = {
 	siteIds: string[];
 	plugins: string[];
@@ -159,7 +161,7 @@ export function ScheduledUpdatesForm( { submitLabel, onSubmit, initial, onSitesC
 					<div>
 						<Button
 							variant="primary"
-							disabled={ ! isValid || isSubmitting || isPrecheckLoading }
+							disabled={ ! isValid || isSubmitting || isPrecheckLoading || BLOCK_CREATE }
 							onClick={ handleSave }
 							__next40pxDefaultSize
 						>

--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -1,0 +1,173 @@
+import {
+	Button,
+	Card,
+	CardBody,
+	Notice,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SectionHeader } from '../../../components/section-header';
+import {
+	NEW_SCHEDULE_DEFAULT_FREQUENCY,
+	NEW_SCHEDULE_DEFAULT_TIME,
+	NEW_SCHEDULE_DEFAULT_WEEKDAY,
+} from '../constants';
+import { formatScheduleCollisionsErrorMulti } from '../helpers';
+import { useEligibleSites } from '../hooks/use-eligible-sites';
+import { useScheduleCollisions } from '../hooks/use-schedule-collisions';
+import FrequencySelection from './frequency-selection';
+import PluginsSelection from './plugins-selection';
+import SitesSelection from './sites-selection';
+import type { Frequency, Weekday } from '../types';
+
+type Inputs = {
+	siteIds: string[];
+	plugins: string[];
+	frequency: Frequency;
+	weekday: Weekday;
+	time: string; // HH:MM 24h
+};
+
+export type InitialValues = Partial< Inputs >;
+export type ScheduledUpdatesFormOnSubmit = ( inputs: Inputs ) => Promise< void > | void;
+
+type Props = {
+	submitLabel: string;
+	onSubmit: ScheduledUpdatesFormOnSubmit;
+	initial?: InitialValues;
+	onSitesChange?: ( ids: string[] ) => void;
+};
+
+export function ScheduledUpdatesForm( { submitLabel, onSubmit, initial, onSitesChange }: Props ) {
+	const { data: eligibleSites = [] } = useEligibleSites();
+	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >(
+		() => initial?.siteIds || []
+	);
+	const [ selectedPluginSlugs, setSelectedPluginSlugs ] = useState< string[] >(
+		initial?.plugins || []
+	);
+	const [ frequency, setFrequency ] = useState< Frequency >(
+		initial?.frequency || NEW_SCHEDULE_DEFAULT_FREQUENCY
+	);
+	const [ weekday, setWeekday ] = useState< Weekday >(
+		initial?.weekday || NEW_SCHEDULE_DEFAULT_WEEKDAY
+	);
+	const [ time, setTime ] = useState( initial?.time || NEW_SCHEDULE_DEFAULT_TIME );
+	const [ validationError, setValidationError ] = useState< string >( '' );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const siteIdsAsNumbers = useMemo(
+		() => selectedSiteIds.map( ( id ) => Number( id ) ),
+		[ selectedSiteIds ]
+	);
+	const collisionsChecker = useScheduleCollisions();
+	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0;
+	const isPrecheckLoading = collisionsChecker.isLoading;
+
+	const handleSave = useCallback( async () => {
+		setValidationError( '' );
+		setIsSubmitting( true );
+
+		try {
+			const collisions = collisionsChecker.validateNow( {
+				siteIds: siteIdsAsNumbers,
+				plugins: selectedPluginSlugs,
+				frequency,
+				weekday,
+				time,
+			} );
+
+			const message = formatScheduleCollisionsErrorMulti( {
+				collisions,
+				eligibleSites,
+				selectedSiteIds: siteIdsAsNumbers,
+			} );
+
+			if ( message ) {
+				throw new Error( message );
+			}
+
+			await onSubmit( {
+				siteIds: selectedSiteIds,
+				plugins: selectedPluginSlugs,
+				frequency,
+				weekday,
+				time,
+			} );
+
+			setIsSubmitting( false );
+		} catch ( err ) {
+			setIsSubmitting( false );
+			setValidationError(
+				( err as { message?: string } )?.message || __( 'Failed to save schedule.' )
+			);
+		}
+	}, [
+		collisionsChecker,
+		siteIdsAsNumbers,
+		selectedPluginSlugs,
+		frequency,
+		weekday,
+		time,
+		eligibleSites,
+		onSubmit,
+		selectedSiteIds,
+	] );
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 6 }>
+					<SectionHeader title={ __( '1. Select sites' ) } />
+					<SitesSelection
+						selection={ selectedSiteIds }
+						onChangeSelection={ ( ids ) => {
+							setSelectedSiteIds( ids );
+							onSitesChange?.( ids );
+						} }
+					/>
+					<SectionHeader
+						title={ __( '2. Select plugins' ) }
+						description={ __(
+							'Plugins not listed below are automatically updated by WordPress.com.'
+						) }
+					/>
+					<PluginsSelection
+						selectedSiteIds={ selectedSiteIds }
+						selection={ selectedPluginSlugs }
+						onChangeSelection={ ( ids ) => setSelectedPluginSlugs( ids ) }
+					/>
+					<SectionHeader title={ __( '3. Select frequency' ) } />
+					<FrequencySelection
+						frequency={ frequency }
+						weekday={ weekday }
+						time={ time }
+						onChange={ ( next ) => {
+							setFrequency( next.frequency );
+							setWeekday( next.weekday );
+							setTime( next.time );
+						} }
+					/>
+					{ validationError && (
+						<Notice status="error" isDismissible={ false }>
+							{ validationError.split( '\n' ).map( ( line, idx ) => (
+								<div key={ idx }>{ line }</div>
+							) ) }
+						</Notice>
+					) }
+					<div>
+						<Button
+							variant="primary"
+							disabled={ ! isValid || isSubmitting || isPrecheckLoading }
+							onClick={ handleSave }
+							__next40pxDefaultSize
+						>
+							{ submitLabel }
+						</Button>
+					</div>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
@@ -50,7 +50,7 @@ type Props = {
 };
 
 function ScheduledUpdatesSitesSelection( { selection, onChangeSelection }: Props ) {
-	const { data: sites = [] } = useEligibleSites();
+	const { data: sites = [], isLoading } = useEligibleSites();
 	const [ view, setView ] = useState< View >( defaultView );
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( sites, view, siteFields );
@@ -80,6 +80,7 @@ function ScheduledUpdatesSitesSelection( { selection, onChangeSelection }: Props
 				onChangeSelection={ ( ids ) => onChangeSelection( ids as string[] ) }
 				getItemId={ ( item: Site ) => String( item.ID ) }
 				actions={ actions }
+				isLoading={ isLoading }
 				defaultLayouts={ {
 					table: {
 						showMedia: true,

--- a/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
@@ -1,11 +1,11 @@
 import { DataViews, Field, View, filterSortAndPaginate, type Action } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
-import { DataViewsCard } from '../../../../components/dataviews-card';
-import { Name, URL, SiteIconLink } from '../../../../sites/site-fields';
-import { getSiteDisplayName } from '../../../../utils/site-name';
-import { getSiteDisplayUrl } from '../../../../utils/site-url';
-import { useEligibleSites } from '../../hooks/use-eligible-sites';
+import { DataViewsCard } from '../../../components/dataviews-card';
+import { Name, URL, SiteIconLink } from '../../../sites/site-fields';
+import { getSiteDisplayName } from '../../../utils/site-name';
+import { getSiteDisplayUrl } from '../../../utils/site-url';
+import { useEligibleSites } from '../hooks/use-eligible-sites';
 import type { Site } from '@automattic/api-core';
 
 const siteFields: Field< Site >[] = [

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -39,12 +39,17 @@ export default function PluginsScheduledUpdatesEdit() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Edit schedule' ) } /> }>
-			{ error && (
-				<Notice status="error" isDismissible={ false }>
-					{ error }
-				</Notice>
-			) }
+		<PageLayout
+			size="small"
+			header={ <PageHeader /> }
+			notices={
+				error && (
+					<Notice status="error" isDismissible={ false }>
+						{ error }
+					</Notice>
+				)
+			}
+		>
 			{ ! loading && ! error && (
 				<ScheduledUpdatesForm
 					submitLabel={ __( 'Save changes' ) }

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	pluginsScheduledUpdatesEditRoute,
+	pluginsScheduledUpdatesRoute,
+} from '../../../app/router/plugins';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import {
+	ScheduledUpdatesForm,
+	type ScheduledUpdatesFormOnSubmit,
+	type InitialValues,
+} from '../components/schedule-form';
+
+/**
+ *
+ * Placeholder hook.
+ */
+function useLoadScheduleById( _scheduleId: string ) {
+	// Placeholder state and derived values until hook is implemented in next task
+	void _scheduleId;
+	return {
+		loading: false,
+		error: '',
+		initial: null as unknown as InitialValues,
+	} as const;
+}
+
+export default function PluginsScheduledUpdatesEdit() {
+	const { scheduleId } = pluginsScheduledUpdatesEditRoute.useParams();
+	const navigate = useNavigate( { from: pluginsScheduledUpdatesEditRoute.fullPath } );
+
+	const { loading, error, initial } = useLoadScheduleById( scheduleId );
+
+	const handleSave: ScheduledUpdatesFormOnSubmit = async ( inputs ) => {
+		void inputs;
+		navigate( { to: pluginsScheduledUpdatesRoute.to } );
+	};
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Edit schedule' ) } /> }>
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
+			{ ! loading && ! error && (
+				<ScheduledUpdatesForm
+					submitLabel={ __( 'Save changes' ) }
+					onSubmit={ handleSave }
+					initial={ initial }
+				/>
+			) }
+		</PageLayout>
+	);
+}

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-create-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-create-schedules.ts
@@ -11,7 +11,7 @@ import { useEligibleSites } from './use-eligible-sites';
 import type { Frequency, Weekday } from '../types';
 import type { Site, CreateSiteUpdateScheduleBody } from '@automattic/api-core';
 
-type CreateInputs = {
+export type CreateInputs = {
 	plugins: string[];
 	frequency: Frequency;
 	weekday: Weekday;

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -1,12 +1,4 @@
 import { useNavigate } from '@tanstack/react-router';
-import {
-	Button,
-	Card,
-	CardBody,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	Notice,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
 import {
@@ -15,92 +7,28 @@ import {
 } from '../../../app/router/plugins';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import { SectionHeader } from '../../../components/section-header';
 import {
-	NEW_SCHEDULE_DEFAULT_FREQUENCY,
-	NEW_SCHEDULE_DEFAULT_TIME,
-	NEW_SCHEDULE_DEFAULT_WEEKDAY,
-} from '../constants';
-import { formatScheduleCollisionsErrorMulti } from '../helpers';
+	ScheduledUpdatesForm,
+	type ScheduledUpdatesFormOnSubmit,
+} from '../components/schedule-form';
 import { useCreateSchedules } from '../hooks/use-create-schedules';
-import { useEligibleSites } from '../hooks/use-eligible-sites';
-import { useScheduleCollisions } from '../hooks/use-schedule-collisions';
-import FrequencySelection from './frequency-selection';
-import PluginsSelection from './plugins-selection';
-import SitesSelection from './sites-selection';
-import type { Frequency, Weekday } from '../types';
-
-const BLOCK_CREATE = false;
 
 function ScheduledUpdatesNew() {
-	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
-	const [ selectedPluginSlugs, setSelectedPluginSlugs ] = useState< string[] >( [] );
-	const [ frequency, setFrequency ] = useState< Frequency >( NEW_SCHEDULE_DEFAULT_FREQUENCY );
-	const [ weekday, setWeekday ] = useState< Weekday >( NEW_SCHEDULE_DEFAULT_WEEKDAY );
-	const [ time, setTime ] = useState( NEW_SCHEDULE_DEFAULT_TIME );
-	const [ validationError, setValidationError ] = useState< string >( '' );
-	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
-	const { data: eligibleSites = [] } = useEligibleSites();
+	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
 	const siteIdsAsNumbers = useMemo(
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),
 		[ selectedSiteIds ]
 	);
-	const collisionsChecker = useScheduleCollisions();
 	const { mutateAsync: runCreate } = useCreateSchedules( siteIdsAsNumbers );
 
-	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0 && ! BLOCK_CREATE;
-	const isPrecheckLoading = collisionsChecker.isLoading;
-
-	const handleCreate = useCallback( async () => {
-		setValidationError( '' );
-		setIsSubmitting( true );
-
-		try {
-			const collisions = collisionsChecker.validateNow( {
-				siteIds: siteIdsAsNumbers,
-				plugins: selectedPluginSlugs,
-				frequency,
-				weekday,
-				time,
-			} );
-
-			const message = formatScheduleCollisionsErrorMulti( {
-				collisions,
-				eligibleSites,
-				selectedSiteIds: siteIdsAsNumbers,
-			} );
-
-			if ( message ) {
-				throw new Error( message );
-			}
-
-			await runCreate( {
-				plugins: selectedPluginSlugs,
-				frequency,
-				weekday,
-				time,
-			} );
-
-			setIsSubmitting( false );
+	const handleSave: ScheduledUpdatesFormOnSubmit = useCallback(
+		async ( inputs ) => {
+			await runCreate( inputs );
 			navigate( { to: pluginsScheduledUpdatesRoute.to } );
-		} catch ( error ) {
-			setIsSubmitting( false );
-			setValidationError(
-				( error as { message?: string } )?.message || __( 'Failed to create schedule.' )
-			);
-		}
-	}, [
-		frequency,
-		weekday,
-		time,
-		selectedPluginSlugs,
-		collisionsChecker,
-		eligibleSites,
-		siteIdsAsNumbers,
-		runCreate,
-		navigate,
-	] );
+		},
+		[ navigate, runCreate ]
+	);
 
 	return (
 		<PageLayout
@@ -114,56 +42,11 @@ function ScheduledUpdatesNew() {
 				/>
 			}
 		>
-			<Card>
-				<CardBody>
-					<VStack spacing={ 6 }>
-						<SectionHeader title={ __( '1. Select sites' ) } />
-						<SitesSelection
-							selection={ selectedSiteIds }
-							onChangeSelection={ ( ids ) => setSelectedSiteIds( ids ) }
-						/>
-						<SectionHeader
-							title={ __( '2. Select plugins' ) }
-							description={ __(
-								'Plugins not listed below are automatically updated by WordPress.com.'
-							) }
-						/>
-						<PluginsSelection
-							selectedSiteIds={ selectedSiteIds }
-							selection={ selectedPluginSlugs }
-							onChangeSelection={ ( ids ) => setSelectedPluginSlugs( ids ) }
-						/>
-						<SectionHeader title={ __( '3. Select frequency' ) } />
-						<FrequencySelection
-							frequency={ frequency }
-							weekday={ weekday }
-							time={ time }
-							onChange={ ( next ) => {
-								setFrequency( next.frequency );
-								setWeekday( next.weekday );
-								setTime( next.time );
-							} }
-						/>
-						{ validationError && (
-							<Notice status="error" isDismissible={ false }>
-								{ validationError.split( '\n' ).map( ( line, idx ) => (
-									<div key={ idx }>{ line }</div>
-								) ) }
-							</Notice>
-						) }
-						<HStack justify="start">
-							<Button
-								variant="primary"
-								disabled={ ! isValid || isSubmitting || isPrecheckLoading }
-								onClick={ handleCreate }
-								__next40pxDefaultSize
-							>
-								{ __( 'Create schedule' ) }
-							</Button>
-						</HStack>
-					</VStack>
-				</CardBody>
-			</Card>
+			<ScheduledUpdatesForm
+				submitLabel={ __( 'Create schedule' ) }
+				onSubmit={ handleSave }
+				onSitesChange={ setSelectedSiteIds }
+			/>
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Proposed Changes

The PR creates the edit route for updating existing schedules. We use the same path as in the original: `/scheduled-updates/edit/:scheduleId`. We add a skeleton form that looks and behaves like "New Schedule". We add some empty/placeholder data and will wire the data layer and mutations on top. For the moment, we assume the same validations will happen with New Schedule creation. 

We add an abstraction layer as "schedule-form" that both "new" and "edit" components share. We'll build this out on top. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm "New Schedule" form works like before: `/v2/plugins/scheduled-udpates/new`
* Create a schedule and go to `/plugins/scheduled-udpates` to grab the ID (we don't have the list view in v2 yet)
* Go to `/v2/scheduled-udpates/edit/:id` and confirm a screen identical to New Schedule renders. There's no data, just the wireframe/skeleton

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
