### PR TITLE
Backup Dashboard: update support links to use WordPress.com for WPCOM sites

### DIFF
--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,4 +1,5 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -20,6 +21,7 @@ import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import SiteBackupDownloadError from './error';
 import SiteBackupDownloadForm from './form';
 import SiteBackupDownloadProgress from './progress';
@@ -165,7 +167,13 @@ function SiteBackupDownload() {
 								} ),
 								{
 									LearnMore: (
-										<ExternalLink href="https://jetpack.com/support/backup/">
+										<ExternalLink
+											href={ localizeUrl(
+												isSelfHostedJetpackConnected( site )
+													? 'https://jetpack.com/support/backup/'
+													: 'https://wordpress.com/support/restore/'
+											) }
+										>
 											{ __( 'Learn more' ) }
 										</ExternalLink>
 									),

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -18,6 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -166,16 +167,14 @@ function SiteBackupDownload() {
 									downloadPointDate,
 								} ),
 								{
-									LearnMore: (
-										<ExternalLink
-											href={ localizeUrl(
-												isSelfHostedJetpackConnected( site )
-													? 'https://jetpack.com/support/backup/'
-													: 'https://wordpress.com/support/restore/'
-											) }
-										>
+									LearnMore: isSelfHostedJetpackConnected( site ) ? (
+										<ExternalLink href={ localizeUrl( 'https://jetpack.com/support/backup/' ) }>
 											{ __( 'Learn more' ) }
 										</ExternalLink>
+									) : (
+										<InlineSupportLink supportContext="backups">
+											{ __( 'Learn more' ) }
+										</InlineSupportLink>
 									),
 								}
 							) }

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -1,4 +1,5 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -21,6 +22,7 @@ import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import SiteBackupRestoreError from './error';
 import SiteBackupRestoreForm from './form';
 import SiteBackupGranularRestoreForm from './granular-form';
@@ -144,7 +146,13 @@ function SiteBackupRestore() {
 								} ),
 								{
 									LearnMore: (
-										<ExternalLink href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/">
+										<ExternalLink
+											href={ localizeUrl(
+												isSelfHostedJetpackConnected( site )
+													? 'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
+													: 'https://wordpress.com/support/restore/'
+											) }
+										>
 											{ __( 'Learn more' ) }
 										</ExternalLink>
 									),

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -19,6 +19,7 @@ import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-
 import { useAnalytics } from '../../app/analytics';
 import { siteBackupRestoreRoute, siteBackupsRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -145,16 +146,18 @@ function SiteBackupRestore() {
 									restorePointDate,
 								} ),
 								{
-									LearnMore: (
+									LearnMore: isSelfHostedJetpackConnected( site ) ? (
 										<ExternalLink
 											href={ localizeUrl(
-												isSelfHostedJetpackConnected( site )
-													? 'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
-													: 'https://wordpress.com/support/restore/'
+												'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
 											) }
 										>
 											{ __( 'Learn more' ) }
 										</ExternalLink>
+									) : (
+										<InlineSupportLink supportContext="backups">
+											{ __( 'Learn more' ) }
+										</InlineSupportLink>
 									),
 								}
 							) }

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -4,6 +4,7 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useFormattedTime } from '../../components/formatted-time';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { BackupState } from './use-backup-state';
@@ -103,15 +104,13 @@ export function BackupNotices( {
 						backupDate
 					),
 					{
-						external: (
+						external: isSelfHostedJetpackConnected( site ) ? (
 							<ExternalLink
-								href={ localizeUrl(
-									isSelfHostedJetpackConnected( site )
-										? 'https://jetpack.com/support/backup/'
-										: 'https://wordpress.com/support/restore/'
-								) }
+								href={ localizeUrl( 'https://jetpack.com/support/backup/' ) }
 								children={ null }
 							/>
+						) : (
+							<InlineSupportLink supportContext="backups" children={ null } />
 						),
 					}
 				) }

--- a/client/dashboard/sites/backups/backup-notices.tsx
+++ b/client/dashboard/sites/backups/backup-notices.tsx
@@ -1,13 +1,17 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useFormattedTime } from '../../components/formatted-time';
 import { Notice } from '../../components/notice';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { BackupState } from './use-backup-state';
+import type { Site } from '@automattic/api-core';
 
 interface BackupNoticesProps {
 	backupState: BackupState;
+	site: Site;
 	timezoneString?: string;
 	gmtOffset?: number;
 }
@@ -15,7 +19,12 @@ interface BackupNoticesProps {
 /**
  * Renders a contextual Notice based on the site's backup status
  */
-export function BackupNotices( { backupState, timezoneString, gmtOffset }: BackupNoticesProps ) {
+export function BackupNotices( {
+	backupState,
+	site,
+	timezoneString,
+	gmtOffset,
+}: BackupNoticesProps ) {
 	const { status, backup } = backupState;
 	const backupDate = useFormattedTime(
 		backup?.started ?? '',
@@ -94,7 +103,16 @@ export function BackupNotices( { backupState, timezoneString, gmtOffset }: Backu
 						backupDate
 					),
 					{
-						external: <ExternalLink href="https://jetpack.com/support/backup/" children={ null } />,
+						external: (
+							<ExternalLink
+								href={ localizeUrl(
+									isSelfHostedJetpackConnected( site )
+										? 'https://jetpack.com/support/backup/'
+										: 'https://wordpress.com/support/restore/'
+								) }
+								children={ null }
+							/>
+						),
 					}
 				) }
 			</Notice>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -198,6 +198,7 @@ export function BackupsListPage() {
 				shouldShowNotices ? (
 					<BackupNotices
 						backupState={ backupState }
+						site={ site }
 						timezoneString={ timezoneString }
 						gmtOffset={ gmtOffset }
 					/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-554

## Proposed Changes

* Updated backup support links in Download, Restore, and Backup notices pages to conditionally render based on site type.
* Wrapped URLs with `localizeUrl()` from `@automattic/i18n-utils` for proper localization.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The backup support links were pointing to `jetpack.com/support/backup/` which isn't relevant for WordPress.com users. This change ensures users see the appropriate documentation based on their site type. This also future-proofs the implementation for when the Jetpack Hosting Dashboard launches, as self-hosted Jetpack sites will automatically get the correct links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Changes are straightforward, so a proofread should be enough. You can also run some quick smoke tests to validate the links for WPCOM sites, by accessing the Download or Restore page.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
