### PR TITLE
Add intent url arg for plans visual split

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -64,11 +64,24 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
+			if ( search.has( 'intent' ) ) {
+				return getVisualSplitPlansIntent( search.get( 'intent' )! );
+			}
 			break;
 		case ONBOARDING_UNIFIED_FLOW:
 			return 'plans-affiliate';
 		default:
 			return null;
+	}
+	return null;
+}
+
+function getVisualSplitPlansIntent( intent: string ): PlansIntent | null {
+	if ( intent === 'default_websitebuilder' ) {
+		return 'plans-website-builder';
+	}
+	if ( intent === 'default_hosting' ) {
+		return 'plans-wordpress-hosting';
 	}
 	return null;
 }
@@ -141,7 +154,7 @@ const PlansStepAdaptor: StepType< {
 
 	// Update plansIntent when the experiment loads
 	useEffect( () => {
-		if ( ! isVisualSplitLoading && props.flow === ONBOARDING_FLOW ) {
+		if ( ! isVisualSplitLoading && props.flow === ONBOARDING_FLOW && ! defaultPlansIntent ) {
 			if ( visualSplitVariation === 'default_websitebuilder' ) {
 				setPlansIntent( 'plans-website-builder' );
 			} else if ( visualSplitVariation === 'default_hosting' ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* allows the default visual plans split (intent) to be set using a URL paramter

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this is needed to allow landing page CTAs to land on either the Website builder or hosting tabs directly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans?intent=default_hosting`
* You should see the hosting split

<img width="1690" height="1051" alt="Screenshot 2025-10-02 at 14 51 24" src="https://github.com/user-attachments/assets/6447a808-6ba6-494a-9e11-f42c1bcaa65f" />


* Go to `/setup/onboarding/plans?intent=default_websitebuilder`
* You should see the website builder split

<img width="1710" height="946" alt="Screenshot 2025-10-02 at 14 51 34" src="https://github.com/user-attachments/assets/c9cef12e-30ec-4d9c-98f9-4585334822c9" />


* Go to `/setup/onboarding/plans`
* You should see the default, full plans grid

<img width="480" height="986" alt="Screenshot 2025-10-02 at 14 51 38" src="https://github.com/user-attachments/assets/f0ef88e4-828f-423d-981b-6f801fe435a9" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
