### PR TITLE
Backups: default DateRangePicker to 30 days

### DIFF
--- a/client/dashboard/app/hooks/use-date-range.ts
+++ b/client/dashboard/app/hooks/use-date-range.ts
@@ -7,17 +7,19 @@ interface UseDateRangeOptions {
 	timezoneString?: string;
 	gmtOffset?: number;
 	autoRefresh?: boolean;
+	defaultDays?: number;
 }
 
 export function useDateRange( {
 	timezoneString,
 	gmtOffset,
 	autoRefresh = false,
+	defaultDays = 7,
 }: UseDateRangeOptions ) {
 	const router = useRouter();
 	const search = router.state.location.search;
 
-	const initial = getDefaultDateRange( timezoneString, gmtOffset );
+	const initial = getDefaultDateRange( timezoneString, gmtOffset, defaultDays );
 	const initialFromUrl = getInitialDateRangeFromSearch( search );
 
 	const [ dateRange, setDateRange ] = useState< { start: Date; end: Date } >(
@@ -44,7 +46,7 @@ export function useDateRange( {
 
 		const tick = () => {
 			const end = new Date();
-			const start = subDays( end, 6 );
+			const start = subDays( end, defaultDays - 1 );
 
 			setDateRange( ( prev ) =>
 				isSameSecond( prev.start, start ) && isSameSecond( prev.end, end ) ? prev : { start, end }
@@ -68,7 +70,7 @@ export function useDateRange( {
 		tick();
 		const intervalId = setInterval( tick, 10 * 1000 );
 		return () => clearInterval( intervalId );
-	}, [ autoRefresh, timezoneString, gmtOffset ] );
+	}, [ autoRefresh, defaultDays, timezoneString, gmtOffset ] );
 
 	return {
 		dateRange,
@@ -77,12 +79,20 @@ export function useDateRange( {
 }
 
 /**
- * Get the default date range (7 days ending today).
+ * Get the default date range ending today.
  */
-export function getDefaultDateRange( timezoneString?: string, gmtOffset?: number ) {
+export function getDefaultDateRange(
+	timezoneString?: string,
+	gmtOffset?: number,
+	defaultDays: number = 7
+) {
 	const siteToday = parseYmdLocal( formatYmd( new Date(), timezoneString, gmtOffset ) )!;
 	return {
-		start: new Date( siteToday.getFullYear(), siteToday.getMonth(), siteToday.getDate() - 6 ),
+		start: new Date(
+			siteToday.getFullYear(),
+			siteToday.getMonth(),
+			siteToday.getDate() - ( defaultDays - 1 )
+		),
 		end: siteToday,
 	};
 }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -61,6 +61,7 @@ export function BackupsListPage() {
 	const { dateRange, handleDateRangeChange } = useDateRange( {
 		timezoneString,
 		gmtOffset,
+		defaultDays: 30,
 	} );
 	const [ selectedBackup, setSelectedBackupInState ] = useState< ActivityLogEntry | null >( null );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-555][1].

## Proposed Changes

Defaults the Backups `DateRangePicker` to 30 days.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Right now it is defaulting to 7 days.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/sites/:slug/backups`
- Check the `DateRangePicker` component in the upper right. It should default to `Last 30 days`.

| Before | After |
| - | - |
| <img width="651" height="611" alt="image" src="https://github.com/user-attachments/assets/d428447e-96d0-4f5e-a065-e38173a7532c" /> | <img width="650" height="611" alt="image" src="https://github.com/user-attachments/assets/d2c0bb54-0705-4e34-9a76-327e2025acfc" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTDASH-555