### PR TITLE
Hosting Dashboard: Move description under heading in `<PageHeader>`

### DIFF
--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -37,9 +37,17 @@ export const SectionHeader = ( {
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
 				<HStack justify="space-between" alignment="center" spacing={ 3 } wrap>
-					<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
-						{ title }
-					</HeadingTag>
+					<VStack>
+						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
+							{ title }
+						</HeadingTag>
+						{ description && (
+							<Text variant="muted" className="dashboard-section-header__description">
+								{ description }
+							</Text>
+						) }
+					</VStack>
+
 					{ /* The wrapper is always needed for view transitions. */ }
 					<ButtonStack
 						justify="flex-end"
@@ -51,11 +59,6 @@ export const SectionHeader = ( {
 					</ButtonStack>
 				</HStack>
 			</HStack>
-			{ description && (
-				<Text variant="muted" className="dashboard-section-header__description">
-					{ description }
-				</Text>
-			) }
 		</VStack>
 	);
 };

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -36,7 +36,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 3 } wrap>
+				<HStack justify="space-between" alignment="center" spacing={ 4 } wrap>
 					<VStack>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }


### PR DESCRIPTION

## Proposed Changes

Move the description into the Header container to stop the actions from separating it.


| Before | After |
|--------|--------|
| <img width="452" height="647" alt="Screenshot 2025-10-01 at 3 14 05 PM" src="https://github.com/user-attachments/assets/ef6227d7-bb66-415e-af2c-5bbb6929aeee" /> | <img width="434" height="630" alt="Screenshot 2025-10-01 at 3 17 28 PM" src="https://github.com/user-attachments/assets/0ce60321-c373-471e-8c03-93695e2d660d" /> | 

## Why are these changes being made?

When there is an action, which can be a button, or datapicker, etc... the title gets _disconnected_ from the title and feels like it's in the middle of nowhere.

## Testing Instructions

- Add actions and a description to a `<PageHeader>`
- Check out the layout on mobile and desktop.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
