### PR TITLE
MCP: fix MCP access state when going to setup

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -212,8 +212,8 @@ const contextLinks = {
 		post_id: 19775,
 	},
 	mcp: {
-		link: 'https://wordpress.com/support/account-settings/',
-		post_id: 80368,
+		link: 'https://wordpress.com/support/model-context-protocol-mcp-settings/',
+		post_id: 418160,
 	},
 	media: {
 		link: 'https://wordpress.com/support/media/',

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -1,5 +1,5 @@
-import { isAutomatticianQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
 	ExternalLink,
@@ -15,19 +15,17 @@ import { sprintf } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { hasEnabledAccountTools } from './utils';
 
-function McpSetupComponent( { path, userSettings } ) {
+function McpSetupComponent( { path } ) {
 	const translate = useTranslate();
-	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// MCP client selection for configuration format
 	const [ selectedMcpClient, setSelectedMcpClient ] = useState( 'claude' );
@@ -127,10 +125,6 @@ function McpSetupComponent( { path, userSettings } ) {
 	// Check if any account-level tools are enabled using the new nested structure
 	const hasEnabledTools = hasEnabledAccountTools( userSettings );
 
-	if ( ! isAutomattician ) {
-		return null;
-	}
-
 	if ( ! hasEnabledTools ) {
 		return (
 			<Main wideLayout className="mcp-setup">
@@ -138,7 +132,7 @@ function McpSetupComponent( { path, userSettings } ) {
 				<DocumentHead title={ translate( 'MCP Setup' ) } />
 				<NavigationHeader navigationItems={ [] } title={ translate( 'MCP Setup' ) } />
 				<SectionHeader label={ translate( 'Setup Required' ) } />
-				<Card style={ { borderRadius: '0' } }>
+				<Card isRounded={ false }>
 					<CardBody>
 						<VStack spacing={ 4 }>
 							<Text as="p" variant="muted">
@@ -205,7 +199,7 @@ function McpSetupComponent( { path, userSettings } ) {
 
 			<div style={ { marginTop: '24px' } }>
 				<SectionHeader label={ translate( 'Client Configuration' ) } />
-				<Card style={ { borderRadius: '0' } }>
+				<Card isRounded={ false }>
 					<CardBody>
 						<VStack spacing={ 6 }>
 							<SelectControl
@@ -320,9 +314,4 @@ function McpSetupComponent( { path, userSettings } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		userSettings: getUserSettings( state ),
-	} ),
-	{}
-)( McpSetupComponent );
+export default McpSetupComponent;

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -9,13 +9,13 @@ import {
 	__experimentalText as Text,
 	Card,
 	CardBody,
-	CardHeader,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
@@ -37,9 +37,10 @@ function McpSetupComponent( { path } ) {
 	// MCP client options
 	const mcpClientOptions = [
 		{ label: 'Claude Desktop', value: 'claude' },
-		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Cursor', value: 'cursor' },
+		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
+		{ label: translate( 'Other MCP client' ), value: 'default' },
 	];
 
 	// Documentation links for each client
@@ -48,7 +49,7 @@ function McpSetupComponent( { path } ) {
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
-		default: 'https://modelcontextprotocol.io/docs/servers',
+		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
 	};
 
 	const serverName = 'wpcom-mcp';
@@ -136,15 +137,15 @@ function McpSetupComponent( { path } ) {
 				<Card isRounded={ false }>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<Text as="p" variant="muted">
+							<Text as="p" size="medium">
 								{ translate( 'No MCP tools are currently enabled for your account.' ) }
 							</Text>
-							<Text as="p" variant="muted">
+							<Text as="p" size="medium">
 								{ translate(
 									'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
 								) }
 							</Text>
-							<Button variant="primary" href="/me/mcp">
+							<Button variant="primary" href="/me/mcp" style={ { alignSelf: 'flex-start' } }>
 								{ translate( 'Go to MCP Settings' ) }
 							</Button>
 						</VStack>
@@ -167,39 +168,41 @@ function McpSetupComponent( { path } ) {
 			<Card style={ { borderRadius: '0' } }>
 				<CardBody>
 					<VStack spacing={ 4 }>
-						<Text as="p">
+						<Text as="p" size="medium">
 							{ translate(
 								'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
 							) }
 						</Text>
-						<Text as="p">
+						<Text as="p" size="medium">
 							{ translate(
 								'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
 							) }
 						</Text>
 						<VStack spacing={ 2 }>
-							<Text as="li">
-								{ translate(
-									'Running a bridge server using the WordPress.com-specific MCP package'
-								) }
-							</Text>
-							<Text as="li">
-								{ translate(
-									'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-								) }
-							</Text>
-							<Text as="li">
-								{ translate(
-									"Providing real-time access to your account's content and management features"
-								) }
-							</Text>
+							<ul>
+								<li>
+									{ translate(
+										'Running a bridge server using the WordPress.com-specific MCP package'
+									) }
+								</li>
+								<li>
+									{ translate(
+										'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
+									) }
+								</li>
+								<li>
+									{ translate(
+										"Providing real-time access to your account's content and management features"
+									) }
+								</li>
+							</ul>
 						</VStack>
 					</VStack>
 				</CardBody>
 			</Card>
 
 			<div style={ { marginTop: '24px' } }>
-				<SectionHeader label={ translate( 'Client Configuration' ) } />
+				<SectionHeader label={ translate( 'MCP Client Configuration' ) } />
 				<Card isRounded={ false }>
 					<CardBody>
 						<VStack spacing={ 6 }>
@@ -215,11 +218,13 @@ function McpSetupComponent( { path } ) {
 
 							{ /* Quick Setup for Claude Desktop */ }
 							{ selectedMcpClient === 'claude' && (
-								<VStack spacing={ 4 }>
-									<CardHeader size={ 20 }>{ translate( 'Quick Setup' ) }</CardHeader>
-									<Text as="p" size="small">
+								<VStack spacing={ 4 } style={ { borderBottom: '1px solid #e0e0e0' } }>
+									<CardHeading tagName="h1" size={ 16 } isBold>
+										{ translate( 'Quick Setup' ) }
+									</CardHeading>
+									<Text as="p" size="medium">
 										{ translate(
-											'For Claude Desktop users, we provide a one-click setup option using our pre-configured MCPB file.'
+											'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
 										) }
 									</Text>
 									<Button
@@ -230,36 +235,39 @@ function McpSetupComponent( { path } ) {
 									>
 										{ translate( 'Download MCPB File' ) }
 									</Button>
-									<VStack spacing={ 2 }>
-										<CardHeader size={ 16 }>{ translate( 'Installation steps:' ) }</CardHeader>
-										<ol style={ { fontSize: 'small' } }>
-											<li>
-												<Text as="p" size="small">
-													{ translate( 'Download the MCPB file using the button above.' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" size="small">
-													{ translate( 'Open the downloaded file by double-clicking it.' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" size="small">
-													{ translate(
-														'Follow the setup instructions from Claude Desktop to install locally.'
-													) }
-												</Text>
-											</li>
-										</ol>
-									</VStack>
+									<Text as="p" size="medium">
+										{ translate( 'Installation steps:' ) }
+									</Text>
+									<ol>
+										<li>
+											<Text as="p" size="medium">
+												{ translate( 'Click the download button above' ) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" size="medium">
+												{ translate( 'Double-click the downloaded file' ) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" size="medium">
+												{ translate( "Follow Claude Desktop's setup instructions" ) }
+											</Text>
+										</li>
+									</ol>
 								</VStack>
 							) }
 
 							{ /* Quick Setup for Cursor */ }
 							{ selectedMcpClient === 'cursor' && (
-								<VStack spacing={ 4 }>
-									<CardHeader size={ 20 }>{ translate( 'Quick Setup' ) }</CardHeader>
-									<Text as="p" size="small">
+								<VStack
+									spacing={ 4 }
+									style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
+								>
+									<CardHeading tagName="h1" size={ 16 } isBold>
+										{ translate( 'Quick Setup' ) }
+									</CardHeading>
+									<Text as="p" size="medium">
 										{ translate(
 											'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
 										) }
@@ -276,7 +284,9 @@ function McpSetupComponent( { path } ) {
 							) }
 
 							<VStack spacing={ 4 }>
-								<CardHeader size={ 20 }>{ translate( 'MCP Server Configuration' ) }</CardHeader>
+								<CardHeading tagName="h1" size={ 16 } isBold>
+									{ translate( 'Manual Setup' ) }
+								</CardHeading>
 
 								<VStack spacing={ 3 }>
 									<div
@@ -290,13 +300,16 @@ function McpSetupComponent( { path } ) {
 											<ExternalLink
 												href={ clientDocumentation[ selectedMcpClient ] }
 												target="_blank"
-												size="small"
+												style={ { fontSize: 'inherit' } }
 											>
 												{ /* translators: %s is the name of the MCP client */ }
-												{ sprintf(
-													translate( 'View setup instructions for %s' ),
-													mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )?.label
-												) }
+												{ selectedMcpClient === 'default'
+													? translate( 'View setup instructions for other MCP client' )
+													: sprintf(
+															translate( 'View setup instructions for %s' ),
+															mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
+																?.label
+													  ) }
 											</ExternalLink>
 										) }
 										<Button
@@ -323,52 +336,54 @@ function McpSetupComponent( { path } ) {
 							</VStack>
 						</VStack>
 						<VStack spacing={ 3 }>
-							<Text as="li" style={ { listStyle: 'none' } }>
-								{ createInterpolateElement(
-									translate(
-										'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-									).replace( '%s', serverName ),
-									{
-										code: (
-											<code
-												key="server-name"
-												style={ {
-													backgroundColor: '#f0f0f1',
-													padding: '2px 6px',
-													borderRadius: '3px',
-													fontFamily: 'monospace',
-													fontSize: '13px',
-												} }
-											>
-												{ serverName }
-											</code>
-										),
-									}
-								) }
-							</Text>
-							<Text as="li" style={ { listStyle: 'none' } }>
-								{ createInterpolateElement(
-									translate(
-										'<code>%s</code> is the official WordPress.com MCP server package'
-									).replace( '%s', '@automattic/mcp-wpcom-remote' ),
-									{
-										code: (
-											<code
-												key="package-name"
-												style={ {
-													backgroundColor: '#f0f0f1',
-													padding: '2px 6px',
-													borderRadius: '3px',
-													fontFamily: 'monospace',
-													fontSize: '13px',
-												} }
-											>
-												@automattic/mcp-wpcom-remote
-											</code>
-										),
-									}
-								) }
-							</Text>
+							<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
+								<li>
+									{ createInterpolateElement(
+										translate(
+											'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+										).replace( '%s', serverName ),
+										{
+											code: (
+												<code
+													key="server-name"
+													style={ {
+														backgroundColor: '#f0f0f1',
+														padding: '2px 6px',
+														borderRadius: '3px',
+														fontFamily: 'monospace',
+														fontSize: '13px',
+													} }
+												>
+													{ serverName }
+												</code>
+											),
+										}
+									) }
+								</li>
+								<li>
+									{ createInterpolateElement(
+										translate(
+											'<code>%s</code> is the official WordPress.com MCP server package'
+										).replace( '%s', '@automattic/mcp-wpcom-remote' ),
+										{
+											code: (
+												<code
+													key="package-name"
+													style={ {
+														backgroundColor: '#f0f0f1',
+														padding: '2px 6px',
+														borderRadius: '3px',
+														fontFamily: 'monospace',
+														fontSize: '13px',
+													} }
+												>
+													@automattic/mcp-wpcom-remote
+												</code>
+											),
+										}
+									) }
+								</li>
+							</ul>
 						</VStack>
 					</CardBody>
 				</Card>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -9,6 +9,7 @@ import {
 	__experimentalText as Text,
 	Card,
 	CardBody,
+	CardHeader,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -212,8 +213,70 @@ function McpSetupComponent( { path } ) {
 								) }
 							/>
 
+							{ /* Quick Setup for Claude Desktop */ }
+							{ selectedMcpClient === 'claude' && (
+								<VStack spacing={ 4 }>
+									<CardHeader size={ 20 }>{ translate( 'Quick Setup' ) }</CardHeader>
+									<Text as="p" size="small">
+										{ translate(
+											'For Claude Desktop users, we provide a one-click setup option using our pre-configured MCPB file.'
+										) }
+									</Text>
+									<Button
+										variant="primary"
+										href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
+										target="_blank"
+										style={ { alignSelf: 'flex-start' } }
+									>
+										{ translate( 'Download MCPB File' ) }
+									</Button>
+									<VStack spacing={ 2 }>
+										<CardHeader size={ 16 }>{ translate( 'Installation steps:' ) }</CardHeader>
+										<ol style={ { fontSize: 'small' } }>
+											<li>
+												<Text as="p" size="small">
+													{ translate( 'Download the MCPB file using the button above.' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" size="small">
+													{ translate( 'Open the downloaded file by double-clicking it.' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" size="small">
+													{ translate(
+														'Follow the setup instructions from Claude Desktop to install locally.'
+													) }
+												</Text>
+											</li>
+										</ol>
+									</VStack>
+								</VStack>
+							) }
+
+							{ /* Quick Setup for Cursor */ }
+							{ selectedMcpClient === 'cursor' && (
+								<VStack spacing={ 4 }>
+									<CardHeader size={ 20 }>{ translate( 'Quick Setup' ) }</CardHeader>
+									<Text as="p" size="small">
+										{ translate(
+											'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+										) }
+									</Text>
+									<Button
+										variant="primary"
+										href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+										target="_blank"
+										style={ { alignSelf: 'flex-start' } }
+									>
+										{ translate( 'Install in Cursor' ) }
+									</Button>
+								</VStack>
+							) }
+
 							<VStack spacing={ 4 }>
-								<Text as="h3">{ translate( 'MCP Server Configuration' ) }</Text>
+								<CardHeader size={ 20 }>{ translate( 'MCP Server Configuration' ) }</CardHeader>
 
 								<VStack spacing={ 3 }>
 									<div


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

Fixes issue with MCP access state not getting updated until a refresh, meaning if the user clicks on the 'Configure' button, Calyspo thinks they need to enable MCP access.

## Proposed Changes

**1. Fixed MCP Access state** - Updated MCP setup page to use React Query instead of Redux. Replaced `isAutomatticianQuery` and Redux `connect` with `userSettingsQuery` and `useSuspenseQuery`, removing the `isAutomattician` check entirely.

**2. Added Quick Setup sections for Claude Desktop and Cursor** - Integrated one-click setup options directly into the client configuration flow, with MCPB download for Claude and direct Cursor install link.

**3. Updated support links and improved styling** - Changed MCP support link to a dedicated MCP settings page, replaced inline `borderRadius` styles with `isRounded={false}` prop, and enhanced the installation steps with proper ordered lists and `CardHeader` components.

## Demo

https://github.com/user-attachments/assets/654be84a-a4ab-4318-96ce-de24e73b9311




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
