### PR TITLE
File Browser: Display `Empty` text when file browser node has no children

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -324,7 +324,7 @@ function FileBrowserNode( {
 				return (
 					<Text
 						variant="muted"
-						style={ { marginInlineStart: showSeparateExpandButton ? 43 : 63, fontStyle: 'italic' } }
+						style={ { marginInlineStart: showSeparateExpandButton ? 36 : 63, fontStyle: 'italic' } }
 					>
 						{ __( 'Empty' ) }
 					</Text>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -3,6 +3,7 @@ import {
 	CheckboxControl,
 	Icon,
 	Spinner,
+	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -281,7 +282,7 @@ function FileBrowserNode( {
 		if ( isSuccess && addedAnyChildren ) {
 			let childIsAlternate = isAlternate;
 
-			return backupFiles.filter( filterItems ).map( ( childItem ) => {
+			const renderedChildren = backupFiles.filter( filterItems ).map( ( childItem ) => {
 				// Let's hide archives that don't have an extension version
 				// and changed extensions item node
 				if (
@@ -318,6 +319,19 @@ function FileBrowserNode( {
 					</div>
 				);
 			} );
+
+			if ( renderedChildren.length === 0 ) {
+				return (
+					<Text
+						variant="muted"
+						style={ { marginInlineStart: showSeparateExpandButton ? 43 : 63, fontStyle: 'italic' } }
+					>
+						{ __( 'Empty' ) }
+					</Text>
+				);
+			}
+
+			return renderedChildren;
 		}
 
 		return null;

--- a/client/sites/staging-site/components/staging-site-sync-modal/style.scss
+++ b/client/sites/staging-site/components/staging-site-sync-modal/style.scss
@@ -11,17 +11,17 @@
 		display: none;
 	}
 
-	.components-checkbox-control__input[type="checkbox"]:disabled:checked {
+	.components-checkbox-control__input[type='checkbox']:disabled:checked {
 		background: #f0f0f0;
 		border-color: #ddd;
 	}
 
-	.components-checkbox-control:has(input[disabled]:checked) {
+	.components-checkbox-control:has( input[disabled]:checked ) {
 		.components-checkbox-control__checked {
 			fill: #a0a5aa;
 		}
 	}
-	
+
 	.components-select-control__input[disabled] {
 		color: #a0a5aa;
 		background-color: #f7f7f7;
@@ -93,7 +93,6 @@
 	}
 
 	.components-checkbox-control {
-		margin-left: 4px;
 		font-size: $font-body-small;
 	}
 
@@ -161,10 +160,6 @@
 		.file-browser-header__selecting {
 			display: none;
 		}
-	}
-
-	.file-browser-node .components-checkbox-control {
-		margin-left: 8px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14747

## Proposed Changes

* Display `Empty` text when file browser node has no children.

| Before | After |
|--------|--------|
| <img width="462" height="692" alt="Markup on 2025-09-29 at 12:13:31" src="https://github.com/user-attachments/assets/d8e770c9-dccc-4234-ba75-6027fbe0bb0e" /> | <img width="464" height="708" alt="Markup on 2025-09-29 at 12:12:22" src="https://github.com/user-attachments/assets/8958b1f5-ff48-4867-9782-2f69ca84a16e" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change is getting the file browser in Calypso closer to the file browser in the Studio app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. If you don't have a WoA site with empty folder (e.g. `/uploads`), create one.
3. Browse the site files through its fresh backup, either through the `Backups` tab: `http://calypso.localhost:3000/v2/sites/{site-slug}/backups/` - or - through the Sync modal of a staging site at the `Overview` tab: `http://calypso.localhost:3000/v2/sites/`.
4. When you open an empty folder, e.g. `/uploads`, `Empty` text should display.
5. There should be no unexpected regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
