### PR TITLE
MCP: Fix useSuspenseQuery bug

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,6 +1,6 @@
 import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	__experimentalVStack as VStack,
@@ -27,7 +27,11 @@ function McpComponent( { path } ) {
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
 	const { data: sites = [] } = useQuery( sitesQuery( { site_visibility: 'visible' } ) );
-	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const {
+		data: userSettings,
+		isLoading: isLoadingUserSettings,
+		error: userSettingsError,
+	} = useQuery( userSettingsQuery() );
 
 	// Site selector state for disabling MCP access on specific sites
 	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
@@ -49,6 +53,11 @@ function McpComponent( { path } ) {
 			);
 		},
 	} );
+
+	// Handle loading and error states
+	if ( isLoadingUserSettings || userSettingsError ) {
+		return null;
+	}
 
 	// Get account-level tools from user settings using the new nested structure
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -1,5 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
 	Button,
 	ExternalLink,
@@ -26,7 +26,11 @@ import { hasEnabledAccountTools } from './utils';
 
 function McpSetupComponent( { path } ) {
 	const translate = useTranslate();
-	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const {
+		data: userSettings,
+		isLoading: isLoadingUserSettings,
+		error: userSettingsError,
+	} = useQuery( userSettingsQuery() );
 
 	// MCP client selection for configuration format
 	const [ selectedMcpClient, setSelectedMcpClient ] = useState( 'claude' );
@@ -124,6 +128,11 @@ function McpSetupComponent( { path } ) {
 		}
 	};
 
+	// Handle loading and error states
+	if ( isLoadingUserSettings || userSettingsError ) {
+		return null;
+	}
+
 	// Check if any account-level tools are enabled using the new nested structure
 	const hasEnabledTools = hasEnabledAccountTools( userSettings );
 
@@ -207,6 +216,8 @@ function McpSetupComponent( { path } ) {
 					<CardBody>
 						<VStack spacing={ 6 }>
 							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 								label={ translate( 'MCP Client' ) }
 								value={ selectedMcpClient }
 								options={ mcpClientOptions }
@@ -324,13 +335,14 @@ function McpSetupComponent( { path } ) {
 										/>
 									</div>
 									<TextareaControl
+										__nextHasNoMarginBottom
 										value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
 										onChange={ () => {} } // Required prop for read-only textarea
 										readOnly
 										help={ translate(
 											"Copy this configuration and paste it into your MCP client's settings."
 										) }
-										style={ { 'min-height': '240px' } }
+										style={ { minHeight: '240px' } }
 									/>
 								</VStack>
 							</VStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

**1. Fixed Suspense errors:** Replaced `useSuspenseQuery` with `useQuery` and added `return null` for loading/error states - the `/me` section doesn't have Suspense boundaries like the dashboard section does.

**2. Fixed WordPress component warnings:** Added `__next40pxDefaultSize`, `__nextHasNoMarginBottom` props to SelectControl/TextareaControl and changed `'min-height'` to `minHeight` - these are deprecation warnings for upcoming WordPress component updates.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
