### PR TITLE
Domain Search Rewrite: Make sure all Stepper flows behave correctly

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
@@ -118,18 +118,13 @@ const copySite: Flow = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery: providedDependencies.lastQuery,
+						} );
 
-						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
-
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
-
-						return navigate( useMyDomainURL as typeof _currentStepSlug );
+						return navigate( useMyDomainURL );
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );

--- a/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
@@ -1,10 +1,13 @@
+import { DomainSuggestion } from '@automattic/api-core';
 import { getPlanPath } from '@automattic/calypso-products';
 import { COPY_SITE_FLOW } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import {
 	clearSignupDestinationCookie,
@@ -22,7 +25,7 @@ import {
 	type ProvidedDependencies,
 	type StepperStep,
 } from '../../internals/types';
-import type { SiteSelect } from '@automattic/data-stores';
+import type { OnboardActions, SiteSelect } from '@automattic/data-stores';
 
 function useIsValidSite() {
 	const urlQueryParams = useQuery();
@@ -70,6 +73,7 @@ function useIsValidSite() {
 
 const COPY_SITE_STEPS = [
 	shouldRenderRewrittenDomainSearch() ? STEPS.DOMAIN_SEARCH : STEPS.DOMAINS,
+	STEPS.USE_MY_DOMAIN,
 	STEPS.SITE_CREATION_STEP,
 	STEPS.PROCESSING,
 	STEPS.AUTOMATED_COPY_SITE,
@@ -94,10 +98,72 @@ const copySite: Flow = {
 		const urlQueryParams = useQuery();
 		const sourceSiteSlug = urlQueryParams.get( 'sourceSlug' ) ?? '';
 		const sourceSite = useSite( sourceSiteSlug );
+		const {
+			setHideFreePlan,
+			setSignupDomainOrigin,
+			setDomainCartItem,
+			setSiteUrl,
+			setDomain,
+			setDomainCartItems,
+		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( _currentStepSlug ) {
 				case 'domains': {
+					if ( ! shouldRenderRewrittenDomainSearch() ) {
+						return navigate( 'create-site', {
+							sourceSlug: sourceSiteSlug,
+						} );
+					}
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						return navigate( useMyDomainURL as typeof _currentStepSlug );
+					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
+					return navigate( 'create-site', {
+						sourceSlug: sourceSiteSlug,
+					} );
+				}
+
+				case 'use-my-domain': {
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
+						const destination = addQueryArgs( '/use-my-domain', {
+							...getQueryArgs( window.location.href ),
+							step: providedDependencies.mode,
+							initialQuery: providedDependencies.domain,
+						} );
+						return navigate( destination as typeof _currentStepSlug );
+					}
+
+					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setHideFreePlan( true );
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
+					}
+
 					return navigate( 'create-site', {
 						sourceSlug: sourceSiteSlug,
 					} );
@@ -140,14 +206,6 @@ const copySite: Flow = {
 			return providedDependencies;
 		};
 
-		const goBack = () => {
-			return;
-		};
-
-		const goNext = () => {
-			return;
-		};
-
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
@@ -156,7 +214,7 @@ const copySite: Flow = {
 			window.location.assign( location );
 		};
 
-		return { goNext, goBack, goToStep, submit, exitFlow };
+		return { goToStep, submit, exitFlow };
 	},
 
 	useAssertConditions() {

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -80,16 +80,11 @@ const domain: FlowV2< typeof initialize > = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
-
-						const lastQueryParam = providedDependencies.lastQuery;
-
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery: providedDependencies.lastQuery,
+						} );
 
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}

--- a/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/hundred-year-domain/hundred-year-domain.ts
@@ -47,19 +47,25 @@ const HundredYearDomainFlow: Flow = {
 		);
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
-			const { domainName, productSlug } = providedDependencies;
-
-			const submittedDomainCartItem = domainRegistration( {
-				productSlug: productSlug as string,
-				domain: domainName as string,
-				extra: { is_hundred_year_domain: true, flow_name: HUNDRED_YEAR_DOMAIN_FLOW },
-				volume: 100,
-			} );
-
 			switch ( _currentStep ) {
 				case 'domains':
 					clearSignupDestinationCookie();
-					setDomainCartItem( submittedDomainCartItem );
+
+					if ( ! shouldRenderRewrittenDomainSearch() ) {
+						const { domainName, productSlug } = providedDependencies;
+
+						const submittedDomainCartItem = domainRegistration( {
+							productSlug: productSlug as string,
+							domain: domainName as string,
+							extra: { is_hundred_year_domain: true, flow_name: HUNDRED_YEAR_DOMAIN_FLOW },
+							volume: 100,
+						} );
+
+						setDomainCartItem( submittedDomainCartItem );
+					} else {
+						setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					}
+
 					return navigate( 'processing' );
 
 				case 'processing':

--- a/client/landing/stepper/declarative-flow/flows/hundred-year-plan/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/hundred-year-plan/hundred-year-plan.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
-import { UserSelect } from '@automattic/data-stores';
+import { OnboardActions, UserSelect } from '@automattic/data-stores';
 import { HUNDRED_YEAR_PLAN_FLOW, addProductsToCart } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -15,6 +15,7 @@ import { ONBOARD_STORE, USER_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import type { ProvidedDependencies, Flow } from '../../internals/types';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HundredYearPlanFlow: Flow = {
 	name: HUNDRED_YEAR_PLAN_FLOW,
@@ -55,7 +56,9 @@ const HundredYearPlanFlow: Flow = {
 	},
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const { setPlanCartItem, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { setPlanCartItem, setPendingAction, setDomainCartItem } = useDispatch(
+			ONBOARD_STORE
+		) as OnboardActions;
 		const currentUser = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 			[]
@@ -103,9 +106,14 @@ const HundredYearPlanFlow: Flow = {
 				case 'setup':
 					return navigate( 'domains' );
 				case 'domains':
+					if ( shouldRenderRewrittenDomainSearch() ) {
+						setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					}
+
 					setPlanCartItem( {
 						product_slug: PLAN_100_YEARS,
 					} );
+
 					return navigate( 'create-site' );
 				case 'create-site':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -1,12 +1,15 @@
-import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
+import { DomainSuggestion } from '@automattic/api-core';
+import { Onboard, OnboardActions, updateLaunchpadSettings } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import {
@@ -34,6 +37,7 @@ const newsletter: Flow = {
 			STEPS.NEWSLETTER_SETUP,
 			STEPS.NEWSLETTER_GOALS,
 			shouldRenderRewrittenDomainSearch() ? STEPS.DOMAIN_SEARCH : STEPS.DOMAINS,
+			STEPS.USE_MY_DOMAIN,
 			STEPS.PLANS,
 			STEPS.PROCESSING,
 			STEPS.SUBSCRIBERS,
@@ -71,6 +75,15 @@ const newsletter: Flow = {
 		const siteSlug = useSiteSlug();
 		const { exitFlow } = useExitFlow();
 
+		const {
+			setSiteUrl,
+			setDomain,
+			setDomainCartItem,
+			setDomainCartItems,
+			setSignupDomainOrigin,
+			setHideFreePlan,
+		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
+
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
@@ -96,8 +109,59 @@ const newsletter: Flow = {
 				case 'newsletterGoals':
 					return navigate( 'domains' );
 
-				case 'domains':
+				case 'domains': {
+					if ( ! shouldRenderRewrittenDomainSearch() ) {
+						return navigate( 'plans' );
+					}
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						return navigate( useMyDomainURL as typeof _currentStep );
+					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
 					return navigate( 'plans' );
+				}
+
+				case 'use-my-domain': {
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
+						const destination = addQueryArgs( '/use-my-domain', {
+							...getQueryArgs( window.location.href ),
+							step: providedDependencies.mode,
+							initialQuery: providedDependencies.domain,
+						} );
+						return navigate( destination as typeof _currentStep );
+					}
+
+					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setHideFreePlan( true );
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
+					}
+
+					return navigate( 'plans' );
+				}
 
 				case 'plans':
 					return navigate( 'create-site' );
@@ -146,25 +210,31 @@ const newsletter: Flow = {
 			}
 		}
 
-		const goNext = async () => {
-			switch ( _currentStep ) {
-				case 'launchpad':
-					skipLaunchpad( {
-						siteId,
-						siteSlug,
-					} );
-					return;
-
-				default:
-					return navigate( 'newsletterSetup' );
+		const getGoNext = () => {
+			if ( _currentStep === 'use-my-domain' ) {
+				return;
 			}
+
+			return () => {
+				switch ( _currentStep ) {
+					case 'launchpad':
+						skipLaunchpad( {
+							siteId,
+							siteSlug,
+						} );
+						return;
+
+					default:
+						return navigate( 'newsletterSetup' );
+				}
+			};
 		};
 
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
 
-		return { goNext, goToStep, submit };
+		return { goNext: getGoNext(), goToStep, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -116,18 +116,13 @@ const newsletter: Flow = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery: providedDependencies.lastQuery,
+						} );
 
-						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
-
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
-
-						return navigate( useMyDomainURL as typeof _currentStep );
+						return navigate( useMyDomainURL );
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -125,11 +125,14 @@ const newsletter: Flow = {
 						return navigate( useMyDomainURL );
 					}
 
+					const suggestion = providedDependencies.suggestion as DomainSuggestion;
+
 					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomain( suggestion );
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+					setHideFreePlan( ! suggestion.is_free );
 
 					return navigate( 'plans' );
 				}

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -143,11 +143,8 @@ const onboarding: FlowV2< typeof initialize > = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
-
-						const lastQueryParam =
+						const initialQuery =
 							// eslint-disable-next-line no-nested-ternary
 							'lastQuery' in providedDependencies
 								? providedDependencies.lastQuery
@@ -155,10 +152,10 @@ const onboarding: FlowV2< typeof initialize > = {
 								? providedDependencies.domainForm?.lastQuery
 								: undefined;
 
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery,
+						} );
 
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}

--- a/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
@@ -1,6 +1,9 @@
+import { OnboardActions } from '@automattic/data-stores';
 import { REBLOGGING_FLOW } from '@automattic/onboarding';
-import { getQueryArg, addQueryArgs } from '@wordpress/url';
+import { useDispatch } from '@wordpress/data';
+import { getQueryArg, addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { shouldRenderRewrittenDomainSearch } from 'calypso/lib/domains/should-render-rewritten-domain-search';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import {
@@ -8,9 +11,12 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import type { Flow, ProvidedDependencies } from '../../internals/types';
+import type { DomainSuggestion } from '@automattic/api-core';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const reblogging: Flow = {
 	name: REBLOGGING_FLOW,
@@ -22,6 +28,7 @@ const reblogging: Flow = {
 	useSteps() {
 		return stepsWithRequiredLogin( [
 			shouldRenderRewrittenDomainSearch() ? STEPS.DOMAIN_SEARCH : STEPS.DOMAINS,
+			STEPS.USE_MY_DOMAIN,
 			STEPS.PLANS,
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PROCESSING,
@@ -30,13 +37,72 @@ const reblogging: Flow = {
 
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
+		const {
+			setSiteUrl,
+			setDomain,
+			setDomainCartItem,
+			setDomainCartItems,
+			setSignupDomainOrigin,
+			setHideFreePlan,
+		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 
 		triggerGuidesForStep( flowName, _currentStepSlug );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( _currentStepSlug ) {
-				case 'domains':
+				case 'domains': {
+					if ( ! shouldRenderRewrittenDomainSearch() ) {
+						return navigate( 'plans' );
+					}
+
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						return navigate( useMyDomainURL as typeof _currentStepSlug );
+					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+
 					return navigate( 'plans' );
+				}
+
+				case 'use-my-domain': {
+					if (
+						providedDependencies &&
+						'mode' in providedDependencies &&
+						providedDependencies.mode &&
+						providedDependencies.domain
+					) {
+						const destination = addQueryArgs( '/use-my-domain', {
+							...getQueryArgs( window.location.href ),
+							step: providedDependencies.mode,
+							initialQuery: providedDependencies.domain,
+						} );
+						return navigate( destination as typeof _currentStepSlug );
+					}
+
+					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
+						setHideFreePlan( true );
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
+					}
+
+					return navigate( 'plans' );
+				}
 
 				case 'plans':
 					return navigate( 'create-site' );
@@ -68,19 +134,11 @@ const reblogging: Flow = {
 			return providedDependencies;
 		};
 
-		const goBack = () => {
-			return;
-		};
-
-		const goNext = async () => {
-			return;
-		};
-
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		return { goToStep, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
@@ -57,18 +57,13 @@ const reblogging: Flow = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery: providedDependencies.lastQuery,
+						} );
 
-						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
-
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
-
-						return navigate( useMyDomainURL as typeof _currentStepSlug );
+						return navigate( useMyDomainURL );
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );

--- a/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/flows/reblogging/reblogging.ts
@@ -66,11 +66,14 @@ const reblogging: Flow = {
 						return navigate( useMyDomainURL );
 					}
 
+					const suggestion = providedDependencies.suggestion as DomainSuggestion;
+
 					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomain( suggestion );
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+					setHideFreePlan( ! suggestion.is_free );
 
 					return navigate( 'plans' );
 				}

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -187,9 +187,7 @@ const startWriting: Flow = {
 						}
 
 						if ( providedDependencies?.freeDomain ) {
-							return window.location.assign(
-								`/setup/start-writing/launchpad?siteId=${ site?.ID }`
-							);
+							return navigate( addQueryArgs( 'launchpad', { siteId: site?.ID } ) );
 						}
 
 						return navigate( 'plans' );
@@ -197,18 +195,23 @@ const startWriting: Flow = {
 
 					if ( providedDependencies.navigateToUseMyDomain ) {
 						const currentQueryArgs = getQueryArgs( window.location.href );
-						currentQueryArgs.step = 'domain-input';
 
-						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+						const useMyDomainURL = addQueryArgs( 'use-my-domain', {
+							...currentQueryArgs,
+							initialQuery: providedDependencies.lastQuery,
+						} );
 
-						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+						return navigate( useMyDomainURL );
+					}
 
-						if ( lastQueryParam !== undefined ) {
-							currentQueryArgs.initialQuery = lastQueryParam;
-							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
-						}
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
+							checklist_statuses: { domain_upsell_deferred: true },
+						} );
+					}
 
-						return navigate( useMyDomainURL as typeof currentStep );
+					if ( ! providedDependencies.domainItem ) {
+						return navigate( addQueryArgs( 'launchpad', { siteId: site?.ID } ) );
 					}
 
 					setSiteUrl( providedDependencies.siteUrl as string );

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -25,6 +25,7 @@ import { useExitFlow } from '../../../hooks/use-exit-flow';
 import { useSiteData } from '../../../hooks/use-site-data';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
+import type { DomainSuggestion } from '@automattic/api-core';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const startWriting: Flow = {
@@ -68,8 +69,15 @@ const startWriting: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
-		const { setSelectedSite, setHideFreePlan, setDomainCartItem, setSignupDomainOrigin } =
-			useDispatch( ONBOARD_STORE ) as OnboardActions;
+		const {
+			setSiteUrl,
+			setSelectedSite,
+			setHideFreePlan,
+			setDomainCartItem,
+			setSignupDomainOrigin,
+			setDomain,
+			setDomainCartItems,
+		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const { site, siteSlug, siteId } = useSiteData();
 		const { exitFlow } = useExitFlow();
 
@@ -170,18 +178,47 @@ const startWriting: Flow = {
 
 					return postFlowNavigator( { siteId, siteSlug } );
 				}
-				case 'domains':
-					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
-							checklist_statuses: { domain_upsell_deferred: true },
-						} );
+				case 'domains': {
+					if ( ! shouldRenderRewrittenDomainSearch() ) {
+						if ( siteId ) {
+							await updateLaunchpadSettings( siteId, {
+								checklist_statuses: { domain_upsell_deferred: true },
+							} );
+						}
+
+						if ( providedDependencies?.freeDomain ) {
+							return window.location.assign(
+								`/setup/start-writing/launchpad?siteId=${ site?.ID }`
+							);
+						}
+
+						return navigate( 'plans' );
 					}
 
-					if ( providedDependencies?.freeDomain ) {
-						return window.location.assign( `/setup/start-writing/launchpad?siteId=${ site?.ID }` );
+					if ( providedDependencies.navigateToUseMyDomain ) {
+						const currentQueryArgs = getQueryArgs( window.location.href );
+						currentQueryArgs.step = 'domain-input';
+
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
+
+						const lastQueryParam = providedDependencies.lastQuery as string | undefined;
+
+						if ( lastQueryParam !== undefined ) {
+							currentQueryArgs.initialQuery = lastQueryParam;
+							useMyDomainURL = addQueryArgs( useMyDomainURL, currentQueryArgs );
+						}
+
+						return navigate( useMyDomainURL as typeof currentStep );
 					}
+
+					setSiteUrl( providedDependencies.siteUrl as string );
+					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
+					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
+					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
 					return navigate( 'plans' );
+				}
 				case 'use-my-domain':
 					if (
 						providedDependencies &&

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -214,11 +214,14 @@ const startWriting: Flow = {
 						return navigate( addQueryArgs( 'launchpad', { siteId: site?.ID } ) );
 					}
 
+					const suggestion = providedDependencies.suggestion as DomainSuggestion;
+
 					setSiteUrl( providedDependencies.siteUrl as string );
-					setDomain( providedDependencies.suggestion as DomainSuggestion );
+					setDomain( suggestion );
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
+					setHideFreePlan( ! suggestion.is_free );
 
 					return navigate( 'plans' );
 				}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -189,7 +189,7 @@ button {
 		}
 	}
 
-	&:not(:has(.wpcom-domain-search-v2)):not(:has(.domain-search--step-container)):not(:has(.domain-search--step-container-v2)) {
+	&:not(:has(.wpcom-domain-search-v2, .domain-search--step-container, .domain-search--step-container-v2)) {
 		// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
 		.components-button.is-primary {
 			border-radius: 4px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -257,23 +257,15 @@ const DomainSearchStep: StepType< {
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const getTopBarRightElement = () => {
-			if ( query && config.allowsUsingOwnDomain ) {
-				return (
-					<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
-						{ __( 'Use a domain I already own' ) }
-					</Step.LinkButton>
-				);
+			if ( query! || ! config.allowsUsingOwnDomain ) {
+				return;
 			}
 
-			if ( isNewHostedSiteCreationFlow( flow ) ) {
-				return (
-					<Step.LinkButton onClick={ () => events.onSkip() }>
-						{ __( 'Decide later' ) }
-					</Step.LinkButton>
-				);
-			}
-
-			return undefined;
+			return (
+				<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
+					{ __( 'Use a domain I already own' ) }
+				</Step.LinkButton>
+			);
 		};
 
 		return (
@@ -319,29 +311,19 @@ const DomainSearchStep: StepType< {
 	};
 
 	const getSkipButton = () => {
-		if ( query && config.allowsUsingOwnDomain ) {
-			return {
-				customizedActionButtons: (
-					<Button
-						className="step-container__navigation-link forward"
-						onClick={ () => events.onExternalDomainClick( query ) }
-						variant="link"
-					>
-						<span>{ __( 'Use a domain I already own' ) }</span>
-					</Button>
-				),
-			};
+		if ( ! query || ! config.allowsUsingOwnDomain ) {
+			return;
 		}
 
-		if ( isAIBuilderFlow( flow ) || isNewsletterFlow( flow ) ) {
-			return {
-				hideSkip: false,
-				skipLabelText: __( 'Decide later' ),
-				onSkip: () => events.onSkip(),
-			};
-		}
-
-		return {};
+		return (
+			<Button
+				className="step-container__navigation-link forward"
+				onClick={ () => events.onExternalDomainClick( query ) }
+				variant="link"
+			>
+				<span>{ __( 'Use a domain I already own' ) }</span>
+			</Button>
+		);
 	};
 
 	return (
@@ -356,7 +338,7 @@ const DomainSearchStep: StepType< {
 			stepContent={ domainSearchElement }
 			recordTracksEvent={ recordTracksEvent }
 			{ ...getBackButton() }
-			{ ...getSkipButton() }
+			customizedActionButtons={ getSkipButton() }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -28,6 +28,7 @@ import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -91,14 +92,32 @@ const DomainSearchStep: StepType< {
 				! isDomainFlow( flow ) &&
 				! isDomainAndPlanFlow( flow ),
 			allowedTlds,
-			allowsUsingOwnDomain: ! isAIBuilderFlow( flow ) && ! isNewHostedSiteCreationFlow( flow ),
+			allowsUsingOwnDomain:
+				! isAIBuilderFlow( flow ) &&
+				! isNewHostedSiteCreationFlow( flow ) &&
+				! isHundredYearPlanFlow( flow ) &&
+				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ flow, tldQuery ] );
+	}, [ flow, tldQuery, query ] );
 
 	const { submit } = navigation;
 
 	const events = useMemo( () => {
 		return {
+			onAddDomainToCart: ( product: MinimalRequestCartProduct ) => {
+				if ( isHundredYearDomainFlow( flow ) ) {
+					return {
+						...product,
+						extra: {
+							...product.extra,
+							is_hundred_year_domain: true,
+						},
+						volume: 100,
+					};
+				}
+
+				return product;
+			},
 			onQueryChange: setQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				window.location.assign(
@@ -106,6 +125,12 @@ const DomainSearchStep: StepType< {
 				);
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
+				if ( domainName && isHundredYearDomainFlow( flow ) ) {
+					return window.location.assign(
+						`/setup/hundred-year-domain-transfer/domains?new=${ domainName }`
+					);
+				}
+
 				submit( {
 					navigateToUseMyDomain: true,
 					lastQuery: domainName,
@@ -138,14 +163,26 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 		};
-	}, [ submit, setQuery ] );
+	}, [ submit, setQuery, flow ] );
 
 	const slots = useMemo( () => {
 		return {
-			BeforeResults: () => <FreeDomainForAYearPromo />,
-			BeforeFullCartItems: () => <FreeDomainForAYearPromo textOnly />,
+			BeforeResults: () => {
+				if ( isHundredYearDomainFlow( flow ) || isHundredYearPlanFlow( flow ) ) {
+					return null;
+				}
+
+				return <FreeDomainForAYearPromo />;
+			},
+			BeforeFullCartItems: () => {
+				if ( isHundredYearDomainFlow( flow ) || isHundredYearPlanFlow( flow ) ) {
+					return null;
+				}
+
+				return <FreeDomainForAYearPromo textOnly />;
+			},
 		};
-	}, [] );
+	}, [ flow ] );
 
 	const headerText = useMemo( () => {
 		if ( isNewsletterFlow( flow ) ) {
@@ -199,6 +236,24 @@ const DomainSearchStep: StepType< {
 			slots={ slots }
 		/>
 	);
+
+	if ( isHundredYearDomainFlow( flow ) || isHundredYearPlanFlow( flow ) ) {
+		return (
+			<HundredYearPlanStepWrapper
+				stepName="domains"
+				flowName={ flow as string }
+				stepContent={ <div className="domains__content">{ domainSearchElement }</div> }
+				formattedHeader={
+					<FormattedHeader
+						id="domains-header"
+						align="center"
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+					/>
+				}
+			/>
+		);
+	}
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const getTopBarRightElement = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -305,7 +305,7 @@ const DomainSearchStep: StepType< {
 		};
 
 		const getTopBarRightElement = () => {
-			if ( query! || ! config.allowsUsingOwnDomain ) {
+			if ( ! query || ! config.allowsUsingOwnDomain ) {
 				return;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -34,6 +34,8 @@ import type { Step as StepType } from '../../types';
 import type { FreeDomainSuggestion } from '@automattic/api-core';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
+const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
+
 import './style.scss';
 
 type UseMyDomain = {
@@ -94,7 +96,10 @@ const DomainSearchStep: StepType< {
 				! isHundredYearDomainFlow( flow ) &&
 				! isDomainFlow( flow ) &&
 				! isDomainAndPlanFlow( flow ),
-			allowedTlds,
+			allowedTlds:
+				isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow )
+					? HUNDRED_YEAR_DOMAIN_TLDS
+					: allowedTlds,
 			allowsUsingOwnDomain:
 				! isAIBuilderFlow( flow ) &&
 				! isNewHostedSiteCreationFlow( flow ) &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -200,6 +200,26 @@ const DomainSearchStep: StepType< {
 	);
 
 	if ( shouldUseStepContainerV2( flow ) ) {
+		const getTopBarRightElement = () => {
+			if ( query && config.allowsUsingOwnDomain ) {
+				return (
+					<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
+						{ translate( 'Use a domain I already own' ) }
+					</Step.LinkButton>
+				);
+			}
+
+			if ( isNewHostedSiteCreationFlow( flow ) ) {
+				return (
+					<Step.LinkButton onClick={ () => events.onSkip() }>
+						{ translate( 'Decide later' ) }
+					</Step.LinkButton>
+				);
+			}
+
+			return undefined;
+		};
+
 		return (
 			<Step.CenteredColumnLayout
 				topBar={
@@ -207,13 +227,7 @@ const DomainSearchStep: StepType< {
 						leftElement={
 							navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 						}
-						rightElement={
-							query && config.allowsUsingOwnDomain ? (
-								<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
-									{ translate( 'Use a domain I already own' ) }
-								</Step.LinkButton>
-							) : undefined
-						}
+						rightElement={ getTopBarRightElement() }
 					/>
 				}
 				columnWidth={ 10 }
@@ -224,6 +238,20 @@ const DomainSearchStep: StepType< {
 			</Step.CenteredColumnLayout>
 		);
 	}
+
+	const getAdditionalStepContainerProps = () => {
+		if ( isAIBuilderFlow( flow ) ) {
+			return {
+				backUrl: `${ site?.URL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }&p=%2F&ai-step=edit`,
+				backLabelText: translate( 'Keep Editing' ),
+				hideSkip: false,
+				skipLabelText: translate( 'Decide later' ),
+				onSkip: () => events.onSkip(),
+			};
+		}
+
+		return {};
+	};
 
 	return (
 		<StepContainer
@@ -236,6 +264,7 @@ const DomainSearchStep: StepType< {
 			}
 			stepContent={ domainSearchElement }
 			recordTracksEvent={ recordTracksEvent }
+			{ ...getAdditionalStepContainerProps() }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -11,9 +11,10 @@ import {
 	Step,
 	StepContainer,
 } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
@@ -22,6 +23,7 @@ import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -54,8 +56,7 @@ type StepSubmission = {
 const DomainSearchStep: StepType< {
 	submits: UseMyDomain | StepSubmission;
 } > = function DomainSearchStep( { navigation, flow } ) {
-	const translate = useTranslate();
-
+	const userSiteCount = useSelector( getCurrentUserSiteCount );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const initialQuery = useQuery().get( 'new' ) ?? '';
@@ -204,7 +205,7 @@ const DomainSearchStep: StepType< {
 			if ( query && config.allowsUsingOwnDomain ) {
 				return (
 					<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
-						{ translate( 'Use a domain I already own' ) }
+						{ __( 'Use a domain I already own' ) }
 					</Step.LinkButton>
 				);
 			}
@@ -212,7 +213,7 @@ const DomainSearchStep: StepType< {
 			if ( isNewHostedSiteCreationFlow( flow ) ) {
 				return (
 					<Step.LinkButton onClick={ () => events.onSkip() }>
-						{ translate( 'Decide later' ) }
+						{ __( 'Decide later' ) }
 					</Step.LinkButton>
 				);
 			}
@@ -239,13 +240,48 @@ const DomainSearchStep: StepType< {
 		);
 	}
 
-	const getAdditionalStepContainerProps = () => {
+	const getBackButton = () => {
 		if ( isAIBuilderFlow( flow ) ) {
 			return {
 				backUrl: `${ site?.URL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }&p=%2F&ai-step=edit`,
-				backLabelText: translate( 'Keep Editing' ),
+				backLabelText: __( 'Keep Editing' ),
+			};
+		}
+
+		const [ sitesBackLabelText, defaultBackUrl ] =
+			userSiteCount === 1
+				? [ __( 'Back to My Home' ), '/home' ]
+				: [ __( 'Back to sites' ), '/sites' ];
+
+		if ( isCopySiteFlow( flow ) ) {
+			return {
+				backUrl: defaultBackUrl,
+				backLabelText: sitesBackLabelText,
+			};
+		}
+
+		return {};
+	};
+
+	const getSkipButton = () => {
+		if ( query && config.allowsUsingOwnDomain ) {
+			return {
+				customizedActionButtons: (
+					<Button
+						className="step-container__navigation-link forward"
+						onClick={ () => events.onExternalDomainClick( query ) }
+						variant="link"
+					>
+						<span>{ __( 'Use a domain I already own' ) }</span>
+					</Button>
+				),
+			};
+		}
+
+		if ( isAIBuilderFlow( flow ) ) {
+			return {
 				hideSkip: false,
-				skipLabelText: translate( 'Decide later' ),
+				skipLabelText: __( 'Decide later' ),
 				onSkip: () => events.onSkip(),
 			};
 		}
@@ -264,7 +300,8 @@ const DomainSearchStep: StepType< {
 			}
 			stepContent={ domainSearchElement }
 			recordTracksEvent={ recordTracksEvent }
-			{ ...getAdditionalStepContainerProps() }
+			{ ...getBackButton() }
+			{ ...getSkipButton() }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -348,6 +348,12 @@ const DomainSearchStep: StepType< {
 			};
 		}
 
+		if ( isDomainAndPlanFlow( flow ) || isNewsletterFlow( flow ) ) {
+			return {
+				goBack: navigation.goBack,
+			};
+		}
+
 		return {};
 	};
 
@@ -372,7 +378,6 @@ const DomainSearchStep: StepType< {
 			stepName="step-container--domain-search"
 			isWideLayout
 			flowName={ flow }
-			goBack={ navigation.goBack }
 			formattedHeader={
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -19,6 +19,7 @@ import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-searc
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
@@ -62,6 +63,8 @@ const DomainSearchStep: StepType< {
 	const siteSlug = useSiteSlugParam();
 	const initialQuery = useQuery().get( 'new' ) ?? '';
 	const tldQuery = useQuery().get( 'tld' );
+	const source = useQuery().get( 'source' );
+	const backTo = useQuery().get( 'back_to' );
 
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
@@ -237,6 +240,11 @@ const DomainSearchStep: StepType< {
 		/>
 	);
 
+	const [ sitesBackLabelText, defaultBackUrl ] =
+		userSiteCount === 1
+			? [ __( 'Back to My Home' ), '/home' ]
+			: [ __( 'Back to sites' ), '/sites' ];
+
 	if ( isHundredYearDomainFlow( flow ) || isHundredYearPlanFlow( flow ) ) {
 		return (
 			<HundredYearPlanStepWrapper
@@ -256,6 +264,46 @@ const DomainSearchStep: StepType< {
 	}
 
 	if ( shouldUseStepContainerV2( flow ) ) {
+		const getTopBarLeftElement = () => {
+			if ( isNewHostedSiteCreationFlow( flow ) ) {
+				return;
+			}
+
+			let backDestination: string | typeof navigation.goBack = '';
+			let backLabelText = '';
+
+			if ( 'site' === source && site?.URL ) {
+				backDestination = site.URL;
+				backLabelText = __( 'Back to My Site' );
+			} else if ( 'my-home' === source && siteSlug ) {
+				backDestination = `/home/${ siteSlug }`;
+				backLabelText = __( 'Back to My Home' );
+			} else if ( 'general-settings' === source && siteSlug ) {
+				backDestination = `/settings/general/${ siteSlug }`;
+				backLabelText = __( 'Back to General Settings' );
+			} else if ( ! isOnboardingFlow( flow ) && navigation.goBack ) {
+				backDestination = navigation.goBack;
+				backLabelText = __( 'Back' );
+			} else {
+				backDestination = defaultBackUrl;
+				backLabelText = sitesBackLabelText;
+
+				if ( backTo && isRelativeUrl( backTo ) ) {
+					backDestination = backTo;
+					backLabelText = __( 'Back' );
+				}
+			}
+
+			return (
+				<Step.BackButton
+					href={ typeof backDestination === 'string' ? backDestination : undefined }
+					onClick={ typeof backDestination === 'function' ? backDestination : undefined }
+				>
+					{ backLabelText }
+				</Step.BackButton>
+			);
+		};
+
 		const getTopBarRightElement = () => {
 			if ( query! || ! config.allowsUsingOwnDomain ) {
 				return;
@@ -272,9 +320,7 @@ const DomainSearchStep: StepType< {
 			<Step.CenteredColumnLayout
 				topBar={
 					<Step.TopBar
-						leftElement={
-							navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
-						}
+						leftElement={ getTopBarLeftElement() }
 						rightElement={ getTopBarRightElement() }
 					/>
 				}
@@ -294,11 +340,6 @@ const DomainSearchStep: StepType< {
 				backLabelText: __( 'Keep Editing' ),
 			};
 		}
-
-		const [ sitesBackLabelText, defaultBackUrl ] =
-			userSiteCount === 1
-				? [ __( 'Back to My Home' ), '/home' ]
-				: [ __( 'Back to sites' ), '/sites' ];
 
 		if ( isCopySiteFlow( flow ) ) {
 			return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -278,7 +278,7 @@ const DomainSearchStep: StepType< {
 			};
 		}
 
-		if ( isAIBuilderFlow( flow ) ) {
+		if ( isAIBuilderFlow( flow ) || isNewsletterFlow( flow ) ) {
 			return {
 				hideSkip: false,
 				skipLabelText: __( 'Decide later' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -224,7 +224,7 @@ const DomainSearchStep: StepType< {
 			config={ config }
 			query={ query }
 			isFirstDomainFreeForFirstYear={
-				isOnboardingFlow( flow ) || isDomainFlow( flow ) || isDomainAndPlanFlow( flow )
+				! isHundredYearDomainFlow( flow ) && ! isHundredYearPlanFlow( flow )
 			}
 			events={ events }
 			flowAllowsMultipleDomainsInCart={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -29,6 +29,10 @@
 	@include break-small {
 		padding-inline: 24px;
 	}
+
+	.step-container__navigation-link {
+		color: #1d2327;
+	}
 }
 
 .step-container-v2--domain-search {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -43,7 +43,8 @@
 	}
 }
 
-.hundred-year-plan-step-wrapper__step-container:has( .wpcom-domain-search-v2 ) {
+.hundred-year-plan-step-wrapper__step-container:has( .wpcom-domain-search-v2 ),
+.hundred-year-plan-step-wrapper__step-container:has( .domain-search--step-container ) {
 	width: 100%;
 
 	.domains__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/style.scss
@@ -62,3 +62,13 @@
 		display: none;
 	}
 }
+
+.hundred-year-plan-step-wrapper__step-container:has( .domain-search ) {
+	width: 100%;
+
+	.domains__content {
+		padding: 0 16px;
+		margin: 0 auto;
+		max-width: 780px;
+	}
+}

--- a/client/signup/steps/domains/legacy/index.jsx
+++ b/client/signup/steps/domains/legacy/index.jsx
@@ -647,13 +647,9 @@ class RenderDomainsStepComponent extends Component {
 
 	shouldHideDomainExplainer = () => {
 		const { flowName } = this.props;
-		return [
-			'domain',
-			DOMAIN_FOR_GRAVATAR_FLOW,
-			'onboarding-with-email',
-			NEW_HOSTED_SITE_FLOW,
-			'domains/add',
-		].includes( flowName );
+		return [ 'domain', DOMAIN_FOR_GRAVATAR_FLOW, 'onboarding-with-email', 'domains/add' ].includes(
+			flowName
+		);
 	};
 
 	shouldHideUseYourDomain = () => {

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -10,7 +10,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
-import { localize, useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
@@ -260,7 +260,6 @@ const DomainSearchUI = (
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
 	}, [ flowName ] );
 
-	const translate = useTranslate();
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
 
 	const { hideBack, backUrl, backLabelText } = useMemo( () => {
@@ -273,18 +272,18 @@ const DomainSearchUI = (
 
 		const [ sitesBackLabelText, defaultBackUrl ] =
 			userSiteCount && userSiteCount === 1
-				? [ translate( 'Back to My Home' ), '/home' ]
-				: [ translate( 'Back to sites' ), '/sites' ];
+				? [ __( 'Back to My Home' ), '/home' ]
+				: [ __( 'Back to sites' ), '/sites' ];
 
 		if ( isDomainForGravatarFlow( flowName ) ) {
 			backUrl = null;
 			backLabelText = null;
 		} else if ( 'with-plugin' === flowName ) {
 			backUrl = '/plugins';
-			backLabelText = translate( 'Back to plugins' );
+			backLabelText = __( 'Back to plugins' );
 		} else if ( isWithThemeFlow( flowName ) ) {
 			backUrl = '/themes';
-			backLabelText = translate( 'Back to themes' );
+			backLabelText = __( 'Back to themes' );
 		} else if ( 'plans-first' === flowName ) {
 			backUrl = getStepUrl( flowName, previousStepName );
 		} else {
@@ -294,7 +293,7 @@ const DomainSearchUI = (
 			const backTo = getQueryArg( window.location.href, 'back_to' )?.toString();
 			if ( backTo && isRelativeUrl( backTo ) ) {
 				backUrl = backTo;
-				backLabelText = translate( 'Back' );
+				backLabelText = __( 'Back' );
 			}
 		}
 
@@ -303,7 +302,7 @@ const DomainSearchUI = (
 			backUrl,
 			backLabelText,
 		};
-	}, [ flowName, previousStepName, goBack, userSiteCount, translate ] );
+	}, [ flowName, previousStepName, goBack, userSiteCount ] );
 
 	const getUseDomainIOwnLink = () => {
 		if ( ! query || ! config.allowsUsingOwnDomain ) {

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -48,6 +48,8 @@ export const SearchForm = () => {
 						onChange={ ( value ) => setLocalQuery( value.trim() ) }
 						onReset={ () => setLocalQuery( '' ) }
 						placeholder={ placeholder }
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus
 					/>
 					{ activeQuery === 'large' && <DomainSearchControls.Submit /> }
 				</HStack>


### PR DESCRIPTION
Closes DOMAINS-1674.

## Proposed Changes

Final PR for this task. Adds feature parity with production in all eligible `/setup` flows (except `domain-upsell` which was handled in #105997), in order of importance:

1. `/setup/onboarding`
2. `/setup/ai-site-builder/domains?siteId=%d`
3. `/setup/new-hosted-site?showDomainStep`
4. `/setup/newsletter`
5. `/setup/reblogging`
6. `/setup/start-writing`
7. `/setup/hundred-year-plan`
8. `/setup/hundred-year-domain`
9. `/setup/copy-site?sourceSlug=%(atomicSiteSlug)`

~10. `/setup/readymade-template` (TBC)~ This flow isn't used anymore and will be removed, please disregard.

## Testing Instructions

Turn the `domain-search-rewrite` feature flag on and verify all of the flows behave like production: the ability to skip, to use an existing domain, the free domain discount, etc.

Don't worry about Tracks events as they'll be introduced in https://github.com/Automattic/wp-calypso/pull/105944.