### PR TITLE
e2e tests: skip Apple authentication tests

### DIFF
--- a/test/e2e/specs/authentication/authentication__apple.spec.ts
+++ b/test/e2e/specs/authentication/authentication__apple.spec.ts
@@ -7,6 +7,10 @@ test.describe( 'Authentication: Apple', { tag: [ tags.AUTHENTICATION ] }, () => 
 		DataHelper.isCalypsoProduction() === false,
 		'Skipping unless running on WordPress.com as Apple authentication requires prod callbacks'
 	);
+	test.skip(
+		true,
+		'Skipping Apple authentication tests as they are too unreliable (account often get locked on Apple)'
+	);
 
 	test( 'As a WordPress.com user, I can use my Apple Id to authenticate ', async ( {
 		clientEmail,

--- a/test/e2e/specs/authentication/authentication__apple.spec.ts
+++ b/test/e2e/specs/authentication/authentication__apple.spec.ts
@@ -7,10 +7,6 @@ test.describe( 'Authentication: Apple', { tag: [ tags.AUTHENTICATION ] }, () => 
 		DataHelper.isCalypsoProduction() === false,
 		'Skipping unless running on WordPress.com as Apple authentication requires prod callbacks'
 	);
-	test.skip(
-		true,
-		'Skipping Apple authentication tests as they are too unreliable (account often get locked on Apple)'
-	);
 
 	test( 'As a WordPress.com user, I can use my Apple Id to authenticate ', async ( {
 		clientEmail,

--- a/test/e2e/specs/authentication/authentication__apple.spec.ts
+++ b/test/e2e/specs/authentication/authentication__apple.spec.ts
@@ -9,7 +9,7 @@ test.describe( 'Authentication: Apple', { tag: [ tags.AUTHENTICATION ] }, () => 
 	);
 	test.skip(
 		true,
-		'Skipping Apple authentication tests as they are too unreliable (account often get locked on Apple)'
+		'Skipping Apple authentication tests as they are too unreliable (account gets locked on Apple)'
 	);
 
 	test( 'As a WordPress.com user, I can use my Apple Id to authenticate ', async ( {


### PR DESCRIPTION


## Proposed Changes

Skip Apple authentication e2e tests.

## Testing Instructions

Run `yarn test:pw:authentication`. `authentication__apple.spec.ts` is skipped.

