### PR TITLE
Domain Search Rewrite: Input reset should clear the query

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -14,6 +14,10 @@ const setSessionStorageQuery = ( query: string ) => {
 	sessionStorage.setItem( SESSION_STORAGE_QUERY_KEY, query );
 };
 
+const clearSessionStorageQuery = () => {
+	sessionStorage.removeItem( SESSION_STORAGE_QUERY_KEY );
+};
+
 export const useQueryHandler = ( {
 	initialQuery: externalInitialQuery,
 	currentSiteUrl,
@@ -41,5 +45,6 @@ export const useQueryHandler = ( {
 	return {
 		query: localQuery,
 		setQuery,
+		clearQuery: clearSessionStorageQuery,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -82,7 +82,7 @@ const DomainSearchStep: StepType< {
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
-	const { query, setQuery } = useQueryHandler( {
+	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery,
 		currentSiteUrl,
 	} );
@@ -138,6 +138,7 @@ const DomainSearchStep: StepType< {
 				return product;
 			},
 			onQueryChange: setQuery,
+			onQueryClear: clearQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				window.location.assign(
 					domainManagementTransferToOtherSite( otherSiteDomain, domainName )
@@ -200,7 +201,7 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 		};
-	}, [ submit, setQuery, flow, siteSlug ] );
+	}, [ submit, setQuery, clearQuery, flow, siteSlug ] );
 
 	const slots = useMemo( () => {
 		return {

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -65,7 +65,7 @@ export default function DomainSearch() {
 	const currentSiteUrl = selectedSite?.URL;
 	const currentSiteId = selectedSite?.ID;
 
-	const { query, setQuery } = useQueryHandler( {
+	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery,
 		currentSiteUrl,
 	} );
@@ -73,6 +73,7 @@ export default function DomainSearch() {
 	const events = useMemo( () => {
 		return {
 			onQueryChange: setQuery,
+			onQueryClear: clearQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
 			},
@@ -112,7 +113,7 @@ export default function DomainSearch() {
 				}
 			},
 		};
-	}, [ selectedSiteSlug, setQuery ] );
+	}, [ selectedSiteSlug, setQuery, clearQuery ] );
 
 	const currentRoute = useSelector( getCurrentRoute );
 

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -80,7 +80,7 @@ const DomainSearchUI = (
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteId = site?.ID ? site.ID : siteId ? parseInt( siteId, 10 ) : undefined;
 
-	const { query, setQuery } = useQueryHandler( {
+	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery: queryObject.new,
 		currentSiteUrl,
 	} );
@@ -88,6 +88,7 @@ const DomainSearchUI = (
 	const events = useMemo( () => {
 		return {
 			onQueryChange: setQuery,
+			onQueryClear: clearQuery,
 			beforeAddDomainToCart: ( product: MinimalRequestCartProduct ) => {
 				if ( isDomainForGravatarFlow( flowName ) ) {
 					return {
@@ -209,6 +210,7 @@ const DomainSearchUI = (
 		stepName,
 		siteSlug,
 		setQuery,
+		clearQuery,
 		submitSignupStep,
 		goToNextStep,
 		locale,

--- a/packages/domain-search/src/components/search-bar/input.tsx
+++ b/packages/domain-search/src/components/search-bar/input.tsx
@@ -8,7 +8,7 @@ const DELAY_TIMEOUT = 300;
 
 export const Input = () => {
 	const { __ } = useI18n();
-	const { query, setQuery } = useDomainSearch();
+	const { query, setQuery, events } = useDomainSearch();
 	const [ localQuery, setLocalQuery ] = useState( query );
 
 	const debouncedPropagateQuery = useDebounce( setQuery, DELAY_TIMEOUT );
@@ -19,9 +19,12 @@ export const Input = () => {
 			onChange={ ( value ) => {
 				const trimmedValue = value.trim();
 
+				setLocalQuery( trimmedValue );
+
 				if ( trimmedValue ) {
-					setLocalQuery( trimmedValue );
 					debouncedPropagateQuery( trimmedValue );
+				} else {
+					events.onQueryClear();
 				}
 			} }
 			label={ __( 'Search for a domain' ) }

--- a/packages/domain-search/src/components/search-bar/test/input.tsx
+++ b/packages/domain-search/src/components/search-bar/test/input.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestDomainSearch } from '../../../test-helpers/renderer';
+import { Input } from '../input';
+
+describe( 'Input', () => {
+	it( 'renders the query', () => {
+		render(
+			<TestDomainSearch query="test">
+				<Input />
+			</TestDomainSearch>
+		);
+
+		expect( screen.getByRole( 'searchbox' ) ).toHaveValue( 'test' );
+	} );
+
+	it( 'changes the input value when the query changes and dispatches the onQueryChange event after a delay', async () => {
+		const user = userEvent.setup();
+
+		const onQueryChange = jest.fn();
+
+		render(
+			<TestDomainSearch query="test" events={ { onQueryChange } }>
+				<Input />
+			</TestDomainSearch>
+		);
+
+		await user.type( screen.getByRole( 'searchbox' ), '2' );
+
+		expect( screen.getByRole( 'searchbox' ) ).toHaveValue( 'test2' );
+
+		expect( onQueryChange ).not.toHaveBeenCalled();
+
+		await waitFor( () => {
+			expect( onQueryChange ).toHaveBeenCalledWith( 'test2' );
+		} );
+	} );
+
+	it( 'clears the query when the clear button is clicked and dispatches the onQueryClear event', async () => {
+		const user = userEvent.setup();
+
+		const onQueryClear = jest.fn();
+
+		render(
+			<TestDomainSearch query="test" events={ { onQueryClear } }>
+				<Input />
+			</TestDomainSearch>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Reset search' } ) );
+
+		expect( screen.getByRole( 'searchbox' ) ).toHaveValue( '' );
+		expect( onQueryClear ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -21,6 +21,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onCheckTransferStatusClick: noop,
 		onMapDomainClick: noop,
 		onQueryChange: noop,
+		onQueryClear: noop,
 		onAddDomainToCart: noop,
 		onQueryAvailabilityCheck: noop,
 		onDomainAddAvailabilityPreCheck: noop,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -41,6 +41,7 @@ export interface DomainSearchEvents {
 	onCheckTransferStatusClick: ( domainName: string ) => void;
 	onMapDomainClick: ( domainName: string ) => void;
 	onQueryChange: ( query: string ) => void;
+	onQueryClear: () => void;
 	onAddDomainToCart: (
 		domainName: string,
 		position: number,


### PR DESCRIPTION
Closes DOMAINS-1698.

## Proposed Changes

There was an issue with the input clearing once a query had been made: clicking it didn't have any effect.

This PR makes it so that when the user clicks the reset button, the input clears but the results stay on the page until they move away from it.

## Testing Instructions

Ensure the `domain-search-rewrite` feature flag is on and enter `/setup`.

Type something in the search box and verify that the results appear.

Click the "X" button in the input to reset the query. Verify the results are still there.

Refresh the page, and the results should be gone.