### PR TITLE
Performance v2: Use Tabs from core component and fix styles on mobile

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -48,8 +48,6 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/components/src/logos',
-							// To be replaced with @wordpress/tabs when ready.
-							'!@automattic/components/src/tabs',
 							'!@automattic/calypso-analytics',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',

--- a/client/dashboard/sites/performance/core-metrics-content.tsx
+++ b/client/dashboard/sites/performance/core-metrics-content.tsx
@@ -40,7 +40,7 @@ export default function CoreMetricsContent( {
 
 	const isOverall = activeTab === 'overall_score';
 	return (
-		<Card>
+		<Card style={ { width: '100%' } }>
 			<CardBody>
 				<VStack spacing={ 4 }>
 					<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">

--- a/client/dashboard/sites/performance/core-metrics-content.tsx
+++ b/client/dashboard/sites/performance/core-metrics-content.tsx
@@ -2,8 +2,6 @@ import { Metrics } from '@automattic/api-core';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Card,
-	CardBody,
 } from '@wordpress/components';
 import { Text } from '../../components/text';
 import {
@@ -40,45 +38,41 @@ export default function CoreMetricsContent( {
 
 	const isOverall = activeTab === 'overall_score';
 	return (
-		<Card style={ { width: '100%' } }>
-			<CardBody>
-				<VStack spacing={ 4 }>
-					<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
-						<VStack spacing={ 4 } alignment="flex-start">
-							<HStack spacing={ 2 } justify="flex-start">
-								<Text size="title" weight={ 500 } as="h2">
-									{ displayName }
-								</Text>
-								<CoreMetricsStatusBadge value={ status } />
-							</HStack>
-
-							{ isOverall ? (
-								<OverallScore size={ 32 } status={ status } value={ value } />
-							) : (
-								<MetricScore
-									size={ 32 }
-									metric={ activeTab as Metrics }
-									status={ status }
-									value={ value }
-								/>
-							) }
-							<CoreMetricsExplanation activeTab={ activeTab } />
-						</VStack>
-						{ numberOfAuditsForMetric > 0 && (
-							<CoreMetricsRecommendLink
-								activeTab={ activeTab }
-								count={ numberOfAuditsForMetric }
-								onClick={ onRecommendationsFilterChange }
-							/>
-						) }
+		<VStack spacing={ 4 }>
+			<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+				<VStack spacing={ 4 } alignment="flex-start">
+					<HStack spacing={ 2 } justify="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ displayName }
+						</Text>
+						<CoreMetricsStatusBadge value={ status } />
 					</HStack>
-					<CoreMetricsChart
-						data={ [] }
-						activeTab={ activeTab }
-						metricsThresholds={ metricsThresholds }
-					/>
+
+					{ isOverall ? (
+						<OverallScore size={ 32 } status={ status } value={ value } />
+					) : (
+						<MetricScore
+							size={ 32 }
+							metric={ activeTab as Metrics }
+							status={ status }
+							value={ value }
+						/>
+					) }
+					<CoreMetricsExplanation activeTab={ activeTab } />
 				</VStack>
-			</CardBody>
-		</Card>
+				{ numberOfAuditsForMetric > 0 && (
+					<CoreMetricsRecommendLink
+						activeTab={ activeTab }
+						count={ numberOfAuditsForMetric }
+						onClick={ onRecommendationsFilterChange }
+					/>
+				) }
+			</HStack>
+			<CoreMetricsChart
+				data={ [] }
+				activeTab={ activeTab }
+				metricsThresholds={ metricsThresholds }
+			/>
+		</VStack>
 	);
 }

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -36,8 +36,8 @@ const CoreMetricsTabs = ( {
 	const isSmall = useViewportMatch( 'small' );
 
 	return (
-		<Card>
-			<Tabs.TabList>
+		<Card style={ { flexGrow: compact ? 1 : 0, flexShrink: compact ? 1 : 0 } }>
+			<Tabs.TabList style={ { maxWidth: '100%' } }>
 				<Tab tabId="overall_score">
 					<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
 						{ compact ? metricsNames.overall_score.shortName : metricsNames.overall_score.name }

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -1,5 +1,5 @@
 import { Metrics } from '@automattic/api-core';
-import { __experimentalVStack as VStack, Card, privateApis } from '@wordpress/components';
+import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Text } from '../../components/text';
@@ -36,59 +36,57 @@ const CoreMetricsTabs = ( {
 	const isSmall = useViewportMatch( 'small' );
 
 	return (
-		<Card style={ { flexGrow: compact ? 1 : 0, flexShrink: compact ? 1 : 0 } }>
-			<Tabs.TabList style={ { maxWidth: '100%' } }>
-				<Tab tabId="overall_score">
-					<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
-						{ compact ? metricsNames.overall_score.shortName : metricsNames.overall_score.name }
-					</Text>
-					<OverallScore
-						lineHeight="32px"
-						status={ mapThresholdsToStatus( 'overall_score', report.overall_score ) }
-						size={ isSmall ? 20 : 16 }
-						value={ report.overall_score }
-					/>
-				</Tab>
-				{ Object.entries( metricsNames ).map(
-					( [ key, { name: displayName, shortName: shortDisplayName } ] ) => {
-						// Overall score is displayed in the first card
-						if ( key === 'overall_score' ) {
-							return null;
-						}
-
-						if (
-							report[ key as keyof SitePerformanceReport ] === undefined ||
-							report[ key as keyof SitePerformanceReport ] === null
-						) {
-							return null;
-						}
-
-						// Only display TBT if INP is not available
-						if ( key === 'tbt' && report[ 'inp' ] !== undefined && report[ 'inp' ] !== null ) {
-							return null;
-						}
-
-						const status = mapThresholdsToStatus( key as Metrics, report[ key as Metrics ] );
-						const metricKey = key as Metrics;
-
-						return (
-							<Tab key={ key } tabId={ metricKey }>
-								<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
-									{ compact ? shortDisplayName : displayName }
-								</Text>
-								<MetricScore
-									lineHeight="32px"
-									metric={ metricKey }
-									status={ status }
-									size={ isSmall ? 20 : 16 }
-									value={ report[ metricKey ] }
-								/>
-							</Tab>
-						);
+		<Tabs.TabList style={ { maxWidth: '100%' } }>
+			<Tab tabId="overall_score">
+				<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
+					{ compact ? metricsNames.overall_score.shortName : metricsNames.overall_score.name }
+				</Text>
+				<OverallScore
+					lineHeight="32px"
+					status={ mapThresholdsToStatus( 'overall_score', report.overall_score ) }
+					size={ isSmall ? 20 : 16 }
+					value={ report.overall_score }
+				/>
+			</Tab>
+			{ Object.entries( metricsNames ).map(
+				( [ key, { name: displayName, shortName: shortDisplayName } ] ) => {
+					// Overall score is displayed in the first card
+					if ( key === 'overall_score' ) {
+						return null;
 					}
-				) }
-			</Tabs.TabList>
-		</Card>
+
+					if (
+						report[ key as keyof SitePerformanceReport ] === undefined ||
+						report[ key as keyof SitePerformanceReport ] === null
+					) {
+						return null;
+					}
+
+					// Only display TBT if INP is not available
+					if ( key === 'tbt' && report[ 'inp' ] !== undefined && report[ 'inp' ] !== null ) {
+						return null;
+					}
+
+					const status = mapThresholdsToStatus( key as Metrics, report[ key as Metrics ] );
+					const metricKey = key as Metrics;
+
+					return (
+						<Tab key={ key } tabId={ metricKey }>
+							<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
+								{ compact ? shortDisplayName : displayName }
+							</Text>
+							<MetricScore
+								lineHeight="32px"
+								metric={ metricKey }
+								status={ status }
+								size={ isSmall ? 20 : 16 }
+								value={ report[ metricKey ] }
+							/>
+						</Tab>
+					);
+				}
+			) }
+		</Tabs.TabList>
 	);
 };
 

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -1,11 +1,18 @@
 import { Metrics } from '@automattic/api-core';
-import { Tabs } from '@automattic/components/src/tabs';
-import { __experimentalVStack as VStack, Card } from '@wordpress/components';
+import { __experimentalVStack as VStack, Card, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Text } from '../../components/text';
 import { metricsNames, mapThresholdsToStatus } from '../../utils/site-performance';
 import { OverallScore, MetricScore } from './core-metrics-score';
 import type { SitePerformanceReport } from '@automattic/api-core';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
 
 const Tab = ( { children, tabId }: { children: React.ReactNode; tabId: string } ) => {
 	const isDesktop = useViewportMatch( 'medium' );

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -1,5 +1,5 @@
 import { Metrics } from '@automattic/api-core';
-import { __experimentalGrid as Grid, privateApis } from '@wordpress/components';
+import { __experimentalHStack as HStack, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useState } from 'react';
@@ -30,12 +30,7 @@ export default function CoreMetrics( {
 			selectedTabId={ activeTab }
 			onSelect={ ( tabId: Metrics ) => setActiveTab( tabId ) }
 		>
-			<Grid
-				alignment="topLeft"
-				columns={ isDesktop ? 2 : 1 }
-				gap={ 6 }
-				templateColumns={ isDesktop ? '220px 1fr' : '1fr' }
-			>
+			<HStack wrap={ ! isDesktop } alignment="flex-start" justify="flex-start" spacing={ 6 }>
 				<CoreMetricsTabs compact={ ! isDesktop } report={ report } />
 				<Tabs.TabPanel tabId={ activeTab }>
 					<CoreMetricsContent
@@ -44,7 +39,7 @@ export default function CoreMetrics( {
 						onRecommendationsFilterChange={ onRecommendationsFilterChange }
 					/>
 				</Tabs.TabPanel>
-			</Grid>
+			</HStack>
 		</Tabs>
 	);
 }

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -1,5 +1,5 @@
 import { Metrics } from '@automattic/api-core';
-import { __experimentalHStack as HStack, privateApis } from '@wordpress/components';
+import { __experimentalHStack as HStack, privateApis, Card, CardBody } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useState } from 'react';
@@ -31,14 +31,20 @@ export default function CoreMetrics( {
 			onSelect={ ( tabId: Metrics ) => setActiveTab( tabId ) }
 		>
 			<HStack wrap={ ! isDesktop } alignment="flex-start" justify="flex-start" spacing={ 6 }>
-				<CoreMetricsTabs compact={ ! isDesktop } report={ report } />
-				<Tabs.TabPanel tabId={ activeTab }>
-					<CoreMetricsContent
-						report={ report }
-						activeTab={ activeTab }
-						onRecommendationsFilterChange={ onRecommendationsFilterChange }
-					/>
-				</Tabs.TabPanel>
+				<Card style={ { flexGrow: ! isDesktop ? 1 : 0, flexShrink: ! isDesktop ? 1 : 0 } }>
+					<CoreMetricsTabs compact={ ! isDesktop } report={ report } />
+				</Card>
+				<Card style={ { width: '100%' } }>
+					<CardBody>
+						<Tabs.TabPanel tabId={ activeTab }>
+							<CoreMetricsContent
+								report={ report }
+								activeTab={ activeTab }
+								onRecommendationsFilterChange={ onRecommendationsFilterChange }
+							/>
+						</Tabs.TabPanel>
+					</CardBody>
+				</Card>
 			</HStack>
 		</Tabs>
 	);

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -1,11 +1,18 @@
 import { Metrics } from '@automattic/api-core';
-import { Tabs } from '@automattic/components/src/tabs';
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { __experimentalGrid as Grid, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useState } from 'react';
 import CoreMetricsContent from './core-metrics-content';
 import CoreMetricsTabs from './core-metrics-tabs';
 import type { SitePerformanceReport } from '@automattic/api-core';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
 
 export default function CoreMetrics( {
 	report,
@@ -21,7 +28,7 @@ export default function CoreMetrics( {
 		<Tabs
 			orientation={ isDesktop ? 'vertical' : 'horizontal' }
 			selectedTabId={ activeTab }
-			onSelect={ ( tabId ) => setActiveTab( tabId as Metrics ) }
+			onSelect={ ( tabId: Metrics ) => setActiveTab( tabId ) }
 		>
 			<Grid
 				alignment="topLeft"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Use Tabs from core component
* Fix styles on mobile

| Before | After |
| - | - |
|<img width="441" height="598" alt="image" src="https://github.com/user-attachments/assets/af425b79-fe0c-4fe6-8b72-0b8d9a3f73f5" />|<img width="441" height="598" alt="image" src="https://github.com/user-attachments/assets/48762add-4843-4516-aa52-612f19f0f51c" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance
* Resize to smaller viewport
* Ensure the Tabs section doesn't overflow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
