### PR TITLE
Handle wp-admin redirection for single media page

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -399,15 +399,7 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 	const { getState } = context.store;
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
-	let wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );
-
-	if ( wpAdminPath === 'upload.php' && !! context.params.mediaId ) {
-		const searchParams = new URLSearchParams( {
-			item: context.params.mediaId,
-		} );
-
-		wpAdminUrl = `${ wpAdminUrl }?${ searchParams.toString() }`;
-	}
+	const wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath, context.params );
 
 	if ( wpAdminUrl ) {
 		window.location = wpAdminUrl;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -399,7 +399,15 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 	const { getState } = context.store;
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
-	const wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );
+	let wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );
+
+	if ( wpAdminPath === 'upload.php' && !! context.params.mediaId ) {
+		const searchParams = new URLSearchParams( {
+			item: context.params.mediaId,
+		} );
+
+		wpAdminUrl = `${ wpAdminUrl }?${ searchParams.toString() }`;
+	}
 
 	if ( wpAdminUrl ) {
 		window.location = wpAdminUrl;

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -20,6 +20,7 @@ export default function () {
 	page(
 		'/media/:domain/:mediaId',
 		siteSelection,
+		redirectIfDuplicatedView( 'upload.php' ),
 		navigation,
 		mediaController.media,
 		makeLayout,

--- a/client/state/sites/selectors/get-site-admin-url.ts
+++ b/client/state/sites/selectors/get-site-admin-url.ts
@@ -1,5 +1,8 @@
+import { Context } from '@automattic/calypso-router';
 import { AppState } from 'calypso/types';
 import getSiteOption from './get-site-option';
+
+const CALYPSO_PARAMS_TO_WP_ADMIN_SEARCH_PARAMS = new Map( [ [ 'mediaId', 'item' ] ] );
 
 /**
  * Returns the url to the wp-admin area for a site, or null if the admin URL
@@ -13,12 +16,27 @@ import getSiteOption from './get-site-option';
 export default function getSiteAdminUrl(
 	state: AppState,
 	siteId: number | null | undefined,
-	path = ''
+	path = '',
+	params: Context[ 'params' ] = {}
 ): string | null {
 	const adminUrl = getSiteOption( state, siteId, 'admin_url' );
 	if ( ! adminUrl ) {
 		return null;
 	}
 
-	return adminUrl + path.replace( /^\//, '' );
+	const searchParams = new URLSearchParams();
+
+	Object.entries( params ).forEach( ( [ key, value ] ) => {
+		const wpAdminSearchParam = CALYPSO_PARAMS_TO_WP_ADMIN_SEARCH_PARAMS.get( key );
+
+		if ( wpAdminSearchParam ) {
+			searchParams.set( wpAdminSearchParam, value );
+		}
+	} );
+
+	const searchParamsValue = searchParams.toString();
+
+	return `${ adminUrl }${ path.replace( /^\//, '' ) }${
+		searchParamsValue ? `?${ searchParamsValue }` : ''
+	}`;
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3135,6 +3135,29 @@ describe( 'selectors', () => {
 
 			expect( adminUrl ).toEqual( 'https://example.wordpress.com/wp-admin/customize.php' );
 		} );
+
+		test( 'should return the admin url with search params if they match a known calypso - wpadmin mapping', () => {
+			const adminUrl = getSiteAdminUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+								},
+							},
+						},
+					},
+				},
+				77203199,
+				'upload.php',
+				{ mediaId: 19 }
+			);
+
+			expect( adminUrl ).toEqual( 'https://example.wordpress.com/wp-admin/upload.php?item=19' );
+		} );
 	} );
 
 	describe( 'getCustomizerUrl()', () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14819

## Proposed Changes

* In order to be able to remove the calypso code related to a site's `Media`, we first need to redirect the single media page to wp-admin, since it's still accessible if you know the direct URL.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are removing calypso code made unnecessary by untangling

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site of yours go to `/wp-admin/upload.php`.
* Click on any media item, and take note of the id next to `?item=` on the URL. If you don't have any media, upload any image.
* Open the live preview.
* Go to `/media/{siteSlugOrId}/{mediaId}`, check that you are redirected to the wp-admin view for that media item

|Before|After|
|---|---|
|<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/dd69e2fd-d40a-4ce3-a9b9-c37c1331f162" />|<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/986b7144-e8bd-433e-b280-3ef84e8393a7" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
