### PR TITLE
Domains HD: Hide DNSSEC badge for connected domains

### DIFF
--- a/client/dashboard/domains/domain-security/summary.tsx
+++ b/client/dashboard/domains/domain-security/summary.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import type { Domain } from '@automattic/api-core';
@@ -13,10 +14,12 @@ export default function NameServersSettingsSummary( { domain }: { domain: Domain
 		badges.push( { text: __( 'SSL Disabled' ), intent: 'error' as const } );
 	}
 
-	if ( domain.is_dnssec_enabled ) {
-		badges.push( { text: __( 'DNSSEC enabled' ), intent: 'success' as const } );
-	} else {
-		badges.push( { text: __( 'DNSSEC disabled' ), intent: undefined } );
+	if ( DomainSubtype.DOMAIN_REGISTRATION === domain.subtype.id ) {
+		if ( domain.is_dnssec_enabled ) {
+			badges.push( { text: __( 'DNSSEC enabled' ), intent: 'success' as const } );
+		} else {
+			badges.push( { text: __( 'DNSSEC disabled' ), intent: undefined } );
+		}
 	}
 
 	return (


### PR DESCRIPTION
Closes [DOTDASH-423](https://linear.app/a8c/issue/DOTDASH-423/remove-the-dnssec-enableddisabled-badge-for-domain-connections)

## Proposed Changes
Hide DNSSEC badge for connected domains in the domain security summary

## Why are these changes being made?
DNSSEC (Domain Name System Security Extensions) is only relevant and manageable for domains that are registered with WordPress.com, not for connected/mapped domains where the DNS is managed externally. Showing DNSSEC status for connected domains is confusing and misleading to users since they cannot control this setting through the WordPress.com interface.

### BEFORE
![Screenshot 2025-09-29 alle 17 19 14](https://github.com/user-attachments/assets/1f12fcf6-4e3f-46ef-9f7b-47a6469810ee)

### AFTER
![Screenshot 2025-09-29 alle 17 20 18](https://github.com/user-attachments/assets/a0d8ac93-a29c-4750-a6c7-2ee03848c597)



## Testing Instructions
- Navigate the to `/v2/domains/:DOMAIN`, where `:DOMAIN` is a connected domain.
- Ensure the DNSSEC badge is not showed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
