### PR TITLE
Dashboard v2: Make Activity Logs buttons always visible

### DIFF
--- a/client/dashboard/sites/logs-activity/dataviews/actions.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/actions.tsx
@@ -21,7 +21,7 @@ export function useActivityActions( {
 	return useMemo( () => {
 		const backupAction: Action< SiteActivityLog > = {
 			id: 'backup',
-			label: __( 'View backup' ),
+			label: __( 'See restore point' ),
 			icon: <Icon icon={ backup } />,
 			disabled: isLoading,
 			isPrimary: true,

--- a/client/dashboard/sites/logs-activity/dataviews/actions.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/actions.tsx
@@ -1,10 +1,8 @@
 import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import { siteBackupDetailRoute } from '../../../app/router/sites';
 import type { SiteActivityLog, Site } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -18,27 +16,9 @@ export function useActivityActions( {
 	isLoading,
 	site,
 }: UseActivityActionsOptions ): Action< SiteActivityLog >[] {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const router = useRouter();
 
 	return useMemo( () => {
-		const copySummaryAction: Action< SiteActivityLog > = {
-			id: 'copy-summary',
-			label: __( 'Copy activity summary' ),
-			disabled: isLoading,
-			supportsBulk: false,
-			callback: async ( items ) => {
-				const [ item ] = items;
-				const summary = item?.summary ?? '';
-				try {
-					await navigator.clipboard.writeText( summary );
-					createSuccessNotice( __( 'Copied activity summary.' ), { type: 'snackbar' } );
-				} catch ( e ) {
-					createErrorNotice( __( 'Activity summary could not be copied.' ), { type: 'snackbar' } );
-				}
-			},
-		};
-
 		const backupAction: Action< SiteActivityLog > = {
 			id: 'backup',
 			label: __( 'View backup' ),
@@ -55,6 +35,6 @@ export function useActivityActions( {
 			},
 		};
 
-		return [ backupAction, copySummaryAction ];
-	}, [ isLoading, createSuccessNotice, createErrorNotice, site, router ] );
+		return [ backupAction ];
+	}, [ isLoading, site, router ] );
 }

--- a/client/dashboard/sites/logs-activity/dataviews/style.scss
+++ b/client/dashboard/sites/logs-activity/dataviews/style.scss
@@ -39,4 +39,9 @@
 			margin: 40px 0 20px;
 		}
 	}
+
+	// Override the opacity of the action buttons to make them always visible.
+	.dataviews-view-table .dataviews-item-actions .components-button:not(.dataviews-all-actions-button) {
+		opacity: 1;
+	}
 }

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -135,7 +135,7 @@ test( 'clicking backup action navigates to backup detail page', async () => {
 		{ timeout: 5000 }
 	);
 
-	const backupButton = screen.getByRole( 'button', { name: /backup/i } );
+	const backupButton = screen.getByRole( 'button', { name: /See restore point/i } );
 	await user.click( backupButton );
 
 	expect( mockNavigate ).toHaveBeenCalledWith( {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTDASH-562/fix-backup-action-icon-to-show-directly-in-the-column

## Proposed Changes

- Removes unnecessary `Copy activity summary` action button from Activity Logs
- Updates backup button label from `View Backup` to `See restore point` as per mockups
- Makes buttons always visible 

<img width="1383" height="871" alt="Screenshot 2025-10-01 at 12 36 33" src="https://github.com/user-attachments/assets/3ad75302-879b-4e32-aa0f-9165a46a8e99" />

## Testing Instructions

- Visit https://wpcalypso.wordpress.com/v2/sites/[site]/logs/activity
- Ensure backup buttons are visible right away
- Ensure `Copy activity summary` button is no longer available
- Hover over the backup button
- Ensure the labels says "See restore point"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
