### PR TITLE
Scan Dashboard: update scan button, disable primary CTA, remove filter by dates

### DIFF
--- a/client/dashboard/sites/scan-active/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-active/dataviews/fields.tsx
@@ -49,9 +49,7 @@ export function getFields( timezoneString?: string, gmtOffset?: number ): Field<
 			id: 'first_detected',
 			label: __( 'Detected on' ),
 			type: 'date',
-			filterBy: {
-				operators: [ 'on', 'before', 'after' ],
-			},
+			filterBy: false,
 			getValue: ( { item } ) => {
 				const date = new Date( item.first_detected );
 				return formatYmd( date );

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -61,9 +61,7 @@ export function getFields( timezoneString?: string, gmtOffset?: number ): Field<
 			id: 'fixed_on',
 			label: __( 'Resolved on' ),
 			type: 'date',
-			filterBy: {
-				operators: [ 'on', 'before', 'after' ],
-			},
+			filterBy: false,
 			getValue: ( { item } ) => {
 				if ( ! item.fixed_on ) {
 					return '';

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -55,7 +55,7 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 
 	const scanState = useScanState( site.ID );
 	const { scan, status } = scanState;
-
+	const isScanInProgress = status === 'enqueued' || status === 'running';
 	const fixableThreatsCount = scan?.threats?.filter( ( threat ) => threat.fixable ).length || 0;
 	const lastScanTime = scan?.most_recent?.timestamp;
 	const lastScanRelativeTime = useTimeSince( lastScanTime || '' );
@@ -82,8 +82,7 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	};
 
 	const renderActiveTab = () => {
-		const showStatus = status === 'enqueued' || status === 'running';
-		if ( showStatus ) {
+		if ( isScanInProgress ) {
 			return <ScanStatus scanState={ scanState } />;
 		}
 		return (
@@ -121,7 +120,11 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 							<ButtonStack>
 								<ScanNowButton site={ site } scanState={ scanState } />
 								{ fixableThreatsCount > 0 && (
-									<Button variant="primary" onClick={ () => setShowBulkFixModal( true ) }>
+									<Button
+										variant="primary"
+										disabled={ isScanInProgress }
+										onClick={ () => setShowBulkFixModal( true ) }
+									>
 										{ sprintf(
 											/* translators: %d: number of threats */
 											_n(

--- a/client/dashboard/sites/scan/scan-now-button.tsx
+++ b/client/dashboard/sites/scan/scan-now-button.tsx
@@ -37,41 +37,11 @@ export function ScanNowButton( { site, scanState }: ScanNowButtonProps ) {
 		triggerScan();
 	};
 
-	const getButtonContent = () => {
-		if ( isEnqueued ) {
-			return {
-				label: __( 'Scan enqueued' ),
-				tooltip: __( 'A scan has been queued and will start shortly.' ),
-			};
-		}
-
-		if ( status === 'running' ) {
-			return {
-				label: __( 'Scan in progress' ),
-				tooltip: __( 'A scan is currently in progress.' ),
-			};
-		}
-
-		return {
-			label: __( 'Scan now' ),
-			tooltip: __( 'Trigger a scan of your site now.' ),
-		};
-	};
-
-	const isBusy = isRunning || isPending || isEnqueued;
+	const isDisabled = isRunning || isPending || isEnqueued;
 
 	return (
-		<Button
-			variant="secondary"
-			onClick={ handleClick }
-			disabled={ isBusy }
-			isBusy={ isBusy }
-			accessibleWhenDisabled
-			description={ getButtonContent().tooltip }
-			label={ getButtonContent().label }
-			showTooltip
-		>
-			{ getButtonContent().label }
+		<Button variant="secondary" onClick={ handleClick } disabled={ isDisabled }>
+			{ __( 'Scan now' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-560

## Proposed Changes

* Improve `Scan now` button consistency (similar to #106088)
  * Remove `isBusy` state from back up now button for a cleaner, more consistent UX.
  * Add backup enqueued notice that displays “Backup starting…” when users click “Back up now”
  * Implement shared state management between `BackupNotices` and `BackupNowButton` components
  * Maintain consistent button labeling ("Back up now") instead of changing to "Backup in progress"
* Disable primary CTA button (Auto-fix threats) when a Scan is in progress
* Remove filters by dates on Scan dataviews

### Screenshots

| Before | After |
|---|---|
| <img width="2106" height="1420" alt="CleanShot 2025-09-30 at 14 30 25@2x" src="https://github.com/user-attachments/assets/73a03dd3-7ceb-4d49-b328-375da4a52a40" /> | <img width="2106" height="1420" alt="CleanShot 2025-09-30 at 14 31 30@2x" src="https://github.com/user-attachments/assets/ec087e19-5eac-4a40-86fa-e006b6961736" /> |
| <img width="850" height="588" alt="CleanShot 2025-09-30 at 14 29 23@2x" src="https://github.com/user-attachments/assets/4caf9a1f-b71f-4e4d-b261-efd07f95b2fa" /> | <img width="850" height="588" alt="CleanShot 2025-09-30 at 14 28 50@2x" src="https://github.com/user-attachments/assets/295b4cff-cdc3-47b1-ba48-8f654c1bcd80" /> |
| <img width="850" height="588" alt="CleanShot 2025-09-30 at 14 29 27@2x" src="https://github.com/user-attachments/assets/0f70523c-8a32-49f3-83d6-02f19b1513f8" /> | <img width="850" height="588" alt="CleanShot 2025-09-30 at 14 29 03@2x" src="https://github.com/user-attachments/assets/a8df0d84-6af5-4efe-8a3e-5af1a2040587" /> |

### Demo

https://github.com/user-attachments/assets/81825227-d059-4efd-b628-62a838aea676

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Design review

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/v2/sites/{site}/scan`
2. Click the "Scan now" button
3. **Expected Results**:
   - Button stays labeled "Scan now" (not "Scan in progress")
   - Auto-fix threats button becomes disabled
   - Button becomes disabled (grayed out) with no busy state
   - Empty state appears immediately: "Preparing to Scan…"
   - Empty state transitions to "Scanning in progress"
   - Buttons re-enable after completion
 4. Ensure you cannot filter dataviews by Detected On and Resolved On fields.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
