### PR TITLE
MCP: Update MCP Settings Forms

### DIFF
--- a/client/dashboard/sites/settings-mcp/index.tsx
+++ b/client/dashboard/sites/settings-mcp/index.tsx
@@ -1,6 +1,7 @@
 import {
 	isAutomatticianQuery,
 	siteBySlugQuery,
+	siteSettingsQuery,
 	userSettingsQuery,
 	userSettingsMutation,
 } from '@automattic/api-queries';
@@ -13,12 +14,14 @@ import {
 	ToggleControl,
 	ExternalLink,
 	__experimentalText as Text,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState, useMemo, useCallback, createElement } from 'react';
+import { useState, useMemo, useCallback } from 'react';
+import { ButtonStack } from '../../components/button-stack';
 import PageLayout from '../../components/page-layout';
 import SettingsPageHeader from '../settings-page-header';
 import { getSiteMcpAbilities, createSiteSpecificApiPayload } from './utils';
@@ -29,6 +32,7 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const { data: siteSettings } = useQuery( siteSettingsQuery( site.ID ) );
 	// Use the standard userSettingsMutation (now supports mcp_abilities)
 	const saveMcpMutation = useMutation( {
 		...userSettingsMutation(),
@@ -42,18 +46,29 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 
 	// Get tools from user settings using the new nested structure
 	const availableTools = useMemo( (): [ string, SiteMcpAbilities[ string ] ][] => {
-		const abilities = getSiteMcpAbilities( userSettings, site.ID );
+		const abilities = getSiteMcpAbilities( userSettings, site.ID, siteSettings as any );
 		return Object.entries( abilities );
-	}, [ userSettings, site.ID ] );
+	}, [ userSettings, site.ID, siteSettings ] );
 
 	const hasTools = availableTools.length > 0;
 
-	const [ formData, setFormData ] = useState< SiteMcpAbilities >( () =>
-		getSiteMcpAbilities( userSettings, site.ID )
-	);
+	const [ formData, setFormData ] = useState< any >( () => {
+		const abilities = getSiteMcpAbilities( userSettings, site.ID, siteSettings as any );
+		return {
+			...abilities,
+		};
+	} );
 
 	// Calculate if any tools are enabled in form data (for master toggle state)
-	const anyToolsEnabled = hasTools && Object.values( formData ).some( ( tool ) => tool.enabled );
+	const anyToolsEnabled =
+		hasTools &&
+		Object.entries( formData ).some(
+			( [ key, value ] ) =>
+				key !== 'accountToolsEnabled' &&
+				typeof value === 'object' &&
+				value &&
+				( value as any ).enabled
+		);
 
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
@@ -69,33 +84,36 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 				createErrorNotice( __( 'Failed to save MCP tools.' ), { type: 'snackbar' } );
 			}
 		},
