### PR TITLE
Reader: allow search options to expand based on language

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -239,6 +239,12 @@
 		top: 30px;
 		right: 45px;
 	}
+
+	.components-toggle-group-control {
+		> div {
+			flex: 1 1 auto;
+		}
+	}
 }
 
 div.is-section-reader:not(.is-logged-in) {


### PR DESCRIPTION
Fixes CML-931

## Proposed Changes

Allow the search options' width to expand based on the language.

**Before**

<img width="333" height="102" alt="Screenshot 2025-09-26 at 17 41 16" src="https://github.com/user-attachments/assets/e8b060d7-9d70-4c89-b518-04720ef3133c" />

**After**

<img width="448" height="115" alt="Screenshot 2025-09-26 at 17 38 36" src="https://github.com/user-attachments/assets/2a908c1e-73b4-478a-a298-aad242d20558" />


## Testing Instructions

* Go to http://calypso.localhost:3000/reader/search?q=bird
    * Ensure the buttons look good for your language
* Go to http://calypso.localhost:3000/me/account
* Switch to Bulgarian
* Go back to http://calypso.localhost:3000/reader/search?q=bird
    * Ensure the buttons still look good (see screenshot above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
