### PR TITLE
Purchase Settings: Fix incorrect tense of expired messages

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -2,9 +2,14 @@ import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { isBefore } from 'date-fns';
 import { useState } from 'react';
 import Notice from '../../../components/notice';
-import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
+import {
+	getDateFromCreditCardExpiry,
+	getRelativeTimeString,
+	isWithinNext,
+} from '../../../utils/datetime';
 import {
 	isExpired,
 	isExpiring,
@@ -21,6 +26,23 @@ import { shouldShowCardExpiringWarning } from './purchase-notice';
 import { UpcomingRenewalsDialog } from './upcoming-renewals-dialog';
 import type { NoticeVariant } from '../../../components/notice/types';
 import type { Purchase } from '@automattic/api-core';
+
+function getCardExpirationTense( purchase: Purchase ): string {
+	if ( ! purchase.payment_expiry ) {
+		return 'expires';
+	}
+
+	try {
+		// Use existing utility that returns the last day of the expiry month
+		const cardExpiryDate = getDateFromCreditCardExpiry( purchase.payment_expiry );
+		const now = new Date();
+
+		return isBefore( cardExpiryDate, now ) ? 'expired' : 'expires';
+	} catch {
+		// Fallback for invalid dates
+		return 'expires';
+	}
+}
 
 export function shouldShowOtherRenewablePurchasesNotice(
 	purchase: Purchase,
@@ -656,13 +678,14 @@ export function OtherRenewablePurchasesNotice( {
 					noticeStatus={ shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info' }
 					noticeText={ createInterpolateElement(
 						sprintf(
-							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
 							__(
-								'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+								'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
 							),
 							{
 								cardType: purchase.payment_card_type,
 								cardNumber: purchase.payment_card_id,
+								tense: getCardExpirationTense( purchase ),
 								cardExpiry: purchase.payment_expiry,
 							}
 						),
@@ -835,13 +858,14 @@ export function OtherRenewablePurchasesNotice( {
 					noticeStatus="info"
 					noticeText={ createInterpolateElement(
 						sprintf(
-							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
 							__(
-								'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+								'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
 							),
 							{
 								cardType: purchase.payment_card_type,
 								cardNumber: purchase.payment_card_id,
+								tense: getCardExpirationTense( purchase ),
 								cardExpiry: purchase.payment_expiry,
 							}
 						),

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -2,14 +2,9 @@ import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { isBefore } from 'date-fns';
 import { useState } from 'react';
 import Notice from '../../../components/notice';
-import {
-	getDateFromCreditCardExpiry,
-	getRelativeTimeString,
-	isWithinNext,
-} from '../../../utils/datetime';
+import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
 import {
 	isExpired,
 	isExpiring,
@@ -18,6 +13,7 @@ import {
 	needsToRenewSoon,
 	isRecentMonthlyPurchase,
 	creditCardExpiresBeforeSubscription,
+	creditCardHasAlreadyExpired,
 	getRenewUrlForPurchases,
 } from '../../../utils/purchase';
 import { getPurchaseUrl, getAddPaymentMethodUrlFor } from '../urls';
@@ -26,23 +22,6 @@ import { shouldShowCardExpiringWarning } from './purchase-notice';
 import { UpcomingRenewalsDialog } from './upcoming-renewals-dialog';
 import type { NoticeVariant } from '../../../components/notice/types';
 import type { Purchase } from '@automattic/api-core';
-
-function getCardExpirationTense( purchase: Purchase ): string {
-	if ( ! purchase.payment_expiry ) {
-		return 'expires';
-	}
-
-	try {
-		// Use existing utility that returns the last day of the expiry month
-		const cardExpiryDate = getDateFromCreditCardExpiry( purchase.payment_expiry );
-		const now = new Date();
-
-		return isBefore( cardExpiryDate, now ) ? 'expired' : 'expires';
-	} catch {
-		// Fallback for invalid dates
-		return 'expires';
-	}
-}
 
 export function shouldShowOtherRenewablePurchasesNotice(
 	purchase: Purchase,
@@ -669,6 +648,28 @@ export function OtherRenewablePurchasesNotice( {
 		}
 
 		if ( currentPurchase.payment_card_id ) {
+			const cardDetails = {
+				cardType: purchase.payment_card_type,
+				cardNumber: purchase.payment_card_id,
+				cardExpiry: purchase.payment_expiry,
+			};
+
+			const translatedMessage = creditCardHasAlreadyExpired( purchase )
+				? sprintf(
+						// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+						__(
+							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+						),
+						cardDetails
+				  )
+				: sprintf(
+						// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+						__(
+							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+						),
+						cardDetails
+				  );
+
 			return (
 				<NoticeContent
 					purchase={ purchase }
@@ -676,21 +677,7 @@ export function OtherRenewablePurchasesNotice( {
 					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
 					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 					noticeStatus={ shouldShowCardExpiringWarning( currentPurchase ) ? 'error' : 'info' }
-					noticeText={ createInterpolateElement(
-						sprintf(
-							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
-							__(
-								'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
-							),
-							{
-								cardType: purchase.payment_card_type,
-								cardNumber: purchase.payment_card_id,
-								tense: getCardExpirationTense( purchase ),
-								cardExpiry: purchase.payment_expiry,
-							}
-						),
-						{ link }
-					) }
+					noticeText={ createInterpolateElement( translatedMessage, { link } ) }
 					noticeActionHref={ getAddPaymentMethodUrlFor( purchase ) }
 					noticeActionText={ __( 'Update all' ) }
 				/>
@@ -849,6 +836,28 @@ export function OtherRenewablePurchasesNotice( {
 		}
 
 		if ( currentPurchase.payment_card_id ) {
+			const cardDetails = {
+				cardType: purchase.payment_card_type,
+				cardNumber: purchase.payment_card_id,
+				cardExpiry: purchase.payment_expiry,
+			};
+
+			const translatedMessage = creditCardHasAlreadyExpired( purchase )
+				? sprintf(
+						// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+						__(
+							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+						),
+						cardDetails
+				  )
+				: sprintf(
+						// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+						__(
+							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
+						),
+						cardDetails
+				  );
+
 			return (
 				<NoticeContent
 					purchase={ purchase }
@@ -856,21 +865,7 @@ export function OtherRenewablePurchasesNotice( {
 					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
 					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 					noticeStatus="info"
-					noticeText={ createInterpolateElement(
-						sprintf(
-							// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
-							__(
-								'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have <link>other upgrades</link> on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.'
-							),
-							{
-								cardType: purchase.payment_card_type,
-								cardNumber: purchase.payment_card_id,
-								tense: getCardExpirationTense( purchase ),
-								cardExpiry: purchase.payment_expiry,
-							}
-						),
-						{ link }
-					) }
+					noticeText={ createInterpolateElement( translatedMessage, { link } ) }
 					noticeActionHref={ getAddPaymentMethodUrlFor( purchase ) }
 					noticeActionText={ __( 'Update all' ) }
 				/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -5,11 +5,10 @@ import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { differenceInCalendarDays, isBefore } from 'date-fns';
+import { differenceInCalendarDays } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Notice from '../../../components/notice';
-import { getDateFromCreditCardExpiry } from '../../../utils/datetime';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -17,6 +16,7 @@ import {
 	isCloseToExpiration,
 	needsToRenewSoon,
 	creditCardExpiresBeforeSubscription,
+	creditCardHasAlreadyExpired,
 	getRenewalUrlFromPurchase,
 } from '../../../utils/purchase';
 import { getPurchaseUrl, getAddPaymentMethodUrlFor, getChangePaymentMethodUrlFor } from '../urls';
@@ -336,49 +336,40 @@ export function shouldShowCardExpiringWarning( purchase: Purchase ): boolean {
 	);
 }
 
-function getCardExpirationTense( purchase: Purchase ): string {
-	if ( ! purchase.payment_expiry ) {
-		return 'expires';
-	}
-
-	try {
-		// Use existing utility that returns the last day of the expiry month
-		const cardExpiryDate = getDateFromCreditCardExpiry( purchase.payment_expiry );
-		const now = new Date();
-
-		return isBefore( cardExpiryDate, now ) ? 'expired' : 'expires';
-	} catch {
-		// Fallback for invalid dates
-		return 'expires';
-	}
-}
-
 function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 	const changePaymentMethodPath = purchase.payment_card_id
 		? getChangePaymentMethodUrlFor( purchase )
 		: getAddPaymentMethodUrlFor( purchase );
 
-	const tense = getCardExpirationTense( purchase );
+	const cardDetails = {
+		cardType: purchase.payment_card_type,
+		cardNumber: purchase.payment_card_id,
+		cardExpiry: purchase.payment_expiry,
+	};
+
+	const linkComponent = {
+		link: <Link to={ changePaymentMethodPath } />,
+	};
+
+	const translatedMessage = creditCardHasAlreadyExpired( purchase )
+		? sprintf(
+				// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+				__(
+					'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
+				),
+				cardDetails
+		  )
+		: sprintf(
+				// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+				__(
+					'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
+				),
+				cardDetails
+		  );
 
 	return (
 		<Notice variant={ shouldShowCardExpiringWarning( purchase ) ? 'error' : 'info' }>
-			{ createInterpolateElement(
-				sprintf(
-					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
-					__(
-						'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
-					),
-					{
-						cardType: purchase.payment_card_type,
-						cardNumber: purchase.payment_card_id,
-						tense: tense,
-						cardExpiry: purchase.payment_expiry,
-					}
-				),
-				{
-					link: <Link to={ changePaymentMethodPath } />,
-				}
-			) }
+			{ createInterpolateElement( translatedMessage, linkComponent ) }
 		</Notice>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -5,10 +5,11 @@ import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { differenceInCalendarDays } from 'date-fns';
+import { differenceInCalendarDays, isBefore } from 'date-fns';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Notice from '../../../components/notice';
+import { getDateFromCreditCardExpiry } from '../../../utils/datetime';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -335,21 +336,42 @@ export function shouldShowCardExpiringWarning( purchase: Purchase ): boolean {
 	);
 }
 
+function getCardExpirationTense( purchase: Purchase ): string {
+	if ( ! purchase.payment_expiry ) {
+		return 'expires';
+	}
+
+	try {
+		// Use existing utility that returns the last day of the expiry month
+		const cardExpiryDate = getDateFromCreditCardExpiry( purchase.payment_expiry );
+		const now = new Date();
+
+		return isBefore( cardExpiryDate, now ) ? 'expired' : 'expires';
+	} catch {
+		// Fallback for invalid dates
+		return 'expires';
+	}
+}
+
 function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 	const changePaymentMethodPath = purchase.payment_card_id
 		? getChangePaymentMethodUrlFor( purchase )
 		: getAddPaymentMethodUrlFor( purchase );
+
+	const tense = getCardExpirationTense( purchase );
+
 	return (
 		<Notice variant={ shouldShowCardExpiringWarning( purchase ) ? 'error' : 'info' }>
 			{ createInterpolateElement(
 				sprintf(
-					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, and cardExpiry is the card expiration date.
+					// translators: cardType is a credit card brand, cardNumber is the last 4 digits of the credit card number, tense is 'expires' or 'expired', and cardExpiry is the card expiration date.
 					__(
-						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
+						'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. Please <link>update your payment information</link>.'
 					),
 					{
 						cardType: purchase.payment_card_type,
 						cardNumber: purchase.payment_card_id,
+						tense: tense,
 						cardExpiry: purchase.payment_expiry,
 					}
 				),

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -730,9 +730,12 @@ class PurchaseNotice extends Component<
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-soon-others-renew-soon-cc-expiring';
 				noticeText = translate(
-					'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+					'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
 					merge( translateOptions, {
-						args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+						args: {
+							...this.creditCardDetails( currentPurchase.payment.creditCard ),
+							tense: this.getCardExpirationTense( currentPurchase.payment.creditCard ),
+						},
 					} )
 				);
 			}
@@ -827,9 +830,12 @@ class PurchaseNotice extends Component<
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-later-others-renew-soon-cc-expiring';
 				noticeText = translate(
-					'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+					'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
 					merge( translateOptions, {
-						args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+						args: {
+							...this.creditCardDetails( currentPurchase.payment.creditCard ),
+							tense: this.getCardExpirationTense( currentPurchase.payment.creditCard ),
+						},
 					} )
 				);
 			}
@@ -896,6 +902,17 @@ class PurchaseNotice extends Component<
 		};
 	};
 
+	/**
+	 * Returns the appropriate tense for card expiration text based on whether the card is expired.
+	 */
+	getCardExpirationTense = ( creditCard: PurchasePaymentCreditCard ) => {
+		const { moment } = this.props;
+		const cardExpiryMoment = moment( creditCard.expiryDate, 'MM/YY' );
+		const isExpired = cardExpiryMoment.isBefore( moment(), 'month' );
+
+		return isExpired ? 'expired' : 'expires';
+	};
+
 	renderCreditCardExpiringNotice() {
 		const { changePaymentMethodPath, purchase, translate } = this.props;
 
@@ -923,10 +940,13 @@ class PurchaseNotice extends Component<
 					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }
 				>
 					{ translate(
-						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
+						'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s ' +
 							'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
 						{
-							args: this.creditCardDetails( purchase.payment.creditCard ),
+							args: {
+								...this.creditCardDetails( purchase.payment.creditCard ),
+								tense: this.getCardExpirationTense( purchase.payment.creditCard ),
+							},
 							components: {
 								a: linkComponent,
 							},

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -26,6 +26,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
+	creditCardHasAlreadyExpired,
 	getName,
 	isCloseToExpiration,
 	isExpired,
@@ -729,15 +730,19 @@ class PurchaseNotice extends Component<
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-soon-others-renew-soon-cc-expiring';
-				noticeText = translate(
-					'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-					merge( translateOptions, {
-						args: {
-							...this.creditCardDetails( currentPurchase.payment.creditCard ),
-							tense: this.getCardExpirationTense( currentPurchase.payment.creditCard ),
-						},
-					} )
-				);
+				noticeText = creditCardHasAlreadyExpired( currentPurchase )
+					? translate(
+							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+							merge( translateOptions, {
+								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+							} )
+					  )
+					: translate(
+							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+							merge( translateOptions, {
+								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+							} )
+					  );
 			}
 		}
 
@@ -829,15 +834,19 @@ class PurchaseNotice extends Component<
 				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
 				noticeActionText = translate( 'Update all' );
 				noticeImpressionName = 'current-renews-later-others-renew-soon-cc-expiring';
-				noticeText = translate(
-					'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
-					merge( translateOptions, {
-						args: {
-							...this.creditCardDetails( currentPurchase.payment.creditCard ),
-							tense: this.getCardExpirationTense( currentPurchase.payment.creditCard ),
-						},
-					} )
-				);
+				noticeText = creditCardHasAlreadyExpired( currentPurchase )
+					? translate(
+							'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+							merge( translateOptions, {
+								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+							} )
+					  )
+					: translate(
+							'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+							merge( translateOptions, {
+								args: this.creditCardDetails( currentPurchase.payment.creditCard ),
+							} )
+					  );
 			}
 		}
 
@@ -902,17 +911,6 @@ class PurchaseNotice extends Component<
 		};
 	};
 
-	/**
-	 * Returns the appropriate tense for card expiration text based on whether the card is expired.
-	 */
-	getCardExpirationTense = ( creditCard: PurchasePaymentCreditCard ) => {
-		const { moment } = this.props;
-		const cardExpiryMoment = moment( creditCard.expiryDate, 'MM/YY' );
-		const isExpired = cardExpiryMoment.isBefore( moment(), 'month' );
-
-		return isExpired ? 'expired' : 'expires';
-	};
-
 	renderCreditCardExpiringNotice() {
 		const { changePaymentMethodPath, purchase, translate } = this.props;
 
@@ -939,19 +937,27 @@ class PurchaseNotice extends Component<
 					showDismiss={ false }
 					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }
 				>
-					{ translate(
-						'Your %(cardType)s ending in %(cardNumber)d %(tense)s %(cardExpiry)s ' +
-							'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
-						{
-							args: {
-								...this.creditCardDetails( purchase.payment.creditCard ),
-								tense: this.getCardExpirationTense( purchase.payment.creditCard ),
-							},
-							components: {
-								a: linkComponent,
-							},
-						}
-					) }
+					{ creditCardHasAlreadyExpired( purchase )
+						? translate(
+								'Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s ' +
+									'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
+								{
+									args: this.creditCardDetails( purchase.payment.creditCard ),
+									components: {
+										a: linkComponent,
+									},
+								}
+						  )
+						: translate(
+								'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
+									'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
+								{
+									args: this.creditCardDetails( purchase.payment.creditCard ),
+									components: {
+										a: linkComponent,
+									},
+								}
+						  ) }
 					{ this.trackImpression( 'credit-card-expiring' ) }
 				</Notice>
 			);

--- a/client/me/purchases/manage-purchase/test/notices.js
+++ b/client/me/purchases/manage-purchase/test/notices.js
@@ -457,7 +457,7 @@ describe( 'PurchaseNotice', () => {
 				/>
 			</ReduxProvider>
 		);
-		expect( screen.getByText( /Your VISA ending in 1111 expires/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Your VISA ending in 1111 expired/ ) ).toBeInTheDocument();
 		expect( screen.getByText( 'update your payment information' ) ).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
Resolves CHE-255

## Proposed Changes

* Fixed incorrect tense in credit card expiration status messaging by adding a second message shown when the card is already expired:
    *  `Your %(cardType)s ending in %(cardNumber)d expired %(cardExpiry)s – before the next renewal. You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.`

## Why are these changes being made?
* Users were seeing confusing messaging where expired credit cards showed "Your card ending in XX expires..." using future tense even when the expiration date was in the past
* This creates a poor user experience and misleading information about payment method status

## Testing Instructions
* Log into http://calypso.localhost:3000/purchases with an account that has at least one active subscription
* Ensure a saved payment card on the account is already expired
* Navigate to: Upgrades → Purchases → Subscription. ex: http://calypso.localhost:3000/purchases/subscriptions/jswork.wordpress.com/1132047
* Locate the subscription that uses the expired card and view its payment method status
* Verify the text now reads "Your card ending in XX expired..." (past tense) instead of "expires..." (future tense)
* Test with cards that expire in the future to ensure they still show proper future tense

Test the same subscriptions for /me/purchases
* Go to http://calypso.localhost:3000/me/purchases
* Make sure the same subscriptions tested above show the same notice.  ex http://calypso.localhost:3000/me/purchases/jswork.wordpress.com/1132047

To force the expiration and renewal data on your sandbox:
edit wpcom/public_html/wp-content/admin-plugins/wpcom-billing/class.my-upgrades.php ~ line 534
```
//USE THIS TO TEST "expired"
			$new_sub->payment_expiry_timestamp = 1577836800; // January 2020 (expired)
			$new_sub->payment_expiry = '01/20';

//USE THIS TO TEST "expires"
			$new_sub->payment_expiry_timestamp = strtotime('+2 days'); // (expires)
			$new_sub->payment_expiry = date( 'm/y', $new_sub->payment_expiry_timestamp );

// Ensure subscriptions are active and renewable
			$new_sub->renew = '1';
			$new_sub->is_auto_renew_enabled = true;
			$new_sub->expiry = date('Y-m-d H:i:s', strtotime('+2 months'));
			$new_sub->expiry_date = date('Y-m-d H:i:s', strtotime('+2 months'));
			$new_sub->is_renewable = 1;
			$new_sub->can_explicit_renew = 1;
			$new_sub->payment_type = 'credit_card';
			$new_sub->expiry_status = 'active';
			$new_sub->status = 'active';
			$new_sub->payment_card_id = 12345;
			$new_sub->payment_card_type = 'visa';
			$new_sub->payment_details = '4242';
```
Or this code to test the V2 routes in the new hosting dashboard: ex: http://calypso.localhost:3000/v2/me/billing/purchases/1132047


edit wpcom/public_html/wp-content/admin-plugins/wpcom-billing/store-subscription.php  add_payment_info_to_purchase ~line 4763
```

//USE THIS TO TEST "expired"
			$purchase->payment_expiry_timestamp = 1577836800; // January 2020 (expired)
			$purchase->payment_expiry = '01/20';

//USE THIS TO TEST "expires"
			$purchase->payment_expiry_timestamp = strtotime('+2 days'); // (expires)
			$purchase->payment_expiry = date( 'm/y', $new_sub->payment_expiry_timestamp );

// Ensure purchases are active and renewable
			$purchase->is_auto_renew_enabled = true;
			$purchase->expiry_date = gmdate( 'Y-m-d H:i:s', strtotime( '+2 months' ) );
			$purchase->is_renewable = true;
			$purchase->can_explicit_renew = true;
			$purchase->payment_type = 'credit_card';
			$purchase->expiry_status = 'active';
			$purchase->payment_card_id = 12345;
			$purchase->payment_card_type = 'visa';
			$purchase->payment_details = '4242';
```


To test additional content, use one site with a single subscription(personal plan) and a second site with multiple subscriptions(Premium with Storage and Email).

single subscription example:
/me/purchases/...
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/ab0ebad9-b346-42ac-b0ae-48e270831720" />
and /purchases/subscriptions/...
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/1e4468b9-e7c9-4323-8fb2-34b2451ed494" />
and v2 hosting dashboard
<img width="1295" height="805" alt="image" src="https://github.com/user-attachments/assets/86312a53-eda1-4341-9731-ff56c6e6bb21" />


multi-subscription example:
/me/purchases/...
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/1ccbdbda-9261-4e1b-8481-881a35646bf6" />
and /purchases/subscriptions/...
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/bd0cb90b-b71e-4b8d-a215-021b6ad0ab12" />
and v2 hosting dashboard
<img width="1295" height="805" alt="image" src="https://github.com/user-attachments/assets/b89f6cd8-8cd3-4014-be85-4ec4385cf734" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
