### PR TITLE
e2e tests: Fix parameter declaration for TEST_GROUP in PlaywrightTestPRMatrix

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -913,7 +913,7 @@ object PlaywrightTestPRMatrix : BuildType({
 	description = "Runs Calypso e2e tests on pull requests using Playwright Test runner with build matrix"
 
 	params {
-		text("TEST_GROUP", "@calypso-pr")
+		param("TEST_GROUP", "@calypso-pr")
         param("DOCKER_IMAGE_BUILD_NUMBER", "${BuildDockerImage.depParamRefs.buildNumber}")
 		param("IGNORE_TEST_GROUP_FOR_E2E_CHANGES", "true")
 	}


### PR DESCRIPTION
Closes [QAO-112](https://linear.app/a8c/issue/QAO-112/calypso-e2e-fix-test-group-parameter-in-pr-checks)

## Proposed Changes

The e2e tests build template was not picking up the value of TEST_GROUP. 

## Testing Instructions

- Check the E2E Tests (Playwright Test) run. Make sure only tests with the `@calypso-pr`tag ran.