### PR TITLE
Dashboard v2: fix upsellDescription nested texts

### DIFF
--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -16,7 +16,6 @@ import { siteRoute, siteBackupsIndexRoute, siteBackupDetailRoute } from '../../a
 import { DateRangePicker } from '../../components/date-range-picker';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { Text } from '../../components/text';
 import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import { BackupDetails } from './backup-details';
@@ -271,13 +270,9 @@ function SiteBackups() {
 			upsellIcon={ backup }
 			upsellTitle={ __( 'Secure your content with Jetpack Backups' ) }
 			upsellImage={ illustrationUrl }
-			upsellDescription={
-				<Text as="p" variant="muted">
-					{ __(
-						'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
-					) }
-				</Text>
-			}
+			upsellDescription={ __(
+				'Protect your site with scheduled and real-time backups—giving you the ultimate “undo” button and peace of mind that your content is always safe.'
+			) }
 		>
 			<FileBrowserProvider locale={ locale } notices={ hostingNotices }>
 				<Outlet />

--- a/client/dashboard/sites/deployments/deployments-callout.tsx
+++ b/client/dashboard/sites/deployments/deployments-callout.tsx
@@ -1,4 +1,3 @@
-import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './deployments-callout-illustration.svg';
@@ -11,12 +10,8 @@ export function getDeploymentsCalloutProps() {
 		upsellIcon: <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } />,
 		upsellTitle: __( 'Deploy from GitHub' ),
 		upsellImage: illustrationUrl,
-		upsellDescription: (
-			<Text as="p" variant="muted">
-				{ __(
-					'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
-				) }
-			</Text>
+		upsellDescription: __(
+			'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
 		),
 	};
 }

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -3,6 +3,7 @@ import { __experimentalText as Text } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import React from 'react';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import illustrationUrl from './upsell-illustration.svg';
@@ -62,7 +63,11 @@ export default function UpsellCallout( {
 			titleAs={ upsellTitleAs }
 			description={
 				<>
-					<Text variant="muted">{ upsellDescription ?? defaultProps.description }</Text>
+					{ React.isValidElement( upsellDescription ) ? (
+						upsellDescription
+					) : (
+						<Text variant="muted">{ upsellDescription ?? defaultProps.description }</Text>
+					) }
 					<Text variant="muted">
 						{ sprintf(
 							// translators: %(businessPlanName)s is the name of the Business plan, %(commercePlanName)s is the name of the Commerce plan

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -18,7 +18,6 @@ export function getActivityLogsCalloutProps() {
 						'Debug issues faster with insights from a comprehensive audit log of all your admin activities.'
 					) }
 				</Text>
-				<br />
 				<Text as="p" variant="muted">
 					{ __(
 						'With your free plan, you can see your 20 most recent events. Upgrade for 30 days of history, plus filtering and date range controls.'

--- a/client/dashboard/sites/logs/logs-callout.tsx
+++ b/client/dashboard/sites/logs/logs-callout.tsx
@@ -1,4 +1,3 @@
-import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
@@ -11,12 +10,8 @@ export function getLogsCalloutProps() {
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Access detailed logs' ),
 		upsellImage: illustrationUrl,
-		upsellDescription: (
-			<Text as="p" variant="muted">
-				{ __(
-					'Quickly identify and fix issues before they impact your visitors with full visibility into your site‘s web server logs and PHP errors.'
-				) }
-			</Text>
+		upsellDescription: __(
+			'Quickly identify and fix issues before they impact your visitors with full visibility into your site‘s web server logs and PHP errors.'
 		),
 	};
 }

--- a/client/dashboard/sites/monitoring/monitoring-callout.tsx
+++ b/client/dashboard/sites/monitoring/monitoring-callout.tsx
@@ -1,4 +1,3 @@
-import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
@@ -11,12 +10,8 @@ export function getMonitoringCalloutProps() {
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Monitor server stats' ),
 		upsellImage: illustrationUrl,
-		upsellDescription: (
-			<Text as="p" variant="muted">
-				{ __(
-					'Track how your server responds to traffic, identify performance bottlenecks, and investigate error spikes to keep your site running smoothly.'
-				) }
-			</Text>
+		upsellDescription: __(
+			'Track how your server responds to traffic, identify performance bottlenecks, and investigate error spikes to keep your site running smoothly.'
 		),
 	};
 }

--- a/client/dashboard/sites/performance/performance-callout.tsx
+++ b/client/dashboard/sites/performance/performance-callout.tsx
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
-import { Text } from '../../components/text';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './performance-callout-illustration.svg';
 import type { Site } from '@automattic/api-core';
@@ -11,12 +10,8 @@ export function getPerformanceCalloutProps() {
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Optimize your site’s performance' ),
 		upsellImage: illustrationUrl,
-		upsellDescription: (
-			<Text as="p" variant="muted">
-				{ __(
-					'Make smarter decisions, boost speed and engagement, and see how your site‘s performing with key metrics and contextual insights.'
-				) }
-			</Text>
+		upsellDescription: __(
+			'Make smarter decisions, boost speed and engagement, and see how your site‘s performing with key metrics and contextual insights.'
 		),
 	};
 }

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -2,15 +2,7 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import {
-	Button,
-	Modal,
-	TabPanel,
-	Card,
-	CardHeader,
-	CardBody,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, Modal, TabPanel, Card, CardHeader, CardBody } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { shield } from '@wordpress/icons';
 import { useState } from 'react';
@@ -105,13 +97,9 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 			upsellIcon={ shield }
 			upsellTitle={ __( 'Scan for security threats' ) }
 			upsellImage={ illustrationUrl }
-			upsellDescription={
-				<Text as="p" variant="muted">
-					{ __(
-						'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
-					) }
-				</Text>
-			}
+			upsellDescription={ __(
+				'Automated daily scans check for malware and security vulnerabilities, with automated fixes for most issues.'
+			) }
 		>
 			<PageLayout
 				header={

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -2,7 +2,7 @@ import { CodeDeploymentData, HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, codeDeploymentsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -141,15 +141,9 @@ function SiteRepositories() {
 				upsellIcon={ <img src={ ghIconUrl } alt={ __( 'GitHub logo' ) } /> }
 				upsellImage={ illustrationUrl }
 				upsellTitle={ __( 'Deploy from GitHub' ) }
-				upsellDescription={
-					<>
-						<Text as="p" variant="muted">
-							{ __(
-								'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
-							) }
-						</Text>
-					</>
-				}
+				upsellDescription={ __(
+					'Connect your GitHub repo directly to your WordPress.com site—with seamless integration, straightforward version control, and automated workflows.'
+				) }
 			>
 				<RepositoriesList />
 			</HostingFeatureGatedWithCallout>


### PR DESCRIPTION

## Proposed Changes

In dashboard v2, the hosting callout component has undergone multiple refactors. We missed the fact that `upsellDescription` will be already rendered inside `<Text>`, so components that are passing `<Text>` will have it nested, which is invalid.

An exception is for Activity Log callout which have 2 paragraphs for the description. To support this, we keep it as ReactElement, and will render it as-is.

## Why are these changes being made?

Hosting Dashboard cleanup / sweeping

## Testing Instructions

1. Go to /v2/sites/:slug of a FREE site
2. Click the hosting features tabs; verify they render the callouts correctly (no visual changes)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
