### PR TITLE
Performance v2: Make the heights of top cards consistent

### DIFF
--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -30,7 +30,7 @@ export default function CoreMetrics( {
 			selectedTabId={ activeTab }
 			onSelect={ ( tabId: Metrics ) => setActiveTab( tabId ) }
 		>
-			<HStack wrap={ ! isDesktop } alignment="flex-start" justify="flex-start" spacing={ 6 }>
+			<HStack wrap={ ! isDesktop } alignment="stretch" justify="flex-start" spacing={ 6 }>
 				<Card style={ { flexGrow: ! isDesktop ? 1 : 0, flexShrink: ! isDesktop ? 1 : 0 } }>
 					<CoreMetricsTabs compact={ ! isDesktop } report={ report } />
 				</Card>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Make the heights of top cards consistent

| Before | After |
| - | - |
|<img width="893" height="455" alt="image" src="https://github.com/user-attachments/assets/f6d248c8-bf33-459a-8ae1-f0f796a25829" />|<img width="893" height="458" alt="image" src="https://github.com/user-attachments/assets/25aad205-e9fe-459e-97a4-986cd37964af" />|
|<img width="895" height="521" alt="image" src="https://github.com/user-attachments/assets/397b2c4c-99b1-4f71-9f99-40adc02875ec" />|<img width="889" height="522" alt="image" src="https://github.com/user-attachments/assets/7ab13a78-3aea-46f7-b135-47742244c685" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/arthurwoadevblog12345.com/performance
* Ensure the heights of top cards consistent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
