### PR TITLE
Hosting Dashboard: refactor opt-in data form to remove the hacky "description field"

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -27,14 +27,8 @@ interface OptInFormData {
 const form = {
 	layout: {
 		type: 'regular' as const,
-		labelPosition: 'top' as const,
 	},
-	fields: [
-		{
-			id: 'optInForm',
-			children: [ 'description', 'enabled' ],
-		},
-	],
+	fields: [ 'enabled' ],
 };
 
 const fields: Field< OptInFormData >[] = [
@@ -53,16 +47,6 @@ const fields: Field< OptInFormData >[] = [
 				/>
 			);
 		},
-	},
-	{
-		id: 'description',
-		Edit: () => (
-			<Text as="p" variant="muted">
-				{ __(
-					'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
-				) }
-			</Text>
-		),
 	},
 ];
 
@@ -121,6 +105,11 @@ export default function PreferencesLanguageForm() {
 			<CardBody>
 				<VStack as="form" onSubmit={ handleSubmit } spacing={ 3 } alignment="flex-start">
 					<SectionHeader title={ __( 'Try the new Hosting Dashboard' ) } level={ 3 } />
+					<Text as="p" variant="muted">
+						{ __(
+							'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
+						) }
+					</Text>
 					<DataForm< OptInFormData >
 						data={ formData }
 						fields={ fields }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/106214 fixed the opt-in form's title so it no longer depends on dataform label. That means the hack that was being used to render the form description as if it were a field is no longer necessary.

This makes the padding between form elements slightly smaller. 12px to 16px. But it is in keeping with the other forms on this preferences page.

**Before**

<img width="1376" height="596" alt="CleanShot 2025-10-03 at 15 00 35@2x" src="https://github.com/user-attachments/assets/4fbccde2-2b33-4697-9510-ab3a797b34f3" />


**After**

<img width="1362" height="622" alt="CleanShot 2025-10-03 at 15 00 42@2x" src="https://github.com/user-attachments/assets/50c89e66-0fb2-4408-9395-22eb9966fe10" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
