### PR TITLE
Performance v2: Don't show the loading state when report fails

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -84,6 +84,36 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 	const hasError = ( isDesktopSelected ? isDesktopReportError : isMobileReportError ) || isError;
 	const { gmtOffset, timezoneString } = siteSettings;
 
+	const renderContent = () => {
+		if ( hasError ) {
+			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
+		}
+
+		if ( isFetchingReport || isRunningReport || ! currentReport ) {
+			return (
+				<ReportLoading
+					isSavedReport={
+						isFetchingReport || ( ! currentReport && ( desktopLoaded || mobileLoaded ) )
+					}
+				/>
+			);
+		}
+
+		return (
+			<>
+				<ReportExpiredNotice
+					reportTimestamp={ currentReport.timestamp }
+					onRetest={ handleReportRefetch }
+				/>
+				<Report
+					report={ currentReport }
+					device={ deviceToggle }
+					hash={ currentPage?.wpcom_performance_report_hash }
+				/>
+			</>
+		);
+	};
+
 	return (
 		<PageLayout>
 			<PageHeader
@@ -118,26 +148,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 					</HStack>
 				}
 			/>
-			{ hasError && <ReportErrorNotice onRetestClick={ handleReportRefetch } /> }
-			{ isFetchingReport || isRunningReport || ! currentReport ? (
-				<ReportLoading
-					isSavedReport={
-						isFetchingReport || ( ! currentReport && ( desktopLoaded || mobileLoaded ) )
-					}
-				/>
-			) : (
-				<>
-					<ReportExpiredNotice
-						reportTimestamp={ currentReport.timestamp }
-						onRetest={ handleReportRefetch }
-					/>
-					<Report
-						report={ currentReport }
-						device={ deviceToggle }
-						hash={ currentPage?.wpcom_performance_report_hash }
-					/>
-				</>
-			) }
+			{ renderContent() }
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14864

## Proposed Changes

* Don't show the loading state when report fails

| Before | After |
| - | - |
|<img width="909" height="560" alt="image" src="https://github.com/user-attachments/assets/f12d532d-9137-4dba-a4bc-514ccf7df772" />|<img width="806" height="282" alt="image" src="https://github.com/user-attachments/assets/b7903bf7-3c58-4f9b-aaf3-b6c674419c26" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance
* Open the Devtool and block the `
https://public-api.wordpress.com/wpcom/v2/site-profiler/metrics/advanced/insights`
* Refresh the page until you see the "An error occurred while testing your site." notice
* Ensure you won't see the loading state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
