### PR TITLE
Update/hd backup scan hooks unit tests

### DIFF
--- a/client/dashboard/sites/backups/test/use-backup-state.test.tsx
+++ b/client/dashboard/sites/backups/test/use-backup-state.test.tsx
@@ -155,6 +155,45 @@ describe( 'useBackupState', () => {
 				expect( result.current.status ).toBe( 'running' );
 			} );
 		} );
+
+		it( 'should continue tracking a backup that is still running', async () => {
+			const runningBackup = createBackupEntry( {
+				status: BackupEntryStatuses.STARTED,
+				percent: '50',
+				period: '1756169052',
+			} );
+			mockBackupsAPI( [ runningBackup ] );
+
+			const { result } = renderHook( () => useBackupState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'running' );
+				expect( result.current.backup?.period ).toBe( '1756169052' );
+			} );
+
+			// Update mock with same backup still running (no status change)
+			const stillRunningBackup = createBackupEntry( {
+				status: BackupEntryStatuses.STARTED,
+				period: '1756169052',
+				percent: '75', // Progress updated but still running
+			} );
+			mockBackupsAPI( [ stillRunningBackup ] );
+
+			// Trigger refetch to simulate polling
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'backups' ],
+			} );
+
+			// Should still be tracking the same backup
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'running' );
+				expect( result.current.backup?.period ).toBe( '1756169052' );
+				expect( result.current.backup?.percent ).toBe( '75' );
+				expect( result.current.hasRecentlyCompleted ).toBe( false );
+			} );
+		} );
 	} );
 
 	describe( 'success state', () => {

--- a/client/dashboard/sites/backups/test/use-backup-state.test.tsx
+++ b/client/dashboard/sites/backups/test/use-backup-state.test.tsx
@@ -5,21 +5,20 @@ import {
 	type BackupEntry,
 	BackupEntryStatuses,
 	BackupEntryErrorStatuses,
+	fetchSiteBackups,
 } from '@automattic/api-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
-import wpcom from 'calypso/lib/wp';
 import { useBackupState } from '../use-backup-state';
 
-// Mock lib/wp to return data directly from our test setup
-jest.mock( 'calypso/lib/wp', () => ( {
-	req: {
-		get: jest.fn(),
-	},
+// Mock the specific fetcher function used by siteBackupsQuery
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchSiteBackups: jest.fn(),
 } ) );
 
-const wpMock = wpcom;
+const mockFetchSiteBackups = fetchSiteBackups as jest.MockedFunction< typeof fetchSiteBackups >;
 
 // Test data factory
 const createBackupEntry = ( overrides: Partial< BackupEntry > = {} ): BackupEntry => ( {
@@ -53,19 +52,14 @@ function TestWrapper( { children }: { children: React.ReactNode } ) {
 	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
 }
 
-// Mock backups API endpoint by setting up the mock response
-function mockBackupsAPI( siteId: number, backups: BackupEntry[] ) {
-	wpMock.req.get.mockImplementation( ( path: string ) => {
-		if ( path === `/sites/${ siteId }/rewind/backups` ) {
-			return Promise.resolve( backups );
-		}
-		return Promise.reject( new Error( `Unexpected path: ${ path }` ) );
-	} );
+// Mock backups API by setting up the mock response
+function mockBackupsAPI( backups: BackupEntry[] ) {
+	mockFetchSiteBackups.mockResolvedValue( backups );
 }
 
 // Clean up after each test
 afterEach( () => {
-	wpMock.req.get.mockReset();
+	mockFetchSiteBackups.mockReset();
 } );
 
 describe( 'useBackupState', () => {
@@ -73,7 +67,7 @@ describe( 'useBackupState', () => {
 
 	beforeEach( () => {
 		// Default to empty backups list
-		mockBackupsAPI( mockSiteId, [] );
+		mockBackupsAPI( [] );
 	} );
 
 	describe( 'idle state', () => {
@@ -94,7 +88,7 @@ describe( 'useBackupState', () => {
 				status: BackupEntryStatuses.FINISHED,
 				percent: '100',
 			} );
-			mockBackupsAPI( mockSiteId, [ finishedBackup ] );
+			mockBackupsAPI( [ finishedBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -112,7 +106,7 @@ describe( 'useBackupState', () => {
 				status: BackupEntryStatuses.ERROR,
 				percent: '95',
 			} );
-			mockBackupsAPI( mockSiteId, [ failedBackup ] );
+			mockBackupsAPI( [ failedBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -133,7 +127,7 @@ describe( 'useBackupState', () => {
 				percent: '45',
 				period: '1756169052',
 			} );
-			mockBackupsAPI( mockSiteId, [ runningBackup ] );
+			mockBackupsAPI( [ runningBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -151,7 +145,7 @@ describe( 'useBackupState', () => {
 				status: BackupEntryStatuses.STARTED,
 				percent: '',
 			} );
-			mockBackupsAPI( mockSiteId, [ backupWithoutPercent ] );
+			mockBackupsAPI( [ backupWithoutPercent ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -171,7 +165,7 @@ describe( 'useBackupState', () => {
 				period: '1756169052',
 				percent: '75',
 			} );
-			mockBackupsAPI( mockSiteId, [ progressBackup ] );
+			mockBackupsAPI( [ progressBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -190,7 +184,7 @@ describe( 'useBackupState', () => {
 				period: '1756169052',
 				percent: '100',
 			} );
-			mockBackupsAPI( mockSiteId, [ completedBackup ] );
+			mockBackupsAPI( [ completedBackup ] );
 
 			// Manually refetch the query to simulate the polling behavior
 			await testQueryClient.refetchQueries( {
@@ -211,7 +205,7 @@ describe( 'useBackupState', () => {
 				period: '1756169052',
 				percent: '100',
 			} );
-			mockBackupsAPI( mockSiteId, [ completedBackup ] );
+			mockBackupsAPI( [ completedBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -230,7 +224,7 @@ describe( 'useBackupState', () => {
 				status: BackupEntryErrorStatuses.ERROR,
 				period: '1756169052',
 			} );
-			mockBackupsAPI( mockSiteId, [ failedBackup ] );
+			mockBackupsAPI( [ failedBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -249,7 +243,7 @@ describe( 'useBackupState', () => {
 				period: '1756169052',
 				percent: '30',
 			} );
-			mockBackupsAPI( mockSiteId, [ progressBackup ] );
+			mockBackupsAPI( [ progressBackup ] );
 
 			const { result } = renderHook( () => useBackupState( mockSiteId ), {
 				wrapper: TestWrapper,
@@ -267,7 +261,7 @@ describe( 'useBackupState', () => {
 				status: BackupEntryErrorStatuses.ERROR,
 				period: '1756169052',
 			} );
-			mockBackupsAPI( mockSiteId, [ failedBackup ] );
+			mockBackupsAPI( [ failedBackup ] );
 
 			// Manually refetch the query to simulate the polling behavior
 			await testQueryClient.refetchQueries( {

--- a/client/dashboard/sites/scan/test/use-scan-state.test.tsx
+++ b/client/dashboard/sites/scan/test/use-scan-state.test.tsx
@@ -1,0 +1,440 @@
+/**
+ * @jest-environment jsdom
+ */
+import { type SiteScan, fetchSiteScan } from '@automattic/api-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { useScanState } from '../use-scan-state';
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchSiteScan: jest.fn(),
+} ) );
+
+const mockFetchSiteScan = fetchSiteScan as jest.MockedFunction< typeof fetchSiteScan >;
+
+const createSiteScan = ( overrides: Partial< SiteScan > = {} ): SiteScan => ( {
+	state: 'idle',
+	threats: [],
+	has_cloud: true,
+	current: undefined,
+	most_recent: {
+		is_initial: false,
+		timestamp: '2025-08-26T00:44:15Z',
+		duration: 120,
+		progress: 100,
+		error: false,
+	},
+	...overrides,
+} );
+
+let testQueryClient: QueryClient;
+
+function TestWrapper( { children }: { children: React.ReactNode } ) {
+	const [ queryClient ] = React.useState(
+		() =>
+			new QueryClient( {
+				defaultOptions: {
+					queries: { retry: false },
+				},
+			} )
+	);
+
+	testQueryClient = queryClient;
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+function mockScanAPI( scan: SiteScan ) {
+	mockFetchSiteScan.mockResolvedValue( scan );
+}
+
+afterEach( () => {
+	mockFetchSiteScan.mockReset();
+} );
+
+describe( 'useScanState', () => {
+	const mockSiteId = 123;
+
+	beforeEach( () => {
+		mockScanAPI( createSiteScan() );
+	} );
+
+	describe( 'idle state', () => {
+		it( 'should return idle when first establishing timestamp baseline', async () => {
+			const scanWithNewTimestamp = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T10:00:00Z',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( scanWithNewTimestamp );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+				expect( typeof result.current.setIsEnqueued ).toBe( 'function' );
+			} );
+		} );
+
+		it( 'should return idle state for default scan data', async () => {
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+				expect( typeof result.current.setIsEnqueued ).toBe( 'function' );
+			} );
+		} );
+	} );
+
+	describe( 'enqueued state', () => {
+		it( 'should return enqueued state when manually enqueued', async () => {
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+
+			act( () => {
+				result.current.setIsEnqueued( true );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'enqueued' );
+			} );
+		} );
+
+		it( 'should reset success state when enqueued', async () => {
+			const scan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T00:44:15Z',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( scan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+
+			const newScan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T01:00:00Z',
+					duration: 130,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( newScan );
+
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'scan' ],
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'success' );
+			} );
+			act( () => {
+				result.current.setIsEnqueued( true );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'enqueued' );
+			} );
+		} );
+	} );
+
+	describe( 'running state', () => {
+		it( 'should detect when scan is currently running', async () => {
+			const runningScan = createSiteScan( {
+				state: 'scanning',
+				current: {
+					is_initial: false,
+					timestamp: '2025-08-26T01:00:00Z',
+					progress: 50,
+				},
+				most_recent: undefined,
+			} );
+			mockScanAPI( runningScan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'running' );
+				expect( result.current.scan ).toEqual( runningScan );
+			} );
+		} );
+
+		it( 'should reset isEnqueued when scan starts running', async () => {
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			act( () => {
+				result.current.setIsEnqueued( true );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'enqueued' );
+			} );
+
+			const runningScan = createSiteScan( {
+				state: 'scanning',
+				current: {
+					is_initial: false,
+					timestamp: '2025-08-26T01:00:00Z',
+					progress: 25,
+				},
+				most_recent: undefined,
+			} );
+			mockScanAPI( runningScan );
+
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'scan' ],
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'running' );
+			} );
+		} );
+	} );
+
+	describe( 'success state', () => {
+		it( 'should return success when hasSucceeded is true', async () => {
+			const scan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T00:44:15Z',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( scan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+
+			// Simulate scan completion with new timestamp
+			const completedScan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T01:00:00Z', // New timestamp
+					duration: 130,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( completedScan );
+
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'scan' ],
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'success' );
+				expect( result.current.scan ).toEqual( completedScan );
+			} );
+		} );
+
+		it( 'should detect new scan completion by timestamp change', async () => {
+			const initialScan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T00:44:15Z',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( initialScan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+
+			const newScan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T02:00:00Z', // Different timestamp
+					duration: 125,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( newScan );
+
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'scan' ],
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'success' );
+			} );
+		} );
+	} );
+
+	describe( 'error state', () => {
+		it( 'should return error state when scan has error and no timestamp', async () => {
+			const errorScan = createSiteScan( {
+				state: 'idle',
+				current: undefined,
+				most_recent: {
+					is_initial: false,
+					timestamp: '',
+					duration: 60,
+					progress: 45,
+					error: true,
+				},
+			} );
+			mockScanAPI( errorScan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'error' );
+				expect( result.current.scan ).toEqual( errorScan );
+			} );
+		} );
+
+		it( 'should return error state with same timestamp as baseline', async () => {
+			const initialScan = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T00:44:15Z',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( initialScan );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+			const errorScan = createSiteScan( {
+				state: 'idle',
+				current: undefined,
+				most_recent: {
+					is_initial: false,
+					timestamp: '2025-08-26T00:44:15Z',
+					duration: 60,
+					progress: 45,
+					error: true,
+				},
+			} );
+			mockScanAPI( errorScan );
+
+			await testQueryClient.refetchQueries( {
+				queryKey: [ 'site', mockSiteId, 'scan' ],
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'error' );
+				expect( result.current.scan ).toEqual( errorScan );
+			} );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'should handle empty timestamp', async () => {
+			const scanWithoutTimestamp = createSiteScan( {
+				most_recent: {
+					is_initial: false,
+					timestamp: '',
+					duration: 120,
+					progress: 100,
+					error: false,
+				},
+			} );
+			mockScanAPI( scanWithoutTimestamp );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+		} );
+
+		it( 'should handle missing most_recent data', async () => {
+			const scanWithoutMostRecent = createSiteScan( {
+				most_recent: undefined,
+				current: undefined,
+			} );
+			mockScanAPI( scanWithoutMostRecent );
+
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+		} );
+	} );
+
+	describe( 'setIsEnqueued function', () => {
+		it( 'should toggle enqueued state', async () => {
+			const { result } = renderHook( () => useScanState( mockSiteId ), {
+				wrapper: TestWrapper,
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+
+			act( () => {
+				result.current.setIsEnqueued( true );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'enqueued' );
+			} );
+			act( () => {
+				result.current.setIsEnqueued( false );
+			} );
+
+			await waitFor( () => {
+				expect( result.current.status ).toBe( 'idle' );
+			} );
+		} );
+	} );
+} );

--- a/packages/api-core/src/site-scan/types.ts
+++ b/packages/api-core/src/site-scan/types.ts
@@ -52,7 +52,7 @@ export interface SiteScan {
 	state: 'unavailable' | 'idle' | 'scanning' | 'provisioning';
 	threats: Threat[];
 	has_cloud: boolean;
-	current: {
+	current?: {
 		is_initial: boolean;
 		timestamp: string;
 		progress: number;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
