### PR TITLE
Restructure configuration for CSP headers

### DIFF
--- a/client/server/middleware/checkout-csp.js
+++ b/client/server/middleware/checkout-csp.js
@@ -7,44 +7,174 @@ import crypto from 'crypto';
  * @returns {string} The complete CSP policy string
  */
 function generateCSPHeader( nonce, isDevelopment ) {
-	const directives = [
-		"default-src 'self'",
-		// Payment processors, fraud prevention, support chat, and analytics
-		`script-src 'self' 'nonce-${ nonce }' https://js.stripe.com https://checkout.stripe.com https://www.paypal.com https://www.paypalobjects.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://cdn.smooch.io https://static.zdassets.com https://ekr.zdassets.com https://*.zendesk.com https://surveys-static-prd.survicate-cdn.com https://survey.survicate.com https://cdn.siftscience.com https://stats.wp.com https://use.typekit.net`,
-		// Styles including Survicate surveys, Smooch chat, and Google Fonts
-		"style-src 'self' 'unsafe-inline' https://surveys-static-prd.survicate-cdn.com https://cdn.smooch.io https://fonts.googleapis.com https://s0.wp.com",
-		"img-src 'self' data: https: blob: https://pixel.wp.com https://s1.wp.com https://s0.wp.com",
-		// API connections - payment processors, WP.com services, and support
-		"connect-src 'self' https://api.stripe.com https://public-api.wordpress.com https://widgets.wp.com https://wpcom.com wss://*.zendesk.com https://*.zendesk.com https://*.smooch.io https://api.smooch.io https://ekr.zdassets.com",
-		// Payment and support frames
-		"frame-src 'self' https://js.stripe.com https://checkout.stripe.com https://hooks.stripe.com https://www.paypal.com https://www.google.com/recaptcha/ https://recaptcha.google.com https://public-api.wordpress.com",
-		// Fonts - allow support widget fonts, WordPress.com fonts, and WooCommerce fonts
-		"font-src 'self' data: https://surveys-static-prd.survicate-cdn.com https://cdn.smooch.io https://fonts.gstatic.com https://s1.wp.com https://s0.wp.com https://use.typekit.net https://woocommerce.com",
-		"object-src 'none'",
-		"base-uri 'self'",
-		"form-action 'self' https://checkout.stripe.com",
-		"frame-ancestors 'none'",
-		'report-uri https://public-api.wordpress.com/csp/',
-	];
+	const directives = {
+		'default-src': {
+			wrapped: [ 'self' ],
+		},
+		'script-src': {
+			// Scripts
+			wrapped: [ 'self', `nonce-${ nonce }` ],
+			raw: [
+				// Payment processors
+				'https://js.stripe.com',
+				'https://checkout.stripe.com',
+				'https://www.paypal.com',
+				'https://www.paypalobjects.com',
+				// Fraud prevention
+				'https://www.google.com/recaptcha/',
+				'https://www.gstatic.com/recaptcha/',
+				'https://cdn.siftscience.com',
+				// Support
+				'https://cdn.smooch.io',
+				'https://static.zdassets.com',
+				'https://ekr.zdassets.com',
+				'https://*.zendesk.com',
+				// Surveys
+				'https://surveys-static-prd.survicate-cdn.com',
+				'https://survey.survicate.com',
+				// Analytics
+				'https://stats.wp.com',
+				// Fonts
+				'https://use.typekit.net',
+			],
+		},
+		'style-src': {
+			// Styles
+			wrapped: [ 'self', 'unsafe-inline' ],
+			raw: [
+				// Surveys
+				'https://surveys-static-prd.survicate-cdn.com',
+				// Support chat
+				'https://cdn.smooch.io',
+				// Fonts
+				'https://fonts.googleapis.com',
+				// Styles from WordPress.com CDN
+				'https://s0.wp.com',
+			],
+		},
+		'img-src': {
+			// Images
+			wrapped: [ 'self' ],
+			raw: [
+				'data:',
+				// TODO: try to drop this loose rule. We should not allow loading images from anywhere.
+				'https:',
+				'blob:',
+				// Images from WordPress.com CDN
+				'https://pixel.wp.com',
+				'https://s0.wp.com',
+				'https://s1.wp.com',
+			],
+		},
+		'connect-src': {
+			// API connections
+			wrapped: [ 'self' ],
+			raw: [
+				// Payment processor
+				'https://api.stripe.com',
+				// WordPress.com services
+				'https://public-api.wordpress.com',
+				'https://widgets.wp.com',
+				'https://wpcom.com',
+				// Support chat
+				'wss://*.zendesk.com',
+				'https://*.zendesk.com',
+				'https://*.smooch.io',
+				'https://api.smooch.io',
+				'https://ekr.zdassets.com',
+			],
+		},
+		'frame-src': {
+			// Allowed frames
+			wrapped: [ 'self' ],
+			raw: [
+				// Payment processors
+				'https://js.stripe.com',
+				'https://checkout.stripe.com',
+				'https://hooks.stripe.com',
+				'https://www.paypal.com',
+				// Fraud/spam prevention
+				'https://www.google.com/recaptcha/',
+				'https://recaptcha.google.com',
+				// WordPress.com services
+				'https://public-api.wordpress.com',
+			],
+		},
+		'font-src': {
+			// Fonts
+			wrapped: [ 'self' ],
+			raw: [
+				'data:',
+				// Surveys
+				'https://surveys-static-prd.survicate-cdn.com',
+				// Support chat
+				'https://cdn.smooch.io',
+				// Fonts from Google Fonts
+				'https://fonts.gstatic.com',
+				// Fonts from WordPress.com CDN
+				'https://s1.wp.com',
+				'https://s0.wp.com',
+				// Fonts from Typekit
+				'https://use.typekit.net',
+				// Fonts from WooCommerce.com
+				'https://woocommerce.com',
+			],
+		},
+		'object-src': {
+			// Allowed objects
+			wrapped: [ 'none' ],
+		},
+		'base-uri': {
+			// Allowed base URIs
+			wrapped: [ 'self' ],
+		},
+		'form-action': {
+			// Allowed form actions
+			wrapped: [ 'self' ],
+			raw: [
+				// Payment processors
+				'https://checkout.stripe.com',
+			],
+		},
+		'frame-ancestors': {
+			// Allowed frame ancestors
+			wrapped: [ 'none' ],
+		},
+		'report-uri': {
+			// Report URI
+			raw: [ 'https://public-api.wordpress.com/csp/' ],
+		},
+	};
 
-	let cspHeader = directives.join( '; ' );
-
-	// In development, allow eval for webpack and HTTP for local resources
 	if ( isDevelopment ) {
 		// Add 'unsafe-eval' to script-src for webpack
-		cspHeader = cspHeader.replace( 'script-src', "script-src 'unsafe-eval'" );
-
-		// URLs that need HTTP versions in development
-		const httpAllowList = [ 'stats.wp.com', 'pixel.wp.com', 's0.wp.com', 's1.wp.com' ];
+		directives[ 'script-src' ].wrapped.push( 'unsafe-eval' );
 
 		// Add HTTP versions alongside HTTPS versions
-		httpAllowList.forEach( ( domain ) => {
-			cspHeader = cspHeader.replace(
-				new RegExp( `https://${ domain.replace( '.', '\\.' ) }`, 'g' ),
-				`https://${ domain } http://${ domain }`
-			);
-		} );
+		const httpAllowList = [ 'stats.wp.com', 'pixel.wp.com', 's0.wp.com', 's1.wp.com' ];
+		for ( const key in directives ) {
+			if ( Array.isArray( directives[ key ].raw ) ) {
+				httpAllowList.forEach( ( httpDomain ) => {
+					if ( directives[ key ].raw.includes( `https://${ httpDomain }` ) ) {
+						directives[ key ].raw.push( `http://${ httpDomain }` );
+					}
+				} );
+			}
+		}
 	}
+
+	const cspHeader = Object.entries( directives )
+		.map( ( [ key, value ] ) => {
+			const wrappedItems = ( Array.isArray( value.wrapped ) ? value.wrapped : [] )
+				.map( ( item ) => `'${ item }'` )
+				.join( ' ' );
+			const rawItems = ( Array.isArray( value.raw ) ? value.raw : [] ).join( ' ' );
+
+			const allExpressions = [ wrappedItems, rawItems ].join( ' ' );
+
+			return `${ key } ${ allExpressions }`;
+		} )
+		.join( '; ' );
 
 	return cspHeader;
 }

