### PR TITLE
Scan: show dates in site timezone

### DIFF
--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -69,3 +69,22 @@ export function useFormattedTime(
 
 	return formatted;
 }
+
+interface FormattedTimeProps {
+	timestamp: string;
+	timezoneString?: string;
+	gmtOffset?: number;
+	formatOptions?: Intl.DateTimeFormatOptions;
+}
+
+export function FormattedTime( {
+	timestamp,
+	timezoneString,
+	gmtOffset,
+	formatOptions = {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	},
+}: FormattedTimeProps ) {
+	return useFormattedTime( timestamp, formatOptions, timezoneString, gmtOffset );
+}

--- a/client/dashboard/sites/backups/dataviews/fields.tsx
+++ b/client/dashboard/sites/backups/dataviews/fields.tsx
@@ -1,27 +1,9 @@
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useFormattedTime } from '../../../components/formatted-time';
+import { FormattedTime } from '../../../components/formatted-time';
 import { gridiconToWordPressIcon } from '../../../utils/gridicons';
 import type { ActivityLogEntry } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
-
-interface FormattedTimeProps {
-	timestamp: string;
-	timezoneString?: string;
-	gmtOffset?: number;
-}
-
-function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
-	return useFormattedTime(
-		timestamp,
-		{
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		},
-		timezoneString,
-		gmtOffset
-	);
-}
 
 export function getFields(
 	timezoneString?: string,

--- a/client/dashboard/sites/scan-active/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/fields.tsx
@@ -5,30 +5,12 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { useFormattedTime } from '../../../components/formatted-time';
+import { FormattedTime } from '../../../components/formatted-time';
 import { formatYmd } from '../../../utils/datetime';
 import { SeverityBadge, getSeverityLabel } from '../../scan/severity-badge';
 import { getThreatIcon, sortSeverity } from '../../scan/utils';
 import type { Threat } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
-
-interface FormattedTimeProps {
-	timestamp: string;
-	timezoneString?: string;
-	gmtOffset?: number;
-}
-
-function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
-	return useFormattedTime(
-		timestamp,
-		{
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		},
-		timezoneString,
-		gmtOffset
-	);
-}
 
 export function getFields( timezoneString?: string, gmtOffset?: number ): Field< Threat >[] {
 	return [

--- a/client/dashboard/sites/scan-active/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/fields.tsx
@@ -12,15 +12,25 @@ import { getThreatIcon, sortSeverity } from '../../scan/utils';
 import type { Threat } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
-const FormattedTime = ( { timestamp }: { timestamp: string } ) => {
-	const formattedTime = useFormattedTime( timestamp, {
-		dateStyle: 'medium',
-		timeStyle: 'short',
-	} );
-	return <>{ formattedTime }</>;
-};
+interface FormattedTimeProps {
+	timestamp: string;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
 
-export function getFields(): Field< Threat >[] {
+function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
+	return useFormattedTime(
+		timestamp,
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
+}
+
+export function getFields( timezoneString?: string, gmtOffset?: number ): Field< Threat >[] {
 	return [
 		{
 			id: 'severity',
@@ -64,7 +74,13 @@ export function getFields(): Field< Threat >[] {
 				const date = new Date( item.first_detected );
 				return formatYmd( date );
 			},
-			render: ( { item } ) => <FormattedTime timestamp={ item.first_detected } />,
+			render: ( { item } ) => (
+				<FormattedTime
+					timestamp={ item.first_detected }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+				/>
+			),
 		},
 		{
 			id: 'auto_fix',

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -11,7 +11,17 @@ import noThreatsIllustration from './no-threats-illustration.svg';
 import type { Threat, Site } from '@automattic/api-core';
 import type { View } from '@wordpress/dataviews';
 
-export function ActiveThreatsDataViews( { site }: { site: Site } ) {
+interface ActiveThreatsDataViewsProps {
+	site: Site;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
+
+export function ActiveThreatsDataViews( {
+	site,
+	timezoneString,
+	gmtOffset,
+}: ActiveThreatsDataViewsProps ) {
 	const [ view, setView ] = useState< View >( {
 		type: 'table',
 		fields: [ 'severity', 'threat', 'first_detected', 'auto_fix' ],
@@ -34,7 +44,7 @@ export function ActiveThreatsDataViews( { site }: { site: Site } ) {
 	const { data: scan, isLoading } = useQuery( siteScanQuery( site.ID ) );
 	const threats = scan?.threats.filter( ( threat ) => threat.status === 'current' ) || [];
 
-	const fields = getFields();
+	const fields = getFields( timezoneString, gmtOffset );
 	const actions = useMemo(
 		() => getActions( site.ID, selection.length ),
 		[ site.ID, selection.length ]

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -12,13 +12,23 @@ import { getThreatIcon, sortSeverity } from '../../scan/utils';
 import type { Threat } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
-const FormattedTime = ( { timestamp }: { timestamp: string } ) => {
-	const formattedTime = useFormattedTime( timestamp, {
-		dateStyle: 'medium',
-		timeStyle: 'short',
-	} );
-	return <>{ formattedTime }</>;
-};
+interface FormattedTimeProps {
+	timestamp: string;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
+
+function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
+	return useFormattedTime(
+		timestamp,
+		{
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		},
+		timezoneString,
+		gmtOffset
+	);
+}
 
 const getStatusLabel = ( status: string ): string => {
 	switch ( status ) {
@@ -42,7 +52,7 @@ const getStatusIntent = ( status: string ): 'default' | 'success' | 'warning' =>
 	}
 };
 
-export function getFields(): Field< Threat >[] {
+export function getFields( timezoneString?: string, gmtOffset?: number ): Field< Threat >[] {
 	return [
 		{
 			id: 'status',
@@ -80,7 +90,15 @@ export function getFields(): Field< Threat >[] {
 				return formatYmd( date );
 			},
 			render: ( { item } ) =>
-				item.fixed_on ? <FormattedTime timestamp={ item.fixed_on } /> : <Text>—</Text>,
+				item.fixed_on ? (
+					<FormattedTime
+						timestamp={ item.fixed_on }
+						timezoneString={ timezoneString }
+						gmtOffset={ gmtOffset }
+					/>
+				) : (
+					<Text>—</Text>
+				),
 		},
 		{
 			id: 'threat',

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -5,30 +5,12 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useFormattedTime } from '../../../components/formatted-time';
+import { FormattedTime } from '../../../components/formatted-time';
 import { formatYmd } from '../../../utils/datetime';
 import { SeverityBadge, getSeverityLabel } from '../../scan/severity-badge';
 import { getThreatIcon, sortSeverity } from '../../scan/utils';
 import type { Threat } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
-
-interface FormattedTimeProps {
-	timestamp: string;
-	timezoneString?: string;
-	gmtOffset?: number;
-}
-
-function FormattedTime( { timestamp, timezoneString, gmtOffset }: FormattedTimeProps ) {
-	return useFormattedTime(
-		timestamp,
-		{
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		},
-		timezoneString,
-		gmtOffset
-	);
-}
 
 const getStatusLabel = ( status: string ): string => {
 	switch ( status ) {

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -10,7 +10,17 @@ import { getFields } from './dataviews/fields';
 import type { Threat, Site } from '@automattic/api-core';
 import type { View } from '@wordpress/dataviews';
 
-export function ScanHistoryDataViews( { site }: { site: Site } ) {
+interface ScanHistoryDataViewsProps {
+	site: Site;
+	timezoneString?: string;
+	gmtOffset?: number;
+}
+
+export function ScanHistoryDataViews( {
+	site,
+	timezoneString,
+	gmtOffset,
+}: ScanHistoryDataViewsProps ) {
 	const [ view, setView ] = useState< View >( {
 		type: 'table',
 		fields: [ 'status', 'fixed_on', 'threat', 'severity' ],
@@ -38,7 +48,7 @@ export function ScanHistoryDataViews( { site }: { site: Site } ) {
 	const { data: scanHistory, isLoading } = useQuery( siteScanHistoryQuery( site.ID ) );
 	const threats = scanHistory?.threats || [];
 
-	const fields = getFields();
+	const fields = getFields( timezoneString, gmtOffset );
 	const actions = getActions( site.ID );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
 

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -1,5 +1,5 @@
 import { HostingFeatures } from '@automattic/api-core';
-import { siteBySlugQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -43,6 +43,16 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const [ showBulkFixModal, setShowBulkFixModal ] = useState( false );
 
+	const { data: siteSettings } = useSuspenseQuery( {
+		...siteSettingsQuery( site.ID ),
+		select: ( s ) => ( {
+			gmtOffset: typeof s?.gmt_offset === 'number' ? s.gmt_offset : 0,
+			timezoneString: s?.timezone_string || undefined,
+		} ),
+	} );
+
+	const { gmtOffset, timezoneString } = siteSettings;
+
 	const scanState = useScanState( site.ID );
 	const { scan, status } = scanState;
 
@@ -76,7 +86,13 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 		if ( showStatus ) {
 			return <ScanStatus scanState={ scanState } />;
 		}
-		return <ActiveThreatsDataViews site={ site } />;
+		return (
+			<ActiveThreatsDataViews
+				site={ site }
+				timezoneString={ timezoneString }
+				gmtOffset={ gmtOffset }
+			/>
+		);
 	};
 
 	return (
@@ -142,7 +158,13 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 					</CardHeader>
 					<CardBody>
 						{ scanTab === 'active' && renderActiveTab() }
-						{ scanTab === 'history' && <ScanHistoryDataViews site={ site } /> }
+						{ scanTab === 'history' && (
+							<ScanHistoryDataViews
+								site={ site }
+								timezoneString={ timezoneString }
+								gmtOffset={ gmtOffset }
+							/>
+						) }
 					</CardBody>
 				</Card>
 			</PageLayout>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-556][1].

Related to #106060.

## Proposed Changes

Show dates in the Scan page in the site timezone, as we currently do in Jetpack Cloud.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This makes the Scan page in line with the Backups one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/:slug/scan`
- Check the dates for active threats and history tabs.
- Confirm they match the dates in Jetpack Cloud.

| Before | After |
| - | - |
| <img width="1249" height="654" alt="image" src="https://github.com/user-attachments/assets/81a2e758-244b-47c6-bcdf-4be977721909" /> | <img width="1247" height="654" alt="image" src="https://github.com/user-attachments/assets/f1f437cc-687d-49d2-9260-baead505a2a4" /> |
| <img width="1248" height="827" alt="image" src="https://github.com/user-attachments/assets/610b7415-b2de-48b8-b290-8902e07d996b" /> | <img width="1244" height="826" alt="image" src="https://github.com/user-attachments/assets/325df7af-31d8-4989-80de-0d295579817c" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-556