### PR TITLE
Notification Settings: Use correct form layout for Email delivery window

### DIFF
--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -36,7 +36,6 @@ const CustomSelectControl = ( { field, data, onChange }: DataFormControlProps< S
 	return (
 		<SelectControl
 			label={ field.label }
-			hideLabelFromVision
 			value={ getValue( { item: data } ) }
 			options={ field.elements ?? [] }
 			help={ field.description }
@@ -224,7 +223,8 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 				id: 'subscription_delivery_window',
 				label: 'Email delivery window',
 				layout: {
-					type: 'regular' as const,
+					type: 'row' as const,
+					alignment: 'start' as const,
 				},
 			},
 			'subscription_delivery_jabber_default',


### PR DESCRIPTION
Close CML-891

## Proposed Changes
* Show the day and hour fields on the same row. 

| Before | After |
|--------|--------|
| <img width="1410" height="912" alt="CleanShot 2025-10-02 at 12 05 59@2x" src="https://github.com/user-attachments/assets/31383214-7997-48c4-b2a2-95792c698bca" /> | <img width="1408" height="910" alt="CleanShot 2025-10-02 at 12 04 55@2x" src="https://github.com/user-attachments/assets/c94ceeb5-0fb8-4c4d-8d00-bd4ca63d7119" /> |

<img width="1408" height="910" alt="CleanShot 2025-10-02 at 12 04 55@2x" src="https://github.com/user-attachments/assets/16fdb3da-d6f1-40f2-b821-e84d463ab08d" />



## Why are these changes being made?
* The form layout was designed to have the fields `Day` and `Hour` on the same row, but when the code was implemented, the `wordpress/dataview` version we used on Calypso did not support it, and now the version we are using does support it.

## Testing Instructions
* Go /v2/me/notifications/emails
* Check if you can see the fields Date and House on the same row

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
