### PR TITLE
Dashboard v2: fix DataViews empty state regression

### DIFF
--- a/client/dashboard/components/dataviews-empty-state/index.tsx
+++ b/client/dashboard/components/dataviews-empty-state/index.tsx
@@ -9,7 +9,6 @@ interface DataViewsEmptyStateProps {
 	description: string;
 	illustration?: ReactNode;
 	title: string;
-	mutedDescription?: boolean;
 }
 
 export function DataViewsEmptyState( {
@@ -17,18 +16,13 @@ export function DataViewsEmptyState( {
 	title,
 	illustration,
 	description,
-	mutedDescription = true,
 }: DataViewsEmptyStateProps ) {
 	return (
 		<VStack spacing={ 6 } alignment="center" className="dashboard-dataviews-empty-state">
 			{ illustration }
 			<VStack spacing={ 2 } alignment="center">
 				<div className="dashboard-dataviews-empty-state__heading">{ title }</div>
-				<Text
-					variant={ mutedDescription ? 'muted' : undefined }
-					align="center"
-					className="dashboard-dataviews-empty-state__sub-heading"
-				>
+				<Text align="center" className="dashboard-dataviews-empty-state__sub-heading">
 					{ description }
 				</Text>
 			</VStack>

--- a/client/dashboard/domains/domain-forwarding/index.tsx
+++ b/client/dashboard/domains/domain-forwarding/index.tsx
@@ -10,7 +10,6 @@ import {
 	domainForwardingEditRoute,
 } from '../../app/router/domains';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { DataViewsEmptyState } from '../../components/dataviews-empty-state';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -174,13 +173,7 @@ function DomainForwarding() {
 					paginationInfo={ paginationInfo }
 					getItemId={ getForwardingId }
 					defaultLayouts={ DEFAULT_LAYOUTS }
-					empty={
-						<DataViewsEmptyState
-							title=""
-							description={ __( 'No forwarding rules found for this domain.' ) }
-							mutedDescription={ false }
-						/>
-					}
+					empty={ <p>{ __( 'No forwarding rules found for this domain.' ) }</p> }
 				/>
 			</DataViewsCard>
 		</PageLayout>

--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -11,7 +11,6 @@ import {
 	domainGlueRecordsEditRoute,
 } from '../../app/router/domains';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { DataViewsEmptyState } from '../../components/dataviews-empty-state';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -149,15 +148,11 @@ function DomainGlueRecords() {
 					isLoading={ isLoading }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					empty={
-						<DataViewsEmptyState
-							title=""
-							description={
-								view.search
-									? __( 'No glue records found.' )
-									: __( 'No glue records found for this domain.' )
-							}
-							mutedDescription={ false }
-						/>
+						<p>
+							{ view.search
+								? __( 'No glue records found.' )
+								: __( 'No glue records found for this domain.' ) }
+						</p>
 					}
 				/>
 			</DataViewsCard>

--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -144,7 +144,7 @@ export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
 					onChangeView={ setView }
 					selection={ selection }
 					onChangeSelection={ handleSelectionChange }
-					empty={ getEmptyStateMessage() }
+					empty={ <p>{ getEmptyStateMessage() }</p> }
 				>
 					<DataViews.Layout />
 				</DataViews>

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -9,7 +9,6 @@ import { closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { DataViewsEmptyState } from '../../components/dataviews-empty-state';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -195,13 +194,7 @@ export default function BlockedSites() {
 						...paginationInfo,
 						infiniteScrollHandler,
 					} }
-					empty={
-						<DataViewsEmptyState
-							title=""
-							description={ __( 'You haven’t blocked any sites yet.' ) }
-							mutedDescription={ false }
-						/>
-					}
+					empty={ <p>{ __( 'You haven’t blocked any sites yet.' ) }</p> }
 					isLoading={ isLoading }
 					onChangeView={ setView }
 				>

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -17,7 +17,6 @@ import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews-card';
 import InlineSupportLink from '../../components/inline-support-link';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
 import SecurityPageHeader from '../security-page-header';
 import ApplicationDetailsModal from './application-details-modal';
 import type { ConnectedApplication } from '@automattic/api-core';
@@ -163,11 +162,7 @@ export default function SecurityConnectedApps() {
 					onChangeView={ () => {} }
 					defaultLayouts={ { table: {} } }
 					paginationInfo={ { totalItems, totalPages: 1 } }
-					empty={
-						<Text as="p" variant="muted" style={ { paddingBlock: '48px' } }>
-							{ __( 'You haven’t connected any apps yet.' ) }
-						</Text>
-					}
+					empty={ <p>{ __( 'You haven’t connected any apps yet.' ) }</p> }
 				>
 					<DataViews.Layout />
 				</DataViews>

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -108,7 +108,7 @@ const ApplicationPasswordsList = ( {
 				getItemId={ ( item ) => item.ID }
 				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
 				defaultLayouts={ { list: {} } }
-				empty={ __( 'No application passwords added.' ) }
+				empty={ <p>{ __( 'No application passwords added.' ) }</p> }
 				isLoading={ isLoading }
 				actions={ [
 					{

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -75,7 +75,7 @@ const SecurityKeysList = ( {
 				getItemId={ ( item ) => item.id }
 				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
 				defaultLayouts={ { list: {} } }
-				empty={ __( 'No security keys registered.' ) }
+				empty={ <p>{ __( 'No security keys registered.' ) }</p> }
 				isLoading={ isLoading }
 				actions={ [
 					{

--- a/client/dashboard/plugins/scheduled-updates/new/plugins-selection/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/plugins-selection/index.tsx
@@ -2,7 +2,6 @@ import { DataViews, Field, View, filterSortAndPaginate, type Action } from '@wor
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../../../../components/dataviews-card';
-import { DataViewsEmptyState } from '../../../../components/dataviews-empty-state';
 import { useEligiblePlugins } from '../../hooks/use-eligible-plugins';
 import type { CorePlugin } from '@automattic/api-core';
 
@@ -67,13 +66,7 @@ function ScheduledUpdatesPluginsSelection( {
 				actions={ actions }
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ paginationInfo }
-				empty={
-					<DataViewsEmptyState
-						title=""
-						description={ __( 'Please select a site to view available plugins.' ) }
-						mutedDescription={ false }
-					/>
-				}
+				empty={ <p>{ __( 'Please select a site to view available plugins.' ) }</p> }
 			/>
 		</DataViewsCard>
 	);

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -11,7 +11,6 @@ import { Icon, seen } from '@wordpress/icons';
 import { useState, useMemo } from 'react';
 import { siteRoute, siteSettingsRepositoriesRoute } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
-import { DataViewsEmptyState } from '../../components/dataviews-empty-state';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -180,15 +179,11 @@ function DeploymentsList() {
 					paginationInfo={ paginationInfo }
 					getItemId={ ( item ) => item.id.toString() }
 					empty={
-						<DataViewsEmptyState
-							title=""
-							description={
-								( view.filters && view.filters.length > 0 ) || view.search
-									? __( 'No deployments found' )
-									: __( 'No deployments yet' )
-							}
-							mutedDescription={ false }
-						/>
+						<p>
+							{ ( view.filters && view.filters.length > 0 ) || view.search
+								? __( 'No deployments found' )
+								: __( 'No deployments yet' ) }
+						</p>
 					}
 				/>
 			</DataViewsCard>

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -94,7 +94,7 @@ export default function LatestActivityCard( {
 						getItemId={ ( item ) => item.activity_id }
 						paginationInfo={ { totalItems: data.length, totalPages: 1 } }
 						defaultLayouts={ { list: {} } }
-						empty={ __( 'No activity yet.' ) }
+						empty={ <p>{ __( 'No activity yet.' ) }</p> }
 					>
 						<DataViews.Layout />
 					</DataViews>

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -90,7 +90,7 @@ function RepositoriesList() {
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item ) => item.repository_name }
-				empty={ emptyTitle }
+				empty={ <p>{ emptyTitle }</p> }
 			/>
 		</DataViewsCard>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

We recently upgraded DataViews to v9:

- https://github.com/Automattic/wp-calypso/pull/105961

We found a regression around DataViews empty state. The new version omits the outer `<p>` now from the empty state component, so we're losing the margins.

In this PR, I fixed that by wrapping all `string` empty state with `<p>`. I also took the opportunity to remove `muted` variant from `<DataViewsEmptyState>`'s `description` for consistency. It's also because that the default DataViews empty state (from Gutenberg's storybook) does not have this gray color.

|Before|After|
|-|-|
|<img width="512" height="123" alt="image" src="https://github.com/user-attachments/assets/71185a5a-d4e7-46dc-9ac7-4cef7951f310" />|<img width="518" height="133" alt="image" src="https://github.com/user-attachments/assets/578622ca-7a1c-4647-b742-2411495baa58" />|


## Testing Instructions

1. It's easiest to check the code changes.
2. Try to smoke test some of the changes; see the screenshot above for example.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
