### PR TITLE
Speed up validation tests by using fireEvent.change for long inputs

### DIFF
--- a/client/dashboard/me/profile-gravatar/test/validation.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/validation.test.tsx
@@ -18,7 +18,7 @@ describe( 'GravatarProfileSection Form Validation', () => {
 			const longName = 'a'.repeat( 251 );
 
 			await user.clear( displayNameInput );
-			await user.type( displayNameInput, longName );
+			fireEvent.change( displayNameInput, { target: { value: longName } } );
 			fireEvent.blur( displayNameInput );
 
 			expect(
@@ -34,7 +34,7 @@ describe( 'GravatarProfileSection Form Validation', () => {
 			const maxLengthName = 'a'.repeat( 250 );
 
 			await user.clear( displayNameInput );
-			await user.type( displayNameInput, maxLengthName );
+			fireEvent.change( displayNameInput, { target: { value: maxLengthName } } );
 			fireEvent.blur( displayNameInput );
 
 			expect(
@@ -50,7 +50,7 @@ describe( 'GravatarProfileSection Form Validation', () => {
 			const longName = 'a'.repeat( 251 );
 
 			await user.clear( displayNameInput );
-			await user.type( displayNameInput, longName );
+			fireEvent.change( displayNameInput, { target: { value: longName } } );
 
 			const saveButton = screen.getByRole( 'button', { name: 'Save' } );
 			expect( saveButton ).toBeDisabled();


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/PLTFRM-1761/fix-slow-validation-tests-for-the-gravatar-profile-section

## Proposed Changes

- Replace user.type() with fireEvent.change() when setting 250/251-character display name values in GravatarProfileSection validation tests.
- Preserve test behavior while avoiding hundreds of simulated keystrokes in jsdom, improving test runtime and reducing timeouts.

## Why are these changes being made?

To prevent timeout issues in tests, as seen in:
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Run_All_Unit_Tests/15856102
- https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Run_All_Unit_Tests/15855585?buildTab=tests

This was due to
- Typing 250+ characters with @testing-library/user-event is slow and can lead to flaky timeouts.
- Dispatching a single change event with the full value is equivalent for validation logic and runs much faster.

## Testing Instructions

- Run the specific test file: `yarn test-client client/dashboard/me/profile-gravatar/test/validation.test.tsx`
- All tests should pass. No UI changes are expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
