### PR TITLE
Hosting Dashboard Plugins: add tracking

### DIFF
--- a/client/dashboard/plugins/manage/components/action-render-modal.tsx
+++ b/client/dashboard/plugins/manage/components/action-render-modal.tsx
@@ -5,9 +5,10 @@ import {
 	Button,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../../app/analytics';
 import type { PluginListRow } from '../types';
 import type { RenderModalProps } from '@wordpress/dataviews';
 
@@ -195,6 +196,16 @@ export default function ActionRenderModal( {
 }: ActionRenderModalProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ isBusy, setIsBusy ] = useState( false );
+	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		recordTracksEvent( `calypso_hosting_dashboard_plugins_${ actionId }_click` );
+	}, [ actionId, recordTracksEvent ] );
+
+	const handleCancel = () => {
+		recordTracksEvent( `calypso_hosting_dashboard_plugins_${ actionId }_cancel_click` );
+		closeModal?.();
+	};
 
 	const buildSuccessPrefix = ( action: string, selected: PluginListRow[] ) => {
 		if ( selected.length === 1 ) {
@@ -409,6 +420,7 @@ export default function ActionRenderModal( {
 	};
 
 	const handleConfirm = async () => {
+		recordTracksEvent( `calypso_hosting_dashboard_plugins_${ actionId }_confirm_click` );
 		setIsBusy( true );
 		try {
 			const { successCount, errorCount } = await onExecute( items );
@@ -454,7 +466,7 @@ export default function ActionRenderModal( {
 				<Button
 					__next40pxDefaultSize
 					variant="tertiary"
-					onClick={ closeModal }
+					onClick={ handleCancel }
 					disabled={ isBusy }
 					accessibleWhenDisabled
 				>

--- a/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { useAnalytics } from '../../../app/analytics';
 import type { ComponentProps } from 'react';
 
 export type FieldActionToggleProps = {
@@ -17,6 +18,8 @@ export type FieldActionToggleProps = {
 	errorOff: string;
 	// Prevent default click (to avoid row selection etc.). Defaults to true.
 	preventDefaultClick?: boolean;
+	// Action identifier used for analytics: e.g. "activate" or "autoupdate".
+	actionId: 'activate' | 'autoupdate';
 };
 
 export default function FieldActionToggle( {
@@ -29,8 +32,10 @@ export default function FieldActionToggle( {
 	successOff,
 	errorOff,
 	preventDefaultClick = true,
+	actionId,
 }: FieldActionToggleProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 
 	return (
 		<ToggleControl
@@ -42,6 +47,11 @@ export default function FieldActionToggle( {
 				}
 			} }
 			onChange={ ( next ) => {
+				recordTracksEvent(
+					`calypso_hosting_dashboard_plugins_${ actionId }_toggle_${
+						next ? 'enable' : 'disable'
+					}_click`
+				);
 				onToggle( next )
 					.then( () => {
 						createSuccessNotice( next ? successOn : successOff, { type: 'snackbar' } );

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -106,6 +106,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 								__( 'Failed to deactivate %s' ),
 								plugin?.name ?? ''
 							) }
+							actionId="activate"
 						/>
 					);
 				},
@@ -158,6 +159,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 								__( 'Failed to disable auto‑updates for %s' ),
 								plugin?.name ?? ''
 							) }
+							actionId="autoupdate"
 						/>
 					);
 				},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of
https://linear.app/a8c/issue/DSGCOM-279/hosting-dashboard-plugins-add-tracking

## Proposed Changes

* Added track events for clickable elements, modals and toggles.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the Hosting Dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/plugins`
* Clicking on the different actions should trigger track events.
* Navigate to a plugin
* On the inspector screen, toggling actions and performing actions should trigger events. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
