### PR TITLE
Add plans intent to the calypso_signup_step_start Tracks event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-start.ts
@@ -1,5 +1,6 @@
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from 'calypso/landing/stepper/constants';
+import { getVisualSplitPlansIntent } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const recordStepStart = (
@@ -7,10 +8,14 @@ const recordStepStart = (
 	step: string,
 	optionalProps?: { [ key: string ]: unknown }
 ) => {
+	const search = new URLSearchParams( window.location.search );
+	const plansIntent = getVisualSplitPlansIntent( search.get( 'intent' ) );
+
 	recordTracksEvent( STEPPER_TRACKS_EVENT_SIGNUP_STEP_START, {
 		flow,
 		step,
 		device: resolveDeviceTypeByViewPort(),
+		plans_intent: plansIntent || 'default',
 		...optionalProps,
 	} );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -28,7 +28,7 @@ import { getTheme, getThemeType } from 'calypso/state/themes/selectors';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { playgroundPlansIntent } from '../playground/lib/plans';
 import UnifiedPlansStep from './unified-plans-step';
-import { getIntervalType } from './util';
+import { getIntervalType, getVisualSplitPlansIntent } from './util';
 import type { Step as StepType } from '../../types';
 import type { PlansIntent } from '@automattic/plans-grid-next';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -72,16 +72,6 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			return 'plans-affiliate';
 		default:
 			return null;
-	}
-	return null;
-}
-
-function getVisualSplitPlansIntent( intent: string ): PlansIntent | null {
-	if ( intent === 'default_websitebuilder' ) {
-		return 'plans-website-builder';
-	}
-	if ( intent === 'default_hosting' ) {
-		return 'plans-wordpress-hosting';
 	}
 	return null;
 }
@@ -154,14 +144,13 @@ const PlansStepAdaptor: StepType< {
 
 	// Update plansIntent when the experiment loads
 	useEffect( () => {
-		if ( ! isVisualSplitLoading && props.flow === ONBOARDING_FLOW && ! defaultPlansIntent ) {
-			if ( visualSplitVariation === 'default_websitebuilder' ) {
-				setPlansIntent( 'plans-website-builder' );
-			} else if ( visualSplitVariation === 'default_hosting' ) {
-				setPlansIntent( 'plans-wordpress-hosting' );
-			} else {
-				setPlansIntent( defaultPlansIntent );
-			}
+		if (
+			! isVisualSplitLoading &&
+			props.flow === ONBOARDING_FLOW &&
+			visualSplitVariation &&
+			! defaultPlansIntent
+		) {
+			setPlansIntent( getVisualSplitPlansIntent( visualSplitVariation as string ) );
 		}
 	}, [ isVisualSplitLoading, visualSplitVariation, props.flow, defaultPlansIntent ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
@@ -6,6 +6,7 @@ import {
 	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
+import { PlansIntent } from '@automattic/plans-grid-next';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import { UnifiedPlansStepProps } from './unified-plans-step';
@@ -111,3 +112,13 @@ export const buildUpgradeFunction = (
 	submitSignupStep( step, signupVals );
 	goToNextStep();
 };
+
+export function getVisualSplitPlansIntent( intent?: string | null ): PlansIntent | null {
+	if ( intent === 'default_websitebuilder' ) {
+		return 'plans-website-builder';
+	}
+	if ( intent === 'default_hosting' ) {
+		return 'plans-wordpress-hosting';
+	}
+	return null;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1759740036102499/1759184540.738069-slack-C095NHTGNF3

## Proposed Changes

* add plans intent to the `calypso_signup_step_start` 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* we need this to track usage of `Website Builder` vs `Hosting` in the visual plan split experiments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans?intent=default_hosting`
* You should see the hosting split
* There should be a `plans_intent` prop in the `calypso_signup_step_start` event with the value `plans-hosting`

<img width="1690" height="1051" alt="Screenshot 2025-10-02 at 14 51 24" src="https://github.com/user-attachments/assets/6447a808-6ba6-494a-9e11-f42c1bcaa65f" />


* Go to `/setup/onboarding/plans?intent=default_websitebuilder`
* You should see the website builder split
* There should be a `plans_intent` prop in the `calypso_signup_step_start` event with the value `plans-website-builder`


* Go to `/setup/onboarding/plans`
* There should be a `plans_intent` prop in the `calypso_signup_step_start` event with the value `default`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?