### PR TITLE
A4A: Implement Copy referral flow.

### DIFF
--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -1,4 +1,5 @@
-export const NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY = 'new_referral_order_id';
+export const NEW_REFERRAL_ORDER_EMAIL_QUERY_PARAM_KEY = 'new_referral_order_email';
+export const NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY = 'new_referral_order_checkout_url';
 export const NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY = 'flow_type';
 
 export const AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY = 'a4a_first_purchase';

--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -1,4 +1,4 @@
-export const REFERRAL_EMAIL_QUERY_PARAM_KEY = 'referral_email';
+export const NEW_REFERRAL_ID_QUERY_PARAM_KEY = 'new_referral_id';
 
 export const AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY = 'a4a_first_purchase';
 

--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -1,4 +1,5 @@
-export const NEW_REFERRAL_ID_QUERY_PARAM_KEY = 'new_referral_id';
+export const NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY = 'new_referral_order_id';
+export const NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY = 'flow_type';
 
 export const AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY = 'a4a_first_purchase';
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -18,7 +18,7 @@ export default function NoticeSummary( { type }: Props ) {
 			case 'agency-purchase':
 				return translate( 'When you purchase:' );
 			case 'request-client-payment':
-				return translate( 'When you send this payment request:' );
+				return translate( 'When you share this payment request:' );
 			default:
 				return null;
 		}
