### PR TITLE
Performance v2: Apply styles to the markdown result

### DIFF
--- a/client/dashboard/sites/performance/performance-insight.scss
+++ b/client/dashboard/sites/performance/performance-insight.scss
@@ -1,0 +1,12 @@
+@import '@wordpress/base-styles/colors';
+@import "@wordpress/base-styles/variables";
+
+.performance-insight__markdown {
+	pre:has(code) {
+		max-width: 100%;
+		padding: $grid-unit-20;
+		border-radius: $radius-small;
+		background-color: $gray-100;
+		overflow: auto;
+	}
+}

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -26,6 +26,7 @@ import type {
 	DeviceToggleType,
 } from './types';
 import type { SitePerformanceReport } from '@automattic/api-core';
+import './performance-insight.scss';
 
 export const PerformanceInsightTitle = ( {
 	insight,
@@ -229,17 +230,16 @@ export const PerformanceInsight = ( {
 						spacing={ 4 }
 						style={ { flexWrap: isDesktop ? 'nowrap' : 'wrap-reverse' } }
 					>
-						<div>
-							<Markdown
-								components={ {
-									a( props ) {
-										return <a target="_blank" { ...props } />;
-									},
-								} }
-							>
-								{ llmAnswer.messages }
-							</Markdown>
-						</div>
+						<Markdown
+							className="performance-insight__markdown"
+							components={ {
+								a( props ) {
+									return <a target="_blank" { ...props } />;
+								},
+							} }
+						>
+							{ llmAnswer.messages }
+						</Markdown>
 						{ showTip && <PerformanceInsightTip /> }
 					</HStack>
 					<PerformanceInsightFeedback chatId={ llmAnswer.chatId } hash={ hash } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-607

## Proposed Changes

* Apply styles to the markdown result. I think we only need styles for `<pre>` element with the `<code>` element 🤔

| Before | After |
| - | - |
|<img width="811" height="222" alt="image" src="https://github.com/user-attachments/assets/41fd843f-d87d-4303-b70a-58d063171052" />|<img width="795" height="253" alt="image" src="https://github.com/user-attachments/assets/e0558d16-2606-44d9-a49f-5fb06693bdfe" />|
|<img width="791" height="360" alt="image" src="https://github.com/user-attachments/assets/0798f01a-e2a3-4cae-9051-14787f1f2815" />|<img width="798" height="389" alt="image" src="https://github.com/user-attachments/assets/fcff0d85-28a7-4c4a-8226-a8bdb53621e2" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance
* Go to see the recommendations as below
  * Ensure text remains visible during webfont load
  * Some third-party resources can be lazy loaded with a facade
* Ensure the styles look good without overflowing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
