### PR TITLE
Dashboard v2: fix opt-in preference form stylings

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -16,6 +16,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import FlashMessage from '../../components/flash-message';
 import { Notice } from '../../components/notice';
+import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
 import type { Field } from '@wordpress/dataviews';
 
@@ -31,7 +32,6 @@ const form = {
 	fields: [
 		{
 			id: 'optInForm',
-			label: __( 'Try the new Hosting Dashboard' ),
 			children: [ 'description', 'enabled' ],
 		},
 	],
@@ -119,7 +119,8 @@ export default function PreferencesLanguageForm() {
 		<Card>
 			<FlashMessage value="dashboard" message={ __( 'Successfully saved preference.' ) } />
 			<CardBody>
-				<VStack as="form" onSubmit={ handleSubmit } spacing={ 4 } alignment="flex-start">
+				<VStack as="form" onSubmit={ handleSubmit } spacing={ 3 } alignment="flex-start">
+					<SectionHeader title={ __( 'Try the new Hosting Dashboard' ) } level={ 3 } />
 					<DataForm< OptInFormData >
 						data={ formData }
 						fields={ fields }


### PR DESCRIPTION

## Proposed Changes

This PR updates the style of the heading text `Try the new Hosting Dashboard`. Currently, it's a bit off compared to the rest of the settings in that page. This PR makes it consistent by using `<SectionHeader>`.


|Before|After|
|-|-|
|<img width="673" height="833" alt="image" src="https://github.com/user-attachments/assets/320d7745-3afd-4cff-a858-24a59222d6c6" />|<img width="674" height="871" alt="image" src="https://github.com/user-attachments/assets/1f7b3b9a-1f42-47d2-ae37-f4d968cd90d3" />


## Why are these changes being made?

Fit n Finish ❤️ 

## Testing Instructions

1. Go to `/v2/me/preferences`
2. Verify the above screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
