### PR TITLE
HD Domain: create new AddDomainButton component

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -43,7 +43,7 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 						iconPosition="left"
 						icon={ globe }
 					>
-						{ __( 'Use a domain I own' ) }
+						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
 					</RouterLinkMenuItem>
 				</>
 			) }

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -1,8 +1,7 @@
-import { Button, Dropdown } from '@wordpress/components';
+import { Button, Dropdown, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import RouterLinkMenuItem from '../components/router-link-menu-item';
 
 export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 	return (
@@ -21,8 +20,8 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 			) }
 			renderContent={ () => (
 				<>
-					<RouterLinkMenuItem
-						to={
+					<MenuItem
+						href={
 							siteSlug
 								? addQueryArgs( '/setup/domain', {
 										siteSlug,
@@ -33,9 +32,9 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 						icon={ search }
 					>
 						{ __( 'Search domain names' ) }
-					</RouterLinkMenuItem>
-					<RouterLinkMenuItem
-						to={
+					</MenuItem>
+					<MenuItem
+						href={
 							siteSlug
 								? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
 								: '/setup/domain-transfer'
@@ -43,8 +42,8 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 						iconPosition="left"
 						icon={ globe }
 					>
-						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
-					</RouterLinkMenuItem>
+						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain names' ) }
+					</MenuItem>
 				</>
 			) }
 		/>

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -20,29 +20,23 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 			) }
 			renderContent={ () => (
 				<>
-					<MenuItem
-						href={
-							siteSlug
-								? addQueryArgs( '/setup/domain', {
-										siteSlug,
-								  } )
-								: '/start/domain'
-						}
-						iconPosition="left"
-						icon={ search }
-					>
-						{ __( 'Search domain names' ) }
+					<MenuItem iconPosition="left" icon={ search }>
+						<Button
+							href={ siteSlug ? addQueryArgs( '/setup/domain', { siteSlug } ) : '/start/domain' }
+						>
+							{ __( 'Search domain names' ) }
+						</Button>
 					</MenuItem>
-					<MenuItem
-						href={
-							siteSlug
-								? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
-								: '/setup/domain-transfer'
-						}
-						iconPosition="left"
-						icon={ globe }
-					>
-						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain names' ) }
+					<MenuItem iconPosition="left" icon={ globe }>
+						<Button
+							href={
+								siteSlug
+									? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
+									: '/setup/domain-transfer'
+							}
+						>
+							{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
+						</Button>
 					</MenuItem>
 				</>
 			) }

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -1,0 +1,52 @@
+import { Button, Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import RouterLinkMenuItem from '../components/router-link-menu-item';
+
+export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					icon={ isOpen ? chevronUp : chevronDown }
+					iconPosition="right"
+					variant="primary"
+					__next40pxDefaultSize
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+				>
+					{ __( 'Add domain name' ) }
+				</Button>
+			) }
+			renderContent={ () => (
+				<>
+					<RouterLinkMenuItem
+						to={
+							siteSlug
+								? addQueryArgs( '/setup/domain', {
+										siteSlug,
+								  } )
+								: '/start/domain'
+						}
+						iconPosition="left"
+						icon={ search }
+					>
+						{ __( 'Search domain names' ) }
+					</RouterLinkMenuItem>
+					<RouterLinkMenuItem
+						to={
+							siteSlug
+								? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
+								: '/setup/domain-transfer'
+						}
+						iconPosition="left"
+						icon={ globe }
+					>
+						{ __( 'Use a domain I own' ) }
+					</RouterLinkMenuItem>
+				</>
+			) }
+		/>
+	);
+}

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,6 +1,5 @@
 import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -9,6 +8,7 @@ import { DataViewsCard } from '../components/dataviews-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
+import { AddDomainButton } from './add-domain-button';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
 import type { DomainsView } from './dataviews';
 import type { DomainSummary } from '@automattic/api-core';
@@ -35,16 +35,7 @@ function Domains() {
 
 	return (
 		<PageLayout
-			header={
-				<PageHeader
-					title={ __( 'Domains' ) }
-					actions={
-						<Button variant="primary" __next40pxDefaultSize href="/setup/domain">
-							{ __( 'Add New Domain' ) }
-						</Button>
-					}
-				/>
-			}
+			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
 			notices={ <OptInWelcome tracksContext="domains" /> }
 		>
 			<DataViewsCard>

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,15 +1,14 @@
 import { siteDomainsQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { siteRoute } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { AddDomainButton } from '../../domains/add-domain-button';
 import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
 import type { DomainsView } from '../../domains/dataviews';
 import type { SiteDomain } from '@automattic/api-core';
@@ -56,15 +55,7 @@ function SiteDomains() {
 			header={
 				<PageHeader
 					title={ __( 'Domains' ) }
-					actions={
-						<Button
-							href={ addQueryArgs( '/setup/domain', { siteSlug: site.slug } ) }
-							variant="primary"
-							__next40pxDefaultSize
-						>
-							{ __( 'Add New Domain' ) }
-						</Button>
-					}
+					actions={ <AddDomainButton siteSlug={ site.slug } /> }
 				/>
 			}
 		>


### PR DESCRIPTION
Closes [DOTDASH-613](https://linear.app/a8c/issue/DOTDASH-613/extend-add-new-domain-behavior)

## Proposed Changes
- Replace simple "Add New Domain" button with a reusable enhanced dropdown component (`AddDomainButton`)
- Update both general domains page and site-specific domains page to use the new component
- Implement smart URL routing based on context (site-specific vs general)

## Why are these changes being made?
Part of HD Domains design.

## Testing Instructions
Test the button in 2 separate context:
- **site domains context**: `v2/sites/SITE/domains`
- **domains context**: `v2/domains`

|![Screenshot 2025-10-07 alle 10 19 04](https://github.com/user-attachments/assets/54c70a8b-fc3a-4df9-aa86-32dd84887855)|
|:---:|
|**Site domains context**|


|![Screenshot 2025-10-07 alle 10 19 50](https://github.com/user-attachments/assets/d1f94bd3-9f64-48ae-8217-5b8332a80e4b)|
|:---:|
|**Domains context**|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
