### PR TITLE
Notification Settings: Use static typed routes instead of strings

### DIFF
--- a/client/dashboard/me/notifications-comments/summary.tsx
+++ b/client/dashboard/me/notifications-comments/summary.tsx
@@ -1,12 +1,13 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { comment } from '@wordpress/icons';
+import { notificationsCommentsRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export const NotificationsCommentsSummary = () => {
 	return (
 		<RouterLinkSummaryButton
-			to="/me/notifications/comments"
+			to={ notificationsCommentsRoute.fullPath }
 			title={ __( 'Comments' ) }
 			description={ __(
 				'Set your notification preferences for activity on comments you’ve made on other sites.'

--- a/client/dashboard/me/notifications-emails/summary.tsx
+++ b/client/dashboard/me/notifications-emails/summary.tsx
@@ -1,12 +1,13 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
+import { notificationsEmailsRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export const NotificationsEmailsSummary = () => {
 	return (
 		<RouterLinkSummaryButton
-			to="/me/notifications/emails"
+			to={ notificationsEmailsRoute.fullPath }
 			title={ __( 'Emails' ) }
 			description={ __(
 				'Manage how you receive emails. Set the frequency, choose a format, or pause all emails. To manage individual site subscriptions'

--- a/client/dashboard/me/notifications-extras/summary.tsx
+++ b/client/dashboard/me/notifications-extras/summary.tsx
@@ -1,12 +1,13 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
+import { notificationsExtrasRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export const NotificationsExtrasSummary = () => {
 	return (
 		<RouterLinkSummaryButton
-			to="/me/notifications/extras"
+			to={ notificationsExtrasRoute.fullPath }
 			title={ __( 'Extras' ) }
 			description={ __(
 				'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'

--- a/client/dashboard/me/notifications-sites/summary.tsx
+++ b/client/dashboard/me/notifications-sites/summary.tsx
@@ -1,12 +1,13 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
+import { notificationsSitesRoute } from '../../app/router/me';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 
 export const NotificationsSitesSummary = () => {
 	return (
 		<RouterLinkSummaryButton
-			to="/me/notifications/sites"
+			to={ notificationsSitesRoute.fullPath }
 			title={ __( 'Sites' ) }
 			description={ __(
 				'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'


### PR DESCRIPTION


## Proposed Changes
* Use tanstack router reference instead of regular strings 

## Why are these changes being made?
* Make it less error-prone.

## Testing Instructions
* Go to `/v2/me/notifications` and check if all inks are working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
