### PR TITLE
Disable renew action for non-owners

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -83,7 +83,7 @@ export default function Actions() {
 	);
 
 	const availableActions = {
-		renew: purchase?.is_renewable,
+		renew: purchase?.is_renewable && domain.current_user_is_owner,
 		transfer: shouldShowTransferAction( domain ),
 		transferIn: shouldShowTransferInAction( domain ),
 		disconnect: shouldShowDisconnectAction( domain ),

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -61,7 +61,8 @@ export default function DomainOverview() {
 						</HStack>
 					}
 					actions={
-						purchase?.can_explicit_renew && (
+						purchase?.can_explicit_renew &&
+						domain.current_user_is_owner && (
 							<Button
 								variant="primary"
 								__next40pxDefaultSize


### PR DESCRIPTION
Closes [DOTDASH-619](https://linear.app/a8c/issue/DOTDASH-619/hide-renew-cta-for-non-owners)

## Proposed Changes
Restrict domain renew action to domain owner.

## Why are these changes being made?
Only domain owner should be able to renew their domains.

## Testing Instructions
-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
