### PR TITLE
A4A: Fix A4A Dataview regression.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -191,7 +191,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 					actions,
 					setDataViewsState,
 					dataViewsState,
-					defaultLayouts: { table: {} },
+					defaultLayouts: { table: {}, list: {} },
 				} }
 			/>
 		</div>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -397,7 +397,7 @@ export const JetpackSitesDataViews = ( {
 				openSitePreviewPane( selectedItem.site.value );
 			}
 		},
-		defaultLayouts: { table: {} },
+		defaultLayouts: { table: {}, list: {} },
 	} );
 
 	useEffect( () => {


### PR DESCRIPTION
After upgrading to DataViews version 9.0.0, a regression was introduced affecting DataViews without default list settings. This PR fixes the problem by ensuring that an empty object is provided as the default for the list.

<img width="598" height="957" alt="Screenshot 2025-09-30 at 2 18 08 AM" src="https://github.com/user-attachments/assets/c7433fe5-6521-4e9f-a849-7d5ba42f1a86" />


Context: p1759164350002999-slack-C047ACYM8UQ

Similar to what is done here: https://github.com/Automattic/wp-calypso/pull/105961#discussion_r2376850669

## Proposed Changes

* For A4A DataViews that use a list, provide an empty object for the list on the default layouts.

## Why are these changes being made?

* UI is broken and causing a broken experience for the users.

## Testing Instructions


* Use the A4A live link and navigate to the `/sites` or `/referrals` page.
* Try to expand a row.
* Confirm that the table list is rendered properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?