--- a/client/server/middleware/checkout-csp.js
+++ b/client/server/middleware/checkout-csp.js
@@ -165,12 +165,10 @@ function generateCSPHeader( nonce, isDevelopment ) {
 
 	const cspHeader = Object.entries( directives )
 		.map( ( [ key, value ] ) => {
-			const wrappedItems = ( Array.isArray( value.wrapped ) ? value.wrapped : [] )
-				.map( ( item ) => `'${ item }'` )
-				.join( ' ' );
-			const rawItems = ( Array.isArray( value.raw ) ? value.raw : [] ).join( ' ' );
+			const wrappedItems = ( value.wrapped ?? [] ).map( ( item ) => `'${ item }'` );
+			const rawItems = value.raw ?? [];
 
-			const allExpressions = [ wrappedItems, rawItems ].join( ' ' );
+			const allExpressions = [ ...wrappedItems, ...rawItems ].join( ' ' );
 
 			return `${ key } ${ allExpressions }`;
 		} )


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* This PR explores a small tweak to provide a more structured definition for defining Content Security policy attributes based on @ebinnion's initial work in the `update/checkout-add-csp` branch.

## Why are these changes being made?

This PR explores a more robust, maintainable format for the CSP definitions from the underlying branch.

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This should be driven by testing for the main branch, as this is a refactor of the code from the branch. I couldn't actually work out how to test the code from the branch myself.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
