### PR TITLE
Disable zoom for login page

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -15,7 +15,7 @@ const Head = ( {
 
 			<meta charSet="utf-8" />
 			<meta httpEquiv="X-UA-Compatible" content="IE=Edge" />
-			<meta name="viewport" content="width=device-width, initial-scale=1" />
+			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -9,6 +9,11 @@
 
 $image-height: 47px;
 
+/* Disable zoom on touch devices – this can cause login issues for apps */
+body.is-section-login {
+	touch-action: pan-x pan-y;
+}
+
 .layout.is-section-login {
 	position: relative;
 	min-height: 100%; // Needed for any screen not yet using a StepContainerV2 wireframe (e.g. magic login).


### PR DESCRIPTION
## Proposed Changes
Disables pinch-to-zoom and auto-zoom for the login page – this will make OAuth login on mobile devices look and work better.

## Why are these changes being made?
* The user's device may auto-zoom, in which case the login appears broken
* The user may inadvertently zoom in, in which case it's not obvious how to fix it

There's no benefit to zooming in on this page – the elements are very large. So we're disabling it.

## Testing Instructions
On a physical device (or a simulator), load WordPress.com in a private browsing window in Safari. Note that the login screen "jumps" and the edges are cut off (the logo on the left, and "Create an account" on the right). Zoom out to fix the viewport, then tap the "Email Address or Username" field. Note that the zoom happens again and the items at the top are cut off.

On the same device, load the calypso.live link for this PR and repeat the process. Note that the zooming no longer takes place.

https://github.com/user-attachments/assets/5c95c63f-3b1e-4267-8159-e26cf36810a2


## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
