### PR TITLE
Fixed button alignment and added Remove product to submit button

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -557,7 +557,7 @@ class CancelPurchaseForm extends Component {
 	}
 
 	renderStepButtons = () => {
-		const { translate, disableButtons } = this.props;
+		const { translate, disableButtons, purchase } = this.props;
 		const { isSubmitting, surveyStep, solution } = this.state;
 		const isCancelling = ( disableButtons || isSubmitting ) && ! solution;
 
@@ -591,7 +591,9 @@ class CancelPurchaseForm extends Component {
 						disabled={ ! this.canGoNext() }
 						onClick={ this.onSubmit }
 					>
-						{ translate( 'Submit' ) }
+						{ translate( 'Remove %(productName)s', {
+							args: { productName: purchase.productName || 'plan' },
+						} ) }
 					</GutenbergButton>
 					<GutenbergButton
 						isSecondary

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -454,10 +454,6 @@
 	}
 }
 
-.cancel-purchase-form__remove-plan-button {
-	margin-right: 1rem;
-}
-
 .cancel-purchase-form__notice-container {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
 Fixes https://linear.app/a8c/issue/CHE-246/fix-unclear-and-misaligned-buttons-in-partner-plan-removal-flow

## Proposed Changes
  * Update button text from generic "Submit" to specific "Remove {productName}" in plan cancellation flow
      *  reused existing translation: https://translate.wordpress.com/projects/wpcom/-all-translated/205472/
  * Fix button alignment by removing horizontal layout styling (margin-right)
  * These changes only affect the two-button layout that appears for agency partners or when skipRemovePlanSurvey=true

## Why are these changes being made?
The plan cancellation flow had two UX issues that created unnecessary friction:
  1. **Unclear button text**: The generic "Submit" button was confusing for users trying to cancel their plan, as it didn't clearly indicate what action would be performed.
  2. **Misaligned buttons**: The two buttons (Submit & Keep plan) were not aligned horizontally (different widths), creating a visual layout issue.

These improvements make the cancellation process clearer and more visually appealing, reducing user confusion during the sensitive plan removal flow.

## Testing Instructions
The two-button layout only appears in specific scenarios:
  - Agency partner purchases (`isPartnerPurchase && isAgencyPartnerType`)
  - When `skipRemovePlanSurvey=true` (user has completed survey before)

  ### Testing Method 1: Code Modification (Easiest)
  1. Temporarily modify `getAllSurveySteps()` in `client/components/marketing-survey/cancel-purchase-form/index.jsx`
  2. Add `return [ REMOVE_PLAN_STEP ];` at the beginning of the function
  3. Navigate to any plan purchase page and click "Remove plan"
  4. Verify the two-button layout shows correct text and alignment

  ### Testing Method 2: Browser DevTools
  1. Navigate to a plan purchase page and click "Remove plan"
  2. Open React DevTools → Components tab
  3. Find `CancelPurchaseForm` component
  4. Edit props: change `skipRemovePlanSurvey: false` to `skipRemovePlanSurvey: true`
  5. Verify the component re-renders with two-button layout

#### Expected Results

#####  Before:
  - Button text: "Submit"
  - Layout: Horizontal alignment with margin-right: 1rem
https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/62eb3821-9329-4c35-9412-a46ae6d977f5/791b39d2-b43f-489a-b61c-f39799136b9f


#####  After:
  - Button text: "Remove WordPress.com Premium" (or actual product name)
  - Layout: Vertical alignment with margin-bottom: 0.5rem
<img width="1310" height="777" alt="image" src="https://github.com/user-attachments/assets/1ebc300b-93e9-418f-94e4-5beccb5e0577" />
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/16973d3e-59c4-44ee-84af-73db5f25c352" />





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ x] Have you checked for TypeScript, React or other console errors?
- [ x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
