### PR TITLE
Dashboard v2: Adjust DateRangePicker UI to match designs

### DIFF
--- a/client/dashboard/components/date-range-picker/index.tsx
+++ b/client/dashboard/components/date-range-picker/index.tsx
@@ -53,7 +53,7 @@ export function DateRangePicker( {
 						<div className="daterange-input__toggle">
 							<Button
 								type="button"
-								variant="secondary"
+								variant="tertiary"
 								onClick={ onToggle }
 								aria-haspopup="dialog"
 								aria-expanded={ isOpen }

--- a/client/dashboard/components/date-range-picker/style.scss
+++ b/client/dashboard/components/date-range-picker/style.scss
@@ -5,24 +5,46 @@
 	align-items: center;
 	width: 100%;
 
-	> * { flex: 0 0 auto; }
+	> * {
+		flex: 0 0 auto;
+	}
 }
 
 /* Popover sizing */
 .daterange-popover .components-popover__content {
 	overflow: visible;
 	width: auto;
-	max-width: calc(100vw - 48px);
+	max-width: calc( 100vw - 48px );
 }
 
-
- /* Body rows */
+/* Body rows */
 .daterange-inputs {
 	margin-bottom: 12px;
 }
 
+.daterange-input {
+	&__field {
+		// The extra class is to make sure it overrides the default button styles
+		&.components-button {
+			background: $white;
+			padding: $grid-unit-05 $grid-unit-05 $grid-unit-05 $grid-unit-10;
+			box-shadow: none;
+			border-radius: $radius-small;
+			border: 1px solid $gray-600;
+		}
+		svg {
+			color: $gray-900;
+			padding: $grid-unit-05;
+		}
+	}
+	&__text {
+		color: $gray-900;
+		padding: 0 $grid-unit-05;
+	}
+}
+
 /* Mobile */
-@media (max-width: 600px) {
+@media ( max-width: 600px ) {
 	.daterange-calendar {
 		display: flex;
 		justify-content: center;
@@ -31,14 +53,14 @@
 }
 
 /* Medium screens: presets and calendar should be centered with no awkward right margin */
-@media (min-width: 601px) and (max-width: 899px) {
+@media ( min-width: 601px ) and ( max-width: 899px ) {
 	.daterange-body {
 		justify-content: space-between !important;
 	}
 }
 
 /* Desktop presets column: ensure a reasonable width to avoid awkward wrapping */
-@media (min-width: 601px) {
+@media ( min-width: 601px ) {
 	.daterange-presets {
 		min-width: 240px;
 	}
@@ -54,9 +76,9 @@
 }
 
 /* Hide native date picker icons inside our date inputs (visual only) */
-.daterange-inputs input[type="date"]::-webkit-calendar-picker-indicator {
+.daterange-inputs input[type='date']::-webkit-calendar-picker-indicator {
 	display: none;
 }
-.daterange-inputs input[type="date"]::-webkit-clear-button {
+.daterange-inputs input[type='date']::-webkit-clear-button {
 	display: none;
 }

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -98,19 +98,26 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			overlay={ <PageLayout header={ <PageHeader title={ __( 'Logs' ) } /> } /> }
 			{ ...getLogsCalloutProps() }
 		>
-			<PageLayout header={ <PageHeader title={ __( 'Logs' ) } /> }>
+			<PageLayout
+				header={
+					<VStack as="div" spacing={ 0 } direction="row" alignment="end">
+						<PageHeader title={ __( 'Logs' ) } />
+
+						<DateRangePicker
+							start={ dateRange.start }
+							end={ dateRange.end }
+							gmtOffset={ gmtOffset }
+							timezoneString={ timezoneString }
+							locale={ locale }
+							onChange={ handleDateRangeChangeWrapper }
+						/>
+					</VStack>
+				}
+			>
 				<VStack as="div" spacing={ 3 }>
 					{ autoRefreshDisabledReason && (
 						<Notice variant="warning">{ autoRefreshDisabledReason }</Notice>
 					) }
-					<DateRangePicker
-						start={ dateRange.start }
-						end={ dateRange.end }
-						gmtOffset={ gmtOffset }
-						timezoneString={ timezoneString }
-						locale={ locale }
-						onChange={ handleDateRangeChangeWrapper }
-					/>
 					<Card className={ `site-logs-card site-logs-card--${ logType }` }>
 						<CardHeader style={ { paddingBottom: '0' } }>
 							<TabPanel


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Change the color and the padding of the DateRange to match the designs
* Move the DatePicker to be included into the header section of the Logs page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In my testing, while comparing the designs, I noticed the DatePicker was not matching the new designs (nor the placement, creating unnecessary space between the Logs title and the DatePicker

REF 
* Backup page with DatePicker GzuR02sJZldvmRnbFsL04l-fi-5864_36755 
* Activity Log page with DatePicker GzuR02sJZldvmRnbFsL04l-fi-5605_65692 

<img width="3460" height="955" alt="CleanShot 2025-09-29 at 16 08 36@2x" src="https://github.com/user-attachments/assets/0d428c62-eb4e-43f7-a4e7-db7c46700dcb" />

<img width="3394" height="1107" alt="CleanShot 2025-09-29 at 16 07 57@2x" src="https://github.com/user-attachments/assets/3b99313c-c9e4-4567-b8ca-4d7d2f58ff15" />



## Testing Instructions

* Visit the `/v2/sites/<site>/logs/activity` and ensure the DatePicker works and matches the design.
* This change also affects the Backup page which, in the designs, was using the same styling (black instead of blue)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?