### PR TITLE
Switch from back button to breadcrumbs in GH deployments

### DIFF
--- a/client/dashboard/components/breadcrumbs/index.tsx
+++ b/client/dashboard/components/breadcrumbs/index.tsx
@@ -1,0 +1,33 @@
+import { Breadcrumbs } from '@automattic/components/src/breadcrumbs';
+import { Link } from '@tanstack/react-router';
+
+interface DashboardBreadcrumbsProps {
+	items: Array< {
+		label: string;
+		path: string;
+	} >;
+}
+
+export default function DashboardBreadcrumbs( { items }: DashboardBreadcrumbsProps ) {
+	if ( items.length === 0 ) {
+		return null;
+	}
+
+	// Convert the items to the format expected by @automattic/components Breadcrumbs
+	const breadcrumbItems = items.map( ( item ) => ( {
+		label: item.label,
+		href: item.path,
+	} ) );
+
+	return (
+		<Breadcrumbs
+			items={ breadcrumbItems }
+			variant="default"
+			renderItemLink={ ( { href, label, ...rest } ) => (
+				<Link to={ href } { ...rest }>
+					{ label }
+				</Link>
+			) }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-page-header/index.tsx
+++ b/client/dashboard/sites/settings-page-header/index.tsx
@@ -3,23 +3,31 @@ import { Button } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { siteRoute } from '../../app/router/sites';
+import DashboardBreadcrumbs from '../../components/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import type { PageHeaderProps } from '../../components/page-header/types';
 
 interface SettingsPageHeaderProps extends PageHeaderProps {
 	backPath?: string;
 	backLabel?: string;
+	breadcrumbs?: Array< {
+		label: string;
+		path: string;
+	} >;
 }
 
 export default function SettingsPageHeader( props: SettingsPageHeaderProps ) {
 	const { siteSlug } = siteRoute.useParams();
-	const { backPath, backLabel, ...pageHeaderProps } = props;
+	const { backPath, backLabel, breadcrumbs, ...pageHeaderProps } = props;
 	const router = useRouter();
 
 	const defaultBackPath = `/sites/${ siteSlug }/settings`;
 	const defaultBackLabel = __( 'Settings' );
 
-	const backButton = (
+	// Use breadcrumbs if provided, otherwise use back button
+	const prefixContent = breadcrumbs ? (
+		<DashboardBreadcrumbs items={ breadcrumbs } />
+	) : (
 		<Button
 			className="dashboard-page-header__back-button"
 			icon={ isRTL() ? chevronRight : chevronLeft }
@@ -31,5 +39,5 @@ export default function SettingsPageHeader( props: SettingsPageHeaderProps ) {
 		</Button>
 	);
 
-	return <PageHeader prefix={ backButton } { ...pageHeaderProps } />;
+	return <PageHeader prefix={ prefixContent } { ...pageHeaderProps } />;
 }

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from '@tanstack/react-router';
 import { Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteRoute } from '../../app/router/sites';
-import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
 import { ConnectRepositoryForm } from './connect-repository-form';
 
 export default function ConnectRepository() {
@@ -21,13 +21,29 @@ export default function ConnectRepository() {
 		navigate( { to: '/sites/$siteSlug/settings/repositories' } );
 	};
 
+	const breadcrumbs = [
+		{
+			label: __( 'Settings' ),
+			path: `/sites/${ siteSlug }/settings`,
+		},
+		{
+			label: __( 'Repositories' ),
+			path: `/sites/${ siteSlug }/settings/repositories`,
+		},
+		{
+			label: __( 'Connect' ),
+			path: `/sites/${ siteSlug }/settings/repositories/connect`,
+		},
+	];
+
 	return (
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
+				<SettingsPageHeader
 					title={ __( 'Connect Repository' ) }
 					description={ __( 'Connect a GitHub repository to deploy code to your WordPress site.' ) }
+					breadcrumbs={ breadcrumbs }
 				/>
 			}
 		>

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -107,6 +107,17 @@ function SiteRepositories() {
 		navigate( { to: '/sites/$siteSlug/settings/repositories/connect' } );
 	};
 
+	const breadcrumbs = [
+		{
+			label: __( 'Settings' ),
+			path: `/sites/${ siteSlug }/settings`,
+		},
+		{
+			label: __( 'Repositories' ),
+			path: `/sites/${ siteSlug }/settings/repositories`,
+		},
+	];
+
 	return (
 		<PageLayout
 			size="small"
@@ -114,6 +125,7 @@ function SiteRepositories() {
 				<SettingsPageHeader
 					title={ __( 'Repositories' ) }
 					description={ __( 'Connect repositories to your WordPress site.' ) }
+					breadcrumbs={ breadcrumbs }
 					actions={
 						<Button variant="primary" __next40pxDefaultSize onClick={ handleConnectRepository }>
 							{ __( 'Connect repository' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-544

## Proposed Changes

This PR moves from `Back` button to breadcrumbs in `Connect Repository` screen and `Repositories` screen:

<img width="1497" height="544" alt="Screenshot 2025-10-02 at 3 22 51 PM" src="https://github.com/user-attachments/assets/a13ae849-4a67-46d1-8251-e570c6db350d" />

<img width="1494" height="704" alt="Screenshot 2025-10-02 at 3 22 34 PM" src="https://github.com/user-attachments/assets/c095de22-e83d-4369-8029-260f4619feb1" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site
* Navigate to `/v2/sites/{yourAtomicSite}/`
* Click on `Deployments` tab and then click on `Go to Repositories`
* Observe that you see the `Settings /` breadcrumb on the top and confirm that it works as a link to settings
* Navigate to `/v2/sites/{yourAtomicSite}/settings/repositories/connect`
* Observe that you can see `Settings / Repositories /` on the top and that both of them bring you to the correct places

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
