### PR TITLE
Notification Settings: Add a back button to all pages

### DIFF
--- a/client/dashboard/me/notifications-comments/index.tsx
+++ b/client/dashboard/me/notifications-comments/index.tsx
@@ -1,7 +1,9 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { DevicesSettings } from './device-settings';
 import { EmailSettings } from './email-settings';
 import { WebSettings } from './web-settings';
@@ -12,6 +14,15 @@ export default function NotificationsComments() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={
+						<RouterLinkButton
+							className="dashboard-page-header__back-button"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							to="/me/notifications"
+						>
+							{ __( 'Back' ) }
+						</RouterLinkButton>
+					}
 					title={ __( 'Comments' ) }
 					description={ __(
 						'Set your notification preferences for activity on comments you’ve made on other sites.'

--- a/client/dashboard/me/notifications-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/index.tsx
@@ -1,8 +1,10 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { PauseAllEmails } from './pause-all-emails';
 import { SubscriptionSettings } from './subscription-settings';
 
@@ -13,6 +15,15 @@ export default function NotificationsEmails() {
 			header={
 				<PageHeader
 					title={ __( 'Emails' ) }
+					prefix={
+						<RouterLinkButton
+							className="dashboard-page-header__back-button"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							to="/me/notifications"
+						>
+							{ __( 'Back' ) }
+						</RouterLinkButton>
+					}
 					description={ createInterpolateElement(
 						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),
 						{

--- a/client/dashboard/me/notifications-extras/index.tsx
+++ b/client/dashboard/me/notifications-extras/index.tsx
@@ -4,9 +4,11 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
 import {
 	WPCOM_OPTION_KEYS,
@@ -42,6 +44,15 @@ export default function NotificationsExtras() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={
+						<RouterLinkButton
+							className="dashboard-page-header__back-button"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							to="/me/notifications"
+						>
+							{ __( 'Back' ) }
+						</RouterLinkButton>
+					}
 					title={ __( 'Extras' ) }
 					description={ __(
 						'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'

--- a/client/dashboard/me/notifications-sites/index.tsx
+++ b/client/dashboard/me/notifications-sites/index.tsx
@@ -2,9 +2,11 @@ import { notificationPushPermissionStateQuery } from '@automattic/api-queries';
 // eslint-disable-next-line no-restricted-imports
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { BrowserNotificationCard } from './browser-notification-card';
 import { BrowserNotificationNotice } from './browser-notification-notice';
 
@@ -16,6 +18,15 @@ export default function NotificationsSites() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={
+						<RouterLinkButton
+							className="dashboard-page-header__back-button"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							to="/me/notifications"
+						>
+							{ __( 'Back' ) }
+						</RouterLinkButton>
+					}
 					title={ __( 'Sites' ) }
 					description={ __(
 						'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'


### PR DESCRIPTION
Close CML-864


## Proposed Changes
* Add a back button to all inner notification subpages


> [!IMPORTANT]
> I started a thread here to check the current state of the back button implementation, since I didn't find any other page using it. 
 

## Screenshots
<img width="2496" height="1902" alt="CleanShot 2025-10-01 at 17 28 45@2x" src="https://github.com/user-attachments/assets/3b0bb032-a823-4d9c-86be-49c9fbf60f16" />



## Testing Instructions
* Go to /v2/me/notifications
* Click on any main button
* Check if you can see the back button
* Check if all back buttons are pointing to the main page properly


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
