### PR TITLE
Hosting Dashboard: Top-left home link in admin bar links to v2 based on preferences

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -52,6 +52,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import canCurrentUserManageSiteOptions from 'calypso/state/sites/selectors/can-current-user-manage-site-options';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -76,6 +77,7 @@ class MasterbarLoggedIn extends Component {
 		loadHelpCenterIcon: PropTypes.bool,
 		isGlobalSidebarVisible: PropTypes.bool,
 		isGravatarDomain: PropTypes.bool,
+		hostingDashboardOptIn: PropTypes.bool,
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
@@ -225,11 +227,15 @@ class MasterbarLoggedIn extends Component {
 			currentRoute,
 			isGlobalSidebarVisible,
 			siteAdminUrl,
+			hostingDashboardOptIn,
 		} = this.props;
 
-		const mySitesUrl = domainOnlySite
+		let mySitesUrl = domainOnlySite
 			? domainManagementList( siteSlug, currentRoute, true )
 			: '/sites';
+		if ( hostingDashboardOptIn ) {
+			mySitesUrl = domainOnlySite ? '/v2/domains' : '/v2/sites';
+		}
 		const icon = this.wordpressIcon();
 
 		if ( ! siteSlug && section === 'sites-dashboard' ) {
@@ -243,11 +249,11 @@ class MasterbarLoggedIn extends Component {
 					[
 						{
 							label: translate( 'Sites' ),
-							url: '/sites',
+							url: hostingDashboardOptIn ? '/v2/sites' : '/sites',
 						},
 						{
 							label: translate( 'Domains' ),
-							url: '/domains/manage',
+							url: hostingDashboardOptIn ? '/v2/domains' : '/domains/manage',
 						},
 					],
 					...( this.props.isSimpleSite
@@ -885,6 +891,7 @@ export default connect(
 				isAtomicSite( state, siteId ) &&
 				getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
+			hostingDashboardOptIn: hasHostingDashboardOptIn( state ),
 		};
 	},
 	{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-400

## Proposed Changes

Depending on the user preference, the (W) in the admin bar should link to the hosting dashboard.

<img width="278"  src="https://github.com/user-attachments/assets/17e40318-a3c0-4265-9258-ce46d634a810" />

This only makes the change in Calypso's admin bar. The change to the admin bar in wp-admin and site front ends is in Jetpack https://github.com/Automattic/jetpack/pull/45155

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Gives effect to the user's opt-in preference.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Opt your test user in to the v2 beta at `/v2/me/preferences`
* Navigate to `/sites`
  * The (W) should link to the v2 site list
* Navigate to `/home/{{ siteSlug }}`
  * The (W) should link to the v2 site list
  * The (W) menu links should direct to the correct v2 locations
* Navigate to `/home/{{ domainOnlySiteSlug }}`
  * The (W) should link to the v2 domain list
  * The (W) menu links should direct to the correct v2 locations
* Opt your test user out of the v2 beta
* Now all these links should point back at the v1 pages again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
