### PR TITLE
Checkout: Remove unused isInModal/onAfterPaymentComplete from CheckoutMain

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -151,7 +151,6 @@ function ClientCheckoutContent() {
 				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/client/subscriptions' }
 				customizedPreviousPath="/client/subscriptions"
-				isInModal={ false }
 				siteSlug=""
 				siteId={ 0 }
 			/>

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -138,7 +138,6 @@ function BillingDragonCheckoutContent( {
 				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/purchases/licenses' }
 				customizedPreviousPath="/marketplace"
-				isInModal={ false }
 				siteSlug=""
 				siteId={ 0 }
 			/>

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -41,7 +41,6 @@ const initialPreparedProductsState: PreparedProductsForCart = {
 export default function usePrepareProductsForCart( {
 	productAliasFromUrl,
 	purchaseId: originalPurchaseId,
-	isInModal,
 	usesJetpackProducts,
 	isPrivate,
 	siteSlug,
@@ -56,7 +55,6 @@ export default function usePrepareProductsForCart( {
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
-	isInModal?: boolean;
 	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	siteSlug: string | undefined;
@@ -138,7 +136,7 @@ export default function usePrepareProductsForCart( {
 	useNothingToAdd( { addHandler, dispatch } );
 
 	// Do not strip products from url until the URL has been parsed
-	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInModal;
+	const areProductsRetrievedFromUrl = ! state.isLoading;
 	const doNotStripProducts = Boolean(
 		! areProductsRetrievedFromUrl ||
 			sitelessCheckoutType === 'jetpack' ||


### PR DESCRIPTION
Fixes SHILL-1128

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR removes two props from `CheckoutMain`: `onAfterPaymentComplete` and `isInModal`. These props were added for the "Editor Checkout Modal" (see https://github.com/Automattic/wp-calypso/pull/48452) but it appears that the modal has been removed because there are no references to these properties anywhere any longer.

It looks like the functionality has been moved to [some sort of separate window](https://github.com/Automattic/wp-calypso/blob/e21bd334a0f097ad4adc68dbf06decdc70765e6d/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts#L211-L218).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Keeping checkout in a modal has always been awkward because some checkout payment methods are async or require multiple steps to complete; to handle those situations, all other checkout flows redirect to the "pending" page which polls the Orders endpoint for the purchase until we know if checkout succeeded or failed. In a modal, there's no way to do that, so instead special handling had to be developed for those situations and it probably never worked quite right. It also left confusing methods around like `onAfterPaymentComplete` which suggests that it will be called when the payment is complete, but in fact will be called when the payment has been submitted, possibly long before it is complete, if it completes at all. If these props are unused, it would be nice to remove them to simplify checkout's API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TypeScript should provide a decent guarantee that this is safe, but manually searching for these props is the most important thing. Note that there is still a `isInModal` prop for the `useCreatePaymentCompleteCallback()` function and the `getThankYouPageUrl()` function. Those are not modified here and are still in use for the `UpsellNudge` which avoids the above-mentioned post-checkout-submit problems by always using a stored credit card which should only very rarely fail after checkout has begin processing (and only if there's a provisioning failure).
