### PR TITLE
Hosting Dashboard > Security: update Account Recovery success messages

### DIFF
--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -60,7 +60,7 @@ export default function RecoveryEmail() {
 		recordTracksEvent( 'calypso_dashboard_security_account_recovery_email_validate_email_click' );
 		validateEmail( formData.email, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery email was saved successfully.' ), {
+				createSuccessNotice( __( 'Recovery email saved.' ), {
 					type: 'snackbar',
 				} );
 			},
@@ -76,7 +76,7 @@ export default function RecoveryEmail() {
 		recordTracksEvent( 'calypso_dashboard_security_account_recovery_email_remove_email_click' );
 		removeEmail( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery email was removed successfully.' ), {
+				createSuccessNotice( __( 'Recovery email removed.' ), {
 					type: 'snackbar',
 				} );
 				setFormData( { email: '' } );
@@ -99,7 +99,7 @@ export default function RecoveryEmail() {
 		);
 		resendValidation( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery email validation was resent successfully.' ), {
+				createSuccessNotice( __( 'Recovery email validation resent.' ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -82,7 +82,7 @@ export default function RecoverySMS() {
 		recordTracksEvent( 'calypso_dashboard_security_account_recovery_sms_validate_sms_click' );
 		validateSMS( formData.smsNumber, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery SMS number was saved successfully.' ), {
+				createSuccessNotice( __( 'Recovery SMS number saved.' ), {
 					type: 'snackbar',
 				} );
 			},
@@ -121,7 +121,7 @@ export default function RecoverySMS() {
 		recordTracksEvent( 'calypso_dashboard_security_account_recovery_sms_remove_sms_click' );
 		removeSMS( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery SMS number was removed successfully.' ), {
+				createSuccessNotice( __( 'Recovery SMS number removed.' ), {
 					type: 'snackbar',
 				} );
 				setFormData( initialFormData );
@@ -142,7 +142,7 @@ export default function RecoverySMS() {
 		setShowResendButton( false );
 		resendValidation( undefined, {
 			onSuccess: () => {
-				createSuccessNotice( __( 'Your recovery SMS validation was resent successfully.' ), {
+				createSuccessNotice( __( 'Recovery SMS validation resent.' ), {
 					type: 'snackbar',
 				} );
 			},


### PR DESCRIPTION
## Proposed Changes

This PR updates the success messages for Account Recovery > Email & SMS

## Why are these changes being made?

* To follow the copy standard of snackbar notifications.

## Testing Instructions

* Open the Calypso live link
* Go to /v2/me/security/account-recovery
* Verify the success messages are updated for the following scenarios:

Email saved:

<img width="199" height="74" alt="Screenshot 2025-09-30 at 1 01 59 PM" src="https://github.com/user-attachments/assets/482bcabc-2222-48f6-bd77-1c4e53f7493c" />

Email resent:

<img width="265" height="72" alt="Screenshot 2025-09-30 at 1 02 09 PM" src="https://github.com/user-attachments/assets/9d59f0f2-4863-4f2e-a0f3-0fbf3150a423" />

Email removed:

<img width="213" height="67" alt="Screenshot 2025-09-30 at 1 01 42 PM" src="https://github.com/user-attachments/assets/403d259b-432e-4284-93ba-6a09a6c9de95" />

SMS added:

<img width="254" height="69" alt="Screenshot 2025-09-30 at 1 02 52 PM" src="https://github.com/user-attachments/assets/9212a8c7-2f06-4fce-9a24-66ccaf770f7b" />

SMS resent:

<img width="265" height="62" alt="Screenshot 2025-09-30 at 1 05 50 PM" src="https://github.com/user-attachments/assets/b6291a4a-4d4b-4e7e-a52b-102eee317ff5" />

SMS removed:

<img width="270" height="65" alt="Screenshot 2025-09-30 at 1 03 01 PM" src="https://github.com/user-attachments/assets/1bf4c9ff-728a-4b1b-a58d-5362e70da583" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
