### PR TITLE
Domain Search Rewrite: Add reset filter functionality

### DIFF
--- a/packages/domain-search/src/components/search-bar/constants.ts
+++ b/packages/domain-search/src/components/search-bar/constants.ts
@@ -1,0 +1,6 @@
+import type { FilterState } from './types';
+
+export const EMPTY_FILTER: FilterState = {
+	exactSldMatchesOnly: false,
+	tlds: [],
+};

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -1,14 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { Dropdown } from '@wordpress/components';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchControls } from '../../ui';
-import { FilterState } from './types';
-
-const emptyFilter: FilterState = {
-	exactSldMatchesOnly: false,
-	tlds: [],
-};
 
 const POPOVER_PROPS = {
 	placement: 'bottom-end',
@@ -18,15 +12,11 @@ const POPOVER_PROPS = {
 };
 
 export const Filter = () => {
-	const { filter, setFilter, query, queries } = useDomainSearch();
+	const { filter, setFilter, query, queries, resetFilter } = useDomainSearch();
 	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery( {
 		...queries.availableTlds( query ),
 		enabled: true,
 	} ) as { data: string[]; isFetching: boolean };
-
-	const resetFilter = useCallback( () => {
-		setFilter( emptyFilter );
-	}, [ setFilter ] );
 
 	const filterCount = useMemo(
 		() => filter.tlds.length + ( filter.exactSldMatchesOnly ? 1 : 0 ),

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,11 +1,23 @@
-import { DomainSuggestionsList } from '../../ui';
+import { useDomainSearch } from '../../page/context';
+import { DomainSuggestionsList, DomainSuggestionFilterReset } from '../../ui';
 import { SearchResultsItem } from './item';
 import { SearchResultsPlaceholder } from './placeholder';
 
 const SearchResults = ( { suggestions }: { suggestions: string[] } ) => {
+	const { filter, resetFilter } = useDomainSearch();
+	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
+
+	if ( suggestions.length === 0 ) {
+		if ( hasActiveFilters ) {
+			return <DomainSuggestionFilterReset onClick={ resetFilter } />;
+		}
+
+		return null;
+	}
+
 	return (
 		<DomainSuggestionsList>
-			{ suggestions?.map( ( suggestion ) => (
+			{ suggestions.map( ( suggestion ) => (
 				<SearchResultsItem key={ suggestion } domainName={ suggestion } />
 			) ) }
 		</DomainSuggestionsList>

--- a/packages/domain-search/src/page/constants.ts
+++ b/packages/domain-search/src/page/constants.ts
@@ -1,0 +1,6 @@
+import type { FilterState } from '../components/search-bar/types';
+
+export const DEFAULT_FILTER: FilterState = {
+	exactSldMatchesOnly: false,
+	tlds: [],
+};

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -5,7 +5,7 @@ import {
 	freeSuggestionQuery,
 } from '@automattic/api-queries';
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
-import { FilterState } from '../components/search-bar/types';
+import { DEFAULT_FILTER } from './constants';
 import { type DomainSearchProps, type DomainSearchContextType } from './types';
 
 const noop = () => {};
@@ -61,6 +61,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		tlds: [],
 	},
 	setFilter: () => {},
+	resetFilter: () => {},
 };
 
 export const DomainSearchContext =
@@ -82,10 +83,7 @@ export const useDomainSearchContextValue = (
 	const { currentSiteUrl, query: externalQuery, cart, events, slots, config } = props;
 
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
-	const [ filter, setFilter ] = useState( {
-		exactSldMatchesOnly: false,
-		tlds: [],
-	} as FilterState );
+	const [ filter, setFilter ] = useState( DEFAULT_FILTER );
 
 	const closeFullCart = useCallback( () => {
 		setIsFullCartOpen( false );
@@ -165,6 +163,7 @@ export const useDomainSearchContextValue = (
 			currentSiteUrl,
 			filter,
 			setFilter,
+			resetFilter: () => setFilter( DEFAULT_FILTER ),
 		};
 	}, [
 		isFullCartOpen,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -79,6 +79,7 @@ export interface DomainSearchContextType
 	setQuery: ( query: string ) => void;
 	filter: FilterState;
 	setFilter: ( filter: FilterState ) => void;
+	resetFilter: () => void;
 	queries: {
 		availableTlds: ( query?: string, vendor?: string ) => ReturnType< typeof availableTldsQuery >;
 		domainSuggestions: (


### PR DESCRIPTION
Addresses p1759496340044589/1759445030.748209-slack-C04H4NY6STW.

## Proposed Changes

The rewritten search UI didn't include the "Disable filters" button, given that there's a filter enabled.

## Testing Instructions

Enter `/setup` with the `domain-search-rewrite` feature flag on and search for anything. Add a TLD filter and ensure the "matches only" checkbox is ticked.

Verify no regular search results show up and the "Disable filters" button is visible. Click it and the filters should go away, bringing more results.

<img width="1101" height="741" alt="image" src="https://github.com/user-attachments/assets/0cef7925-5a09-4c71-b378-6cc3b3e0435a" />
