### PR TITLE
Hosting Dashboard: Use sentence case for fields

### DIFF
--- a/client/dashboard/docs/typography-and-copy.md
+++ b/client/dashboard/docs/typography-and-copy.md
@@ -12,7 +12,7 @@ e.g. it’s instead of it's
 
 Rule of thumb: use sentence case for almost everything.
 
-Button labels, modal titles, and form labels; they all use sentence case.
+Button labels, modal titles, form labels, and DataViews field labels; they all use sentence case.
 
 Treat "Hosting Dashboard" like a proper noun. Capitalize it when referring to the product.
 

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -72,7 +72,7 @@ export const getContactFormFields = (
 	return [
 		{
 			id: 'firstName',
-			label: __( 'First Name' ),
+			label: __( 'First name' ),
 			type: 'text',
 			isValid: {
 				required: true,
@@ -80,7 +80,7 @@ export const getContactFormFields = (
 		},
 		{
 			id: 'lastName',
-			label: __( 'Last Name' ),
+			label: __( 'Last name' ),
 			type: 'text',
 			isValid: {
 				required: true,
@@ -130,7 +130,7 @@ export const getContactFormFields = (
 		},
 		{
 			id: 'address2',
-			label: __( 'Address Line 2' ),
+			label: __( 'Address line 2' ),
 			type: 'text',
 		},
 		{
@@ -150,7 +150,7 @@ export const getContactFormFields = (
 		},
 		{
 			id: 'postalCode',
-			label: __( 'Post Code' ),
+			label: __( 'Post code' ),
 			type: 'text',
 			isValid: {
 				required: true,

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -67,7 +67,7 @@ export default function DomainForwardingForm( {
 
 	const isPermanentField = {
 		id: 'isPermanent',
-		label: __( 'HTTP Redirect Type' ),
+		label: __( 'HTTP redirect type' ),
 		type: 'text' as const,
 		Edit: 'radio',
 		elements: [

--- a/client/dashboard/domains/domain-forwarding/index.tsx
+++ b/client/dashboard/domains/domain-forwarding/index.tsx
@@ -114,7 +114,7 @@ function DomainForwarding() {
 			},
 			{
 				id: 'forward_paths',
-				label: __( 'Path Forwarding' ),
+				label: __( 'Path forwarding' ),
 				enableHiding: true,
 				enableSorting: true,
 				enableGlobalSearch: false,
@@ -124,7 +124,7 @@ function DomainForwarding() {
 			},
 			{
 				id: 'is_permanent',
-				label: __( 'Redirect Type' ),
+				label: __( 'Redirect type' ),
 				enableHiding: true,
 				enableSorting: true,
 				enableGlobalSearch: false,

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -127,7 +127,7 @@ test( 'shows advanced settings panel', async () => {
 	await user.click( advancedPanel );
 
 	await waitFor( () => {
-		expect( screen.getByText( 'HTTP Redirect Type' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'HTTP redirect type' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Path forwarding' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
@@ -161,7 +161,7 @@ test( 'shows advanced settings panel expanded when initial data has non-default 
 	// Advanced settings panel should be expanded due to non-default values
 	await waitFor( () => {
 		expect( screen.getByText( 'Advanced settings' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'HTTP Redirect Type' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'HTTP redirect type' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Path forwarding' ) ).toBeInTheDocument();
 	} );
 } );
@@ -234,7 +234,7 @@ test( 'handles advanced settings correctly when updating', async () => {
 	await user.click( advancedPanel );
 
 	await waitFor( () => {
-		expect( screen.getByText( 'HTTP Redirect Type' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'HTTP redirect type' ) ).toBeInTheDocument();
 	} );
 
 	// Change redirect type to permanent

--- a/client/dashboard/domains/domain-glue-records/form.tsx
+++ b/client/dashboard/domains/domain-glue-records/form.tsx
@@ -54,7 +54,7 @@ export default function DomainGlueRecordsForm( {
 		() => [
 			{
 				id: 'nameServer',
-				label: __( 'Name Server' ),
+				label: __( 'Name server' ),
 				placeholder: 'ns1',
 				type: 'text' as const,
 				Edit: ( { field, data, onChange } ) => {
@@ -93,7 +93,7 @@ export default function DomainGlueRecordsForm( {
 			},
 			{
 				id: 'ipAddress',
-				label: __( 'IP Address' ),
+				label: __( 'IP address' ),
 				placeholder: '123.45.78.9',
 				type: 'text',
 				isValid: {

--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -79,7 +79,7 @@ function DomainGlueRecords() {
 		() => [
 			{
 				id: 'nameServer',
-				label: __( 'Name Server' ),
+				label: __( 'Name server' ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,
@@ -97,7 +97,7 @@ function DomainGlueRecords() {
 			},
 			{
 				id: 'ipAddress',
-				label: __( 'IP Address' ),
+				label: __( 'IP address' ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,

--- a/client/dashboard/emails/dataviews.tsx
+++ b/client/dashboard/emails/dataviews.tsx
@@ -15,7 +15,7 @@ import type { Action, Field, View } from '@wordpress/dataviews';
 export const emailFields: Field< Email >[] = [
 	{
 		id: 'emailAddress',
-		label: __( 'Email Address' ),
+		label: __( 'Email address' ),
 		enableGlobalSearch: true,
 		render: ( { item }: { item: Email } ) => {
 			let iconEl = <Icon icon={ wordpress } size={ 28 } className="professional-email-icon" />;

--- a/client/dashboard/sites/logs-activity/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/fields.tsx
@@ -87,7 +87,7 @@ export function useActivityFields( {
 			{
 				id: 'published_utc',
 				type: 'datetime',
-				label: __( 'Date & Time (UTC)' ),
+				label: __( 'Date & time (UTC)' ),
 				enableHiding: true,
 				enableSorting: true,
 				getValue: ( { item } ) => item.published,

--- a/client/dashboard/sites/logs/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs/dataviews/fields.tsx
@@ -215,7 +215,7 @@ export function useFields( {
 			{
 				id: 'http_host',
 				type: 'text',
-				label: __( 'HTTP Host' ),
+				label: __( 'HTTP host' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.http_host,
 				filterBy: { operators: [] as Operator[] },
@@ -223,7 +223,7 @@ export function useFields( {
 			{
 				id: 'http_referer',
 				type: 'text',
-				label: __( 'HTTP Referrer' ),
+				label: __( 'HTTP referrer' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.http_referer,
 				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
@@ -242,7 +242,7 @@ export function useFields( {
 			{
 				id: 'http_user_agent',
 				type: 'text',
-				label: __( 'User Agent' ),
+				label: __( 'User agent' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.http_user_agent,
 				filterBy: { operators: [] as Operator[] },
@@ -250,7 +250,7 @@ export function useFields( {
 			{
 				id: 'http_version',
 				type: 'text',
-				label: __( 'HTTP Version' ),
+				label: __( 'HTTP version' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.http_version,
 				filterBy: { operators: [] as Operator[] },
@@ -278,7 +278,7 @@ export function useFields( {
 			{
 				id: 'request_completion',
 				type: 'text',
-				label: __( 'Request Completion' ),
+				label: __( 'Request completion' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.request_completion,
 				filterBy: { operators: [] as Operator[] },
@@ -286,7 +286,7 @@ export function useFields( {
 			{
 				id: 'request_time',
 				type: 'text',
-				label: __( 'Request Time' ),
+				label: __( 'Request time' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.request_time,
 				filterBy: { operators: [] as Operator[] },

--- a/client/dashboard/sites/scan-active/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/fields.tsx
@@ -55,7 +55,7 @@ export function getFields(): Field< Threat >[] {
 		},
 		{
 			id: 'first_detected',
-			label: __( 'Detected On' ),
+			label: __( 'Detected on' ),
 			type: 'date',
 			filterBy: {
 				operators: [ 'on', 'before', 'after' ],

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -67,7 +67,7 @@ export function getFields(): Field< Threat >[] {
 		},
 		{
 			id: 'fixed_on',
-			label: __( 'Resolved On' ),
+			label: __( 'Resolved on' ),
 			type: 'date',
 			filterBy: {
 				operators: [ 'on', 'before', 'after' ],

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -328,7 +328,7 @@ export const ConnectRepositoryForm = ( {
 			},
 			{
 				id: 'branch',
-				label: __( 'Deployment Branch' ),
+				label: __( 'Deployment branch' ),
 				type: 'text' as const,
 				Edit: 'select',
 				elements: branchOptions,
@@ -339,14 +339,14 @@ export const ConnectRepositoryForm = ( {
 			},
 			{
 				id: 'targetDir',
-				label: __( 'Destination Directory' ),
+				label: __( 'Destination directory' ),
 				type: 'text' as const,
 				help: __( 'This path is relative to the server root.' ),
 				disabled: () => ! selectedRepository,
 			},
 			{
 				id: 'isAutomated',
-				label: __( 'Automated Deployments' ),
+				label: __( 'Automated deployments' ),
 				type: 'text' as const,
 				Edit: AutomatedToggle,
 			},

--- a/client/dashboard/sites/settings-repositories/dataviews/fields.tsx
+++ b/client/dashboard/sites/settings-repositories/dataviews/fields.tsx
@@ -50,7 +50,7 @@ export function useRepositoryFields() {
 			},
 			{
 				id: 'target_dir',
-				label: __( 'Target Directory' ),
+				label: __( 'Target directory' ),
 				getValue: ( { item } ) => item.target_dir,
 				render: ( { item } ) => <TargetDirDisplay targetDir={ item.target_dir } />,
 				enableHiding: true,
@@ -58,7 +58,7 @@ export function useRepositoryFields() {
 			},
 			{
 				id: 'auto_deploy',
-				label: __( 'Auto Deploy' ),
+				label: __( 'Auto deploy' ),
 				getValue: ( { item } ) => ( item.is_automated ? 'On' : 'Off' ),
 				render: ( { item } ) => (
 					<Text size="small" style={ { color: '#3b3b3b' } }>

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -90,17 +90,17 @@ export default function SftpCard( {
 		},
 		{
 			id: 'port',
-			label: __( 'port' ),
+			label: __( 'Port' ),
 			Edit: ClipboardInputControlEdit,
 		},
 		{
 			id: 'username',
-			label: __( 'username' ),
+			label: __( 'Username' ),
 			Edit: ClipboardInputControlEdit,
 		},
 		{
 			id: 'password',
-			label: __( 'password' ),
+			label: __( 'Password' ),
 			Edit: ( { field, data } ) => {
 				const { getValue } = field;
 				const value = getValue( { item: data } );

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -215,7 +215,7 @@ export default function SshCard( {
 	const fields: Field< SshCardFormData >[] = [
 		{
 			id: 'connection_command',
-			label: __( 'connection command' ),
+			label: __( 'Connection command' ),
 			Edit: ( { field, data } ) => {
 				return (
 					<ClipboardInputControl


### PR DESCRIPTION
## Proposed Changes

Update field labels to use sentence case.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that the field labels are using sentence case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
