### PR TITLE
/support: Sticky header on frontpage

### DIFF
--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -16,6 +16,13 @@ $breakpoint-desktop: 1440px; //Desktop size.
 		z-index: 1;
 	}
 
+	&:not(.navigation-only) .navigation-header {
+		background: #f7f8ff;
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
 	.navigation-header {
 		padding: 0 24px;
 
@@ -318,6 +325,10 @@ $breakpoint-desktop: 1440px; //Desktop size.
 	@media ( min-width: $breakpoint-mobile ) {
 		margin-left: 0;
 		top: 32px;
+
+		.navigation-header {
+			top: 32px;
+		}
 	}
 }
 


### PR DESCRIPTION
As you scroll down the page, the navigation should lock to the top of the browser. As people scroll, this will help them navigate to other areas and access the search. You can see the behaviour [in this prototype](https://www.figma.com/proto/fpIiz5rD1tlm7PZ0IXv2jw/New-Support-Center-prototype?node-id=13-1498&p=f&t=MzGwKNIjb7fMGzNF-1&scaling=min-zoom&content-scaling=fixed&page-id=1%3A92&starting-point-node-id=50%3A9910&show-proto-sidebar=1).

Fixes https://linear.app/a8c/issue/DOTSUP-272/support-navigation-handle-feedback

## Testing
1. sandbox widgets
2. 'yarn dev --sync' from 'apps/happy-blocks'
3. Test wordpress.com/support on desktop and mobile, on frontpage and other pages

