### PR TITLE
Hosting Dashboard Plugins: Remove bulk actions

### DIFF
--- a/client/dashboard/plugins/manage/actions/activate.tsx
+++ b/client/dashboard/plugins/manage/actions/activate.tsx
@@ -27,5 +27,4 @@ export const activateAction: Action< PluginListRow > = {
 	isEligible: ( item: PluginListRow ) => {
 		return [ 'some', 'none' ].includes( item.isActive );
 	},
-	supportsBulk: true,
 };

--- a/client/dashboard/plugins/manage/actions/deactivate.tsx
+++ b/client/dashboard/plugins/manage/actions/deactivate.tsx
@@ -27,5 +27,4 @@ export const deactivateAction: Action< PluginListRow > = {
 	isEligible: ( item: PluginListRow ) => {
 		return [ 'some', 'all' ].includes( item.isActive );
 	},
-	supportsBulk: true,
 };

--- a/client/dashboard/plugins/manage/actions/delete.tsx
+++ b/client/dashboard/plugins/manage/actions/delete.tsx
@@ -28,5 +28,4 @@ export const deleteAction: Action< PluginListRow > = {
 	isEligible: ( item: PluginListRow ) => {
 		return item.isActive === 'none';
 	},
-	supportsBulk: true,
 };

--- a/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
@@ -27,5 +27,4 @@ export const disableAutoupdateAction: Action< PluginListRow > = {
 	isEligible: ( item: PluginListRow ) => {
 		return [ 'some', 'all' ].includes( item.areAutoUpdatesEnabled );
 	},
-	supportsBulk: true,
 };

--- a/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
@@ -27,5 +27,4 @@ export const enableAutoupdateAction: Action< PluginListRow > = {
 	isEligible: ( item: PluginListRow ) => {
 		return [ 'some', 'none' ].includes( item.areAutoUpdatesEnabled );
 	},
-	supportsBulk: true,
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDEV-235/add-option-to-choose-sites-when-deactivating-plugin

| Before | After |
|--------|--------|
| <img width="1529" height="1289" alt="Screenshot 2025-10-08 at 13 20 57" src="https://github.com/user-attachments/assets/c01d7624-57c7-4b4b-bc94-f1cf84cc3b0d" />|<img width="1527" height="1288" alt="Screenshot 2025-10-08 at 13 20 38" src="https://github.com/user-attachments/assets/a6760e75-c914-4060-b4f9-f394ba4d1ed2" />| 

## Proposed Changes

* Removed bulk actions from the main plugins list dataview

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `v2/plugins`
* You shouldn't be able to select multiple plugins.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
