### PR TITLE
Settings: Add back styles to the deprecated Security Settings screen

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -23,6 +23,8 @@ import SpamFilteringSettings from './spam-filtering-settings';
 import Sso from './sso';
 import wrapSettingsForm from './wrap-settings-form';
 
+import './style.scss';
+
 class SiteSettingsFormSecurity extends Component {
 	render() {
 		const {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14878

## Proposed Changes

* Add back the Site Settings styles to the (deprecated) Security Settings screen.

| Before | After |
|--------|--------|
| <img width="1496" height="1738" alt="Screenshot 2025-10-06 at 12 17 53" src="https://github.com/user-attachments/assets/25e89edb-6f0d-4a34-9a7b-3890c3e8566c" /> | <img width="1496" height="1738" alt="Screenshot 2025-10-06 at 12 18 04" src="https://github.com/user-attachments/assets/716e05d0-3010-4231-9e58-5d10d2347156" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While cleaning up post-Untangling-Calypso dead code (https://github.com/Automattic/wp-calypso/pull/106178), the site-settings/styles.scss file was removed from the main site-settings component, effectively removing it from the various Calypso Settings tabs.

Security Settings is a legacy screen that's only supposed to be used in very edge cases. A newer Hosting Dashboard version exists, but the Calypso one is still recommended by the support docs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick an Atomic site.
* Navigate to `/settings/security/:SITE`.
* Check the nested settings are aligned correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
