### PR TITLE
MCP: fix security key prompt

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,5 +1,5 @@
 import { sitesQuery } from '@automattic/api-queries';
-import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries/src/me-settings';
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,4 +1,5 @@
-import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { sitesQuery } from '@automattic/api-queries';
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries/src/me-settings';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -17,6 +18,8 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { SectionHeader } from '../../dashboard/components/section-header';
 import PreferencesLoginSiteDropdown from '../../dashboard/me/preferences-login/site-dropdown';
@@ -309,6 +312,7 @@ function McpComponent( { path } ) {
 					}
 				) }
 			/>
+			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 			{ renderContent() }
 		</Main>
 	);

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -1,5 +1,4 @@
-import { sitesQuery } from '@automattic/api-queries';
-import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import { sitesQuery, userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -1,4 +1,4 @@
-import { userSettingsQuery } from '@automattic/api-queries';
+import { userSettingsQuery } from '@automattic/api-queries/src/me-settings';
 import { useQuery } from '@tanstack/react-query';
 import {
 	Button,
@@ -22,6 +22,8 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
 import { hasEnabledAccountTools } from './utils';
 
 function McpSetupComponent( { path } ) {
@@ -142,6 +144,7 @@ function McpSetupComponent( { path } ) {
 				<PageViewTracker path={ path } title="MCP Setup" />
 				<DocumentHead title={ translate( 'MCP Setup' ) } />
 				<NavigationHeader navigationItems={ [] } title={ translate( 'MCP Setup' ) } />
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<SectionHeader label={ translate( 'Setup Required' ) } />
 				<Card isRounded={ false }>
 					<CardBody>
@@ -169,6 +172,8 @@ function McpSetupComponent( { path } ) {
 			<PageViewTracker path={ path } title="MCP Setup" />
 			<DocumentHead title={ translate( 'MCP Setup' ) } />
 			<NavigationHeader navigationItems={ [] } title={ translate( 'MCP Setup' ) } />
+
+			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
 			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/mcp">
 				{ translate( 'WordPress.com MCP Setup' ) }

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -1,4 +1,4 @@
-import { userSettingsQuery } from '@automattic/api-queries/src/me-settings';
+import { userSettingsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import {
 	Button,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Added `<ReauthRequired>` component to both `/me/mcp` and `/me/mcp-setup` pages
* Added `twoStepAuthorization` import for security key authentication

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
