### PR TITLE
Rename migration flow request submitted facebook event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -12,7 +12,7 @@ import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-pa
 import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
 import {
 	recordMigrationCredentialsEvent,
-	recordMigrationCredentialsFacebookEvent,
+	recordMigrationRequestSubmittedFacebookEvent,
 } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
@@ -102,7 +102,7 @@ const SiteMigrationCredentials: StepType< {
 
 		// Fire Google Ads tracking event when credentials are submitted
 		recordMigrationCredentialsEvent( 'SiteMigrationCredentials' );
-		recordMigrationCredentialsFacebookEvent( 'SiteMigrationCredentials' );
+		recordMigrationRequestSubmittedFacebookEvent( 'SiteMigrationCredentials' );
 
 		siteId && dispatch( resetSite( siteId ) );
 		return navigation.submit?.( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -4,7 +4,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	recordMigrationCredentialsEvent,
-	recordMigrationCredentialsFacebookEvent,
+	recordMigrationRequestSubmittedFacebookEvent,
 } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { CredentialsForm } from './components/credentials-form';
 import type { Step as StepType } from '../../types';
@@ -29,7 +29,7 @@ const SiteMigrationFallbackCredentials: StepType< {
 
 		// Fire Google Ads tracking event when credentials are submitted
 		recordMigrationCredentialsEvent( 'SiteMigrationFallbackCredentials' );
-		recordMigrationCredentialsFacebookEvent( 'SiteMigrationFallbackCredentials' );
+		recordMigrationRequestSubmittedFacebookEvent( 'SiteMigrationFallbackCredentials' );
 
 		return navigation.submit?.( { action, from } );
 	};

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -85,7 +85,7 @@ export function recordMigrationStartFacebookEvent( componentName ) {
  * @param {string} componentName - The name of the component firing the event
  * @returns {void}
  */
-export function recordMigrationCredentialsFacebookEvent( componentName ) {
+export function recordMigrationRequestSubmittedFacebookEvent( componentName ) {
 	if ( ! mayWeTrackByTracker( 'facebook' ) ) {
 		debug( `${ componentName }: skipping Facebook tracking as ad tracking is disallowed` );
 		return;

--- a/client/lib/analytics/ad-tracking/record-migration-events.js
+++ b/client/lib/analytics/ad-tracking/record-migration-events.js
@@ -91,8 +91,8 @@ export function recordMigrationCredentialsFacebookEvent( componentName ) {
 		return;
 	}
 
-	const params = [ 'trackCustom', 'MigrationCredentials' ];
-	debug( `${ componentName }: [Facebook] Migration Credentials`, params );
+	const params = [ 'trackCustom', 'MigrationRequestSubmitted' ];
+	debug( `${ componentName }: [Facebook] Migration Request Submitted`, params );
 	window.fbq( ...params );
 }
 


### PR DESCRIPTION

Part of #

## Proposed Changes

* @debbiengWP requested the MigrationCredentials event to be renamed to MigrationRequestSubmitted

## Why are these changes being made?

* Clarity for Data

## Testing Instructions

* Start with /move logged in (easier to test that way)
* Then once the Stepper signup kicks in, go to calypso.localhost:3000 and add &flags=ad-tracking
* Proceed with the migration until the end and always select migration instead of import in the flows
* At the final step, either provide a username/password to a hosting site or upload a file like this `https://drive.google.com/file/d/12AVNATkW-M9eTyNs9QTBHG3QympAJopO/view?ths=true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