@@ -99,7 +99,7 @@ export default function NoticeSummary( { type }: Props ) {
 			case 'request-client-payment':
 				return [
 					translate(
-						"We'll email your client with instructions to create a WordPress.com account and complete their purchase. Once their payment is successful, they'll be enrolled in an automatically renewing subscription, billed monthly or annually, based on their selection at checkout. The client may cancel their subscription at any time."
+						"Your client will receive instructions to create a WordPress.com account and complete their purchase. Once their payment is successful, they'll be enrolled in an automatically renewing subscription (monthly or annual, based on checkout). They can cancel anytime."
 					),
 					translate(
 						"After their purchase, you'll be able to manage the products on your client's behalf."

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -12,7 +12,11 @@ import {
 	A4A_REFERRALS_DASHBOARD,
 	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { NEW_REFERRAL_ID_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
+import {
+	NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY,
+} from 'calypso/a8c-for-agencies/constants';
+import { ReferralOrderFlowType } from 'calypso/a8c-for-agencies/sections/referrals/types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
@@ -85,7 +89,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 	const { isFeedbackShown } = useShowFeedback( FeedbackType.ReferralCompleted );
 
 	const handleRequestPayment = useCallback(
-		( flowType: 'send' | 'copy' ) => {
+		( flowType: ReferralOrderFlowType ) => {
 			if ( ! hasCompletedForm ) {
 				return;
 			}
@@ -115,8 +119,8 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 						page.redirect(
 							isFeedbackShown
 								? addQueryArgs( A4A_REFERRALS_DASHBOARD, {
-										[ NEW_REFERRAL_ID_QUERY_PARAM_KEY ]: referral.id,
-										flowType,
+										[ NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY ]: referral.id,
+										[ NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY ]: flowType,
 								  } )
 								: addQueryArgs( A4A_FEEDBACK_LINK, {
 										args: { email },

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,18 +1,18 @@
 import page from '@automattic/calypso-router';
 import { Button, FormLabel, Tooltip } from '@automattic/components';
-import { Icon, warning } from '@wordpress/icons';
+import { customLink, Icon, send, warning } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
 	A4A_REFERRALS_DASHBOARD,
 	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
+import { NEW_REFERRAL_ID_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
@@ -65,7 +65,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		setMessage( event.currentTarget.value );
 	}, [] );
 
-	const { mutate: requestPayment, isPending, isSuccess } = useRequestClientPaymentMutation();
+	const { mutate: requestPayment, isPending } = useRequestClientPaymentMutation();
 
 	const hasCompletedForm = !! email && !! message;
 
@@ -82,78 +82,89 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		[ checkoutItems ]
 	);
 
-	const handleRequestPayment = useCallback( () => {
-		if ( ! hasCompletedForm ) {
-			return;
-		}
-		if ( ! emailValidator.validate( email ) ) {
-			setValidationError( { email: translate( 'Please provide correct email address' ) } );
-			return;
-		}
-		dispatch(
-			recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
-		);
-		requestPayment(
-			{
-				client_email: email,
-				client_message: message,
-				product_ids: productIds,
-				licenses: licenses,
-			},
-			{
-				onError: ( error ) => {
-					dispatch(
-						errorNotice(
-							error.code === 'cannot_refer_to_client'
-								? translate(
-										'Referring products to your own company is not allowed and against our {{a}}terms of service{{/a}}.',
-										{
-											components: {
-												a: (
-													<a
-														href="https://automattic.com/for-agencies/program-incentives/"
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
-										}
-								  )
-								: error.message
-						)
-					);
-				},
-			}
-		);
-	}, [
-		dispatch,
-		email,
-		hasCompletedForm,
-		licenses,
-		message,
-		productIds,
-		requestPayment,
-		translate,
-	] );
-
 	const { isFeedbackShown } = useShowFeedback( FeedbackType.ReferralCompleted );
 
-	useEffect( () => {
-		if ( isSuccess && !! email ) {
-			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REGULAR );
-			page.redirect(
-				isFeedbackShown
-					? addQueryArgs( A4A_REFERRALS_DASHBOARD, { [ REFERRAL_EMAIL_QUERY_PARAM_KEY ]: email } )
-					: addQueryArgs( A4A_FEEDBACK_LINK, {
-							args: { email },
-							type: FeedbackType.ReferralCompleted,
-					  } )
+	const handleRequestPayment = useCallback(
+		( flowType: 'send' | 'copy' ) => {
+			if ( ! hasCompletedForm ) {
+				return;
+			}
+			if ( ! emailValidator.validate( email ) ) {
+				setValidationError( { email: translate( 'Please provide correct email address' ) } );
+				return;
+			}
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
 			);
-			setEmail( '' );
-			setMessage( '' );
-			onClearCart();
-		}
-	}, [ email, isSuccess, onClearCart, isFeedbackShown ] );
+			requestPayment(
+				{
+					client_email: email,
+					client_message: message,
+					product_ids: productIds,
+					licenses: licenses,
+					flow_type: flowType,
+				},
+				{
+					onSuccess: ( referral ) => {
+						navigator.clipboard.writeText( referral.checkout_url );
+
+						sessionStorage.setItem(
+							MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
+							MARKETPLACE_TYPE_REGULAR
+						);
+						page.redirect(
+							isFeedbackShown
+								? addQueryArgs( A4A_REFERRALS_DASHBOARD, {
+										[ NEW_REFERRAL_ID_QUERY_PARAM_KEY ]: referral.id,
+										flowType,
+								  } )
+								: addQueryArgs( A4A_FEEDBACK_LINK, {
+										args: { email },
+										type: FeedbackType.ReferralCompleted,
+								  } )
+						);
+						setEmail( '' );
+						setMessage( '' );
+						onClearCart();
+					},
+					onError: ( error ) => {
+						dispatch(
+							errorNotice(
+								error.code === 'cannot_refer_to_client'
+									? translate(
+											'Referring products to your own company is not allowed and against our {{a}}terms of service{{/a}}.',
+											{
+												components: {
+													a: (
+														<a
+															href="https://automattic.com/for-agencies/program-incentives/"
+															target="_blank"
+															rel="noopener noreferrer"
+														/>
+													),
+												},
+											}
+									  )
+									: error.message
+							)
+						);
+					},
+				}
+			);
+		},
+		[
+			dispatch,
+			email,
+			hasCompletedForm,
+			isFeedbackShown,
+			licenses,
+			message,
+			onClearCart,
+			productIds,
+			requestPayment,
+			translate,
+		]
+	);
 
 	return (
 		<>
@@ -196,7 +207,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 			<NoticeSummary type="request-client-payment" />
 
 			<div
-				className="checkout__aside-actions"
+				className="checkout__aside-actions is-row"
 				role="button"
 				tabIndex={ 0 }
 				onMouseEnter={ () => setShowVerifyAccountToolip( true ) }
@@ -206,12 +217,25 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				<Button
 					ref={ ctaButtonRef }
 					primary
-					onClick={ handleRequestPayment }
+					onClick={ () => handleRequestPayment( 'send' ) }
 					disabled={ ! hasCompletedForm || isUserUnverified }
 					busy={ isPending }
 				>
-					{ translate( 'Request payment from client' ) }
+					<Icon icon={ send } />
+					{ translate( 'Send to Client' ) }
 					{ isUserUnverified && <Icon icon={ warning } /> }
+				</Button>
+
+				{ translate( 'or' ) }
+
+				<Button
+					primary
+					onClick={ () => handleRequestPayment( 'copy' ) }
+					disabled={ ! hasCompletedForm || isUserUnverified }
+					busy={ isPending }
+				>
+					<Icon icon={ customLink } />
+					{ translate( 'Copy referral link' ) }
 				</Button>
 
 				<Tooltip
@@ -229,18 +253,6 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 						}
 					) }
 				</Tooltip>
-			</div>
-
-			<div className="checkout__summary-notice-item">
-				{ translate(
-					'{{b}}Important:{{/b}} Your referral order link is only valid for {{u}}7 days{{/u}}. Please notify your client to complete the payment within this timeframe to avoid expiration.',
-					{
-						components: {
-							b: <b />,
-							u: <u />,
-						},
-					}
-				) }
 			</div>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -13,7 +13,8 @@ import {
 	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
-	NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_EMAIL_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY,
 	NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY,
 } from 'calypso/a8c-for-agencies/constants';
 import { ReferralOrderFlowType } from 'calypso/a8c-for-agencies/sections/referrals/types';
@@ -119,7 +120,8 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 						page.redirect(
 							isFeedbackShown
 								? addQueryArgs( A4A_REFERRALS_DASHBOARD, {
-										[ NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY ]: referral.id,
+										[ NEW_REFERRAL_ORDER_EMAIL_QUERY_PARAM_KEY ]: email,
+										[ NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY ]: referral.checkout_url,
 										[ NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY ]: flowType,
 								  } )
 								: addQueryArgs( A4A_FEEDBACK_LINK, {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -378,3 +378,19 @@
 	margin-block-start: 8px;
 	@include body-small;
 }
+
+.checkout__aside-actions.is-row {
+	flex-direction: row;
+	gap: 16px;
+	align-items: center;
+	justify-content: center;
+
+	> .button {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+		align-items: center;
+		justify-content: center;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
@@ -12,6 +12,7 @@ export interface MutationRequestClientPaymentVariables {
 		product_id: number;
 		license_id: number;
 	}[];
+	flow_type: 'send' | 'copy';
 }
 
 interface APIError {
@@ -26,6 +27,7 @@ function mutationRequestClientPayment( {
 	product_ids,
 	agencyId,
 	licenses,
+	flow_type,
 }: MutationRequestClientPaymentVariables & { agencyId?: number } ): Promise< ReferralAPIResponse > {
 	if ( ! agencyId ) {
 		throw new Error( 'Agency ID is required request a client payment' );
@@ -33,7 +35,7 @@ function mutationRequestClientPayment( {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/agency/${ agencyId }/referrals`,
-		body: { client_email, client_message, product_ids, licenses },
+		body: { client_email, client_message, product_ids, licenses, flow_type },
 	} );
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/re
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ReferralAPIResponse } from '../../referrals/types';
+import { ReferralAPIResponse, ReferralOrderFlowType } from '../../referrals/types';
 
 export interface MutationRequestClientPaymentVariables {
 	client_email: string;
@@ -12,7 +12,7 @@ export interface MutationRequestClientPaymentVariables {
 		product_id: number;
 		license_id: number;
 	}[];
-	flow_type: 'send' | 'copy';
+	flow_type: ReferralOrderFlowType;
 }
 
 interface APIError {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -12,7 +12,7 @@ import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/compone
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
+import { NEW_REFERRAL_ID_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
@@ -53,8 +53,8 @@ export default function ReferralsOverview() {
 		titleField: 'client',
 	} );
 
-	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
-		REFERRAL_EMAIL_QUERY_PARAM_KEY
+	const { value: newReferralId, setValue: setNewReferralId } = useUrlQueryParam(
+		NEW_REFERRAL_ID_QUERY_PARAM_KEY
 	);
 
 	const isDesktop = useDesktopBreakpoint();
@@ -66,6 +66,10 @@ export default function ReferralsOverview() {
 	const { data: referrals, isFetching: isFetchingReferrals } = useFetchReferrals();
 
 	const hasReferrals = !! referrals?.length;
+
+	const newReferral = useMemo( () => {
+		return newReferralId ? referrals?.find( ( referral ) => referral.id === newReferralId ) : null;
+	}, [ newReferralId, referrals ] );
 
 	// To ensure the selected item is updated when the referrals list is updated
 	// as we optimistically update the referrals list
@@ -106,10 +110,10 @@ export default function ReferralsOverview() {
 		>
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop isFullWidth={ hasReferrals }>
-					{ !! referralEmail && (
+					{ !! newReferral && (
 						<NewReferralOrderNotification
-							email={ referralEmail }
-							onClose={ () => setReferralEmail( '' ) }
+							referral={ newReferral }
+							onClose={ () => setNewReferralId( '' ) }
 							isFullWidth={ hasReferrals }
 						/>
 					) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -13,7 +13,8 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-pa
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
-	NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_EMAIL_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY,
 	NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY,
 } from 'calypso/a8c-for-agencies/constants';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
@@ -57,12 +58,16 @@ export default function ReferralsOverview() {
 		titleField: 'client',
 	} );
 
-	const { value: newReferralOrderId, setValue: setNewReferralOrderId } = useUrlQueryParam(
-		NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY
+	const { value: newReferralOrderEmail, setValue: setNewReferralOrderEmail } = useUrlQueryParam(
+		NEW_REFERRAL_ORDER_EMAIL_QUERY_PARAM_KEY
 	);
+
 	const { value: newReferralFlowType, setValue: setNewReferralFlowType } = useUrlQueryParam(
 		NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY
 	);
+
+	const { value: newReferralOrderCheckoutUrl, setValue: setNewReferralOrderCheckoutUrl } =
+		useUrlQueryParam( NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY );
 
 	const isDesktop = useDesktopBreakpoint();
 
@@ -73,16 +78,6 @@ export default function ReferralsOverview() {
 	const { data: referrals, isFetching: isFetchingReferrals } = useFetchReferrals();
 
 	const hasReferrals = !! referrals?.length;
-
-	const newReferralOrder = useMemo( () => {
-		if ( ! newReferralOrderId ) {
-			return null;
-		}
-
-		return referrals
-			?.flatMap( ( referral ) => referral.referrals )
-			.find( ( referral_order ) => referral_order.id === Number( newReferralOrderId ) );
-	}, [ newReferralOrderId, referrals ] );
 
 	// To ensure the selected item is updated when the referrals list is updated
 	// as we optimistically update the referrals list
@@ -123,12 +118,14 @@ export default function ReferralsOverview() {
 		>
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop isFullWidth={ hasReferrals }>
-					{ !! newReferralOrder && (
+					{ !! newReferralOrderEmail && (
 						<NewReferralOrderNotification
-							referralOrder={ newReferralOrder }
+							referralOrderEmail={ newReferralOrderEmail }
+							referralOrderCheckoutUrl={ newReferralOrderCheckoutUrl }
 							onClose={ () => {
-								setNewReferralOrderId( '' );
+								setNewReferralOrderEmail( '' );
 								setNewReferralFlowType( '' );
+								setNewReferralOrderCheckoutUrl( '' );
 							} }
 							isFullWidth={ hasReferrals }
 							flowType={ newReferralFlowType as ReferralOrderFlowType }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -12,7 +12,10 @@ import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/compone
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { NEW_REFERRAL_ID_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
+import {
+	NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY,
+	NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY,
+} from 'calypso/a8c-for-agencies/constants';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
@@ -31,6 +34,7 @@ import MissingPaymentSettingsNotice from '../../common/missing-payment-settings-
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import ReferralDetails from '../../referral-details';
+import { ReferralOrderFlowType } from '../../types';
 import LayoutBodyContent from './layout-body-content';
 import NewReferralOrderNotification from './new-referral-order-notification';
 
@@ -53,8 +57,11 @@ export default function ReferralsOverview() {
 		titleField: 'client',
 	} );
 
-	const { value: newReferralId, setValue: setNewReferralId } = useUrlQueryParam(
-		NEW_REFERRAL_ID_QUERY_PARAM_KEY
+	const { value: newReferralOrderId, setValue: setNewReferralOrderId } = useUrlQueryParam(
+		NEW_REFERRAL_ORDER_ID_QUERY_PARAM_KEY
+	);
+	const { value: newReferralFlowType, setValue: setNewReferralFlowType } = useUrlQueryParam(
+		NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY
 	);
 
 	const isDesktop = useDesktopBreakpoint();
@@ -67,9 +74,15 @@ export default function ReferralsOverview() {
 
 	const hasReferrals = !! referrals?.length;
 
-	const newReferral = useMemo( () => {
-		return newReferralId ? referrals?.find( ( referral ) => referral.id === newReferralId ) : null;
-	}, [ newReferralId, referrals ] );
+	const newReferralOrder = useMemo( () => {
+		if ( ! newReferralOrderId ) {
+			return null;
+		}
+
+		return referrals
+			?.flatMap( ( referral ) => referral.referrals )
+			.find( ( referral_order ) => referral_order.id === Number( newReferralOrderId ) );
+	}, [ newReferralOrderId, referrals ] );
 
 	// To ensure the selected item is updated when the referrals list is updated
 	// as we optimistically update the referrals list
@@ -110,11 +123,15 @@ export default function ReferralsOverview() {
 		>
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop isFullWidth={ hasReferrals }>
-					{ !! newReferral && (
+					{ !! newReferralOrder && (
 						<NewReferralOrderNotification
-							referral={ newReferral }
-							onClose={ () => setNewReferralId( '' ) }
+							referralOrder={ newReferralOrder }
+							onClose={ () => {
+								setNewReferralOrderId( '' );
+								setNewReferralFlowType( '' );
+							} }
 							isFullWidth={ hasReferrals }
+							flowType={ newReferralFlowType as ReferralOrderFlowType }
 						/>
 					) }
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -1,40 +1,89 @@
+import { Button } from '@wordpress/components';
+import { customLink } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
-import { ReferralAPIResponse } from '../../types';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
 type Props = {
-	referralOrder: ReferralAPIResponse;
+	referralOrderEmail: string;
+	referralOrderCheckoutUrl: string;
 	onClose?: () => void;
 	isFullWidth?: boolean;
 	flowType: 'send' | 'copy';
 };
 
 export default function NewReferralOrderNotification( {
-	referralOrder,
+	referralOrderEmail,
+	referralOrderCheckoutUrl,
 	onClose,
 	isFullWidth,
+	flowType,
 }: Props ) {
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const onCloseClick = () => {
 		setShowBanner( false );
 		onClose?.();
 	};
 
+	const onCopyLinkClick = () => {
+		navigator.clipboard.writeText( referralOrderCheckoutUrl );
+
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_notification_copy_link_button_click' ) );
+		navigator.clipboard
+			.writeText( referralOrderCheckoutUrl )
+			.then( () => {
+				dispatch(
+					successNotice( translate( 'Link has been copied to clipboard' ), {
+						id: 'copy-referral-link-success',
+						duration: 3000,
+					} )
+				);
+			} )
+			.catch( () => {
+				dispatch(
+					errorNotice( translate( "Couldn't copy link to clipboard" ), {
+						id: 'copy-referral-link-error',
+						duration: 5000,
+					} )
+				);
+			} );
+	};
+
 	return (
 		showBanner && (
-			<LayoutBanner isFullWidth={ isFullWidth } level="success" onClose={ onCloseClick }>
-				{ translate(
-					'Your referral order was emailed to %(referralEmail)s for payment.{{br/}}Once they pay you can assign the items that were purchased.',
-					{
-						components: { br: <br /> },
-						args: { referralEmail: referralOrder.client.email },
-						comment: 'The %(referralEmail)s is the email where referral order was sent.',
-					}
-				) }
+			<LayoutBanner
+				isFullWidth={ isFullWidth }
+				level="success"
+				onClose={ onCloseClick }
+				title={
+					( flowType === 'send'
+						? translate( 'Referral sent to %(referralEmail)s', {
+								args: { referralEmail: referralOrderEmail },
+						  } )
+						: translate( 'Order link copied to your clipboard' ) ) as string
+				}
+			>
+				<div className="new-referral-order-notification">
+					{ translate(
+						'The referral order link is valid for 14 days, so be sure to share it with your client and have them complete the payment before it expires.'
+					) }
+
+					<Button
+						variant="secondary"
+						onClick={ onCopyLinkClick }
+						icon={ customLink }
+						iconPosition="left"
+					>
+						{ flowType === 'send' ? translate( 'Copy link' ) : translate( 'Copy link again' ) }
+					</Button>
+				</div>
 			</LayoutBanner>
 		)
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -1,14 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { Referral } from '../../types';
 
 type Props = {
-	email: string;
+	referral: Referral;
 	onClose?: () => void;
 	isFullWidth?: boolean;
 };
 
-export default function NewReferralOrderNotification( { email, onClose, isFullWidth }: Props ) {
+export default function NewReferralOrderNotification( { referral, onClose, isFullWidth }: Props ) {
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
@@ -25,7 +26,7 @@ export default function NewReferralOrderNotification( { email, onClose, isFullWi
 					'Your referral order was emailed to %(referralEmail)s for payment.{{br/}}Once they pay you can assign the items that were purchased.',
 					{
 						components: { br: <br /> },
-						args: { referralEmail: email },
+						args: { referralEmail: referral.client.email },
 						comment: 'The %(referralEmail)s is the email where referral order was sent.',
 					}
 				) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -1,15 +1,20 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
-import { Referral } from '../../types';
+import { ReferralAPIResponse } from '../../types';
 
 type Props = {
-	referral: Referral;
+	referralOrder: ReferralAPIResponse;
 	onClose?: () => void;
 	isFullWidth?: boolean;
+	flowType: 'send' | 'copy';
 };
 
-export default function NewReferralOrderNotification( { referral, onClose, isFullWidth }: Props ) {
+export default function NewReferralOrderNotification( {
+	referralOrder,
+	onClose,
+	isFullWidth,
+}: Props ) {
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
@@ -26,7 +31,7 @@ export default function NewReferralOrderNotification( { referral, onClose, isFul
 					'Your referral order was emailed to %(referralEmail)s for payment.{{br/}}Once they pay you can assign the items that were purchased.',
 					{
 						components: { br: <br /> },
-						args: { referralEmail: referral.client.email },
+						args: { referralEmail: referralOrder.client.email },
 						comment: 'The %(referralEmail)s is the email where referral order was sent.',
 					}
 				) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -215,3 +215,10 @@ $data-view-border-color: #f1f1f1;
 	flex-direction: column;
 	height: calc(100vh - 32px);
 }
+
+.new-referral-order-notification {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	align-items: flex-start;
+}

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -41,3 +41,5 @@ export interface ReferralAPIResponse {
 	status: string;
 	checkout_url: string;
 }
+
+export type ReferralOrderFlowType = 'send' | 'copy';


### PR DESCRIPTION
This PR adds the feature for copying the referral link within the referral checkout process.

**NOTE: The Copy referral flow will still trigger an email. I will address this in a separate backend PR.**

Context: p1758103344244159-slack-C07T87RHK44

## Proposed Changes

* Modify the checkout process so that the agency can opt-in and copy the referral link directly, instead of sending an email to the client.
* We will introduce a new field, `flow_type`, which informs the backend whether an email should be sent. This field will also be used to decide the banner content in the success feedback.

## Why are these changes being made?

* This is part of the referral enhancement project.

## Testing Instructions

* Use the A4A live link to go to the `/marketplace` page.
* Toggle referral and create referral order.
* Verify that in the checkout screen. You are presented with two options.
   <img width="509" height="245" alt="Screenshot 2025-10-03 at 12 12 02 AM" src="https://github.com/user-attachments/assets/2e94fefa-6921-4075-bf8f-5f6a37c84865" />
* Clicking the 'Copy referral link' would redirect you the referral overview page with the following banner with the referral link saved on your clipboard.
   <img width="1352" height="191" alt="Screenshot 2025-10-03 at 12 10 46 AM" src="https://github.com/user-attachments/assets/bba9e965-990e-4048-9b44-4c0a73a42113" />
* Clicking the 'Send to client' would redirect you the referral overview page with the following banner.
   <img width="1346" height="184" alt="Screenshot 2025-10-03 at 12 10 35 AM" src="https://github.com/user-attachments/assets/fbba7a4c-bb44-4e99-ad98-346452594dee" />
* Verify that the copy link CTA is working properly in the notification banner.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?