### PR TITLE
Hosting Dashboard: Monitoring - minor UI improvements and refactoring

### DIFF
--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -114,7 +114,7 @@ export default function MonitoringCard( {
 	return (
 		<Card className={ clsx( 'dashboard-monitoring-card', className ) }>
 			<CardBody>
-				<VStack spacing={ 4 } className="dashboard-monitoring-card__body">
+				<VStack spacing={ 4 } className="dashboard-monitoring-card__body" justify="flex-start">
 					{ tracksId && (
 						<ComponentViewTracker
 							eventName="calypso_dashboard_monitoring_card_impression"

--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -114,7 +114,7 @@ export default function MonitoringCard( {
 	return (
 		<Card className={ clsx( 'dashboard-monitoring-card', className ) }>
 			<CardBody>
-				<VStack spacing={ 4 }>
+				<VStack spacing={ 4 } className="dashboard-monitoring-card__body">
 					{ tracksId && (
 						<ComponentViewTracker
 							eventName="calypso_dashboard_monitoring_card_impression"
@@ -123,7 +123,7 @@ export default function MonitoringCard( {
 					) }
 					{ topContent }
 					{ children && (
-						<VStack className={ contentClassNames } spacing={ 2 } justify="center">
+						<VStack className={ contentClassNames } spacing={ 2 } justify="space-between">
 							{ renderContent() }
 						</VStack>
 					) }

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -1,10 +1,6 @@
 .dashboard-monitoring-card {
 	flex-grow: 1;
 
-	.dashboard-monitoring-card__body {
-		justify-content: flex-start;
-	}
-
 	.components-card__body, .dashboard-monitoring-card__body {
 		height: 100%;
 	}

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -1,7 +1,17 @@
 .dashboard-monitoring-card {
 	flex-grow: 1;
 
+	.dashboard-monitoring-card__body {
+		justify-content: flex-start;
+	}
+
+	.components-card__body, .dashboard-monitoring-card__body {
+		height: 100%;
+	}
+
 	.dashboard-monitoring-card__content {
+		flex-grow: 1;
+
 		&__is-loading {
 			display: flex;
 			justify-content: center;

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -12,17 +12,15 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { useMemo, createElement, Element } from '@wordpress/element';
 import { Text } from '../../components/text';
+import {
+	convertTimeRangeToUnix,
+	chartColors,
+	getLineChartTickNumber,
+	getLineChartTickLabel,
+} from '../monitoring/utils';
 import MonitoringCard from '../monitoring-card';
 import type { HTTPCodeSerie } from './http-codes';
-import type { TimeRange } from '../monitoring/types';
 import type { Site, SiteHostingMetrics } from '@automattic/api-core';
-
-function convertTimeRangeToUnix( timeRange: number ): TimeRange {
-	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;
-	const end = Math.floor( new Date().getTime() / 1000 );
-
-	return { start, end };
-}
 
 type SiteMetricsData = {
 	responseStatusData: HttpStatusDataPoints | undefined;
@@ -101,7 +99,6 @@ function useSiteMetricsData(
 	};
 }
 
-const chartColors = [ '#3858E9', '#5BA300', '#F57600', '#B51963' ];
 const chartGlyphs = [
 	GlyphCircle,
 	GlyphCross,
@@ -176,39 +173,10 @@ export default function MonitoringHttpResponsesCard( {
 	}
 
 	const lessThanMediumViewport = useViewportMatch( 'medium', '<' );
-
-	let numTicks: undefined | number;
-	switch ( timeRange ) {
-		case 168:
-			numTicks = lessThanMediumViewport ? 3 : 7;
-			break;
-		case 72:
-			numTicks = lessThanMediumViewport ? 3 : 6;
-			break;
-		case 24:
-		case 6:
-			numTicks = lessThanMediumViewport ? 4 : 12;
-			break;
-	}
-
 	const xAxisOptions = {
-		tickFormat: ( date: string ) => {
-			const d = new Date( date );
-
-			if ( timeRange <= 24 ) {
-				return `${ d.getHours() }:${ d.getMinutes().toString().padStart( 2, '0' ) }`;
-			}
-
-			if ( timeRange > 72 || ( timeRange > 24 && lessThanMediumViewport ) ) {
-				return `${ d.toLocaleDateString() }`;
-			}
-
-			return `${ d.toLocaleDateString() } ${ d.getHours() }:${ d
-				.getMinutes()
-				.toString()
-				.padStart( 2, '0' ) }`;
-		},
-		numTicks: numTicks,
+		tickFormat: ( date: string ) =>
+			getLineChartTickLabel( date, timeRange, lessThanMediumViewport ),
+		numTicks: getLineChartTickNumber( timeRange, lessThanMediumViewport ),
 	};
 
 	const getLegendIcon = ( key: string ) => {

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -8,16 +8,14 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import { Text } from '../../components/text';
+import {
+	convertTimeRangeToUnix,
+	getLineChartTickNumber,
+	getLineChartTickLabel,
+} from '../monitoring/utils';
 import MonitoringCard from '../monitoring-card';
-import type { PeriodData, TimeRange } from '../monitoring/types';
+import type { PeriodData } from '../monitoring/types';
 import type { Site } from '@automattic/api-core';
-
-function convertTimeRangeToUnix( timeRange: number ): TimeRange {
-	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;
-	const end = Math.floor( new Date().getTime() / 1000 );
-
-	return { start, end };
-}
 
 type SiteMetricsData = {
 	requestsData: DataPointDate[] | undefined;
@@ -119,39 +117,10 @@ export default function MonitoringPerformanceCard( {
 	];
 
 	const lessThanMediumViewport = useViewportMatch( 'medium', '<' );
-
-	let numTicks: undefined | number;
-	switch ( timeRange ) {
-		case 168:
-			numTicks = lessThanMediumViewport ? 3 : 7;
-			break;
-		case 72:
-			numTicks = lessThanMediumViewport ? 3 : 6;
-			break;
-		case 24:
-		case 6:
-			numTicks = lessThanMediumViewport ? 4 : 12;
-			break;
-	}
-
 	const xAxisOptions = {
-		tickFormat: ( date: string ) => {
-			const d = new Date( date );
-
-			if ( timeRange <= 24 ) {
-				return `${ d.getHours() }:${ d.getMinutes().toString().padStart( 2, '0' ) }`;
-			}
-
-			if ( timeRange > 72 || ( timeRange > 24 && lessThanMediumViewport ) ) {
-				return `${ d.toLocaleDateString() }`;
-			}
-
-			return `${ d.toLocaleDateString() } ${ d.getHours() }:${ d
-				.getMinutes()
-				.toString()
-				.padStart( 2, '0' ) }`;
-		},
-		numTicks: numTicks,
+		tickFormat: ( date: string ) =>
+			getLineChartTickLabel( date, timeRange, lessThanMediumViewport ),
+		numTicks: getLineChartTickNumber( timeRange, lessThanMediumViewport ),
 	};
 
 	const getLegendIcon = ( key: string ) => {

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -56,13 +56,13 @@ function useSiteRequestMethodsData( siteId: number, timeRange: number ): SiteReq
 
 			return Object.entries( methodsMap ).map(
 				( [ method, value ]: [ string, number ], index ): DataPointPercentage => {
-					const valuePercentage = Math.round( ( value * 100 ) / sum );
+					const valuePercentage = ( value * 100 ) / sum;
 
 					return {
 						label: method.toUpperCase(),
-						value: Math.round( value * 100 ) / 100,
+						value: value,
 						percentage: valuePercentage,
-						valueDisplay: valuePercentage.toString() + '%',
+						valueDisplay: ( Math.round( valuePercentage * 10 ) / 100 ).toString() + '%',
 						color: chartColors[ index % chartColors.length ],
 					};
 				}

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -4,23 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { convertTimeRangeToUnix, chartColors } from '../monitoring/utils';
 import MonitoringCard from '../monitoring-card';
-import type { LegendData, TimeRange } from '../monitoring/types';
+import type { LegendData } from '../monitoring/types';
 import type { Site, SiteHostingMetrics } from '@automattic/api-core';
-
-function convertTimeRangeToUnix( timeRange: number ): TimeRange {
-	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;
-	const end = Math.floor( new Date().getTime() / 1000 );
-
-	return { start, end };
-}
 
 type SiteRequestMethodsData = {
 	data: DataPointPercentage[];
 	isLoading: boolean;
 };
-
-const chartColors = [ '#3858E9', '#5BA300', '#F57600', '#B51963' ];
 
 function useSiteRequestMethodsData( siteId: number, timeRange: number ): SiteRequestMethodsData {
 	const { start, end } = useMemo( () => convertTimeRangeToUnix( timeRange ), [ timeRange ] );

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -1,7 +1,10 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
 import { DataPointPercentage, PieChart, Legend } from '@automattic/charts';
 import { useQuery } from '@tanstack/react-query';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MonitoringCard from '../monitoring-card';
@@ -57,14 +60,14 @@ function useResponseTypesData( siteId: number, timeRange: number ): ResponseType
 
 			return Object.entries( methodsMap ).map(
 				( [ method, value ]: [ string, number ], index ): DataPointPercentage => {
-					const valuePercentage = Math.round( ( value * 100 ) / sum );
+					const valuePercentage = ( value * 100 ) / sum;
 
 					return {
 						label:
 							method === 'php' ? 'Dynamic' : method.slice( 0, 1 ).toUpperCase() + method.slice( 1 ),
-						value: Math.round( value * 100 ) / 100,
+						value: value,
 						percentage: valuePercentage,
-						valueDisplay: valuePercentage.toString() + '%',
+						valueDisplay: ( Math.round( valuePercentage * 10 ) / 10 ).toString() + '%',
 						color: chartColors[ index % chartColors.length ],
 					};
 				}
@@ -104,17 +107,19 @@ export default function MonitoringResponseTypesCard( {
 			isLoading={ isLoading }
 			className="dashboard-monitoring-card--row-layout"
 		>
-			<Legend chartId="response-types-chart" items={ mapDataForLegend( data ) } />
-			<HStack alignment="center">
-				<PieChart
-					chartId="response-types-chart"
-					thickness={ 0.3 }
-					gapScale={ 0.02 }
-					size={ 300 }
-					data={ data }
-					showLabels={ false }
-				/>
-			</HStack>
+			<VStack justify="space-between" expanded>
+				<Legend chartId="response-types-chart" items={ mapDataForLegend( data ) } />
+				<HStack alignment="center">
+					<PieChart
+						chartId="response-types-chart"
+						thickness={ 0.3 }
+						gapScale={ 0.02 }
+						size={ 300 }
+						data={ data }
+						showLabels={ false }
+					/>
+				</HStack>
+			</VStack>
 		</MonitoringCard>
 	);
 }

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -7,23 +7,15 @@ import {
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { convertTimeRangeToUnix, chartColors } from '../monitoring/utils';
 import MonitoringCard from '../monitoring-card';
-import type { LegendData, TimeRange } from '../monitoring/types';
+import type { LegendData } from '../monitoring/types';
 import type { Site, SiteHostingMetrics } from '@automattic/api-core';
-
-function convertTimeRangeToUnix( timeRange: number ): TimeRange {
-	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;
-	const end = Math.floor( new Date().getTime() / 1000 );
-
-	return { start, end };
-}
 
 type ResponseTypesData = {
 	data: DataPointPercentage[];
 	isLoading: boolean;
 };
-
-const chartColors = [ '#3858E9', '#5BA300', '#F57600', '#B51963' ];
 
 function useResponseTypesData( siteId: number, timeRange: number ): ResponseTypesData {
 	const { start, end } = useMemo( () => convertTimeRangeToUnix( timeRange ), [ timeRange ] );

--- a/client/dashboard/sites/monitoring/utils.ts
+++ b/client/dashboard/sites/monitoring/utils.ts
@@ -1,0 +1,52 @@
+import type { TimeRange } from './types';
+
+export function convertTimeRangeToUnix( timeRange: number ): TimeRange {
+	const start = Math.floor( new Date().getTime() / 1000 ) - timeRange * 3600;
+	const end = Math.floor( new Date().getTime() / 1000 );
+
+	return { start, end };
+}
+
+export const chartColors = [ '#3858E9', '#5BA300', '#F57600', '#B51963' ];
+
+export function getLineChartTickNumber(
+	timeRange: number,
+	lessThanMediumViewport: boolean
+): number | undefined {
+	let numTicks: undefined | number;
+	switch ( timeRange ) {
+		case 168:
+			numTicks = lessThanMediumViewport ? 3 : 7;
+			break;
+		case 72:
+			numTicks = lessThanMediumViewport ? 3 : 6;
+			break;
+		case 24:
+		case 6:
+			numTicks = lessThanMediumViewport ? 4 : 12;
+			break;
+	}
+
+	return numTicks;
+}
+
+export function getLineChartTickLabel(
+	date: string,
+	timeRange: number,
+	lessThanMediumViewport: boolean
+): string {
+	const d = new Date( date );
+
+	if ( timeRange <= 24 ) {
+		return `${ d.getHours() }:${ d.getMinutes().toString().padStart( 2, '0' ) }`;
+	}
+
+	if ( timeRange > 72 || ( timeRange > 24 && lessThanMediumViewport ) ) {
+		return `${ d.toLocaleDateString() }`;
+	}
+
+	return `${ d.toLocaleDateString() } ${ d.getHours() }:${ d
+		.getMinutes()
+		.toString()
+		.padStart( 2, '0' ) }`;
+}


### PR DESCRIPTION
## Proposed Changes
* Extract some duplicated code into shared functions.
* Improve UI as suggested in the [previous PR](https://github.com/Automattic/wp-calypso/pull/106045#pullrequestreview-3268204025).
* Resolve the occasional total percentage issues by getting rid of rounding when unnecessary.

## Why are these changes being made?
https://linear.app/a8c/issue/DOTDASH-156

## Testing Instructions
1. Load the page `/v2/sites/your-site-slug/monitoring`, confirm all the charts show up fine.
2. Try switching between time spans, confirm the data gets refreshed correctly, and all the graph containers preserve their size during data loading.
3. Confirm the issues mentioned [here](https://github.com/Automattic/wp-calypso/pull/106045#pullrequestreview-3268204025) are resolved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
