### PR TITLE
e2e tests: override default jest timeout for onboarding test and improve url check

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -25,6 +25,9 @@ declare const browser: Browser;
 describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
 	function () {
+		// Some of these steps can take more than the default timeout.
+		jest.setTimeout( 240 * 1000 );
+
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();
 
@@ -87,15 +90,15 @@ describe(
 
 			it( 'Wait for the Atomic transfer to complete', async function () {
 				await page.waitForURL( /.*transferring-hosted-site.*/ );
+				await page.waitForURL( /wp-admin/, {
+					timeout: 180 * 1000,
+				} );
 			} );
 		} );
 
 		describe( 'View WP Admin', function () {
 			it( 'WP Admin', async function () {
-				await page.waitForURL( /wp-admin/, {
-					timeout: 180 * 1000,
-				} );
-
+				await page.waitForURL( /wp-admin/ );
 				siteSlug = new URL( page.url() ).hostname;
 			} );
 		} );


### PR DESCRIPTION


## Proposed Changes

One of the test steps was using a bigger timeout than the global test timeout, and the test was sometimes failing with "Exceeded timeout of 120000 ms for a test."

I also move the wait for the URL change in the previous step where it made more sense.


## Testing Instructions

```
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
```
