### PR TITLE
Ensure we set the user's email on Survicate after they log in on sign up

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -299,10 +299,17 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
 
-		// Load Survicate
+		/**
+		 * Load Survicate and set visitor traits on each step navigation.
+		 *
+		 * This runs on every step change to ensure:
+		 * - Survicate script loads successfully (retries if initial load failed)
+		 * - Visitor traits are updated when user authentication state changes
+		 * - Analytics tracking works correctly throughout the onboarding flow
+		 */
 		useEffect( () => {
 			addSurvicate();
-		}, [] );
+		}, [ currentStepSlug ] );
 
 		// Preload the visual split experiment
 		useEffect( () => {

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -14,6 +14,11 @@ const workspaceId = 'e4794374cce15378101b63de24117572';
 const setSurvicateVisitorTraits = () => {
 	const user = getCurrentUser();
 
+	if ( isUserOnAnonymousPaths() ) {
+		survicateDebug( 'Not setting Survicate visitor traits because user is on an anonymous path' );
+		return;
+	}
+
 	if ( ! user || ! user.email ) {
 		survicateDebug( 'Not setting Survicate visitor traits because user is not logged in' );
 
@@ -45,30 +50,17 @@ export function mayWeLoadSurvicateScript() {
 	return config( 'survicate_enabled' );
 }
 
-export function ensureVisitorTraitsAreSet() {
-	const user = getCurrentUser();
-
-	if ( ! user || ! user.email ) {
-		return;
-	}
-
-	let shouldSetVisitorTraits = false;
-	const visitorStorageKey = `survi::${ workspaceId }::FeedbackButton::allvisitor`;
-
-	try {
-		const visitorData = localStorage.getItem( visitorStorageKey );
-		const parsedVisitorData = visitorData ? JSON.parse( visitorData ) : null;
-		shouldSetVisitorTraits =
-			! parsedVisitorData || parsedVisitorData?.attributes?.email !== user.email;
-	} catch ( error ) {
-		survicateDebug( 'Failed to parse visitor data from localStorage:', error );
-		shouldSetVisitorTraits = true;
-	}
-
-	if ( shouldSetVisitorTraits ) {
-		survicateDebug( 'Setting Survicate visitor traits due to no visitor data found' );
-		setTimeout( setSurvicateVisitorTraits, 1000 );
-	}
+/**
+ * Checks if the user is on an anonymous path.
+ * @returns {boolean} True if the user is on an anonymous path, false otherwise
+ */
+export function isUserOnAnonymousPaths() {
+	return [
+		'/log-in',
+		'/setup/onboarding/user',
+		'/log-in/lostpassword',
+		'/account/user-social',
+	].includes( window.location.pathname );
 }
 
 export function addSurvicate() {
@@ -84,7 +76,7 @@ export function addSurvicate() {
 	}
 
 	if ( survicateScriptLoaded && mayWeLoadSurvicateScript() ) {
-		ensureVisitorTraitsAreSet();
+		setTimeout( setSurvicateVisitorTraits, 1000 );
 	}
 
 	if ( survicateScriptLoaded ) {

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -6,6 +6,7 @@ import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 const survicateDebug = debug( 'calypso:analytics:survicate' );
 
 let survicateScriptLoaded = false;
+const workspaceId = 'e4794374cce15378101b63de24117572';
 
 /**
  * Sets Survicate visitor traits with current user data
@@ -44,9 +45,33 @@ export function mayWeLoadSurvicateScript() {
 	return config( 'survicate_enabled' );
 }
 
-export function addSurvicate() {
-	const workspaceId = 'e4794374cce15378101b63de24117572';
+export function ensureVisitorTraitsAreSet() {
+	const user = getCurrentUser();
 
+	if ( ! user || ! user.email ) {
+		return;
+	}
+
+	let shouldSetVisitorTraits = false;
+	const visitorStorageKey = `survi::${ workspaceId }::FeedbackButton::allvisitor`;
+
+	try {
+		const visitorData = localStorage.getItem( visitorStorageKey );
+		const parsedVisitorData = visitorData ? JSON.parse( visitorData ) : null;
+		shouldSetVisitorTraits =
+			! parsedVisitorData || parsedVisitorData?.attributes?.email !== user.email;
+	} catch ( error ) {
+		survicateDebug( 'Failed to parse visitor data from localStorage:', error );
+		shouldSetVisitorTraits = true;
+	}
+
+	if ( shouldSetVisitorTraits ) {
+		survicateDebug( 'Setting Survicate visitor traits due to no visitor data found' );
+		setTimeout( setSurvicateVisitorTraits, 1000 );
+	}
+}
+
+export function addSurvicate() {
 	// Only add survicate for en languages
 	if ( ! getLocaleSlug().startsWith( 'en' ) ) {
 		survicateDebug( 'Not loading Survicate script for non-en language' );
@@ -58,8 +83,17 @@ export function addSurvicate() {
 		return;
 	}
 
-	if ( survicateScriptLoaded || ! mayWeLoadSurvicateScript() ) {
-		survicateDebug( 'Not loading Survicate script' );
+	if ( survicateScriptLoaded && mayWeLoadSurvicateScript() ) {
+		ensureVisitorTraitsAreSet();
+	}
+
+	if ( survicateScriptLoaded ) {
+		survicateDebug( 'Survicate script already loaded' );
+		return;
+	}
+
+	if ( ! mayWeLoadSurvicateScript() ) {
+		survicateDebug( 'Not loading Survicate script due to config setting' );
 		return;
 	}
 

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -60,6 +60,8 @@ export function isUserOnAnonymousPaths() {
 		'/setup/onboarding/user',
 		'/log-in/lostpassword',
 		'/account/user-social',
+		'/log-in/link',
+		'/log-in/qr',
 	].includes( window.location.pathname );
 }
 
@@ -75,11 +77,8 @@ export function addSurvicate() {
 		return;
 	}
 
-	if ( survicateScriptLoaded && mayWeLoadSurvicateScript() ) {
-		setTimeout( setSurvicateVisitorTraits, 1000 );
-	}
-
 	if ( survicateScriptLoaded ) {
+		setTimeout( setSurvicateVisitorTraits, 1000 );
 		survicateDebug( 'Survicate script already loaded' );
 		return;
 	}

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -111,6 +111,10 @@ describe( 'survicate', () => {
 		// Restore original DOM methods
 		document.createElement = originalCreateElement;
 		document.getElementsByTagName = originalGetElementsByTagName;
+
+		// Clean up document and window objects
+		document.body.innerHTML = '';
+		window.location = null;
 	} );
 
 	describe( 'mayWeLoadSurvicateScript', () => {

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -32,6 +32,7 @@ describe( 'survicate', () => {
 	let originalGetElementsByTagName;
 	let mayWeLoadSurvicateScript;
 	let addSurvicate;
+	let isUserOnAnonymousPaths;
 
 	beforeAll( () => {
 		// Set up DOM mocks
@@ -63,6 +64,7 @@ describe( 'survicate', () => {
 			const survicateModule = require( 'calypso/lib/analytics/survicate' );
 			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
 			addSurvicate = survicateModule.addSurvicate;
+			isUserOnAnonymousPaths = survicateModule.isUserOnAnonymousPaths;
 		} );
 
 		// Mock DOM methods
@@ -124,6 +126,26 @@ describe( 'survicate', () => {
 
 			expect( mayWeLoadSurvicateScript() ).toBe( false );
 			expect( config ).toHaveBeenCalledWith( 'survicate_enabled' );
+		} );
+	} );
+
+	describe( 'isUserOnAnonymousPaths', () => {
+		test.each( [
+			// Anonymous paths should return true
+			[ '/log-in', true ],
+			[ '/setup/onboarding/user', true ],
+			[ '/log-in/lostpassword', true ],
+			[ '/account/user-social', true ],
+			// Non-anonymous paths should return false
+			[ '/sites', false ],
+			[ '/home', false ],
+		] )( 'should return %s for path %s', ( pathname, expected ) => {
+			Object.defineProperty( window, 'location', {
+				value: { pathname },
+				writable: true,
+			} );
+
+			expect( isUserOnAnonymousPaths() ).toBe( expected );
 		} );
 	} );
 
@@ -361,6 +383,63 @@ describe( 'survicate', () => {
 			// Second call should not create another script
 			addSurvicate();
 			expect( document.createElement ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should set visitor traits when user is not on anonymous paths', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			// Set non-anonymous path
+			Object.defineProperty( window, 'location', {
+				value: { pathname: '/home' },
+				writable: true,
+			} );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			addSurvicate();
+
+			// Simulate script load
+			mockScript.onload();
+
+			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
+				email: 'test@example.com',
+			} );
+		} );
+
+		test( 'should retry setting visitor traits when script is already loaded', () => {
+			const mockUser = {
+				email: 'test@example.com',
+			};
+			getCurrentUser.mockReturnValue( mockUser );
+
+			Object.defineProperty( window, 'location', {
+				value: { pathname: '/home' },
+				writable: true,
+			} );
+
+			global._sva = {
+				setVisitorTraits: jest.fn(),
+			};
+
+			// First call - loads script
+			addSurvicate();
+			mockScript.onload();
+
+			// Clear the mock to track subsequent calls
+			global._sva.setVisitorTraits.mockClear();
+
+			// Second call - should retry setting visitor traits without loading script again
+			addSurvicate();
+
+			// Should have called setVisitorTraits again via setTimeout
+			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
+				email: 'test@example.com',
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOMX-62](https://linear.app/a8c/issue/DOMX-62/ensure-survicate-will-set-the-users-email-whenever-is-possible)

Follow-up of https://github.com/Automattic/wp-calypso/pull/105641

Currently, we're seeing about 1k/h of calypso_survicate_user_not_available_error on the Survicate script and we want to fix the root cause of it.

## Proposed Changes

* We're now retrying to set the user's email after a new user just came through onboarding.
* We're not trying to set Survicate user.email information on known anonymous paths as we don't have the user object yet.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to ensure all users can benefit from Survicate surveys

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a guest profile browser, follow the video instructions 

https://github.com/user-attachments/assets/bf77e257-793e-4d76-aee5-1853939f6011


* Make sure your user attribute is set:

<img width="1222" height="962" alt="image" src="https://github.com/user-attachments/assets/02c1e258-74ca-4554-9473-3644a93b0a44" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
