### PR TITLE
Dashboard v2: show opt-in banner in v1 global sidebar

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -9,6 +9,7 @@ import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSection } from 'calypso/state/ui/selectors';
 import Sidebar from '../sidebar';
+import SidebarFooter from '../sidebar/footer';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import './style.scss';
 
@@ -17,6 +18,7 @@ const GlobalSidebar = ( {
 	onClick = undefined,
 	className = '',
 	path = '',
+	footer,
 	...props
 } ) => {
 	const wrapperRef = useRef( null );
@@ -96,6 +98,7 @@ const GlobalSidebar = ( {
 					{ children }
 				</Sidebar>
 			</div>
+			<SidebarFooter>{ footer }</SidebarFooter>
 		</div>
 	);
 };

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -165,11 +165,7 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	.sidebar__footer {
-		display: flex;
-		gap: 8px;
-		align-items: center;
 		padding: 16px 24px;
-		flex-wrap: wrap;
 
 		.sidebar__menu-icon {
 			margin-right: 0;

--- a/client/my-sites/hosting-dashboard-opt-in-banner/illustration.svg
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/illustration.svg
@@ -1,0 +1,61 @@
+<svg width="219" height="110" viewBox="0 0 219 110" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_87_19176)">
+<path d="M0 8C0 3.58172 3.58172 0 8 0H211C215.418 0 219 3.58172 219 8V102C219 106.418 215.418 110 211 110H8C3.58172 110 0 106.418 0 102V8Z" fill="#1C2226"/>
+<rect opacity="0.2" y="-16" width="219" height="126" rx="8" fill="url(#pattern0_87_19176)"/>
+<rect x="45.6574" y="100.343" width="41.6852" height="74.6852" rx="4.34259" transform="rotate(-90 45.6574 100.343)" stroke="url(#paint0_linear_87_19176)" stroke-width="0.685178"/>
+<rect x="98.6574" y="51.3426" width="41.6852" height="74.6852" rx="4.34259" transform="rotate(-90 98.6574 51.3426)" stroke="url(#paint1_linear_87_19176)" stroke-width="0.685178"/>
+<rect x="45.6574" y="51.3426" width="41.6852" height="45.6852" rx="4.34259" transform="rotate(-90 45.6574 51.3426)" stroke="url(#paint2_linear_87_19176)" stroke-width="0.685178"/>
+<rect x="127.657" y="100.343" width="41.6852" height="45.6852" rx="4.34259" transform="rotate(-90 127.657 100.343)" stroke="url(#paint3_linear_87_19176)" stroke-width="0.685178"/>
+<g style="mix-blend-mode:color-dodge" filter="url(#filter0_f_87_19176)">
+<circle cx="-55.5745" cy="51.4255" r="56.4255" fill="url(#paint4_linear_87_19176)"/>
+</g>
+<g style="mix-blend-mode:color-dodge" filter="url(#filter1_f_87_19176)">
+<circle cx="274.425" cy="51.4255" r="56.4255" fill="url(#paint5_linear_87_19176)"/>
+</g>
+</g>
+<defs>
+<pattern id="pattern0_87_19176" patternContentUnits="objectBoundingBox" width="0.0169498" height="0.0294603">
+<use xlink:href="#image0_87_19176" transform="scale(0.00013242 0.000230159)"/>
+</pattern>
+<filter id="filter0_f_87_19176" x="-192.036" y="-85.0361" width="272.923" height="272.923" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="40.0181" result="effect1_foregroundBlur_87_19176"/>
+</filter>
+<filter id="filter1_f_87_19176" x="137.964" y="-85.0361" width="272.923" height="272.923" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="40.0181" result="effect1_foregroundBlur_87_19176"/>
+</filter>
+<linearGradient id="paint0_linear_87_19176" x1="87" y1="100" x2="24.2601" y2="134.762" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint1_linear_87_19176" x1="140" y1="51.0002" x2="77.2601" y2="85.7616" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint2_linear_87_19176" x1="87" y1="51.0002" x2="42.1946" y2="91.823" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint3_linear_87_19176" x1="169" y1="100" x2="124.195" y2="140.823" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="1" stop-color="#069E08"/>
+</linearGradient>
+<linearGradient id="paint4_linear_87_19176" x1="-55.5914" y1="66.3356" x2="-141.447" y2="26.9731" gradientUnits="userSpaceOnUse">
+<stop stop-color="#069E08"/>
+<stop offset="0.371802" stop-color="#069E08" stop-opacity="0.9"/>
+<stop offset="1" stop-color="#069E08" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint5_linear_87_19176" x1="274.409" y1="66.3356" x2="188.553" y2="26.9731" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3858E9"/>
+<stop offset="0.371802" stop-color="#3858E9" stop-opacity="0.9"/>
+<stop offset="1" stop-color="#3858E9" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_87_19176">
+<rect width="219" height="110" rx="8" ry="8" />
+</clipPath>
+<image id="image0_87_19176" width="128" height="128" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAD7SURBVHgB7djBTcNAEAXQCRWkBJdACe4AOqIE3AG0QCWmg9DJsFEsIYREnE0uGb8nzW1v/+8cJgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgRjJzbPPa5pA/5jZvbYagphbufgn+nOObfVDHEv6c681KUEiu+/l/NkFw/1qQQ/Ybo7iHqO8l+j1HcVsowGP0e4ridlHccY/HFXZNFLaFDcA/tlCAr+j3GcVtoQAf0a98AcrL0+m31xDcvxbklJebghrSKZilBGs2wST8wvJ0Gn7P3xvhsAQ/BgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMCNfANoz/IwJL551QAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -1,0 +1,95 @@
+import {
+	Button,
+	Card,
+	CardBody,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import {
+	getPreference,
+	isFetchingPreferences,
+	isSavingPreference,
+	preferencesLastSaveError,
+} from 'calypso/state/preferences/selectors';
+import illustratioUrl from './illustration.svg';
+import type { HostingDashboardOptIn } from '@automattic/api-core';
+
+export default function HostingDashboardOptInBanner() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const savedPreference = useSelector(
+		( state ) => getPreference( state, 'hosting-dashboard-opt-in' ) as HostingDashboardOptIn | null
+	);
+
+	const isFetching = useSelector( isFetchingPreferences );
+	const isSaving = useSelector( isSavingPreference );
+	const lastSaveError = useSelector( preferencesLastSaveError );
+
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const handleClick = async () => {
+		setIsSubmitting( true );
+
+		recordTracksEvent( 'calypso_dashboard_opt_in_banner_click' );
+
+		const preference = {
+			value: 'opt-in',
+			updated_at: new Date().toISOString(),
+		} satisfies HostingDashboardOptIn;
+
+		await dispatch( savePreference( 'hosting-dashboard-opt-in', preference ) );
+
+		if ( lastSaveError ) {
+			dispatch(
+				errorNotice( translate( 'Failed to save preference.' ), {
+					duration: 5000,
+				} )
+			);
+		} else {
+			window.location.href = '/v2';
+		}
+	};
+
+	if ( isFetching || savedPreference?.value === 'opt-out' ) {
+		return null;
+	}
+
+	return (
+		<>
+			<TrackComponentView eventName="calypso_dashboard_opt_in_banner_impression" />
+			<Card>
+				<CardBody style={ { padding: '12px' } }>
+					<VStack spacing={ 3 }>
+						<img src={ illustratioUrl } alt="illustration" />
+						<VStack spacing={ 1 }>
+							<Text as="p" weight={ 500 }>
+								{ translate( 'Your dashboard, simplified' ) }
+							</Text>
+							<Text as="p" variant="muted">
+								{ translate( 'Try an easier way to manage your sites and hosting features.' ) }
+							</Text>
+						</VStack>
+						<div>
+							<Button
+								variant="secondary"
+								size="compact"
+								isBusy={ isSubmitting && isSaving }
+								onClick={ handleClick }
+							>
+								{ translate( 'Try it out' ) }
+							</Button>
+						</div>
+					</VStack>
+				</CardBody>
+			</Card>
+		</>
+	);
+}

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -28,6 +28,8 @@ export default function HostingDashboardOptInBanner() {
 	const savedPreference = useSelector(
 		( state ) => getPreference( state, 'hosting-dashboard-opt-in' ) as HostingDashboardOptIn | null
 	);
+	const hasOptedIn = savedPreference?.value === 'opt-in';
+	const hasOptedOut = savedPreference?.value === 'opt-out';
 
 	const isFetching = useSelector( isFetchingPreferences );
 	const isSaving = useSelector( isSavingPreference );
@@ -36,6 +38,11 @@ export default function HostingDashboardOptInBanner() {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	const handleClick = async () => {
+		if ( hasOptedIn ) {
+			window.location.href = '/v2';
+			return;
+		}
+
 		setIsSubmitting( true );
 
 		dispatch( recordTracksEvent( 'calypso_hosting_dashboard_opt_in_banner_click' ) );
@@ -59,7 +66,7 @@ export default function HostingDashboardOptInBanner() {
 		}
 	};
 
-	if ( isFetching || savedPreference?.value === 'opt-out' ) {
+	if ( isFetching || hasOptedOut ) {
 		return null;
 	}
 
@@ -72,7 +79,9 @@ export default function HostingDashboardOptInBanner() {
 						<img src={ illustratioUrl } alt="illustration" />
 						<VStack spacing={ 1 }>
 							<Text as="p" weight={ 500 }>
-								{ translate( 'Your dashboard, simplified' ) }
+								{ hasOptedIn && ! isSubmitting
+									? translate( 'Looking for your new dashboard?' )
+									: translate( 'Your dashboard, simplified' ) }
 							</Text>
 							<Text as="p" variant="muted">
 								{ translate( 'Try an easier way to manage your sites and hosting features.' ) }
@@ -85,7 +94,9 @@ export default function HostingDashboardOptInBanner() {
 								isBusy={ isSubmitting && isSaving }
 								onClick={ handleClick }
 							>
-								{ translate( 'Try it out' ) }
+								{ hasOptedIn && ! isSubmitting
+									? translate( 'Go to new dashboard' )
+									: translate( 'Try it out' ) }
 							</Button>
 						</div>
 					</VStack>

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -38,7 +38,7 @@ export default function HostingDashboardOptInBanner() {
 	const handleClick = async () => {
 		setIsSubmitting( true );
 
-		recordTracksEvent( 'calypso_dashboard_opt_in_banner_click' );
+		dispatch( recordTracksEvent( 'calypso_hosting_dashboard_opt_in_banner_click' ) );
 
 		const preference = {
 			value: 'opt-in',
@@ -48,6 +48,7 @@ export default function HostingDashboardOptInBanner() {
 		await dispatch( savePreference( 'hosting-dashboard-opt-in', preference ) );
 
 		if ( lastSaveError ) {
+			setIsSubmitting( false );
 			dispatch(
 				errorNotice( translate( 'Failed to save preference.' ), {
 					duration: 5000,
@@ -64,7 +65,7 @@ export default function HostingDashboardOptInBanner() {
 
 	return (
 		<>
-			<TrackComponentView eventName="calypso_dashboard_opt_in_banner_impression" />
+			<TrackComponentView eventName="calypso_hosting_dashboard_opt_in_banner_impression" />
 			<Card>
 				<CardBody style={ { padding: '12px' } }>
 					<VStack spacing={ 3 }>

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { withCurrentRoute } from 'calypso/components/route';
 import GlobalSidebar, { GLOBAL_SIDEBAR_EVENTS } from 'calypso/layout/global-sidebar';
+import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
@@ -47,12 +48,14 @@ class MySitesNavigation extends Component {
 	}
 
 	renderGlobalSidebar() {
-		const asyncProps = {
-			placeholder: null,
-			path: this.props.path,
-		};
 		return (
-			<GlobalSidebar { ...asyncProps }>
+			<GlobalSidebar
+				path={ this.props.path }
+				footer={
+					config.isEnabled( 'dashboard/v2' ) &&
+					! this.props.isGlobalSidebarCollapsed && <HostingDashboardOptInBanner />
+				}
+			>
 				<MySitesSidebarUnifiedBody
 					isGlobalSidebarCollapsed={ this.props.isGlobalSidebarCollapsed }
 					path={ this.props.path }

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -9,6 +9,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
+import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
 import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { AppState } from 'calypso/types';
 import { SidebarIconPlugins } from '../../sidebar/static-data/global-sidebar-menu';
@@ -43,6 +44,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					"Enhance your site's features with plugins, or schedule updates to fit your needs."
 				)
 			}
+			footer={ isEnabled( 'dashboard/v2' ) && ! isCollapsed && <HostingDashboardOptInBanner /> }
 		>
 			<SidebarMenu>
 				{ ! isEnabled( 'plugins/universal-header' ) && (


### PR DESCRIPTION
Part of DOTDASH-486

## Proposed Changes

This PR implements the v2 dashboard opt-in banner in the v1 dashboard:

<img width="972" height="721" alt="image" src="https://github.com/user-attachments/assets/fde230d8-2737-4c8a-8117-926f832fb051" />

## Out of Scope

Mobile experience is out of scope for now:

<img width="313" height="267" alt="image" src="https://github.com/user-attachments/assets/82650818-f941-4eac-ad14-2fa0a69fc4fd" />


## Testing Instructions

1. Make sure you clear the `hosting-dashboard-opt-in` preference if you've ever set that.
2. Go to the following routes; verify you DON'T see the banner as shown above:
   - `/reader`
3. Go to the following routes; verify you SEE the banner as shown above:
   - `/sites`
   - `/domains/manage`
   - `/plugins/scheduled-updates`
 4. Verify the `calypso_dashboard_opt_in_banner_impression` event is fired.
4. Click the `Try it out` button.
5. Verify the `calypso_dashboard_opt_in_banner_click` event is fired.
6. Verify you are redirected to `/v2`.
7. Click the "Preferences" link here

<img width="679" height="192" alt="image" src="https://github.com/user-attachments/assets/2a11d8ee-abf2-4b38-9a83-5503989bdd13" />

8. Verify that the toggle is on:

<img width="685" height="220" alt="image" src="https://github.com/user-attachments/assets/6eec85df-b9b6-41ba-a2ae-e51b48f63b33" />

9. Toggle it off to opt-out, then click Save.
10. Go to `/sites`; verify you no longer see the banner.
11. To reset the experience, clear the preference:

<img width="704" height="434" alt="image" src="https://github.com/user-attachments/assets/b2162f7d-e468-416d-a911-444c23d77a01" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
