### PR TITLE
FileBrowser: Mark backup time display props as deprecated in `FileBrowser` component

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -17,7 +17,8 @@ export interface FileBrowserConfig {
 	alwaysInclude?: string[];
 	showFileCard?: boolean;
 	/**
-	 * @deprecated This prop will be removed once the new Staging Sync Modal is live.
+	 * @deprecated This prop will be removed once the new Staging Sync Modal
+	 * in the V2 dashboard (client/dashboard/sites/staging-site-sync-modal/index.tsx) is live.
 	 * The backup time display is now handled directly in the modal components.
 	 */
 	showBackupTime?: boolean;
@@ -36,8 +37,9 @@ interface FileBrowserProps {
 	hasCredentials?: boolean;
 	isRestoreEnabled?: boolean;
 	/**
-	 * @deprecated This prop will be removed once the new Staging Sync Modal is live.
-	 * The backup date display is now handled directly in the modal components.
+	 * @deprecated This prop will be removed once the new Staging Sync Modal
+	 * in the V2 dashboard (client/dashboard/sites/staging-site-sync-modal/index.tsx) is live.
+	 * The backup time display is now handled directly in the modal components.
 	 */
 	displayBackupDate?: string;
 
@@ -79,7 +81,7 @@ function FileBrowser( {
 	return (
 		<div>
 			{ ( fileBrowserConfig?.showHeader ?? true ) && <FileBrowserHeader rewindId={ rewindId } /> }
-			{ /* @TODO: remove this block once the new Staging Sync Modal is live */ }
+			{ /* @TODO: remove this block once the new Staging Sync Modal in the V2 dashboard (client/dashboard/sites/staging-site-sync-modal/index.tsx) is live */ }
 			{ fileBrowserConfig?.showBackupTime && displayBackupDate && (
 				<HStack alignment="left" spacing={ 1 }>
 					<Text

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -16,6 +16,10 @@ export interface FileBrowserConfig {
 	expandDirectoriesOnClick?: boolean;
 	alwaysInclude?: string[];
 	showFileCard?: boolean;
+	/**
+	 * @deprecated This prop will be removed once the new Staging Sync Modal is live.
+	 * The backup time display is now handled directly in the modal components.
+	 */
 	showBackupTime?: boolean;
 	showSeparateExpandButton?: boolean;
 	siteId?: number;
@@ -31,6 +35,10 @@ interface FileBrowserProps {
 	// Optional site data props
 	hasCredentials?: boolean;
 	isRestoreEnabled?: boolean;
+	/**
+	 * @deprecated This prop will be removed once the new Staging Sync Modal is live.
+	 * The backup date display is now handled directly in the modal components.
+	 */
 	displayBackupDate?: string;
 
 	// Tracks analytics callback


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-14673

## Proposed Changes

* Mark `showBackupTime` and `displayBackupDate` as deprecated. They are only used for the staging sites Sync modal in the V1 dashboard and shouldn't be used anywhere else anymore. We will remove them completely once we migrate to using V2.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Code clean-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
