### PR TITLE
UI Package: Add ActionList component

### DIFF
--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,8 +1,8 @@
+import { ActionList } from '@automattic/ui';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
-import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { canTransferSite, canLeaveSite, canResetSite } from '../features';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,6 +77,7 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "yarn clean && tsup",
+		"dev": "tsup --watch",
 		"prepack": "yarn build",
 		"storybook:start": "storybook dev -p 56851"
 	}

--- a/packages/ui/src/action-list/action-item.stories.tsx
+++ b/packages/ui/src/action-list/action-item.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Button, Icon } from '@wordpress/components';
+import { cog } from '@wordpress/icons';
+import { ActionItem } from './action-item';
+
+const meta: Meta< typeof ActionItem > = {
+	title: 'UI/ActionList/ActionItem',
+	component: ActionItem,
+	tags: [ 'autodocs' ],
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof ActionItem >;
+
+export const Default: Story = {
+	args: {
+		title: 'Action item title',
+		description: 'Action item description',
+		actions: (
+			<Button variant="secondary" size="compact">
+				Action
+			</Button>
+		),
+	},
+};
+
+export const WithMultipleActions: Story = {
+	args: {
+		title: 'Action item title',
+		description: 'Action item description',
+		actions: (
+			<>
+				<Button variant="secondary" size="compact">
+					Action 1
+				</Button>
+				<Button variant="secondary" size="compact" isDestructive>
+					Action 2
+				</Button>
+			</>
+		),
+	},
+};
+
+export const WithIcon: Story = {
+	args: {
+		title: 'Action item title',
+		description: 'Action item description',
+		decoration: <Icon icon={ cog } />,
+		actions: (
+			<Button variant="secondary" size="compact">
+				Action
+			</Button>
+		),
+	},
+};
+
+export const WithImage: Story = {
+	args: {
+		title: 'Action item title',
+		description: 'Action item description',
+		decoration: <Icon icon={ <img src="https://placecats.com/300/200" alt="Cat" /> } />,
+		actions: (
+			<Button variant="secondary" size="compact">
+				Action
+			</Button>
+		),
+	},
+};

--- a/packages/ui/src/action-list/action-item.tsx
+++ b/packages/ui/src/action-list/action-item.tsx
@@ -1,0 +1,60 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Disabled,
+} from '@wordpress/components';
+import cx from 'clsx';
+import { forwardRef } from 'react';
+import styles from './style.module.scss';
+import type { ActionItemProps } from './types';
+
+function UnforwardedActionItem(
+	{ title, description, decoration, actions, className, status }: ActionItemProps,
+	ref: React.ForwardedRef< HTMLSpanElement >
+) {
+	return (
+		<Disabled isDisabled={ status === 'disabled' }>
+			<VStack
+				className={ cx(
+					styles[ 'action-item' ],
+					{
+						[ styles[ 'action-item--muted' ] ]: status === 'disabled' || status === 'complete',
+					},
+					className
+				) }
+				ref={ ref }
+				as="span"
+			>
+				<HStack spacing={ 3 } justify="flex-start" alignment="center" as="span">
+					{ !! decoration && (
+						<span className={ styles[ 'action-item__decoration' ] }>{ decoration }</span>
+					) }
+					<HStack as="span">
+						<VStack spacing={ 1 } as="span">
+							<Text weight={ 500 } lineHeight="20px">
+								{ title }
+							</Text>
+							{ description && (
+								<Text variant="muted" lineHeight="20px">
+									{ description }
+								</Text>
+							) }
+						</VStack>
+						<HStack
+							className={ styles[ 'action-item__actions' ] }
+							justify="flex-end"
+							expanded={ false }
+							as="span"
+							spacing={ 3 }
+						>
+							{ actions }
+						</HStack>
+					</HStack>
+				</HStack>
+			</VStack>
+		</Disabled>
+	);
+}
+
+export const ActionItem = forwardRef( UnforwardedActionItem );

