### PR TITLE
e2e tests: update failures conditions to support TeamCity muted tests

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -5,6 +5,8 @@ import _self.lib.utils.mergeTrunk
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 
 object CalypsoE2ETestsBuildTemplate : Template({
 	name = "Calypso E2E Tests Build Template"

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -153,8 +153,28 @@ object CalypsoE2ETestsBuildTemplate : Template({
 		}
   }
 
-  artifactRules = """
+  	artifactRules = """
 		test/e2e/output => %PROJECT%/output
 		test/e2e/blob-report => blob-report
 	""".trimIndent()
+  
+  	failureConditions {
+		executionTimeoutMin = 20
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
+		nonZeroExitCode = false
+
+		// Support retries using the --onlyFailures flag in Jest.
+		supportTestRetry = true
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
+	}
 })


### PR DESCRIPTION

Closes QAO-109

## Proposed Changes

Update the failure conditions in the build template to not fail on non 0 exit codes. This allows builds to report success if only tests muted on TeamCity are failing.

## Testing Instructions

- e2e tests pass in CI
