### PR TITLE
Hosting Dashboard: Monitoring - minor UI improvements (3)

### DIFF
--- a/client/dashboard/sites/monitoring-card/card.stories.tsx
+++ b/client/dashboard/sites/monitoring-card/card.stories.tsx
@@ -33,8 +33,6 @@ type Story = StoryObj< typeof meta >;
 const defaultArgs = {
 	title: 'Server performance',
 	description: 'Requests per minute and average server response time.',
-	onAnchorClick: () => {},
-	onDownloadClick: () => {},
 	isLoading: false,
 };
 

--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -24,6 +24,7 @@ interface MonitoringCardProps {
 	isLoading?: boolean;
 	onDownloadClick?: () => void;
 	onAnchorClick?: () => void;
+	onChartClick?: () => void;
 	tracksId?: string;
 	children?: ReactNode;
 	cardLabel?: string;
@@ -36,6 +37,7 @@ export default function MonitoringCard( {
 	isLoading,
 	onDownloadClick,
 	onAnchorClick,
+	onChartClick,
 	tracksId,
 	children,
 	cardLabel,
@@ -66,14 +68,17 @@ export default function MonitoringCard( {
 						</Text>
 					</HStack>
 					<HStack spacing={ 2 } alignment="center" expanded={ false }>
-						<Button
-							icon={ chartBarIcon }
-							label={ sprintf(
-								/* translators: %s is the card title */
-								__( 'View %s chart.' ),
-								title
-							) }
-						/>
+						{ onChartClick && (
+							<Button
+								icon={ chartBarIcon }
+								label={ sprintf(
+									/* translators: %s is the card title */
+									__( 'View %s chart.' ),
+									title
+								) }
+								onClick={ onChartClick }
+							/>
+						) }
 						{ onDownloadClick && (
 							<Button
 								icon={ downloadIcon }

--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -3,15 +3,8 @@ import {
 	CardBody,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	Button,
 	Spinner,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import {
-	chartBar as chartBarIcon,
-	download as downloadIcon,
-	link as linkIcon,
-} from '@wordpress/icons';
 import clsx from 'clsx';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import { Text } from '../../components/text';
@@ -22,9 +15,6 @@ interface MonitoringCardProps {
 	title: string;
 	description?: ReactNode;
 	isLoading?: boolean;
-	onDownloadClick?: () => void;
-	onAnchorClick?: () => void;
-	onChartClick?: () => void;
 	tracksId?: string;
 	children?: ReactNode;
 	cardLabel?: string;
@@ -35,9 +25,6 @@ export default function MonitoringCard( {
 	title,
 	description,
 	isLoading,
-	onDownloadClick,
-	onAnchorClick,
-	onChartClick,
 	tracksId,
 	children,
 	cardLabel,
@@ -61,48 +48,9 @@ export default function MonitoringCard( {
 	const topContent = (
 		<HStack justify="space-between" alignment="flex-start">
 			<VStack spacing={ 4 } className="dashboard-monitoring-card__header">
-				<HStack justify="space-between">
-					<HStack spacing={ 1 } alignment="center" expanded={ false }>
-						<Text weight="bold" size="15px">
-							{ title }
-						</Text>
-					</HStack>
-					<HStack spacing={ 2 } alignment="center" expanded={ false }>
-						{ onChartClick && (
-							<Button
-								icon={ chartBarIcon }
-								label={ sprintf(
-									/* translators: %s is the card title */
-									__( 'View %s chart.' ),
-									title
-								) }
-								onClick={ onChartClick }
-							/>
-						) }
-						{ onDownloadClick && (
-							<Button
-								icon={ downloadIcon }
-								label={ sprintf(
-									/* translators: %s is the card title */
-									__( 'Download %s data.' ),
-									title
-								) }
-								onClick={ onDownloadClick }
-							/>
-						) }
-						{ onAnchorClick && (
-							<Button
-								icon={ linkIcon }
-								label={ sprintf(
-									/* translators: %s is the card title */
-									__( 'Permalink: %s.' ),
-									title
-								) }
-								onClick={ onAnchorClick }
-							/>
-						) }
-					</HStack>
-				</HStack>
+				<Text weight="bold" size="15px">
+					{ title }
+				</Text>
 				<HStack justify="flex-start" alignment="baseline">
 					<Text variant="muted">{ renderDescription() }</Text>
 				</HStack>

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -82,9 +82,24 @@
 }
 
 .dashboard-monitoring-card--row-layout {
-	.pie-chart > svg {
-		/* Prevent the chart from overflowing its container. */
-		max-width: 100%;
+	.pie-chart {
+		position: relative;
+
+		> svg {
+			/* Prevent the chart from overflowing its container. */
+			max-width: 100%;
+		}
+
+		> div[role="tooltip"] {
+			position: absolute;
+			margin-top: 20px;
+			margin-inline-start: 20px;
+			border-radius: 4px;
+			border: 1px solid #DDD;
+			background: #FFF;
+			padding: 16px;
+			text-wrap: nowrap;
+		}
 	}
 
 	.dashboard-monitoring-card__content {

--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -29,10 +29,19 @@
 	.dashboard-monitoring-card__header {
 		flex-grow: 1;
 	}
+
+	.dashboard-monitoring-card--legend,
+	.dashboard-monitoring-card__line-chart > div[role="list"] {
+		display: flex;
+		gap: 10px;
+		flex-wrap: wrap;
+	}
 }
 
 .dashboard-monitoring-card__line-chart {
 	flex-direction: column-reverse !important;
+	gap: 20px;
+	justify-content: start;
 
 	svg {
 		/* Ensure the chart numbers are not clipped. */
@@ -73,10 +82,6 @@
 }
 
 .dashboard-monitoring-card--row-layout {
-	.visx-legend-label > span {
-		margin-inline-start: 5px;
-	}
-
 	.pie-chart > svg {
 		/* Prevent the chart from overflowing its container. */
 		max-width: 100%;

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -197,8 +197,6 @@ export default function MonitoringHttpResponsesCard( {
 			cardLabel="http-responses"
 			title={ cardLabel }
 			description={ cardDescription }
-			onDownloadClick={ () => {} }
-			onAnchorClick={ () => {} }
 			isLoading={ isLoading }
 		>
 			<LineChart

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -144,8 +144,6 @@ export default function MonitoringPerformanceCard( {
 			cardLabel="server-performance"
 			title={ __( 'Server performance' ) }
 			description={ __( 'Requests per minute and average server response time.' ) }
-			onDownloadClick={ () => {} }
-			onAnchorClick={ () => {} }
 			isLoading={ isLoading }
 		>
 			{ isLoading || requestsData || responseTimeData ? (

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -92,7 +92,11 @@ export default function MonitoringRequestMethodsCard( {
 			isLoading={ isLoading }
 			className="dashboard-monitoring-card--row-layout"
 		>
-			<Legend chartId="request-methods-chart" items={ mapDataForLegend( data ) } />
+			<Legend
+				chartId="request-methods-chart"
+				items={ mapDataForLegend( data ) }
+				className="dashboard-monitoring-card--legend"
+			/>
 			<HStack alignment="center">
 				<PieChart
 					chartId="request-methods-chart"

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -89,8 +89,6 @@ export default function MonitoringRequestMethodsCard( {
 		<MonitoringCard
 			title={ __( 'HTTP request methods' ) }
 			description={ __( 'Percentage of traffic per HTTP request method.' ) }
-			onDownloadClick={ () => {} }
-			onAnchorClick={ () => {} }
 			isLoading={ isLoading }
 			className="dashboard-monitoring-card--row-layout"
 		>

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -105,6 +105,7 @@ export default function MonitoringRequestMethodsCard( {
 					size={ 300 }
 					data={ data }
 					showLabels={ false }
+					withTooltips
 				/>
 			</HStack>
 		</MonitoringCard>

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -94,8 +94,6 @@ export default function MonitoringResponseTypesCard( {
 		<MonitoringCard
 			title={ __( 'Response types' ) }
 			description={ __( 'Percentage of dynamic versus static responses.' ) }
-			onDownloadClick={ () => {} }
-			onAnchorClick={ () => {} }
 			isLoading={ isLoading }
 			className="dashboard-monitoring-card--row-layout"
 		>

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -111,6 +111,7 @@ export default function MonitoringResponseTypesCard( {
 						size={ 300 }
 						data={ data }
 						showLabels={ false }
+						withTooltips
 					/>
 				</HStack>
 			</VStack>

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -98,7 +98,11 @@ export default function MonitoringResponseTypesCard( {
 			className="dashboard-monitoring-card--row-layout"
 		>
 			<VStack justify="space-between" expanded>
-				<Legend chartId="response-types-chart" items={ mapDataForLegend( data ) } />
+				<Legend
+					chartId="response-types-chart"
+					items={ mapDataForLegend( data ) }
+					className="dashboard-monitoring-card--legend"
+				/>
 				<HStack alignment="center">
 					<PieChart
 						chartId="response-types-chart"

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -132,7 +132,7 @@ function SiteMonitoring() {
 						spacing={ isSmallViewport ? 5 : 10 }
 					>
 						<VStack spacing={ 2 }>
-							<PageHeader title={ __( 'Monitoring' ) } />
+							<PageHeader />
 							<Text variant="muted">{ getDateRange( timeRange, locale ) }</Text>
 						</VStack>
 

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -143,6 +143,7 @@ function SiteMonitoring() {
 								onChange={ handleTimeRangeChange }
 								label={ __( 'Time period' ) }
 								hideLabelFromVision
+								style={ { textWrap: 'nowrap' } }
 							>
 								<ToggleGroupControlOption value="6-hours" label={ __( '6 hours' ) } />
 								<ToggleGroupControlOption value="24-hours" label={ __( '24 hours' ) } />

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -68,8 +68,6 @@ function SiteMonitoringBody( {
 
 	return (
 		<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
-			<Text variant="muted">{ getDateRange( timeRange, locale ) }</Text>
-
 			<MonitoringPerformanceCard site={ site } timeRange={ hoursMap[ timeRange ] } />
 
 			<HStack wrap alignment="stretch" spacing={ isSmallViewport ? 4 : 8 }>
@@ -133,7 +131,11 @@ function SiteMonitoring() {
 						wrap
 						spacing={ isSmallViewport ? 5 : 10 }
 					>
-						<PageHeader title={ __( 'Monitoring' ) } />
+						<VStack spacing={ 2 }>
+							<PageHeader title={ __( 'Monitoring' ) } />
+							<Text variant="muted">{ getDateRange( timeRange, locale ) }</Text>
+						</VStack>
+
 						<div>
 							<ToggleGroupControl
 								value={ timeRange }


### PR DESCRIPTION
## Proposed Changes
- Remove card icon-buttons.
- Disable text wrap for time span selectors.
- Adjust gap between the header and the subheader.
- Make legend horizontal.
- Add tooltips for the donut charts.

## Why are these changes being made?
https://linear.app/a8c/issue/DOTDASH-156
p1759192131763409-slack-C0982082MSR

## Testing Instructions
1. Load the page `/v2/sites/your-site-slug/monitoring`.
2. Confirm the page loads and everything looks good.
3. Check the tooltips on the donut charts, confirm they work well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
