### PR TITLE
Calypso Theme Showcase: Ensure Community tier themes are only installable on the Business plan

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -4,6 +4,7 @@ import {
 	FEATURE_UPLOAD_THEMES,
 	WPCOM_FEATURES_INSTALL_PLUGINS,
 	FEATURE_INSTALL_THEMES,
+	WPCOM_FEATURES_COMMUNITY_THEMES,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -1148,6 +1149,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		siteId,
 		canInstallPlugins,
 		canInstallThemes,
+		canInstallCommunityThemes,
 		isActive,
 		isLoggedIn,
 		isPremium,
@@ -1203,7 +1205,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	// isWporgTheme is true for some free themes we offer, so we need to check the tier instead.
 	else if (
 		( themeTier === 'community' || themeTier?.slug === 'community' ) &&
-		! canInstallThemes
+		( ! canInstallThemes || ! canInstallCommunityThemes )
 	) {
 		defaultOption = 'upgradePlanForDotOrgThemes';
 	} else {
@@ -1289,6 +1291,7 @@ export default connect(
 			showTryAndCustomize: shouldShowTryAndCustomize( state, themeId, siteId ),
 			canInstallPlugins: siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PLUGINS ),
 			canInstallThemes: siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ),
+			canInstallCommunityThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_COMMUNITY_THEMES ),
 			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -8,6 +8,8 @@ import {
 	getPlan,
 	TERM_ANNUALLY,
 	findFirstSimilarPlanKey,
+	FEATURE_INSTALL_THEMES,
+	WPCOM_FEATURES_COMMUNITY_THEMES,
 } from '@automattic/calypso-products';
 import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { addQueryArgs } from '@wordpress/url';
@@ -247,7 +249,8 @@ function getAllThemeOptions( { translate, isFSEActive, isGlobalStylesOnPersonal 
 		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			isJetpackSite( state, siteId ) ||
-			isSiteWpcomAtomic( state, siteId ) ||
+			( siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) &&
+				siteHasFeature( state, siteId, WPCOM_FEATURES_COMMUNITY_THEMES ) ) ||
 			! isUserLoggedIn( state ) ||
 			! siteId ||
 			isExternallyManagedTheme( state, themeId ) ||

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -4,6 +4,7 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	FEATURE_INSTALL_THEMES,
 	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+	WPCOM_FEATURES_COMMUNITY_THEMES,
 } from '@automattic/calypso-products';
 import {
 	FREE_THEME,
@@ -45,7 +46,10 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	if ( type === DOT_ORG_THEME ) {
-		return siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
+		return (
+			siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) &&
+			siteHasFeature( state, siteId, WPCOM_FEATURES_COMMUNITY_THEMES )
+		);
 	}
 
 	if ( type === BUNDLED_THEME ) {

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -294,6 +294,10 @@ export const WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED = 'premium-themes';
  * WPCOM) to `premium-themes-limited` so it better reflects the actual feature.
  */
 export const WPCOM_FEATURES_PREMIUM_THEMES_LIMITED = 'personal-themes';
+export const WPCOM_FEATURES_PARTNER_THEMES = 'partner-themes';
+export const WPCOM_FEATURES_COMMUNITY_THEMES = 'community-themes';
+export const WPCOM_FEATURES_WOOCOMMERCE_THEMES = 'woocommerce-themes';
+export const WPCOM_FEATURES_SENSEI_THEMES = 'sensei-themes';
 export const WPCOM_FEATURES_PRIORITY_SUPPORT = 'priority_support';
 export const WPCOM_FEATURES_REAL_TIME_BACKUPS = 'real-time-backups';
 export const WPCOM_FEATURES_SCAN = 'scan';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-93

## Proposed Changes

* Add granular features for Theme Tiers.
* Use the new `WPCOM_FEATURES_COMMUNITY_THEMES` feature, only included on the Business plan, to ensure Community themes can only be installed on the Business plan when accessed via the (Calypso) Theme Showcase.

This change does not affect the Core theme screens.

**Note**

I've added all the tier features, but only used the Community one. The reason is that updating theme-options.js is not for the faint of heart, and I don't want to risk introducing regression for an otherwise very specific change.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Summer Special introduced some inconsistencies in how theme tiers are handled on the Personal and Premium plans on WoW.

This change, alongside 193265-ghe-Automattic/wpcom, restores the original Business plan requirement of Community themes in the Theme Showcase.

It also semi-intentionally introduces a discrepancy between the (Calypso) Theme Showcase and the Core theme screens, where Community themes can be installed as part of the Summer Special. This discrepancy will be used to more accurately compare usage data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a Personal or Premium site on WoW via Summer Special.
* Enter the Theme Showcase (`/themes/:SITE`).
* Search for a Community theme (e.g. Astra).
* Try to activate the theme.
* ⚠️ You should be redirected to the Checkout page with the Business plan in cart.
* Now switch to a Business site on Wow.
* Try to activate a Community theme.
* ⚠️ The theme should activate correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
