### PR TITLE
Performance v2: Implement PerformanceInsightTable

### DIFF
--- a/client/dashboard/sites/performance/performance-insight-screenshot.tsx
+++ b/client/dashboard/sites/performance/performance-insight-screenshot.tsx
@@ -1,0 +1,242 @@
+/**
+ * This file is a react port of the Lighthouse element screenshot renderer.
+ * The original code is available at https://github.com/GoogleChrome/lighthouse/blob/main/report/renderer/element-screenshot-renderer.js
+ *
+ * These functions define {Rect}s and {Size}s using two different coordinate spaces:
+ *   1. Screenshot coords (SC suffix): where 0,0 is the top left of the screenshot image
+ *   2. Display coords (DC suffix): that match the CSS pixel coordinate space of the LH report's page.
+ */
+
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+
+type Size = {
+	width: number;
+	height: number;
+};
+
+type Rect = Size & {
+	left: number;
+	top: number;
+};
+
+type InsightScreenshotProps = {
+	nodeId: string;
+	screenshot: {
+		data: string;
+		width: number;
+		height: number;
+	};
+	elementRectSC: Rect;
+	maxRenderSizeDC: Size;
+};
+
+const computeZoomFactor = ( elementRectSC: Size, renderContainerSizeDC: Size ) => {
+	const targetClipToViewportRatio = 0.75;
+	const zoomRatioXY = {
+		x: renderContainerSizeDC.width / elementRectSC.width,
+		y: renderContainerSizeDC.height / elementRectSC.height,
+	};
+	const zoomFactor = targetClipToViewportRatio * Math.min( zoomRatioXY.x, zoomRatioXY.y );
+	return Math.min( 1, zoomFactor );
+};
+
+const clamp = ( value: number, min: number, max: number ) => {
+	if ( value < min ) {
+		return min;
+	}
+	if ( value > max ) {
+		return max;
+	}
+	return value;
+};
+
+function getElementRectCenterPoint( rect: Rect ) {
+	return {
+		x: rect.left + rect.width / 2,
+		y: rect.top + rect.height / 2,
+	};
+}
+
+const getScreenshotPositions = (
+	elementRectSC: Rect,
+	elementPreviewSizeSC: Size,
+	screenshotSize: Size
+) => {
+	const elementRectCenter = getElementRectCenterPoint( elementRectSC );
+
+	// Try to center clipped region.
+	const screenshotLeftVisibleEdge = clamp(
+		elementRectCenter.x - elementPreviewSizeSC.width / 2,
+		0,
+		screenshotSize.width - elementPreviewSizeSC.width
+	);
+	const screenshotTopVisisbleEdge = clamp(
+		elementRectCenter.y - elementPreviewSizeSC.height / 2,
+		0,
+		screenshotSize.height - elementPreviewSizeSC.height
+	);
+
+	return {
+		screenshot: {
+			left: screenshotLeftVisibleEdge,
+			top: screenshotTopVisisbleEdge,
+		},
+		clip: {
+			left: elementRectSC.left - screenshotLeftVisibleEdge,
+			top: elementRectSC.top - screenshotTopVisisbleEdge,
+		},
+	};
+};
+
+const renderClipPathInScreenshot = (
+	clipId: string,
+	positionClip: { top: number; left: number },
+	elementRect: Size,
+	elementPreviewSize: Size
+) => {
+	// Normalize values between 0-1.
+	const top = positionClip.top / elementPreviewSize.height;
+	const bottom = top + elementRect.height / elementPreviewSize.height;
+	const left = positionClip.left / elementPreviewSize.width;
+	const right = left + elementRect.width / elementPreviewSize.width;
+
+	const polygonsPoints = [
+		`0,0             1,0            1,${ top }          0,${ top }`,
+		`0,${ bottom }     1,${ bottom }    1,1               0,1`,
+		`0,${ top }        ${ left },${ top } ${ left },${ bottom } 0,${ bottom }`,
+		`${ right },${ top } 1,${ top }       1,${ bottom }       ${ right },${ bottom }`,
+	];
+
+	return (
+		<svg style={ { width: 0, height: 0 } }>
+			<defs>
+				<clipPath clipPathUnits="objectBoundingBox" id={ clipId }>
+					{ polygonsPoints.map( ( points, i ) => (
+						<polygon key={ i } points={ points } />
+					) ) }
+				</clipPath>
+			</defs>
+		</svg>
+	);
+};
+
+export const InsightScreenshot = ( {
+	nodeId,
+	screenshot,
+	elementRectSC,
+	maxRenderSizeDC,
+}: InsightScreenshotProps ) => {
+	const zoomFactor = computeZoomFactor( elementRectSC, maxRenderSizeDC );
+
+	const elementPreviewSizeSC = {
+		width: maxRenderSizeDC.width / zoomFactor,
+		height: maxRenderSizeDC.height / zoomFactor,
+	};
+
+	elementPreviewSizeSC.width = Math.min( screenshot.width, elementPreviewSizeSC.width );
+	elementPreviewSizeSC.height = Math.min( screenshot.height, elementPreviewSizeSC.height );
+
+	/* This preview size is either the size of the thumbnail or size of the Lightbox */
+	const elementPreviewSizeDC = {
+		width: elementPreviewSizeSC.width * zoomFactor,
+		height: elementPreviewSizeSC.height * zoomFactor,
+	};
+
+	const positions = getScreenshotPositions( elementRectSC, elementPreviewSizeSC, {
+		width: screenshot.width,
+		height: screenshot.height,
+	} );
+
+	return (
+		<div
+			aria-hidden="true"
+			style={ {
+				position: 'relative',
+				backgroundImage: `url(${ screenshot.data })`,
+				width: elementPreviewSizeDC.width + 'px',
+				height: elementPreviewSizeDC.height + 'px',
+				backgroundPositionY: -( positions.screenshot.top * zoomFactor ) + 'px',
+				backgroundPositionX: -( positions.screenshot.left * zoomFactor ) + 'px',
+				backgroundSize: `${ screenshot.width * zoomFactor }px ${
+					screenshot.height * zoomFactor
+				}px`,
+			} }
+		>
+			<div
+				style={ {
+					position: 'absolute',
+					width: elementPreviewSizeDC.width + 'px',
+					height: elementPreviewSizeDC.height + 'px',
+					clipPath: `url(#${ nodeId })`,
+					background: '#50575e',
+					opacity: 0.8,
+				} }
+			>
+				{ renderClipPathInScreenshot(
+					nodeId,
+					positions.clip,
+					elementRectSC,
+					elementPreviewSizeSC
+				) }
+			</div>
+			<div
+				style={ {
+					position: 'absolute',
+					width: clamp( elementRectSC.width * zoomFactor, 0, elementPreviewSizeDC.width ) + 'px',
+					height: clamp( elementRectSC.height * zoomFactor, 0, elementPreviewSizeDC.height ) + 'px',
+					left: clamp( positions.clip.left * zoomFactor, 0, elementPreviewSizeDC.width ) + 'px',
+					top: clamp( positions.clip.top * zoomFactor, 0, elementPreviewSizeDC.height ) + 'px',
+					border: '2px solid #f0c930',
+				} }
+			></div>
+		</div>
+	);
+};
+
+export const InsightScreenshotWithOverlay = ( {
+	nodeId,
+	screenshot,
+	elementRectSC,
+	maxRenderSizeDC,
+}: InsightScreenshotProps ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const maxLightboxSize = {
+		width: window.innerWidth * 0.95,
+		height: window.innerHeight * 0.8,
+	};
+
+	return (
+		<>
+			<Button
+				variant="link"
+				aria-label={ __( 'View screenshot' ) }
+				onClick={ () => setIsOpen( true ) }
+			>
+				<InsightScreenshot
+					nodeId={ nodeId }
+					screenshot={ screenshot }
+					elementRectSC={ elementRectSC }
+					maxRenderSizeDC={ maxRenderSizeDC }
+				/>
+			</Button>
+			{ isOpen && (
+				<Modal
+					__experimentalHideHeader
+					onRequestClose={ () => setIsOpen( false ) }
+					contentLabel={ __( 'Screenshot preview' ) }
+					className="performance-profiler-insight-screenshot__overlay"
+				>
+					<InsightScreenshot
+						nodeId={ nodeId + '-overlay' }
+						screenshot={ screenshot }
+						elementRectSC={ elementRectSC }
+						maxRenderSizeDC={ maxLightboxSize }
+					/>
+				</Modal>
+			) }
+		</>
+	);
+};

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -1,5 +1,4 @@
 import { DataViews } from '@wordpress/dataviews';
