### PR TITLE
Update domain-only "attach to a site" card

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,9 +1,9 @@
 import { Domain, DomainSubtype } from '@automattic/api-core';
 import { siteByIdQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { ButtonStack } from '../../components/button-stack';
+import { globe } from '@wordpress/icons';
 import OverviewCard from '../../sites/overview-card';
 import SiteIcon from '../../sites/site-icon';
 
@@ -25,29 +25,20 @@ export default function FeaturedCardSite( { domain }: Props ) {
 
 	return (
 		<OverviewCard
-			title={ __( 'Site' ) }
-			heading={ <span style={ { wordBreak: 'break-all' } }>{ site.name }</span> }
+			title={ shouldShowAddAttachSite ? __( 'Attach to a site' ) : __( 'Site' ) }
+			heading={
+				<span style={ { wordBreak: 'break-all' } }>
+					{ shouldShowAddAttachSite ? 'No site attached' : site.name }
+				</span>
+			}
 			link={
 				shouldShowAddAttachSite
 					? `/domains/${ domain.domain }/transfer/other-site`
 					: `/sites/${ site.slug }`
 			}
-			icon={ <SiteIcon site={ site } /> }
+			icon={ shouldShowAddAttachSite ? <Icon icon={ globe } /> : <SiteIcon site={ site } /> }
 			description={
-				shouldShowAddAttachSite ? __( 'Attach to an existing site' ) : domain.site_slug
-			}
-			bottom={
-				shouldShowAddAttachSite && (
-					<ButtonStack>
-						<Button
-							size="compact"
-							variant="primary"
-							href={ `/start/site-selected/?siteSlug=${ site.slug }&siteId=${ site.ID }` }
-						>
-							{ __( 'Add a new site' ) }
-						</Button>
-					</ButtonStack>
-				)
+				shouldShowAddAttachSite ? __( 'Attach to an existing site.' ) : domain.site_slug
 			}
 		/>
 	);

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -28,7 +28,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			title={ shouldShowAddAttachSite ? __( 'Attach to a site' ) : __( 'Site' ) }
 			heading={
 				<span style={ { wordBreak: 'break-all' } }>
-					{ shouldShowAddAttachSite ? 'No site attached' : site.name }
+					{ shouldShowAddAttachSite ? __( 'No site attached' ) : site.name }
 				</span>
 			}
 			link={
@@ -38,7 +38,9 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			}
 			icon={ shouldShowAddAttachSite ? <Icon icon={ globe } /> : <SiteIcon site={ site } /> }
 			description={
-				shouldShowAddAttachSite ? __( 'Attach to an existing site.' ) : domain.site_slug
+				shouldShowAddAttachSite
+					? __( 'Attach this domain name to an existing site.' )
+					: domain.site_slug
 			}
 		/>
 	);

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -3,7 +3,7 @@ import { siteByIdQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { globe } from '@wordpress/icons';
+import { layout } from '@wordpress/icons';
 import OverviewCard from '../../sites/overview-card';
 import SiteIcon from '../../sites/site-icon';
 
@@ -36,7 +36,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 					? `/domains/${ domain.domain }/transfer/other-site`
 					: `/sites/${ site.slug }`
 			}
-			icon={ shouldShowAddAttachSite ? <Icon icon={ globe } /> : <SiteIcon site={ site } /> }
+			icon={ shouldShowAddAttachSite ? <Icon icon={ layout } /> : <SiteIcon site={ site } /> }
 			description={
 				shouldShowAddAttachSite
 					? __( 'Attach this domain name to an existing site.' )


### PR DESCRIPTION
Closes [DOTDAS-621](https://linear.app/a8c/issue/DOTDASH-621/update-attach-a-site-card-design)

## Proposed Changes
Update Site overview card for domain-only sites.
* Removed the "Add a new site" button
* Updated the UI to show a globe icon instead of site icon when no site is attached
* Updated text content and descriptions for better clarity

![Screenshot 2025-10-08 alle 14 13 49](https://github.com/user-attachments/assets/e699d80c-aec3-4f98-9960-5fd5859b1301)

## Why are these changes being made?
Streamlines the user experience by focusing on the primary action (attaching to existing site) through the main card link

## Testing Instructions
- Navigate to the domain management page for a domain-only site and confirm that the card appears as shown in the attached screenshot.
- Ensure the cta goes to `v2/domains/[DOMANI]transfer/other-site`
- Ensure that regular domains continue to follow the original behavior

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
