### PR TITLE
Hosting Dashboard: update last backup card to include failed state

### DIFF
--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -78,7 +78,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 		enabled: !! lastBackup && FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ),
 	} );
 
-	if ( isLoading && lastBackup === undefined ) {
+	if ( isLoading ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
 	}
 

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -31,7 +31,7 @@ function BackupCardFailed( { site, backup }: { site: Site; backup?: SiteActivity
 	const description = backup
 		? sprintf(
 				/* translators: %s: time since last successful backup, e.g. '2h ago' */
-				__( 'Last successful backup is %s old.' ),
+				__( 'Last successful backup was %s.' ),
 				timeSinceLastSuccessful
 		  )
 		: 'No successful backups found.';
@@ -63,7 +63,7 @@ function BackupCardSuccess( { site, lastBackup }: { site: Site; lastBackup: Site
 }
 
 function BackupCardContent( { site }: { site: Site } ) {
-	const { data: lastBackup } = useQuery( {
+	const { data: lastBackup, isLoading } = useQuery( {
 		...siteActivityLogQuery( site.ID, {
 			name: [ ...SUCCESSFUL_BACKUP_ACTIVITIES, ...FAILED_BACKUP_ACTIVITIES ],
 			number: 1,
@@ -78,7 +78,7 @@ function BackupCardContent( { site }: { site: Site } ) {
 		enabled: !! lastBackup && FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ),
 	} );
 
-	if ( lastBackup === undefined ) {
+	if ( isLoading && lastBackup === undefined ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
 	}
 

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -1,14 +1,14 @@
 import { HostingFeatures } from '@automattic/api-core';
-import { siteLastBackupQuery } from '@automattic/api-queries';
+import { siteActivityLogQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
 import { useFormattedTime } from '../../components/formatted-time';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import OverviewCard from '../overview-card';
-import type { Site } from '@automattic/api-core';
+import type { Site, SiteActivityLog } from '@automattic/api-core';
 
 const CARD_PROPS = {
 	icon: backup,
@@ -16,12 +16,67 @@ const CARD_PROPS = {
 	tracksId: 'backup',
 };
 
-function BackupCardContent( { site }: { site: Site } ) {
-	const { data: lastBackup } = useQuery( siteLastBackupQuery( site.ID ) );
-	const lastBackupTime = lastBackup?.published ?? new Date( 0 ).toISOString();
+const SUCCESSFUL_BACKUP_ACTIVITIES = [
+	'rewind__backup_complete_full',
+	'rewind__backup_complete_initial',
+	'rewind__backup_only_complete_full',
+	'rewind__backup_only_complete_initial',
+];
 
-	const timeSinceLastBackup = useTimeSince( lastBackupTime );
-	const formattedLastBackupTime = useFormattedTime( lastBackupTime, { timeStyle: 'short' } );
+const FAILED_BACKUP_ACTIVITIES = [ 'rewind__backup_error', 'rewind__backup_only_error' ];
+
+function BackupCardFailed( { site, backup }: { site: Site; backup?: SiteActivityLog } ) {
+	const timeSinceLastSuccessful = useTimeSince( backup?.published ?? new Date( 0 ).toISOString() );
+
+	const description = backup
+		? sprintf(
+				/* translators: %s: time since last successful backup, e.g. '2h ago' */
+				__( 'Last successful backup is %s old.' ),
+				timeSinceLastSuccessful
+		  )
+		: 'No successful backups found.';
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ __( 'Backup failed' ) }
+			description={ description }
+			link={ getBackupUrl( site ) }
+			intent="error"
+		/>
+	);
+}
+
+function BackupCardSuccess( { site, lastBackup }: { site: Site; lastBackup: SiteActivityLog } ) {
+	const timeSinceLastBackup = useTimeSince( lastBackup.published );
+	const formattedLastBackupTime = useFormattedTime( lastBackup.published, { timeStyle: 'short' } );
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			heading={ timeSinceLastBackup }
+			description={ formattedLastBackupTime }
+			link={ getBackupUrl( site ) }
+			intent="success"
+		/>
+	);
+}
+
+function BackupCardContent( { site }: { site: Site } ) {
+	const { data: lastBackup } = useQuery( {
+		...siteActivityLogQuery( site.ID, {
+			name: [ ...SUCCESSFUL_BACKUP_ACTIVITIES, ...FAILED_BACKUP_ACTIVITIES ],
+			number: 1,
+		} ),
+		select: ( data ) => data.activityLogs[ 0 ],
+	} );
+
+	const { data: lastSuccessfulBackup } = useQuery( {
+		...siteActivityLogQuery( site.ID, { name: SUCCESSFUL_BACKUP_ACTIVITIES, number: 1 } ),
+		select: ( data ) => data.activityLogs[ 0 ],
+		// Only fetch successful backups if there are any failed backups
+		enabled: !! lastBackup && FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ),
+	} );
 
 	if ( lastBackup === undefined ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
@@ -38,15 +93,11 @@ function BackupCardContent( { site }: { site: Site } ) {
 		);
 	}
 
-	return (
-		<OverviewCard
-			{ ...CARD_PROPS }
-			heading={ timeSinceLastBackup }
-			description={ formattedLastBackupTime }
-			link={ getBackupUrl( site ) }
-			intent="success"
-		/>
-	);
+	if ( FAILED_BACKUP_ACTIVITIES.includes( lastBackup.name ) ) {
+		return <BackupCardFailed site={ site } backup={ lastSuccessfulBackup } />;
+	}
+
+	return <BackupCardSuccess site={ site } lastBackup={ lastBackup } />;
 }
 
 export default function BackupCard( { site }: { site: Site } ) {

--- a/client/dashboard/sites/overview-backup-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-backup-card/test/index.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { HostingFeatures } from '@automattic/api-core';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import BackupCard from '../index';
+import type { Site, ActivityLogsData } from '@automattic/api-core';
+
+const mockSiteId = 123;
+
+const mockFetchSiteActivityLog = jest.fn();
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchSiteActivityLog: ( ...args: unknown[] ) => mockFetchSiteActivityLog( ...args ),
+} ) );
+
+const mockSite: Site = {
+	ID: mockSiteId,
+	plan: {
+		features: {
+			active: [ HostingFeatures.BACKUPS ],
+		},
+	},
+	is_wpcom_atomic: true,
+} as Site;
+
+jest.mock( '../../../app/auth', () => ( {
+	useAuth: () => mockSite,
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../../../app/locale', () => ( {
+	useLocale: () => 'en',
+} ) );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'BackupCard', () => {
+	test( 'shows "No backups yet" when there are no backups', async () => {
+		mockFetchSiteActivityLog.mockResolvedValue( {
+			activityLogs: [],
+			totalItems: 0,
+			pages: 0,
+			itemsPerPage: 0,
+			totalPages: 0,
+		} as ActivityLogsData );
+
+		render( <BackupCard site={ mockSite } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'No backups yet' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Your first backup will be ready soon.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	test( 'shows successful backup information', async () => {
+		const twoHoursAgo = new Date( Date.now() - 2 * 60 * 60 * 1000 ).toISOString();
+
+		mockFetchSiteActivityLog.mockResolvedValue( {
+			activityLogs: [
+				{
+					id: '1',
+					activity_id: '1',
+					name: 'rewind__backup_complete_full',
+					published: twoHoursAgo,
+					status: 'success',
+				},
+			],
+			totalItems: 1,
+			pages: 1,
+			itemsPerPage: 1,
+			totalPages: 1,
+		} as ActivityLogsData );
+
+		render( <BackupCard site={ mockSite } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( '2h ago' ) ).toBeInTheDocument();
+			expect( screen.queryByText( 'Backup failed' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'shows failed backup with last successful backup time', async () => {
+		mockFetchSiteActivityLog
+			.mockResolvedValueOnce( {
+				activityLogs: [
+					{
+						id: '2',
+						activity_id: '2',
+						name: 'rewind__backup_error',
+						published: new Date().toISOString(),
+						status: 'error',
+					},
+				],
+				totalItems: 1,
+				pages: 1,
+				itemsPerPage: 1,
+				totalPages: 1,
+			} as ActivityLogsData )
+			.mockResolvedValueOnce( {
+				activityLogs: [
+					{
+						id: '1',
+						activity_id: '1',
+						name: 'rewind__backup_complete_full',
+						published: new Date( Date.now() - 3 * 24 * 60 * 60 * 1000 ).toISOString(), // 3 days ago
+						status: 'success',
+					},
+				],
+				totalItems: 1,
+				pages: 1,
+				itemsPerPage: 1,
+				totalPages: 1,
+			} as ActivityLogsData );
+
+		render( <BackupCard site={ mockSite } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Backup failed' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Last successful backup was 3d ago.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	test( 'shows "No successful backups found" when backup failed and no successful backup exists', async () => {
+		mockFetchSiteActivityLog
+			.mockResolvedValueOnce( {
+				activityLogs: [
+					{
+						id: '2',
+						activity_id: '2',
+						name: 'rewind__backup_error',
+						published: new Date().toISOString(),
+						status: 'error',
+					},
+				],
+				totalItems: 1,
+				pages: 1,
+				itemsPerPage: 1,
+				totalPages: 1,
+			} as ActivityLogsData )
+			.mockResolvedValueOnce( {
+				activityLogs: [],
+				totalItems: 0,
+				pages: 0,
+				itemsPerPage: 0,
+				totalPages: 0,
+			} as ActivityLogsData );
+
+		render( <BackupCard site={ mockSite } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Backup failed' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No successful backups found.' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/packages/api-core/src/site-activity-log/types.ts
+++ b/packages/api-core/src/site-activity-log/types.ts
@@ -115,7 +115,7 @@ export interface ActivityLogParams {
 	number?: number;
 	not_group?: string;
 	group?: string[];
-	name?: string;
+	name?: string[];
 	text_search?: string;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-148

## Proposed Changes

* Extended the overview Backup card to show the last successful backup time when the current backup has failed
* Refactored BackupCardContent to use separate components for failed and successful states (following the pattern from ScanCard)
* Fetch the last backup using an Activity Log query filtered by backup activity names
* Conditionally fetch the last successful backup only when the last backup failed
* Updated ActivityLogParams type to support name filtering with string[]
* Added unit tests

> [!NOTE]
> This will only works for self-hosted Jetpack sites. WPCOM sites doesn't get an error logged on the Activity Log.

### Screenshots
_Sorry for the quality, I asked Claude to take those captures to optimize time._

**No backups yet**
<img width="318" height="141" alt="backup-card-state-1-no-backups" src="https://github.com/user-attachments/assets/d9066ff8-c453-4bc1-a90b-90dcee9582d1" />

**Successful backup**
<img width="318" height="141" alt="backup-card-state-2-successful" src="https://github.com/user-attachments/assets/aee7793a-8e0c-4558-a4ea-05677050c245" />

**Failed backup with successful history**
<img width="318" height="141" alt="backup-card-state-3-failed-with-history" src="https://github.com/user-attachments/assets/51be82eb-5aae-420f-9f70-518e45aad218" />

**Failed backup without successful history**
<img width="318" height="141" alt="backup-card-state-4-failed-no-history" src="https://github.com/user-attachments/assets/d8c0f1e6-8f4e-4b08-8fee-006ce4420bb2" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can either trust the unit tests (`yarn test-client client/dashboard/sites/overview-backup-card/test`), or:

1. Open the Hosting Dashboard’s Overview page for a site with backups. Confirm the backup card renders correctly for WPCOM sites and does not show a failed state.  
2. On a self-hosted site, reproduce a failed state:
   - Make sure there is a recent successful backup.
   - Start a backup. After it progresses to about 15% or more, shut down the web server.
   - Check the Activity Log to confirm the error was recorded.
   - Return to the dashboard and confirm the card shows “Backup failed.”

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
