### PR TITLE
Domain Search Rewrite: Make sure cart is on top the masterbar in the in-Calypso view

### DIFF
--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -18,6 +18,10 @@
 			left: var( --sidebar-width-min );
 		}
 	}
+
+	.domains-full-cart {
+		z-index: z-index( 'root', '.drawer' );
+	}
 }
 
 body:has( .calypso-domain-search ) {


### PR DESCRIPTION
Part of pdtkmj-40Z-p2#comment-7750.

## Proposed Changes

Fixes a bug where the full cart drawer was showing behind the masterbar within `/domains/add/%s`.

| Before | After |
| --- | --- |
| <img width="914" height="764" alt="image" src="https://github.com/user-attachments/assets/c616f75e-00b1-447d-9794-eda338408527" /> | <img width="535" height="323" alt="image" src="https://github.com/user-attachments/assets/118c99c3-5ff6-467b-893c-ca492aa22c3d" /> |

## Testing Instructions

Enter `/domains/add/%s`, add a domain to the cart and click "View cart". Make sure the masterbar is behind it.