### PR TITLE
Update hosting dashboard purchases endpoints to 1.2

### DIFF
--- a/packages/api-core/src/me-purchases/fetchers.ts
+++ b/packages/api-core/src/me-purchases/fetchers.ts
@@ -5,7 +5,7 @@ import type { Purchase } from '../purchase';
 export async function fetchUserPurchases(): Promise< Purchase[] > {
 	const data = await wpcom.req.get( {
 		path: '/me/purchases',
-		apiVersion: '1.1',
+		apiVersion: '1.2',
 	} );
 	return data.map( normalizePurchase );
 }
@@ -13,7 +13,7 @@ export async function fetchUserPurchases(): Promise< Purchase[] > {
 export async function fetchUserTransferredPurchases(): Promise< Purchase[] > {
 	const data = await wpcom.req.get( {
 		path: '/me/purchases/transferred',
-		apiVersion: '1.1',
+		apiVersion: '1.2',
 	} );
 	return data.map( normalizePurchase );
 }

--- a/packages/api-core/src/site-purchases/fetchers.ts
+++ b/packages/api-core/src/site-purchases/fetchers.ts
@@ -5,7 +5,7 @@ import type { Purchase } from '../purchase';
 export async function fetchSitePurchases( siteId: number | string ): Promise< Purchase[] > {
 	const data = await wpcom.req.get( {
 		path: `/sites/${ siteId }/purchases`,
-		apiVersion: '1.1',
+		apiVersion: '1.2',
 	} );
 	return data.map( normalizePurchase );
 }

--- a/packages/api-core/src/upgrades/fetchers.ts
+++ b/packages/api-core/src/upgrades/fetchers.ts
@@ -5,7 +5,7 @@ import type { Purchase } from '../purchase';
 export async function fetchPurchase( purchaseId: number ): Promise< Purchase > {
 	const data = await wpcom.req.get( {
 		path: `/upgrades/${ purchaseId }`,
-		apiVersion: '1.1',
+		apiVersion: '1.2',
 	} );
 	return normalizePurchase( data );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SHILL-1057

## Proposed Changes

In 191236-ghe-Automattic/wpcom and 193428-ghe-Automattic/wpcom, we made new versions of the purchases endpoints that have a more organized return data type. This PR switches the hosting dashboard to use those new endpoints. There should be no change in behavior but since the hosting dashboard is not yet launched this provides a slightly safer way to verify these versions work as expected before using them in the rest of calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `v2/me/billing/purchases`; you'll need to use calypso.localhost or the calypso.live environments.

Verify that your purchases appear as they did without this PR.