### PR TITLE
HD Domains: Add transfer in action in domain overview

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -137,7 +137,7 @@ export default function Actions() {
 				) }
 				{ availableActions.transferIn && (
 					<ActionList.ActionItem
-						title={ __( 'Transfer your domain to WordPress.com' ) }
+						title={ __( 'Bring your domain to WordPress.com' ) }
 						description={ __( 'Manage your site and domain all in one place.' ) }
 						actions={
 							<RouterLinkButton

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import {
 	domainQuery,
 	disconnectDomainMutation,
@@ -25,6 +26,7 @@ import { SectionHeader } from '../../components/section-header';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import {
 	shouldShowTransferAction,
+	shouldShowTransferInAction,
 	shouldShowDisconnectAction,
 	shouldShowDeleteAction,
 	shouldShowCancelAction,
@@ -83,6 +85,7 @@ export default function Actions() {
 	const availableActions = {
 		renew: purchase?.is_renewable,
 		transfer: shouldShowTransferAction( domain ),
+		transferIn: shouldShowTransferInAction( domain ),
 		disconnect: shouldShowDisconnectAction( domain ),
 		delete: shouldShowDeleteAction( domain, purchase, site ),
 		cancel: shouldShowCancelAction( domain, purchase ),
@@ -115,11 +118,32 @@ export default function Actions() {
 				{ availableActions.transfer && (
 					<ActionList.ActionItem
 						title={ __( 'Transfer' ) }
-						description={ __( 'Transfer this domain to another site or WordPress.com user.' ) }
+						description={
+							domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
+								? __( 'Transfer this domain connection to another site or WordPress.com user.' )
+								: __( 'Transfer this domain to another site or WordPress.com user.' )
+						}
 						actions={
 							<RouterLinkButton
 								size="compact"
 								variant="secondary"
+								to={ domainTransferRoute.fullPath }
+								params={ { domainName } }
+							>
+								{ __( 'Transfer' ) }
+							</RouterLinkButton>
+						}
+					/>
+				) }
+				{ availableActions.transferIn && (
+					<ActionList.ActionItem
+						title={ __( 'Transfer your domain to WordPress.com' ) }
+						description={ __( 'Manage your site and domain all in one place.' ) }
+						actions={
+							<RouterLinkButton
+								size="compact"
+								variant="secondary"
+								// TODO: use the correct route once the domain transfer in route is created
 								to={ domainTransferRoute.fullPath }
 								params={ { domainName } }
 							>

--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -77,6 +77,12 @@ export const shouldShowCancelAction = ( domain: Domain, purchase?: Purchase ) =>
 	return true;
 };
 
+export const shouldShowTransferInAction = ( domain: Domain ) => {
+	return (
+		domain.is_eligible_for_inbound_transfer && domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION
+	);
+};
+
 // Delete action utils
 export const getDeleteTitle = ( domain: Domain ) => {
 	switch ( domain.subtype.id ) {


### PR DESCRIPTION
Closes [DOTDASH-497](https://linear.app/a8c/issue/DOTDASH-497/show-transfer-option-for-connected-domains)

## Proposed Changes
- Add "Transfer your domain to WordPress.com" action for eligible domain connections 
- Update transfer action description to be more specific for domain connections vs regular domains

![Screenshot 2025-10-03 alle 09 52 39](https://github.com/user-attachments/assets/29825b56-2bdc-4d79-a4aa-04d353c7dc53)

## Why are these changes being made?
This change enhances the domain management experience by providing users with a clear path to transfer their externally managed domains to WordPress.com. Currently, users with domain connections that are eligible for inbound transfer don't have a visible way to initiate this process from the domain overview page. This addition makes the transfer-in functionality more discoverable and accessible, allowing users to consolidate their domain and site management in one place.

## Testing Instructions
- Visit the domain overview page for a domain connection and verify that the new action is visible.
- Also check that the existing transfer copy is updated for domain connections.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
