### PR TITLE
Replace more logic with isDashboardBackport

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/index.tsx
@@ -9,6 +9,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, cloudDownload, cloudUpload } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import {
 	getProductionSiteId,
 	getStagingSiteId,
@@ -86,30 +87,30 @@ export default function StagingSiteSyncDropdown( {
 	}
 
 	const renderModal = () => {
-		if ( [ '/v2', '/ciab' ].some( ( path ) => window?.location?.pathname?.startsWith( path ) ) ) {
+		if ( isDashboardBackport() ) {
 			return (
-				<StagingSiteSyncModal
-					onClose={ handleCloseModal }
-					syncType={ syncDirection }
-					environment={ environment }
-					productionSiteId={ productionSiteId }
-					stagingSiteId={ stagingSiteId }
-					onSyncStart={ handleSyncStart }
-				/>
+				<Suspense fallback={ null }>
+					<StagingSiteSyncModalV1
+						onClose={ handleCloseModal }
+						syncType={ syncDirection }
+						environment={ environment }
+						productionSiteId={ productionSiteId }
+						stagingSiteId={ stagingSiteId }
+						onSyncStart={ handleSyncStart }
+					/>
+				</Suspense>
 			);
 		}
 
 		return (
-			<Suspense fallback={ null }>
-				<StagingSiteSyncModalV1
-					onClose={ handleCloseModal }
-					syncType={ syncDirection }
-					environment={ environment }
-					productionSiteId={ productionSiteId }
-					stagingSiteId={ stagingSiteId }
-					onSyncStart={ handleSyncStart }
-				/>
-			</Suspense>
+			<StagingSiteSyncModal
+				onClose={ handleCloseModal }
+				syncType={ syncDirection }
+				environment={ environment }
+				productionSiteId={ productionSiteId }
+				stagingSiteId={ stagingSiteId }
+				onSyncStart={ handleSyncStart }
+			/>
 		);
 	};
 

--- a/client/dashboard/utils/site-backup.ts
+++ b/client/dashboard/utils/site-backup.ts
@@ -1,3 +1,4 @@
+import { isDashboardBackport } from './is-dashboard-backport';
 import { isSelfHostedJetpackConnected } from './site-types';
 import type { Site } from '@automattic/api-core';
 
@@ -6,7 +7,7 @@ export function getBackupUrl( site: Site ) {
 		return `https://cloud.jetpack.com/backup/${ site.slug }`;
 	}
 
-	return [ '/v2', '/ciab' ].some( ( path ) => window?.location?.pathname?.startsWith( path ) )
-		? `/sites/${ site.slug }/backups`
-		: `https://wordpress.com/backup/${ site.slug }`;
+	return isDashboardBackport()
+		? `https://wordpress.com/backup/${ site.slug }`
+		: `/sites/${ site.slug }/backups`;
 }


### PR DESCRIPTION
## Proposed Changes

Follow up of https://github.com/Automattic/wp-calypso/pull/106174. A couple of logic replacements fell through the cracks, sorry.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
