### PR TITLE
Add the hosting dashboard domain transfer setup flow

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -13,6 +13,8 @@ import {
 	domainWhoisQuery,
 	domainConnectionSetupInfoQuery,
 	rawUserPreferencesQuery,
+	domainAvailabilityQuery,
+	domainInboundTransferStatusQuery,
 } from '@automattic/api-queries';
 import {
 	createRoute,
@@ -555,6 +557,30 @@ export const domainConnectionSetupRoute = createRoute( {
 	)
 );
 
+export const domainTransferSetupRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Domain transfer setup' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'domains/$domainName/domain-transfer-setup',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainAvailabilityQuery( domainName ) ),
+			queryClient.ensureQueryData( domainInboundTransferStatusQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../domains/domain-connection-setup/transfer-setup' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-setup' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createDomainsRoutes = () => {
 	return [
 		domainsRoute,
@@ -562,6 +588,7 @@ export const createDomainsRoutes = () => {
 			domainOverviewRoute,
 			domainDnsRoute.addChildren( [ domainDnsIndexRoute, domainDnsAddRoute, domainDnsEditRoute ] ),
 			domainConnectionSetupRoute,
+			domainTransferSetupRoute,
 			domainForwardingRoute.addChildren( [
 				domainForwardingIndexRoute,
 				domainForwardingAddRoute,

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -565,8 +565,8 @@ export const domainTransferSetupRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => rootRoute,
-	path: 'domains/$domainName/domain-transfer-setup',
+	getParentRoute: () => domainRoute,
+	path: 'domain-transfer-setup',
 	loader: async ( { params: { domainName } } ) => {
 		await Promise.all( [
 			queryClient.ensureQueryData( domainAvailabilityQuery( domainName ) ),

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -150,6 +150,9 @@ export default function DomainConnectionSetup() {
 	).includes( currentStepName as string );
 
 	const StepsComponent = currentStep.component;
+	if ( StepsComponent === null ) {
+		return null;
+	}
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain connection setup' ) } /> }>

--- a/client/dashboard/domains/domain-connection-setup/steps-map.ts
+++ b/client/dashboard/domains/domain-connection-setup/steps-map.ts
@@ -8,6 +8,10 @@ import {
 	Login,
 	SuggestedRecords,
 	SuggestedStart,
+	TransferStart,
+	TransferLogin,
+	TransferUnlock,
+	TransferAuthCode,
 } from './steps';
 import { StepName, StepType, DomainConnectionStepsMap } from './types';
 
@@ -192,5 +196,87 @@ export const connectASubdomainDomainConnectionStepsMap: DomainConnectionStepsMap
 		component: SuggestedStart,
 		prev: StepName.SUBDOMAIN_ADVANCED_UPDATE,
 		singleColumnLayout: true,
+	},
+};
+
+export const transferLockedDomainStepsDefinition: DomainConnectionStepsMap = {
+	[ StepName.TRANSFER_START ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.START,
+		component: TransferStart,
+		next: StepName.TRANSFER_LOGIN,
+	},
+	[ StepName.TRANSFER_LOGIN ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.LOG_IN_TO_PROVIDER,
+		get name() {
+			return __( 'Log in to provider' );
+		},
+		component: TransferLogin,
+		next: StepName.TRANSFER_UNLOCK,
+		prev: StepName.TRANSFER_START,
+	},
+	[ StepName.TRANSFER_UNLOCK ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.UNLOCK_DOMAIN,
+		get name() {
+			return __( 'Unlock domain' );
+		},
+		component: TransferUnlock,
+		next: StepName.TRANSFER_AUTH_CODE,
+		prev: StepName.TRANSFER_LOGIN,
+	},
+	[ StepName.TRANSFER_AUTH_CODE ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.ENTER_AUTH_CODE,
+		get name() {
+			return __( 'Authorize the transfer' );
+		},
+		component: TransferAuthCode,
+		next: 'unused transfer domain step',
+		prev: StepName.TRANSFER_UNLOCK,
+	},
+	[ 'unused transfer domain step' ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.FINALIZE,
+		get name() {
+			return __( 'Finalize transfer' );
+		},
+	},
+};
+
+export const transferUnlockedDomainStepsDefinition: DomainConnectionStepsMap = {
+	[ StepName.TRANSFER_START ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.START,
+		component: TransferStart,
+		next: StepName.TRANSFER_LOGIN,
+	},
+	[ StepName.TRANSFER_LOGIN ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.LOG_IN_TO_PROVIDER,
+		get name() {
+			return __( 'Log in to provider' );
+		},
+		component: TransferLogin,
+		next: StepName.TRANSFER_AUTH_CODE,
+		prev: StepName.TRANSFER_START,
+	},
+	[ StepName.TRANSFER_AUTH_CODE ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.ENTER_AUTH_CODE,
+		get name() {
+			return __( 'Authorize the transfer' );
+		},
+		component: TransferAuthCode,
+		next: 'unused transfer domain step',
+		prev: StepName.TRANSFER_LOGIN,
+	},
+	[ 'unused transfer domain step' ]: {
+		mode: DomainConnectionSetupMode.TRANSFER,
+		stepType: StepType.FINALIZE,
+		get name() {
+			return __( 'Finalize transfer' );
+		},
 	},
 };

--- a/client/dashboard/domains/domain-connection-setup/steps-map.ts
+++ b/client/dashboard/domains/domain-connection-setup/steps-map.ts
@@ -13,7 +13,7 @@ import {
 	TransferUnlock,
 	TransferAuthCode,
 } from './steps';
-import { StepName, StepType, DomainConnectionStepsMap } from './types';
+import { StepName, StepType, DomainConnectionStepsMap, DomainTransferStepsMap } from './types';
 
 export const connectADomainDomainConnectionStepsMap: DomainConnectionStepsMap = {
 	// Suggested flow
@@ -199,7 +199,7 @@ export const connectASubdomainDomainConnectionStepsMap: DomainConnectionStepsMap
 	},
 };
 
-export const transferLockedDomainStepsDefinition: DomainConnectionStepsMap = {
+export const transferLockedDomainStepsDefinition: DomainTransferStepsMap = {
 	[ StepName.TRANSFER_START ]: {
 		mode: DomainConnectionSetupMode.TRANSFER,
 		stepType: StepType.START,
@@ -233,19 +233,19 @@ export const transferLockedDomainStepsDefinition: DomainConnectionStepsMap = {
 			return __( 'Authorize the transfer' );
 		},
 		component: TransferAuthCode,
-		next: 'unused transfer domain step',
 		prev: StepName.TRANSFER_UNLOCK,
 	},
-	[ 'unused transfer domain step' ]: {
+	[ StepName.UNUSED_TRANSFER_DOMAIN_STEP ]: {
 		mode: DomainConnectionSetupMode.TRANSFER,
 		stepType: StepType.FINALIZE,
+		component: null,
 		get name() {
 			return __( 'Finalize transfer' );
 		},
 	},
 };
 
-export const transferUnlockedDomainStepsDefinition: DomainConnectionStepsMap = {
+export const transferUnlockedDomainStepsDefinition: DomainTransferStepsMap = {
 	[ StepName.TRANSFER_START ]: {
 		mode: DomainConnectionSetupMode.TRANSFER,
 		stepType: StepType.START,
@@ -269,12 +269,12 @@ export const transferUnlockedDomainStepsDefinition: DomainConnectionStepsMap = {
 			return __( 'Authorize the transfer' );
 		},
 		component: TransferAuthCode,
-		next: 'unused transfer domain step',
 		prev: StepName.TRANSFER_LOGIN,
 	},
-	[ 'unused transfer domain step' ]: {
+	[ StepName.UNUSED_TRANSFER_DOMAIN_STEP ]: {
 		mode: DomainConnectionSetupMode.TRANSFER,
 		stepType: StepType.FINALIZE,
+		component: null,
 		get name() {
 			return __( 'Finalize transfer' );
 		},

--- a/client/dashboard/domains/domain-connection-setup/steps/index.ts
+++ b/client/dashboard/domains/domain-connection-setup/steps/index.ts
@@ -5,3 +5,7 @@ export * from './advanced-start';
 export * from './advanced-records';
 export * from './done';
 export * from './dc-start';
+export * from './transfer-start';
+export * from './transfer-login';
+export * from './transfer-unlock';
+export * from './transfer-auth-code';

--- a/client/dashboard/domains/domain-connection-setup/steps/login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/login.tsx
@@ -21,7 +21,7 @@ export function Login( {
 	domainName,
 	onNextStep,
 	isOwnershipVerificationFlow,
-}: StepComponentProps ) {
+}: Pick< StepComponentProps, 'domainName' | 'onNextStep' | 'isOwnershipVerificationFlow' > ) {
 	const { data: availability, isLoading: isLoadingAvailability } = useQuery( {
 		...domainAvailabilityQuery( domainName ),
 		enabled: isOwnershipVerificationFlow,
@@ -46,7 +46,7 @@ export function Login( {
 								{ __( 'We need to confirm that you are authorized to connect this domain.' ) }
 							</Text>
 						) }
-						{ ! isLoadingAvailability && ! isConnectSupported && (
+						{ isOwnershipVerificationFlow && ! isLoadingAvailability && ! isConnectSupported && (
 							<Notice variant="error">{ __( 'This domain cannot be connected.' ) }</Notice>
 						) }
 						{ ! isLoadingAvailability && (

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
@@ -1,3 +1,5 @@
+import { checkDomainAuthCode, startDomainInboundTransfer } from '@automattic/api-core';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -9,16 +11,62 @@ import {
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import Notice from '../../../components/notice';
 import { TransferStepComponentProps } from '../types';
 
-export function TransferAuthCode( { domainName }: TransferStepComponentProps ) {
-	// const recordTransferButtonClickInUseYourDomain = useCallback(
-	// 	() => recordTracksEvent( 'calypso_use_your_domain_transfer_click', { domain } ),
-	// 	[ domain ]
-	// );
+export function TransferAuthCode( { domainName, siteId }: TransferStepComponentProps ) {
+	const [ authCode, setAuthCode ] = useState( '' );
+	const [ isValidating, setIsValidating ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+	const navigate = useNavigate();
+
+	const handleValidate = async () => {
+		if ( ! authCode.trim() ) {
+			setError( __( 'Please enter an authorization code.' ) );
+			return;
+		}
+
+		if ( ! siteId ) {
+			setError( __( 'Site ID is missing. Please try again.' ) );
+			return;
+		}
+
+		setError( null );
+		setIsValidating( true );
+
+		try {
+			const authCodeResult = await checkDomainAuthCode( domainName, authCode );
+
+			if ( ! authCodeResult.success ) {
+				setError( __( 'The authorization code is incorrect. Please check and try again.' ) );
+				setIsValidating( false );
+				return;
+			}
+
+			await startDomainInboundTransfer( siteId, domainName, authCode );
+
+			navigate( {
+				to: '/domains/$domainName',
+				params: { domainName },
+			} );
+		} catch ( err ) {
+			const errorMessage =
+				err instanceof Error ? err.message : __( 'An unexpected error occurred.' );
+			setError(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to start transfer: %s' ),
+					errorMessage
+				)
+			);
+			setIsValidating( false );
+		}
+	};
 
 	return (
 		<VStack spacing={ 6 }>
+			{ error && <Notice variant="error">{ error }</Notice> }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 4 }>
@@ -38,16 +86,29 @@ export function TransferAuthCode( { domainName }: TransferStepComponentProps ) {
 						<InputControl
 							label={ __( 'Authorization code' ) }
 							placeholder={ __( 'Enter authorization code' ) }
+							value={ authCode }
+							onChange={ ( value: string | undefined ) => {
+								setAuthCode( value || '' );
+								setError( null );
+							} }
+							disabled={ isValidating }
 						/>
 
 						<Text as="p">
 							{ __(
-								'Once you’ve entered the authorization code, click on the button below to proceed.'
+								"Once you've entered the authorization code, click on the button below to proceed."
 							) }
 						</Text>
 
 						<HStack justify="flex-start">
-							<Button variant="primary">{ __( 'Check readiness for transfer' ) }</Button>
+							<Button
+								variant="primary"
+								onClick={ handleValidate }
+								isBusy={ isValidating }
+								disabled={ isValidating }
+							>
+								{ __( 'Initiate domain name transfer' ) }
+							</Button>
 						</HStack>
 					</VStack>
 				</CardBody>

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
@@ -1,0 +1,48 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+	__experimentalText as Text,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function TransferAuthCode() {
+	// const recordTransferButtonClickInUseYourDomain = useCallback(
+	// 	() => recordTracksEvent( 'calypso_use_your_domain_transfer_click', { domain } ),
+	// 	[ domain ]
+	// );
+
+	return (
+		<VStack spacing={ 6 }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<Text as="p">
+							{ __(
+								'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'
+							) }
+						</Text>
+
+						<InputControl
+							label={ __( 'Authorization code' ) }
+							placeholder={ __( 'Enter authorization code' ) }
+						/>
+
+						<Text as="p">
+							{ __(
+								'Once you’ve entered the authorization code, click on the button below to proceed.'
+							) }
+						</Text>
+
+						<HStack justify="flex-start">
+							<Button variant="primary">{ __( 'Check readiness for transfer' ) }</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
@@ -5,11 +5,13 @@ import {
 	CardBody,
 	Button,
 	__experimentalText as Text,
+	__experimentalHeading as Heading,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { TransferStepComponentProps } from '../types';
 
-export function TransferAuthCode() {
+export function TransferAuthCode( { domainName }: TransferStepComponentProps ) {
 	// const recordTransferButtonClickInUseYourDomain = useCallback(
 	// 	() => recordTracksEvent( 'calypso_use_your_domain_transfer_click', { domain } ),
 	// 	[ domain ]
@@ -20,6 +22,13 @@ export function TransferAuthCode() {
 			<Card>
 				<CardBody>
 					<VStack spacing={ 4 }>
+						<Heading level="3">
+							{ sprintf(
+								/* translators: %s: the domain name that is being transferred (ex.: example.com) */
+								__( 'Enter the authorization code for %s.' ),
+								domainName
+							) }
+						</Heading>
 						<Text as="p">
 							{ __(
 								'A domain authorization code is a unique code linked only to your domain, it might also be called a secret code, auth code, or EPP code. You can usually find this in your domain settings page.'

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
@@ -1,6 +1,6 @@
-import { StepComponentProps } from '../types';
+import { TransferStepComponentProps } from '../types';
 import { Login } from './login';
 
-export function TransferLogin( props: StepComponentProps ) {
+export function TransferLogin( props: TransferStepComponentProps ) {
 	return <Login { ...props } />;
 }

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
@@ -1,0 +1,6 @@
+import { StepComponentProps } from '../types';
+import { Login } from './login';
+
+export function TransferLogin( props: StepComponentProps ) {
+	return <Login { ...props } />;
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-login.tsx
@@ -2,5 +2,11 @@ import { TransferStepComponentProps } from '../types';
 import { Login } from './login';
 
 export function TransferLogin( props: TransferStepComponentProps ) {
-	return <Login { ...props } />;
+	return (
+		<Login
+			domainName={ props.domainName }
+			onNextStep={ props.onNextStep }
+			isOwnershipVerificationFlow={ false }
+		/>
+	);
 }

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-start.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-start.tsx
@@ -8,13 +8,13 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import Notice from '../../../components/notice';
-import { StepComponentProps } from '../types';
+import { TransferStepComponentProps } from '../types';
 
 export function TransferStart( {
 	onNextStep,
 	inboundTransferStatusInfo,
 	domainName,
-}: StepComponentProps ) {
+}: TransferStepComponentProps ) {
 	const isDomainTransferrable =
 		! inboundTransferStatusInfo?.in_redemption &&
 		inboundTransferStatusInfo?.transfer_eligible_date === null;

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-start.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-start.tsx
@@ -1,0 +1,60 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import Notice from '../../../components/notice';
+import { StepComponentProps } from '../types';
+
+export function TransferStart( {
+	onNextStep,
+	inboundTransferStatusInfo,
+	domainName,
+}: StepComponentProps ) {
+	const isDomainTransferrable =
+		! inboundTransferStatusInfo?.in_redemption &&
+		inboundTransferStatusInfo?.transfer_eligible_date === null;
+
+	return (
+		<VStack spacing={ 6 }>
+			{ ! isDomainTransferrable && (
+				<Notice variant="error">
+					{ sprintf(
+						/* translators: %s: the domain name that is being transferred (ex.: example.com) */
+						__( 'The domain %s is not transferable.' ),
+						domainName
+					) }
+				</Notice>
+			) }
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<Text as="p">
+							{ __(
+								'For this setup you will need to log in to your current domain provider and go through a few steps.'
+							) }
+						</Text>
+
+						<Notice variant="info" title={ __( 'How long will it take?' ) }>
+							{ __( 'It takes 10–20 minutes to set up.' ) }
+							<br />
+							{ __(
+								'It can take up to 5 days for the domain to be transferred, depending on your provider.'
+							) }
+						</Notice>
+
+						<HStack justify="flex-start">
+							<Button variant="primary" onClick={ onNextStep } disabled={ ! isDomainTransferrable }>
+								{ __( 'Start setup' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
@@ -10,9 +10,9 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lock } from '@wordpress/icons';
-import { StepComponentProps } from '../types';
+import { TransferStepComponentProps } from '../types';
 
-export function TransferUnlock( { onNextStep }: StepComponentProps ) {
+export function TransferUnlock( { onNextStep }: TransferStepComponentProps ) {
 	return (
 		<VStack spacing={ 6 }>
 			{ /*domainStatusError && ! checkInProgress && (

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
@@ -1,0 +1,49 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+	CardBody,
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { lock } from '@wordpress/icons';
+import { StepComponentProps } from '../types';
+
+export function TransferUnlock( { onNextStep }: StepComponentProps ) {
+	return (
+		<VStack spacing={ 6 }>
+			{ /*domainStatusError && ! checkInProgress && (
+				<Notice variant="error">{ getErrorMessage() }</Notice>
+			) */ }
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<HStack justify="flex-start" alignment="center">
+							<Icon icon={ lock } />
+							<Heading level="3">{ __( 'Your domain is locked' ) }</Heading>
+						</HStack>
+						<Text as="p">
+							{ __(
+								'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
+							) }
+						</Text>
+						<Text as="p">
+							{ __(
+								'It might take a few minutes for any changes to take effect. Once you have unlocked your domain click on the button below to proceed.'
+							) }
+						</Text>
+
+						<HStack justify="flex-start">
+							<Button variant="primary" onClick={ onNextStep }>
+								{ __( 'I’ve unlocked my domain' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
@@ -1,3 +1,4 @@
+import { fetchDomainInboundTransferStatus } from '@automattic/api-core';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -10,35 +11,105 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { lock } from '@wordpress/icons';
+import { useState } from 'react';
+import Notice from '../../../components/notice';
 import { TransferStepComponentProps } from '../types';
 
-export function TransferUnlock( { onNextStep }: TransferStepComponentProps ) {
+export function TransferUnlock( {
+	onNextStep,
+	domainName,
+	inboundTransferStatusInfo,
+}: TransferStepComponentProps ) {
+	const [ isChecking, setIsChecking ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+	const [ allowSkip, setAllowSkip ] = useState( false );
+
+	const isInitiallyUnlocked = inboundTransferStatusInfo?.unlocked === true;
+	const isInitiallyUnknown = inboundTransferStatusInfo?.unlocked === null;
+
+	const handleCheckUnlock = async () => {
+		setIsChecking( true );
+		setError( null );
+
+		try {
+			const result = await fetchDomainInboundTransferStatus( domainName );
+
+			if ( result.unlocked === true || allowSkip || isInitiallyUnknown ) {
+				onNextStep();
+			} else if ( result.unlocked === null ) {
+				setError( __( "Can't get the domain's lock status" ) );
+				setAllowSkip( true );
+				setIsChecking( false );
+			} else {
+				setError( __( 'Your domain is still locked' ) );
+				setIsChecking( false );
+			}
+		} catch {
+			setError( __( "Can't get the domain's lock status" ) );
+			setAllowSkip( true );
+			setIsChecking( false );
+		}
+	};
+
+	const getErrorMessage = () => {
+		if ( allowSkip ) {
+			return __(
+				"Can't get the domain's lock status. If you've already unlocked it, wait a few minutes and try again."
+			);
+		}
+		return __(
+			"Your domain is still locked. If you've already unlocked it, wait a few minutes and try again."
+		);
+	};
+
+	const getHeadingText = () => {
+		if ( isInitiallyUnknown || allowSkip ) {
+			return __( "Can't get the domain's lock status" );
+		}
+		return __( 'Your domain is locked' );
+	};
+
+	const getButtonText = () => {
+		if ( isInitiallyUnknown || allowSkip ) {
+			return __( 'Skip domain lock verification' );
+		}
+		return __( "I've unlocked my domain" );
+	};
+
 	return (
 		<VStack spacing={ 6 }>
-			{ /*domainStatusError && ! checkInProgress && (
-				<Notice variant="error">{ getErrorMessage() }</Notice>
-			) */ }
+			{ error && ! isChecking && <Notice variant="error">{ getErrorMessage() }</Notice> }
 			<Card>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<HStack justify="flex-start" alignment="center">
-							<Icon icon={ lock } />
-							<Heading level="3">{ __( 'Your domain is locked' ) }</Heading>
-						</HStack>
+						{ ! isInitiallyUnlocked && (
+							<HStack justify="flex-start" alignment="center">
+								<Icon icon={ lock } />
+								<Heading level="3">{ getHeadingText() }</Heading>
+							</HStack>
+						) }
 						<Text as="p">
+							{ ( isInitiallyUnknown || allowSkip ) && (
+								<>{ __( 'Please check that your domain is unlocked.' ) } </>
+							) }
 							{ __(
-								'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
+								"Domain providers lock domains to prevent unauthorized transfers. You'll need to unlock it on your domain provider's settings page. Some domain providers require you to contact them via their customer support to unlock it."
 							) }
 						</Text>
 						<Text as="p">
-							{ __(
-								'It might take a few minutes for any changes to take effect. Once you have unlocked your domain click on the button below to proceed.'
-							) }
+							{ __( 'It might take a few minutes for any changes to take effect.' ) }
+							<br />
+							{ __( 'Once you have unlocked your domain click on the button below to proceed.' ) }
 						</Text>
 
 						<HStack justify="flex-start">
-							<Button variant="primary" onClick={ onNextStep }>
-								{ __( 'I’ve unlocked my domain' ) }
+							<Button
+								variant="primary"
+								onClick={ handleCheckUnlock }
+								isBusy={ isChecking }
+								disabled={ isChecking }
+							>
+								{ getButtonText() }
 							</Button>
 						</HStack>
 					</VStack>

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -19,7 +19,7 @@ import {
 	transferLockedDomainStepsDefinition,
 	transferUnlockedDomainStepsDefinition,
 } from './steps-map';
-import { DomainConnectionStepsMap, StepName, type StepNameValue } from './types';
+import { DomainTransferStepsMap, StepName, type StepNameValue } from './types';
 import { getProgressStepList } from './utils';
 
 export default function DomainConnectionSetup() {
@@ -37,7 +37,7 @@ export default function DomainConnectionSetup() {
 		initialStepName ? ( initialStepName as StepNameValue ) : StepName.TRANSFER_START
 	);
 
-	const stepsDefinition: DomainConnectionStepsMap =
+	const stepsDefinition: DomainTransferStepsMap =
 		inboundTransferStatusInfo.unlocked === true
 			? transferUnlockedDomainStepsDefinition
 			: transferLockedDomainStepsDefinition;
@@ -64,6 +64,10 @@ export default function DomainConnectionSetup() {
 
 	const StepsComponent = currentStep.component;
 
+	if ( StepsComponent === null ) {
+		return null;
+	}
+
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain name transfer setup' ) } /> }>
 			{ currentStep.prev && (
@@ -86,13 +90,6 @@ export default function DomainConnectionSetup() {
 					stepType={ currentStep.stepType }
 					mode={ currentStep.mode }
 					onNextStep={ setNextStepName }
-					setPage={ setCurrentStepName }
-					verificationInProgress={ false }
-					isOwnershipVerificationFlow={ false }
-					showErrors={ false }
-					isFirstVisit={ false }
-					queryError={ null }
-					queryErrorDescription={ null }
 					inboundTransferStatusInfo={ inboundTransferStatusInfo }
 				/>
 			</VStack>

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -1,5 +1,6 @@
 import {
 	domainInboundTransferStatusQuery,
+	domainQuery,
 	// domainAvailabilityQuery
 } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -24,6 +25,8 @@ import { getProgressStepList } from './utils';
 
 export default function DomainConnectionSetup() {
 	const { domainName } = domainTransferSetupRoute.useParams();
+
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 
 	const { data: inboundTransferStatusInfo } = useSuspenseQuery(
 		domainInboundTransferStatusQuery( domainName )
@@ -91,6 +94,7 @@ export default function DomainConnectionSetup() {
 					mode={ currentStep.mode }
 					onNextStep={ setNextStepName }
 					inboundTransferStatusInfo={ inboundTransferStatusInfo }
+					siteId={ domain.blog_id }
 				/>
 			</VStack>
 		</PageLayout>

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -1,0 +1,101 @@
+import {
+	domainInboundTransferStatusQuery,
+	// domainAvailabilityQuery
+} from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useState } from 'react';
+import { domainTransferSetupRoute } from '../../app/router/domains';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import Progress from './components/progress';
+import {
+	transferLockedDomainStepsDefinition,
+	transferUnlockedDomainStepsDefinition,
+} from './steps-map';
+import { DomainConnectionStepsMap, StepName, type StepNameValue } from './types';
+import { getProgressStepList } from './utils';
+
+export default function DomainConnectionSetup() {
+	const { domainName } = domainTransferSetupRoute.useParams();
+
+	const { data: inboundTransferStatusInfo } = useSuspenseQuery(
+		domainInboundTransferStatusQuery( domainName )
+	);
+
+	// const { data: availabilityData } = useSuspenseQuery( domainAvailabilityQuery( domainName ) );
+
+	const { step: initialStepName } = domainTransferSetupRoute.useSearch();
+
+	const [ currentStepName, setCurrentStepName ] = useState< StepNameValue >( () =>
+		initialStepName ? ( initialStepName as StepNameValue ) : StepName.TRANSFER_START
+	);
+
+	const stepsDefinition: DomainConnectionStepsMap =
+		inboundTransferStatusInfo.unlocked === true
+			? transferUnlockedDomainStepsDefinition
+			: transferLockedDomainStepsDefinition;
+
+	const currentStep = stepsDefinition[ currentStepName as StepNameValue ];
+	if ( ! currentStep ) {
+		return null;
+	}
+
+	const setNextStepName = () => {
+		const next = stepsDefinition[ currentStepName as StepNameValue ]?.next;
+		next && setCurrentStepName( next );
+	};
+
+	const goBack = () => {
+		if ( currentStep.prev ) {
+			setCurrentStepName( currentStep.prev );
+		}
+	};
+
+	const showProgress = Object.keys(
+		getProgressStepList( currentStep.mode, stepsDefinition )
+	).includes( currentStepName as string );
+
+	const StepsComponent = currentStep.component;
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain name transfer setup' ) } /> }>
+			{ currentStep.prev && (
+				<HStack>
+					<Button icon={ isRTL() ? chevronRight : chevronLeft } onClick={ goBack }>
+						{ __( 'Back' ) }
+					</Button>
+				</HStack>
+			) }
+			{ showProgress && (
+				<Progress
+					steps={ getProgressStepList( currentStep.mode, stepsDefinition ) }
+					currentStepName={ currentStepName }
+				/>
+			) }
+			<VStack spacing={ 6 }>
+				<StepsComponent
+					domainName={ domainName }
+					stepName={ currentStepName }
+					stepType={ currentStep.stepType }
+					mode={ currentStep.mode }
+					onNextStep={ setNextStepName }
+					setPage={ setCurrentStepName }
+					verificationInProgress={ false }
+					isOwnershipVerificationFlow={ false }
+					showErrors={ false }
+					isFirstVisit={ false }
+					queryError={ null }
+					queryErrorDescription={ null }
+					inboundTransferStatusInfo={ inboundTransferStatusInfo }
+				/>
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/transfer-setup.tsx
@@ -1,8 +1,4 @@
-import {
-	domainInboundTransferStatusQuery,
-	domainQuery,
-	// domainAvailabilityQuery
-} from '@automattic/api-queries';
+import { domainInboundTransferStatusQuery, domainQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -23,7 +19,7 @@ import {
 import { DomainTransferStepsMap, StepName, type StepNameValue } from './types';
 import { getProgressStepList } from './utils';
 
-export default function DomainConnectionSetup() {
+export default function DomainTransferSetup() {
 	const { domainName } = domainTransferSetupRoute.useParams();
 
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
@@ -32,18 +28,17 @@ export default function DomainConnectionSetup() {
 		domainInboundTransferStatusQuery( domainName )
 	);
 
-	// const { data: availabilityData } = useSuspenseQuery( domainAvailabilityQuery( domainName ) );
-
 	const { step: initialStepName } = domainTransferSetupRoute.useSearch();
 
 	const [ currentStepName, setCurrentStepName ] = useState< StepNameValue >( () =>
 		initialStepName ? ( initialStepName as StepNameValue ) : StepName.TRANSFER_START
 	);
 
-	const stepsDefinition: DomainTransferStepsMap =
+	const [ stepsDefinition ] = useState< DomainTransferStepsMap >( () =>
 		inboundTransferStatusInfo.unlocked === true
 			? transferUnlockedDomainStepsDefinition
-			: transferLockedDomainStepsDefinition;
+			: transferLockedDomainStepsDefinition
+	);
 
 	const currentStep = stepsDefinition[ currentStepName as StepNameValue ];
 	if ( ! currentStep ) {

--- a/client/dashboard/domains/domain-connection-setup/types.ts
+++ b/client/dashboard/domains/domain-connection-setup/types.ts
@@ -89,6 +89,7 @@ export type TransferStepComponentProps = {
 	mode: DomainConnectionSetupModeValue | null;
 	onNextStep: () => void;
 	inboundTransferStatusInfo?: DomainInboundTransferStatus;
+	siteId?: number;
 };
 
 export type TransferStepDefinition = {

--- a/client/dashboard/domains/domain-connection-setup/types.ts
+++ b/client/dashboard/domains/domain-connection-setup/types.ts
@@ -48,6 +48,7 @@ export const StepName = {
 	SUBDOMAIN_ADVANCED_UPDATE: 'subdomain_advanced_update',
 	SUBDOMAIN_ADVANCED_VERIFYING: 'subdomain_advanced_verifying',
 	SUBDOMAIN_ADVANCED_CONNECTED: 'subdomain_advanced_connected',
+	UNUSED_TRANSFER_DOMAIN_STEP: 'unused_transfer_domain_step',
 } as const;
 
 export type StepTypeValue = ( typeof StepType )[ keyof typeof StepType ];
@@ -69,12 +70,30 @@ export type StepComponentProps = {
 	queryError: string | null;
 	queryErrorDescription: string | null;
 	isOwnershipVerificationFlow: boolean;
-	inboundTransferStatusInfo?: DomainInboundTransferStatus;
 };
 
 export type StepDefinition = {
 	name?: string;
-	component: React.ComponentType< StepComponentProps >;
+	component: React.ComponentType< StepComponentProps > | null;
+	mode: DomainConnectionSetupModeValue;
+	stepType: StepTypeValue;
+	next?: StepNameValue;
+	prev?: StepNameValue;
+	singleColumnLayout?: boolean;
+};
+
+export type TransferStepComponentProps = {
+	domainName: string;
+	stepType: StepTypeValue;
+	stepName: StepNameValue;
+	mode: DomainConnectionSetupModeValue | null;
+	onNextStep: () => void;
+	inboundTransferStatusInfo?: DomainInboundTransferStatus;
+};
+
+export type TransferStepDefinition = {
+	name?: string;
+	component: React.ComponentType< TransferStepComponentProps > | null;
 	mode: DomainConnectionSetupModeValue;
 	stepType: StepTypeValue;
 	next?: StepNameValue;
@@ -85,6 +104,8 @@ export type StepDefinition = {
 export type ProgressStepList = Partial< Record< StepNameValue, string > >;
 
 export type DomainConnectionStepsMap = Partial< Record< StepNameValue, StepDefinition > >;
+
+export type DomainTransferStepsMap = Partial< Record< StepNameValue, TransferStepDefinition > >;
 
 export type DNSRecord = {
 	type: string;

--- a/client/dashboard/domains/domain-connection-setup/types.ts
+++ b/client/dashboard/domains/domain-connection-setup/types.ts
@@ -2,6 +2,7 @@ import {
 	type DomainConnectionSetupModeValue,
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
+	DomainInboundTransferStatus,
 } from '@automattic/api-core';
 
 export const StepType = {
@@ -68,6 +69,7 @@ export type StepComponentProps = {
 	queryError: string | null;
 	queryErrorDescription: string | null;
 	isOwnershipVerificationFlow: boolean;
+	inboundTransferStatusInfo?: DomainInboundTransferStatus;
 };
 
 export type StepDefinition = {

--- a/client/dashboard/domains/domain-connection-setup/utils.ts
+++ b/client/dashboard/domains/domain-connection-setup/utils.ts
@@ -13,6 +13,7 @@ import {
 	StepNameValue,
 	DomainConnectionStepsMap,
 	ProgressStepList,
+	DomainTransferStepsMap,
 } from './types';
 
 export const getStepName = (
@@ -28,7 +29,7 @@ export const getStepName = (
 
 export const getProgressStepList = (
 	mode: DomainConnectionSetupModeValue,
-	stepsDefinition: DomainConnectionStepsMap
+	stepsDefinition: DomainConnectionStepsMap | DomainTransferStepsMap
 ): ProgressStepList => {
 	const modeSteps = Object.fromEntries(
 		Object.entries( stepsDefinition ).filter(

--- a/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
+++ b/client/dashboard/domains/domain-overview/transferred-domain-details.tsx
@@ -1,13 +1,14 @@
 import { Domain, DomainTransferStatus } from '@automattic/api-core';
 import {
-	Button,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { domainTransferSetupRoute } from '../../app/router/domains';
 import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
 
 export default function TransferredDomainDetails( { domain }: { domain: Domain } ) {
 	const {
@@ -129,9 +130,13 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 		return (
 			// To do: add cta once we implemented the transfer flow
 			<HStack>
-				<Button variant="primary">
+				<RouterLinkButton
+					variant="primary"
+					to={ domainTransferSetupRoute.fullPath }
+					params={ { domainName: domain_name } }
+				>
 					{ last_transfer_error ? __( 'Restart Transfer' ) : __( 'Start Transfer' ) }
-				</Button>
+				</RouterLinkButton>
 			</HStack>
 		);
 	};
@@ -141,8 +146,7 @@ export default function TransferredDomainDetails( { domain }: { domain: Domain }
 		<Notice variant={ errorLevel ? 'error' : 'info' }>
 			<VStack spacing={ 4 }>
 				{ renderDescriptionText() }
-				{ /* To do: add cta once we implemented the transfer flow */ }
-				{ /* { renderStartTransferButton() } */ }
+				{ renderStartTransferButton() }
 			</VStack>
 		</Notice>
 	);

--- a/packages/api-core/src/domain-transfer/fetchers.ts
+++ b/packages/api-core/src/domain-transfer/fetchers.ts
@@ -1,0 +1,11 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { DomainInboundTransferStatus } from './types';
+
+export async function fetchDomainInboundTransferStatus(
+	domainName: string
+): Promise< DomainInboundTransferStatus > {
+	return await wpcom.req.get( {
+		path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-core/src/domain-transfer/fetchers.ts
+++ b/packages/api-core/src/domain-transfer/fetchers.ts
@@ -1,11 +1,24 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DomainInboundTransferStatus } from './types';
+import type { AuthCodeCheckResult, DomainInboundTransferStatus } from './types';
 
 export async function fetchDomainInboundTransferStatus(
 	domainName: string
 ): Promise< DomainInboundTransferStatus > {
 	return await wpcom.req.get( {
 		path: `/domains/${ encodeURIComponent( domainName ) }/inbound-transfer-status`,
-		apiVersion: '1.1',
 	} );
+}
+
+export async function checkDomainAuthCode(
+	domain: string,
+	authCode: string
+): Promise< AuthCodeCheckResult > {
+	return wpcom.req.get< AuthCodeCheckResult >(
+		{
+			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-check-auth-code`,
+		},
+		{
+			auth_code: authCode,
+		}
+	);
 }

--- a/packages/api-core/src/domain-transfer/index.ts
+++ b/packages/api-core/src/domain-transfer/index.ts
@@ -1,2 +1,3 @@
+export * from './fetchers';
 export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/domain-transfer/mutators.ts
+++ b/packages/api-core/src/domain-transfer/mutators.ts
@@ -106,3 +106,22 @@ export async function transferDomainToSite(
 		path: `/sites/${ siteId }/domains/${ domain }/transfer-to-site/${ targetSiteId }`,
 	} );
 }
+
+export async function startDomainInboundTransfer(
+	siteId: number,
+	domain: string,
+	authCode: string
+): Promise< void > {
+	if ( ! domain || ! siteId ) {
+		throw new Error( 'Missing siteId or domain' );
+	}
+
+	return wpcom.req.get(
+		{
+			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ siteId }`,
+		},
+		{
+			auth_code: authCode,
+		}
+	);
+}

--- a/packages/api-core/src/domain-transfer/types.ts
+++ b/packages/api-core/src/domain-transfer/types.ts
@@ -16,3 +16,8 @@ export type DomainInboundTransferStatus = {
 	transfer_restriction_status: string;
 	unlocked: boolean | null;
 };
+
+export type AuthCodeCheckResult = {
+	success: boolean;
+	error?: string;
+};

--- a/packages/api-core/src/domain-transfer/types.ts
+++ b/packages/api-core/src/domain-transfer/types.ts
@@ -3,3 +3,16 @@ export type IpsTag = {
 	registrarName: string;
 	registrarUrl: string;
 };
+
+export type DomainInboundTransferStatus = {
+	creation_date: string;
+	admin_email: string;
+	in_redemption: boolean;
+	registrar: string;
+	registrar_iana_id: string;
+	privacy: boolean;
+	term_maximum_in_years: number;
+	transfer_eligible_date: string;
+	transfer_restriction_status: string;
+	unlocked: boolean | null;
+};

--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -8,6 +8,7 @@ import {
 	deleteDomainTransferRequest,
 	domainTransferToUser,
 	transferDomainToSite,
+	fetchDomainInboundTransferStatus,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
@@ -87,4 +88,10 @@ export const transferDomainToSiteMutation = ( domain: string, siteId: number ) =
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainQuery( domain ) );
 		},
+	} );
+
+export const domainInboundTransferStatusQuery = ( domainName: string ) =>
+	queryOptions( {
+		queryKey: [ 'domains', domainName, 'inbound-transfer-status' ],
+		queryFn: () => fetchDomainInboundTransferStatus( domainName ),
 	} );


### PR DESCRIPTION
Part of [DOTDASH-344: Create the Use My Domain flow in the Hosting Dasboard](https://linear.app/a8c/issue/DOTDASH-344/create-the-use-my-domain-flow-in-the-hosting-dasboard)

## Proposed Changes

* Adds a new `domain-transfer-setup` route that would show the steps to initiate a pending start domain transfer

## Why are these changes being made?

* We plan on using the setup/domains flow when purchasing a domain for an existing site. One part of that would be domain transfers - we'll allow the customer to purchase the transfer first and then initiate the transfer by unlocking the domain and entering the auth code

## Testing Instructions

* For a domain that's in pending start state go to `/v2/domains/{domain_name}/domain-transfer-setup` and see if you can go through the flow and initiate the transfer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
