### PR TITLE
v2 Plugins - Scheduled Updates: Pre-fill form with schedule data for Edit

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/constants.ts
+++ b/client/dashboard/plugins/scheduled-updates/constants.ts
@@ -1,5 +1,14 @@
 import type { Frequency, Weekday } from './types';
 
+export const WEEKDAYS = [
+	'Sunday',
+	'Monday',
+	'Tuesday',
+	'Wednesday',
+	'Thursday',
+	'Friday',
+	'Saturday',
+] as const;
 export const NEW_SCHEDULE_DEFAULT_TIME = '04:00';
 export const NEW_SCHEDULE_DEFAULT_FREQUENCY: Frequency = 'daily';
 export const NEW_SCHEDULE_DEFAULT_WEEKDAY: Weekday = 'Monday';

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -10,22 +10,8 @@ import PageLayout from '../../../components/page-layout';
 import {
 	ScheduledUpdatesForm,
 	type ScheduledUpdatesFormOnSubmit,
-	type InitialValues,
 } from '../components/schedule-form';
-
-/**
- *
- * Placeholder hook.
- */
-function useLoadScheduleById( _scheduleId: string ) {
-	// Placeholder state and derived values until hook is implemented in next task
-	void _scheduleId;
-	return {
-		loading: false,
-		error: '',
-		initial: null as unknown as InitialValues,
-	} as const;
-}
+import { useLoadScheduleById } from '../hooks/use-load-schedule-by-id';
 
 export default function PluginsScheduledUpdatesEdit() {
 	const { scheduleId } = pluginsScheduledUpdatesEditRoute.useParams();

--- a/client/dashboard/plugins/scheduled-updates/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/helpers.ts
@@ -180,3 +180,21 @@ export function formatScheduleCollisionsErrorMulti( {
 
 	return lines.join( '\n' );
 }
+
+/**
+ * Normalize a schedule ID coming from a human-readable URL,
+ * in case it includes derived suffixes like "-daily-<interval>-<HH:MM>",
+ * which are not part of the map key.
+ *
+ * Why this exists:
+ * - Pretty URLs may append metadata to the base schedule ID (e.g., "-daily-<interval>-<HH:MM>")
+ * so links are readable and reflect key params.
+ * - The base ID is the canonical storage key used by the API; suffixes are not part of the map key.
+ * - Uniqueness is per site; the same base ID can exist on multiple sites, which is expected in multisite.
+ * @param id string Possibly-suffixed schedule ID from the route
+ * @returns string Base schedule ID suitable for API map lookups
+ */
+export function normalizeScheduleId( id: string ): string {
+	const m = id.match( /^(.*)-(daily|weekly)-(\d+)-(\d{2}:\d{2})$/ );
+	return m ? m[ 1 ] : id;
+}

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-load-schedule-by-id.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-load-schedule-by-id.ts
@@ -2,6 +2,7 @@ import { hostingUpdateSchedulesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from '@wordpress/element';
 import { WEEKDAYS } from '../constants';
+import { normalizeScheduleId } from '../helpers';
 import type { InitialValues } from '../components/schedule-form';
 
 type Result = {
@@ -24,12 +25,12 @@ export function useLoadScheduleById( scheduleId: string ): Result {
 		}
 
 		const sitesMap = data?.sites || {};
+		const normalizedId = normalizeScheduleId( scheduleId );
 
 		const participatingSiteIds: string[] = [];
 		let firstSchedule = undefined;
-
 		for ( const [ siteIdStr, schedulesMap ] of Object.entries( sitesMap ) ) {
-			const sched = schedulesMap[ scheduleId ];
+			const sched = schedulesMap[ normalizedId ];
 			if ( sched ) {
 				participatingSiteIds.push( siteIdStr );
 				if ( ! firstSchedule ) {

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-load-schedule-by-id.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-load-schedule-by-id.ts
@@ -1,0 +1,63 @@
+import { hostingUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from '@wordpress/element';
+import { WEEKDAYS } from '../constants';
+import type { InitialValues } from '../components/schedule-form';
+
+type Result = {
+	loading: boolean;
+	error: string;
+	initial?: InitialValues;
+};
+
+/**
+ * Load a schedule by its ID from the multisite/hosting update schedules endpoint.
+ * @param scheduleId {string} - The ID of the schedule to load.
+ * @returns {Result} The loading state, error message, and initial values for the schedule.
+ */
+export function useLoadScheduleById( scheduleId: string ): Result {
+	const { data, isLoading } = useQuery( hostingUpdateSchedulesQuery() );
+
+	const derived = useMemo< Result >( () => {
+		if ( isLoading ) {
+			return { loading: true, error: '' };
+		}
+
+		const sitesMap = data?.sites || {};
+
+		const participatingSiteIds: string[] = [];
+		let firstSchedule = undefined;
+
+		for ( const [ siteIdStr, schedulesMap ] of Object.entries( sitesMap ) ) {
+			const sched = schedulesMap[ scheduleId ];
+			if ( sched ) {
+				participatingSiteIds.push( siteIdStr );
+				if ( ! firstSchedule ) {
+					firstSchedule = sched;
+				}
+			}
+		}
+
+		if ( participatingSiteIds.length === 0 || ! firstSchedule ) {
+			return { loading: false, error: 'Schedule not found.' };
+		}
+
+		const timestampSec = firstSchedule.timestamp ?? 0;
+		const date = new Date( timestampSec * 1000 );
+		const hours = date.getHours();
+		const time = `${ String( hours ).padStart( 2, '0' ) }:00`;
+		const weekday = WEEKDAYS[ date.getDay() ];
+
+		const initial: InitialValues = {
+			siteIds: participatingSiteIds,
+			plugins: firstSchedule.args || [],
+			frequency: firstSchedule.schedule || 'daily',
+			weekday,
+			time,
+		};
+
+		return { loading: false, error: '', initial };
+	}, [ data, isLoading, scheduleId ] );
+
+	return derived;
+}

--- a/client/dashboard/plugins/scheduled-updates/types.ts
+++ b/client/dashboard/plugins/scheduled-updates/types.ts
@@ -1,17 +1,9 @@
+import type { WEEKDAYS } from './constants';
 import type { Site } from '@automattic/api-core';
-export type Weekday =
-	| 'Monday'
-	| 'Tuesday'
-	| 'Wednesday'
-	| 'Thursday'
-	| 'Friday'
-	| 'Saturday'
-	| 'Sunday';
 
+export type Weekday = ( typeof WEEKDAYS )[ number ];
 export type Frequency = 'daily' | 'weekly';
-
 export type TimeSlot = { frequency: Frequency; timestamp: number };
-
 export type ScheduleCollisions = {
 	timeCollisions: { error: string; collidingSiteIds: number[] };
 	pluginCollisions: { error: string; collidingSiteIds: number[] };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Proposed Changes

- Load initial data given a schedule ID to pre-fill the schedule-form when visiting `v2/plugins/scheduled-udpates/edit/$scheduleId`, using the present multisite/hosting query for schedules
- Parity with original (v1 dashboard - `/plugins/scheduled-udpates/edit/...`) in handling suffixed IDs e.g. `-<frequency>-<interval>-<HH:MM>`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-udpates/` to access the list view, and grab a schedule ID to edit
* Go to `/v2/plugins/scheduled-update/edit/$schedule-id`  and confirm the page renders with prepopuated fields based on the schedule
  * Try a schedule with multiple sites and plugins

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
