### PR TITLE
Dashboard v2: Fix the SSL status on the wpcom domain

### DIFF
--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
 	const { data: sslDetails } = useQuery( sslDetailsQuery( domain.domain ) );
 
-	if ( sslDetails?.certificate_provisioned ) {
+	if ( sslDetails?.certificate_provisioned || domain.wpcom_domain ) {
 		return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
 	}
 

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -139,7 +139,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 	};
 
 	const renderBadge = () => {
-		if ( sslDetails.certificate_provisioned ) {
+		if ( sslDetails.certificate_provisioned || domain.wpcom_domain ) {
 			return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
 		}
 		return <Badge intent="warning">{ __( 'SSL pending' ) }</Badge>;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the SSL status on the wpcom domain as it should always be active

| Before | After |
|-|-|
| <img width="119" height="47" alt="image" src="https://github.com/user-attachments/assets/0d449df8-0b8a-4629-8901-c934ac29c36a" />|<img width="107" height="47" alt="image" src="https://github.com/user-attachments/assets/dd4217c2-1877-45b9-a994-faba62daa51b" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/domains
* Ensure the SSL status on the wpcom domain is `SSL active` instead of `SSL pending`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
