### PR TITLE
Dashboard v2: hide Settings -> Repositories in v1

### DIFF
--- a/client/dashboard/sites/settings-repositories/summary.tsx
+++ b/client/dashboard/sites/settings-repositories/summary.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import BranchIcon from '../deployments/icons/branch';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
@@ -11,6 +12,9 @@ export default function RepositoriesSettingsSummary( {
 	site: Site;
 	density?: Density;
 } ) {
+	if ( isDashboardBackport() ) {
+		return null;
+	}
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/repositories` }


### PR DESCRIPTION
## Proposed Changes

Hide this menu item in v1 as it's not applicable. Currently this menu item does nothing in v1.

<img width="679" height="733" alt="image" src="https://github.com/user-attachments/assets/85cba760-52c6-49b5-8a53-2b634f6dbdcf" />


## Testing Instructions

1. Go to `/sites/:slug/settings` of an Atomic site.
2. Verify you do NOT see the above menu item.
3. Go to `/v2/sites/:slug/settings` of an Atomic site.
4. Verify you SEE the above menu item.
5. Verify it can still be clicked and opens the correct thing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
