### PR TITLE
E2E tests don't wait for parent to load when making sub-item selection in sidebar

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -80,11 +80,6 @@ export class SidebarComponent {
 
 		await this.page.dispatchEvent( itemSelector, 'click' );
 
-		// Wait for navigation after clicking the top level item.
-		await this.page.waitForURL( `**${ hrefItemSelector }`, {
-			waitUntil: 'domcontentloaded',
-		} );
-
 		// Sub-level menu item selector.
 		if ( subitem ) {
 			const subitemSelector = `.is-toggle-open a:has(:text-is("${ subitem }"):visible), .wp-menu-open .wp-submenu a:has(:text-is("${ subitem }"):visible)`;
@@ -95,6 +90,11 @@ export class SidebarComponent {
 
 			await this.page.dispatchEvent( subitemSelector, 'click' );
 			await this.page.waitForURL( `**${ hrefSubItemSelector }`, {
+				waitUntil: 'domcontentloaded',
+			} );
+		} else {
+			// Otherwise wait for navigation after clicking the top level item.
+			await this.page.waitForURL( `**${ hrefItemSelector }`, {
 				waitUntil: 'domcontentloaded',
 			} );
 		}


### PR DESCRIPTION


## Proposed Changes

Attempt to fix e2e test failure introduced in https://github.com/Automattic/wp-calypso/pull/106222

Afaict the change made to the `SidebarComponent` page object in #106222 was to make tests more robust by waiting for sidebar navigation to complete. However it did this be

- Clicking sidebar item link
- Waiting for it to load
- Clicking sidebar sub-item link if present
- Waiting for it to load
- Proceeding with test ...

This seemed to work for the `Jetpack > Stats` link that was tested in #106222, but it doesn't work for the `Appearance > Theme` link. Clicking "Appearance" doesn't cause a navigation, and so the test gets stuck on the second step.

This PR updates the `SidebarComponent` so that it only waits on the final link navigation. Like this:

- Click sidebar item link
- If: there's no sub-item to click
  - Wait for it to load
- Otherwise:
  - Click sidebar sub-item link
  - Wait for it to load
- Proceed with test ...

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