-		[ formData, userSettings, site.ID, saveMcpMutation, createErrorNotice ]
+		[ formData, userSettings, site.ID, siteSettings, saveMcpMutation, createErrorNotice ]
 	);
 
 	const handleMasterToggle = useCallback(
 		( enabled: boolean ) => {
 			// Get the complete list of available tools from userSettings
-			const currentAbilities = getSiteMcpAbilities( userSettings, site.ID );
-			const updatedTools: SiteMcpAbilities = {};
+			const currentAbilities = getSiteMcpAbilities( userSettings, site.ID, siteSettings as any );
+			const updatedTools: any = {};
 
 			// Update all available tools to the same enabled state
 			Object.entries( currentAbilities ).forEach( ( [ toolId, tool ] ) => {
 				updatedTools[ toolId ] = {
-					...tool,
+					...( tool as any ),
 					enabled,
 				};
 			} );
 
+			// Preserve the accountToolsEnabled setting
+			updatedTools.accountToolsEnabled = formData.accountToolsEnabled;
+
 			setFormData( updatedTools );
 		},
-		[ userSettings, site.ID ]
+		[ userSettings, site.ID, formData.accountToolsEnabled ]
 	);
 
 	const handleToolChange = useCallback( ( toolId: string, enabled: boolean ) => {
-		setFormData( ( prev ) => ( {
+		setFormData( ( prev: any ) => ( {
 			...prev,
 			[ toolId ]: {
-				...prev[ toolId ],
+				...( prev[ toolId ] as any ),
 				enabled,
 			},
 		} ) );
@@ -107,7 +125,7 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 			toolId,
 			{
 				...tool,
-				enabled: formData[ toolId ]?.enabled ?? tool.enabled,
+				enabled: ( formData[ toolId ] as any )?.enabled ?? ( tool as any ).enabled,
 			},
 		] );
 	}, [ availableTools, formData ] );
@@ -116,48 +134,6 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 	if ( ! isAutomattician ) {
 		return null;
 	}
-
-	// Group tools by type first, then by category
-	const groupedByType: Record<
-		string,
-		Record< string, [ string, SiteMcpAbilities[ string ] ][] >
-	> = tools.reduce(
-		(
-			typeGroups: Record< string, Record< string, [ string, SiteMcpAbilities[ string ] ][] > >,
-			[ toolId, tool ]
-		) => {
-			const type = tool.type || 'tool'; // Default to 'tool' instead of 'other'
-			const category = tool.category || 'General';
-
-			// Only include the three main types
-			if ( ! [ 'tool', 'resource', 'prompt' ].includes( type ) ) {
-				return typeGroups;
-			}
-
-			if ( ! typeGroups[ type ] ) {
-				typeGroups[ type ] = {};
-			}
-			if ( ! typeGroups[ type ][ category ] ) {
-				typeGroups[ type ][ category ] = [];
-			}
-			typeGroups[ type ][ category ].push( [ toolId, tool ] );
-			return typeGroups;
-		},
-		{} as Record< string, Record< string, [ string, SiteMcpAbilities[ string ] ][] > >
-	);
-
-	// Type descriptions
-	const typeDescriptions: Record< string, string > = {
-		tool: __(
-			'Tools allow AI assistants to read and search your WordPress.com data. These are view-only capabilities that cannot modify your content or settings.'
-		),
-		resource: __(
-			'Resources provide AI assistants with read-only access to your data, such as site statistics or user information.'
-		),
-		prompt: __(
-			'Prompts help AI assistants understand context and provide better responses to your queries.'
-		),
-	};
 
 	const renderContent = () => {
 		if ( ! hasTools ) {
@@ -173,9 +149,9 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 		}
 
 		return (
-			<form onSubmit={ handleSubmit }>
-				<Card>
-					<CardBody>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
 						<VStack spacing={ 4 }>
 							<div
 								style={ { display: 'flex', justifyContent: 'space-between', alignItems: 'center' } }
@@ -191,80 +167,71 @@ function SettingsMcpComponent( { siteSlug }: { siteSlug: string } ) {
 									</Button>
 								) }
 							</div>
-						</VStack>
-					</CardBody>
-				</Card>
 
-				{ hasTools && anyToolsEnabled && (
-					<>
-						{ Object.entries( groupedByType ).map( ( [ type, typeCategories ] ) => {
-							const typeKey = type as 'tool' | 'resource' | 'prompt';
-							return (
-								<div key={ type } style={ { marginTop: '24px' } }>
-									<Text as="h1">{ __( 'Site-level MCP Tools' ) }</Text>
-									<Text as="p" variant="muted" style={ { marginBottom: '16px' } }>
-										{ typeDescriptions[ typeKey ] }
+							{ hasTools && anyToolsEnabled && (
+								<VStack spacing={ 3 }>
+									<Heading level={ 4 }>{ __( 'Site-specific MCP Tools' ) }</Heading>
+									<Text as="p" variant="muted">
+										{ __( 'Control which MCP tools are available for this site.' ) }
 									</Text>
-									<Card>
-										<CardBody>
-											<VStack spacing={ 6 }>
-												{ Object.entries( typeCategories ).map( ( [ category, categoryTools ] ) => (
-													<VStack key={ category } spacing={ 4 }>
-														<Text as="h3" style={ { textTransform: 'capitalize' } }>
-															{ category }
-														</Text>
-														{ categoryTools.map( ( [ toolId, tool ] ) => (
-															<VStack key={ toolId } spacing={ 3 }>
-																<ToggleControl
-																	checked={ tool.enabled }
-																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-																	label={ tool.title }
-																	help={ tool.description }
-																/>
-															</VStack>
-														) ) }
-													</VStack>
-												) ) }
-											</VStack>
-										</CardBody>
-									</Card>
-								</div>
-							);
-						} ) }
-					</>
-				) }
+									<VStack spacing={ 4 }>
+										{ tools
+											.filter( ( [ toolId ] ) => toolId !== 'accountToolsEnabled' )
+											.map( ( [ toolId, tool ] ) => (
+												<ToggleControl
+													key={ toolId }
+													checked={ tool.enabled }
+													onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+													label={ tool.title }
+													help={ tool.description }
+												/>
+											) ) }
+									</VStack>
+								</VStack>
+							) }
 
-				{ anyToolsEnabled && (
-					<>
-						<div style={ { marginTop: '24px' } }>
-							<Text as="h1">{ __( 'Account-level MCP Tools' ) }</Text>
-							<Text as="p" variant="muted" style={ { margin: 0 } }>
-								{ createInterpolateElement(
-									__(
-										'Account-level MCP tools are available across all your sites, <a>manage account MCP settings</a>.'
-									),
-									{
-										a: createElement( 'a', { href: '/me/mcp', target: '_blank' } ),
-									}
-								) }
-							</Text>
-						</div>
-					</>
-				) }
+							{ anyToolsEnabled && (
+								<VStack spacing={ 3 }>
+									<Heading level={ 4 }>{ __( 'Account-level MCP Tools' ) }</Heading>
+									<Text as="p" variant="muted">
+										{ createInterpolateElement(
+											__(
+												'Account-level tools work across all sites. <a>Manage account MCP settings</a>.'
+											),
+											{
+												a: <a href="/me/mcp" target="_blank" rel="noreferrer" />,
+											}
+										) }
+									</Text>
+									<ToggleControl
+										checked={ formData.accountToolsEnabled ?? true }
+										onChange={ ( checked ) =>
+											setFormData( ( prev: any ) => ( { ...prev, accountToolsEnabled: checked } ) )
+										}
+										label={ __( 'Account-level MCP tools' ) }
+										help={ __(
+											'When enabled, account-level MCP tools will be available on this site.'
+										) }
+									/>
+								</VStack>
+							) }
 
-				{ hasTools && (
-					<div style={ { marginTop: '24px' } }>
-						<Button
-							variant="primary"
-							type="submit"
-							isBusy={ saveMcpMutation.isPending }
-							disabled={ saveMcpMutation.isPending }
-						>
-							{ saveMcpMutation.isPending ? __( 'Saving…' ) : __( 'Save MCP tools' ) }
-						</Button>
-					</div>
-				) }
-			</form>
+							{ hasTools && (
+								<ButtonStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ saveMcpMutation.isPending }
+										disabled={ saveMcpMutation.isPending }
+									>
+										{ saveMcpMutation.isPending ? __( 'Saving…' ) : __( 'Save MCP tools' ) }
+									</Button>
+								</ButtonStack>
+							) }
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
 		);
 	};
 

