### PR TITLE
Dashboard v2: send no impression event after user has opt'd in

### DIFF
--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -72,7 +72,9 @@ export default function HostingDashboardOptInBanner() {
 
 	return (
 		<>
-			<TrackComponentView eventName="calypso_hosting_dashboard_opt_in_banner_impression" />
+			{ ! hasOptedIn && (
+				<TrackComponentView eventName="calypso_hosting_dashboard_opt_in_banner_impression" />
+			) }
 			<Card>
 				<CardBody style={ { padding: '12px' } }>
 					<VStack spacing={ 3 }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

Follows on from https://github.com/Automattic/wp-calypso/pull/106130. In #106130 the banner sends `_impression` events whenever the banner is rendered. However it only sends `_click` events when the banner is really opting in. If the user has already opt'd in then the `_click` event isn't sent.

Makes sense, but the `_impression` event should be symmetrical with the `_click` event IMO.

This PR ensures the `_impression` event isn't sent when the user has already opt'd in.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Make sure you clear the `hosting-dashboard-opt-in` preference if you've ever set that.
2. Go to the following routes; verify you DON'T see the banner as shown above:
   - `/reader`
3. Go to the following routes; verify you SEE the banner as shown above:
   - `/sites`
   - `/domains/manage`
   - `/plugins/scheduled-updates`
 4. Verify the `calypso_dashboard_opt_in_banner_impression` event is fired.
4. Click the `Try it out` button.
5. Verify the `calypso_dashboard_opt_in_banner_click` event is fired.
6. Verify you are redirected to `/v2`.
7. Click the "Preferences" link here

<img width="679" height="192" alt="image" src="https://github.com/user-attachments/assets/2a11d8ee-abf2-4b38-9a83-5503989bdd13" />

8. Verify that the toggle is on:

<img width="685" height="220" alt="image" src="https://github.com/user-attachments/assets/6eec85df-b9b6-41ba-a2ae-e51b48f63b33" />

9. Toggle it off to opt-out, then click Save.
10. Go to `/sites`; verify you no longer see the banner.
11. To reset the experience, clear the preference:

<img width="704" height="434" alt="image" src="https://github.com/user-attachments/assets/b2162f7d-e468-416d-a911-444c23d77a01" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
