### PR TITLE
Domain Search Rewrite: Correctly determine if a domain should be free for the first year

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import { isPlan } from '@automattic/calypso-products';
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -65,16 +66,28 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 
 	return useMemo( () => {
 		const domainItems = flowAllowsMultipleDomainsInCart ? getDomainsInCart( responseCart ) : [];
+		const isPlanInCart =
+			responseCart.products.find( ( product ) => isPlan( product ) ) !== undefined;
+		// If there's a plan in the cart, the backend will already set the first domain as free.
+		// We have to check this here since there might already be a plan in the shopping cart
+		// when a user starts a domain search flow.
+		const shouldFirstDomainBeFree = isFirstDomainFreeForFirstYear && ! isPlanInCart;
 
 		// Order domains from most expensive to least expensive
 		domainItems.sort( ( a, b ) => {
+			// Put the bundled domain at the top, if there's one
+			if ( responseCart.bundled_domain === a.meta ) {
+				return -1;
+			} else if ( responseCart.bundled_domain === b.meta ) {
+				return 1;
+			}
 			return b.item_subtotal_integer - a.item_subtotal_integer;
 		} );
 
 		const total = formatCurrency(
 			domainItems.reduce(
 				( acc, item, index ) =>
-					acc + ( index === 0 && isFirstDomainFreeForFirstYear ? 0 : item.item_subtotal_integer ),
+					acc + ( index === 0 && shouldFirstDomainBeFree ? 0 : item.item_subtotal_integer ),
 				0
 			),
 			responseCart.currency ?? 'USD',
@@ -86,7 +99,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 
 		const cart: ComponentProps< typeof DomainSearch >[ 'cart' ] = {
 			items: domainItems.map( ( domainItem, index ) =>
-				wpcomCartToDomainSearchCart( domainItem, index === 0 && isFirstDomainFreeForFirstYear )
+				wpcomCartToDomainSearchCart( domainItem, index === 0 && shouldFirstDomainBeFree )
 			),
 			total,
 			hasItem: ( domain ) => !! domainItems.find( ( item ) => item.meta === domain ),
@@ -116,7 +129,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 
 		return {
 			cart,
-			isNextDomainFree: isFirstDomainFreeForFirstYear
+			isNextDomainFree: shouldFirstDomainBeFree
 				? domainItems.length === 0
 				: responseCart.next_domain_is_free,
 			items: domainItems,

--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -68,9 +68,11 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 		const domainItems = flowAllowsMultipleDomainsInCart ? getDomainsInCart( responseCart ) : [];
 		const isPlanInCart =
 			responseCart.products.find( ( product ) => isPlan( product ) ) !== undefined;
-		// If there's a plan in the cart, the backend will already set the first domain as free.
-		// We have to check this here since there might already be a plan in the shopping cart
-		// when a user starts a domain search flow.
+		// If there's an annual plan in the cart, the backend will already set the first domain as free.
+		// If there's a monthly plan in the cart, the backend will not set the first domain as free and
+		// we'll also not set it as free here, which is correct since monthly plans don't have a free domain.
+		// We have to check if there's a plan in the cart here since the user's cart might not be empty
+		// when they start a domain search flow.
 		const shouldFirstDomainBeFree = isFirstDomainFreeForFirstYear && ! isPlanInCart;
 
 		// Order domains from most expensive to least expensive


### PR DESCRIPTION
Fixes [DOMAINS-1682](https://linear.app/a8c/issue/DOMAINS-1682)

## Proposed Changes

This PR fixes the problem where two domains were shown as free in the shopping cart. It adds a check in `useWPCOMShoppingCartForDomainSearch` to see if a plan is already present in the cart and determine if the most expensive domain should be shown as free (if there's no plan in the cart) or not.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="1125" height="1036" alt="Screenshot 2025-10-07 at 16 46 19" src="https://github.com/user-attachments/assets/66413ee3-2b8e-49c7-8657-afe30d5fec3f" /> | <img width="954" height="1080" alt="Screenshot 2025-10-07 at 19 09 43" src="https://github.com/user-attachments/assets/119cc7b0-2f34-4e9f-88e4-6785a085e766" /> |

## Why are these changes being made?

The changes implemented in #105724 didn't take into account that a plan might be present in the user's shopping cart when they begin a domain flow. If a plan is in the cart, the most expensive domain is already set as free in the backend. Then the frontend changes of #105724 showed the second most expensive domain as free too, when it wasn't. This PR fixes this inconsistency by 

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/setup/onboarding` with the `domain-search-rewrite` flag enabled
- Ensure your cart is empty and doesn't contain a plan (check the response from the `/rest/v1.1/me/shopping-cart` endpoint call)
- If it contains a plan, make a request to the `/rest/v1.1/me/shopping-cart/no-site` endpoint with the following payload to empty it:

```
{"blog_id":0,"products":[],"coupon":"","temporary":false,"tax":null}
```

(I usually run this request by copying one of the browser's request as `cURL`, updating the payload and running it from my terminal)

- Add at least two domains to the cart
- Open the full cart and ensure only the most expensive one is free
- Ensure the calculated total price for the cart is correct
- Now empty the cart again
- Add a Personal plan to your cart by making a request to the `` endpoint with the following payload:

```
{"blog_id":0,"products":[{"product_slug":"personal-bundle","meta":"","volume":1,"quantity":null,"product_id":1009,"extra":{"added_from_shopping_cart":true}}],"coupon":"","temporary":false,"tax":null}
```

- Add at least two domains to the cart
- Open the full cart and ensure only the most expensive one is free
- Ensure the calculated total price for the cart is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
