### PR TITLE
Hide titles on mobile for staging sites sync modal

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -16,6 +16,7 @@ import {
 	CheckboxControl,
 	SelectControl,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement, useState, useCallback, useMemo } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
@@ -72,11 +73,12 @@ interface EnvironmentLabelProps {
 }
 
 const EnvironmentLabel = ( { environmentType, siteTitle }: EnvironmentLabelProps ) => {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	return (
 		<VStack spacing={ 1 }>
 			<HStack spacing={ 2 }>
 				<Environment environmentType={ environmentType } />
-				{ siteTitle && (
+				{ siteTitle && ! isSmallViewport && (
 					<Text
 						variant="muted"
 						style={ {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-14595

## Proposed Changes

This PR hides the titles for the staging and production sites on mobile from the staging site sync modal as discussed in https://linear.app/a8c/issue/DOTCOM-14595/hard-to-read-pull-=-to-site-titles-on-mobile#comment-0260a957

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have a staging site and an Atomic site
* Navigate to `/v2/sites/{yourAtomicSite}`
* Switch to the mobile view
* Click on the `Sync` button to open the modal
* Confirm that the titles of the staging and production sites are hidden
* Confirm that the titles are still present when you switch to the regular view 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
