### PR TITLE
Hosting Dashboard: Keep the current path when switching the site.

### DIFF
--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet, notFound } from '@tanstack/react-router';
+import { Outlet, notFound, useLocation } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	MenuGroup,
@@ -33,6 +33,7 @@ function Site() {
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const location = useLocation();
 
 	if ( ! canManageSite( site ) ) {
 		throw notFound();
@@ -48,7 +49,16 @@ function Site() {
 							items={ sites }
 							value={ site }
 							getItemName={ getSiteDisplayName }
-							getItemUrl={ ( site ) => `/sites/${ site.slug }` }
+							getItemUrl={ ( site ) => {
+								const currentPath = location.pathname;
+								const sitePattern = `/sites/${ siteSlug }`;
+
+								if ( currentPath.includes( sitePattern ) ) {
+									return currentPath.replace( sitePattern, `/sites/${ site.slug }` );
+								}
+
+								return `/sites/${ site.slug }`;
+							} }
 							renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
 							open={ isSwitcherOpen }
 							onToggle={ setIsSwitcherOpen }


### PR DESCRIPTION
## Proposed Changes

Preserve the current location when you switch your site to avoid redirect back to the `/overview`.


## Why are these changes being made?

Currently, when you change your site in the site switcher, you are redirected to the `Overview`. 
This is counter-productive.

Reasons why you wouldn't want that experience:
- You choose the wrong site, navigate to a page.
- You are trying to compare two sites
  - Maybe you are looking at performance or monitoring. 


## Screenshot

### Before
https://github.com/user-attachments/assets/dd2818cd-dbea-4e6e-a024-0bd54925e83e

### After
https://github.com/user-attachments/assets/96e8486d-4b80-4d9c-8ecf-81a563f427cc

## Considerations
### What happens if the page doesn't exist for the site?

Currently, we expect to show all pages for all sites with upgrade notices, so there should be a page. For edge cases where there isn't a page, a 404 feels acceptable. 

Otherwise, an app-wide redirect makes more sense.


## Testing Instructions

1. On any page (excluding the overview).
2. Change your site using the site switcher.
3. Expect to be on the same page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
