### PR TITLE
Hosting Dashboard Domain Upsell: Do not use Link component to link to domain-and-plan Stepper flow

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -1,6 +1,5 @@
 import { domainSuggestionsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
 import { __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -104,7 +103,7 @@ const DomainUpsellCardContent = ( {
 						) : (
 							<TextBlur>{ search }</TextBlur>
 						),
-						link: <Link to={ chooseYourOwnUrl } onClick={ handleChooseYourOwn } />,
+						link: <a href={ chooseYourOwnUrl } onClick={ handleChooseYourOwn } />,
 					} ) }
 				</Text>
 			}


### PR DESCRIPTION
Closes DOMAINS-1691.

## Proposed Changes

We were mistakenly using the `<Link />` component to link to a Stepper flow, but by using that component, it adheres automatically to the `/v2` base URL, which is wrong.

## Testing Instructions

Enter `/v2/sites/%s` and click the domain upsell card link. Verify you're sent to `/setup/domain-and-plan` instead of `/v2/setup/domain-and-plan`.