### PR TITLE
Hosting Dashboard: Add tests for domain glue records

### DIFF
--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -60,7 +60,7 @@ export default function EditDomainGlueRecords() {
 				onSubmit={ handleSubmit }
 				isSubmitting={ updateMutation.isPending }
 				isEdit
-				submitButtonText={ __( 'Update glue record' ) }
+				submitButtonText={ __( 'Update record' ) }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-glue-records/summary.tsx
+++ b/client/dashboard/domains/domain-glue-records/summary.tsx
@@ -1,11 +1,14 @@
 import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { Domain } from '@automattic/api-core';
 
-export default function DomainGlueRecordsSettingsSummary( { domain }: { domain: Domain } ) {
+interface Props {
+	domainName: string;
+}
+
+export default function DomainGlueRecordsSettingsSummary( { domainName }: Props ) {
 	return (
 		<RouterLinkSummaryButton
-			to={ `/domains/${ domain.domain }/glue-records` }
+			to={ `/domains/${ domainName }/glue-records` }
 			title={ __( 'Glue records' ) }
 			badges={ [] }
 			density={ 'medium' as const }

--- a/client/dashboard/domains/domain-glue-records/test/add.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/add.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import DomainGlueRecordsForm from '../form';
+import type { DomainGlueRecord } from '@automattic/api-core';
+
+const domainName = 'example.com';
+
+interface RenderFormProps {
+	initialData?: DomainGlueRecord | null;
+	onSubmit?: ( data: DomainGlueRecord ) => void;
+	isSubmitting?: boolean;
+	isEdit?: boolean;
+	submitButtonText?: string;
+}
+
+function renderForm( props: RenderFormProps = {} ) {
+	const defaultProps = {
+		domainName,
+		onSubmit: jest.fn(),
+		isSubmitting: false,
+		isEdit: false,
+		submitButtonText: 'Add record',
+		...props,
+	};
+
+	return render( <DomainGlueRecordsForm { ...defaultProps } /> );
+}
+
+afterEach( () => nock.cleanAll() );
+
+test( 'renders domain glue records form with correct fields', async () => {
+	renderForm();
+
+	expect( screen.getByText( /Name server/ ) ).toBeInTheDocument();
+	expect( screen.getByText( /IP address/ ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'button', { name: 'Add record' } ) ).toBeInTheDocument();
+} );
+
+test( 'pre-fills form with initial data when provided', async () => {
+	const initialData = {
+		nameserver: 'give-me-cat-memes',
+		ip_addresses: [ '1.2.3.4' ],
+	};
+
+	renderForm( {
+		initialData,
+	} );
+
+	expect( screen.getByDisplayValue( 'give-me-cat-memes' ) ).toBeInTheDocument();
+	expect( screen.getByDisplayValue( '1.2.3.4' ) ).toBeInTheDocument();
+} );
+
+test( 'calls onSubmit with correct data when form is submitted', async () => {
+	const user = userEvent.setup();
+	const mockOnSubmit = jest.fn();
+
+	renderForm( { onSubmit: mockOnSubmit } );
+
+	// Fill in valid nameserver
+	const nameserverInput = screen.getByRole( 'textbox', { name: /Name server/ } );
+	await user.type( nameserverInput, 'give-me-cat-memes' );
+
+	// Fill in valid IP address
+	const ipAddressInput = screen.getByRole( 'textbox', { name: /IP address/ } );
+	await user.type( ipAddressInput, '1.2.3.4' );
+
+	// Submit the form
+	const submitButton = screen.getByRole( 'button', { name: 'Add record' } );
+	await user.click( submitButton );
+
+	expect( mockOnSubmit ).toHaveBeenCalledWith( {
+		nameserver: `give-me-cat-memes.${ domainName }`,
+		ip_addresses: [ '1.2.3.4' ],
+	} );
+} );
+
+test( 'disables submit button when isSubmitting is true', async () => {
+	renderForm( { isSubmitting: true } );
+
+	const submitButton = screen.getByRole( 'button', { name: 'Add record' } );
+	expect( submitButton ).toBeDisabled();
+} );
+
+test( 'shows validation error when nameserver is invalid', async () => {
+	const user = userEvent.setup();
+
+	renderForm();
+
+	// Fill in invalid nameserver
+	const nameserverInput = screen.getByRole( 'textbox', { name: /Name server/ } );
+	await user.type( nameserverInput, '(╯°□°)╯︵ ┻━┻' );
+	await user.tab(); // This will blur the field
+
+	// Validation error should appear after blur
+	expect( screen.getByText( 'Please enter a valid name server.' ) ).toBeInTheDocument();
+} );
+
+test( 'shows validation error when IP address is invalid', async () => {
+	const user = userEvent.setup();
+
+	renderForm();
+
+	// Fill in invalid IP address
+	const ipAddressInput = screen.getByRole( 'textbox', { name: /IP address/ } );
+	await user.type( ipAddressInput, '(-■_■)' );
+	await user.tab(); // This will blur the field
+
+	// Validation error should appear after blur
+	expect( screen.getByText( 'Please enter a valid IP address.' ) ).toBeInTheDocument();
+} );

--- a/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
@@ -34,7 +34,7 @@ const mockDeleteDomainGlueRecordApiRequest = ( {
 }: {
 	responseCode?: number;
 } = {} ) => {
-	return nock( 'https://public-api.wordpress.com:443' )
+	return nock( 'https://public-api.wordpress.com' )
 		.delete( `/wpcom/v2/domains/glue-records/${ domainName }`, {
 			name_server: glueRecord.nameserver,
 		} )

--- a/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainGlueRecord } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import DomainGlueRecordDeleteModal from '../delete-modal';
+
+const domainName = 'example.com';
+const glueRecord: DomainGlueRecord = {
+	nameserver: 'ns1',
+	ip_addresses: [ '1.2.3.4' ],
+};
+
+interface RenderDeleteModalProps {
+	onClose?: () => void;
+}
+
+function renderDeleteModal( props: RenderDeleteModalProps = {} ) {
+	const defaultProps = {
+		domainName,
+		glueRecord,
+		onClose: jest.fn(),
+		...props,
+	};
+
+	return render( <DomainGlueRecordDeleteModal { ...defaultProps } /> );
+}
+
+const mockDeleteDomainGlueRecordApiRequest = ( {
+	responseCode = 500,
+}: {
+	responseCode?: number;
+} = {} ) => {
+	return nock( 'https://public-api.wordpress.com:443' )
+		.delete( `/wpcom/v2/domains/glue-records/${ domainName }`, {
+			name_server: glueRecord.nameserver,
+		} )
+		.once()
+		.reply( responseCode );
+};
+
+afterEach( () => nock.cleanAll() );
+
+test( 'renders delete modal with correct title and buttons', async () => {
+	renderDeleteModal();
+
+	expect(
+		screen.getByText( 'Are you sure you want to delete this glue record?' )
+	).toBeInTheDocument();
+	expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'button', { name: 'Delete' } ) ).toBeInTheDocument();
+} );
+
+test( 'calls onClose when Cancel button is clicked', async () => {
+	const user = userEvent.setup();
+	const mockOnClose = jest.fn();
+
+	renderDeleteModal( { onClose: mockOnClose } );
+
+	await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+	expect( mockOnClose ).toHaveBeenCalled();
+} );
+
+test( 'calls delete mutation and onClose when Delete button is clicked and the request is successful', async () => {
+	const user = userEvent.setup();
+	const mockOnClose = jest.fn();
+
+	renderDeleteModal( { onClose: mockOnClose } );
+
+	mockDeleteDomainGlueRecordApiRequest();
+
+	await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+	// Wait for the mutation to complete
+	await screen.findByText( 'Are you sure you want to delete this glue record?' );
+
+	expect( mockOnClose ).toHaveBeenCalled();
+} );
+
+test( 'calls delete mutation and onClose when Delete button is clicked and the request fails', async () => {
+	const user = userEvent.setup();
+	const mockOnClose = jest.fn();
+
+	renderDeleteModal( { onClose: mockOnClose } );
+
+	mockDeleteDomainGlueRecordApiRequest( { responseCode: 500 } );
+
+	await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+	// Wait for the mutation to complete
+	await screen.findByText( 'Are you sure you want to delete this glue record?' );
+
+	expect( mockOnClose ).toHaveBeenCalled();
+} );

--- a/client/dashboard/domains/domain-glue-records/test/form.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/form.test.tsx
@@ -43,7 +43,7 @@ test( 'renders domain glue records form with correct fields', async () => {
 
 test( 'pre-fills form with initial data when provided', async () => {
 	const initialData = {
-		nameserver: 'give-me-cat-memes',
+		nameserver: 'ns1',
 		ip_addresses: [ '1.2.3.4' ],
 	};
 
@@ -51,7 +51,7 @@ test( 'pre-fills form with initial data when provided', async () => {
 		initialData,
 	} );
 
-	expect( screen.getByDisplayValue( 'give-me-cat-memes' ) ).toBeInTheDocument();
+	expect( screen.getByDisplayValue( 'ns1' ) ).toBeInTheDocument();
 	expect( screen.getByDisplayValue( '1.2.3.4' ) ).toBeInTheDocument();
 } );
 
@@ -63,7 +63,7 @@ test( 'calls onSubmit with correct data when form is submitted', async () => {
 
 	// Fill in valid nameserver
 	const nameserverInput = screen.getByRole( 'textbox', { name: /Name server/ } );
-	await user.type( nameserverInput, 'give-me-cat-memes' );
+	await user.type( nameserverInput, 'ns1' );
 
 	// Fill in valid IP address
 	const ipAddressInput = screen.getByRole( 'textbox', { name: /IP address/ } );
@@ -74,9 +74,19 @@ test( 'calls onSubmit with correct data when form is submitted', async () => {
 	await user.click( submitButton );
 
 	expect( mockOnSubmit ).toHaveBeenCalledWith( {
-		nameserver: `give-me-cat-memes.${ domainName }`,
+		nameserver: `ns1.${ domainName }`,
 		ip_addresses: [ '1.2.3.4' ],
 	} );
+} );
+
+test( 'nameserver is read only when isEdit is true', async () => {
+	renderForm( { isEdit: true, initialData: { nameserver: 'ns1', ip_addresses: [ '1.2.3.4' ] } } );
+
+	// Check that the nameserver value is rendered as text
+	expect( screen.getByText( 'ns1' ) ).toBeInTheDocument();
+
+	// There should be no textbox for nameserver
+	expect( screen.queryByRole( 'textbox', { name: /Name server/ } ) ).toBeNull();
 } );
 
 test( 'disables submit button when isSubmitting is true', async () => {

--- a/client/dashboard/domains/domain-glue-records/test/form.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/form.test.tsx
@@ -3,7 +3,6 @@
  */
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainGlueRecordsForm from '../form';
 import type { DomainGlueRecord } from '@automattic/api-core';
@@ -30,8 +29,6 @@ function renderForm( props: RenderFormProps = {} ) {
 
 	return render( <DomainGlueRecordsForm { ...defaultProps } /> );
 }
-
-afterEach( () => nock.cleanAll() );
 
 test( 'renders domain glue records form with correct fields', async () => {
 	renderForm();

--- a/client/dashboard/domains/domain-glue-records/test/index.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/index.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainGlueRecord } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import DomainGlueRecords from '../index';
+
+const domainName = 'example.com';
+
+jest.mock( '../../../app/router/domains', () => ( {
+	...jest.requireActual( '../../../app/router/domains' ),
+	domainRoute: {
+		useParams: () => ( { domainName: 'example.com' } ),
+	},
+} ) );
+
+const defaultGlueRecords = [
+	{
+		nameserver: 'ns1',
+		ip_addresses: [ '1.2.3.4' ],
+	},
+	{
+		nameserver: 'ns2',
+		ip_addresses: [ '2.3.4.5' ],
+	},
+];
+
+const mockFetchDomainGlueRecordsApiRequest = ( {
+	responseCode = 200,
+	data = defaultGlueRecords,
+}: {
+	responseCode?: number;
+	data?: DomainGlueRecord[];
+} = {} ) => {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/domains/glue-records/${ domainName }` )
+		.reply( responseCode, data );
+};
+
+afterEach( () => nock.cleanAll() );
+
+test( 'renders glue records table with data', async () => {
+	mockFetchDomainGlueRecordsApiRequest();
+
+	render( <DomainGlueRecords /> );
+
+	expect( await screen.findByText( 'Glue records' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'link', { name: 'Add glue record' } ) ).toBeInTheDocument();
+
+	// Check if the table rows are rendered
+	expect( await screen.findByText( 'ns1' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'link', { name: 'ns1' } ) );
+	expect( screen.getByText( '1.2.3.4' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'ns2' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'link', { name: 'ns2' } ) );
+	expect( screen.getByText( '2.3.4.5' ) ).toBeInTheDocument();
+} );
+
+test( 'renders empty state when no glue records exist', async () => {
+	mockFetchDomainGlueRecordsApiRequest( { data: [] } );
+
+	render( <DomainGlueRecords /> );
+
+	expect( await screen.findByText( 'Glue records' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'link', { name: 'Add glue record' } ) ).toBeInTheDocument();
+	expect( screen.getByText( 'No glue records found for this domain.' ) ).toBeInTheDocument();
+} );
+
+test( 'renders actions when a row is hovered', async () => {
+	const user = userEvent.setup();
+
+	mockFetchDomainGlueRecordsApiRequest();
+
+	render( <DomainGlueRecords /> );
+
+	const actions = await screen.findAllByLabelText( 'Actions' );
+	await user.click( actions[ 0 ] );
+
+	expect( screen.getByText( 'Edit' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Delete' ) ).toBeInTheDocument();
+} );

--- a/client/dashboard/domains/domain-glue-records/test/index.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/index.test.tsx
@@ -69,7 +69,7 @@ test( 'renders empty state when no glue records exist', async () => {
 	expect( screen.getByText( 'No glue records found for this domain.' ) ).toBeInTheDocument();
 } );
 
-test( 'renders actions when a row is hovered', async () => {
+test( 'renders actions when the actions menu is clicked', async () => {
 	const user = userEvent.setup();
 
 	mockFetchDomainGlueRecordsApiRequest();

--- a/client/dashboard/domains/domain-glue-records/test/summary.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/summary.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import DomainGlueRecordsSettingsSummary from '../summary';
+
+const domainName = 'example.com';
+
+function renderSummary() {
+	return render( <DomainGlueRecordsSettingsSummary domainName={ domainName } /> );
+}
+
+afterEach( () => nock.cleanAll() );
+
+test( 'renders domain glue records summary with correct title and link', async () => {
+	renderSummary();
+
+	expect( screen.getByRole( 'link', { name: 'Glue records' } ) ).toHaveAttribute(
+		'href',
+		`/domains/${ domainName }/glue-records`
+	);
+} );

--- a/client/dashboard/domains/domain-glue-records/test/summary.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/summary.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainGlueRecordsSettingsSummary from '../summary';
 
@@ -11,8 +10,6 @@ const domainName = 'example.com';
 function renderSummary() {
 	return render( <DomainGlueRecordsSettingsSummary domainName={ domainName } /> );
 }
-
-afterEach( () => nock.cleanAll() );
 
 test( 'renders domain glue records summary with correct title and link', async () => {
 	renderSummary();

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -77,7 +77,7 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 		// TODO: Add property that shows or hides this option depending on the availability of the feature
 	) {
 		buttonListItems.push(
-			<DomainGlueRecordsSettingsSummary key="glue-records" domain={ domain } />
+			<DomainGlueRecordsSettingsSummary key="glue-records" domainName={ domain.domain } />
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-387

## Proposed Changes

* This PR adds tests for the glue records screens.
* Updates button texts to improve consistency with other screens.

<img width="732" height="365" alt="image" src="https://github.com/user-attachments/assets/aa7feefe-f66d-44ca-9c8d-06b6c9c104b9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tests help with out quality initiative.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should be passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
