### PR TITLE
HD Domains: Fix transfer domain overview UI and action conflicts

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -2,7 +2,6 @@ import {
 	domainQuery,
 	disconnectDomainMutation,
 	removePurchaseMutation,
-	siteByIdQuery,
 	sitePurchaseQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
@@ -26,7 +25,7 @@ import { getDomainRenewalUrl } from '../../utils/domain';
 import {
 	shouldShowTransferAction,
 	shouldShowDisconnectAction,
-	shouldShowDeleteAction,
+	shouldShowRemoveAction,
 	shouldShowCancelAction,
 	getDeleteTitle,
 	getDeleteLabel,
@@ -38,13 +37,13 @@ export default function Actions() {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 	const { data: purchase } = useQuery(
 		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
 	);
 	const { mutate: disconnectDomain, isPending: isDisconnecting } = useMutation(
 		disconnectDomainMutation( domainName )
 	);
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { mutate: deleteDomain, isPending: isDeleting } = useMutation( removePurchaseMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ isDisconnectDialogOpen, setIsDisconnectDialogOpen ] = useState( false );
@@ -84,7 +83,7 @@ export default function Actions() {
 		renew: purchase?.is_renewable,
 		transfer: shouldShowTransferAction( domain ),
 		disconnect: shouldShowDisconnectAction( domain ),
-		delete: shouldShowDeleteAction( domain, purchase, site ),
+		remove: shouldShowRemoveAction( domain, purchase ),
 		cancel: shouldShowCancelAction( domain, purchase ),
 	};
 
@@ -145,7 +144,7 @@ export default function Actions() {
 						}
 					/>
 				) }
-				{ availableActions.delete && (
+				{ availableActions.remove && (
 					<ActionList.ActionItem
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }
@@ -154,9 +153,7 @@ export default function Actions() {
 								size="compact"
 								variant="secondary"
 								isDestructive
-								isBusy={ isDeleting }
-								disabled={ isDeleting }
-								onClick={ () => setIsDeleteDialogOpen( true ) }
+								href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }` }
 							>
 								{ getDeleteLabel( domain ) }
 							</Button>
@@ -172,7 +169,7 @@ export default function Actions() {
 								size="compact"
 								variant="secondary"
 								isDestructive
-								href={ `/me/purchases/${ domain.domain }/${ purchase?.ID }/cancel` }
+								href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }/cancel` }
 							>
 								{ getDeleteLabel( domain ) }
 							</Button>

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -70,7 +70,7 @@ export const shouldShowCancelAction = ( domain: Domain, purchase?: Purchase ) =>
 		return false;
 	}
 
-	if ( ! purchase || ! purchase.is_cancelable ) {
+	if ( ! purchase || ! purchase.is_cancelable || purchase.is_removable ) {
 		return false;
 	}
 

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -1,6 +1,5 @@
-import { Domain, DomainSubtype, DomainTransferStatus, Purchase, Site } from '@automattic/api-core';
+import { Domain, DomainSubtype, DomainTransferStatus, Purchase } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
-import { isAkismetProduct } from '../../utils/purchase';
 
 export const transferableTypes: DomainSubtype[] = [
 	DomainSubtype.DEFAULT_ADDRESS,
@@ -8,6 +7,18 @@ export const transferableTypes: DomainSubtype[] = [
 	DomainSubtype.DOMAIN_REGISTRATION,
 ];
 export const disconnectableTypes: DomainSubtype[] = [ DomainSubtype.DOMAIN_REGISTRATION ];
+
+export const canAutoRenewBeTurnedOff = ( purchase: Purchase ) => {
+	if ( [ 'included', 'expired' ].includes( purchase.expiry_status ) ) {
+		return false;
+	}
+
+	if ( purchase.is_refundable && purchase.refund_amount > 0 ) {
+		return true;
+	}
+
+	return purchase.is_auto_renew_enabled;
+};
 
 export const shouldShowTransferAction = ( domain: Domain ) => {
 	if (
@@ -38,22 +49,26 @@ export const shouldShowDisconnectAction = ( domain: Domain ) => {
 	return true;
 };
 
-export const shouldShowDeleteAction = ( domain: Domain, purchase?: Purchase, site?: Site ) => {
+export const shouldShowRemoveAction = ( domain: Domain, purchase?: Purchase ) => {
 	if (
 		! domain.current_user_is_owner ||
 		domain.pending_registration ||
 		domain.move_to_new_site_pending ||
-		domain.transfer_status === DomainTransferStatus.PENDING_ASYNC
+		domain.transfer_status === DomainTransferStatus.PENDING_ASYNC ||
+		domain.is_hundred_year_domain
 	) {
 		return false;
 	}
 
-	if (
-		! purchase ||
-		! purchase.is_removable ||
-		// If we have a disconnected site that is _not_ a Jetpack purchase _or_ an Akismet purchase, no removal allowed.
-		( ! site && ! purchase.is_jetpack_plan_or_product && ! isAkismetProduct( purchase ) )
-	) {
+	if ( ! purchase ) {
+		return false;
+	}
+
+	if ( purchase.is_locked ) {
+		return false;
+	}
+
+	if ( canAutoRenewBeTurnedOff( purchase ) ) {
 		return false;
 	}
 
@@ -65,12 +80,28 @@ export const shouldShowCancelAction = ( domain: Domain, purchase?: Purchase ) =>
 		! domain.current_user_is_owner ||
 		domain.pending_registration ||
 		domain.move_to_new_site_pending ||
-		domain.transfer_status === DomainTransferStatus.PENDING_ASYNC
+		domain.transfer_status === DomainTransferStatus.PENDING_ASYNC ||
+		domain.is_hundred_year_domain
 	) {
 		return false;
 	}
 
-	if ( ! purchase || ! purchase.is_cancelable || purchase.is_removable ) {
+	if ( ! purchase ) {
+		return false;
+	}
+
+	if ( purchase.is_locked ) {
+		return false;
+	}
+
+	if ( ! canAutoRenewBeTurnedOff( purchase ) ) {
+		return false;
+	}
+
+	if (
+		purchase.product_slug === 'domain_transfer' &&
+		! ( purchase.is_refundable && purchase.refund_amount > 0 )
+	) {
 		return false;
 	}
 

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -52,11 +52,22 @@ export default function DomainOverview() {
 						<HStack spacing={ 2 } alignment="center" justify="flex-start">
 							{ domain.subtype?.label && <Badge>{ domain.subtype.label }</Badge> }
 							<span>
-								{ domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
-									? // translators: date is the date the domain was connected.
-									  sprintf( __( 'Connected on %(date)s' ), { date: formattedRegistrationDate } )
-									: // translators: date is the date the domain was registered.
-									  sprintf( __( 'Registered on %(date)s' ), { date: formattedRegistrationDate } ) }
+								{ ( () => {
+									switch ( domain.subtype.id ) {
+										case DomainSubtype.DOMAIN_CONNECTION:
+											// translators: date is the date the domain was connected.
+											return sprintf( __( 'Connected on %(date)s' ), {
+												date: formattedRegistrationDate,
+											} );
+										case DomainSubtype.DOMAIN_REGISTRATION:
+											// translators: date is the date the domain was registered.
+											return sprintf( __( 'Registered on %(date)s' ), {
+												date: formattedRegistrationDate,
+											} );
+										default:
+											return null;
+									}
+								} )() }
 							</span>
 						</HStack>
 					}
@@ -88,8 +99,12 @@ export default function DomainOverview() {
 			{ domain.is_pending_icann_verification && (
 				<IcannSuspensionNotice domainName={ domain.domain } />
 			) }
-			<FeaturedCards />
-			<DomainOverviewSettings domain={ domain } />
+			{ domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER && (
+				<>
+					<FeaturedCards />
+					<DomainOverviewSettings domain={ domain } />
+				</>
+			) }
 			<Actions />
 		</PageLayout>
 	);


### PR DESCRIPTION
Closes [DOTDASH-559](https://linear.app/a8c/issue/DOTDASH-559/fix-domain-setting-overview-for-domain-transfers)


## Proposed Changes
- Update remove/cancel actions logic in domain overview: we discussed to handle the cancelation in the purchase page in this first release.
- Conditionally hide Registration/Connection date for domain transfers and other domain subtype
- Conditionally hide `FeaturedCards` and `DomainOverviewSettings` components for domain transfers to show only transfer-relevant information

## Why are these changes being made?
The domain overview page was showing inappropriate UI elements and actions for domain transfers. Specifically:
- Action Conflicts: The cancel action was being shown even when a purchase was removable, leading to confusing duplicate actions (both "Cancel" and "Delete" buttons appearing)
- Irrelevant Content: Domain transfers were showing standard domain management features (renewal cards, DNS settings, etc.) that don't apply during the transfer process, creating a cluttered and confusing interface
- Missing Edge Cases: The previous ternary operator only handled DOMAIN_CONNECTION vs other types, but didn't properly handle DOMAIN_TRANSFER and other subtypes, potentially showing incorrect date descriptions

## Testing Instructions
- Visit this url `v2/domains/[your-domain]` for a pending transfer domain and verify that UI looks like the screenshot below (note: the warning panel could be different, depending on the transfer status)
- Also verify that registrations/connections are still working correctly
- Verify that the cancel cta goes to purchases page for different kind of domains (connection, registration, mapping)

<img width="1522" height="982" alt="transfer" src="https://github.com/user-attachments/assets/eed5f597-8fb7-490c-a35d-bfcc3ef14f98" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
