### PR TITLE
Domain Search Rewrite: Enable feature flag in WPCalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domain-search-rewrite": false,
+		"domain-search-rewrite": true,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Addresses p1759537997769219/1759495443.965589-slack-C04H4NY6STW.

## Proposed Changes

Enables the `domain-search-rewrite` flag in `wpcalypso.wordpress.com` as well.

Verify [Pre-release E2E tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/15837800?buildTab=overview) are still passing.