### PR TITLE
Add primary site address selector

### DIFF
--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -69,7 +69,9 @@ function SiteDomains() {
 				/>
 			}
 		>
-			<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />
+			{ ! isLoading && siteDomains && (
+				<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />
+			) }
 			<DataViewsCard>
 				<DataViews< SiteDomain >
 					data={ filteredData || [] }

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -11,6 +11,7 @@ import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
+import PrimaryDomainSelector from './primary-domain-selector';
 import type { DomainsView } from '../../domains/dataviews';
 import type { SiteDomain } from '@automattic/api-core';
 
@@ -68,6 +69,7 @@ function SiteDomains() {
 				/>
 			}
 		>
+			<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />
 			<DataViewsCard>
 				<DataViews< SiteDomain >
 					data={ filteredData || [] }

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -95,9 +95,10 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 	const renderMessage = () => {
 		if ( ! canUserSetPrimaryDomainOnThisSite ) {
 			return createInterpolateElement(
-				'Your site plan doesn’t allow you to set a custom domain as a primary site address. <upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink>Learn more</learnMoreLink>.',
+				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink>Learn more</learnMoreLink>.',
 				{
 					upgradeLink: <a href={ `/plans/${ site.slug }` } />,
+					br: <br />,
 					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
 				}
 			);
@@ -157,37 +158,35 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		<Notice variant="info" title={ __( 'Primary site address' ) }>
 			<VStack spacing={ 4 }>
 				<Text as="p">{ renderMessage() }</Text>
-				{ canUserSetPrimaryDomainOnThisSite && domainsList.length > 0 && (
+				{ canUserSetPrimaryDomainOnThisSite && domainsList.length > 0 && ! showForm && (
 					<HStack justify="flex-start">
-						<Button variant="link" onClick={ () => setShowForm( ! showForm ) }>
+						<Button variant="link" onClick={ () => setShowForm( true ) }>
 							{ __( 'Change primary site address' ) }
 						</Button>
 					</HStack>
 				) }
-				<HStack justify="flex-start" alignment="flex-end">
-					{ showForm && (
-						<>
-							<form>
-								<DataForm< { primaryDomain: string } >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: { primaryDomain?: string } ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-							</form>
-							<Button
-								variant="primary"
-								onClick={ handleSubmit }
-								__next40pxDefaultSize
-								disabled={ formData.primaryDomain === '' || setPrimaryDomainMutation.isPending }
-							>
-								{ __( 'Save' ) }
-							</Button>
-						</>
-					) }
-				</HStack>
+				{ showForm && (
+					<HStack justify="flex-start" alignment="flex-end">
+						<form>
+							<DataForm< { primaryDomain: string } >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: { primaryDomain?: string } ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+						</form>
+						<Button
+							variant="primary"
+							onClick={ handleSubmit }
+							__next40pxDefaultSize
+							disabled={ formData.primaryDomain === '' || setPrimaryDomainMutation.isPending }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				) }
 			</VStack>
 		</Notice>
 	);

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -19,7 +19,7 @@ import { userHasFlag } from '../../utils/user';
 import type { Field } from '@wordpress/dataviews';
 
 interface PrimaryDomainSelectorProps {
-	domains: SiteDomain[] | undefined;
+	domains: SiteDomain[];
 	site: Site;
 	user: User;
 }

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -138,6 +138,8 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 							type: 'snackbar',
 						}
 					);
+					setShowForm( false );
+					setFormData( { primaryDomain: '' } );
 				},
 				onError: () => {
 					createErrorNotice(
@@ -179,7 +181,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 								variant="primary"
 								onClick={ handleSubmit }
 								__next40pxDefaultSize
-								disabled={ formData.primaryDomain === '' }
+								disabled={ formData.primaryDomain === '' || setPrimaryDomainMutation.isPending }
 							>
 								{ __( 'Save' ) }
 							</Button>

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -1,0 +1,194 @@
+import { type SiteDomain, type Site, type User, DomainSubtype } from '@automattic/api-core';
+import { siteSetPrimaryDomainMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState, useMemo } from 'react';
+import InlineSupportLink from '../../components/inline-support-link';
+import { Notice } from '../../components/notice';
+import { userHasFlag } from '../../utils/user';
+import type { Field } from '@wordpress/dataviews';
+
+interface PrimaryDomainSelectorProps {
+	domains: SiteDomain[];
+	site: Site;
+	user: User;
+}
+
+const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorProps ) => {
+	const [ formData, setFormData ] = useState< { primaryDomain: string } >( {
+		primaryDomain: '',
+	} );
+	const [ showForm, setShowForm ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const primaryWithPlanOnly = userHasFlag( user, 'calypso_allow_nonprimary_domains_without_plan' );
+	const isOnFreePlan = site?.plan?.is_free ?? false;
+	const canUserSetPrimaryDomainOnThisSite =
+		! ( primaryWithPlanOnly && isOnFreePlan ) &&
+		( site?.plan?.features?.active.includes( 'set-primary-custom-domain' ) ?? false );
+	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
+	const currentPrimaryDomain = domains.find( ( domain ) => domain.primary_domain )?.domain;
+	const domainsList = useMemo( () => {
+		if ( ! domains || ! site ) {
+			return [];
+		}
+		const hasWpcomStagingDomain = domains.find( ( domain ) => domain.is_wpcom_staging_domain );
+		return domains.filter( ( domain ) => {
+			// Basic eligibility criteria
+			const isEligible =
+				( domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION ||
+					domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) &&
+				domain.can_set_as_primary &&
+				! domain.primary_domain &&
+				! domain.aftermarket_auction;
+
+			if ( ! isEligible ) {
+				return false;
+			}
+
+			// Additional filtering for wpcom staging domains
+			if ( hasWpcomStagingDomain && domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}, [ domains, site ] );
+
+	if ( ! domains || ! site ) {
+		return null;
+	}
+
+	const fields: Field< { primaryDomain: string } >[] = [
+		{
+			id: 'primaryDomain',
+			label: __( 'Primary domain' ),
+			elements: [
+				{
+					label: 'Select a domain',
+					value: '',
+				},
+				...domainsList.map( ( domain ) => {
+					return {
+						label: domain.domain,
+						value: domain.domain,
+					};
+				} ),
+			],
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'primaryDomain' ],
+	};
+
+	const renderMessage = () => {
+		if ( ! canUserSetPrimaryDomainOnThisSite ) {
+			return createInterpolateElement(
+				'Your site plan doesn’t allow you to set a custom domain as a primary site address. <upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink>Learn more</learnMoreLink>.',
+				{
+					upgradeLink: <a href={ `/plans/${ site.slug }` } />,
+					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
+				}
+			);
+		}
+		if ( domainsList.length === 0 ) {
+			return createInterpolateElement(
+				'Before changing your primary site address you must register or connect a new custom domain. <learnMoreLink>Learn more</learnMoreLink>.',
+				{
+					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
+				}
+			);
+		}
+
+		return createInterpolateElement(
+			'The current primary site address for this site is: <currentPrimaryDomain />. This is the site address your visitors will see while browsing your site. <learnMoreLink>Learn more</learnMoreLink>.',
+			{
+				currentPrimaryDomain: <strong>{ currentPrimaryDomain }</strong>,
+				learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
+			}
+		);
+	};
+
+	const handleSubmit = () => {
+		if ( ! formData.primaryDomain ) {
+			return;
+		}
+		setPrimaryDomainMutation.mutate(
+			{ siteId: site.ID, domain: formData.primaryDomain },
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						sprintf(
+							/* translators: %s is domain */
+							__( 'Primary domain changed: all domains will redirect to %s.' ),
+							formData.primaryDomain
+						),
+						{
+							type: 'snackbar',
+						}
+					);
+				},
+				onError: () => {
+					createErrorNotice(
+						__( 'Something went wrong and we couldn’t change your primary domain.' ),
+						{
+							type: 'snackbar',
+						}
+					);
+				},
+			}
+		);
+	};
+
+	return (
+		<Notice variant="info" title={ __( 'Primary site address' ) }>
+			<VStack spacing={ 4 }>
+				<Text as="p">{ renderMessage() }</Text>
+				{ canUserSetPrimaryDomainOnThisSite && domainsList.length > 0 && (
+					<HStack justify="flex-start">
+						<Button variant="link" onClick={ () => setShowForm( ! showForm ) }>
+							{ __( 'Change primary site address' ) }
+						</Button>
+					</HStack>
+				) }
+				<HStack justify="flex-start" alignment="flex-end">
+					{ showForm && (
+						<>
+							<form>
+								<DataForm< { primaryDomain: string } >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: { primaryDomain?: string } ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+							</form>
+							<Button
+								variant="primary"
+								onClick={ handleSubmit }
+								__next40pxDefaultSize
+								disabled={ formData.primaryDomain === '' }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</>
+					) }
+				</HStack>
+			</VStack>
+		</Notice>
+	);
+};
+
+export default PrimaryDomainSelector;

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -19,7 +19,7 @@ import { userHasFlag } from '../../utils/user';
 import type { Field } from '@wordpress/dataviews';
 
 interface PrimaryDomainSelectorProps {
-	domains: SiteDomain[];
+	domains: SiteDomain[] | undefined;
 	site: Site;
 	user: User;
 }

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -74,7 +74,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 			label: __( 'Primary domain' ),
 			elements: [
 				{
-					label: 'Select a domain',
+					label: __( 'Select a domain name' ),
 					value: '',
 				},
 				...domainsList.map( ( domain ) => {
@@ -132,7 +132,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 					createSuccessNotice(
 						sprintf(
 							/* translators: %s is domain */
-							__( 'Primary domain changed: all domains will redirect to %s.' ),
+							__( 'Primary site address changed: all domains will redirect to %s.' ),
 							formData.primaryDomain
 						),
 						{
@@ -144,7 +144,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 				},
 				onError: () => {
 					createErrorNotice(
-						__( 'Something went wrong and we couldn’t change your primary domain.' ),
+						__( 'Something went wrong and we couldn’t change your primary site address.' ),
 						{
 							type: 'snackbar',
 						}

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -88,7 +88,7 @@ export function isValidNameServerSubdomain( nameServerSubdomain: string ): boole
 	return true;
 }
 
-const shouldUpgradeToMakeDomainPrimary = ( {
+export function shouldUpgradeToMakeDomainPrimary( {
 	domain,
 	site,
 	user,
@@ -96,7 +96,7 @@ const shouldUpgradeToMakeDomainPrimary = ( {
 	domain: DomainSummary;
 	site: Site;
 	user: User;
-} ) => {
+} ) {
 	return (
 		[ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
 			domain.subtype.id
@@ -109,7 +109,7 @@ const shouldUpgradeToMakeDomainPrimary = ( {
 		!! site.plan?.is_free &&
 		! hasPlanFeature( site, DotcomFeatures.SET_PRIMARY_CUSTOM_DOMAIN )
 	);
-};
+}
 
 export function canSetAsPrimary( {
 	domain,


### PR DESCRIPTION
Closes [DOTDASH-603](https://linear.app/a8c/issue/DOTDASH-603/add-set-primary-domain-component-in-sitedomains)

## Proposed Changes
Add Primary Domain Selector Component that allows users to change their site's primary domain directly from the dashboard sites domains page

## Why are these changes being made?
The dashboard sites domains page was missing the ability to change the primary domain, which is a core domain management feature.

<img width="1566" height="328" alt="primary-closed" src="https://github.com/user-attachments/assets/6fd90cfc-94be-48dc-8e9d-014db2fbbd01" />

<img width="1754" height="388" alt="primary open" src="https://github.com/user-attachments/assets/099f01bc-28ef-4da3-ba18-3ea4d4e6da89" />

![Screenshot 2025-10-03 alle 16 51 07](https://github.com/user-attachments/assets/fc3a14d1-622c-43b9-a31b-b4f672fc1e77)

![Screenshot 2025-10-03 alle 16 49 12](https://github.com/user-attachments/assets/1505d89b-4997-4c8d-839c-4049d74475d7)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist
Ensure the component is working properly. Try to change the primary site address.
Also verify that the component is handling correctly free sites or site with a plan but without a custom domain).

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
