### PR TITLE
Stats e2e: Fix the Stats e2e and an issue in the SidebarComponent

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -76,17 +76,19 @@ export class SidebarComponent {
 		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
 		await this.page.dispatchEvent( itemSelector, 'click' );
 
+		// Wait for navigation after clicking the top level item.
+		await this.page.waitForNavigation( { timeout: 30 * 1000 } );
+
 		// Sub-level menu item selector.
 		if ( subitem ) {
 			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible, .wp-menu-open .wp-submenu :text-is("${ subitem }"):visible`;
-			await Promise.all( [
-				this.page.waitForNavigation( { timeout: 30 * 1000 } ),
-				this.page.dispatchEvent( subitemSelector, 'click' ),
-			] );
+			await this.page.dispatchEvent( subitemSelector, 'click' );
 		}
 
 		const currentURL = this.page.url();
 		// Do not verify selected menu items or retry if navigation takes user out of Calypso (eg. WP-Admin, Widgets editor)...
+		console.log( currentURL );
+		console.log( getCalypsoURL() );
 		if ( ! currentURL.startsWith( getCalypsoURL() ) ) {
 			return;
 		}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -73,19 +73,34 @@ export class SidebarComponent {
 		}
 
 		// Top level menu item selector.
-		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
+		const itemSelector = `${ selectors.sidebar } a:has(:text-is("${ item }"):visible)`;
+
+		// We need to grab the href before clicking, as after clicking the DOM may change. For Stats, for example, we go to WP-Admin.
+		const hrefItemSelector = ( await this.page.getAttribute( itemSelector, 'href' ) ) as string;
+
 		await this.page.dispatchEvent( itemSelector, 'click' );
 
 		// Wait for navigation after clicking the top level item.
-		await this.page.waitForNavigation( { timeout: 30 * 1000 } );
+		await this.page.waitForURL( `**${ hrefItemSelector }`, {
+			waitUntil: 'domcontentloaded',
+		} );
 
 		// Sub-level menu item selector.
 		if ( subitem ) {
-			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible, .wp-menu-open .wp-submenu :text-is("${ subitem }"):visible`;
+			const subitemSelector = `.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`;
+			const hrefSubItemSelector = ( await this.page.getAttribute(
+				subitemSelector,
+				'href'
+			) ) as string;
+
 			await this.page.dispatchEvent( subitemSelector, 'click' );
+			await this.page.waitForURL( `**${ hrefSubItemSelector }`, {
+				waitUntil: 'domcontentloaded',
+			} );
 		}
 
 		const currentURL = this.page.url();
+
 		// Do not verify selected menu items or retry if navigation takes user out of Calypso (eg. WP-Admin, Widgets editor)...
 		if ( ! currentURL.startsWith( getCalypsoURL() ) ) {
 			return;

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -87,8 +87,6 @@ export class SidebarComponent {
 
 		const currentURL = this.page.url();
 		// Do not verify selected menu items or retry if navigation takes user out of Calypso (eg. WP-Admin, Widgets editor)...
-		console.log( currentURL );
-		console.log( getCalypsoURL() );
 		if ( ! currentURL.startsWith( getCalypsoURL() ) ) {
 			return;
 		}

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -47,7 +47,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 			);
 		}
 		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Jetpack', 'Stats' );
+		await sidebarComponent.navigate( 'Stats' );
 	} );
 
 	describe( 'Traffic', function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Fix the Stats navigation menu location in the e2e test
* Fix an issue in SidebarComponent where we don't wait for the page to load after clicking on a menu item

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* bugfix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TC?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
