### PR TITLE
Domain Search Rewrite: Hook events in get availability notice

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -265,6 +265,7 @@ const DomainSearchWithCart = ( {
 		<DomainSearch
 			{ ...props }
 			currentSiteUrl={ currentSiteUrl }
+			currentSiteId={ currentSiteId }
 			config={ config }
 			cart={ cart }
 			events={ events }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -24,6 +24,8 @@ import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import {
+	domainAddNew,
+	domainManagementList,
 	domainManagementTransferToOtherSite,
 	domainManagementList,
 } from 'calypso/my-sites/domains/paths';
@@ -145,6 +147,9 @@ const DomainSearchStep: StepType< {
 				}
 
 				window.location.assign( domainManagementList( siteSlug ) );
+			},
+			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
+				window.location.assign( domainAddNew( otherSiteDomain, domainName ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( domainName && isHundredYearDomainFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -23,10 +23,14 @@ import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementTransferToOtherSite,
+	domainManagementList,
+} from 'calypso/my-sites/domains/paths';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
+import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
@@ -63,6 +67,7 @@ const DomainSearchStep: StepType< {
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
+	const siteId = useSiteIdParam();
 	const initialQuery = useQuery().get( 'new' ) ?? '';
 	const tldQuery = useQuery().get( 'tld' );
 	const source = useQuery().get( 'source' );
@@ -70,6 +75,8 @@ const DomainSearchStep: StepType< {
 
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
+	// eslint-disable-next-line no-nested-ternary
+	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
 	const { query, setQuery } = useQueryHandler( {
 		initialQuery,
@@ -132,6 +139,13 @@ const DomainSearchStep: StepType< {
 					domainManagementTransferToOtherSite( otherSiteDomain, domainName )
 				);
 			},
+			onMakePrimaryAddressClick: () => {
+				if ( ! siteSlug ) {
+					return;
+				}
+
+				window.location.assign( domainManagementList( siteSlug ) );
+			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( domainName && isHundredYearDomainFlow( flow ) ) {
 					return window.location.assign(
@@ -171,7 +185,7 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 		};
-	}, [ submit, setQuery, flow ] );
+	}, [ submit, setQuery, flow, siteSlug ] );
 
 	const slots = useMemo( () => {
 		return {
@@ -226,7 +240,7 @@ const DomainSearchStep: StepType< {
 					? 'domain-search--step-container-v2'
 					: 'domain-search--step-container'
 			}
-			currentSiteId={ site?.ID }
+			currentSiteId={ currentSiteId }
 			currentSiteUrl={ currentSiteUrl }
 			flowName={ flow }
 			config={ config }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -26,6 +26,8 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import {
 	domainAddNew,
 	domainManagementList,
+	domainManagementRoot,
+	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
 	domainManagementList,
 } from 'calypso/my-sites/domains/paths';
@@ -150,6 +152,11 @@ const DomainSearchStep: StepType< {
 			},
 			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
 				window.location.assign( domainAddNew( otherSiteDomain, domainName ) );
+			},
+			onCheckTransferStatusClick: ( domainName: string ) => {
+				window.location.assign(
+					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
+				);
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( domainName && isHundredYearDomainFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -29,7 +29,7 @@ import {
 	domainManagementRoot,
 	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
-	domainManagementList,
+	domainMapping,
 } from 'calypso/my-sites/domains/paths';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useQuery } from '../../../../hooks/use-query';
@@ -157,6 +157,9 @@ const DomainSearchStep: StepType< {
 				window.location.assign(
 					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
 				);
+			},
+			onMapDomainClick: ( domainName: string ) => {
+				window.location.assign( domainMapping( siteSlug, domainName ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( domainName && isHundredYearDomainFlow( flow ) ) {

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -59,6 +59,7 @@ export default function DomainSearch() {
 
 	const initialQuery = queryArguments?.suggestion?.toString() ?? '';
 	const currentSiteUrl = selectedSite?.URL;
+	const currentSiteId = selectedSite?.ID;
 
 	const { query, setQuery } = useQueryHandler( {
 		initialQuery,
@@ -70,6 +71,9 @@ export default function DomainSearch() {
 			onQueryChange: setQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
+			},
+			onMakePrimaryAddressClick: () => {
+				page( domainManagementList( selectedSiteSlug ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( ! selectedSiteSlug ) {
@@ -120,7 +124,7 @@ export default function DomainSearch() {
 			{ ! hasPlan( cart.responseCart ) && <NewDomainsRedirectionNoticeUpsell /> }
 			<WPCOMDomainSearch
 				className="domain-search--calypso"
-				currentSiteId={ selectedSite?.ID }
+				currentSiteId={ currentSiteId }
 				currentSiteUrl={ currentSiteUrl }
 				flowName={ FLOW_NAME }
 				config={ config }
@@ -131,7 +135,7 @@ export default function DomainSearch() {
 			/>
 			<QueryProductsList />
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ selectedSite?.ID && <QuerySiteDomains siteId={ selectedSite?.ID } /> }
+			{ selectedSite?.ID && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 		</Main>
 	);
 }

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -24,6 +24,8 @@ import {
 	domainAddEmailUpsell,
 	domainAddNew,
 	domainManagementList,
+	domainManagementRoot,
+	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
 	domainUseMyDomain,
 } from '../paths';
@@ -78,6 +80,13 @@ export default function DomainSearch() {
 			},
 			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
 				page( domainAddNew( otherSiteDomain, domainName ) );
+			},
+			onCheckTransferStatusClick: ( domainName: string ) => {
+				page(
+					selectedSiteSlug
+						? domainManagementTransferIn( selectedSiteSlug, domainName )
+						: domainManagementRoot()
+				);
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( ! selectedSiteSlug ) {

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -27,6 +27,7 @@ import {
 	domainManagementRoot,
 	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
+	domainMapping,
 	domainUseMyDomain,
 } from '../paths';
 
@@ -87,6 +88,9 @@ export default function DomainSearch() {
 						? domainManagementTransferIn( selectedSiteSlug, domainName )
 						: domainManagementRoot()
 				);
+			},
+			onMapDomainClick: ( domainName: string ) => {
+				page( domainMapping( selectedSiteSlug, domainName ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( ! selectedSiteSlug ) {

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -22,6 +22,7 @@ import useCartKey from '../../checkout/use-cart-key';
 import NewDomainsRedirectionNoticeUpsell from '../domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
+	domainAddNew,
 	domainManagementList,
 	domainManagementTransferToOtherSite,
 	domainUseMyDomain,
@@ -74,6 +75,9 @@ export default function DomainSearch() {
 			},
 			onMakePrimaryAddressClick: () => {
 				page( domainManagementList( selectedSiteSlug ) );
+			},
+			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
+				page( domainAddNew( otherSiteDomain, domainName ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
 				if ( ! selectedSiteSlug ) {

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -20,6 +20,7 @@ import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import {
+	domainMapping,
 	domainAddNew,
 	domainManagementList,
 	domainManagementRoot,
@@ -117,6 +118,9 @@ const DomainSearchUI = (
 				page(
 					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
 				);
+			},
+			onMapDomainClick: ( domainName: string ) => {
+				page( domainMapping( siteSlug, domainName ) );
 			},
 			onExternalDomainClick( initialQuery?: string ) {
 				if ( isDomainOnlyFlow ) {

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -20,6 +20,7 @@ import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import {
+	domainAddNew,
 	domainManagementList,
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
@@ -106,6 +107,9 @@ const DomainSearchUI = (
 				}
 
 				page( domainManagementList( siteSlug ) );
+			},
+			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
+				page( domainAddNew( otherSiteDomain, domainName ) );
 			},
 			onExternalDomainClick( initialQuery?: string ) {
 				if ( isDomainOnlyFlow ) {

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -22,6 +22,8 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import {
 	domainAddNew,
 	domainManagementList,
+	domainManagementRoot,
+	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -110,6 +112,11 @@ const DomainSearchUI = (
 			},
 			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
 				page( domainAddNew( otherSiteDomain, domainName ) );
+			},
+			onCheckTransferStatusClick: ( domainName: string ) => {
+				page(
+					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
+				);
 			},
 			onExternalDomainClick( initialQuery?: string ) {
 				if ( isDomainOnlyFlow ) {

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -19,11 +19,15 @@ import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
+import {
+	domainManagementList,
+	domainManagementTransferToOtherSite,
+} from 'calypso/my-sites/domains/paths';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { USE_MY_DOMAIN_SECTION_NAME, UseMyDomain } from './use-my-domain';
 import type { StepProps } from './types';
 
@@ -62,8 +66,15 @@ const DomainSearchUI = (
 	const isDomainOnlyFlow = flowName === 'domain';
 	const isOnboardingWithEmailFlow = flowName === 'onboarding-with-email';
 
+	const site = useSelector( getSelectedSite );
+
 	const siteSlug = queryObject.siteSlug;
-	const currentSiteUrl = siteSlug ? `https://${ siteSlug }` : undefined;
+	const siteId = queryObject.siteId;
+
+	// eslint-disable-next-line no-nested-ternary
+	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
+	// eslint-disable-next-line no-nested-ternary
+	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
 	const { query, setQuery } = useQueryHandler( {
 		initialQuery: queryObject.new,
@@ -88,6 +99,13 @@ const DomainSearchUI = (
 			},
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
+			},
+			onMakePrimaryAddressClick: () => {
+				if ( ! siteSlug ) {
+					return;
+				}
+
+				page( domainManagementList( siteSlug ) );
 			},
 			onExternalDomainClick( initialQuery?: string ) {
 				if ( isDomainOnlyFlow ) {
@@ -338,6 +356,7 @@ const DomainSearchUI = (
 					flowName={ flowName }
 					query={ query }
 					currentSiteUrl={ currentSiteUrl }
+					currentSiteId={ currentSiteId }
 					events={ events }
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -76,6 +76,11 @@ export interface DomainSuggestionQuery {
 	 * Domain category slug
 	 */
 	category_slug?: string;
+
+	/**
+	 * The site slug
+	 */
+	site_slug?: string;
 }
 
 export interface DomainSuggestion {

--- a/packages/api-queries/src/domain-availability.ts
+++ b/packages/api-queries/src/domain-availability.ts
@@ -1,9 +1,12 @@
-import { fetchDomainAvailability } from '@automattic/api-core';
+import { type DomainAvailabilityQuery, fetchDomainAvailability } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const domainAvailabilityQuery = ( domainName: string ) =>
+export const domainAvailabilityQuery = (
+	domainName: string,
+	params: Partial< DomainAvailabilityQuery > = {}
+) =>
 	queryOptions( {
-		queryKey: [ 'domain-availability', domainName ],
-		queryFn: () => fetchDomainAvailability( domainName ),
+		queryKey: [ 'domain-availability', domainName, params ],
+		queryFn: () => fetchDomainAvailability( domainName, params ),
 		meta: { persist: false },
 	} );

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -17,7 +17,6 @@ const AVAILABLE_DOMAIN_STATUSES = [
 
 /**
  * Determines whether the availability notice should be hidden for a given domain availability
- *
  * @param availability - Domain availability returned from the availability endpoint
  * @returns True if the availability notice should be hidden, false otherwise.
  */
@@ -89,6 +88,7 @@ export const SearchNotice = () => {
 
 		if (
 			isDomainMapped &&
+			availability.status !== DomainAvailabilityStatus.REGISTERED_SAME_SITE &&
 			availability.status !== DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER &&
 			availability.status !== DomainAvailabilityStatus.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE &&
 			availability.status !== DomainAvailabilityStatus.MAPPED_SAME_SITE_REGISTRABLE

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -12,7 +12,7 @@ const SkipSuggestion = () => {
 	if ( currentSiteUrl ) {
 		return (
 			<DomainSearchSkipSuggestion
-				existingSiteUrl={ currentSiteUrl.replace( /^https?:\/\//, '' ) }
+				existingSiteUrl={ currentSiteUrl }
 				onSkip={ () => events.onSkip() }
 				disabled={ !! isMutating }
 			/>

--- a/packages/domain-search/src/helpers/get-availability-notice.tsx
+++ b/packages/domain-search/src/helpers/get-availability-notice.tsx
@@ -449,9 +449,7 @@ export const getAvailabilityNotice = (
 						args: { domain },
 						components: {
 							strong: <strong />,
-							button: (
-								<button onClick={ () => events.onMapDomainClick( currentSiteUrl, domain ) } />
-							),
+							button: <button onClick={ () => events.onMapDomainClick( domain ) } />,
 						},
 					}
 				);

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -91,13 +91,16 @@ export const useDomainSearch = () => {
 };
 
 export const useDomainSearchContextValue = ( {
-	currentSiteUrl,
+	currentSiteUrl: externalSiteUrl,
+	currentSiteId,
 	query: externalQuery,
 	cart,
 	events,
 	slots,
 	config,
 }: DomainSearchProps ): typeof DEFAULT_CONTEXT_VALUE => {
+	const currentSiteUrl = externalSiteUrl?.replace( /^https?:\/\//, '' );
+
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
 	const [ filter, setFilter ] = useState( DEFAULT_FILTER );
 
@@ -140,6 +143,7 @@ export const useDomainSearchContextValue = ( {
 						tlds: filter.tlds.length > 0 ? filter.tlds : allowedTlds,
 						exact_sld_matches_only: filter.exactSldMatchesOnly,
 						include_internal_move_eligible: normalizedConfig.includeOwnedDomainInSuggestions,
+						site_slug: currentSiteUrl,
 					} ),
 					enabled: false,
 					staleTime: Infinity,
@@ -157,8 +161,12 @@ export const useDomainSearchContextValue = ( {
 					refetchOnMount: false,
 					refetchOnWindowFocus: false,
 				} ),
-				domainAvailability: ( domainName ) => ( {
-					...domainAvailabilityQuery( domainName ),
+				domainAvailability: ( domainName, isCartPreCheck = false ) => ( {
+					...domainAvailabilityQuery( domainName, {
+						vendor: normalizedConfig.vendor,
+						blog_id: currentSiteId,
+						is_cart_pre_check: isCartPreCheck,
+					} ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,
@@ -208,6 +216,7 @@ export const useDomainSearchContextValue = ( {
 		normalizedEvents,
 		slots,
 		currentSiteUrl,
+		currentSiteId,
 		normalizedConfig,
 		filter,
 		setFilter,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -39,7 +39,7 @@ export interface DomainSearchEvents {
 	onTransferDomainToWordPressComClick: ( domainName: string ) => void;
 	onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onCheckTransferStatusClick: ( domainName: string ) => void;
-	onMapDomainClick: ( currentSiteSlug: string, domainName: string ) => void;
+	onMapDomainClick: ( domainName: string ) => void;
 	onQueryChange: ( query: string ) => void;
 	onAddDomainToCart: (
 		domainName: string,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -89,6 +89,7 @@ export interface DomainSearchProps {
 	query?: string;
 	events?: Partial< DomainSearchEvents >;
 	currentSiteUrl?: string;
+	currentSiteId?: number;
 	config?: Partial< DomainSearchConfig >;
 }
 


### PR DESCRIPTION
Closes DOMAINS-1673.

## Proposed Changes

Hooks the remaining events in the `getAvailabilityNotice` function.

## Why are these changes being made?

Feature parity.

## Testing Instructions

### onMakePrimaryAddressClick

Enter `/domains/add/%s` and verify you had a different domain registered on this site. Type it in the search bar and verify the notice shows up with the action item. Click it and you will be redirected to the domain management page for this site, where you can switch the primary domain.

Production sets the primary domain automatically but I think it's too aggressive. I think redirecting the user is a better UX here @ramynasr. Let me know what you think. EDIT: We'll move forward with that behavior.

<img width="730" height="519" alt="image" src="https://github.com/user-attachments/assets/b59920ff-ab4b-492b-8791-30ed8918e880" />

### onRegisterDomainClick

Enter `/domains/add/%s` and search for a domain that is connected to your site but registered elsewhere. You should see the "%(domain) is already connected to your site [...] Register it to the connected site" notice, which should send you to the domain search page of the site that is connecting the domain.

### onCheckTransferStatusClick

- Enter `/start/domain` and type a domain that has a transfer to WPCOM in progress. Click the CTA in the notice and you should be redirected to `/domains/manage`.
- Enter `/setup/domain?siteSlug=%s` or `/domains/add/%s` and search for the same domain. This time you should be redirected to the transfer status of the domain.

### onMapDomainClick

This is a funny one. It was introduced 8 years ago when we didn't support premium domains, and it should match whenever the availability returned from the API is `available_premium`. Are we still returning that? I didn't manage to reproduce it myself.

If it's possible, then clicking the CTA in the notice should send you to `/domains/add/mapping/%siteSlug`, given you entered `/domains/add/%s`. Otherwise, in generic flows like `/start/domain`, it should not display the CTA.