### PR TITLE
Jetpack: Stats, remove th geocode api key

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -420,7 +419,6 @@ class StatsGeochart extends Component {
 		if ( window.google && window.google.charts ) {
 			window.google.charts.load( '45', {
 				packages: [ 'geochart' ],
-				mapsApiKey: config( 'google_maps_and_places_api_key' ),
 			} );
 			window.google.charts.setOnLoadCallback( this.drawRegionsMap );
 			clearTimeout( this.timer );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -154,7 +154,6 @@
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
-	"google_maps_and_places_api_key": "AIzaSyAJN-ceOpTLP1CSQdyoRLS4VT9Zlsibkeg",
 	"push_notification_vapid_key": "BDQlTOrVTrxRM0i-gCsrxjxOyul281c5WVdfstXaqZqTSpjSI9M-E99CvwwJRWDkZ0goa8VSqUCgwiexxcDuXCs",
 	"enable_all_sections": true,
 	"sections": {


### PR DESCRIPTION
This PR is a maintenance PR that removes the geocode api key. 

The key is not being used any more to geocode things. We want to remove it since it could be used in ways that would get us to incur costs. 

After this change the geochart still looks the same as before. I think this is because do provide the coordinates with the city data. So no geocoding is needed.
<img width="661" height="576" alt="Screenshot 2025-10-02 at 6 03 05 AM" src="https://github.com/user-attachments/assets/3772d9f9-8db7-4750-88af-b10e4810eeda" />


See p1759291025873139-slack-C02AVAR9B

## Proposed Changes

* Removes the google maps api key from the code base. 
 

## Why are these changes being made?

* Maintenance and code clean up. 

## Testing Instructions
* Load this PR and visit a site that has the cities enabled for the in stats. 
* Notice that the map of the cities displays as expected. 

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?