### PR TITLE
Dashboard v2: Update Profile name fields to have row layout

### DIFF
--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -13,14 +13,14 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import { DataForm } from '@wordpress/dataviews';
+import { useViewportMatch } from '@wordpress/compose';
+import { DataForm, Field, Form } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useCallback } from 'react';
 import FlashMessage from '../../components/flash-message';
 import { SectionHeader } from '../../components/section-header';
 import UsernameSection from './username-section';
 import type { UserSettings } from '@automattic/api-core';
-import type { Field, Form } from '@wordpress/dataviews';
 import './style.scss';
 
 interface PersonalDetailsSectionProps {
@@ -32,6 +32,7 @@ export default function PersonalDetailsSection( {
 }: PersonalDetailsSectionProps ) {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	const [ edits, setEdits ] = useState< Partial< UserSettings > >( {} );
 
@@ -125,8 +126,7 @@ export default function PersonalDetailsSection( {
 
 	const nameForm: Form = {
 		layout: {
-			type: 'regular' as const,
-			labelPosition: 'top' as const,
+			type: isMobile ? ( 'regular' as const ) : ( 'row' as const ),
 		},
 		fields: [ 'first_name', 'last_name' ],
 	};


### PR DESCRIPTION
Linear: https://linear.app/a8c/issue/DOTDASH-515/update-profile-name-fields

## Proposed Changes

Now that we have [DataViews 9.0.0](https://github.com/Automattic/wp-calypso/pull/105961), we can adjust the first and last name fields to be side-by-side in one row instead of stacked, as per the Figma design!

We still want it stacked on mobile view though.

<img width="750" height="562" alt="Screenshot 2025-09-29 at 8 06 54 AM" src="https://github.com/user-attachments/assets/5622a915-1bce-4dc1-b87e-aa8f085fe56d" />

**Mobile view:**
<img width="357" height="712" alt="Screenshot 2025-09-29 at 8 07 04 AM" src="https://github.com/user-attachments/assets/5b7587a4-d777-402d-b464-28cebaf9db50" />

## Why are these changes being made?
We want the UI/UX to be intuitive for users!

## Testing Instructions

- `yarn start`
- Visit: http://calypso.localhost:3000/v2/me/profile
- Make sure first & last name fields are in one row and they still work!
- Change to mobile view and make sure the fields are stacked now

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
