### PR TITLE
Composite Checkout: Remove final CheckoutProvider custom provider

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -235,7 +235,11 @@ export default function PaymentMethodSelector( {
 				{ currentPaymentMethodNotAvailable && purchase && (
 					<CurrentPaymentMethodNotAvailableNotice purchase={ purchase } />
 				) }
-				<CheckoutPaymentMethods className="payment-method-selector__list" isComplete={ false } />
+				<CheckoutPaymentMethods
+					className="payment-method-selector__list"
+					isComplete={ false }
+					onPageLoadError={ logError }
+				/>
 				<TOSItemWrapper>
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -710,6 +710,7 @@ export default function CheckoutMainContent( {
 						<CheckoutStep
 							className="checkout-contact-form-step"
 							stepId="contact-form"
+							onPageLoadError={ onPageLoadError }
 							isCompleteCallback={ async () => {
 								// Touch the fields so they display validation errors
 								shouldShowContactDetailsValidationErrors && touchContactFields();
@@ -834,6 +835,7 @@ export default function CheckoutMainContent( {
 						) }
 						validatingButtonText={ validatingButtonText }
 						validatingButtonAriaLabel={ validatingButtonText }
+						onPageLoadError={ onPageLoadError }
 						isCompleteCallback={ () => {
 							// We want to consider this step complete only if there is a
 							// payment method selected and it does not have required fields.

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -3,7 +3,6 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useCallback, useContext } from 'react';
-import CheckoutContext from '../lib/checkout-context';
 import joinClasses from '../lib/join-classes';
 import { PaymentMethodProviderContext } from '../lib/payment-method-provider-context';
 import { useAvailablePaymentMethodIds } from '../lib/payment-methods';
@@ -15,7 +14,7 @@ import {
 	useIsStepComplete,
 	useFormStatus,
 } from '../public-api';
-import { FormStatus } from '../types';
+import { CheckoutPageErrorCallback, FormStatus } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import RadioButton from './radio-button';
 import type { ReactNode } from 'react';
@@ -34,13 +33,14 @@ export default function CheckoutPaymentMethods( {
 	summary,
 	isComplete,
 	className,
+	onPageLoadError,
 }: {
 	summary?: boolean;
 	isComplete: boolean;
 	className?: string;
+	onPageLoadError?: CheckoutPageErrorCallback;
 } ) {
 	const { __ } = useI18n();
-	const { onPageLoadError } = useContext( CheckoutContext );
 	const { onPaymentMethodChanged } = useContext( PaymentMethodProviderContext );
 	const onError = useCallback(
 		( error: Error ) => onPageLoadError?.( 'payment_method_load', error ),

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -59,7 +59,6 @@ export function CheckoutProvider( {
 						onPaymentComplete={ onPaymentComplete }
 						onPaymentRedirect={ onPaymentRedirect }
 						onPaymentError={ onPaymentError }
-						onPageLoadError={ onPageLoadError }
 						isLoading={ isLoading }
 						isValidating={ isValidating }
 						redirectToUrl={ redirectToUrl }

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,15 +1,13 @@
 import { ThemeProvider } from '@emotion/react';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useMemo } from 'react';
-import CheckoutContext from '../lib/checkout-context';
+import { useCallback, useEffect } from 'react';
 import defaultTheme from '../lib/theme';
 import { validateArg, validatePaymentMethods } from '../lib/validation';
 import { CheckoutProviderProps } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormAndTransactionProvider } from './form-and-transaction-provider';
 import { PaymentMethodProvider } from './payment-method-provider';
-import type { CheckoutContextInterface } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
@@ -39,14 +37,6 @@ export function CheckoutProvider( {
 		initiallySelectedPaymentMethodId,
 	};
 
-	// Create a big blob of state to store in React Context for use by all this Provider's children.
-	const value: CheckoutContextInterface = useMemo(
-		() => ( {
-			onPageLoadError,
-		} ),
-		[ onPageLoadError ]
-	);
-
 	const { __ } = useI18n();
 	const errorMessage = __( 'Sorry, there was an error loading this page.' );
 	const onLoadError = useCallback(
@@ -69,11 +59,12 @@ export function CheckoutProvider( {
 						onPaymentComplete={ onPaymentComplete }
 						onPaymentRedirect={ onPaymentRedirect }
 						onPaymentError={ onPaymentError }
+						onPageLoadError={ onPageLoadError }
 						isLoading={ isLoading }
 						isValidating={ isValidating }
 						redirectToUrl={ redirectToUrl }
 					>
-						<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
+						{ children }
 					</FormAndTransactionProvider>
 				</ThemeProvider>
 			</PaymentMethodProvider>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -1180,8 +1180,14 @@ export function CheckoutStepGroup( {
 	);
 }
 
-const paymentMethodStepProps = getDefaultPaymentMethodStep();
 export function PaymentMethodStep( props: Partial< CheckoutStepProps > ) {
+	const paymentMethodStepProps = useMemo(
+		() =>
+			getDefaultPaymentMethodStep( {
+				onPageLoadError: props.onPageLoadError,
+			} ),
+		[ props.onPageLoadError ]
+	);
 	return <CheckoutStep { ...{ ...paymentMethodStepProps, ...props } } />;
 }
 PaymentMethodStep.isCheckoutStep = true;

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -14,7 +14,6 @@ import {
 	useMemo,
 } from 'react';
 import { getDefaultPaymentMethodStep } from '../components/default-steps';
-import CheckoutContext from '../lib/checkout-context';
 import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
 import { usePaymentMethod } from '../lib/payment-methods';
@@ -36,6 +35,7 @@ import type {
 	CheckoutStepGroupStore,
 	StepChangedCallback,
 	MakeStepActive,
+	CheckoutPageErrorCallback,
 } from '../types';
 import type { ReactNode, HTMLAttributes, PropsWithChildren, ReactElement } from 'react';
 
@@ -468,6 +468,7 @@ export const CheckoutStep = ( {
 	nextStepButtonAriaLabel,
 	validatingButtonText,
 	validatingButtonAriaLabel,
+	onPageLoadError,
 }: CheckoutStepProps ) => {
 	const { __ } = useI18n();
 	const { actions } = useContext( CheckoutStepGroupContext );
@@ -480,7 +481,6 @@ export const CheckoutStep = ( {
 	const { stepNumber, nextStepNumber, isStepActive, isStepComplete, areStepsActive } = useContext(
 		CheckoutSingleStepDataContext
 	);
-	const { onPageLoadError } = useContext( CheckoutContext );
 	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
 	const makeStepActive = useMakeStepActive();
 	const setThisStepCompleteStatus = ( newStatus: boolean ) =>
@@ -650,12 +650,14 @@ export function CheckoutFormSubmit( {
 	submitButtonFooter,
 	disableSubmitButton,
 	submitButton,
+	onPageLoadError,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
 	submitButtonFooter?: ReactNode;
 	disableSubmitButton?: boolean;
 	submitButton?: ReactNode;
+	onPageLoadError?: CheckoutPageErrorCallback;
 } ) {
 	const { state } = useContext( CheckoutStepGroupContext );
 	const { activeStepNumber, totalSteps, stepCompleteStatus } = state;
@@ -663,7 +665,6 @@ export function CheckoutFormSubmit( {
 	const areAllStepsComplete = Object.values( stepCompleteStatus ).every(
 		( isComplete ) => isComplete === true
 	);
-	const { onPageLoadError } = useContext( CheckoutContext );
 	const onSubmitButtonLoadError = useCallback(
 		( error: Error ) => onPageLoadError?.( 'submit_button_load', error ),
 		[ onPageLoadError ]

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -1,13 +1,19 @@
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
-import type { CheckoutStepProps } from '../types';
+import type { CheckoutPageErrorCallback, CheckoutStepProps } from '../types';
 
-export function getDefaultPaymentMethodStep(): CheckoutStepProps {
+export function getDefaultPaymentMethodStep( {
+	onPageLoadError,
+}: {
+	onPageLoadError?: CheckoutPageErrorCallback;
+} ): CheckoutStepProps {
 	return {
 		stepId: 'payment-method-step',
 		isCompleteCallback: () => true,
 		className: 'checkout__payment-method-step',
 		titleContent: <CheckoutPaymentMethodsTitle />,
-		activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
+		activeStepContent: (
+			<CheckoutPaymentMethods onPageLoadError={ onPageLoadError } isComplete={ false } />
+		),
 		completeStepContent: <CheckoutPaymentMethods summary isComplete />,
 	};
 }

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-import { CheckoutContextInterface } from '../types';
-
-const defaultCheckoutContext: CheckoutContextInterface = {};
-
-const CheckoutContext = createContext( defaultCheckoutContext );
-
-export default CheckoutContext;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -24,6 +24,7 @@ export interface CheckoutStepProps {
 	nextStepButtonAriaLabel?: string;
 	validatingButtonText?: string;
 	validatingButtonAriaLabel?: string;
+	onPageLoadError?: CheckoutPageErrorCallback;
 }
 
 export type IsCompleteCallback = () => boolean | Promise< boolean >;
@@ -93,10 +94,6 @@ export interface PaymentMethodProviderContextInterface {
 	paymentMethodId: string | null | undefined;
 	setPaymentMethodId: ( id: string ) => void;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
-}
-
-export interface CheckoutContextInterface {
-	onPageLoadError?: CheckoutPageErrorCallback;
 }
 
 export type ReactStandardAction< T = string, P = unknown > = P extends void

--- a/packages/composite-checkout/test/utils/default-checkout-steps.tsx
+++ b/packages/composite-checkout/test/utils/default-checkout-steps.tsx
@@ -58,7 +58,7 @@ function CheckoutReviewOrder( { items }: { items: LineItem[] } ) {
 }
 
 export function DefaultCheckoutSteps( { items }: { items: LineItem[] } ) {
-	const paymentMethodStep = getDefaultPaymentMethodStep();
+	const paymentMethodStep = getDefaultPaymentMethodStep( {} );
 	return (
 		<CheckoutStepGroup>
 			<CheckoutStepBody


### PR DESCRIPTION
Fixes SHILL-1131

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

CheckoutProvider does too much. Previous efforts have been made (#81796, #81793, #80529, #101974, #102074) to move toward making it just a wrapper for a series of other providers (perhaps eventually replacing it entirely?), but there's still state that it maintains.

This PR removes the final piece of state that was not included in other providers: `onPageLoadError`. That prop is then added to the three places that actually need it: `CheckoutProvider`, `CheckoutStep`, and `CheckoutPaymentMethods`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit checkout in calypso and verify that it loads correctly.
