### PR TITLE
Plugins Management: Add `No` text fallback for plugins with no updates available

### DIFF
--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -149,6 +149,8 @@ export function useFields(
 							</Button>
 						);
 					}
+
+					return translate( 'No' );
 				},
 			},
 		],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-238

## Proposed Changes

* add `No` text fallback for plugins with no updates available

| Before | After |
|--------|--------|
| <img width="2976" height="702" alt="Markup on 2025-10-02 at 15:00:24" src="https://github.com/user-attachments/assets/3c2fd547-3069-4efc-964e-dc35d73c7052" /> | <img width="2960" height="704" alt="Markup on 2025-10-02 at 14:59:05" src="https://github.com/user-attachments/assets/aada039e-f2a1-49f6-90be-c7acb7006d0a" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve user experience and make it clear that a specific plugin does not need any updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso live link in the comment below).
2. Head over to http://calypso.localhost:3000/plugins/manage/sites and review the values in the `Update available` column.
3. The plugins that do not need a plugin update should now have the `No` text in the column. Plugins that have updates available should still have update buttons rendered, e.g.:

<img width="2806" height="414" alt="Markup on 2025-10-02 at 15:32:21" src="https://github.com/user-attachments/assets/ecb8381c-b328-40e8-b447-09010651bac3" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
