### PR TITLE
Hosting Dashboard: Minor issues fixes

### DIFF
--- a/client/dashboard/components/dataviews-card/index.tsx
+++ b/client/dashboard/components/dataviews-card/index.tsx
@@ -2,11 +2,11 @@ import { Card, CardBody } from '@wordpress/components';
 import { forwardRef } from 'react';
 
 function UnforwardedDataViewsCard(
-	{ children }: { children: React.ReactNode },
+	{ className, children }: { className?: string; children: React.ReactNode },
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
 	return (
-		<Card ref={ ref }>
+		<Card ref={ ref } className={ className }>
 			<CardBody>{ children }</CardBody>
 		</Card>
 	);

--- a/client/dashboard/domains/domain-connection-setup/steps/advanced-records.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/advanced-records.tsx
@@ -57,7 +57,7 @@ export function AdvancedRecords( {
 					<Text as="p">
 						{ isSubdomainFlow
 							? __( 'Update the A and CNAME records for your subdomain to point to WordPress.com.' )
-							: __( "Update your domain's A records and CNAME record to point to WordPress.com." ) }
+							: __( 'Update your domain’s A records and CNAME record to point to WordPress.com.' ) }
 					</Text>
 
 					<RecordsList records={ records } />

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -141,7 +141,7 @@ export default function DomainContactVerification() {
 					) }
 				</Text>
 				<ul>
-					<li>{ __( "Valid drivers' license" ) }</li>
+					<li>{ __( 'Valid drivers’ license' ) }</li>
 					<li>{ __( 'Valid national ID cards (for non-UK residents)' ) }</li>
 					<li>{ __( 'Utility bills (last 3 months)' ) }</li>
 					<li>{ __( 'Bank statement (last 3 months)' ) }</li>

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -73,30 +73,28 @@ function Emails() {
 
 	return (
 		<PageLayout header={ <PageHeader /> } notices={ <OptInWelcome tracksContext="emails" /> }>
-			<DataViewsCard>
-				<div className="emails__dataviews">
-					<DataViews
-						data={ filteredData }
-						isLoading={ isLoadingEmails || isLoadingSites || isLoadingDomains }
-						fields={ emailFields }
-						view={ view }
-						onChangeView={ setView }
-						selection={ selection.map( ( item ) => item.id ) }
-						onChangeSelection={ ( ids ) =>
-							setSelection( emails.filter( ( email ) => ids.includes( email.id ) ) )
-						}
-						actions={ actions }
-						defaultLayouts={ { table: {} } }
-						paginationInfo={ paginationInfo }
-						empty={
-							domainsWithoutEmails ? (
-								<NoEmailsAvailableEmptyState />
-							) : (
-								<NoDomainsAvailableEmptyState />
-							)
-						}
-					/>
-				</div>
+			<DataViewsCard className="emails__dataviews">
+				<DataViews
+					data={ filteredData }
+					isLoading={ isLoadingEmails || isLoadingSites || isLoadingDomains }
+					fields={ emailFields }
+					view={ view }
+					onChangeView={ setView }
+					selection={ selection.map( ( item ) => item.id ) }
+					onChangeSelection={ ( ids ) =>
+						setSelection( emails.filter( ( email ) => ids.includes( email.id ) ) )
+					}
+					actions={ actions }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ paginationInfo }
+					empty={
+						domainsWithoutEmails ? (
+							<NoEmailsAvailableEmptyState />
+						) : (
+							<NoDomainsAvailableEmptyState />
+						)
+					}
+				/>
 			</DataViewsCard>
 		</PageLayout>
 	);

--- a/client/dashboard/emails/resources/email-empty-illustration.tsx
+++ b/client/dashboard/emails/resources/email-empty-illustration.tsx
@@ -33,8 +33,8 @@ export default function EmailEmptyIllustration() {
 					y2="139.373"
 					gradientUnits="userSpaceOnUse"
 				>
-					<stop stop-color="#3858E9" />
-					<stop offset="1" stop-color="#069E08" />
+					<stop stopColor="#3858E9" />
+					<stop offset="1" stopColor="#069E08" />
 				</linearGradient>
 				<image
 					id="image0_213_6195"

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -282,7 +282,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 		return (
 			<ActionList.ActionItem
 				title={ __( 'Downgrade or cancel your subscription' ) }
-				description={ __( "We'll be sorry to see you go!" ) }
+				description={ __( 'We’ll be sorry to see you go!' ) }
 				actions={
 					<Button
 						variant="secondary"
@@ -301,7 +301,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 		return (
 			<ActionList.ActionItem
 				title={ __( 'Remove subscription' ) }
-				description={ __( "We'll be sorry to see you go!" ) }
+				description={ __( 'We’ll be sorry to see you go!' ) }
 				actions={
 					<Button
 						variant="secondary"

--- a/client/dashboard/me/profile-deletion/alternatives-modal.tsx
+++ b/client/dashboard/me/profile-deletion/alternatives-modal.tsx
@@ -34,7 +34,7 @@ export default function AlternativesModal( {
 		...( siteCount > 0
 			? [
 					{
-						text: __( "Change your site's address" ),
+						text: __( 'Change your site’s address' ),
 						to: '/domains',
 						supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
 					},
@@ -67,7 +67,7 @@ export default function AlternativesModal( {
 		<Modal title={ __( 'Are you sure?' ) } onRequestClose={ onClose }>
 			<VStack spacing={ 6 }>
 				<Text>
-					{ __( "Here's a few options to try before you permanently delete your account." ) }
+					{ __( 'Here’s a few options to try before you permanently delete your account.' ) }
 				</Text>
 				<ActionList>
 					{ alternativeOptions.map( ( option ) => (

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -126,11 +126,13 @@ export default function PluginsScheduledUpdates() {
 					onChangeView={ setView }
 					isLoading={ isLoading }
 					empty={
-						scheduledUpdates.length === 0
-							? __( 'No scheduled updates yet.' )
-							: __(
-									"We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
-							  )
+						<p>
+							{ scheduledUpdates.length === 0
+								? __( 'No scheduled updates yet.' )
+								: __(
+										'We couldn’t find any schedules based on your search criteria. You might want to check your search terms and try again.'
+								  ) }
+						</p>
 					}
 					actions={ [
 						{

--- a/client/dashboard/sites/settings-repositories/advanced-workflow-validation.tsx
+++ b/client/dashboard/sites/settings-repositories/advanced-workflow-validation.tsx
@@ -51,7 +51,7 @@ export const AdvancedWorkflowValidation = ( {
 			},
 			upload_artifact_with_required_name: {
 				label: __( 'The uploaded artifact has the required name' ),
-				description: __( "Ensure that your workflow uploads an artifact named 'wpcom'. Example:" ),
+				description: __( 'Ensure that your workflow uploads an artifact named ‘wpcom’. Example:' ),
 				content: uploadArtifactExample(),
 			},
 		};

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -73,6 +73,7 @@ const RepositorySelector = ( {
 			</HStack>
 			<ComboboxControl
 				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 				allowReset
 				value={ currentValue === '' ? '' : currentValue?.toString() || '' }
 				onChange={ ( value ) => {
@@ -113,6 +114,7 @@ const GitHubAccountSelector = ( {
 			</HStack>
 			<SelectControl
 				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 				aria-label={ __( 'GitHub account' ) }
 				value={ getValue?.( { item: data } ) }
 				onChange={ ( value ) => {
@@ -139,6 +141,7 @@ const AutomatedToggle = ( {
 
 	return (
 		<ToggleControl
+			__nextHasNoMarginBottom
 			label={ hideLabelFromVision ? '' : field.label }
 			checked={ currentValue }
 			onChange={ ( value ) => onChange( { [ id ]: value } ) }


### PR DESCRIPTION
## Proposed Changes

Fixes: 
- Add support to className props to DataViewsCard
- Fixes SVG prop name in tsx
- Fixes warning due to lack of  __nextHasNoMarginBottom
- Ensure usage of curly quotes
- Ensure DataViews empty state message is wrapped in <p> 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
