### PR TITLE
Jetpack Blaze: Fix "Site is not published" link

### DIFF
--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -258,10 +258,7 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 					{
 						components: {
 							sitePrivacySettingsLink: (
-								<a
-									href={ `https://wordpress.com/settings/general/${ selectedSite.domain }#site-privacy-settings` }
-									rel="noreferrer"
-								/>
+								<a href={ `/settings/reading/${ selectedSite.domain }` } rel="noreferrer" />
 							),
 						},
 					}


### PR DESCRIPTION
## Proposed Changes

On the Jetpack Blaze page (`/advertising/${site}`) when a site is **not** published

* Fix the link to not be hardcoded to https://wordpress.com
* Fix the link to show the `Reading` settings page not `General` settings page

<img width="1387" height="917" alt="Screenshot 2025-09-30 at 10 44 44 am" src="https://github.com/user-attachments/assets/043b2332-708d-4aff-a4bc-590627d3f34e" />

## Why are these changes being made?

* Improve user experience to make it easier to set site to Public to use Jetpack Blaze

## Testing Instructions

1. Visit http://calypso.localhost:3000/advertising/<sitename>
2. Make sure "here" link now links Settings -> Reading page for the site on the current environment (not hard coded to WordPress.com)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
