### PR TITLE
Hosting Dashboard: Site PHP and Web logs - introduce built-in infinite scroll 

### DIFF
--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -2,18 +2,12 @@ import { LogType, PHPLog, ServerLog, SiteLogsParams } from '@automattic/api-core
 import { siteLogsInfiniteQuery } from '@automattic/api-queries';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import {
-	ToggleControl,
-	Button,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
-} from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, View, Filter, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useEffect, useCallback } from 'react';
+import { useMemo, useEffect, useCallback, useRef, useLayoutEffect } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { LogsDownloader } from '../downloader';
 import {
@@ -45,6 +39,8 @@ export type SiteLogsDataViewsProps = {
 	site: Site;
 };
 
+const DEFAULT_PER_PAGE = 50;
+
 function SiteLogsDataViews( {
 	logType,
 	dateRange,
@@ -62,6 +58,8 @@ function SiteLogsDataViews( {
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 	const search = router.state.location.search;
+	const rafIdRef = useRef< number | null >( null );
+	const dataviewsRef = useRef< HTMLDivElement | null >( null );
 
 	const [ view, setView ] = useView( {
 		logType,
@@ -81,15 +79,55 @@ function SiteLogsDataViews( {
 		end: endSec,
 		filter,
 		sortOrder: view.sort?.direction,
-		pageSize: view.perPage,
+		pageSize: DEFAULT_PER_PAGE,
 	};
 
 	const { data, isLoading, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage } =
 		useInfiniteQuery( siteLogsInfiniteQuery( site.ID, params ) );
 
+	const handleResize = useCallback( () => {
+		if ( ! dataviewsRef.current ) {
+			return;
+		}
+
+		if ( rafIdRef.current ) {
+			cancelAnimationFrame( rafIdRef.current );
+		}
+
+		rafIdRef.current = requestAnimationFrame( () => {
+			if ( ! dataviewsRef.current ) {
+				return;
+			}
+
+			const { top } = dataviewsRef.current.getBoundingClientRect();
+			const maxHeight = window.innerHeight - top - 32 - 1;
+			dataviewsRef.current.style.maxHeight = `${ maxHeight }px`;
+		} );
+	}, [] );
+
 	useEffect( () => {
 		setView( ( value ) => ( { ...value, page: 1 } ) );
 	}, [ dateRangeVersion, setView ] );
+
+	useLayoutEffect( () => {
+		dataviewsRef.current = document.querySelector< HTMLDivElement >( '.dataviews-wrapper' );
+		if ( ! dataviewsRef.current ) {
+			return;
+		}
+
+		handleResize();
+		window.addEventListener( 'resize', handleResize );
+		window.addEventListener( 'orientationchange', handleResize );
+
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+			window.removeEventListener( 'orientationchange', handleResize );
+
+			if ( rafIdRef.current ) {
+				cancelAnimationFrame( rafIdRef.current );
+			}
+		};
+	}, [ logType, handleResize ] );
 
 	const phpLogs = useMemo< PhpLogWithId[] >( () => {
 		if ( logType !== LogType.PHP ) {
@@ -105,58 +143,7 @@ function SiteLogsDataViews( {
 		return buildServerLogsWithId( ( data?.pages as Array< { logs?: ServerLog[] } > ) ?? [] );
 	}, [ data?.pages, logType ] );
 
-	const currentPage = view.page ?? 1;
-	const perPage = view.perPage ?? 50;
-	const displayedPhpLogs = useMemo(
-		() => phpLogs.slice( 0, currentPage * perPage ),
-		[ phpLogs, currentPage, perPage ]
-	);
-	const displayedServerLogs = useMemo(
-		() => serverLogs.slice( 0, currentPage * perPage ),
-		[ serverLogs, currentPage, perPage ]
-	);
-
-	const handleLoadMore = useCallback( () => {
-		// Reveal what we already have loaded
-		const totalLoaded = logType === LogType.PHP ? phpLogs.length : serverLogs.length;
-		const displayedCount =
-			logType === LogType.PHP ? displayedPhpLogs.length : displayedServerLogs.length;
-		if ( displayedCount < totalLoaded ) {
-			setView( ( prev ) => ( { ...prev, page: ( prev.page ?? 1 ) + 1 } ) );
-		}
-
-		// Proactively fetch the next cursor page when we're within one page of the end.
-		// This keeps hasNextPage accurate and lets the "Load more" button reveal items immediately.
-		const remainingLoaded =
-			( logType === LogType.PHP ? phpLogs.length : serverLogs.length ) - currentPage * perPage;
-		const shouldPrefetch = hasNextPage && ! isFetchingNextPage && remainingLoaded <= perPage;
-		if ( shouldPrefetch ) {
-			fetchNextPage();
-		}
-	}, [
-		displayedPhpLogs.length,
-		displayedServerLogs.length,
-		phpLogs.length,
-		serverLogs.length,
-		logType,
-		currentPage,
-		perPage,
-		hasNextPage,
-		isFetchingNextPage,
-		fetchNextPage,
-		setView,
-	] );
-
-	const scrollToTop = () => {
-		window.scrollTo( 0, 0 );
-	};
-
 	const fields = useFields( { logType, timezoneString, gmtOffset } );
-
-	const paginationInfo = {
-		totalItems: logType === LogType.PHP ? displayedPhpLogs.length : displayedServerLogs.length,
-		totalPages: 1,
-	};
 
 	const onChangeView = ( next: View ) => {
 		// Disable auto-refresh when the user changes the page
@@ -256,12 +243,33 @@ function SiteLogsDataViews( {
 		</>
 	);
 
+	const logs = logType === LogType.PHP ? phpLogs : serverLogs;
+
+	const infiniteScrollHandler = useCallback( () => {
+		if ( hasNextPage && ! isFetchingNextPage ) {
+			fetchNextPage();
+		}
+	}, [ hasNextPage, isFetchingNextPage, fetchNextPage ] );
+
+	const paginationInfo = {
+		totalItems: logs.length,
+		totalPages: 1,
+		infiniteScrollHandler,
+	};
+
+	useEffect( () => {
+		setView( ( currentView ) => ( {
+			...currentView,
+			perPage: Math.max( logs.length, currentView.perPage ?? DEFAULT_PER_PAGE ),
+		} ) );
+	}, [ logs.length, setView ] );
+
 	return (
 		<>
 			{ logType === LogType.PHP ? (
 				<DataViews< PHPLog >
-					data={ displayedPhpLogs }
-					isLoading={ isLoading && displayedPhpLogs.length === 0 }
+					data={ phpLogs }
+					isLoading={ isLoading }
 					paginationInfo={ paginationInfo }
 					fields={ fields as Field< PHPLog >[] }
 					getItemId={ ( item ) => item.id }
@@ -274,8 +282,8 @@ function SiteLogsDataViews( {
 				/>
 			) : (
 				<DataViews< ServerLog >
-					data={ displayedServerLogs }
-					isLoading={ isLoading && displayedServerLogs.length === 0 }
+					data={ serverLogs }
+					isLoading={ isLoading }
 					paginationInfo={ paginationInfo }
 					fields={ fields as Field< ServerLog >[] }
 					getItemId={ ( item ) => item.id }
@@ -287,27 +295,6 @@ function SiteLogsDataViews( {
 					header={ LogsHeader }
 				/>
 			) }
-
-			<VStack spacing={ 2 }>
-				<Spacer margin={ 0 } paddingTop={ 3 } />
-				<HStack alignment="center" spacing={ 2 }>
-					<Button
-						variant="primary"
-						onClick={ handleLoadMore }
-						disabled={
-							! hasNextPage &&
-							( logType === LogType.PHP ? displayedPhpLogs.length : displayedServerLogs.length ) >=
-								( logType === LogType.PHP ? phpLogs.length : serverLogs.length )
-						}
-					>
-						{ __( 'Load more' ) }
-					</Button>
-					<Button variant="tertiary" onClick={ scrollToTop }>
-						{ __( 'Back to top' ) }
-					</Button>
-				</HStack>
-				<Spacer margin={ 0 } paddingTop={ 3 } />
-			</VStack>
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106042

## Proposed Changes

* Introduce built-in infinite scroll

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
