### PR TITLE
v2 Plugins - Scheduled Updates: Exclude current schedule from validations in Edit

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -39,9 +39,20 @@ type Props = {
 	onSubmit: ScheduledUpdatesFormOnSubmit;
 	initial?: InitialValues;
 	onSitesChange?: ( ids: string[] ) => void;
+	/**
+	 * Context about the currently edited schedule (if any) so the form
+	 * can exclude it from collision validation.
+	 */
+	editedSchedule?: { siteIds: number[]; scheduleId: string };
 };
 
-export function ScheduledUpdatesForm( { submitLabel, onSubmit, initial, onSitesChange }: Props ) {
+export function ScheduledUpdatesForm( {
+	submitLabel,
+	onSubmit,
+	initial,
+	onSitesChange,
+	editedSchedule,
+}: Props ) {
 	const { data: eligibleSites = [] } = useEligibleSites();
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >(
 		() => initial?.siteIds || []
@@ -63,7 +74,10 @@ export function ScheduledUpdatesForm( { submitLabel, onSubmit, initial, onSitesC
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),
 		[ selectedSiteIds ]
 	);
-	const collisionsChecker = useScheduleCollisions();
+	const collisionsChecker = useScheduleCollisions(
+		undefined,
+		editedSchedule ? { exclude: editedSchedule } : undefined
+	);
 	const isValid = selectedSiteIds.length > 0 && selectedPluginSlugs.length > 0;
 	const isPrecheckLoading = collisionsChecker.isLoading;
 

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -41,6 +41,10 @@ export default function PluginsScheduledUpdatesEdit() {
 					submitLabel={ __( 'Save changes' ) }
 					onSubmit={ handleSave }
 					initial={ initial }
+					editedSchedule={ {
+						siteIds: ( initial?.siteIds || [] ).map( ( id ) => Number( id ) ),
+						scheduleId,
+					} }
 				/>
 			) }
 		</PageLayout>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Proposed Changes

The schedule form in v2 dashboard currently applies two forms of validation: time slot and plugin selection. 
- When editing an existing schedule in `/v2/plugins/scheduled-updates/edit/:schedule-id`, we want to exclude the current schedule from collision detection in the UI (the current schedule's selected sites). 
- Ensures parity with the original v1 dashboard when editing multi-site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/edit-schedule

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-udpates/` to access the list view, and grab a schedule ID to edit
* Go to `/v2/plugins/scheduled-update/edit/$schedule-id`  and confirm the page renders with prepopulated fields based on the schedule
  * Try a schedule with multiple sites and plugins
  * Ensure that no plugin or time slot collisions are present (communicated in Notices) when clicking on "Update Schedule". We don't have the server wired yet, but these are client-site pre-checks/validations.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
