### PR TITLE
Scan: fix 'Fix threat' modal title

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -1,20 +1,21 @@
 import { Icon } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
 import { BulkFixThreatsModal } from '../../scan/components/bulk-fix-threats-modal';
 import { FixThreatModal } from '../../scan/components/fix-threat-modal';
 import { IgnoreThreatModal } from '../../scan/components/ignore-threat-modal';
 import type { Threat } from '@automattic/api-core';
 
-export function getActions( siteId: number ): Action< Threat >[] {
+export function getActions( siteId: number, threatCount: number ): Action< Threat >[] {
+	const fixTitle = _n( 'Fix threat', 'Fix threats', threatCount );
 	return [
 		{
 			id: 'fix',
 			isPrimary: true,
 			icon: <Icon icon={ tool } />,
-			label: __( 'Fix threat' ),
-			modalHeader: __( 'Fix threat' ),
+			label: fixTitle,
+			modalHeader: fixTitle,
 			supportsBulk: true,
 			RenderModal: ( { items, closeModal } ) => {
 				if ( items.length === 1 ) {

--- a/client/dashboard/sites/scan-active/dataviews/actions.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/actions.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@wordpress/components';
 import { Action } from '@wordpress/dataviews';
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { tool } from '@wordpress/icons';
 import { BulkFixThreatsModal } from '../../scan/components/bulk-fix-threats-modal';
 import { FixThreatModal } from '../../scan/components/fix-threat-modal';
@@ -8,7 +8,8 @@ import { IgnoreThreatModal } from '../../scan/components/ignore-threat-modal';
 import type { Threat } from '@automattic/api-core';
 
 export function getActions( siteId: number, threatCount: number ): Action< Threat >[] {
-	const fixTitle = _n( 'Fix threat', 'Fix threats', threatCount );
+	// The action could be triggered directly, with no previous selection, hence we should consider 0 threats as well.
+	const fixTitle = threatCount <= 1 ? __( 'Fix threat' ) : __( 'Fix threats' );
 	return [
 		{
 			id: 'fix',

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -19,11 +19,15 @@ export function ActiveThreatsDataViews( { site }: { site: Site } ) {
 		sort: { field: 'severity', direction: 'desc' },
 	} );
 
+	const [ selection, setSelection ] = useState< string[] >( [] );
 	const { data: scan, isLoading } = useQuery( siteScanQuery( site.ID ) );
 	const threats = scan?.threats.filter( ( threat ) => threat.status === 'current' ) || [];
 
 	const fields = getFields();
-	const actions = useMemo( () => getActions( site.ID ), [ site.ID ] );
+	const actions = useMemo(
+		() => getActions( site.ID, selection.length ),
+		[ site.ID, selection.length ]
+	);
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
 	const lastScanTime = scan?.most_recent?.timestamp;
 	const recentScanRelativeTime = useTimeSince( lastScanTime || '' );
@@ -77,9 +81,11 @@ export function ActiveThreatsDataViews( { site }: { site: Site } ) {
 			fields={ fields }
 			getItemId={ ( item ) => item.id.toString() }
 			isLoading={ isLoading }
+			onChangeSelection={ setSelection }
 			onChangeView={ setView }
 			paginationInfo={ paginationInfo }
 			searchLabel={ __( 'Search' ) }
+			selection={ selection }
 			view={ view }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-539][1].

## Proposed Changes

Make use of plural in the `Fix threat` modal title.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This was missing from #106030, so here's the follow-up for it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/:slug/scan`
- Select one or more threats.
- Click on the wrench icon in the `DataViews` component.
- Check whether the modal title is in the singular or plural form as expected.

| Singular | Plural
| - | - |
| <img width="530" height="563" alt="image" src="https://github.com/user-attachments/assets/ceac0f76-df4b-4b41-a2e4-56bb62cbae27" /> | <img width="524" height="441" alt="image" src="https://github.com/user-attachments/assets/3227b5da-1ac2-4fc9-9236-2bb0c60526e9" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-539