### PR TITLE
Dashboard v2: Keep the current path when switching either site or domain

### DIFF
--- a/client/dashboard/app/hooks/use-build-current-route-link.ts
+++ b/client/dashboard/app/hooks/use-build-current-route-link.ts
@@ -1,0 +1,28 @@
+import { useRouter, useMatches } from '@tanstack/react-router';
+import { useCallback } from 'react';
+import type { ToOptions } from '@tanstack/react-router';
+
+const useBuildCurrentRouteLink = () => {
+	const router = useRouter();
+	const matches = useMatches();
+	const lastMatch = matches[ matches.length - 1 ];
+
+	return useCallback(
+		( options: ToOptions ) => {
+			return router.buildLocation( {
+				to: lastMatch.fullPath,
+				params: {
+					...lastMatch.params,
+					...options.params,
+				},
+				search: {
+					...lastMatch.search,
+					...options.search,
+				},
+			} ).href;
+		},
+		[ router, lastMatch ]
+	);
+};
+
+export default useBuildCurrentRouteLink;

--- a/client/dashboard/app/hooks/use-build-current-route-link.ts
+++ b/client/dashboard/app/hooks/use-build-current-route-link.ts
@@ -15,10 +15,6 @@ const useBuildCurrentRouteLink = () => {
 					...lastMatch.params,
 					...options.params,
 				},
-				search: {
-					...lastMatch.search,
-					...options.search,
-				},
 			} ).href;
 		},
 		[ router, lastMatch ]

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -4,6 +4,7 @@ import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { globe } from '@wordpress/icons';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
@@ -17,6 +18,7 @@ function Domain() {
 	const { domainName } = domainRoute.useParams();
 	const domains = useQuery( domainsQuery() ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	return (
 		<>
@@ -27,7 +29,9 @@ function Domain() {
 							items={ domains }
 							value={ domain }
 							getItemName={ ( domain ) => domain.domain }
-							getItemUrl={ ( domain ) => `/domains/${ domain.domain }` }
+							getItemUrl={ ( domain ) =>
+								buildCurrentRouteLink( { params: { domainName: domain.domain } } )
+							}
 							renderItemIcon={ ( { context } ) =>
 								context === 'list' ? null : (
 									<Icon className="domain-icon" icon={ globe } size={ 24 } />

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -26,6 +26,7 @@ import { Icon, chevronDownSmall, plus } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import Environment from '../../components/environment';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import {
@@ -94,6 +95,8 @@ const EnvironmentSwitcherDropdown = ( {
 	isStagingSiteDeleting: boolean;
 	isStagingSiteCreating: boolean;
 } ) => {
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
 	// TODO: Handle upsell.
 	const handleUpsell = () => {};
 
@@ -112,12 +115,18 @@ const EnvironmentSwitcherDropdown = ( {
 		<NavigableMenu>
 			<MenuGroup>
 				{ productionSite && canManageSite( productionSite ) && (
-					<RouterLinkMenuItem to={ `/sites/${ productionSite.slug }` } onClick={ onClose }>
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: productionSite.slug } } ) }
+						onClick={ onClose }
+					>
 						<Environment environmentType="production" />
 					</RouterLinkMenuItem>
 				) }
 				{ showStagingSite && (
-					<RouterLinkMenuItem to={ `/sites/${ stagingSite.slug }` } onClick={ onClose }>
+					<RouterLinkMenuItem
+						to={ buildCurrentRouteLink( { params: { siteSlug: stagingSite.slug } } ) }
+						onClick={ onClose }
+					>
 						<Environment environmentType="staging" />
 					</RouterLinkMenuItem>
 				) }

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet, notFound, useLocation } from '@tanstack/react-router';
+import { Outlet, notFound } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	MenuGroup,
@@ -12,6 +12,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
 import HeaderBar from '../../components/header-bar';
@@ -33,7 +34,7 @@ function Site() {
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const location = useLocation();
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	if ( ! canManageSite( site ) ) {
 		throw notFound();
@@ -49,16 +50,9 @@ function Site() {
 							items={ sites }
 							value={ site }
 							getItemName={ getSiteDisplayName }
-							getItemUrl={ ( site ) => {
-								const currentPath = location.pathname;
-								const sitePattern = `/sites/${ siteSlug }`;
-
-								if ( currentPath.includes( sitePattern ) ) {
-									return currentPath.replace( sitePattern, `/sites/${ site.slug }` );
-								}
-
-								return `/sites/${ site.slug }`;
-							} }
+							getItemUrl={ ( site ) =>
+								buildCurrentRouteLink( { params: { siteSlug: site.slug } } )
+							}
 							renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
 							open={ isSwitcherOpen }
 							onToggle={ setIsSwitcherOpen }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106228

## Proposed Changes

* Added `useBuildCurrentRouteLink` to return the function to build the link based on the current route and given parameters. The `search` parameter may cause some issues, e.g.: the page_id is not supported on other sites. As a result, don't keep it during the switch.
* Kept the current path when switching either site or domain
* Fix the performance data won't be updated when the site changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Select any site
* Switch to different tabs, e.g. Performance
* Switch to different site
* Ensure the current path is kept and the data is updated
* Go to /v2/domains
* Select any domain > any settings
* Switch to different domain
* Ensure the current path is kept and the data is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
