### PR TITLE
Scan Dashboard: improve column sizing for better space allocation

### DIFF
--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -17,6 +17,17 @@ export function ActiveThreatsDataViews( { site }: { site: Site } ) {
 		fields: [ 'severity', 'threat', 'first_detected', 'auto_fix' ],
 		perPage: 10,
 		sort: { field: 'severity', direction: 'desc' },
+		layout: {
+			styles: {
+				threat: {
+					minWidth: '500px',
+				},
+				first_detected: {
+					maxWidth: '175px',
+					minWidth: '140px',
+				},
+			},
+		},
 	} );
 
 	const [ selection, setSelection ] = useState< string[] >( [] );

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -87,7 +87,7 @@ export function getFields(): Field< Threat >[] {
 			label: __( 'Details' ),
 			getValue: ( { item } ) => item.title,
 			render: ( { item } ) => (
-				<HStack spacing={ 2 } justify="flex-start" wrap>
+				<HStack spacing={ 2 } justify="flex-start">
 					<Icon
 						className="site-scan-threats__type-icon"
 						icon={ getThreatIcon( item ) }

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -19,6 +19,20 @@ export function ScanHistoryDataViews( { site }: { site: Site } ) {
 			field: 'fixed_on',
 			direction: 'desc',
 		},
+		layout: {
+			styles: {
+				status: {
+					maxWidth: '100px',
+				},
+				threat: {
+					minWidth: '500px',
+				},
+				fixed_on: {
+					maxWidth: '175px',
+					minWidth: '160px',
+				},
+			},
+		},
 	} );
 
 	const { data: scanHistory, isLoading } = useQuery( siteScanHistoryQuery( site.ID ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-519

## Proposed Changes

* Optimize column sizing in scan DataViews for better space allocation

| Tab | Before | After |
|---|---|---|
| Active | <img width="2188" height="1498" alt="CleanShot 2025-09-28 at 19 58 36@2x" src="https://github.com/user-attachments/assets/1a66be48-9e77-417c-939c-bfca8b891a31" /> | <img width="2188" height="1434" alt="CleanShot 2025-09-28 at 19 58 23@2x" src="https://github.com/user-attachments/assets/6637d778-ad7b-42f0-bf5e-56d3a7b20a47" /> |
| History | <img width="2198" height="1208" alt="CleanShot 2025-09-28 at 19 56 57@2x" src="https://github.com/user-attachments/assets/0badadc3-6aa8-4102-bc42-021a3d4fc411" /> | <img width="2198" height="1208" alt="CleanShot 2025-09-28 at 19 57 22@2x" src="https://github.com/user-attachments/assets/b94e5a29-74eb-4646-b2bf-349c9914c32b" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

DOTDASH-519

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/v2/sites/{site-slug}/scan` in the Hosting Dashboard.
2. Ensure the dataviews looks as images shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
