### PR TITLE
Staging Sites: Disable `Cancel` button in both Sync modals during sync mutation

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -582,7 +582,11 @@ function StagingSiteSyncModalInner( {
 						</HStack>
 
 						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ handleClose }>
+							<Button
+								variant="tertiary"
+								onClick={ handleClose }
+								disabled={ pullMutation.isPending || pushMutation.isPending }
+							>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -621,7 +621,11 @@ function SyncModal( {
 						</HStack>
 
 						<HStack justify="flex-end" spacing={ 4 }>
-							<Button variant="tertiary" onClick={ handleClose }>
+							<Button
+								variant="tertiary"
+								onClick={ handleClose }
+								disabled={ pullMutation.isPending || pushMutation.isPending }
+							>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-14869

## Proposed Changes

* disable `Cancel` button in both Sync modals during staging site sync mutation

https://github.com/user-attachments/assets/3b5725f0-c7e8-4177-a69d-6db0ca311560

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As user clicks the `Push` / `Pull` button on one of the Sync modals, this button goes into the busy state while the mutation is pending. This PR disables the `Cancel` button during the same time to prevent any confusion that the initiated sync could still be cancelled.

This change also ensures the `Cancel` button behaves in the same way as other existing modals (Delete site and Delete Staging site).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. Head over to the V2 dashboard and create a staging site.
3. Initiate staging site sync and observe the `Cancel` button. It should get disabled as soon as the `Push` / `Pull` button is clicked.
4. Navigate to the V1 dashboard and initiate the sync again. The `Cancel` button should behave in the same way as in V2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
