### PR TITLE
Hosting Dashboard Logs: Fix PageHeader

### DIFF
--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -98,20 +98,21 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	return (
 		<PageLayout
 			header={
-				<VStack as="div" spacing={ 0 } direction="row" alignment="end">
-					<PageHeader title={ __( 'Logs' ) } />
-
-					{ shouldShowDateRangePicker && (
-						<DateRangePicker
-							start={ dateRange.start }
-							end={ dateRange.end }
-							gmtOffset={ gmtOffset }
-							timezoneString={ timezoneString }
-							locale={ locale }
-							onChange={ handleDateRangeChangeWrapper }
-						/>
-					) }
-				</VStack>
+				<PageHeader
+					title={ __( 'Logs' ) }
+					actions={
+						shouldShowDateRangePicker ? (
+							<DateRangePicker
+								start={ dateRange.start }
+								end={ dateRange.end }
+								gmtOffset={ gmtOffset }
+								timezoneString={ timezoneString }
+								locale={ locale }
+								onChange={ handleDateRangeChangeWrapper }
+							/>
+						) : undefined
+					}
+				/>
 			}
 		>
 			<VStack as="div" spacing={ 3 }>


### PR DESCRIPTION
## Proposed Changes

Fixes alignment issues with the Logs screen PageHeader:

| Before | After |
| --- | --- |
| <img width="1376" height="874" alt="SCR-20251001-neli" src="https://github.com/user-attachments/assets/bae81f88-6f5f-4419-8300-14651783eb3f" /> |  <img width="1404" height="894" alt="SCR-20251001-nemv" src="https://github.com/user-attachments/assets/a0f651de-5ed1-40e7-a61d-baeab1e3f77f" /> |

| Before | After |
| <img width="1660" height="984" alt="SCR-20251001-neor" src="https://github.com/user-attachments/assets/b39b2bda-4b8f-4f78-8c07-d3ef4e01088c" /> | <img width="1638" height="1019" alt="SCR-20251001-nepu" src="https://github.com/user-attachments/assets/967ba864-5bf1-4290-89e9-b1bda6a6389c" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a simple site and click on the Logs tab
* Ensure that the header title alignment is flex-start instead of center
* Select a WoA site and click on the Logs tab
* Ensure that the header title is vertically aligned with the DatePicker

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
