### PR TITLE
Add garden site identifiers

### DIFF
--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -75,6 +75,10 @@ function createMockSite( overrides: Partial< Site > = {} ): Site {
 		was_migration_trial: false,
 		was_hosting_trial: false,
 		was_upgraded_from_trial: false,
+		is_garden: false,
+		garden_name: null,
+		garden_partner: null,
+		garden_is_provisioned: null,
 		...overrides,
 	};
 }

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,7 +1,9 @@
 import type { Site } from '@automattic/api-core';
 
 export function isSelfHostedJetpackConnected( site: Site ) {
-	return site.jetpack_connection && ! site.is_wpcom_atomic && ! site.is_wpcom_flex;
+	return (
+		site.jetpack_connection && ! site.is_wpcom_atomic && ! site.is_wpcom_flex && ! site.is_garden
+	);
 }
 
 export function isP2( site: Site ) {
@@ -9,7 +11,15 @@ export function isP2( site: Site ) {
 }
 
 export function isSimple( site: Site ) {
-	return ! site.jetpack && ! site.is_wpcom_atomic;
+	return ! site.jetpack && ! site.is_wpcom_atomic && ! site.is_garden;
+}
+
+export function isGarden( site: Site ) {
+	return site.is_garden;
+}
+
+export function isCommerceGarden( site: Site ) {
+	return site.is_garden && site.garden_name === 'commerce';
 }
 
 export function isStagingSite( site: Site ) {

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -32,6 +32,10 @@ export const SITE_FIELDS = [
 	'was_migration_trial',
 	'was_hosting_trial',
 	'was_upgraded_from_trial',
+	'is_garden',
+	'garden_name',
+	'garden_partner',
+	'garden_is_provisioned',
 ];
 
 export const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -75,4 +75,8 @@ export interface Site {
 	was_migration_trial: boolean;
 	was_hosting_trial: boolean;
 	was_upgraded_from_trial: boolean;
+	is_garden: boolean;
+	garden_name: string | null;
+	garden_partner: string | null;
+	garden_is_provisioned: boolean | null;
 }


### PR DESCRIPTION
Add the garden site type, pulling new properties from WPcom and using them to distinguish garden sites from other site types.