### PR TITLE
Flex sites: Retrieve the is_wpcom_flex flag in the sites API response

### DIFF
--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -58,6 +58,7 @@ function createMockSite( overrides: Partial< Site > = {} ): Site {
 		is_coming_soon: false,
 		is_private: false,
 		is_wpcom_atomic: false,
+		is_wpcom_flex: false,
 		is_wpcom_staging_site: false,
 		is_vip: false,
 		lang: 'en',

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -33,6 +33,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_a4a_client',
 	'is_a4a_dev_site',
 	'is_a8c',
+	'is_wpcom_flex',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -17,6 +17,7 @@ export const SITE_FIELDS = [
 	'is_coming_soon',
 	'is_private',
 	'is_wpcom_atomic',
+	'is_wpcom_flex',
 	'is_wpcom_staging_site',
 	'hosting_provider_guess',
 	'lang',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -54,6 +54,7 @@ export interface Site {
 	is_coming_soon: boolean;
 	is_private: boolean;
 	is_wpcom_atomic: boolean;
+	is_wpcom_flex: boolean;
 	is_wpcom_staging_site: boolean;
 	is_vip: boolean;
 	lang: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -133,6 +133,7 @@ export interface SiteDetails {
 	is_deleted?: boolean;
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
+	is_wpcom_flex?: boolean;
 	is_wpcom_staging_site?: boolean;
 	is_a4a_client?: boolean;
 	is_a4a_dev_site?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-18

## Proposed Changes

* Add the is_wpcom_flex field to the list of sites fields so that it could be used in various flows.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need a way to determine if a site is a flex site on the front-end.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the instructions from 192692-ghe-Automattic/wpcom to create a flex site.
* Make sure that  193483-ghe-Automattic/wpcom is either merged or checked out on your sandbox.
* Sandbox public-api, start Calypso, navigate to /setup/domain/site-picker and confirm that your flex site appears in the list of sites and the API response contains the `is_wpcom_flex` flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
