### PR TITLE
Adjust the display of Back button on Repositories page

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -905,6 +905,11 @@ export const siteSettingsRepositoriesRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'repositories',
+	validateSearch: ( search ): { from?: 'deployments' } => {
+		return {
+			from: search.from === 'deployments' ? 'deployments' : undefined,
+		};
+	},
 } );
 
 export const siteSettingsRepositoriesIndexRoute = createRoute( {

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -18,7 +18,6 @@ import {
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RouterLinkButton from '../../components/router-link-button';
 import { useDeploymentFields } from './dataviews/fields';
 import { DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews/views';
 import { DeploymentLogsModalContent } from './deployment-logs/deployment-logs-modal-content';
@@ -162,14 +161,19 @@ function DeploymentsList() {
 					title={ __( 'Deployments' ) }
 					actions={
 						<>
-							<RouterLinkButton
-								to={ siteSettingsRepositoriesRoute.fullPath }
-								params={ { siteSlug } }
+							<Button
 								variant="secondary"
 								__next40pxDefaultSize
+								onClick={ () =>
+									navigate( {
+										to: siteSettingsRepositoriesRoute.fullPath,
+										params: { siteSlug },
+										search: { from: 'deployments' },
+									} )
+								}
 							>
 								{ __( 'Go to repositories' ) }
-							</RouterLinkButton>
+							</Button>
 							<Button
 								variant="primary"
 								__next40pxDefaultSize

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -18,6 +18,7 @@ import {
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { useDeploymentFields } from './dataviews/fields';
 import { DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews/views';
 import { DeploymentLogsModalContent } from './deployment-logs/deployment-logs-modal-content';
@@ -161,19 +162,15 @@ function DeploymentsList() {
 					title={ __( 'Deployments' ) }
 					actions={
 						<>
-							<Button
+							<RouterLinkButton
+								to={ siteSettingsRepositoriesRoute.fullPath }
+								params={ { siteSlug } }
+								search={ { from: 'deployments' } }
 								variant="secondary"
 								__next40pxDefaultSize
-								onClick={ () =>
-									navigate( {
-										to: siteSettingsRepositoriesRoute.fullPath,
-										params: { siteSlug },
-										search: { from: 'deployments' },
-									} )
-								}
 							>
 								{ __( 'Go to repositories' ) }
-							</Button>
+							</RouterLinkButton>
 							<Button
 								variant="primary"
 								__next40pxDefaultSize

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -116,10 +116,13 @@ function RepositoriesList() {
 }
 
 function SiteRepositories() {
+	const router = useRouter();
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
+	const search = router.state.location.search as Record< string, string > | undefined;
+	const showBackToDeployments = search?.from === 'deployments';
 
 	const handleConnectRepository = () => {
 		navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } );
@@ -158,24 +161,26 @@ function SiteRepositories() {
 					<RepositoriesList />
 				</HostingFeatureGatedWithCallout>
 			</PageLayout>
-			<HStack className="dashboard-snackbars">
-				<Snackbar
-					icon={ <Icon icon={ keyboardReturn } style={ { fill: 'currentcolor' } } /> }
-					actions={ [
-						{
-							label: __( 'Navigate' ),
-							onClick: () => {
-								navigate( {
-									to: siteDeploymentsListRoute.fullPath,
-									params: { siteSlug },
-								} );
+			{ showBackToDeployments && (
+				<HStack className="dashboard-snackbars">
+					<Snackbar
+						icon={ <Icon icon={ keyboardReturn } style={ { fill: 'currentcolor' } } /> }
+						actions={ [
+							{
+								label: __( 'Navigate' ),
+								onClick: () => {
+									navigate( {
+										to: siteDeploymentsListRoute.fullPath,
+										params: { siteSlug },
+									} );
+								},
 							},
-						},
-					] }
-				>
-					{ __( 'Back to Deployments' ) }
-				</Snackbar>
-			</HStack>
+						] }
+					>
+						{ __( 'Back to Deployments' ) }
+					</Snackbar>
+				</HStack>
+			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -116,12 +116,11 @@ function RepositoriesList() {
 }
 
 function SiteRepositories() {
-	const router = useRouter();
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
-	const search = router.state.location.search as Record< string, string > | undefined;
+	const search = siteSettingsRepositoriesRoute.useSearch();
 	const showBackToDeployments = search?.from === 'deployments';
 
 	const handleConnectRepository = () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTDASH-620

## Proposed Changes

This ensures that `Back to Deployments` button shows on the `Repositories` page only when you come from the `Deployments` page and not from anywhere else:

https://github.com/user-attachments/assets/ec8dcfd5-da9b-4a7a-82d6-1325f9c7ef3c

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the back button shows at all times even if you don't come from `Deployments`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure that you have an Atomic site 
* Navigate to `/v2/sites/{yourAtomicSite}/deployments`
* Click on the `Go to repositories` button in the top right corner
* Confirm that you can see the back button at the bottom of the screen
* Navigate to `/v2/sites/{yourAtomicSite}/settings`
* Click on `GitHub repositories` setting
* Confirm that once you arrive on `Repositories` page, you don't see the back button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
