### PR TITLE
Add breadcrumbs to "Connect Repository" page

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -905,17 +905,22 @@ export const siteSettingsRepositoriesRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'repositories',
+} );
+
+export const siteSettingsRepositoriesIndexRoute = createRoute( {
+	getParentRoute: () => siteSettingsRepositoriesRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../sites/settings-repositories' ).then( ( d ) =>
-		createLazyRoute( 'site-settings-repositories' )( {
+		createLazyRoute( 'site-settings-repositories-index' )( {
 			component: d.default,
 		} )
 	)
 );
 
 export const siteSettingsRepositoriesConnectRoute = createRoute( {
-	getParentRoute: () => siteSettingsRoute,
-	path: 'repositories/connect',
+	getParentRoute: () => siteSettingsRepositoriesRoute,
+	path: 'connect',
 } ).lazy( () =>
 	import( '../../sites/settings-repositories/connect-repository' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-repositories-connect' )( {
@@ -925,8 +930,8 @@ export const siteSettingsRepositoriesConnectRoute = createRoute( {
 );
 
 export const siteSettingsRepositoriesManageRoute = createRoute( {
-	getParentRoute: () => siteSettingsRoute,
-	path: 'repositories/manage/$deploymentId',
+	getParentRoute: () => siteSettingsRepositoriesRoute,
+	path: 'manage/$deploymentId',
 	parseParams: ( params ) => ( {
 		deploymentId: Number( params.deploymentId ),
 	} ),
@@ -1072,9 +1077,11 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 			siteSettingsWordPressRoute,
 			siteSettingsPHPRoute,
 			siteSettingsAgencyRoute,
-			siteSettingsRepositoriesRoute,
-			siteSettingsRepositoriesConnectRoute,
-			siteSettingsRepositoriesManageRoute,
+			siteSettingsRepositoriesRoute.addChildren( [
+				siteSettingsRepositoriesIndexRoute,
+				siteSettingsRepositoriesConnectRoute,
+				siteSettingsRepositoriesManageRoute,
+			] ),
 			siteSettingsHundredYearPlanRoute,
 			siteSettingsPrimaryDataCenterRoute,
 			siteSettingsStaticFile404Route,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -919,6 +919,13 @@ export const siteSettingsRepositoriesIndexRoute = createRoute( {
 );
 
 export const siteSettingsRepositoriesConnectRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Connect repository' ),
+			},
+		],
+	} ),
 	getParentRoute: () => siteSettingsRepositoriesRoute,
 	path: 'connect',
 } ).lazy( () =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -912,7 +912,7 @@ export const siteSettingsRepositoriesIndexRoute = createRoute( {
 	path: '/',
 } ).lazy( () =>
 	import( '../../sites/settings-repositories' ).then( ( d ) =>
-		createLazyRoute( 'site-settings-repositories-index' )( {
+		createLazyRoute( 'site-settings-repositories' )( {
 			component: d.default,
 		} )
 	)

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -15,7 +15,8 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { siteRoute } from '../../app/router/sites';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { siteRoute, siteSettingsRepositoriesRoute } from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -27,10 +28,10 @@ export default function ConnectRepository() {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: installations } = useSuspenseQuery( githubInstallationsQuery() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const navigate = useNavigate( { from: '/sites/$siteSlug/settings/repositories/connect' } );
+	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 
 	const handleCancel = () => {
-		navigate( { to: '/sites/$siteSlug/settings/repositories' } );
+		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
 	};
 
 	const createMutation = useMutation( {
@@ -39,7 +40,7 @@ export default function ConnectRepository() {
 			createSuccessNotice( __( 'Repository connected successfully.' ), {
 				type: 'snackbar',
 			} );
-			navigate( { to: '/sites/$siteSlug/settings/repositories' } );
+			navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
 		},
 		onError: ( error ) => {
 			createErrorNotice(
@@ -67,6 +68,7 @@ export default function ConnectRepository() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Connect Repository' ) }
 					description={ __( 'Connect a GitHub repository to deploy code to your WordPress site.' ) }
 				/>

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -7,7 +7,13 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { siteDeploymentsListRoute, siteRoute } from '../../app/router/sites';
+import {
+	siteDeploymentsListRoute,
+	siteRoute,
+	siteSettingsRepositoriesConnectRoute,
+	siteSettingsRepositoriesManageRoute,
+	siteSettingsRepositoriesRoute,
+} from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -52,7 +58,7 @@ function RepositoriesList() {
 			label: __( 'Configure repository' ),
 			callback: ( items ) => {
 				router.navigate( {
-					to: '/sites/$siteSlug/settings/repositories/manage/$deploymentId',
+					to: siteSettingsRepositoriesManageRoute.fullPath,
 					params: {
 						siteSlug: siteSlug,
 						deploymentId: items[ 0 ].id,
@@ -111,11 +117,11 @@ function RepositoriesList() {
 function SiteRepositories() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const navigate = useNavigate( { from: '/sites/$siteSlug/settings/repositories' } );
+	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
 
 	const handleConnectRepository = () => {
-		navigate( { to: '/sites/$siteSlug/settings/repositories/connect' } );
+		navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-544

## Proposed Changes

This PR adds breadcrumbs to `Connect Repository` page:

<img width="1512" height="891" alt="Screenshot 2025-10-07 at 2 32 28 PM" src="https://github.com/user-attachments/assets/20150940-9d66-4ba3-9fba-4613aa089889" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use Calypso Live Link
* Ensure that you have an Atomic site
* Navigate to `/v2/sites/{yourAtomicSite}/settings/repositories/connect`
* Observe that there are breadcrumbs on the top
* Try using breadcrumbs for navigation and confirm they work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
