### PR TITLE
Remove unused initialInstallationId

### DIFF
--- a/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
@@ -12,10 +12,6 @@ import {
 import { openPopup } from '../../utils/open-popup';
 import { useSaveGitHubCredentialsMutation } from './use-save-github-credentials-mutation';
 
-interface UseLiveInstallationsParameters {
-	initialInstallationId?: number;
-}
-
 const NOTICE_ID = 'github-app-install-notice';
 
 const AUTHORIZATION_URL =
@@ -23,9 +19,7 @@ const AUTHORIZATION_URL =
 
 const INSTALLATION_URL = 'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-install';
 
-export const useLiveInstallations = ( {
-	initialInstallationId,
-}: UseLiveInstallationsParameters = {} ) => {
+export const useLiveInstallations = () => {
 	const {
 		data: installations,
 		error: installationsError,
@@ -42,19 +36,8 @@ export const useLiveInstallations = ( {
 			return;
 		}
 
-		if ( initialInstallationId ) {
-			const preselectedInstallation = installations.find(
-				( installation ) => installation.external_id === initialInstallationId
-			);
-
-			if ( preselectedInstallation ) {
-				setInstallation( preselectedInstallation );
-				return;
-			}
-		}
-
 		setInstallation( installations[ 0 ] );
-	}, [ installations, installation, initialInstallationId ] );
+	}, [ installations, installation ] );
 
 	const authorizeApp = async ( { code }: { code: string } ) => {
 		const response = await postLoginRequest( 'exchange-social-auth-code', {

--- a/client/sites/deployments/components/repositories/browse-repositories.tsx
+++ b/client/sites/deployments/components/repositories/browse-repositories.tsx
@@ -9,12 +9,12 @@ import { GitHubBrowseRepositoriesList } from './repository-list';
 
 import './style.scss';
 
-type GitHubBrowseRepositoriesProps = {
-	initialInstallationId?: number;
-} & Pick< ComponentProps< typeof GitHubBrowseRepositoriesList >, 'onSelectRepository' >;
+type GitHubBrowseRepositoriesProps = Pick<
+	ComponentProps< typeof GitHubBrowseRepositoriesList >,
+	'onSelectRepository'
+>;
 
 export const GitHubBrowseRepositories = ( {
-	initialInstallationId,
 	onSelectRepository,
 }: GitHubBrowseRepositoriesProps ) => {
 	const { __ } = useI18n();
@@ -24,9 +24,7 @@ export const GitHubBrowseRepositories = ( {
 		installations,
 		onNewInstallationRequest,
 		isLoadingInstallations,
-	} = useLiveInstallations( {
-		initialInstallationId: initialInstallationId,
-	} );
+	} = useLiveInstallations();
 
 	const [ query, setQuery ] = useState( '' );
 


### PR DESCRIPTION
## Proposed Changes

While working around this functionality, I found that we don't use `initialInstallationId.` And I haven't found in history that it was used before. Looks like some leftover during development.
So with this PR we just clean it up. 

## Testing Instructions
1. Open Deployments tab
2. Click on Select repository
3. Assert that it works