### PR TITLE
MCP: Update MCP tool access layout 

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -15,11 +15,13 @@ import {
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { SectionHeader } from '../../dashboard/components/section-header';
 import PreferencesLoginSiteDropdown from '../../dashboard/me/preferences-login/site-dropdown';
 import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from './utils';
@@ -27,6 +29,7 @@ import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from './utils';
 function McpComponent( { path } ) {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const { data: sites = [] } = useQuery( sitesQuery( { site_visibility: 'visible' } ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
@@ -37,12 +40,15 @@ function McpComponent( { path } ) {
 		onSuccess: ( newData ) => {
 			// Update the cache with the new data from the API response
 			queryClient.setQueryData( userSettingsQuery().queryKey, newData );
+			// Show success notification using Redux dispatch with unique ID to prevent stacking
+			dispatch( successNotice( translate( 'MCP settings saved.' ), { id: 'mcp-settings-saved' } ) );
 		},
-		meta: {
-			snackbar: {
-				success: translate( 'MCP settings saved.' ),
-				error: translate( 'Failed to save MCP settings.' ),
-			},
+		// eslint-disable-next-line no-unused-vars
+		onError: ( error ) => {
+			// Show error notification using Redux dispatch with unique ID to prevent stacking
+			dispatch(
+				errorNotice( translate( 'Failed to save MCP settings.' ), { id: 'mcp-settings-error' } )
+			);
 		},
 	} );
 
@@ -101,7 +107,7 @@ function McpComponent( { path } ) {
 			// Enabling: remove from sites array (use defaults)
 			if ( siteIndex >= 0 ) {
 				// Remove the site entry entirely
-				newSites = currentSites.filter( ( _, index ) => index !== siteIndex );
+				newSites = currentSites.filter( ( site, index ) => index !== siteIndex );
 			} else {
 				// Site not in array, already using defaults
 				newSites = currentSites;
@@ -125,10 +131,28 @@ function McpComponent( { path } ) {
 			];
 		}
 
-		// Create payload with updated sites array (minimal structure)
+		// For the API payload, we need to send the site being toggled as an array
+		// The API expects sites to be an array with blog_id fields
+		const sitesPayload = [];
+		if ( enabled ) {
+			// Enabling: send the site with account_tools_enabled: true
+			sitesPayload.push( {
+				blog_id: parseInt( siteId ),
+				account_tools_enabled: true,
+			} );
+		} else {
+			// Disabling: send the site with account_tools_enabled: false
+			sitesPayload.push( {
+				blog_id: parseInt( siteId ),
+				account_tools_enabled: false,
+			} );
+		}
+
+		// Only include sites in payload if there are any sites to send
+		// Don't include account object - only send the sites being changed
 		const payload = {
 			mcp_abilities: {
-				sites: newSites,
+				...( sitesPayload.length > 0 && { sites: sitesPayload } ),
 			},
 		};
 		mutation.mutate( payload );

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,283 +1,268 @@
-import { isAutomatticianQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import {
+	isAutomatticianQuery,
+	sitesQuery,
+	userSettingsQuery,
+	userSettingsMutation,
+} from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
+	ToggleControl,
 	Card,
 	CardBody,
-	CardHeader,
-	ToggleControl,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, createElement } from 'react';
-import { connect, useDispatch as useReduxDispatch } from 'react-redux';
+import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormButton from 'calypso/components/forms/form-button';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import { saveUserSettings } from 'calypso/state/user-settings/actions';
-import { isUpdatingUserSettings } from 'calypso/state/user-settings/selectors';
-import { getAccountMcpAbilities, createAccountApiPayload } from './utils';
+import { SectionHeader } from '../../dashboard/components/section-header';
+import PreferencesLoginSiteDropdown from '../../dashboard/me/preferences-login/site-dropdown';
+import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from './utils';
 
-function McpComponent( { path, userSettings, isUpdating } ) {
+function McpComponent( { path } ) {
 	const translate = useTranslate();
-	const reduxDispatch = useReduxDispatch();
+	const queryClient = useQueryClient();
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
+	const { data: sites = [] } = useQuery( sitesQuery( { site_visibility: 'visible' } ) );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	// Use the standard userSettingsMutation with simple auto-save
+	const mutation = useMutation( {
+		...userSettingsMutation(),
+		onSuccess: ( newData ) => {
+			// Update the cache with the new data from the API response
+			queryClient.setQueryData( userSettingsQuery().queryKey, newData );
+		},
+		meta: {
+			snackbar: {
+				success: translate( 'MCP settings saved.' ),
+				error: translate( 'Failed to save MCP settings.' ),
+			},
+		},
+	} );
 
 	// Get account-level tools from user settings using the new nested structure
 	const mcpAbilities = getAccountMcpAbilities( userSettings );
 	const availableTools = Object.entries( mcpAbilities );
 	const hasTools = availableTools.length > 0;
 
-	const [ formData, setFormData ] = useState( {
-		mcp_abilities: mcpAbilities,
-	} );
+	// Site selector state for disabling MCP access on specific sites
+	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
 
-	// Calculate if any tools are enabled (for master toggle and individual toggle disabled state)
+	// Check if any tools are enabled (for master toggle state)
 	const anyToolsEnabled =
-		hasTools && Object.values( formData.mcp_abilities ).some( ( tool ) => tool.enabled );
-
-	// Check if form data has changed from original user settings
-	const hasUnsavedChanges = ( () => {
-		const originalAbilities = getAccountMcpAbilities( userSettings );
-		if ( ! originalAbilities || ! formData.mcp_abilities ) {
-			return false;
-		}
-
-		return Object.keys( originalAbilities ).some( ( toolId ) => {
-			const originalEnabled = originalAbilities[ toolId ]?.enabled;
-			const currentEnabled = formData.mcp_abilities[ toolId ]?.enabled;
-			return originalEnabled !== currentEnabled;
-		} );
-	} )();
-
-	// Update form data when userSettings changes
-	useEffect( () => {
-		const accountAbilities = getAccountMcpAbilities( userSettings );
-		setFormData( {
-			mcp_abilities: accountAbilities,
-		} );
-	}, [ userSettings ] );
+		hasTools && Object.values( mcpAbilities ).some( ( tool ) => tool.enabled );
 
 	if ( ! isAutomattician ) {
 		return null;
 	}
 
-	const handleSubmit = ( e ) => {
-		e.preventDefault();
-
-		// Create the new nested API payload for account-level settings
-		const settingsData = createAccountApiPayload( userSettings, formData.mcp_abilities );
-
-		// Save using the new nested structure
-		reduxDispatch( saveUserSettings( settingsData ) );
-	};
-
 	const handleToolChange = ( toolId, enabled ) => {
-		setFormData( ( prev ) => ( {
-			...prev,
+		// Create minimal payload with only the changed tool (just boolean)
+		const payload = {
 			mcp_abilities: {
-				...prev.mcp_abilities,
-				[ toolId ]: {
-					...prev.mcp_abilities[ toolId ],
-					enabled,
+				account: {
+					[ toolId ]: enabled,
 				},
 			},
-		} ) );
+		};
+		mutation.mutate( payload );
 	};
 
 	const handleMasterToggle = ( enabled ) => {
-		setFormData( ( prev ) => ( {
-			...prev,
-			mcp_abilities: Object.keys( prev.mcp_abilities ).reduce( ( acc, toolId ) => {
-				acc[ toolId ] = {
-					...prev.mcp_abilities[ toolId ],
-					enabled,
-				};
-				return acc;
-			}, {} ),
-		} ) );
+		// Create payload with all tools set to the same state (just booleans)
+		const accountAbilities = {};
+		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
+			accountAbilities[ toolId ] = enabled;
+		} );
+
+		const payload = {
+			mcp_abilities: {
+				account: accountAbilities,
+			},
+		};
+		mutation.mutate( payload );
+	};
+
+	const handleSiteToggle = ( siteId, enabled ) => {
+		// Get current sites array from nested structure
+		const currentSites = userSettings?.mcp_abilities?.sites || [];
+
+		// Find existing site entry
+		const siteIndex = currentSites.findIndex( ( site ) => site.blog_id === parseInt( siteId ) );
+
+		let newSites;
+		if ( enabled ) {
+			// Enabling: remove from sites array (use defaults)
+			if ( siteIndex >= 0 ) {
+				// Remove the site entry entirely
+				newSites = currentSites.filter( ( _, index ) => index !== siteIndex );
+			} else {
+				// Site not in array, already using defaults
+				newSites = currentSites;
+			}
+		} else if ( siteIndex >= 0 ) {
+			// Disabling: update existing site entry
+			newSites = [ ...currentSites ];
+			newSites[ siteIndex ] = {
+				...newSites[ siteIndex ],
+				account_tools_enabled: false,
+			};
+		} else {
+			// Disabling: add new site entry with override
+			newSites = [
+				...currentSites,
+				{
+					blog_id: parseInt( siteId ),
+					account_tools_enabled: false,
+					abilities: {},
+				},
+			];
+		}
+
+		// Create payload with updated sites array (minimal structure)
+		const payload = {
+			mcp_abilities: {
+				sites: newSites,
+			},
+		};
+		mutation.mutate( payload );
+	};
+
+	// Helper function to render tools section using ExtrasToggleCard pattern
+	const renderToolsSection = ( tools ) => {
+		if ( ! tools || tools.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<Card isRounded={ false }>
+				<CardBody>
+					<VStack spacing={ 8 }>
+						<SectionHeader
+							level={ 3 }
+							title={ translate( 'Available MCP Tools' ) }
+							description={ translate(
+								'Configure which MCP tools are available for your account.'
+							) }
+						/>
+
+						{ /* Individual tool toggles */ }
+						<VStack>
+							{ tools.map( ( [ toolId, tool ] ) => (
+								<ToggleControl
+									key={ toolId }
+									__nextHasNoMarginBottom
+									checked={ tool.enabled }
+									disabled={ mutation.isPending }
+									label={ tool.title }
+									help={ tool.description }
+									onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+								/>
+							) ) }
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		);
 	};
 
 	const renderContent = () => {
-		// Get tools from user settings, but use form data for current state
-		const tools = availableTools.map( ( [ toolId, tool ] ) => [
-			toolId,
-			{
-				...tool,
-				enabled: formData.mcp_abilities?.[ toolId ]?.enabled ?? tool.enabled,
-			},
-		] );
-
-		// Group tools by type first, then by category
-		const groupedByType = tools.reduce( ( typeGroups, [ toolId, tool ] ) => {
-			const type = tool.type || 'tool'; // Default to 'tool' instead of 'other'
-			const category = tool.category || 'General';
-
-			// Only include the three main types
-			if ( ! [ 'tool', 'resource', 'prompt' ].includes( type ) ) {
-				return typeGroups;
-			}
-
-			if ( ! typeGroups[ type ] ) {
-				typeGroups[ type ] = {};
-			}
-			if ( ! typeGroups[ type ][ category ] ) {
-				typeGroups[ type ][ category ] = [];
-			}
-			typeGroups[ type ][ category ].push( [ toolId, tool ] );
-			return typeGroups;
-		}, {} );
-
-		// Type descriptions
-		const typeDescriptions = {
-			tool: translate(
-				'Tools allow AI assistants to read and search your WordPress.com data. These are view-only capabilities that cannot modify your content or settings.'
-			),
-			resource: translate(
-				'Resources provide AI assistants with read-only access to your data, such as site statistics or user information.'
-			),
-			prompt: translate(
-				'Prompts help AI assistants understand context and provide better responses to your queries.'
-			),
-		};
-
-		// Type display names
-		const typeDisplayNames = {
-			tool: translate( 'Tools' ),
-			resource: translate( 'Resources' ),
-			prompt: translate( 'Prompts' ),
-		};
+		// Use mcpAbilities directly since we're using auto-save
+		const accountToolsToShow = availableTools;
 
 		return (
-			<form onSubmit={ handleSubmit }>
-				<Card style={ { borderRadius: '0' } }>
-					<CardHeader size="small">
-						<VStack spacing={ 2 }>
-							<Text as="h1">{ translate( 'Account-level MCP tools' ) }</Text>
-							<Text as="p" variant="muted">
-								{ translate(
-									'These tools are available across all your sites. You can enable or disable them here to control access globally.'
-								) }
-							</Text>
-						</VStack>
-					</CardHeader>
+			<VStack spacing={ 8 }>
+				{ /* MCP Tool Access Master Toggle */ }
+				<Card isRounded={ false }>
 					<CardBody>
-						{ hasTools ? (
-							<VStack spacing={ 3 }>
-								<div
-									style={ {
-										display: 'flex',
-										justifyContent: 'space-between',
-										alignItems: 'center',
-									} }
-								>
-									<ToggleControl
-										checked={ anyToolsEnabled }
-										onChange={ handleMasterToggle }
-										label={ translate( 'Allow MCP access' ) }
-									/>
-									{ anyToolsEnabled && (
-										<Button variant="secondary" href="/me/mcp-setup">
-											{ translate( 'Configure MCP Client' ) }
-										</Button>
-									) }
-								</div>
-							</VStack>
-						) : (
-							<Text as="p" variant="muted">
-								{ translate( 'No MCP tools are currently available.' ) }
-							</Text>
-						) }
+						<VStack spacing={ 8 }>
+							<SectionHeader
+								level={ 3 }
+								title={ translate( 'MCP Tool Access' ) }
+								description={ translate(
+									'Configure MCP access for your WordPress.com account. Enable access globally and control which tools are available.'
+								) }
+							/>
+
+							<div
+								style={ {
+									display: 'flex',
+									justifyContent: 'space-between',
+									alignItems: 'center',
+								} }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									checked={ anyToolsEnabled }
+									onChange={ handleMasterToggle }
+									label={
+										<Text weight="bold">
+											{ anyToolsEnabled
+												? translate( 'Disable MCP Tool Access' )
+												: translate( 'Enable MCP Tool Access' ) }
+										</Text>
+									}
+								/>
+								{ anyToolsEnabled && (
+									<Button variant="secondary" href="/me/mcp-setup">
+										{ translate( 'Configure MCP Client' ) }
+									</Button>
+								) }
+							</div>
+						</VStack>
 					</CardBody>
 				</Card>
 
+				{ /* Account Tools Sections */ }
+				{ hasTools && renderToolsSection( accountToolsToShow ) }
+
+				{ /* Site-Specific Settings */ }
 				{ hasTools && anyToolsEnabled && (
-					<>
-						{ Object.entries( groupedByType ).map( ( [ type, typeCategories ] ) => (
-							<div key={ type } style={ { marginTop: '24px' } }>
-								<Card style={ { borderRadius: '0' } }>
-									<CardHeader size="small">
-										<VStack spacing={ 2 }>
-											<Text as="h1">{ typeDisplayNames[ type ] }</Text>
-											<Text as="p" variant="muted">
-												{ typeDescriptions[ type ] }
+					<Card isRounded={ false }>
+						<CardBody>
+							<VStack spacing={ 8 }>
+								<SectionHeader
+									level={ 3 }
+									title={ translate( 'Site-specific MCP settings' ) }
+									description={ translate(
+										'Select a site below to disable MCP access for that site only. This will override the global settings.'
+									) }
+								/>
+
+								<PreferencesLoginSiteDropdown
+									sites={ sites }
+									value={ selectedSiteId }
+									onChange={ setSelectedSiteId }
+									label={ translate( 'Select a site to disable MCP access' ) }
+									isLoading={ false }
+								/>
+
+								{ selectedSiteId && anyToolsEnabled && (
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ getSiteAccountToolsEnabled( userSettings, selectedSiteId ) }
+										disabled={ mutation.isPending }
+										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
+										label={
+											<Text weight="bold">
+												{ getSiteAccountToolsEnabled( userSettings, selectedSiteId )
+													? translate( 'Disable MCP access for this site' )
+													: translate( 'Enable MCP access for this site' ) }
 											</Text>
-										</VStack>
-									</CardHeader>
-									<CardBody>
-										<VStack spacing={ 6 }>
-											{ Object.entries( typeCategories ).map( ( [ category, categoryTools ] ) => (
-												<VStack key={ category } spacing={ 4 }>
-													<Text as="h3" style={ { textTransform: 'capitalize' } }>
-														{ category }
-													</Text>
-													<VStack spacing={ 4 }>
-														{ categoryTools.map( ( [ toolId, tool ] ) => (
-															<VStack key={ toolId } spacing={ 3 }>
-																<ToggleControl
-																	checked={ tool.enabled }
-																	onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-																	label={ tool.title }
-																	help={ tool.description }
-																	disabled={ ! anyToolsEnabled }
-																/>
-															</VStack>
-														) ) }
-													</VStack>
-												</VStack>
-											) ) }
-										</VStack>
-									</CardBody>
-								</Card>
-							</div>
-						) ) }
-					</>
+										}
+									/>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
 				) }
-
-				{ hasTools && anyToolsEnabled && (
-					<>
-						<div style={ { marginTop: '24px' } }>
-							<Card>
-								<CardBody>
-									<VStack spacing={ 3 }>
-										<Text as="h4" style={ { margin: 0 } }>
-											{ translate( 'Site-specific MCP settings' ) }
-										</Text>
-										<Text as="p" variant="muted" style={ { margin: 0 } }>
-											{ createInterpolateElement(
-												translate(
-													'Account-level MCP tools are available on all your sites. You can manage site-specific MCP access and overrides in <a>individual site settings</a>.'
-												),
-												{
-													a: createElement( 'a', {
-														href: '/sites',
-														target: '_blank',
-														style: { textDecoration: 'underline' },
-													} ),
-												}
-											) }
-										</Text>
-									</VStack>
-								</CardBody>
-							</Card>
-						</div>
-					</>
-				) }
-
-				{ hasTools && (
-					<div style={ { marginTop: '24px' } }>
-						<FormButton isSubmitting={ isUpdating } disabled={ isUpdating || ! hasUnsavedChanges }>
-							{ isUpdating ? translate( 'Saving…' ) : translate( 'Save MCP tools' ) }
-						</FormButton>
-					</div>
-				) }
-			</form>
+			</VStack>
 		);
 	};
 
@@ -302,10 +287,4 @@ function McpComponent( { path, userSettings, isUpdating } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		userSettings: getUserSettings( state ),
-		isUpdating: isUpdatingUserSettings( state ),
-	} ),
-	{}
-)( McpComponent );
+export default McpComponent;

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,9 +1,5 @@
-import {
-	isAutomatticianQuery,
-	sitesQuery,
-	userSettingsQuery,
-	userSettingsMutation,
-} from '@automattic/api-queries';
+import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
@@ -30,9 +26,11 @@ function McpComponent( { path } ) {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
-	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const { data: sites = [] } = useQuery( sitesQuery( { site_visibility: 'visible' } ) );
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
+	// Site selector state for disabling MCP access on specific sites
+	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
 
 	// Use the standard userSettingsMutation with simple auto-save
 	const mutation = useMutation( {
@@ -53,20 +51,13 @@ function McpComponent( { path } ) {
 	} );
 
 	// Get account-level tools from user settings using the new nested structure
-	const mcpAbilities = getAccountMcpAbilities( userSettings );
+	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
 	const availableTools = Object.entries( mcpAbilities );
 	const hasTools = availableTools.length > 0;
-
-	// Site selector state for disabling MCP access on specific sites
-	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
 
 	// Check if any tools are enabled (for master toggle state)
 	const anyToolsEnabled =
 		hasTools && Object.values( mcpAbilities ).some( ( tool ) => tool.enabled );
-
-	if ( ! isAutomattician ) {
-		return null;
-	}
 
 	const handleToolChange = ( toolId, enabled ) => {
 		// Create minimal payload with only the changed tool (just boolean)
@@ -171,9 +162,7 @@ function McpComponent( { path } ) {
 						<SectionHeader
 							level={ 3 }
 							title={ translate( 'Available MCP Tools' ) }
-							description={ translate(
-								'Configure which MCP tools are available for your account.'
-							) }
+							description={ translate( 'Choose which AI tools you want to use.' ) }
 						/>
 
 						{ /* Individual tool toggles */ }
@@ -210,7 +199,7 @@ function McpComponent( { path } ) {
 								level={ 3 }
 								title={ translate( 'MCP Tool Access' ) }
 								description={ translate(
-									'Configure MCP access for your WordPress.com account. Enable access globally and control which tools are available.'
+									'Control which MCP tools can access your WordPress.com account and sites.'
 								) }
 							/>
 
@@ -255,7 +244,7 @@ function McpComponent( { path } ) {
 									level={ 3 }
 									title={ translate( 'Site-specific MCP settings' ) }
 									description={ translate(
-										'Select a site below to disable MCP access for that site only. This will override the global settings.'
+										'Choose a site to block all MCP tools for all users on that site. This overrides your account settings.'
 									) }
 								/>
 
@@ -270,12 +259,12 @@ function McpComponent( { path } ) {
 								{ selectedSiteId && anyToolsEnabled && (
 									<ToggleControl
 										__nextHasNoMarginBottom
-										checked={ getSiteAccountToolsEnabled( userSettings, selectedSiteId ) }
+										checked={ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId ) }
 										disabled={ mutation.isPending }
 										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
 										label={
 											<Text weight="bold">
-												{ getSiteAccountToolsEnabled( userSettings, selectedSiteId )
+												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
 													? translate( 'Disable MCP access for this site' )
 													: translate( 'Enable MCP access for this site' ) }
 											</Text>
@@ -289,6 +278,11 @@ function McpComponent( { path } ) {
 			</VStack>
 		);
 	};
+
+	// Check if MCP settings feature is enabled
+	if ( ! config.isEnabled( 'mcp-settings' ) ) {
+		return null;
+	}
 
 	return (
 		<Main wideLayout className="mcp">

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -183,17 +183,17 @@ function McpSetupComponent( { path, userSettings } ) {
 							) }
 						</Text>
 						<VStack spacing={ 2 }>
-							<Text as="li" style={ { listStyle: 'none' } }>
+							<Text as="li">
 								{ translate(
 									'Running a bridge server using the WordPress.com-specific MCP package'
 								) }
 							</Text>
-							<Text as="li" style={ { listStyle: 'none' } }>
+							<Text as="li">
 								{ translate(
 									'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
 								) }
 							</Text>
-							<Text as="li" style={ { listStyle: 'none' } }>
+							<Text as="li">
 								{ translate(
 									"Providing real-time access to your account's content and management features"
 								) }

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,8 +1,6 @@
-import { isAutomatticianQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useQuery } from '@tanstack/react-query';
 import {
 	bell,
 	category,
@@ -202,11 +200,11 @@ class MeSidebar extends Component {
 						preloadSectionName="developer"
 					/>
 
-					{ this.props.isAutomattician && (
+					{ config.isEnabled( 'mcp-settings' ) && (
 						<SidebarItem
 							selected={ path.startsWith( '/mcp' ) }
 							link="/me/mcp"
-							label={ translate( 'MCP' ) + ' (' + translate( 'A8C Only' ) + ')' }
+							label={ translate( 'MCP' ) }
 							customIcon={ <McpIcon style={ { padding: '2px', boxSizing: 'border-box' } } /> }
 							onNavigate={ this.onNavigate }
 							preloadSectionName="mcp"
@@ -293,10 +291,4 @@ const ConnectedMeSidebar = withCurrentRoute(
 	)( localize( MeSidebar ) )
 );
 
-// Wrapper component to add React Query support
-function MeSidebarWithQuery( props ) {
-	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
-	return <ConnectedMeSidebar { ...props } isAutomattician={ isAutomattician } />;
-}
-
-export default MeSidebarWithQuery;
+export default ConnectedMeSidebar;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AIINT-187/add-account-tools-toggle-to-site-settings

This PR refactors the MCP settings UI from a Redux-based form with manual save to an auto-save pattern using React Query, and adds site-specific account tools access control.

This now uses the `mcp-settings` feature flag - rather than checking if the user is an Automattican.

## Proposed Changes

1. **Auto-save Pattern**: Removed form submission entirely - each toggle change now saves immediately via mutation without requiring a "Save" button

2. **React Query Migration**: 
   - Replaced Redux (`connect`, `useReduxDispatch`, selectors/actions) with `@tanstack/react-query` hooks
   - Uses `useSuspenseQuery` for userSettings and `useMutation` for updates
   - Implements optimistic cache updates via `queryClient.setQueryData()`
   - Added mutation success/error snackbar notifications

3. **Site-Specific Access Control UI**:
   - Added `PreferencesLoginSiteDropdown` for site selection
   - New `handleSiteToggle()` manages per-site `account_tools_enabled` flag
   - Sites with default settings (enabled) are removed from the sites array to optimize payload size
   - Sites with disabled access are added/updated in the sites array

4. **Simplified UI Structure**:
   - Removed tool categorization by type (tool/resource/prompt) and category grouping
   - Consolidated into single flat list of account-level tools
   - Replaced `CardHeader` with reusable `SectionHeader` component
   - Removed `createInterpolateElement` in favor of simpler text

5. **State Management**:
   - Eliminated local `formData` state and `useEffect` sync logic
   - Reads directly from `mcpAbilities` for current state (single source of truth)
   - Removed `hasUnsavedChanges` tracking since changes save immediately

6. **Utils Updates**:
   - New `getSiteAccountToolsEnabled()` helper checks site-specific overrides
   - Updated `getAccountMcpAbilities()` to support both nested and flat response structures for backward compatibility
   - Simplified `createAccountApiPayload()` documentation

7. **Payload Structure**: Matches backend changes - sends minimal payloads with only changed values using nested `mcp_abilities.account` and `mcp_abilities.sites` structure

## Screenshot

<img width="858" height="1265" alt="Screenshot 2025-09-30 at 14 58 43" src="https://github.com/user-attachments/assets/12c3b577-f168-4f7c-9c8f-57c9ac2dbf42" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Requires 193089-ghe-Automattic/wpcom applied to sandbox
* Sandbox `public-api.wordpress.com`
* Test MCP tool access via Claude or some other MCP client.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?