### PR TITLE
Dashboard Backups: fix timezone and capitalization in progress notice

### DIFF
--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -6,7 +6,8 @@ export function useFormattedTime(
 	timestamp: string,
 	formatOptions?: Intl.DateTimeFormatOptions,
 	timezoneString?: string,
-	gmtOffset?: number
+	gmtOffset?: number,
+	lowercaseCalendarLabel?: boolean
 ) {
 	const locale = useLocale();
 
@@ -39,10 +40,14 @@ export function useFormattedTime(
 
 		if ( isToday ) {
 			if ( formatOptions?.timeStyle ) {
+				if ( lowercaseCalendarLabel ) {
+					// translators: time today
+					return sprintf( __( 'today at %s' ), formatted );
+				}
 				// translators: time today
 				return sprintf( __( 'Today at %s' ), formatted );
 			}
-			return __( 'Today' );
+			return lowercaseCalendarLabel ? __( 'today' ) : __( 'Today' );
 		} else if ( timezoneString ) {
 			return formatDate( date, locale, {
 				...formatOptions,

--- a/client/dashboard/components/formatted-time/test/index.tsx
+++ b/client/dashboard/components/formatted-time/test/index.tsx
@@ -15,13 +15,21 @@ function TestFormattedTime( {
 	formatOptions,
 	timezoneString,
 	gmtOffset,
+	lowercaseCalendarLabel,
 }: {
 	timestamp: string;
 	formatOptions?: Intl.DateTimeFormatOptions;
 	timezoneString?: string;
 	gmtOffset?: number;
+	lowercaseCalendarLabel?: boolean;
 } ) {
-	const formatted = useFormattedTime( timestamp, formatOptions, timezoneString, gmtOffset );
+	const formatted = useFormattedTime(
+		timestamp,
+		formatOptions,
+		timezoneString,
+		gmtOffset,
+		lowercaseCalendarLabel
+	);
 	return <span data-testid="formatted-time">{ formatted }</span>;
 }
 
@@ -226,5 +234,36 @@ describe( 'useFormattedTime', () => {
 		expect( formattedElement ).toHaveTextContent( /September 25, 2025/ );
 		expect( formattedElement ).toHaveTextContent( /9:00 PM/ );
 		expect( formattedElement ).not.toHaveTextContent( /Today/ );
+	} );
+
+	test( 'formats as lowercase "today at" when lowercaseCalendarLabel is true', () => {
+		const timestamp = '2025-09-26T20:00:00Z';
+		const timezoneString = 'America/Los_Angeles';
+		const formatOptions = { timeStyle: 'short' as const };
+
+		render(
+			<TestFormattedTime
+				timestamp={ timestamp }
+				timezoneString={ timezoneString }
+				formatOptions={ formatOptions }
+				lowercaseCalendarLabel
+			/>
+		);
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( /today at 1:00 PM/ );
+		expect( formattedElement ).not.toHaveTextContent( /Today/ );
+	} );
+
+	test( 'formats as lowercase "today" when lowercaseCalendarLabel is true without time style', () => {
+		const timestamp = '2025-09-26T10:30:00Z';
+
+		render( <TestFormattedTime timestamp={ timestamp } lowercaseCalendarLabel /> );
+
+		const formattedElement = screen.getByTestId( 'formatted-time' );
+		expect( formattedElement ).toBeVisible();
+		expect( formattedElement ).toHaveTextContent( 'today' );
+		expect( formattedElement ).not.toHaveTextContent( 'Today' );
 	} );
 } );

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -23,7 +23,8 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 			timeStyle: 'short',
 		},
 		timezoneString,
-		gmtOffset
+		gmtOffset,
+		true // Use lowercase calendar label
 	);
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
@@ -57,9 +58,9 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 				) }
 			>
 				{ sprintf(
-					/* translators: %s is a date, like "Today at 10:00". */
+					/* translators: %s is a date, like "today at 10:00". */
 					__( 'We’re making a backup of your site from %s' ),
-					backupDate.toLowerCase()
+					backupDate
 				) }
 			</Notice>
 		);
@@ -87,11 +88,11 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 			>
 				{ createInterpolateElement(
 					sprintf(
-						/* translators: %s is a date, like "Today at 10:00" */
+						/* translators: %s is a date, like "today at 10:00" */
 						__(
 							'We weren’t able to finish your backup from %s, but don’t worry — your existing data is safe. <external>Check our help guide</external> or contact support to get this resolved.'
 						),
-						backupDate.toLowerCase()
+						backupDate
 					),
 					{
 						external: <ExternalLink href="https://jetpack.com/support/backup/" children={ null } />,

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -59,7 +59,7 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 				{ sprintf(
 					/* translators: %s is a date, like "Today at 10:00". */
 					__( 'We’re making a backup of your site from %s' ),
-					backupDate
+					backupDate.toLowerCase()
 				) }
 			</Notice>
 		);
@@ -91,7 +91,7 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 						__(
 							'We weren’t able to finish your backup from %s, but don’t worry — your existing data is safe. <external>Check our help guide</external> or contact support to get this resolved.'
 						),
-						backupDate
+						backupDate.toLowerCase()
 					),
 					{
 						external: <ExternalLink href="https://jetpack.com/support/backup/" children={ null } />,

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -90,7 +90,7 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 					sprintf(
 						/* translators: %s is a date, like "today at 10:00" */
 						__(
-							'We weren’t able to finish your backup from %s, but don’t worry — your existing data is safe. <external>Check our help guide</external> or contact support to get this resolved.'
+							'We weren’t able to finish your backup from %s, but don’t worry—your existing data is safe. <external>Check our help guide</external> or contact support to get this resolved.'
 						),
 						backupDate
 					),

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -18,7 +18,7 @@ interface BackupNoticesProps {
 export function BackupNotices( { backupState, timezoneString, gmtOffset }: BackupNoticesProps ) {
 	const { status, backup } = backupState;
 	const backupDate = useFormattedTime(
-		backup?.started ?? '',
+		backup?.started ? backup.started.replace( ' ', 'T' ) + 'Z' : '',
 		{
 			timeStyle: 'short',
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-534

## Proposed Changes
* Changed backup date display to lowercase for consistency (e.g., "today at 2:45 PM" instead of "Today at 2:45 PM")
* Fixed in progress backup date which was using the wrong timezone

| Before | After |
|---|---|
| <img width="2654" height="370" alt="CleanShot 2025-09-29 at 16 02 12@2x" src="https://github.com/user-attachments/assets/ac0f2b71-bb5c-42f6-80e3-b7f464931446" /> | <img width="2640" height="360" alt="CleanShot 2025-09-29 at 16 01 19@2x" src="https://github.com/user-attachments/assets/c27a02f3-1d53-40e9-9cd1-fe57c2399b7e" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/v2/sites/{site}/backups`
2. Click the "Back up now" button
3. Ensure it reflects the time on your site timezone and it looks as the capture shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
