### PR TITLE
v2 Plugins - Scheduled Updates: `useReconcileSchedules` hook and wire for Editing

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -21,8 +21,6 @@ import PluginsSelection from './plugins-selection';
 import SitesSelection from './sites-selection';
 import type { Frequency, Weekday } from '../types';
 
-const BLOCK_CREATE = false;
-
 type Inputs = {
 	siteIds: string[];
 	plugins: string[];
@@ -175,7 +173,7 @@ export function ScheduledUpdatesForm( {
 					<div>
 						<Button
 							variant="primary"
-							disabled={ ! isValid || isSubmitting || isPrecheckLoading || BLOCK_CREATE }
+							disabled={ ! isValid || isSubmitting || isPrecheckLoading }
 							onClick={ handleSave }
 							__next40pxDefaultSize
 						>

--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -21,7 +21,7 @@ import PluginsSelection from './plugins-selection';
 import SitesSelection from './sites-selection';
 import type { Frequency, Weekday } from '../types';
 
-const BLOCK_CREATE = true;
+const BLOCK_CREATE = false;
 
 type Inputs = {
 	siteIds: string[];

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -11,6 +11,7 @@ import {
 	ScheduledUpdatesForm,
 	type ScheduledUpdatesFormOnSubmit,
 } from '../components/schedule-form';
+import { useEditSchedules } from '../hooks/use-edit-schedules';
 import { useLoadScheduleById } from '../hooks/use-load-schedule-by-id';
 
 export default function PluginsScheduledUpdatesEdit() {
@@ -18,9 +19,19 @@ export default function PluginsScheduledUpdatesEdit() {
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesEditRoute.fullPath } );
 
 	const { loading, error, initial } = useLoadScheduleById( scheduleId );
+	const { mutateAsync: runEdit } = useEditSchedules(
+		scheduleId,
+		( initial?.siteIds || [] ).map( ( id ) => Number( id ) )
+	);
 
 	const handleSave: ScheduledUpdatesFormOnSubmit = async ( inputs ) => {
-		void inputs;
+		await runEdit( {
+			siteIds: inputs.siteIds.map( ( id ) => Number( id ) ),
+			plugins: inputs.plugins,
+			frequency: inputs.frequency,
+			weekday: inputs.weekday,
+			time: inputs.time,
+		} );
 		navigate( { to: pluginsScheduledUpdatesRoute.to } );
 	};
 

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Notice } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	pluginsScheduledUpdatesEditRoute,
@@ -19,14 +20,22 @@ export default function PluginsScheduledUpdatesEdit() {
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesEditRoute.fullPath } );
 
 	const { loading, error, initial } = useLoadScheduleById( scheduleId );
+	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
+
+	useEffect( () => {
+		if ( initial?.siteIds ) {
+			setSelectedSiteIds( initial.siteIds );
+		}
+	}, [ initial?.siteIds ] );
+
 	const { mutateAsync: runEdit } = useEditSchedules(
 		scheduleId,
-		( initial?.siteIds || [] ).map( ( id ) => Number( id ) )
+		initial?.siteIds || [],
+		selectedSiteIds
 	);
 
 	const handleSave: ScheduledUpdatesFormOnSubmit = async ( inputs ) => {
 		await runEdit( {
-			siteIds: inputs.siteIds.map( ( id ) => Number( id ) ),
 			plugins: inputs.plugins,
 			frequency: inputs.frequency,
 			weekday: inputs.weekday,
@@ -56,6 +65,7 @@ export default function PluginsScheduledUpdatesEdit() {
 						siteIds: ( initial?.siteIds || [] ).map( ( id ) => Number( id ) ),
 						scheduleId,
 					} }
+					onSitesChange={ setSelectedSiteIds }
 				/>
 			) }
 		</PageLayout>

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -12,8 +12,8 @@ import {
 	ScheduledUpdatesForm,
 	type ScheduledUpdatesFormOnSubmit,
 } from '../components/schedule-form';
-import { useEditSchedules } from '../hooks/use-edit-schedules';
 import { useLoadScheduleById } from '../hooks/use-load-schedule-by-id';
+import { useReconcileSchedules } from '../hooks/use-reconcile-schedules';
 
 export default function PluginsScheduledUpdatesEdit() {
 	const { scheduleId } = pluginsScheduledUpdatesEditRoute.useParams();
@@ -28,14 +28,14 @@ export default function PluginsScheduledUpdatesEdit() {
 		}
 	}, [ initial?.siteIds ] );
 
-	const { mutateAsync: runEdit } = useEditSchedules(
+	const { mutateAsync: runReconcile } = useReconcileSchedules(
 		scheduleId,
 		initial?.siteIds || [],
 		selectedSiteIds
 	);
 
 	const handleSave: ScheduledUpdatesFormOnSubmit = async ( inputs ) => {
-		await runEdit( {
+		await runReconcile( {
 			plugins: inputs.plugins,
 			frequency: inputs.frequency,
 			weekday: inputs.weekday,

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
@@ -1,0 +1,44 @@
+import { deleteSiteUpdateSchedule, type Site } from '@automattic/api-core';
+import { queryClient, siteUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useCallback } from '@wordpress/element';
+import { useAnalytics } from '../../../app/analytics';
+import { normalizeScheduleId } from '../helpers';
+import { useEligibleSites } from './use-eligible-sites';
+
+/**
+ * Batch delete an existing schedule across multiple sites and track analytics.
+ * @param {number[]} siteIds Sites to delete from
+ * @param {string} scheduleId Base schedule ID to delete
+ */
+export function useDeleteSchedules( siteIds: number[], scheduleId: string ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { data: eligibleSites = [] } = useEligibleSites();
+	const normalizedId = normalizeScheduleId( scheduleId );
+	const mutateAsync = useCallback( async () => {
+		const errors: string[] = [];
+		const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
+
+		await Promise.all(
+			siteIds.map( async ( siteId ) => {
+				try {
+					await deleteSiteUpdateSchedule( siteId, normalizedId );
+					await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+					const site = siteMap.get( siteId );
+					if ( site ) {
+						recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+							site_slug: site.slug,
+						} );
+					}
+				} catch ( e ) {
+					errors.push( `Delete failed for site ${ siteId }` );
+				}
+			} )
+		);
+
+		if ( errors.length ) {
+			throw new Error( errors.join( '\n' ) );
+		}
+	}, [ siteIds, normalizedId, eligibleSites, recordTracksEvent ] );
+
+	return { mutateAsync } as const;
+}

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
@@ -4,14 +4,24 @@ import {
 	deleteSiteUpdateSchedule,
 	type CreateSiteUpdateScheduleBody,
 	type EditSiteUpdateScheduleBody,
+	type Site,
 } from '@automattic/api-core';
-import { queryClient, siteUpdateSchedulesQuery } from '@automattic/api-queries';
+import {
+	queryClient,
+	siteUpdateSchedulesQuery,
+	hostingUpdateSchedulesQuery,
+	siteJetpackMonitorSettingsCreateMutation,
+} from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
 import { useCallback } from '@wordpress/element';
-import { normalizeScheduleId, prepareTimestamp } from '../helpers';
+import { useAnalytics } from '../../../app/analytics';
+import { CRON_CHECK_INTERVAL } from '../constants';
+import { normalizeScheduleId, prepareTimestamp, runWithConcurrency } from '../helpers';
+import { useEligibleSites } from './use-eligible-sites';
 import type { Frequency, Weekday } from '../types';
 
 type Inputs = {
-	siteIds: number[]; // selected sites after user edits
+	siteIds: string[]; // selected sites after user edits
 	plugins: string[];
 	frequency: Frequency;
 	weekday: Weekday;
@@ -25,14 +35,21 @@ type Inputs = {
  * - Diffs sites into create/edit/delete sets based on the new selection
  * - Builds the schedule timestamp from `frequency`, `weekday`, and `time`
  * - Runs per-site API calls: POST (create), PUT (edit using normalized base schedule ID), DELETE (remove)
- * - Invalidates per-site schedule queries after each operation
+ * - Invalidates per-site schedule queries after each operation and the hosting aggregate after all
+ * - Emits Tracks analytics for created/edited/deleted schedules and creates Jetpack Monitors for created sites
  *
  * Resolves when all operations complete; rejects if any operation fails.
  * @param {string} scheduleId The (possibly suffixed) schedule identifier from the route.
- * @param {number[]} originalSiteIds The sites currently participating in the schedule.
+ * @param {string[]} originalSiteIds The sites currently participating in the schedule.
  * @returns {{ mutateAsync: ( inputs: Inputs ) => Promise< void > }} Hook API
  */
-export function useEditSchedules( scheduleId: string, originalSiteIds: number[] ) {
+export function useEditSchedules( scheduleId: string, originalSiteIds: string[] ) {
+	const { recordTracksEvent } = useAnalytics();
+	const { data: eligibleSites = [] } = useEligibleSites();
+	const { mutateAsync: createMonitorForSite } = useMutation(
+		siteJetpackMonitorSettingsCreateMutation()
+	);
+
 	const mutateAsync = useCallback(
 		async ( { siteIds, plugins, frequency, weekday, time }: Inputs ) => {
 			const timestamp = prepareTimestamp( frequency, weekday, time );
@@ -44,8 +61,8 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: number[] 
 
 			const normalizedId = normalizeScheduleId( scheduleId );
 
-			const selected = new Set( siteIds );
-			const original = new Set( originalSiteIds );
+			const selected = new Set( siteIds.map( Number ) );
+			const original = new Set( originalSiteIds.map( Number ) );
 
 			const toCreate: number[] = [];
 			const toEdit: number[] = [];
@@ -69,17 +86,50 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: number[] 
 
 			const errors: string[] = [];
 
+			// Map sites for analytics and monitors
+			const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
+			const eventDate = new Date( timestamp * 1000 );
+			const hours = eventDate.getHours();
+			const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
+
 			// Run creates
 			await Promise.all(
 				toCreate.map( async ( siteId ) => {
 					try {
 						await createSiteUpdateSchedule( siteId, body );
 						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+						const site = siteMap.get( siteId );
+						if ( site ) {
+							recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
+								site_slug: site.slug,
+								frequency,
+								plugins_number: plugins.length,
+								hours,
+								weekday: weekdayIndex,
+							} );
+						}
 					} catch ( e ) {
 						errors.push( `Create failed for site ${ siteId }` );
 					}
 				} )
 			);
+
+			// Create monitors for successfully scheduled sites
+			const monitorTasks = toCreate
+				.map( ( id ) => siteMap.get( id ) )
+				.filter( ( site ): site is Site => Boolean( site ) )
+				.map( ( site ) => async () => {
+					await createMonitorForSite( {
+						siteId: site.ID,
+						body: {
+							urls: [
+								{ monitor_url: site.URL, check_interval: CRON_CHECK_INTERVAL },
+								{ monitor_url: site.URL + '/wp-cron.php', check_interval: CRON_CHECK_INTERVAL },
+							],
+						},
+					} );
+				} );
+			await runWithConcurrency( monitorTasks, 4 );
 
 			// Run edits
 			await Promise.all(
@@ -87,6 +137,16 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: number[] 
 					try {
 						await editSiteUpdateSchedule( siteId, normalizedId, body );
 						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+						const site = siteMap.get( siteId );
+						if ( site ) {
+							recordTracksEvent( 'calypso_scheduled_updates_edit_schedule', {
+								site_slug: site.slug,
+								frequency,
+								plugins_number: plugins.length,
+								hours,
+								weekday: weekdayIndex,
+							} );
+						}
 					} catch ( e ) {
 						errors.push( `Edit failed for site ${ siteId }` );
 					}
@@ -99,17 +159,26 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: number[] 
 					try {
 						await deleteSiteUpdateSchedule( siteId, normalizedId );
 						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+						const site = siteMap.get( siteId );
+						if ( site ) {
+							recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+								site_slug: site.slug,
+							} );
+						}
 					} catch ( e ) {
 						errors.push( `Delete failed for site ${ siteId }` );
 					}
 				} )
 			);
 
+			// Invalidate hosting aggregate schedules so list/collisions refresh
+			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+
 			if ( errors.length ) {
 				throw new Error( errors.join( '\n' ) );
 			}
 		},
-		[ scheduleId, originalSiteIds ]
+		[ scheduleId, originalSiteIds, eligibleSites, recordTracksEvent, createMonitorForSite ]
 	);
 
 	return { mutateAsync } as const;

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
@@ -1,101 +1,49 @@
 import {
 	editSiteUpdateSchedule,
-	deleteSiteUpdateSchedule,
-	type CreateSiteUpdateScheduleBody,
 	type EditSiteUpdateScheduleBody,
 	type Site,
 } from '@automattic/api-core';
-import {
-	queryClient,
-	siteUpdateSchedulesQuery,
-	hostingUpdateSchedulesQuery,
-} from '@automattic/api-queries';
-import { useCallback, useMemo } from '@wordpress/element';
+import { queryClient, siteUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useCallback } from '@wordpress/element';
 import { useAnalytics } from '../../../app/analytics';
 import { normalizeScheduleId, prepareTimestamp } from '../helpers';
-import { useCreateSchedules } from './use-create-schedules';
 import { useEligibleSites } from './use-eligible-sites';
 import type { Frequency, Weekday } from '../types';
 
-type Inputs = {
+export type EditBatchInputs = {
 	plugins: string[];
 	frequency: Frequency;
 	weekday: Weekday;
-	time: string; // HH:MM 24h
+	time: string;
 };
 
 /**
- * Edits plugin update schedules across sites for a given schedule ID.
- *
- * Given the original participating sites and the current selection, returns a `mutateAsync( inputs )`
- * function that:
- * - Diffs sites into create/edit/delete sets based on the new selection
- * - Builds the schedule timestamp from `frequency`, `weekday`, and `time`
- * - Runs batch create via the existing create flow hook, and per-site edit/delete calls
- * - Invalidates per-site schedule queries and the hosting aggregate after all
- * - Emits Tracks analytics for edited/deleted schedules; create events/monitors are handled by the
- *   reused create hook
- *
- * Resolves when all operations complete; rejects if any operation fails.
- * @param {string} scheduleId The (possibly suffixed) schedule identifier from the route.
- * @param {string[]} originalSiteIds The sites currently participating in the schedule.
- * @param {string[]} selectedSiteIds The sites currently selected in the form (live state).
- * @returns {{ mutateAsync: ( inputs: Inputs ) => Promise< void > }} Hook API
+ * Batch edit an existing schedule across multiple sites and track analytics.
+ * @param {number[]} siteIds Sites to edit
+ * @param {string} scheduleId Base schedule ID to edit
  */
-export function useEditSchedules(
-	scheduleId: string,
-	originalSiteIds: string[],
-	selectedSiteIds: string[]
-) {
+export function useEditSchedules( siteIds: number[], scheduleId: string ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: eligibleSites = [] } = useEligibleSites();
 	const normalizedId = normalizeScheduleId( scheduleId );
 
-	// Compute create subset once per render for hook composition
-	const toCreate = useMemo( () => {
-		const current = new Set( selectedSiteIds.map( Number ) );
-		const original = new Set( originalSiteIds.map( Number ) );
-		return Array.from( current ).filter( ( id ) => ! original.has( id ) );
-	}, [ selectedSiteIds, originalSiteIds ] );
-
-	// Instantiate the existing batch create hook for the create subset
-	const { mutateAsync: runCreate } = useCreateSchedules( toCreate );
-
 	const mutateAsync = useCallback(
-		async ( { plugins, frequency, weekday, time }: Inputs ) => {
+		async ( { plugins, frequency, weekday, time }: EditBatchInputs ) => {
 			const timestamp = prepareTimestamp( frequency, weekday, time );
-			const body: EditSiteUpdateScheduleBody & CreateSiteUpdateScheduleBody = {
+			const body: EditSiteUpdateScheduleBody = {
 				plugins,
 				schedule: { interval: frequency, timestamp },
 				health_check_paths: [],
 			};
 
-			// Compute edit/delete sets from submitted inputs to be authoritative
-			const current = new Set( selectedSiteIds.map( Number ) );
-			const original = new Set( originalSiteIds.map( Number ) );
-			const toEdit = Array.from( current ).filter( ( id ) => original.has( id ) );
-			const toDelete = Array.from( original ).filter( ( id ) => ! current.has( id ) );
-
 			const errors: string[] = [];
-
-			// Run creates via shared hook (reuse analytics + monitors)
-			if ( toCreate.length > 0 ) {
-				try {
-					await runCreate( { plugins, frequency, weekday, time } );
-				} catch ( e ) {
-					errors.push( 'Create failed for one or more sites.' );
-				}
-			}
-
-			// Map sites for edit/delete analytics
 			const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
 			const eventDate = new Date( timestamp * 1000 );
 			const hours = eventDate.getHours();
 			const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
 
-			// Run edits
 			await Promise.all(
-				toEdit.map( async ( siteId ) => {
+				siteIds.map( async ( siteId ) => {
 					try {
 						await editSiteUpdateSchedule( siteId, normalizedId, body );
 						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
@@ -115,40 +63,11 @@ export function useEditSchedules(
 				} )
 			);
 
-			// Run deletes
-			await Promise.all(
-				toDelete.map( async ( siteId ) => {
-					try {
-						await deleteSiteUpdateSchedule( siteId, normalizedId );
-						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
-						const site = siteMap.get( siteId );
-						if ( site ) {
-							recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
-								site_slug: site.slug,
-							} );
-						}
-					} catch ( e ) {
-						errors.push( `Delete failed for site ${ siteId }` );
-					}
-				} )
-			);
-
-			// Invalidate hosting aggregate schedules so list/collisions refresh
-			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
-
 			if ( errors.length ) {
 				throw new Error( errors.join( '\n' ) );
 			}
 		},
-		[
-			selectedSiteIds,
-			originalSiteIds,
-			toCreate,
-			runCreate,
-			eligibleSites,
-			recordTracksEvent,
-			normalizedId,
-		]
+		[ siteIds, normalizedId, eligibleSites, recordTracksEvent ]
 	);
 
 	return { mutateAsync } as const;

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
@@ -1,5 +1,4 @@
 import {
-	createSiteUpdateSchedule,
 	editSiteUpdateSchedule,
 	deleteSiteUpdateSchedule,
 	type CreateSiteUpdateScheduleBody,
@@ -10,18 +9,15 @@ import {
 	queryClient,
 	siteUpdateSchedulesQuery,
 	hostingUpdateSchedulesQuery,
-	siteJetpackMonitorSettingsCreateMutation,
 } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useAnalytics } from '../../../app/analytics';
-import { CRON_CHECK_INTERVAL } from '../constants';
-import { normalizeScheduleId, prepareTimestamp, runWithConcurrency } from '../helpers';
+import { normalizeScheduleId, prepareTimestamp } from '../helpers';
+import { useCreateSchedules } from './use-create-schedules';
 import { useEligibleSites } from './use-eligible-sites';
 import type { Frequency, Weekday } from '../types';
 
 type Inputs = {
-	siteIds: string[]; // selected sites after user edits
 	plugins: string[];
 	frequency: Frequency;
 	weekday: Weekday;
@@ -31,27 +27,42 @@ type Inputs = {
 /**
  * Edits plugin update schedules across sites for a given schedule ID.
  *
- * Given the original participating sites, returns a `mutateAsync( inputs )` function that:
+ * Given the original participating sites and the current selection, returns a `mutateAsync( inputs )`
+ * function that:
  * - Diffs sites into create/edit/delete sets based on the new selection
  * - Builds the schedule timestamp from `frequency`, `weekday`, and `time`
- * - Runs per-site API calls: POST (create), PUT (edit using normalized base schedule ID), DELETE (remove)
- * - Invalidates per-site schedule queries after each operation and the hosting aggregate after all
- * - Emits Tracks analytics for created/edited/deleted schedules and creates Jetpack Monitors for created sites
+ * - Runs batch create via the existing create flow hook, and per-site edit/delete calls
+ * - Invalidates per-site schedule queries and the hosting aggregate after all
+ * - Emits Tracks analytics for edited/deleted schedules; create events/monitors are handled by the
+ *   reused create hook
  *
  * Resolves when all operations complete; rejects if any operation fails.
  * @param {string} scheduleId The (possibly suffixed) schedule identifier from the route.
  * @param {string[]} originalSiteIds The sites currently participating in the schedule.
+ * @param {string[]} selectedSiteIds The sites currently selected in the form (live state).
  * @returns {{ mutateAsync: ( inputs: Inputs ) => Promise< void > }} Hook API
  */
-export function useEditSchedules( scheduleId: string, originalSiteIds: string[] ) {
+export function useEditSchedules(
+	scheduleId: string,
+	originalSiteIds: string[],
+	selectedSiteIds: string[]
+) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: eligibleSites = [] } = useEligibleSites();
-	const { mutateAsync: createMonitorForSite } = useMutation(
-		siteJetpackMonitorSettingsCreateMutation()
-	);
+	const normalizedId = normalizeScheduleId( scheduleId );
+
+	// Compute create subset once per render for hook composition
+	const toCreate = useMemo( () => {
+		const current = new Set( selectedSiteIds.map( Number ) );
+		const original = new Set( originalSiteIds.map( Number ) );
+		return Array.from( current ).filter( ( id ) => ! original.has( id ) );
+	}, [ selectedSiteIds, originalSiteIds ] );
+
+	// Instantiate the existing batch create hook for the create subset
+	const { mutateAsync: runCreate } = useCreateSchedules( toCreate );
 
 	const mutateAsync = useCallback(
-		async ( { siteIds, plugins, frequency, weekday, time }: Inputs ) => {
+		async ( { plugins, frequency, weekday, time }: Inputs ) => {
 			const timestamp = prepareTimestamp( frequency, weekday, time );
 			const body: EditSiteUpdateScheduleBody & CreateSiteUpdateScheduleBody = {
 				plugins,
@@ -59,77 +70,28 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: string[] 
 				health_check_paths: [],
 			};
 
-			const normalizedId = normalizeScheduleId( scheduleId );
-
-			const selected = new Set( siteIds.map( Number ) );
+			// Compute edit/delete sets from submitted inputs to be authoritative
+			const current = new Set( selectedSiteIds.map( Number ) );
 			const original = new Set( originalSiteIds.map( Number ) );
-
-			const toCreate: number[] = [];
-			const toEdit: number[] = [];
-			const toDelete: number[] = [];
-
-			// Determine create and edit
-			for ( const id of selected ) {
-				if ( original.has( id ) ) {
-					toEdit.push( id );
-				} else {
-					toCreate.push( id );
-				}
-			}
-
-			// Determine delete
-			for ( const id of original ) {
-				if ( ! selected.has( id ) ) {
-					toDelete.push( id );
-				}
-			}
+			const toEdit = Array.from( current ).filter( ( id ) => original.has( id ) );
+			const toDelete = Array.from( original ).filter( ( id ) => ! current.has( id ) );
 
 			const errors: string[] = [];
 
-			// Map sites for analytics and monitors
+			// Run creates via shared hook (reuse analytics + monitors)
+			if ( toCreate.length > 0 ) {
+				try {
+					await runCreate( { plugins, frequency, weekday, time } );
+				} catch ( e ) {
+					errors.push( 'Create failed for one or more sites.' );
+				}
+			}
+
+			// Map sites for edit/delete analytics
 			const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
 			const eventDate = new Date( timestamp * 1000 );
 			const hours = eventDate.getHours();
 			const weekdayIndex = frequency === 'weekly' ? eventDate.getDay() : undefined;
-
-			// Run creates
-			await Promise.all(
-				toCreate.map( async ( siteId ) => {
-					try {
-						await createSiteUpdateSchedule( siteId, body );
-						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
-						const site = siteMap.get( siteId );
-						if ( site ) {
-							recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
-								site_slug: site.slug,
-								frequency,
-								plugins_number: plugins.length,
-								hours,
-								weekday: weekdayIndex,
-							} );
-						}
-					} catch ( e ) {
-						errors.push( `Create failed for site ${ siteId }` );
-					}
-				} )
-			);
-
-			// Create monitors for successfully scheduled sites
-			const monitorTasks = toCreate
-				.map( ( id ) => siteMap.get( id ) )
-				.filter( ( site ): site is Site => Boolean( site ) )
-				.map( ( site ) => async () => {
-					await createMonitorForSite( {
-						siteId: site.ID,
-						body: {
-							urls: [
-								{ monitor_url: site.URL, check_interval: CRON_CHECK_INTERVAL },
-								{ monitor_url: site.URL + '/wp-cron.php', check_interval: CRON_CHECK_INTERVAL },
-							],
-						},
-					} );
-				} );
-			await runWithConcurrency( monitorTasks, 4 );
 
 			// Run edits
 			await Promise.all(
@@ -178,7 +140,15 @@ export function useEditSchedules( scheduleId: string, originalSiteIds: string[] 
 				throw new Error( errors.join( '\n' ) );
 			}
 		},
-		[ scheduleId, originalSiteIds, eligibleSites, recordTracksEvent, createMonitorForSite ]
+		[
+			selectedSiteIds,
+			originalSiteIds,
+			toCreate,
+			runCreate,
+			eligibleSites,
+			recordTracksEvent,
+			normalizedId,
+		]
 	);
 
 	return { mutateAsync } as const;

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-edit-schedules.ts
@@ -1,0 +1,116 @@
+import {
+	createSiteUpdateSchedule,
+	editSiteUpdateSchedule,
+	deleteSiteUpdateSchedule,
+	type CreateSiteUpdateScheduleBody,
+	type EditSiteUpdateScheduleBody,
+} from '@automattic/api-core';
+import { queryClient, siteUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useCallback } from '@wordpress/element';
+import { normalizeScheduleId, prepareTimestamp } from '../helpers';
+import type { Frequency, Weekday } from '../types';
+
+type Inputs = {
+	siteIds: number[]; // selected sites after user edits
+	plugins: string[];
+	frequency: Frequency;
+	weekday: Weekday;
+	time: string; // HH:MM 24h
+};
+
+/**
+ * Edits plugin update schedules across sites for a given schedule ID.
+ *
+ * Given the original participating sites, returns a `mutateAsync( inputs )` function that:
+ * - Diffs sites into create/edit/delete sets based on the new selection
+ * - Builds the schedule timestamp from `frequency`, `weekday`, and `time`
+ * - Runs per-site API calls: POST (create), PUT (edit using normalized base schedule ID), DELETE (remove)
+ * - Invalidates per-site schedule queries after each operation
+ *
+ * Resolves when all operations complete; rejects if any operation fails.
+ * @param {string} scheduleId The (possibly suffixed) schedule identifier from the route.
+ * @param {number[]} originalSiteIds The sites currently participating in the schedule.
+ * @returns {{ mutateAsync: ( inputs: Inputs ) => Promise< void > }} Hook API
+ */
+export function useEditSchedules( scheduleId: string, originalSiteIds: number[] ) {
+	const mutateAsync = useCallback(
+		async ( { siteIds, plugins, frequency, weekday, time }: Inputs ) => {
+			const timestamp = prepareTimestamp( frequency, weekday, time );
+			const body: EditSiteUpdateScheduleBody & CreateSiteUpdateScheduleBody = {
+				plugins,
+				schedule: { interval: frequency, timestamp },
+				health_check_paths: [],
+			};
+
+			const normalizedId = normalizeScheduleId( scheduleId );
+
+			const selected = new Set( siteIds );
+			const original = new Set( originalSiteIds );
+
+			const toCreate: number[] = [];
+			const toEdit: number[] = [];
+			const toDelete: number[] = [];
+
+			// Determine create and edit
+			for ( const id of selected ) {
+				if ( original.has( id ) ) {
+					toEdit.push( id );
+				} else {
+					toCreate.push( id );
+				}
+			}
+
+			// Determine delete
+			for ( const id of original ) {
+				if ( ! selected.has( id ) ) {
+					toDelete.push( id );
+				}
+			}
+
+			const errors: string[] = [];
+
+			// Run creates
+			await Promise.all(
+				toCreate.map( async ( siteId ) => {
+					try {
+						await createSiteUpdateSchedule( siteId, body );
+						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+					} catch ( e ) {
+						errors.push( `Create failed for site ${ siteId }` );
+					}
+				} )
+			);
+
+			// Run edits
+			await Promise.all(
+				toEdit.map( async ( siteId ) => {
+					try {
+						await editSiteUpdateSchedule( siteId, normalizedId, body );
+						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+					} catch ( e ) {
+						errors.push( `Edit failed for site ${ siteId }` );
+					}
+				} )
+			);
+
+			// Run deletes
+			await Promise.all(
+				toDelete.map( async ( siteId ) => {
+					try {
+						await deleteSiteUpdateSchedule( siteId, normalizedId );
+						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+					} catch ( e ) {
+						errors.push( `Delete failed for site ${ siteId }` );
+					}
+				} )
+			);
+
+			if ( errors.length ) {
+				throw new Error( errors.join( '\n' ) );
+			}
+		},
+		[ scheduleId, originalSiteIds ]
+	);
+
+	return { mutateAsync } as const;
+}

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
@@ -2,7 +2,7 @@ import { queryClient, hostingUpdateSchedulesQuery } from '@automattic/api-querie
 import { useCallback, useMemo } from '@wordpress/element';
 import { useCreateSchedules } from './use-create-schedules';
 import { useDeleteSchedules } from './use-delete-schedules';
-import { useEditSchedules } from './use./use-edit-schedules';
+import { useEditSchedules } from './use-edit-schedules';
 import type { Frequency, Weekday } from '../types';
 
 type Inputs = {

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
@@ -1,0 +1,80 @@
+import { queryClient, hostingUpdateSchedulesQuery } from '@automattic/api-queries';
+import { useCallback, useMemo } from '@wordpress/element';
+import { useCreateSchedules } from './use-create-schedules';
+import { useDeleteSchedules } from './use-delete-schedules';
+import { useEditSchedules } from './use./use-edit-schedules';
+import type { Frequency, Weekday } from '../types';
+
+type Inputs = {
+	plugins: string[];
+	frequency: Frequency;
+	weekday: Weekday;
+	time: string; // HH:MM 24h
+};
+
+/**
+ * Reconcile plugin update schedules across sites for a given schedule ID and track analytics.
+ *
+ * Operations performed on submit:
+ * - Create: computes `toCreate` (sites added to the schedule) and delegates to `useCreateSchedules`
+ * to batch-create schedules, including Tracks + Jetpack Monitor side-effects.
+ * - Edit: computes `toEdit` (sites that keep the schedule) and delegates to `useEditSchedules`
+ * to batch-edit schedule parameters and track edit analytics.
+ * - Delete: computes `toDelete` (sites removed from the schedule) and delegates to
+ * `useDeleteSchedules` to batch-delete the schedule and track delete analytics.
+ * - Cache: invalidates the hosting aggregate query after all operations complete.
+ *
+ * Note: Batch hooks normalize the provided schedule ID where needed; no optimistic updates.
+ * @param {string} scheduleId The (possibly suffixed) schedule identifier from the route.
+ * @param {string[]} scheduleSiteIds The sites currently participating in the schedule.
+ * @param {string[]} selectedSiteIds The sites currently selected in the form (live state).
+ * @returns {{ mutateAsync: ( inputs: { plugins: string[]; frequency: Frequency; weekday: Weekday; time: string } ) => Promise< void > }} Hook API
+ */
+export function useReconcileSchedules(
+	scheduleId: string,
+	scheduleSiteIds: string[],
+	selectedSiteIds: string[]
+) {
+	const toCreate = useMemo( () => {
+		const current = new Set( selectedSiteIds.map( Number ) );
+		const original = new Set( scheduleSiteIds.map( Number ) );
+		return Array.from( current ).filter( ( id ) => ! original.has( id ) );
+	}, [ selectedSiteIds, scheduleSiteIds ] );
+
+	const toEdit = useMemo( () => {
+		const current = new Set( selectedSiteIds.map( Number ) );
+		const original = new Set( scheduleSiteIds.map( Number ) );
+		return Array.from( current ).filter( ( id ) => original.has( id ) );
+	}, [ selectedSiteIds, scheduleSiteIds ] );
+
+	const toDelete = useMemo( () => {
+		const current = new Set( selectedSiteIds.map( Number ) );
+		const original = new Set( scheduleSiteIds.map( Number ) );
+		return Array.from( original ).filter( ( id ) => ! current.has( id ) );
+	}, [ selectedSiteIds, scheduleSiteIds ] );
+
+	const { mutateAsync: runCreate } = useCreateSchedules( toCreate );
+	const { mutateAsync: runEdit } = useEditSchedules( toEdit, scheduleId );
+	const { mutateAsync: runDelete } = useDeleteSchedules( toDelete, scheduleId );
+
+	const mutateAsync = useCallback(
+		async ( { plugins, frequency, weekday, time }: Inputs ) => {
+			const tasks: Promise< unknown >[] = [];
+			if ( toCreate.length ) {
+				tasks.push( runCreate( { plugins, frequency, weekday, time } ) );
+			}
+			if ( toEdit.length ) {
+				tasks.push( runEdit( { plugins, frequency, weekday, time } ) );
+			}
+			if ( toDelete.length ) {
+				tasks.push( runDelete() );
+			}
+
+			await Promise.all( tasks );
+			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+		},
+		[ toCreate, toEdit, toDelete, runCreate, runEdit, runDelete ]
+	);
+
+	return { mutateAsync } as const;
+}

--- a/packages/api-core/src/site-update-schedules/mutators.ts
+++ b/packages/api-core/src/site-update-schedules/mutators.ts
@@ -31,8 +31,9 @@ export async function deleteSiteUpdateSchedule(
 	siteId: number,
 	scheduleId: string
 ): Promise< unknown > {
-	return await wpcom.req.delete( {
+	return await wpcom.req.post( {
 		path: `/sites/${ siteId }/update-schedules/${ scheduleId }`,
+		method: 'DELETE',
 		apiNamespace: 'wpcom/v2',
 	} );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-215/implement-edit-of-existing-schedules-in-v2-hd
Closes https://linear.app/a8c/issue/DSGCOM-215/implement-edit-of-existing-schedules-in-v2-hd

## Proposed Changes

We complete the Editing of existing schedules by wiring in the necessary mutation and orchestration logic (on par with the original v1 dashboard). Errors are captured and displayed, and successful create/edit/delete operations are tracked for analytics, as originally intended.

- The PR reuses the `useCreateSchedules` hook, and introduces similar abstractions for `useEditSchedules` and `useDeleteSchedules`  to cover the logic needed. 
- The PR creates a `useReconcileSchedules` hook that orchestrates the operation in a way that's reusable and can be called from anywhere e.g., from the main view. cc @sdnunca  

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/DSGCOM-215/implement-edit-of-existing-schedules-in-v2-hd

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plugins/scheduled-udpates/` to access the list view, and grab a schedule ID to edit
- Go to `/v2/plugins/scheduled-update/edit/$schedule-id` and confirm the page renders with prepopulated fields based on the schedule
- Modify any of the sections (sites, plugins, time slot) and confirm updating works as expected
- Try a schedule with multiple sites and plugins

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
