### PR TITLE
Domains 1634 add unit and integration tests to new UI

### DIFF
--- a/packages/domain-search/jest.config.js
+++ b/packages/domain-search/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
 	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: [ '<rootDir>/src/test/setup.ts' ],
 };

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -66,6 +66,7 @@
 		"@types/jest": "^29.5.14",
 		"@wordpress/base-styles": "^5.23.0",
 		"copyfiles": "^2.4.1",
+		"nock": "^13.5.6",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"storybook": "^8.6.14",

--- a/packages/domain-search/src/components/cart/index.tsx
+++ b/packages/domain-search/src/components/cart/index.tsx
@@ -1,56 +1,28 @@
-import { useIsMutating, useMutation } from '@tanstack/react-query';
-import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
+import { useIsMutating } from '@tanstack/react-query';
+import { useLayoutEffect } from 'react';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainsFullCart,
-	DomainsFullCartItem,
 	DomainsFullCartItems,
 	DomainsFullCartSkipButton,
 	DomainsMiniCart,
 } from '../../ui';
-import type { SelectedDomain } from '../../page/types';
-
-const CartItem = ( { item }: { item: SelectedDomain } ) => {
-	const { cart } = useDomainSearch();
-
-	const {
-		mutate: removeProductFromCart,
-		isPending,
-		reset,
-		error,
-		submittedAt,
-	} = useMutation( {
-		mutationFn: ( uuid: string ) => {
-			return cart.onRemoveItem( uuid );
-		},
-		networkMode: 'always',
-		retry: false,
-	} );
-
-	const isMutating = !! useIsMutating();
-	const isCurrentMutation = useIsCurrentMutation( submittedAt );
-
-	return (
-		<DomainsFullCartItem
-			key={ item.uuid }
-			domain={ item }
-			disabled={ isMutating }
-			isBusy={ isPending }
-			onRemove={ () => removeProductFromCart( item.uuid ) }
-			errorMessage={ isCurrentMutation ? error?.message : undefined }
-			removeErrorMessage={ reset }
-		/>
-	);
-};
+import { CartItem } from './item';
 
 export const Cart = () => {
 	const { cart, isFullCartOpen, closeFullCart, config, events, openFullCart, slots } =
 		useDomainSearch();
 
+	const isMutating = !! useIsMutating();
+
 	const totalItems = cart.items.length;
 	const totalPrice = cart.total;
 
-	const isMutating = !! useIsMutating();
+	useLayoutEffect( () => {
+		if ( totalItems === 0 && isFullCartOpen ) {
+			closeFullCart();
+		}
+	}, [ totalItems, isFullCartOpen, closeFullCart ] );
 
 	return (
 		<>

--- a/packages/domain-search/src/components/cart/item.tsx
+++ b/packages/domain-search/src/components/cart/item.tsx
@@ -1,0 +1,38 @@
+import { useMutation, useIsMutating } from '@tanstack/react-query';
+import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
+import { useDomainSearch } from '../../page/context';
+import { DomainsFullCartItem } from '../../ui';
+import type { SelectedDomain } from '../../page/types';
+
+export const CartItem = ( { item }: { item: SelectedDomain } ) => {
+	const { cart } = useDomainSearch();
+
+	const {
+		mutate: removeProductFromCart,
+		isPending,
+		reset,
+		error,
+		submittedAt,
+	} = useMutation( {
+		mutationFn: ( uuid: string ) => {
+			return cart.onRemoveItem( uuid );
+		},
+		networkMode: 'always',
+		retry: false,
+	} );
+
+	const isMutating = !! useIsMutating();
+	const isCurrentMutation = useIsCurrentMutation( submittedAt );
+
+	return (
+		<DomainsFullCartItem
+			key={ item.uuid }
+			domain={ item }
+			disabled={ isMutating }
+			isBusy={ isPending }
+			onRemove={ () => removeProductFromCart( item.uuid ) }
+			errorMessage={ isCurrentMutation ? error?.message : undefined }
+			removeErrorMessage={ reset }
+		/>
+	);
+};

--- a/packages/domain-search/src/components/search-bar/filter.tsx
+++ b/packages/domain-search/src/components/search-bar/filter.tsx
@@ -16,14 +16,14 @@ export const Filter = () => {
 	const { data: availableTlds = [], isFetching: isFetchingTlds } = useQuery( {
 		...queries.availableTlds( query ),
 		enabled: true,
-	} ) as { data: string[]; isFetching: boolean };
+	} );
 
 	const filterCount = useMemo(
 		() => filter.tlds.length + ( filter.exactSldMatchesOnly ? 1 : 0 ),
 		[ filter ]
 	);
 
-	if ( ! isFetchingTlds && ( ! availableTlds || availableTlds.length === 0 ) ) {
+	if ( ! isFetchingTlds && availableTlds.length === 0 ) {
 		return null;
 	}
 

--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -16,10 +16,7 @@ const AVAILABLE_DOMAIN_STATUSES = [
 ];
 
 /**
- * Determines whether the availability notice should be hidden for a given domain availability
- *
- * @param availability - Domain availability returned from the availability endpoint
- * @returns True if the availability notice should be hidden, false otherwise.
+ * Determines whether the availability notice should be hidden for a given domain availability.
  */
 const shouldHideAvailabilityNotice = (
 	availability: DomainAvailability,

--- a/packages/domain-search/src/helpers/get-availability-notice.tsx
+++ b/packages/domain-search/src/helpers/get-availability-notice.tsx
@@ -519,11 +519,10 @@ export const getAvailabilityNotice = (
 				}
 			);
 			break;
+	}
 
-		default:
-			message = translate(
-				'Sorry, there was a problem processing your request. Please try again in a few minutes.'
-			);
+	if ( ! message ) {
+		return null;
 	}
 
 	return {

--- a/packages/domain-search/src/hooks/test/use-has-scrolled-to-end.ts
+++ b/packages/domain-search/src/hooks/test/use-has-scrolled-to-end.ts
@@ -1,0 +1,21 @@
+import { hasScrolledToEnd } from '../use-has-scrolled-to-end';
+
+describe( 'useHasScrolledToEnd#hasScrolledToEnd', () => {
+	it( 'returns false when element is not scrolled to the end', () => {
+		expect( hasScrolledToEnd( { scrollHeight: 500, scrollTop: 0, clientHeight: 100 } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns true when element is scrolled to the end', () => {
+		expect( hasScrolledToEnd( { scrollHeight: 500, scrollTop: 400, clientHeight: 100 } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'returns true when element is scrolled to the end with fractional scrollTop', () => {
+		expect( hasScrolledToEnd( { scrollHeight: 500, scrollTop: 399.5, clientHeight: 100 } ) ).toBe(
+			true
+		);
+	} );
+} );

--- a/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
+++ b/packages/domain-search/src/hooks/use-has-scrolled-to-end.ts
@@ -1,7 +1,21 @@
 import { RefObject, useEffect, useState } from 'react';
 
+export const hasScrolledToEnd = ( {
+	scrollHeight,
+	scrollTop,
+	clientHeight,
+}: {
+	scrollHeight: number;
+	scrollTop: number;
+	clientHeight: number;
+} ) => {
+	// NOTE: scrollTop might be fractional in some browsers, so without this Math.abs() trick
+	// sometimes the result won't be a whole number, causing the comparison to fail.
+	return Math.abs( scrollHeight - clientHeight - scrollTop ) < 1;
+};
+
 export const useHasScrolledToEnd = ( contentRef: RefObject< HTMLElement > ) => {
-	const [ hasScrolledToEnd, setHasScrolledToEnd ] = useState( false );
+	const [ hasScrolledToEndResult, setHasScrolledToEndResult ] = useState( false );
 
 	useEffect( () => {
 		const contentElement = contentRef.current;
@@ -13,12 +27,8 @@ export const useHasScrolledToEnd = ( contentRef: RefObject< HTMLElement > ) => {
 		const checkIfScrollHasReachedBottom = () => {
 			const { scrollHeight, scrollTop, clientHeight } = contentElement;
 
-			// NOTE: scrollTop is fractional, while scrollHeight and clientHeight are
-			// not, so without this Math.abs() trick then sometimes the result won't
-			// work because scrollTop may not be exactly equal to el.scrollHeight -
-			// el.clientHeight when scrolled to the bottom.
-			if ( Math.abs( scrollHeight - clientHeight - scrollTop ) < 1 ) {
-				setHasScrolledToEnd( true );
+			if ( hasScrolledToEnd( { scrollHeight, scrollTop, clientHeight } ) ) {
+				setHasScrolledToEndResult( true );
 			}
 		};
 
@@ -31,5 +41,5 @@ export const useHasScrolledToEnd = ( contentRef: RefObject< HTMLElement > ) => {
 		};
 	}, [ contentRef ] );
 
-	return hasScrolledToEnd;
+	return hasScrolledToEndResult;
 };

--- a/packages/domain-search/src/hooks/use-request-tracking.ts
+++ b/packages/domain-search/src/hooks/use-request-tracking.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEvent } from '@wordpress/compose';
+import { useEffect, useRef } from 'react';
+import { useDomainSearch } from '../page/context';
+
+export const useRequestTracking = () => {
+	const { query, events, queries } = useDomainSearch();
+	const lastQueryChangeTime = useRef( 0 );
+
+	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery(
+		queries.domainSuggestions( query )
+	);
+
+	const { data: availabilityData, isLoading: isLoadingQueryAvailability } = useQuery(
+		queries.domainAvailability( query )
+	);
+
+	useEffect( () => {
+		lastQueryChangeTime.current = Date.now();
+	}, [ query ] );
+
+	const triggerSuggestionsReceiveEvent = useEvent( () => {
+		const suggestionsReceiveResponseTime = Date.now() - lastQueryChangeTime.current;
+		events.onSuggestionsReceive(
+			query,
+			suggestions.map( ( suggestion ) => suggestion.domain_name ),
+			suggestionsReceiveResponseTime
+		);
+	} );
+
+	useEffect( () => {
+		if ( ! isLoadingSuggestions ) {
+			triggerSuggestionsReceiveEvent();
+		}
+	}, [ triggerSuggestionsReceiveEvent, isLoadingSuggestions ] );
+
+	const triggerQueryAvailabilityCheckEvent = useEvent( () => {
+		const availabilityCheckResponseTime = Date.now() - lastQueryChangeTime.current;
+		events.onQueryAvailabilityCheck(
+			availabilityData!.status,
+			query,
+			availabilityCheckResponseTime
+		);
+	} );
+
+	useEffect( () => {
+		if ( ! isLoadingQueryAvailability && availabilityData ) {
+			triggerQueryAvailabilityCheckEvent();
+		}
+	}, [ triggerQueryAvailabilityCheckEvent, isLoadingQueryAvailability, availabilityData ] );
+};

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -15,7 +15,7 @@ export const useSuggestionsList = () => {
 
 	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
 		...queries.freeSuggestion( query ),
-		enabled: true,
+		enabled: config.skippable,
 	} );
 
 	const { isLoading: isLoadingQueryAvailability } = useQuery( {

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -90,11 +90,14 @@ export const useDomainSearch = () => {
 	return context;
 };
 
-export const useDomainSearchContextValue = (
-	props: DomainSearchProps
-): typeof DEFAULT_CONTEXT_VALUE => {
-	const { currentSiteUrl, query: externalQuery, cart, events, slots, config } = props;
-
+export const useDomainSearchContextValue = ( {
+	currentSiteUrl,
+	query: externalQuery,
+	cart,
+	events,
+	slots,
+	config,
+}: DomainSearchProps ): typeof DEFAULT_CONTEXT_VALUE => {
 	const [ isFullCartOpen, setIsFullCartOpen ] = useState( false );
 	const [ filter, setFilter ] = useState( DEFAULT_FILTER );
 
@@ -149,7 +152,7 @@ export const useDomainSearchContextValue = (
 							? query.includes( '.blog' )
 							: false,
 					} ),
-					enabled: normalizedConfig.skippable,
+					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,
 					refetchOnWindowFocus: false,

--- a/packages/domain-search/src/page/index.tsx
+++ b/packages/domain-search/src/page/index.tsx
@@ -1,7 +1,8 @@
 import { queryClient } from '@automattic/api-queries';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { useEvent } from '@wordpress/compose';
 import clsx from 'clsx';
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { DomainSearchContext, useDomainSearchContextValue } from './context';
 import { InitialState } from './initial-state';
 import { ResultsPage } from './results';
@@ -12,19 +13,13 @@ import './style.scss';
 export const DomainSearch = ( props: DomainSearchProps ) => {
 	const contextValue = useDomainSearchContextValue( props );
 
-	const cartItemsLength = contextValue.cart.items.length;
-	const isFullCartOpen = contextValue.isFullCartOpen;
-	const closeFullCart = contextValue.closeFullCart;
+	const onPageView = useEvent( () => {
+		contextValue.events.onPageView();
+	} );
 
 	useEffect( () => {
-		contextValue.events.onPageView();
-	}, [] );
-
-	useLayoutEffect( () => {
-		if ( cartItemsLength === 0 && isFullCartOpen ) {
-			closeFullCart();
-		}
-	}, [ cartItemsLength, isFullCartOpen, closeFullCart ] );
+		onPageView();
+	}, [ onPageView ] );
 
 	const getContent = () => {
 		if ( ! contextValue.query ) {

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -6,6 +6,7 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
+import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
 
@@ -13,6 +14,8 @@ export const ResultsPage = () => {
 	const { slots, config } = useDomainSearch();
 
 	const { isLoading, featuredSuggestions, regularSuggestions } = useSuggestionsList();
+
+	useRequestTracking();
 
 	return (
 		<VStack spacing={ 8 } className="domain-search--results">

--- a/packages/domain-search/src/page/test/index.tsx
+++ b/packages/domain-search/src/page/test/index.tsx
@@ -16,7 +16,7 @@ describe( 'DomainSearch', () => {
 	} );
 
 	it( 'renders the results page when a query is provided', () => {
-		mockGetSuggestions( [] );
+		mockGetSuggestions( 'test', [] );
 
 		render(
 			<DomainSearch

--- a/packages/domain-search/src/page/test/index.tsx
+++ b/packages/domain-search/src/page/test/index.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { buildCart } from '../../test/factories/cart';
+import { mockGetSuggestions } from '../../test/mocks/suggestions';
+import { DomainSearch } from '../index';
+
+describe( 'DomainSearch', () => {
+	it( 'renders the initial state when no query is provided', () => {
+		render(
+			<DomainSearch
+				cart={ buildCart() }
+				slots={ { BeforeResults: () => <div>Before Results</div> } }
+			/>
+		);
+
+		expect( screen.queryByText( 'Before Results' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the results page when a query is provided', () => {
+		mockGetSuggestions( [] );
+
+		render(
+			<DomainSearch
+				cart={ buildCart() }
+				query="test"
+				slots={ { BeforeResults: () => <div>Before Results</div> } }
+			/>
+		);
+
+		expect( screen.getByText( 'Before Results' ) ).toBeInTheDocument();
+	} );
+
+	it( 'fires the onPageView event when the component mounts', () => {
+		const onPageView = jest.fn();
+
+		render( <DomainSearch cart={ buildCart() } events={ { onPageView } } /> );
+
+		expect( onPageView ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/domain-search/src/page/test/initial-state.tsx
+++ b/packages/domain-search/src/page/test/initial-state.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { TestDomainSearch } from '../../test/renderer';
+import { InitialState } from '../initial-state';
+
+describe( 'InitialState', () => {
+	it( 'renders the search form', () => {
+		render(
+			<TestDomainSearch>
+				<InitialState />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getByRole( 'searchbox' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the already own domain CTA when config allows it', () => {
+		render(
+			<TestDomainSearch
+				events={ { onExternalDomainClick: jest.fn() } }
+				config={ { allowsUsingOwnDomain: true } }
+			>
+				<InitialState />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getByText( /already have a domain/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the already own domain CTA when config disallows it', () => {
+		render(
+			<TestDomainSearch config={ { allowsUsingOwnDomain: false } }>
+				<InitialState />
+			</TestDomainSearch>
+		);
+
+		expect( screen.queryByText( /already have a domain/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render the already own domain CTA when onExternalDomainClick is not provided', () => {
+		render(
+			<TestDomainSearch config={ { allowsUsingOwnDomain: true } }>
+				<InitialState />
+			</TestDomainSearch>
+		);
+
+		expect( screen.queryByText( /already have a domain/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onExternalDomainClick when CTA is clicked', () => {
+		const onExternalDomainClick = jest.fn();
+
+		render(
+			<TestDomainSearch
+				config={ { allowsUsingOwnDomain: true } }
+				events={ { onExternalDomainClick } }
+			>
+				<InitialState />
+			</TestDomainSearch>
+		);
+
+		screen.getByText( /already have a domain/i ).click();
+		expect( onExternalDomainClick ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1,0 +1,200 @@
+import { DomainAvailabilityStatus } from '@automattic/api-core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { buildAvailability } from '../../test/factories/availability';
+import { buildFreeSuggestion, buildSuggestion } from '../../test/factories/suggestions';
+import { mockGetAvailability } from '../../test/mocks/availability';
+import { mockGetFreeSuggestion, mockGetSuggestions } from '../../test/mocks/suggestions';
+import { TestDomainSearch } from '../../test/renderer';
+import { ResultsPage } from '../results';
+
+describe( 'ResultsPage', () => {
+	it( 'renders the search bar and filters', () => {
+		render(
+			<TestDomainSearch>
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getByLabelText( 'Search for a domain' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Filter, no filters applied' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders featured and regular suggestions', async () => {
+		mockGetSuggestions( 'test', [
+			buildSuggestion( { domain_name: 'test.com' } ),
+			buildSuggestion( { domain_name: 'test.net' } ),
+			buildSuggestion( { domain_name: 'test.org' } ),
+		] );
+
+		render(
+			<TestDomainSearch query="test">
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		const recommended = await screen.findByTitle( 'test.com' );
+
+		expect( recommended ).toBeInTheDocument();
+		expect( recommended ).toHaveAttribute( 'data-testid', 'featured-suggestion' );
+		expect( recommended ).toHaveTextContent( 'Recommended' );
+
+		const bestAlternative = await screen.findByTitle( 'test.net' );
+
+		expect( bestAlternative ).toBeInTheDocument();
+		expect( bestAlternative ).toHaveAttribute( 'data-testid', 'featured-suggestion' );
+		expect( bestAlternative ).toHaveTextContent( 'Best alternative' );
+
+		const regular = await screen.findByTitle( 'test.org' );
+
+		expect( regular ).toBeInTheDocument();
+		expect( regular ).toHaveAttribute( 'data-testid', 'suggestion' );
+		expect( regular ).not.toHaveTextContent( 'Recommended' );
+		expect( regular ).not.toHaveTextContent( 'Best alternative' );
+	} );
+
+	it( 'renders the before results slot if passed', () => {
+		render(
+			<TestDomainSearch slots={ { BeforeResults: () => <div>Before Results</div> } }>
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getByText( 'Before Results' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the placeholders while loading', () => {
+		render(
+			<TestDomainSearch>
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getAllByLabelText( 'Loading featured domain suggestion' ) ).toHaveLength( 2 );
+		expect( screen.queryByLabelText( 'Loading free domain suggestion' ) ).not.toBeInTheDocument();
+		expect( screen.getAllByLabelText( 'Loading domain suggestion' ) ).toHaveLength( 10 );
+	} );
+
+	it( 'renders the search notice when applicable', async () => {
+		mockGetSuggestions( 'wordpress.com', [] );
+
+		mockGetAvailability(
+			buildAvailability( {
+				domain_name: 'wordpress.com',
+				tld: 'com',
+				status: DomainAvailabilityStatus.SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE,
+				mappable: 'mapped_domain',
+			} )
+		);
+
+		render(
+			<TestDomainSearch query="wordpress.com">
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		const [ , notice ] = await screen.findAllByText(
+			'This domain is already mapped to a WordPress.com site.'
+		);
+
+		expect( notice ).toBeInTheDocument();
+	} );
+
+	it( 'renders the unavailable search result when applicable', async () => {
+		mockGetSuggestions( 'a8ctesting.com', [] );
+
+		mockGetAvailability(
+			buildAvailability( {
+				domain_name: 'a8ctesting.com',
+				tld: 'com',
+				status: DomainAvailabilityStatus.TRANSFERRABLE,
+				mappable: 'mappable',
+			} )
+		);
+
+		render(
+			<TestDomainSearch query="a8ctesting.com">
+				<ResultsPage />
+			</TestDomainSearch>
+		);
+
+		expect( await screen.findByText( /is already registered./ ) ).toHaveTextContent(
+			'a8ctesting.com is already registered.'
+		);
+	} );
+
+	describe( 'free suggestion', () => {
+		it( 'renders the skip suggestion placeholder when eligible and loading', () => {
+			render(
+				<TestDomainSearch config={ { skippable: true } }>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( screen.getByLabelText( 'Loading free domain suggestion' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the free suggestion', async () => {
+			mockGetSuggestions( 'site', [] );
+
+			mockGetFreeSuggestion( 'site', buildFreeSuggestion( { domain_name: 'site.wordpress.com' } ) );
+
+			render(
+				<TestDomainSearch config={ { skippable: true } } query="site">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect(
+				await screen.findByLabelText( 'Skip purchase and continue with site.wordpress.com' )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'tracking', () => {
+		it( 'fires the onSuggestionsReceive event when the suggestions are received', async () => {
+			const onSuggestionsReceive = jest.fn();
+
+			mockGetSuggestions( 'test', [
+				buildSuggestion( { domain_name: 'test.com' } ),
+				buildSuggestion( { domain_name: 'test.net' } ),
+				buildSuggestion( { domain_name: 'test.org' } ),
+			] );
+
+			render(
+				<TestDomainSearch events={ { onSuggestionsReceive } } query="test">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onSuggestionsReceive ).toHaveBeenCalledWith(
+					'test',
+					[ 'test.com', 'test.net', 'test.org' ],
+					expect.any( Number )
+				);
+			} );
+		} );
+
+		it( 'fires the onQueryAvailabilityCheck event when the availability is checked', async () => {
+			const onQueryAvailabilityCheck = jest.fn();
+
+			mockGetAvailability(
+				buildAvailability( { domain_name: 'test.com', status: DomainAvailabilityStatus.AVAILABLE } )
+			);
+
+			render(
+				<TestDomainSearch events={ { onQueryAvailabilityCheck } } query="test.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onQueryAvailabilityCheck ).toHaveBeenCalledWith(
+					DomainAvailabilityStatus.AVAILABLE,
+					'test.com',
+					expect.any( Number )
+				);
+			} );
+		} );
+	} );
+} );

--- a/packages/domain-search/src/test/factories/availability.ts
+++ b/packages/domain-search/src/test/factories/availability.ts
@@ -1,0 +1,17 @@
+import { DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
+
+export const buildAvailability = (
+	availability: Partial< DomainAvailability > = {}
+): DomainAvailability => {
+	return {
+		domain_name: availability.domain_name ?? 'example.com',
+		tld: availability.tld ?? 'com',
+		status: availability.status ?? DomainAvailabilityStatus.AVAILABLE,
+		mappable: availability.mappable ?? 'mappable',
+		supports_privacy: availability.supports_privacy ?? true,
+		root_domain_provider: availability.root_domain_provider ?? 'wpcom',
+		cost: availability.cost ?? 'Free',
+		currency_code: availability.currency_code ?? 'USD',
+		...availability,
+	};
+};

--- a/packages/domain-search/src/test/factories/cart.ts
+++ b/packages/domain-search/src/test/factories/cart.ts
@@ -1,0 +1,12 @@
+import { DomainSearchCart } from '../../page/types';
+
+export const buildCart = ( overrides: Partial< DomainSearchCart > = {} ): DomainSearchCart => {
+	return {
+		items: [],
+		total: '',
+		onAddItem: jest.fn(),
+		onRemoveItem: jest.fn(),
+		hasItem: jest.fn(),
+		...overrides,
+	};
+};

--- a/packages/domain-search/src/test/factories/suggestions.ts
+++ b/packages/domain-search/src/test/factories/suggestions.ts
@@ -1,0 +1,30 @@
+import type { DomainSuggestion, FreeDomainSuggestion } from '@automattic/api-core';
+
+export const buildFreeSuggestion = (
+	suggestion: Partial< FreeDomainSuggestion > = {}
+): FreeDomainSuggestion => {
+	return {
+		domain_name: suggestion.domain_name ?? 'example.wordpress.com',
+		cost: 'Free',
+		is_free: true,
+	};
+};
+
+export const buildSuggestion = (
+	suggestion: Partial< DomainSuggestion > = {}
+): DomainSuggestion => {
+	return {
+		domain_name: suggestion.domain_name ?? 'example.com',
+		currency_code: 'USD',
+		max_reg_years: 10,
+		multi_year_reg_allowed: true,
+		product_id: 123,
+		product_slug: 'dotcom_domain',
+		raw_price: 40,
+		relevance: 0.9,
+		supports_privacy: true,
+		vendor: 'donuts',
+		cost: suggestion.cost ?? '$5',
+		...suggestion,
+	};
+};

--- a/packages/domain-search/src/test/mocks/availability.ts
+++ b/packages/domain-search/src/test/mocks/availability.ts
@@ -1,0 +1,8 @@
+import nock from 'nock';
+import type { DomainAvailability } from '@automattic/api-core';
+
+export const mockGetAvailability = ( availability: DomainAvailability ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.3/domains/${ availability.domain_name }/is-available` )
+		.reply( 200, availability );
+};

--- a/packages/domain-search/src/test/mocks/suggestions.ts
+++ b/packages/domain-search/src/test/mocks/suggestions.ts
@@ -1,8 +1,32 @@
 import nock from 'nock';
-import type { DomainSuggestion } from '@automattic/api-core';
+import type { DomainSuggestion, FreeDomainSuggestion } from '@automattic/api-core';
 
-export const mockGetSuggestions = ( suggestions: DomainSuggestion[] ) => {
+export const mockGetSuggestions = ( query: string, suggestions: DomainSuggestion[] ) => {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/domains/suggestions' )
-		.reply( 200, { body: suggestions } );
+		.query( {
+			include_wordpressdotcom: false,
+			include_dotblogsubdomain: false,
+			only_wordpressdotcom: false,
+			quantity: 30,
+			vendor: 'variation2_front',
+			exact_sld_matches_only: false,
+			include_internal_move_eligible: true,
+			query,
+		} )
+		.reply( 200, suggestions );
+};
+
+export const mockGetFreeSuggestion = ( query: string, freeSuggestion: FreeDomainSuggestion ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/domains/suggestions' )
+		.query( {
+			quantity: 1,
+			include_wordpressdotcom: true,
+			include_dotblogsubdomain: false,
+			only_wordpressdotcom: false,
+			vendor: 'dot',
+			query,
+		} )
+		.reply( 200, [ freeSuggestion ] );
 };

--- a/packages/domain-search/src/test/mocks/suggestions.ts
+++ b/packages/domain-search/src/test/mocks/suggestions.ts
@@ -1,0 +1,8 @@
+import nock from 'nock';
+import type { DomainSuggestion } from '@automattic/api-core';
+
+export const mockGetSuggestions = ( suggestions: DomainSuggestion[] ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/domains/suggestions' )
+		.reply( 200, { body: suggestions } );
+};

--- a/packages/domain-search/src/test/renderer.tsx
+++ b/packages/domain-search/src/test/renderer.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DomainSearchContext, useDomainSearchContextValue } from '../page/context';
+import { buildCart } from './factories/cart';
+import type { DomainSearchProps } from '../page/types';
+
+export const TestDomainSearch = ( {
+	cart = buildCart(),
+	queryClient = new QueryClient(),
+	...props
+}: Partial< DomainSearchProps > & { queryClient?: QueryClient; children: React.ReactNode } ) => {
+	const contextValue = useDomainSearchContextValue( { cart, ...props } );
+
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<DomainSearchContext.Provider value={ contextValue }>
+				{ props.children }
+			</DomainSearchContext.Provider>
+		</QueryClientProvider>
+	);
+};

--- a/packages/domain-search/src/test/setup.ts
+++ b/packages/domain-search/src/test/setup.ts
@@ -1,0 +1,17 @@
+import nock from 'nock';
+
+// Disables all network requests for all tests.
+nock.disableNetConnect();
+
+beforeAll( () => {
+	// reactivate nock on test start
+	if ( ! nock.isActive() ) {
+		nock.activate();
+	}
+} );
+
+afterAll( () => {
+	// helps clean up nock after each test run and avoid memory leaks
+	nock.restore();
+	nock.cleanAll();
+} );

--- a/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
@@ -35,6 +35,7 @@ export const DomainSearchControlsFilterButton = forwardRef(
 			<div className="domain-search-controls__filters">
 				<Button
 					icon={ funnel }
+					aria-label={ ariaLabel }
 					variant="secondary"
 					showTooltip
 					onClick={ onClick }
@@ -42,13 +43,7 @@ export const DomainSearchControlsFilterButton = forwardRef(
 					disabled={ disabled }
 				/>
 				{ !! count && (
-					<div
-						className="domain-search-controls__filters-count"
-						/* translators: %d: number of active filters */
-						aria-label={ ariaLabel }
-						aria-live="polite"
-						role="status"
-					>
+					<div className="domain-search-controls__filters-count" aria-hidden="true">
 						{ count }
 					</div>
 				) }

--- a/packages/domain-search/src/ui/domain-search-controls/filter-popover-tld.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-popover-tld.tsx
@@ -8,10 +8,12 @@ type Props = {
 export const FilterPopoverTld = ( { tld, addTldToFilter }: Props ) => {
 	return (
 		<Text
+			as="button"
 			className="domain-search-controls__filters-popover-available-tld"
 			isBlock
 			key={ tld }
-			role="button"
+			role="option"
+			tabIndex={ 0 }
 			size="small"
 			lineHeight="1.5"
 			onClick={ () => {

--- a/packages/domain-search/src/ui/domain-search-controls/filter-popover.scss
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-popover.scss
@@ -17,6 +17,8 @@
 .domain-search-controls__filters-popover-available-tld {
 	cursor: pointer;
 	padding: 6px 16px;
+	width: 100%;
+	text-align: left;
 
 	&:hover {
 		background: var( --wp-admin-theme-color );

--- a/packages/domain-search/src/ui/domain-search-controls/filter-popover.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-popover.tsx
@@ -103,7 +103,7 @@ export const DomainSearchControlsFilterPopover = ( {
 				className="domain-search-controls__filters-popover-available-tlds-container"
 				isRounded={ false }
 			>
-				<Scrollable scrollDirection="y" style={ { maxHeight: '18.5rem' } }>
+				<Scrollable role="listbox" scrollDirection="y" style={ { maxHeight: '18.5rem' } }>
 					{ tldList.map( ( tld ) => {
 						return tld.isLabel ? (
 							<FilterPopoverLabel key={ tld.text } text={ tld.text } />
@@ -139,7 +139,6 @@ export const DomainSearchControlsFilterPopover = ( {
 						__nextHasNoMarginBottom
 						__experimentalShowHowTo={ false }
 						__experimentalValidateInput={ validateTld }
-						label=""
 						value={ temporaryFilter.tlds }
 						suggestions={ availableTlds }
 						onChange={ ( tokens ) => {
@@ -158,6 +157,7 @@ export const DomainSearchControlsFilterPopover = ( {
 						label={ __( 'Show exact matches only' ) }
 						checked={ temporaryFilter.exactSldMatchesOnly }
 						onChange={ setExactMatchesOnlyInFilter }
+						__nextHasNoMarginBottom
 					/>
 					<HStack spacing={ 4 } className="domain-search-controls__filters-popover-buttons">
 						<Button __next40pxDefaultSize variant="secondary" onClick={ onClear }>

--- a/packages/domain-search/src/ui/domain-search-controls/test/filter-button.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/test/filter-button.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { DomainSearchControlsFilterButton } from '../filter-button';
+
+describe( 'DomainSearchControlsFilterButton', () => {
+	it( 'says no filter applied if there are no selected TLDs', () => {
+		render( <DomainSearchControlsFilterButton count={ 0 } onClick={ jest.fn() } /> );
+		expect( screen.getByLabelText( 'Filter, no filters applied' ) ).toBeInTheDocument();
+	} );
+
+	it( 'says one filter applied if there is one selected TLD', () => {
+		render( <DomainSearchControlsFilterButton count={ 1 } onClick={ jest.fn() } /> );
+		expect( screen.getByLabelText( 'Filter, 1 filter applied' ) ).toBeInTheDocument();
+	} );
+
+	it( 'says multiple filters applied if there are multiple selected TLDs', () => {
+		render( <DomainSearchControlsFilterButton count={ 2 } onClick={ jest.fn() } /> );
+		expect( screen.getByLabelText( 'Filter, 2 filters applied' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/domain-search/src/ui/domain-search-controls/test/filter-popover.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/test/filter-popover.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DomainSearchControlsFilterPopover } from '../filter-popover';
+
+describe( 'DomainSearchControlsFilterPopover', () => {
+	const defaultProps = {
+		filter: {
+			tlds: [],
+			exactSldMatchesOnly: false,
+		},
+		availableTlds: [ 'com', 'net', 'org' ],
+		onApply: jest.fn(),
+		onClear: jest.fn(),
+	};
+
+	it( 'renders the filter popover with default state', () => {
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } /> );
+
+		expect( screen.getByPlaceholderText( 'Search for an ending' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Show exact matches only' ) ).not.toBeChecked();
+		expect( screen.getByText( 'Clear' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Apply' ) ).toBeInTheDocument();
+	} );
+
+	it( 'displays available TLDs', () => {
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } /> );
+
+		expect( screen.getByText( '.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.net' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.org' ) ).toBeInTheDocument();
+	} );
+
+	it( 'remove TLDs from the list when they are selected', async () => {
+		const fireEvent = userEvent.setup();
+
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } /> );
+
+		await fireEvent.click( screen.getByText( '.com' ) );
+
+		expect( screen.queryByText( '.com' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'splits TLDs into recommended and explore more sections', () => {
+		render(
+			<DomainSearchControlsFilterPopover
+				{ ...defaultProps }
+				availableTlds={ [ 'com', 'net', 'org', 'co.uk', 'de', 'fr', 'es', 'it', 'nl', 'be' ] }
+			/>
+		);
+
+		const allItems = screen.getByRole( 'listbox' );
+
+		expect( allItems.children[ 0 ].textContent ).toBe( 'Recommended endings' );
+		expect( allItems.children[ 1 ].textContent ).toBe( '.com' );
+		expect( allItems.children[ 2 ].textContent ).toBe( '.net' );
+		expect( allItems.children[ 3 ].textContent ).toBe( '.org' );
+		expect( allItems.children[ 4 ].textContent ).toBe( '.co.uk' );
+		expect( allItems.children[ 5 ].textContent ).toBe( '.de' );
+		expect( allItems.children[ 6 ].textContent ).toBe( 'Explore more endings' );
+		expect( allItems.children[ 7 ].textContent ).toBe( '.be' );
+		expect( allItems.children[ 8 ].textContent ).toBe( '.es' );
+		expect( allItems.children[ 9 ].textContent ).toBe( '.fr' );
+		expect( allItems.children[ 10 ].textContent ).toBe( '.it' );
+		expect( allItems.children[ 11 ].textContent ).toBe( '.nl' );
+	} );
+
+	it( 'remove category headings from the list when they are selected', async () => {
+		const fireEvent = userEvent.setup();
+
+		render(
+			<DomainSearchControlsFilterPopover
+				{ ...defaultProps }
+				availableTlds={ [ 'com', 'net', 'org', 'co.uk', 'de', 'fr' ] }
+			/>
+		);
+
+		expect( screen.getByText( 'Recommended endings' ) ).toBeInTheDocument();
+
+		await fireEvent.click( screen.getByText( '.com' ) );
+		await fireEvent.click( screen.getByText( '.net' ) );
+		await fireEvent.click( screen.getByText( '.org' ) );
+		await fireEvent.click( screen.getByText( '.co.uk' ) );
+		await fireEvent.click( screen.getByText( '.de' ) );
+
+		expect( screen.queryByText( 'Recommended endings' ) ).not.toBeInTheDocument();
+
+		expect( screen.queryByText( 'Explore more endings' ) ).toBeInTheDocument();
+
+		await fireEvent.click( screen.getByText( '.fr' ) );
+
+		expect( screen.queryByText( 'Explore more endings' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onApply with updated filter when Apply is clicked', async () => {
+		const fireEvent = userEvent.setup();
+
+		const onApply = jest.fn();
+
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } onApply={ onApply } /> );
+
+		// Toggle exact matches
+		await fireEvent.click( screen.getByLabelText( 'Show exact matches only' ) );
+
+		// Click apply
+		await fireEvent.click( screen.getByText( 'Apply' ) );
+
+		expect( onApply ).toHaveBeenCalledWith( {
+			tlds: [],
+			exactSldMatchesOnly: true,
+		} );
+	} );
+
+	it( 'calls onClear when Clear button is clicked', async () => {
+		const fireEvent = userEvent.setup();
+
+		const onClear = jest.fn();
+
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } onClear={ onClear } /> );
+
+		await fireEvent.click( screen.getByText( 'Clear' ) );
+
+		expect( onClear ).toHaveBeenCalled();
+	} );
+
+	it( 'updates filter when TLD is selected', async () => {
+		const fireEvent = userEvent.setup();
+
+		const onApply = jest.fn();
+
+		render( <DomainSearchControlsFilterPopover { ...defaultProps } onApply={ onApply } /> );
+
+		// Click a TLD
+		await fireEvent.click( screen.getByText( '.com' ) );
+
+		// Click apply
+		await fireEvent.click( screen.getByText( 'Apply' ) );
+
+		expect( onApply ).toHaveBeenCalledWith( {
+			tlds: [ 'com' ],
+			exactSldMatchesOnly: false,
+		} );
+	} );
+} );

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
@@ -1,9 +1,13 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { __ } from '@wordpress/i18n';
 import { DomainSearchSkipSuggestionSkeleton } from './index.skeleton';
 
 export const DomainSearchSkipSuggestionPlaceholder = () => {
 	return (
 		<DomainSearchSkipSuggestionSkeleton
+			role="status"
+			aria-busy="true"
+			aria-label={ __( 'Loading free domain suggestion' ) }
 			title={ <LoadingPlaceholder width="11.625rem" height="1.25rem" /> }
 			subtitle={ <LoadingPlaceholder width="14.3125rem" height="0.5rem" /> }
 			right={ <LoadingPlaceholder width="7.4375rem" height="2.5rem" /> }

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
@@ -1,17 +1,24 @@
 import { Card, CardBody } from '@wordpress/components';
 import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
+import type { ComponentProps } from 'react';
 
-interface Props {
+interface Props extends Omit< ComponentProps< typeof Card >, 'children' | 'title' > {
 	title: React.ReactNode;
 	subtitle: React.ReactNode;
 	right?: React.ReactNode;
 }
 
-export const DomainSearchSkipSuggestionSkeleton = ( { title, subtitle, right }: Props ) => {
+export const DomainSearchSkipSuggestionSkeleton = ( {
+	title,
+	subtitle,
+	right,
+	...props
+}: Props ) => {
 	const { containerRef, activeQuery } = useDomainSuggestionContainer();
 
 	return (
 		<Card
+			{ ...props }
 			className="domain-search-skip-suggestion"
 			ref={ containerRef }
 			size={ activeQuery === 'large' ? 'medium' : 'small' }

--- a/packages/domain-search/src/ui/domain-suggestion/featured.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.placeholder.tsx
@@ -10,7 +10,7 @@ export const FeaturedPlaceholder = () => {
 		<FeaturedSkeleton
 			role="status"
 			aria-busy="true"
-			aria-label={ __( 'Loading domain suggestion' ) }
+			aria-label={ __( 'Loading featured domain suggestion' ) }
 			ref={ containerRef }
 			activeQuery={ activeQuery }
 			badges={ <LoadingPlaceholder width="6.3125rem" height="1.5rem" /> }

--- a/packages/domain-search/src/ui/domain-suggestion/featured.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.tsx
@@ -73,6 +73,7 @@ const Featured = ( {
 				role="listitem"
 				title={ `${ domain }.${ tld }` }
 				ref={ containerRef }
+				data-testid="featured-suggestion"
 				activeQuery={ activeQuery }
 				className={ clsx( 'domain-suggestion-featured', {
 					'domain-suggestion-featured--highlighted': isHighlighted,

--- a/packages/domain-search/src/ui/domain-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/index.tsx
@@ -71,6 +71,7 @@ const DomainSuggestionComponent = ( {
 	return (
 		<SuggestionSkeleton
 			role="listitem"
+			data-testid="suggestion"
 			title={ `${ domain }.${ tld }` }
 			domainName={ domainNameElement }
 			price={ price }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,7 @@ __metadata:
     copyfiles: "npm:^2.4.1"
     i18n-calypso: "workspace:^"
     moment: "npm:^2.30.1"
+    nock: "npm:^13.5.6"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     storybook: "npm:^8.6.14"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
