### PR TITLE
Hosting Dashboard Plugins: filter unmanageable sites

### DIFF
--- a/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
+++ b/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
@@ -31,10 +31,12 @@ export function mapApiPluginsToDataViewPlugins(
 		return [];
 	}
 
-	const sitesById = userSites.reduce( ( acc, site ) => {
-		acc.set( site.ID, site );
-		return acc;
-	}, new Map< number, Site >() );
+	const sitesById = userSites
+		.filter( ( site ) => site.capabilities.update_plugins )
+		.reduce( ( acc, site ) => {
+			acc.set( site.ID, site );
+			return acc;
+		}, new Map< number, Site >() );
 
 	const pluginsBySite = response.sites;
 	const map = new Map< string, Aggregated >();

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -66,23 +66,25 @@ export const usePlugin = ( pluginSlug: string ) => {
 		: undefined;
 
 	const [ sitesWithThisPlugin, sitesWithoutThisPlugin ]: [ SiteWithPluginData[], Site[] ] = sites
-		? sites.reduce(
-				( acc, site ) => {
-					if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
-						const isPluginActive = pluginBySiteId.get( site.ID )?.active ?? false;
-						const actionLinks = actionLinksBySiteId.get( Number( site.ID ) ) || {
-							Settings: `${ site.URL }/wp-admin/plugins.php`,
-						};
+		? sites
+				.filter( ( site ) => site.capabilities.update_plugins )
+				.reduce(
+					( acc, site ) => {
+						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
+							const isPluginActive = pluginBySiteId.get( site.ID )?.active ?? false;
+							const actionLinks = actionLinksBySiteId.get( Number( site.ID ) ) || {
+								Settings: `${ site.URL }/wp-admin/plugins.php`,
+							};
 
-						acc[ 0 ].push( { ...site, isPluginActive, actionLinks } );
-					} else {
-						acc[ 1 ].push( site );
-					}
+							acc[ 0 ].push( { ...site, isPluginActive, actionLinks } );
+						} else {
+							acc[ 1 ].push( site );
+						}
 
-					return acc;
-				},
-				[ [], [] ] as [ SiteWithPluginData[], Site[] ]
-		  )
+						return acc;
+					},
+					[ [], [] ] as [ SiteWithPluginData[], Site[] ]
+				)
 		: [ [], [] ];
 
 	return {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of
https://linear.app/a8c/issue/DSGCOM-280/hosting-dashboard-plugins-filter-sites-and-activate-action-by-site
## Proposed Changes

* We now filter sites that the user does not have the capabilities to manage.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
 
* As part of our ongoing effort to modernize the hosting dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/plugins` 
* Open the network inspector and filter by site
* Inspect the response for a site that does not have the update_plugin capability
* The site should not be listed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
