### PR TITLE
Notification Settings: Add track events to Notification > Comments

### DIFF
--- a/client/dashboard/me/notifications-comments/device-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/device-settings/index.tsx
@@ -17,9 +17,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { SettingsPanel, type SettingsOption } from '../../../../components/settings-panel';
+import { useAnalytics } from '../../../app/analytics';
 import { SectionHeader } from '../../../components/section-header';
 
 export const DevicesSettings = () => {
+	const { recordTracksEvent } = useAnalytics();
 	const { data } = useSuspenseQuery( userNotificationsSettingsQuery() );
 	const { mutate: updateSettings } = useMutation( {
 		...userNotificationsSettingsMutation(),
@@ -57,6 +59,12 @@ export const DevicesSettings = () => {
 				};
 			}
 			return device;
+		} );
+
+		recordTracksEvent( 'calypso_dashboard_notifications_devices_settings_updated', {
+			device_id: selectedDeviceId,
+			setting_name: updated.id,
+			setting_value: updated.value,
 		} );
 
 		updateSettings( {

--- a/client/dashboard/me/notifications-comments/email-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/email-settings/index.tsx
@@ -12,10 +12,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { SettingsPanel, type SettingsOption } from '../../../../components/settings-panel';
+import { useAnalytics } from '../../../app/analytics';
 import { SectionHeader } from '../../../components/section-header';
 
 export const EmailSettings = () => {
 	const { data } = useSuspenseQuery( userNotificationsSettingsQuery() );
+	const { recordTracksEvent } = useAnalytics();
 	const { mutate: updateSettings } = useMutation( {
 		...userNotificationsSettingsMutation(),
 		meta: {
@@ -33,6 +35,11 @@ export const EmailSettings = () => {
 		} ) > 0;
 
 	const handleChange = ( updated: SettingsOption ) => {
+		recordTracksEvent( 'calypso_dashboard_notifications_email_settings_updated', {
+			setting_name: updated.id,
+			setting_value: updated.value,
+		} );
+
 		updateSettings( {
 			data: {
 				other: {

--- a/client/dashboard/me/notifications-comments/web-settings/index.tsx
+++ b/client/dashboard/me/notifications-comments/web-settings/index.tsx
@@ -13,9 +13,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { SettingsPanel, type SettingsOption } from '../../../../components/settings-panel';
+import { useAnalytics } from '../../../app/analytics';
 import { SectionHeader } from '../../../components/section-header';
 
 export const WebSettings = () => {
+	const { recordTracksEvent } = useAnalytics();
+
 	const { data } = useSuspenseQuery( {
 		...userNotificationsSettingsQuery(),
 		meta: {
@@ -45,6 +48,11 @@ export const WebSettings = () => {
 				timeline: { ...settings, [ updated.id ]: updated.value },
 			},
 		} as InputUserNotificationSettings;
+
+		recordTracksEvent( 'calypso_dashboard_notifications_timeline_settings_updated', {
+			setting_name: updated.id,
+			setting_value: updated.value,
+		} );
 
 		updateSettings( { data: updatedSettings } );
 	};


### PR DESCRIPTION
Closes CML-944

## Proposed Changes
* Add track event: `calypso_dashboard_notifications_devices_settings_updated` 
* Add track event: `calypso_dashboard_notifications_email_settings_updated`
* Add track event: `calypso_dashboard_notifications_timeline_settings_updated`


## Testing Instructions

* Go to `/v2/me/notifications/comments`
* Update values on the 3 Cards (Web, Emails, Devices)
* Check if the events are triggered. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
