### PR TITLE
A4A: Referral section shinning

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -1,4 +1,4 @@
-import { Button, WooLogo, WordPressLogo } from '@automattic/components';
+import { Button, WordPressLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { formatNumber } from '@automattic/number-formatters';
 import { reusableBlock } from '@wordpress/icons';
@@ -58,7 +58,6 @@ export default function LayoutBodyContent( {
 	}, [ dispatch ] );
 
 	const accountStatus = getAccountStatus( tipaltiData, translate );
-	const isPayable = !! tipaltiData?.IsPayable;
 
 	const hasPayeeAccount = !! accountStatus?.status;
 	const bankAccountCTAText = hasPayeeAccount
@@ -164,6 +163,19 @@ export default function LayoutBodyContent( {
 				) : (
 					<>
 						<StepSection heading={ translate( 'How do I start?' ) }>
+							<StepSectionItem
+								iconClassName="referrals-overview__opacity-70-percent"
+								icon={ reusableBlock }
+								heading={ translate( 'Refer products and hosting' ) }
+								description={ translate( 'Receive up to a 50% commission.' ) }
+								buttonProps={ {
+									children: translate( 'Get started' ),
+									compact: true,
+									primary: hasPayeeAccount,
+									href: A4A_MARKETPLACE_PRODUCTS_LINK,
+									onClick: onGetStartedClick,
+								} }
+							/>
 							<StepSectionItem
 								icon={ tipaltiLogo }
 								heading={ translate( 'Prepare to get paid' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -208,41 +208,6 @@ export default function LayoutBodyContent( {
 										: undefined
 								}
 							/>
-							<StepSectionItem
-								iconClassName="referrals-overview__opacity-70-percent"
-								icon={ reusableBlock }
-								heading={ translate( 'Refer products and hosting' ) }
-								description={ translate( 'Receive up to a 50% commission.' ) }
-								buttonProps={ {
-									children: translate( 'Get started' ),
-									compact: true,
-									primary: hasPayeeAccount,
-									disabled: ! isPayable,
-									href: A4A_MARKETPLACE_PRODUCTS_LINK,
-									onClick: onGetStartedClick,
-								} }
-							/>
-							<StepSectionItem
-								className="referrals-overview__step-section-woo-payments"
-								icon={ <WooLogo /> }
-								heading={ translate( 'Install WooPayments' ) }
-								description={ translate(
-									'Receive a revenue share of 5 basis points on the total payments{{nbsp/}}volume.',
-									{
-										components: {
-											nbsp: <>&nbsp;</>,
-										},
-									}
-								) }
-								buttonProps={ {
-									children: translate( 'Learn how' ),
-									compact: true,
-									primary: hasPayeeAccount,
-									href: 'https://woocommerce.com/payments/',
-									rel: 'noreferrer',
-									target: '_blank',
-								} }
-							/>
 						</StepSection>
 						<StepSection
 							className="referrals-overview__step-section-learn-more"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This PR updates the Referral Empty View (part of the Meetup Shine Project) to move the `Refer products and hosting` item to the top and remove the `Install WooPayments` item.

<img width="740" height="504" alt="image" src="https://github.com/user-attachments/assets/e1a7847d-57c9-4a0c-a50d-4c38d6ceed9a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply this change, check the code
- Launch a Live Site with the link below.
- With an agency without referrals, go to the Referral section and check the view. It should look like the screenshot above.
- If you don't have one, you can set the `referrals` variable to [] in the `referrals/primary/referrals-overview/index.tsx` file:

```
const { isFetching: isFetchingReferrals } = useFetchReferrals();

	const referrals = [];
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