--- a/packages/ui/src/action-list/index.stories.tsx
+++ b/packages/ui/src/action-list/index.stories.tsx
@@ -1,0 +1,151 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Button, Icon } from '@wordpress/components';
+import { cog } from '@wordpress/icons';
+import { ActionList } from './index';
+
+const meta: Meta< typeof ActionList > = {
+	title: 'UI/ActionList',
+	component: ActionList,
+	tags: [ 'autodocs' ],
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof ActionList >;
+
+export const Default: Story = {
+	args: {
+		children: (
+			<ActionList.ActionItem
+				title="Action item title"
+				description="Action item description"
+				actions={
+					<Button variant="secondary" size="compact">
+						Action
+					</Button>
+				}
+			/>
+		),
+	},
+};
+
+export const WithTitle: Story = {
+	args: {
+		title: 'Action List',
+		children: (
+			<ActionList.ActionItem
+				title="Action item title"
+				description="Action item description"
+				actions={
+					<Button variant="secondary" size="compact">
+						Action
+					</Button>
+				}
+			/>
+		),
+	},
+};
+
+export const WithDescription: Story = {
+	args: {
+		title: 'Action List',
+		description: 'description',
+		children: (
+			<ActionList.ActionItem
+				title="Action item title"
+				description="Action item description"
+				actions={
+					<Button variant="secondary" size="compact">
+						Action
+					</Button>
+				}
+			/>
+		),
+	},
+};
+
+export const WithMultipleActionItems: Story = {
+	args: {
+		title: 'Action List',
+		description: 'description',
+		children: (
+			<>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					actions={
+						<Button variant="secondary" size="compact">
+							Action
+						</Button>
+					}
+				/>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					actions={
+						<Button variant="secondary" size="compact">
+							Action
+						</Button>
+					}
+				/>
+			</>
+		),
+	},
+};
+
+export const FullExample: Story = {
+	args: {
+		title: 'Action List',
+		description: 'description',
+		children: (
+			<>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					actions={
+						<Button variant="secondary" size="compact">
+							Action
+						</Button>
+					}
+				/>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					actions={
+						<>
+							<Button variant="secondary" size="compact">
+								Action 1
+							</Button>
+							<Button variant="secondary" size="compact" isDestructive>
+								Action 2
+							</Button>
+						</>
+					}
+				/>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					decoration={ <Icon icon={ cog } /> }
+					actions={
+						<Button variant="secondary" size="compact">
+							Action
+						</Button>
+					}
+				/>
+				<ActionList.ActionItem
+					title="Action item title"
+					description="Action item description"
+					decoration={ <Icon icon={ <img src="https://placecats.com/300/200" alt="Cat" /> } /> }
+					actions={
+						<Button variant="secondary" size="compact">
+							Action
+						</Button>
+					}
+				/>
+			</>
+		),
+	},
+};

--- a/packages/ui/src/action-list/index.tsx
+++ b/packages/ui/src/action-list/index.tsx
@@ -1,0 +1,51 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import cx from 'clsx';
+import { forwardRef } from 'react';
+import { ActionItem } from './action-item';
+import styles from './style.module.scss';
+import type { ActionListProps } from './types';
+
+function UnforwardedActionList(
+	{ title, description, children, className }: ActionListProps,
+	ref: React.ForwardedRef< HTMLDivElement >
+) {
+	return (
+		<Card className={ cx( styles[ 'action-list' ], className ) } ref={ ref }>
+			<CardBody>
+				{ ( title || description ) && (
+					<VStack className={ styles[ 'action-list__heading' ] } spacing={ 2 }>
+						{ title && (
+							<Text size="15px" weight={ 500 } lineHeight="20px">
+								{ title }
+							</Text>
+						) }
+						{ description && (
+							<Text variant="muted" lineHeight="20px">
+								{ description }
+							</Text>
+						) }
+					</VStack>
+				) }
+				<VStack className={ styles[ 'action-list__actions' ] } spacing={ 0 }>
+					{ children }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export const ActionList = Object.assign( forwardRef( UnforwardedActionList ), {
+	/**
+	 * Renders a action item inside the `ActionList` component.
+	 */
+	ActionItem: Object.assign( ActionItem, {
+		displayName: 'ActionList.ActionItem',
+	} ),
+} );
+
+export * from './types';

--- a/packages/ui/src/action-list/style.module.scss
+++ b/packages/ui/src/action-list/style.module.scss
@@ -1,0 +1,64 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.action-list {
+	.action-list__heading {
+		padding-top: $grid-unit-10;
+		padding-bottom: $grid-unit-15;
+	}
+
+	.action-list__heading ~ .action-list__actions {
+		margin: -$grid-unit-10 0;
+	}
+
+	.action-list__actions {
+		margin: -$grid-unit-20 0;
+	}
+}
+
+
+.action-item {
+	padding: $grid-unit-20 0;
+	border-block-end: 1px solid $gray-100;
+	
+	&--muted {
+		opacity: 0.5;
+	}
+
+	&:last-child {
+		border-block-end: none;
+	}
+
+	.action-item__decoration {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-50;
+		height: $grid-unit-50;
+		flex-shrink: 0;
+		border-radius: $radius-small;
+		overflow: hidden;
+
+		&:has(svg) {
+			border: 1px solid $gray-200;
+		}
+
+		svg {
+			width: $grid-unit-30;
+			height: $grid-unit-30;
+			flex-shrink: 0;
+			fill: $gray-700;
+		}
+
+		img {
+			width: 100%;
+			height: 100%;
+			flex-shrink: 0;
+			object-fit: cover;
+		}
+	}
+
+	.action-item__actions {
+		flex-shrink: 0;
+	}
+}

--- a/packages/ui/src/action-list/types.ts
+++ b/packages/ui/src/action-list/types.ts
@@ -1,0 +1,57 @@
+export interface ActionItemProps {
+	/**
+	 * The main label that identifies the action.
+	 */
+	title: string;
+
+	/**
+	 * Optional supporting text that provides additional context or
+	 * detail about the action.
+	 */
+	description?: string;
+
+	/**
+	 * An optional visual element such as an icon or small illustration
+	 * to enhance recognition or provide visual interest.
+	 */
+	decoration?: React.ReactNode;
+
+	/**
+	 * Renders a button that invokes the related action.
+	 */
+	actions: React.ReactNode;
+
+	/**
+	 * Additional class name to apply to the action item container.
+	 */
+	className?: string;
+
+	/**
+	 * Indicates the current status of the action item.
+	 */
+	status?: 'complete' | 'disabled';
+}
+
+export interface ActionListProps {
+	/**
+	 * The main label that identifies the action list.
+	 */
+	title?: string;
+
+	/**
+	 * Optional supporting text that provides additional context or
+	 * detail about the action list.
+	 */
+	description?: string;
+
+	/**
+	 * The elements, which should include one instance of the `ActionList.ActionItem`
+	 * component.
+	 */
+	children: React.ReactNode;
+
+	/**
+	 * Additional class name to apply to the action item container.
+	 */
+	className?: string;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,3 @@
+export * from './action-list';
 export { Badge } from './badge';
 export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';


### PR DESCRIPTION
We want to use the [`ActionList` component](https://github.com/Automattic/wp-calypso/pull/103371) in Next Admin, thus we need to move the component from the dashboard to the ui package to make it available via npm.

<img width="701" height="373" alt="image" src="https://github.com/user-attachments/assets/bd489c8f-70a3-4293-8456-074196806428" />


## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
