### PR TITLE
Domain Search Rewrite: Add label to filter button

### DIFF
--- a/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
@@ -35,7 +35,7 @@ export const DomainSearchControlsFilterButton = forwardRef(
 			<div className="domain-search-controls__filters">
 				<Button
 					icon={ funnel }
-					aria-label={ ariaLabel }
+					label={ ariaLabel }
 					variant="secondary"
 					showTooltip
 					onClick={ onClick }


### PR DESCRIPTION
Reported in pdtkmj-40Z-p2#comment-7750.

## Proposed Changes

Adds a more descriptive label when hover over it:

<img width="189" height="136" alt="image" src="https://github.com/user-attachments/assets/cdafc173-f980-41a6-978f-ad46fb9d14f3" />

## Testing Instructions

Hover the filter button and you should see a more descriptive label about the status of the filter.