### PR TITLE
Update copy on the Manage repositories button

### DIFF
--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -131,7 +131,7 @@ function DeploymentsList() {
 								variant="secondary"
 								__next40pxDefaultSize
 							>
-								{ __( 'Manage repositories' ) }
+								{ __( 'Go to repositories' ) }
 							</RouterLinkButton>
 							<Button
 								variant="primary"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-544

## Proposed Changes

This PR updates the copy on the `Manage repositories` button to `Go to repositories` on the `Deployments` screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site and connect one or multiple repositories to it
* Navigate to `/v2/sites/{yourAtomicSite}/deployments`
* Observe the `Go to repositories` button instead of `Manage repositories`

<img width="1458" height="310" alt="Screenshot 2025-10-01 at 9 39 38 AM" src="https://github.com/user-attachments/assets/604f23ae-c00f-491c-95db-0c1121e1a9b6" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
