### PR TITLE
Notification Settings:  Add tracking to the Notification > Sites pages

### DIFF
--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
@@ -14,6 +14,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { SettingsOption, SettingsPanel } from '../../../../../components/settings-panel';
+import { useAnalytics } from '../../../../app/analytics';
 import { getFieldLabel } from '../../helpers/translations';
 import { useSiteSettings, useSettingsMutation } from '../../hooks';
 import { ApplySettingsToAllSitesConfirmationModal } from '../apply-settings-to-all-sites-confirmation-modal';
@@ -23,6 +24,7 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 	const { data: devices } = useSuspenseQuery( userNotificationsDevicesQuery() );
 	const { mutate: updateSettings, isPending: isUpdating } = useSettingsMutation();
 	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
+	const { recordTracksEvent } = useAnalytics();
 
 	const [ selectedDeviceId, setSelectedDeviceId ] = useState< string | undefined >(
 		devices?.[ 0 ]?.device_id
@@ -38,6 +40,12 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 	};
 
 	const handleChange = ( item: SettingsOption ) => {
+		recordTracksEvent( 'calypso_dashboard_notifications_devices_settings_updated', {
+			setting_name: item.id,
+			setting_value: item.value,
+			site_id: siteId,
+		} );
+
 		updateSettings( {
 			data: {
 				blogs: [
@@ -104,6 +112,11 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 		if ( ! blogSettings ) {
 			return;
 		}
+		recordTracksEvent( 'calypso_dashboard_notifications_settings_apply_to_all_sites', {
+			stream: 'devices',
+			device_to_be_used_as_template: siteId,
+			site_to_be_used_as_template: siteId,
+		} );
 
 		updateSettings( {
 			data: {


### PR DESCRIPTION

Closes CML-945

## Proposed Changes
* Add the `calypso_dashboard_notifications_devices_settings_updated`
* Add the `calypso_dashboard_notifications_email_settings_updated`
* Add the `calypso_dashboard_notifications_timeline_settings_updated`
* Add the `calypso_dashboard_notifications_settings_apply_to_all_sites`


## Testing Instructions
* Go to `/v2/me/notifications/sites`
*  Update at least one setting on each panel (Web, Email, Devices)
* Check if the events above were triggered (based on the tab name)
* Use the `apply to all sites`
* Check if the  event calypso_dashboard_notifications_settings_apply_to_all_sites was triggered


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
