### PR TITLE
Fix the v2 Logs title alignment when there is no datepicker

### DIFF
--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -98,7 +98,7 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	return (
 		<PageLayout
 			header={
-				<VStack as="div" spacing={ 0 } direction="row" alignment="end">
+				<VStack as="div" spacing={ 0 } direction="row" alignment="end" justify="flex-start">
 					<PageHeader title={ __( 'Logs' ) } />
 
 					{ shouldShowDateRangePicker && (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

* Make the Logs title always align to the left 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While testing, I noticed that PR #106106 introduced a UI regression with the Logs title aligning to the center when there isn't the DatePicker

## Testing Instructions

**BEFORE**
<img width="2738" height="724" alt="CleanShot 2025-09-30 at 18 41 08@2x" src="https://github.com/user-attachments/assets/7ddfb358-ddf8-42e5-ac58-777168b4f111" />


**AFTER**
<img width="2812" height="830" alt="CleanShot 2025-09-30 at 18 37 14@2x" src="https://github.com/user-attachments/assets/bfb4f283-d0ba-4b72-8707-92767e40eb72" />

* Go into a free site and check the Logs page on `/v2/sites/<site>/logs/activity`, ensure the `Logs` title is on the left (even on mobile)
* Do the same for a site with full activity logs access. The DatePicker should appear on the right and the title on the left (as in the screenshots)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