--- a/client/dashboard/sites/settings-mcp/utils.ts
+++ b/client/dashboard/sites/settings-mcp/utils.ts
@@ -13,8 +13,9 @@ export type McpAbilitiesApiStructure = {
  */
 export function getSiteMcpAbilities(
 	userSettings: { mcp_abilities?: McpAbilities } | null | undefined,
-	siteId: string | number
-): SiteMcpAbilities {
+	siteId: string | number,
+	siteSettings?: { default_tools?: boolean } | null | undefined
+): SiteMcpAbilities & { accountToolsEnabled?: boolean } {
 	const siteIdStr = String( siteId );
 	const mcpData = userSettings?.mcp_abilities;
 
@@ -50,7 +51,25 @@ export function getSiteMcpAbilities(
 		}
 	} );
 
-	return mergedAbilities;
+	// Determine if account tools should be enabled
+	// Check if there are any enabled account-level abilities
+	const hasEnabledAccountTools =
+		mcpData.account && Object.values( mcpData.account ).some( ( ability ) => ability.enabled );
+
+	// Check if site has default tools enabled (from site settings)
+	const hasDefaultSiteTools = siteSettings?.default_tools === true;
+
+	// Set accountToolsEnabled to true if:
+	// 1. Explicitly set in site overrides, OR
+	// 2. There are enabled account-level tools, OR
+	// 3. Site has default tools available
+	const accountToolsEnabled =
+		siteOverrides.accountToolsEnabled ?? ( hasEnabledAccountTools || hasDefaultSiteTools );
+
+	return {
+		...mergedAbilities,
+		accountToolsEnabled,
+	};
 }
 
 /**
@@ -165,7 +184,7 @@ export function convertAbilitiesFromApi(
 export function createSiteSpecificApiPayload(
 	userSettings: { mcp_abilities?: McpAbilities } | null | undefined,
 	siteId: string | number,
-	abilities: SiteMcpAbilities
+	abilities: SiteMcpAbilities & { accountToolsEnabled?: boolean }
 ): { mcp_abilities: McpAbilitiesApiStructure } {
 	const siteIdNum = Number( siteId );
 	const mcpData = userSettings?.mcp_abilities;
@@ -180,6 +199,11 @@ export function createSiteSpecificApiPayload(
 	// Find only the abilities that differ from defaults
 	const siteOverrides: Record< string, boolean > = {};
 	Object.entries( abilities ).forEach( ( [ abilityName, ability ] ) => {
+		// Skip the accountToolsEnabled field
+		if ( abilityName === 'accountToolsEnabled' ) {
+			return;
+		}
+
 		const defaultAbility = defaultSiteAbilities[ abilityName ];
 
 		// Only store if it differs from the default
@@ -187,6 +211,11 @@ export function createSiteSpecificApiPayload(
 			siteOverrides[ abilityName ] = ability.enabled;
 		}
 	} );
+
+	// Add accountToolsEnabled if it's set (and not the default true)
+	if ( abilities.accountToolsEnabled !== undefined && abilities.accountToolsEnabled !== true ) {
+		siteOverrides.accountToolsEnabled = abilities.accountToolsEnabled;
+	}
 
 	// Create the optimized payload (only include site-specific overrides)
 	const payload: McpAbilitiesApiStructure = {};

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -4,14 +4,14 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
+	__experimentalHeading as Heading,
 	Card,
 	CardBody,
-	CardHeader,
 	ToggleControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, createElement } from 'react';
+import { useState, useEffect } from 'react';
 import { connect, useDispatch as useReduxDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormButton from 'calypso/components/forms/form-button';
@@ -22,6 +22,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
+import { ButtonStack } from '../../dashboard/components/button-stack';
 import { getAccountMcpAbilities, createAccountApiPayload } from './utils';
 
 function McpComponent( { path, userSettings, isUpdating } ) {
@@ -114,62 +115,12 @@ function McpComponent( { path, userSettings, isUpdating } ) {
 			},
 		] );
 
-		// Group tools by type first, then by category
-		const groupedByType = tools.reduce( ( typeGroups, [ toolId, tool ] ) => {
-			const type = tool.type || 'tool'; // Default to 'tool' instead of 'other'
-			const category = tool.category || 'General';
-
-			// Only include the three main types
-			if ( ! [ 'tool', 'resource', 'prompt' ].includes( type ) ) {
-				return typeGroups;
-			}
-
-			if ( ! typeGroups[ type ] ) {
-				typeGroups[ type ] = {};
-			}
-			if ( ! typeGroups[ type ][ category ] ) {
-				typeGroups[ type ][ category ] = [];
-			}
-			typeGroups[ type ][ category ].push( [ toolId, tool ] );
-			return typeGroups;
-		}, {} );
-
-		// Type descriptions
-		const typeDescriptions = {
-			tool: translate(
-				'Tools allow AI assistants to read and search your WordPress.com data. These are view-only capabilities that cannot modify your content or settings.'
-			),
-			resource: translate(
-				'Resources provide AI assistants with read-only access to your data, such as site statistics or user information.'
-			),
-			prompt: translate(
-				'Prompts help AI assistants understand context and provide better responses to your queries.'
-			),
-		};
-
-		// Type display names
-		const typeDisplayNames = {
-			tool: translate( 'Tools' ),
-			resource: translate( 'Resources' ),
-			prompt: translate( 'Prompts' ),
-		};
-
 		return (
-			<form onSubmit={ handleSubmit }>
-				<Card style={ { borderRadius: '0' } }>
-					<CardHeader size="small">
-						<VStack spacing={ 2 }>
-							<Text as="h1">{ translate( 'Account-level MCP tools' ) }</Text>
-							<Text as="p" variant="muted">
-								{ translate(
-									'These tools are available across all your sites. You can enable or disable them here to control access globally.'
-								) }
-							</Text>
-						</VStack>
-					</CardHeader>
-					<CardBody>
-						{ hasTools ? (
-							<VStack spacing={ 3 }>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							{ hasTools ? (
 								<div
 									style={ {
 										display: 'flex',
@@ -188,96 +139,63 @@ function McpComponent( { path, userSettings, isUpdating } ) {
 										</Button>
 									) }
 								</div>
-							</VStack>
-						) : (
-							<Text as="p" variant="muted">
-								{ translate( 'No MCP tools are currently available.' ) }
-							</Text>
-						) }
-					</CardBody>
-				</Card>
+							) : (
+								<Text as="p" variant="muted">
+									{ translate( 'No MCP tools are currently available.' ) }
+								</Text>
+							) }
 
-				{ hasTools && anyToolsEnabled && (
-					<>
-						{ Object.entries( groupedByType ).map( ( [ type, typeCategories ] ) => (
-							<div key={ type } style={ { marginTop: '24px' } }>
-								<Card style={ { borderRadius: '0' } }>
-									<CardHeader size="small">
-										<VStack spacing={ 2 }>
-											<Text as="h1">{ typeDisplayNames[ type ] }</Text>
-											<Text as="p" variant="muted">
-												{ typeDescriptions[ type ] }
-											</Text>
-										</VStack>
-									</CardHeader>
-									<CardBody>
-										<VStack spacing={ 6 }>
-											{ Object.entries( typeCategories ).map( ( [ category, categoryTools ] ) => (
-												<VStack key={ category } spacing={ 4 }>
-													<Text as="h3" style={ { textTransform: 'capitalize' } }>
-														{ category }
-													</Text>
-													<VStack spacing={ 4 }>
-														{ categoryTools.map( ( [ toolId, tool ] ) => (
-															<VStack key={ toolId } spacing={ 3 }>
-																<ToggleControl
-																	checked={ tool.enabled }
-																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-																	label={ tool.title }
-																	help={ tool.description }
-																	disabled={ ! anyToolsEnabled }
-																/>
-															</VStack>
-														) ) }
-													</VStack>
-												</VStack>
-											) ) }
-										</VStack>
-									</CardBody>
-								</Card>
-							</div>
-						) ) }
-					</>
-				) }
-
-				{ hasTools && anyToolsEnabled && (
-					<>
-						<div style={ { marginTop: '24px' } }>
-							<Card>
-								<CardBody>
-									<VStack spacing={ 3 }>
-										<Text as="h4" style={ { margin: 0 } }>
-											{ translate( 'Site-specific MCP settings' ) }
-										</Text>
-										<Text as="p" variant="muted" style={ { margin: 0 } }>
-											{ createInterpolateElement(
-												translate(
-													'Account-level MCP tools are available on all your sites. You can manage site-specific MCP access and overrides in <a>individual site settings</a>.'
-												),
-												{
-													a: createElement( 'a', {
-														href: '/sites',
-														target: '_blank',
-														style: { textDecoration: 'underline' },
-													} ),
-												}
-											) }
-										</Text>
+							{ hasTools && anyToolsEnabled && (
+								<VStack spacing={ 3 }>
+									<Heading level={ 4 }>{ translate( 'Account-level MCP Tools' ) }</Heading>
+									<Text as="p" variant="muted">
+										{ translate( 'Control which MCP tools are available across all your sites.' ) }
+									</Text>
+									<VStack spacing={ 4 }>
+										{ tools.map( ( [ toolId, tool ] ) => (
+											<ToggleControl
+												key={ toolId }
+												checked={ tool.enabled }
+												onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+												label={ tool.title }
+												help={ tool.description }
+												disabled={ ! anyToolsEnabled }
+											/>
+										) ) }
 									</VStack>
-								</CardBody>
-							</Card>
-						</div>
-					</>
-				) }
+								</VStack>
+							) }
 
-				{ hasTools && (
-					<div style={ { marginTop: '24px' } }>
-						<FormButton isSubmitting={ isUpdating } disabled={ isUpdating || ! hasUnsavedChanges }>
-							{ isUpdating ? translate( 'Saving…' ) : translate( 'Save MCP tools' ) }
-						</FormButton>
-					</div>
-				) }
-			</form>
+							{ hasTools && anyToolsEnabled && (
+								<VStack spacing={ 3 }>
+									<Heading level={ 4 }>{ translate( 'Site-specific MCP settings' ) }</Heading>
+									<Text as="p" variant="muted">
+										{ createInterpolateElement(
+											translate(
+												'Account-level tools work across all sites. <a>Manage site-specific MCP settings</a> to control which tools are available on a specific site.'
+											),
+											{
+												a: <a href="/sites" target="_blank" rel="noreferrer" />,
+											}
+										) }
+									</Text>
+								</VStack>
+							) }
+
+							{ hasTools && (
+								<ButtonStack justify="flex-start">
+									<FormButton
+										isSubmitting={ isUpdating }
+										disabled={ isUpdating || ! hasUnsavedChanges }
+									>
+										{ isUpdating ? translate( 'Saving…' ) : translate( 'Save MCP tools' ) }
+									</FormButton>
+								</ButtonStack>
+							) }
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AIINT-187/add-account-tools-toggle-to-site-settings and https://linear.app/a8c/issue/AIINT-178/update-calypso-settings-pages

## Proposed Changes

* Update layout/markup to be more in line with other settings pages
* Add new toggle in site-specific settings to allow user to disable account-level tools at site level.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
