### PR TITLE
Notifications Settings: Add breadcrumbs to all pages

### DIFF
--- a/client/dashboard/me/notifications-comments/index.tsx
+++ b/client/dashboard/me/notifications-comments/index.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { DevicesSettings } from './device-settings';
@@ -12,6 +13,7 @@ export default function NotificationsComments() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Comments' ) }
 					description={ __(
 						'Set your notification preferences for activity on comments you’ve made on other sites.'

--- a/client/dashboard/me/notifications-emails/index.tsx
+++ b/client/dashboard/me/notifications-emails/index.tsx
@@ -1,6 +1,7 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { PauseAllEmails } from './pause-all-emails';
@@ -12,6 +13,7 @@ export default function NotificationsEmails() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Emails' ) }
 					description={ createInterpolateElement(
 						__( 'To manage individual site subscriptions, <link>go to the Reader</link>.' ),

--- a/client/dashboard/me/notifications-extras/index.tsx
+++ b/client/dashboard/me/notifications-extras/index.tsx
@@ -5,6 +5,7 @@ import {
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
@@ -43,6 +44,7 @@ export default function NotificationsExtras() {
 			header={
 				<PageHeader
 					title={ __( 'Extras' ) }
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					description={ __(
 						'Get curated extras like reports, digests, and community updates, so you can stay tuned for what’s happening in the WordPress ecosystem.'
 					) }

--- a/client/dashboard/me/notifications-sites/index.tsx
+++ b/client/dashboard/me/notifications-sites/index.tsx
@@ -1,6 +1,7 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Suspense } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { BrowserNotificationCard } from './browser-notification-card';
@@ -15,6 +16,7 @@ export default function NotificationsSites() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Sites' ) }
 					description={ __(
 						'Set your notification preferences for different site activities, such as new comments, mentions or followers. Choose to be notified by email, in-product, or both.'


### PR DESCRIPTION
Closes CML-864

## Proposed Changes
* Add the recently implemented automatically calculated breadcrumbs 

## Why are these changes being made?
* It uses the [recently implemented breadcrumb](https://github.com/Automattic/wp-calypso/pull/106245) component 

## Testing Instructions
* Go to the following URLs and check if you can see the breadcrumb  and the link is going to `/v2/me/notifications`

`/v2/me/notifications/sites` 
`/v2/me/notifications/comments`
`/v2/me/notifications/emails`
`/v2/me/notifications/extras`



<img width="2038" height="1708" alt="CleanShot 2025-10-07 at 13 57 11@2x" src="https://github.com/user-attachments/assets/7488ef5a-53ef-45a4-b611-b1b629904a53" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
