### PR TITLE
Support only displaying the Storage add-on on the `/add-ons` page

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -9,7 +9,7 @@ import type { SiteId } from 'calypso/types';
 interface Props extends Omit< CardProps, 'addOnMeta' > {
 	addOns: ( AddOnMeta | null )[];
 	siteId?: SiteId;
-	productFilter?: string;
+	storageOnly?: boolean;
 }
 
 const Container = styled.div`
@@ -29,12 +29,11 @@ const AddOnsGrid = ( {
 	actionSecondary,
 	highlightFeatured,
 	siteId,
-	productFilter,
+	storageOnly,
 }: Props ) => {
-	const nonStorageAddOns =
-		productFilter === 'storage'
-			? []
-			: addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
+	const nonStorageAddOns = storageOnly
+		? []
+		: addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
 	return (
 		<Container>
 			{ nonStorageAddOns.map( ( addOn ) =>

--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -9,6 +9,7 @@ import type { SiteId } from 'calypso/types';
 interface Props extends Omit< CardProps, 'addOnMeta' > {
 	addOns: ( AddOnMeta | null )[];
 	siteId?: SiteId;
+	productFilter?: string;
 }
 
 const Container = styled.div`
@@ -28,8 +29,12 @@ const AddOnsGrid = ( {
 	actionSecondary,
 	highlightFeatured,
 	siteId,
+	productFilter,
 }: Props ) => {
-	const nonStorageAddOns = addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
+	const nonStorageAddOns =
+		productFilter === 'storage'
+			? []
+			: addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
 	return (
 		<Container>
 			{ nonStorageAddOns.map( ( addOn ) =>

--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -1,5 +1,6 @@
 import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
+import { useMemo } from 'react';
 import AddOnCard from 'calypso/sites/components/add-ons/add-ons-card';
 import StorageAddOnCard from './storage-add-ons-card';
 import type { AddOnMeta } from '@automattic/data-stores';
@@ -31,9 +32,11 @@ const AddOnsGrid = ( {
 	siteId,
 	storageOnly,
 }: Props ) => {
-	const nonStorageAddOns = storageOnly
-		? []
-		: addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
+	const nonStorageAddOns = useMemo(
+		() =>
+			storageOnly ? [] : addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE ),
+		[ addOns, storageOnly ]
+	);
 	return (
 		<Container>
 			{ nonStorageAddOns.map( ( addOn ) =>

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -12,6 +12,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AddOnsGrid from './components/add-ons-grid';
 import type { ReactElement } from 'react';
@@ -91,8 +92,11 @@ const NoAccess = () => {
 const AddOnsMain = () => {
 	const selectedSite = useSelector( getSelectedSite ) ?? null;
 	const addOns = AddOns.useAddOns( { selectedSiteId: selectedSite?.ID } );
+	const queryArguments = useSelector( getCurrentQueryArguments );
 
 	const checkoutLink = AddOns.useAddOnCheckoutLink();
+
+	const productFilter = queryArguments?.product as string | undefined;
 
 	const canManageSite = useSelector( ( state ) => {
 		if ( ! selectedSite ) {
@@ -132,6 +136,7 @@ const AddOnsMain = () => {
 					addOns={ addOns }
 					siteId={ selectedSite?.ID }
 					highlightFeatured
+					productFilter={ productFilter }
 				/>
 			</ContentWithHeader>
 		</>

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -96,7 +96,7 @@ const AddOnsMain = () => {
 
 	const checkoutLink = AddOns.useAddOnCheckoutLink();
 
-	const productFilter = queryArguments?.product as string | undefined;
+	const storageOnly = queryArguments?.product === 'storage';
 
 	const canManageSite = useSelector( ( state ) => {
 		if ( ! selectedSite ) {
@@ -136,7 +136,7 @@ const AddOnsMain = () => {
 					addOns={ addOns }
 					siteId={ selectedSite?.ID }
 					highlightFeatured
-					productFilter={ productFilter }
+					storageOnly={ storageOnly }
 				/>
 			</ContentWithHeader>
 		</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CMM-826

## Proposed Changes

* Adding a new URL query `product=storage` to the `/add-ons` web page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See the Linear issue for context.

## Testing Instructions

Verify that the `/add-ons/<site-domain>` page displays all add-ons.

Verify that the `/add-ons/<site-domain>?product=storage` page displays the storage add-on only.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
