### PR TITLE
FileBrowser: Make `notices` optional in `FileBrowserProvider`

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -569,13 +569,9 @@ function StagingSiteSyncModalInner( {
 
 export default function StagingSiteSyncModal( props: StagingSiteSyncModalProps ) {
 	const locale = useLocale();
-	const notices = {
-		showError: () => {},
-		showSuccess: () => {},
-	};
 
 	return (
-		<FileBrowserProvider locale={ locale } notices={ notices }>
+		<FileBrowserProvider locale={ locale }>
 			<StagingSiteSyncModalInner { ...props } />
 		</FileBrowserProvider>
 	);

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-context.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-context.tsx
@@ -10,7 +10,7 @@ interface NoticeHandlers {
 interface FileBrowserContextValue {
 	fileBrowserState: FileBrowserStateActions;
 	locale: string;
-	notices: NoticeHandlers;
+	notices?: NoticeHandlers;
 }
 
 const FileBrowserContext = createContext< FileBrowserContextValue | null >( null );
@@ -26,7 +26,7 @@ export const useFileBrowserContext = () => {
 interface FileBrowserProviderProps {
 	children: React.ReactNode;
 	locale: string;
-	notices: NoticeHandlers;
+	notices?: NoticeHandlers;
 }
 
 /**

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -63,7 +63,7 @@ function FileInfoCard( {
 
 	// Dispatch an error notice if the download could not be prepared
 	const handlePrepareDownloadError = useCallback( () => {
-		notices.showError( __( 'There was an error preparing your download. Please try again.' ) );
+		notices?.showError( __( 'There was an error preparing your download. Please try again.' ) );
 	}, [ notices ] );
 
 	const { prepareDownload, prepareDownloadStatus, downloadUrl } = usePrepareDownload(
@@ -83,7 +83,7 @@ function FileInfoCard( {
 
 	const handleDownloadError = useCallback( () => {
 		setIsProcessingDownload( false );
-		notices.showError( __( 'There was an error processing your download. Please try again.' ) );
+		notices?.showError( __( 'There was an error processing your download. Please try again.' ) );
 	}, [ notices ] );
 
 	const trackDownloadByType = useCallback(
@@ -177,7 +177,7 @@ function FileInfoCard( {
 
 	const prepareDownloadClick = useCallback( () => {
 		if ( ! item.period || ! fileInfo?.manifestFilter || ! fileInfo?.dataType ) {
-			notices.showError( __( 'There was an error preparing your download. Please try again.' ) );
+			notices?.showError( __( 'There was an error preparing your download. Please try again.' ) );
 			return;
 		}
 
@@ -244,7 +244,7 @@ function FileInfoCard( {
 	// Dispatch an error notice if the file info could not be retrieved
 	useEffect( () => {
 		if ( isError ) {
-			notices.showError(
+			notices?.showError(
 				__( 'There was an error retrieving your file information. Please try again.' )
 			);
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14635

## Proposed Changes

* make the `notices` optional (as they are not needed in all cases where `FileBrowser` is used)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Code clean-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. Head over to the following places where the `FileBrowser` is used and check there are no regressions:
  - The `Backups` tab in the V2 dashboard (`http://calypso.localhost:3000/v2/sites/{site-slug}/backups/`) - try to browse through the files, view and download some of them
  - The `Sync` staging site modal in the V2 dashboard (`http://calypso.localhost:3000/v2/sites/{site-slug}`) - try to browse the files in the modal
  - The `Sync` staging site modal in the V1 dashboard (`http://calypso.localhost:3000/sites/{site-slug}`) - try to browse the files in the modal
  - Jetpack Cloud - use the Jetpack Cloud Live link in the comment below to access backup of one of your WoA test sites; try to browse the files, view and download some of them

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
