### PR TITLE
Hosting Dashboard: Update preferences dev helper to make properties editable

### DIFF
--- a/client/dashboard/app/dev-tools/preferences.scss
+++ b/client/dashboard/app/dev-tools/preferences.scss
@@ -1,15 +1,29 @@
 @import '@wordpress/base-styles/variables';
 
-.preferences-helper__current-preferences {
+.preferences-helper__preference {
 	font-size: $font-size-small;
 	text-transform: none;
+	font-weight: normal;
 }
 
-.environment.is-prefs:not(:hover) .preferences-helper__current-preferences {
+.preferences-helper__preference-content {
+	padding-inline-start: 36px;
+
+	ul {
+		margin: 0;
+		padding: 0;
+
+		li {
+			margin-bottom: 8px;
+		}
+	}
+}
+
+.environment.is-prefs:not(:hover) .preferences-helper__preferences {
 	display: none;
 }
 
-.environment.is-prefs:hover .preferences-helper__current-preferences {
+.environment.is-prefs:hover .preferences-helper__preferences {
 	display: block;
 	inset-inline-end: 0;
 	max-height: 80vh;

--- a/client/dashboard/app/dev-tools/preferences.scss
+++ b/client/dashboard/app/dev-tools/preferences.scss
@@ -7,14 +7,14 @@
 }
 
 .preferences-helper__preference-content {
-	padding-inline-start: 36px;
+	padding-inline-start: $grid-unit-40;
 
 	ul {
 		margin: 0;
 		padding: 0;
 
 		li {
-			margin-bottom: 8px;
+			margin-bottom: $grid-unit-10;
 		}
 	}
 }

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -6,39 +6,174 @@ import {
 import { QueryClientProvider, useMutation, useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 	Button,
+	CheckboxControl,
 	Card,
 	CardBody,
 	CardDivider,
 } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Text } from '../../components/text';
 import type { UserPreferences } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
 import './preferences.scss';
 
-function Preference( { name }: { name: string } ) {
+type InputType = 'string' | 'number' | 'checkbox';
+type InputValue = string | number | boolean;
+
+const formattedValue = ( inputType: InputType, value?: InputValue ) => {
+	if ( inputType === 'number' ) {
+		return Number( value );
+	}
+
+	if ( inputType === 'checkbox' ) {
+		return Boolean( value );
+	}
+
+	return value;
+};
+
+const renderPreference = ( name: string, value: any ) => {
+	if ( typeof value === 'string' ) {
+		return <EditablePreference inputType="string" name={ name } value={ value } />;
+	}
+
+	if ( typeof value === 'boolean' ) {
+		return <EditablePreference inputType="checkbox" name={ name } value={ value } />;
+	}
+
+	if ( typeof value === 'number' ) {
+		return <EditablePreference inputType="number" name={ name } value={ value } />;
+	}
+
+	if ( Array.isArray( value ) ) {
+		return <ArrayPreference value={ value } />;
+	}
+
+	return null;
+};
+
+function ArrayPreference( { value }: { value: InputValue[] } ) {
+	return (
+		<ul>
+			{ value.map( ( preference, index ) => (
+				<li key={ index }>{ JSON.stringify( preference ) }</li>
+			) ) }
+		</ul>
+	);
+}
+
+function EditablePreference( {
+	inputType,
+	name,
+	value,
+}: {
+	inputType: InputType;
+	name: string;
+	value: InputValue;
+} ) {
+	const { mutate: savePreference } = useMutation(
+		userPreferenceMutation( name as keyof UserPreferences )
+	);
+	const [ formData, setFormData ] = useState( { [ name ]: value } );
+
+	const handleSave = () => {
+		savePreference( formData[ name ] );
+	};
+
+	const handleReset = () => {
+		setFormData( { [ name ]: value } );
+	};
+
+	const fields: Field< { [ name ]: InputValue } >[] = useMemo(
+		() => [
+			{
+				id: name,
+				Edit: ( { field, onChange, data } ) => {
+					const { id, getValue } = field;
+					if ( inputType === 'checkbox' ) {
+						return (
+							<CheckboxControl
+								__nextHasNoMarginBottom
+								checked={ getValue( { item: data } ) }
+								onChange={ ( newValue ) =>
+									onChange( { [ id ]: formattedValue( inputType, newValue ) } )
+								}
+							/>
+						);
+					}
+
+					return (
+						<InputControl
+							type={ inputType }
+							value={ getValue( { item: data } ) }
+							size="small"
+							onChange={ ( newValue ) =>
+								onChange( { [ id ]: formattedValue( inputType, newValue ) } )
+							}
+							hideLabelFromVision
+						/>
+					);
+				},
+			},
+		],
+		[ name, inputType ]
+	);
+
+	const isDirty = formData[ name ] !== value;
+
+	return (
+		<VStack>
+			<DataForm< { [ name ]: InputValue } >
+				data={ formData }
+				fields={ fields }
+				form={ {
+					layout: { type: 'regular' as const },
+					fields: [ name ],
+				} }
+				onChange={ ( edits ) => {
+					setFormData( ( current ) => ( { ...current, ...edits } ) );
+				} }
+			/>
+			<HStack justify="flex-start" spacing={ 1 }>
+				<Button variant="primary" size="small" disabled={ ! isDirty } onClick={ handleSave }>
+					{ __( 'Save' ) }
+				</Button>
+				<Button variant="secondary" size="small" disabled={ ! isDirty } onClick={ handleReset }>
+					{ __( 'Reset' ) }
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}
+
+function Preference( { name, value }: { name: string; value: any } ) {
 	const { mutate: unsetPreference } = useMutation(
 		userPreferenceMutation( name as keyof UserPreferences )
 	);
 
-	const handleClick = () => {
-		unsetPreference( null as unknown as UserPreferences[ keyof UserPreferences ] );
-	};
-
 	return (
-		<div>
+		<div className="preferences-helper__preference">
 			<HStack justify="flex-start" spacing={ 1 }>
 				<Button
 					icon={ closeSmall }
 					size="compact"
 					title={ __( 'Unset preference' ) }
-					onClick={ handleClick }
+					onClick={ () =>
+						unsetPreference( null as unknown as UserPreferences[ keyof UserPreferences ] )
+					}
 				/>
 				<Text>{ name }</Text>
 			</HStack>
+			<div className="preferences-helper__preference-content">
+				{ renderPreference( name, value ) }
+			</div>
 		</div>
 	);
 }
@@ -53,12 +188,12 @@ function PreferenceList() {
 	return (
 		<div>
 			<div>{ __( 'Preferences' ) }</div>
-			<Card size="xSmall" className="preferences-helper__current-preferences">
+			<Card size="xSmall" className="preferences-helper__preferences">
 				{ entries.length > 0 ? (
-					entries.map( ( [ name ], index ) => (
+					entries.map( ( [ name, value ], index ) => (
 						<Fragment key={ name }>
 							<CardBody>
-								<Preference name={ name } />
+								<Preference name={ name } value={ value } />
 							</CardBody>
 							{ index < entries.length - 1 && <CardDivider /> }
 						</Fragment>

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -25,9 +25,8 @@ import type { Field } from '@wordpress/dataviews';
 import './preferences.scss';
 
 type InputType = 'string' | 'number' | 'checkbox';
-type InputValue = string | number | boolean;
 
-const formattedValue = ( inputType: InputType, value?: InputValue ) => {
+const formattedValue = ( inputType: InputType, value?: unknown ) => {
 	if ( inputType === 'number' ) {
 		return Number( value );
 	}
@@ -84,6 +83,7 @@ function EditablePreference( {
 	const [ formData, setFormData ] = useState( { [ name ]: value } );
 
 	const handleSave = () => {
+		// @ts-expect-error - formData[ name ] is unknown
 		savePreference( formData[ name ] );
 	};
 
@@ -91,7 +91,7 @@ function EditablePreference( {
 		setFormData( { [ name ]: value } );
 	};
 
-	const fields: Field< { [ name ]: InputValue } >[] = useMemo(
+	const fields: Field< { [ name ]: unknown } >[] = useMemo(
 		() => [
 			{
 				id: name,
@@ -130,7 +130,7 @@ function EditablePreference( {
 
 	return (
 		<VStack>
-			<DataForm< { [ name ]: InputValue } >
+			<DataForm< { [ name ]: unknown } >
 				data={ formData }
 				fields={ fields }
 				form={ {

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -39,7 +39,7 @@ const formattedValue = ( inputType: InputType, value?: InputValue ) => {
 	return value;
 };
 
-const renderPreference = ( name: string, value: any ) => {
+const renderPreference = ( name: string, value: unknown ) => {
 	if ( typeof value === 'string' ) {
 		return <EditablePreference inputType="string" name={ name } value={ value } />;
 	}
@@ -59,7 +59,7 @@ const renderPreference = ( name: string, value: any ) => {
 	return null;
 };
 
-function ArrayPreference( { value }: { value: InputValue[] } ) {
+function ArrayPreference( { value }: { value: unknown[] } ) {
 	return (
 		<ul>
 			{ value.map( ( preference, index ) => (
@@ -76,7 +76,7 @@ function EditablePreference( {
 }: {
 	inputType: InputType;
 	name: string;
-	value: InputValue;
+	value: unknown;
 } ) {
 	const { mutate: savePreference } = useMutation(
 		userPreferenceMutation( name as keyof UserPreferences )
@@ -96,12 +96,12 @@ function EditablePreference( {
 			{
 				id: name,
 				Edit: ( { field, onChange, data } ) => {
-					const { id, getValue } = field;
+					const { id } = field;
 					if ( inputType === 'checkbox' ) {
 						return (
 							<CheckboxControl
 								__nextHasNoMarginBottom
-								checked={ getValue( { item: data } ) }
+								checked={ data[ id ] as unknown as boolean }
 								onChange={ ( newValue ) =>
 									onChange( { [ id ]: formattedValue( inputType, newValue ) } )
 								}
@@ -112,7 +112,7 @@ function EditablePreference( {
 					return (
 						<InputControl
 							type={ inputType }
-							value={ getValue( { item: data } ) }
+							value={ data[ id ] as unknown as string }
 							size="small"
 							onChange={ ( newValue ) =>
 								onChange( { [ id ]: formattedValue( inputType, newValue ) } )
@@ -153,7 +153,7 @@ function EditablePreference( {
 	);
 }
 
-function Preference( { name, value }: { name: string; value: any } ) {
+function Preference( { name, value }: { name: string; value: unknown } ) {
 	const { mutate: unsetPreference } = useMutation(
 		userPreferenceMutation( name as keyof UserPreferences )
 	);

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -34,4 +34,5 @@ export interface UserPreferences {
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
 	'sites-view'?: SitesViewPreferences;
+	[ key: string ]: unknown;
 }

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -34,5 +34,4 @@ export interface UserPreferences {
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
 	'sites-view'?: SitesViewPreferences;
-	[ key: string ]: unknown;
 }


### PR DESCRIPTION
## Proposed Changes

This PR improves the preferences dev helper to make the preference value editable.

<img width="378" height="862" alt="SCR-20251008-obrr" src="https://github.com/user-attachments/assets/f173dbe6-29e9-4713-836e-cf0327529d2e" />

>[!NOTE]
>Object-formatted preferences will be addressed separately.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the preferences helper correctly displays the preference value
* Ensure that the preference value is editable for strings, number, and boolean preferences

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [s] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
