### PR TITLE
Streamlined pricing cleanup: Remove experiment code from the main checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -9,10 +9,6 @@ import debugFactory from 'debug';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
@@ -41,8 +37,7 @@ function getUpsellVariant( currentVariant: WPCOMProductVariant, variants: WPCOMP
 function getUpsellTextForVariant(
 	upsellVariant: WPCOMProductVariant,
 	percentSavings: number,
-	__: any,
-	isStreamlinedPrice: boolean
+	__: any
 ) {
 	if ( upsellVariant.productBillingTermInMonths === 12 ) {
 		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
@@ -57,11 +52,10 @@ function getUpsellTextForVariant(
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 24 ) {
-		const cardTitle = isStreamlinedPrice
-			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying for two years' )
-			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' );
+		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		const cardTitle = __(
+			'<strong>Save %(percentSavings)d%% extra</strong> by paying for two years'
+		);
 		return {
 			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
 				strong: createElement( 'strong' ),
@@ -72,11 +66,10 @@ function getUpsellTextForVariant(
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 36 ) {
-		const cardTitle = isStreamlinedPrice
-			? // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%% extra</strong> by paying for three years' )
-			: // translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-			  __( '<strong>Save %(percentSavings)d%%</strong> by paying for three years' );
+		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		const cardTitle = __(
+			'<strong>Save %(percentSavings)d%% extra</strong> by paying for three years'
+		);
 		return {
 			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
 				strong: createElement( 'strong' ),
@@ -110,10 +103,6 @@ export function CheckoutSidebarPlanUpsell() {
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const plan = responseCart.products.find(
 		( product ) => isPlan( product ) && ! isJetpackPlan( product )
-	);
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-	const isStreamlinedPrice = isStreamlinedPriceCheckoutTreatment(
-		streamlinedPriceExperimentAssignment
 	);
 
 	const variants = useGetProductVariants( plan );
@@ -201,33 +190,18 @@ export function CheckoutSidebarPlanUpsell() {
 		currentVariant.introductoryInterval === 1 &&
 		currentVariant.introductoryTerm === 'year';
 
-	const upsellText = getUpsellTextForVariant(
-		upsellVariant,
-		percentSavings,
-		__,
-		isStreamlinedPrice
-	);
+	const upsellText = getUpsellTextForVariant( upsellVariant, percentSavings, __ );
 
 	if ( ! upsellText ) {
 		return;
 	}
 
-	const { cardTitle, cellLabel, ctaText } = upsellText;
+	const { cardTitle, ctaText } = upsellText;
 
 	return (
 		<>
 			<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
-					{ ! isStreamlinedPrice && (
-						<>
-							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-								<strong>{ __( 'Plan' ) }</strong>
-							</div>
-							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-								<strong>{ isComparisonWithIntroOffer ? cellLabel : __( 'Cost' ) }</strong>
-							</div>
-						</>
-					) }
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ currentVariant.variantLabel.adjective }
 					</div>
@@ -260,12 +234,10 @@ export function CheckoutSidebarPlanUpsell() {
 						} ) }
 					</div>
 				</div>
-				{ isStreamlinedPrice && (
-					<CheckoutSummaryFeaturedList
-						responseCart={ responseCart }
-						isCartUpdating={ FormStatus.VALIDATING === formStatus }
-					/>
-				) }
+				<CheckoutSummaryFeaturedList
+					responseCart={ responseCart }
+					isCartUpdating={ FormStatus.VALIDATING === formStatus }
+				/>
 				<PromoCardCTA
 					cta={ {
 						disabled: isFormLoading,

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -1,14 +1,8 @@
 import { MaterialIcon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { formatCurrency } from '@automattic/number-formatters';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import useCartKey from '../../use-cart-key';
 
 const CreditCardPayButtonWrapper = styled.span`
@@ -37,7 +31,6 @@ const StyledMaterialIcon = styled( MaterialIcon )`
 export function CheckoutSubmitButtonContent() {
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const { formStatus } = useFormStatus();
@@ -54,20 +47,10 @@ export function CheckoutSubmitButtonContent() {
 		return <CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>;
 	}
 
-	const total = formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
-		isSmallestUnit: true,
-		stripZeros: true,
-	} );
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
-				? __( 'Pay now' )
-				: sprintf(
-						/* translators: %s is the total to be paid in localized currency */
-						__( 'Pay %s now' ),
-						total
-				  ) }
+			{ __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,9 +1,5 @@
 import { isWpComPlan } from '@automattic/calypso-products';
 import { FunctionComponent } from 'react';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceRadioTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
@@ -14,17 +10,8 @@ import type { ItemVariationPickerProps } from './types';
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
 
-	if ( isStreamlinedPriceExperimentLoading ) {
-		return null;
-	}
-
-	if (
-		isWpComPlan( selectedItem.product_slug ) &&
-		isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
-	) {
+	if ( isWpComPlan( selectedItem.product_slug ) ) {
 		return <ItemVariationRadioButtons { ...props } />;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -20,10 +20,6 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -316,12 +312,7 @@ function LineItemWrapper( {
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
 	const signupFlowName = getSignupCompleteFlowName();
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
-	const isStreamlinedPrice =
-		! isStreamlinedPriceExperimentLoading &&
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
-		isWpComPlan( product.product_slug );
+	const shouldShowComparison = isWpComPlan( product.product_slug );
 
 	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
 		isDeletable = false;
@@ -443,7 +434,7 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
-				shouldShowComparison={ isStreamlinedPrice }
+				shouldShowComparison={ shouldShowComparison }
 				compareToPrice={ compareToPrice }
 			>
 				<DropdownWrapper>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1194,16 +1194,16 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 
 function IntroductoryOfferCallout( {
 	product,
-	isStreamlinedPrice,
+	shouldShowComparison,
 }: {
 	product: ResponseCartProduct;
-	isStreamlinedPrice?: boolean;
+	shouldShowComparison?: boolean;
 } ) {
 	const translate = useTranslate();
 	const introductoryOffer = getItemIntroductoryOfferDisplay(
 		translate,
 		product,
-		isStreamlinedPrice
+		shouldShowComparison
 	);
 
 	if ( ! introductoryOffer ) {
@@ -1535,7 +1535,7 @@ function CheckoutLineItem( {
 							<DomainDiscountCallout product={ product } />
 							<IntroductoryOfferCallout
 								product={ product }
-								isStreamlinedPrice={ shouldShowComparison }
+								shouldShowComparison={ shouldShowComparison }
 							/>
 							<JetpackAkismetSaleCouponCallout product={ product } />
 						</LineItemMeta>

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -12,7 +12,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 	isPriceIncrease,
 	context,
 	remainingRenewalsUsingOffer = 0,
-	isStreamlinedPrice,
+	shouldShowComparison,
 }: {
 	translate: typeof i18n.translate;
 	intervalUnit: string;
@@ -21,7 +21,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 	isPriceIncrease: boolean;
 	context: string;
 	remainingRenewalsUsingOffer: number;
-	isStreamlinedPrice?: boolean;
+	shouldShowComparison?: boolean;
 } ): string {
 	let text = isPriceIncrease
 		? translate( 'First billing period', { textOnly: true } )
@@ -85,7 +85,7 @@ export function getIntroductoryOfferIntervalDisplay( {
 					i18n.getLocaleSlug()?.startsWith( 'en' ) ||
 					i18n.hasTranslation( 'Additional discount for first year' );
 				text =
-					! isPriceIncrease && isStreamlinedPrice && isAdditionalDiscountTranslated
+					! isPriceIncrease && shouldShowComparison && isAdditionalDiscountTranslated
 						? translate( 'Additional discount for first year' )
 						: text;
 			} else {
@@ -212,7 +212,7 @@ export function getPremiumDomainIntroductoryOfferDisplay(
 export function getItemIntroductoryOfferDisplay(
 	translate: typeof i18n.translate,
 	product: ResponseCartProduct,
-	isStreamlinedPrice?: boolean
+	shouldShowComparison?: boolean
 ) {
 	// Introductory offer manual renewals often have prorated prices that are
 	// difficult to display as a simple discount so we keep their display
@@ -245,7 +245,7 @@ export function getItemIntroductoryOfferDisplay(
 		isPriceIncrease: doesIntroductoryOfferHavePriceIncrease( product ),
 		context: 'checkout',
 		remainingRenewalsUsingOffer: product.introductory_offer_terms.transition_after_renewal_count,
-		isStreamlinedPrice,
+		shouldShowComparison,
 	} );
 
 	return { enabled: true, text };

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -140,7 +140,7 @@ function getDiscountReasonForIntroductoryOffer(
 	translate: ReturnType< typeof useTranslate >,
 	allowFreeText: boolean,
 	isPriceIncrease: boolean,
-	isStreamlinedPrice?: boolean
+	shouldShowComparison?: boolean
 ): string {
 	return getIntroductoryOfferIntervalDisplay( {
 		translate,
@@ -150,7 +150,7 @@ function getDiscountReasonForIntroductoryOffer(
 		isPriceIncrease,
 		context: 'checkout',
 		remainingRenewalsUsingOffer: terms.transition_after_renewal_count,
-		isStreamlinedPrice,
+		shouldShowComparison,
 	} );
 }
 
@@ -219,7 +219,7 @@ function makeIntroductoryOfferCostOverrideUnique(
 	product: ResponseCartProduct,
 	translate: ReturnType< typeof useTranslate >,
 	allowFreeText: boolean,
-	isStreamlinedPrice?: boolean
+	shouldShowComparison?: boolean
 ): ResponseCartCostOverride {
 	if ( 'introductory-offer' !== costOverride.override_code || ! product.introductory_offer_terms ) {
 		return costOverride;
@@ -246,7 +246,7 @@ function makeIntroductoryOfferCostOverrideUnique(
 			translate,
 			allowFreeText,
 			isPriceIncrease,
-			isStreamlinedPrice
+			shouldShowComparison
 		),
 	};
 }
@@ -341,7 +341,7 @@ export function doesIntroductoryOfferHavePriceIncrease( product: ResponseCartPro
 export function filterCostOverridesForLineItem(
 	product: ResponseCartProduct,
 	translate: ReturnType< typeof useTranslate >,
-	isStreamlinedPrice?: boolean
+	shouldShowComparison?: boolean
 ): LineItemCostOverrideForDisplay[] {
 	const costOverrides = product?.cost_overrides ?? [];
 
@@ -357,7 +357,7 @@ export function filterCostOverridesForLineItem(
 					product,
 					translate,
 					true,
-					isStreamlinedPrice
+					shouldShowComparison
 				)
 			)
 			.map( ( costOverride ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1029](https://linear.app/a8c/issue/M4R73CH-1029/cleanup-experiment-code)

## Proposed Changes

* removes unnecessary checks and consolidates CSS
* removes feature list components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* removing experiment code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using EUR and IDR (intro offer) go through the `/setup/onboarding` flow
* Ensure the are no visible style differences on checkout

| EUR | IDR |
|--------|--------|
| <img width="480" alt="screencapture-calypso-localhost-3000-checkout-test79729-wordpress-com-2025-10-03-13_29_43" src="https://github.com/user-attachments/assets/968ea57b-4146-44ab-b18b-8dc7a42a11e3" /> | <img width="480" alt="screencapture-calypso-localhost-3000-checkout-test79729-wordpress-com-2025-10-03-13_29_13" src="https://github.com/user-attachments/assets/4b10f6c9-7065-48e8-8342-87d685ed487a" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
