### PR TITLE
Hosting Dashboard: Change purchase settings URL to /purchases/ID

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -148,7 +148,7 @@ export const purchaseSettingsRoute = createRoute( {
 			purchase,
 		};
 	},
-	path: '/purchases/purchase/$purchaseId',
+	path: '/purchases/$purchaseId',
 } ).lazy( () =>
 	import( '../../me/billing-purchases/purchase-settings' ).then( ( d ) =>
 		createLazyRoute( 'purchases-purchase-settings' )( {

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 import { useLocale } from '../../app/locale';
+import { getPurchaseUrlForId } from '../../me/billing-purchases/urls';
 import OverviewCard from '../../sites/overview-card';
 import { formatDate } from '../../utils/datetime';
 
@@ -29,7 +30,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 			title={ domain.auto_renewing ? __( 'Renews' ) : __( 'Expires' ) }
 			heading={ formattedDate }
 			icon={ <Icon icon={ calendar } /> }
-			link={ `/me/billing/purchases/purchase/${ domain.subscription_id }` }
+			link={ getPurchaseUrlForId( domain.subscription_id ) }
 			description={
 				domain.auto_renewing ? __( 'Auto-renew is enabled.' ) : __( 'Auto-renew is disabled.' )
 			}

--- a/client/dashboard/me/billing-purchases/urls.ts
+++ b/client/dashboard/me/billing-purchases/urls.ts
@@ -10,7 +10,7 @@ export function getPurchaseUrlForId( id: number | string ) {
 		console.error( 'Cannot display manage purchase page for subscription without ID' );
 		throw new Error( 'Cannot display manage purchase page for subscription without ID' );
 	}
-	return `/me/billing/purchases/purchase/${ id }`;
+	return `/me/billing/purchases/${ id }`;
 }
 
 export function getAddPaymentMethodUrlFor( purchase: Purchase ): string {

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -12,6 +12,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
+import { getPurchaseUrlForId } from '../../me/billing-purchases/urls';
 import {
 	getJetpackProductsForSite,
 	getSitePlanDisplayName,
@@ -113,7 +114,7 @@ function WpcomPlanCard( {
 		}
 
 		if ( isV2Page ) {
-			return { link: `/me/billing/purchases/purchase/${ purchase?.ID }` };
+			return { link: purchase ? getPurchaseUrlForId( purchase.ID ) : '/me/billing/purchases' };
 		}
 
 		return { externalLink: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }` };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1122/hosting-dashboard-change-purchase-settings-url-to-purchasesid-instead

## Proposed Changes

This PR changes the hosting dashboard purchase settings page URL from `/me/billing/purchases/purchase/ID` to `/me/billing/purchases/ID`. I had made the original more verbose to allow for flexibility but I think it's too complex.

## Testing Instructions

Make sure I didn't miss anywhere that uses the old route.