### PR TITLE
Add logs to understand users' path on Survicate false return

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -20,6 +20,9 @@ const setSurvicateVisitorTraits = () => {
 		recordTracksEvent( 'calypso_survicate_user_not_available_error', {
 			user_exists: !! user,
 			user_has_email: !! ( user && user.email ),
+			referrer: document.referrer || '',
+			pathname: window.location.pathname || '',
+			hostname: window.location.hostname || '',
 		} );
 
 		return;

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -43,6 +43,21 @@ describe( 'survicate', () => {
 		// Reset all mocks
 		jest.clearAllMocks();
 
+		// Mock document.referrer and window.location
+		Object.defineProperty( document, 'referrer', {
+			value: 'https://example.com/previous-page',
+			writable: true,
+		} );
+
+		Object.defineProperty( window, 'location', {
+			value: {
+				pathname: '/current-page',
+				hostname: 'calypso.wordpress.com',
+				href: 'https://calypso.wordpress.com/current-page',
+			},
+			writable: true,
+		} );
+
 		// Set up fresh module imports
 		jest.isolateModules( () => {
 			const survicateModule = require( 'calypso/lib/analytics/survicate' );
@@ -227,6 +242,9 @@ describe( 'survicate', () => {
 				{
 					user_exists: false,
 					user_has_email: false,
+					referrer: 'https://example.com/previous-page',
+					pathname: '/current-page',
+					hostname: 'calypso.wordpress.com',
 				}
 			);
 		} );
@@ -269,6 +287,9 @@ describe( 'survicate', () => {
 				{
 					user_exists: true,
 					user_has_email: false,
+					referrer: 'https://example.com/previous-page',
+					pathname: '/current-page',
+					hostname: 'calypso.wordpress.com',
 				}
 			);
 		} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/105726

## Proposed Changes

* We're logging more information to understand the root cause of an undefined user

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to ensure all instances of Survate have an user


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
