### PR TITLE
Update/show site redirects in sites

### DIFF
--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -11,7 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { hasHostingFeature } from '../../utils/site-features';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
-import { getSiteDisplayUrl } from '../../utils/site-url';
+import { getSiteDisplayUrl, getSiteFormattedUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { PHPVersion } from '../site-fields';
 import type { Site } from '@automattic/api-core';
@@ -61,9 +61,10 @@ const HostingProvider = ( { site }: { site: Site } ) => {
 };
 
 const SiteOverviewFields = ( { site }: { site: Site } ) => {
-	const { URL: url } = site;
+	const url = getSiteFormattedUrl( site );
 	const wpVersion = getFormattedWordPressVersion( site );
 	const hasPHPFeature = hasHostingFeature( site, HostingFeatures.PHP );
+	const hasSiteRedirect = site.options?.is_redirect;
 
 	return (
 		<HStack className="site-overview-fields" spacing={ 1 } justify="flex-start">
@@ -72,6 +73,17 @@ const SiteOverviewFields = ( { site }: { site: Site } ) => {
 					{ getSiteDisplayUrl( site ) }
 				</ExternalLink>
 			</Field>
+			{ hasSiteRedirect && (
+				<Field>
+					<Text variant="muted">
+						{ sprintf(
+							/* translators: %s: the URL this site is redirected to, e.g.: http://example.com */
+							__( 'Redirects to %s' ),
+							site.URL
+						) }
+					</Text>
+				</Field>
+			) }
 			{ wpVersion && (
 				<Field title={ __( 'WordPress' ) }>
 					{ isSelfHostedJetpackConnected( site ) ? (

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -29,6 +29,7 @@ import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isSelfHostedJetpackConnected, isP2 } from '../../utils/site-types';
+import { getSiteFormattedUrl } from '../../utils/site-url';
 import { canManageSite } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SiteIcon from '../site-icon';
@@ -95,7 +96,7 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 		<ExternalLink
 			className="dataviews-url-field"
 			style={ titleFieldTextOverflowStyles }
-			href={ site.URL }
+			href={ getSiteFormattedUrl( site ) }
 		>
 			{ value }
 		</ExternalLink>

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -9,7 +9,20 @@ import type { Site } from '@automattic/api-core';
  * installations.
  */
 export function getSiteDisplayUrl( site: Site ) {
+	if ( site.options?.is_redirect ) {
+		return site.slug;
+	}
 	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
+}
+
+/**
+ * Returns the actual formatted URL for the site considering site redirects
+ */
+export function getSiteFormattedUrl( site: Site ) {
+	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
+		return site.options.unmapped_url;
+	}
+	return site.URL;
 }
 
 /**

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -19,7 +19,6 @@ export async function fetchSites( {
 		{
 			include_a8c_owned,
 			include_domain_only: false,
-			include_redirect: false,
 			site_activity: 'active',
 			site_visibility,
 			fields: JOINED_SITE_FIELDS,

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -39,6 +39,7 @@ export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 export const SITE_OPTIONS = [
 	'admin_url',
 	'created_at',
+	'unmapped_url',
 	'is_difm_lite_in_progress',
 	'is_summer_special_2025',
 	'is_domain_only',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -21,6 +21,7 @@ export interface SiteOptions {
 	admin_url: string;
 	created_at?: string;
 	is_domain_only?: boolean;
+	is_redirect?: boolean;
 	is_difm_lite_in_progress?: boolean;
 	is_summer_special_2025?: boolean;
 	is_wpforteams_site?: boolean;
@@ -30,6 +31,7 @@ export interface SiteOptions {
 	site_intent?: string;
 	software_version: string;
 	updated_at?: string;
+	unmapped_url?: string;
 	wordads?: boolean;
 	woocommerce_is_active?: boolean;
 	wpcom_production_blog_id?: number;


### PR DESCRIPTION
We don't want to just hide sites with Site redirect upgrade because those are sites that customers should still be able to manage. Instead we should properly show that those sites redirect to a different URL.

This is just to show the sites in the list and show where they're pointed to - we do have a few other tasks that would actually show the site redirect option in Site Settings (and we can link there from the "Redirects to" line from the overview.

It looks like this in the Site Overview:
<img width="934" height="212" alt="Screenshot 2025-10-07 at 13 17 32" src="https://github.com/user-attachments/assets/9c198665-b5c7-4ffa-ac7b-d759c6b30cdb" />

Part of [DOTDASH-537: Show site redirect sites in the sites list in the Hosting Dashboard](https://linear.app/a8c/issue/DOTDASH-537/show-site-redirect-sites-in-the-sites-list-in-the-hosting-dashboard)

## Proposed Changes

* Don't filter sites with site redirect upgrade
* Show the proper URL in the list of sites and in the overview screen for a site
* Also in the overview screen show where the redirect sends you to

## Why are these changes being made?

* Sites with Site redirect are regular sites that redirect the customer to another URL - we should not just hide them. We should show them and allow the customer to change/remove the site redirect if they want to

## Testing Instructions

* Make sure that you have a site with active Site Redirect then go to /v2/sites and make sure you can see it. Once you click on it you should see a "Redirects to {URL}" below the Overview header

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
