### PR TITLE
v2 HD - Flex: Show default wpcom sub-menu when flex site, Jetpack or not

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -98,7 +98,11 @@ export const siteRoute = createRoute( {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 
 		const overviewUrl = `/sites/${ siteSlug }`;
-		if ( isSelfHostedJetpackConnected( site ) && ! location.pathname.endsWith( overviewUrl ) ) {
+		if (
+			isSelfHostedJetpackConnected( site ) &&
+			! site.is_wpcom_flex &&
+			! location.pathname.endsWith( overviewUrl )
+		) {
 			throw redirect( { to: overviewUrl } );
 		}
 

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -15,7 +15,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 	const { supports } = useAppContext();
 	const siteSlug = site.slug;
 
-	if ( isSelfHostedJetpackConnected( site ) ) {
+	if ( isSelfHostedJetpackConnected( site ) && ! site.is_wpcom_flex ) {
 		return (
 			<ResponsiveMenu label={ __( 'Site Menu' ) }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/DOTMART-19/hd-v2-enable-the-navigation-for-flex-sites-to-work-as-wpcom-atomic

## Proposed Changes

This PR enables the navigation (menu & sub-menu) in v2 dashboard for the Flex sites. This sets it to the default menu irrespective of the Jetpack status/flag on the site. Flex sites may have JP installed.

| Before | After |
|--------|--------|
| <img width="700" alt="Screenshot 2025-10-08 at 3 33 43 PM" src="https://github.com/user-attachments/assets/b4d6ad13-b582-4dc6-928e-1bc9251586d0" /> | <img width="700" alt="Screenshot 2025-10-08 at 3 30 49 PM" src="https://github.com/user-attachments/assets/f71a0493-0e95-4045-a5fc-233d53c789a3" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/DOTMART-19/hd-v2-enable-the-navigation-for-flex-sites-to-work-as-wpcom-atomic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/sites/$siteId` with a usage-based (Flex) site. Follow instructions in 192692-ghe-Automattic/wpcom to create one.
* Confirm menu & sub-menu render as default (not Jetpack). Per media above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?