### PR TITLE
Dashboard v2: Fix Activity Logs Datetime column to overlap when the timezone name is long.

### DIFF
--- a/client/dashboard/sites/logs-activity/dataviews/views.ts
+++ b/client/dashboard/sites/logs-activity/dataviews/views.ts
@@ -22,8 +22,8 @@ export function useActivityView( {
 		fields: [ 'published', 'event', 'actor' ],
 		layout: {
 			styles: {
-				published: { maxWidth: '175px', minWidth: '140px' },
-				published_utc: { maxWidth: '175px', minWidth: '140px' },
+				published: { maxWidth: '300px', minWidth: '175px' },
+				published_utc: { maxWidth: '200px', minWidth: '175px' },
 				actor: { maxWidth: '150px', minWidth: '75px' },
 				event: { minWidth: '500px' },
 			},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-563

## Proposed Changes

* Make the datetime column longer to ensure it doesn't overlap with the other columns

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed that when using timezones with a very long name the column name could overlap if you add columns to the view or even in the default view (if the timezone name is really long)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
<img width="2794" height="828" alt="CleanShot 2025-10-01 at 17 47 03@2x" src="https://github.com/user-attachments/assets/607dd72a-b264-4d71-8082-b144794cf979" />

<img width="2826" height="928" alt="CleanShot 2025-10-01 at 17 46 49@2x" src="https://github.com/user-attachments/assets/edc09f47-a196-4606-8c97-894405a084b2" />

* Change your site timezone to a longer one (America/North Dakota/New Salem is one of the longest. If you use America/Los Angeles then test it by adding new fields to the view via the clog button).
* Ensure the column name doesn't overlap as it did before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