-import { __, sprintf } from '@wordpress/i18n';
 import Markdown from 'react-markdown';
 import { Text } from '../../components/text';
 import { getFormattedNumber, getFormattedSize } from '../../utils/site-performance';
@@ -89,12 +88,11 @@ const PerformanceInsightTable = ( {
 				switch ( valueType ) {
 					case 'ms':
 					case 'timespanMs':
-						// translators: %(ms)d is the value to be displayed in milliseconds.
-						return sprintf( __( '%(ms)dms' ), { ms: getFormattedNumber( value ) } );
+						return `${ getFormattedNumber( value ) }ms`;
 					case 'bytes':
 						return getFormattedSize( Number( value ) || 0 );
 					case 'numeric':
-						return getFormattedNumber( value, 2 );
+						return getFormattedNumber( value );
 					case 'link':
 						return <Markdown>{ value.toString() }</Markdown>;
 					case 'score':

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -1,9 +1,9 @@
 import { DataViews } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import Markdown from 'react-markdown';
-import { InsightScreenshotWithOverlay } from 'calypso/performance-profiler/components/metrics-insight/insight-screenshot'; // eslint-disable-line
 import { Text } from '../../components/text';
 import { getFormattedNumber, getFormattedSize } from '../../utils/site-performance';
+import { InsightScreenshotWithOverlay } from './performance-insight-screenshot';
 import type {
 	PerformanceMetricsDetailsQueryResponse,
 	PerformanceMetricsDetailsItem,

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -1,0 +1,150 @@
+import { DataViews } from '@wordpress/dataviews';
+import { __, sprintf } from '@wordpress/i18n';
+import Markdown from 'react-markdown';
+import { InsightScreenshotWithOverlay } from 'calypso/performance-profiler/components/metrics-insight/insight-screenshot'; // eslint-disable-line
+import { Text } from '../../components/text';
+import { getFormattedNumber, getFormattedSize } from '../../utils/site-performance';
+import type {
+	PerformanceMetricsDetailsQueryResponse,
+	PerformanceMetricsDetailsItem,
+} from './types';
+import type { SitePerformanceReport } from '@automattic/api-core';
+
+const renderNode = (
+	data: { [ key: string ]: any },
+	fullPageScreenshot: SitePerformanceReport[ 'fullPageScreenshot' ]
+) => {
+	const rect = data.boundingRect;
+
+	if ( fullPageScreenshot && rect && rect.width !== 0 && rect.height !== 0 ) {
+		const maxThumbnailSize = { width: 147, height: 100 };
+		return (
+			<InsightScreenshotWithOverlay
+				nodeId={ data.lhId }
+				screenshot={ fullPageScreenshot.screenshot }
+				elementRectSC={ rect }
+				maxRenderSizeDC={ maxThumbnailSize }
+			/>
+		);
+	}
+	return (
+		<div>
+			<p>{ data?.nodeLabel }</p>
+			<code>{ data?.snippet }</code>
+		</div>
+	);
+};
+
+const PerformanceInsightTable = ( {
+	details,
+	fullPageScreenshot,
+}: {
+	details: PerformanceMetricsDetailsQueryResponse;
+	fullPageScreenshot: SitePerformanceReport[ 'fullPageScreenshot' ];
+} ) => {
+	const { headings = [], items = [] } = details ?? {};
+	const fields = headings.map( ( heading ) => ( {
+		id: heading.key,
+		label: heading.label,
+		enableSorting: false,
+		enableHiding: false,
+		render: ( { item }: { item: PerformanceMetricsDetailsItem } ) => {
+			const value =
+				heading.subItemsHeading && item.__isSubItem
+					? item[ heading.subItemsHeading.key ]
+					: item[ heading.key ];
+
+			const valueType =
+				heading.subItemsHeading && item.__isSubItem
+					? heading.subItemsHeading.valueType ?? heading.valueType
+					: heading.valueType;
+
+			if ( typeof value === 'object' ) {
+				switch ( value?.type ) {
+					case 'node':
+						return renderNode( value, fullPageScreenshot );
+
+					case 'code':
+						return (
+							<div>
+								<pre>
+									<code>{ value?.value }</code>
+								</pre>
+							</div>
+						);
+					case 'numeric':
+						return getFormattedNumber( value.value );
+					case 'url':
+					case 'source-location':
+						if ( typeof value.location === 'object' ) {
+							return [ value.location.url, value.location.line, value.location.column ].join( ':' );
+						}
+						return value?.url;
+				}
+
+				return value?.value;
+			}
+
+			if ( typeof value === 'string' || typeof value === 'number' ) {
+				switch ( valueType ) {
+					case 'ms':
+					case 'timespanMs':
+						// translators: %(ms)d is the value to be displayed in milliseconds.
+						return sprintf( __( '%(ms)dms' ), { ms: getFormattedNumber( value ) } );
+					case 'bytes':
+						return getFormattedSize( Number( value ) || 0 );
+					case 'numeric':
+						return getFormattedNumber( value, 2 );
+					case 'link':
+						return <Markdown>{ value.toString() }</Markdown>;
+					case 'score':
+						return <Text intent={ Number( value ) > 6 ? 'error' : 'warning' }>{ value }</Text>;
+					default:
+						return <span style={ { wordBreak: 'break-all' } }>{ value }</span>;
+				}
+			}
+			return value;
+		},
+	} ) );
+
+	const view = {
+		fields: fields.map( ( field ) => field.id ),
+		type: 'table' as const,
+		groupByField: details.isEntityGrouped ? 'entity' : undefined,
+		layout: {
+			enableMoving: false,
+		},
+	};
+
+	return (
+		<DataViews< PerformanceMetricsDetailsItem & { id: string; __isSubItem?: boolean } >
+			data={
+				details.isEntityGrouped
+					? items
+							.map( ( item, i ) => [
+								{
+									...item,
+									id: `${ i }`,
+								},
+								...( item.subItems?.items ?? [] ).map( ( subItem, j ) => ( {
+									...subItem,
+									id: `${ item.entity }- ${ j }`,
+									entity: item.entity,
+									__isSubItem: true,
+								} ) ),
+							] )
+							.flat()
+					: items.map( ( item, i ) => ( { ...item, id: `${ i }` } ) )
+			}
+			fields={ fields }
+			view={ view }
+			defaultLayouts={ { table: {} } }
+			paginationInfo={ { totalItems: items.length, totalPages: 1 } }
+			onChangeView={ () => {} }
+		>
+			<DataViews.Layout />
+		</DataViews>
+	);
+};
+
+export default PerformanceInsightTable;

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@automattic/ui';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
 	Button,
 	ExternalLink,
 } from '@wordpress/components';
@@ -14,6 +15,7 @@ import { useLocale } from '../../app/locale';
 import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
 import LLMNotice from './llm-notice';
+import PerformanceInsightTable from './performance-insight-table';
 import useLoadingSteps from './use-loading-steps';
 import type {
 	PerformanceMetricsItemQueryResponse,
@@ -119,7 +121,6 @@ const PerformanceInsightFeedback = () => {
 	);
 };
 
-// TODO: Implement detail.
 const PerformanceInsightDetail = ( {
 	details,
 	fullPageScreenshot,
@@ -127,9 +128,30 @@ const PerformanceInsightDetail = ( {
 	details: PerformanceMetricsDetailsQueryResponse;
 	fullPageScreenshot: SitePerformanceReport[ 'fullPageScreenshot' ];
 } ) => {
-	console.log( { details, fullPageScreenshot } ); // eslint-disable-line no-console
+	if ( details.type === 'table' || details.type === 'opportunity' ) {
+		return (
+			<PerformanceInsightTable details={ details } fullPageScreenshot={ fullPageScreenshot } />
+		);
+	}
 
-	return <>Performance Insight Detail</>;
+	if ( details.type === 'list' ) {
+		const tables = details.items ?? [];
+
+		return tables.map( ( item, index ) => (
+			<PerformanceInsightTable
+				key={ index }
+				details={ item as unknown as PerformanceMetricsDetailsQueryResponse }
+				fullPageScreenshot={ fullPageScreenshot }
+			/>
+		) );
+	}
+
+	if ( details.type === 'criticalrequestchain' ) {
+		// TODO: We should render the insight tree but I cannot find any sample data...
+		return null;
+	}
+
+	return null;
 };
 
 export const PerformanceInsight = ( {
@@ -150,7 +172,8 @@ export const PerformanceInsight = ( {
 	const locale = useLocale();
 	const isDesktop = useViewportMatch( 'medium' );
 	const { data: llmAnswer } = useSupportChatLLMQuery(
-		insight,
+		// TODO: Fix types
+		insight as any,
 		hash,
 		isWpcom,
 		true,
@@ -182,10 +205,13 @@ export const PerformanceInsight = ( {
 					</HStack>
 					<PerformanceInsightFeedback />
 					{ insight.details?.type && (
-						<PerformanceInsightDetail
-							details={ insight.details }
-							fullPageScreenshot={ fullPageScreenshot }
-						/>
+						<>
+							<Spacer marginBottom={ 0 } />
+							<PerformanceInsightDetail
+								details={ insight.details }
+								fullPageScreenshot={ fullPageScreenshot }
+							/>
+						</>
 					) }
 				</>
 			) : (

--- a/client/dashboard/sites/performance/types.ts
+++ b/client/dashboard/sites/performance/types.ts
@@ -1,12 +1,42 @@
 export type DeviceToggleType = 'mobile' | 'desktop';
 
+type PerformanceMetricsDetailsHeading = {
+	key: string;
+	label: string;
+	valueType: string;
+	subItemsHeading?: { key: string; valueType?: string };
+};
+
+type PerformanceMetricsDetailsItemObject = {
+	location?: {
+		url: string;
+		line: number;
+		column: number;
+	};
+} & Record< string, string | number >;
+
+type PerformanceMetricsDetailsSubItemObject = {
+	items: Record< string, string | number >[];
+	type: 'subitems';
+} & Record< string, string | number >;
+
+export type PerformanceMetricsDetailsItem = {
+	subItems?: PerformanceMetricsDetailsSubItemObject;
+} & Record<
+	string,
+	| string
+	| number
+	| boolean
+	| PerformanceMetricsDetailsItemObject
+	| PerformanceMetricsDetailsSubItemObject
+>;
+
 export interface PerformanceMetricsDetailsQueryResponse {
 	type: 'table' | 'opportunity' | 'list' | 'criticalrequestchain';
-	headings?: Array< { key: string; label: string; valueType: string } >;
-	items?: Array< {
-		[ key: string ]: string | number | { [ key: string ]: unknown };
-	} >;
-	chains?: Array< { [ key: string ]: unknown } >;
+	headings?: PerformanceMetricsDetailsHeading[];
+	items?: PerformanceMetricsDetailsItem[];
+	chains?: Record< string, unknown >[];
+	isEntityGrouped?: boolean;
 }
 
 export interface PerformanceMetricsItemQueryResponse {

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -147,8 +147,14 @@ export const getDisplayValue = ( metric: Metrics, value: number ): string => {
 };
 
 export function getFormattedSize( size: number ) {
-	const i = size === 0 ? 0 : Math.floor( Math.log( size ) / Math.log( 1024 ) );
+	if ( size === 0 ) {
+		return '0 B';
+	}
+
+	const i = Math.floor( Math.log( size ) / Math.log( 1024 ) );
 	return (
-		+( size / Math.pow( 1024, i ) ).toFixed( 2 ) * 1 + ' ' + [ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
+		getFormattedNumber( size / Math.pow( 1024, i ) ) * 1 +
+		' ' +
+		[ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
 	);
 }

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -118,7 +118,9 @@ export const getDisplayUnit = ( metric: Metrics ) => {
 	return '';
 };
 
-const max2Decimals = ( val: number ) => Number( Number( val ).toFixed( 2 ) );
+export function getFormattedNumber( value: number | string, dec = 2 ) {
+	return Number( Number( value ?? 0 ).toFixed( dec ) );
+}
 
 export const getFormattedValue = ( metric: Metrics, value: number ): number => {
 	if ( value === null || value === undefined ) {
@@ -130,10 +132,10 @@ export const getFormattedValue = ( metric: Metrics, value: number ): number => {
 	}
 
 	if ( [ 'lcp', 'fcp', 'ttfb', 'inp', 'tbt' ].includes( metric ) ) {
-		return max2Decimals( value / 1000 );
+		return getFormattedNumber( value / 1000 );
 	}
 
-	return max2Decimals( value );
+	return getFormattedNumber( value );
 };
 
 export const getDisplayValue = ( metric: Metrics, value: number ): string => {
@@ -143,3 +145,10 @@ export const getDisplayValue = ( metric: Metrics, value: number ): string => {
 
 	return [ getFormattedValue( metric, value ), getDisplayUnit( metric ) ].join( '' );
 };
+
+export function getFormattedSize( size: number ) {
+	const i = size === 0 ? 0 : Math.floor( Math.log( size ) / Math.log( 1024 ) );
+	return (
+		+( size / Math.pow( 1024, i ) ).toFixed( 2 ) * 1 + ' ' + [ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106216

## Proposed Changes

* Implement PerformanceInsightTable and InsightScreenshotWithOverlay

| Reduce the impact of third-party code | Properly size images | Largest Contentful Paint element |
| - | - | - |
|<img width="1183" height="981" alt="image" src="https://github.com/user-attachments/assets/d422de0d-8c7e-4202-8e3e-ab721469fc66" />|<img width="644" height="174" alt="image" src="https://github.com/user-attachments/assets/5bcf7dae-cdcc-432f-9690-68ce7c00d317" />|<img width="568" height="445" alt="image" src="https://github.com/user-attachments/assets/e5e18b19-eef6-4d01-bf8f-f4bcc2a9ed5b" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance
* Open the recommendation panel below
  * Check `Reduce the impact of third-party code` for the nested items
  * Check either `Largest Contentful Paint element` or `Properly size images` for the screenshot with overlay
* Ensure the insight table renders correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
