### PR TITLE
Show the domain subtype below the domain name and a few other small fixes

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,7 +1,11 @@
 import { DomainSubtype } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import { Link } from '@tanstack/react-router';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { domainOverviewRoute } from '../../app/router/domains';
 import { textOverflowStyles } from './utils';
@@ -26,14 +30,19 @@ export const DomainNameField = ( {
 			params={ { siteSlug, domainName: domain.domain } }
 			disabled={ domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS }
 		>
-			<HStack spacing={ 1 }>
-				<span style={ textOverflowStyles }>{ value }</span>
-				{ showPrimaryDomainBadge && domain.primary_domain && (
-					<span style={ { flexShrink: 0 } }>
-						<Badge>{ __( 'Primary' ) }</Badge>
-					</span>
+			<VStack spacing={ 0 }>
+				<HStack spacing={ 1 }>
+					<span style={ textOverflowStyles }>{ value }</span>
+					{ showPrimaryDomainBadge && domain.primary_domain && (
+						<span style={ { flexShrink: 0 } }>
+							<Badge>{ __( 'Primary' ) }</Badge>
+						</span>
+					) }
+				</HStack>
+				{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
+					<Text variant="muted">{ domain.subtype.label }</Text>
 				) }
-			</HStack>
+			</VStack>
 		</Link>
 	);
 };

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -30,7 +30,7 @@ export const DomainNameField = ( {
 			params={ { siteSlug, domainName: domain.domain } }
 			disabled={ domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS }
 		>
-			<VStack spacing={ 0 }>
+			<VStack spacing={ 1 }>
 				<HStack spacing={ 1 }>
 					<span style={ textOverflowStyles }>{ value }</span>
 					{ showPrimaryDomainBadge && domain.primary_domain && (

--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution, reusableBlock } from '@wordpress/icons';
@@ -13,7 +14,10 @@ export const DomainExpiryField = ( {
 	isCompact?: boolean;
 } ) => {
 	if ( ! domain.expiry ) {
-		return __( 'Free forever' );
+		if ( domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) {
+			return __( 'Free forever' );
+		}
+		return '-';
 	}
 
 	const isAutoRenewing = Boolean( domain.auto_renewing );

--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -1,13 +1,26 @@
-import { DomainSummary } from '@automattic/api-core';
+import { DomainSubtype, DomainSummary } from '@automattic/api-core';
 import { sslDetailsQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 
 export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
-	const { data: sslDetails } = useQuery( sslDetailsQuery( domain.domain ) );
+	const { data: sslDetails } = useQuery( {
+		...sslDetailsQuery( domain.domain ),
+		enabled:
+			domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER &&
+			domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS,
+	} );
 
-	if ( sslDetails?.certificate_provisioned || domain.wpcom_domain ) {
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER ) {
+		// TODO: only show this if there is no active domain connection for the domain transfer
+		return '-';
+	}
+
+	if (
+		domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
+		sslDetails?.certificate_provisioned
+	) {
 		return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
 	}
 

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -22,6 +22,7 @@ export const useFields = ( {
 }: {
 	site?: Site;
 	showPrimaryDomainBadge?: boolean;
+	inOverview?: boolean;
 } = {} ) => {
 	const { data: domains } = useQuery( domainsQuery() );
 

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -82,7 +82,15 @@ export const useFields = ( {
 				label: __( 'Type' ),
 				enableHiding: false,
 				enableSorting: false,
-				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.label ?? '',
+				elements: [
+					{ value: DomainSubtype.DOMAIN_REGISTRATION, label: __( 'Domain name registration' ) },
+					{ value: DomainSubtype.DOMAIN_TRANSFER, label: __( 'Domain name transfer' ) },
+					{ value: DomainSubtype.DOMAIN_CONNECTION, label: __( 'Domain name connection' ) },
+				],
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
+				},
+				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.id ?? '',
 			},
 			// {
 			// 	id: 'owner',

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -18,6 +18,7 @@ const THREE_DAYS_IN_MINUTES = 3 * 1440;
 export const useFields = ( {
 	site,
 	showPrimaryDomainBadge = true,
+	inOverview = false,
 }: {
 	site?: Site;
 	showPrimaryDomainBadge?: boolean;
@@ -146,7 +147,9 @@ export const useFields = ( {
 				},
 				render: ( { item } ) => {
 					// Site Overview does not show the Status column, so we use this column for error messages.
+					// TODO: move this inside the DomainExpiryField component?
 					if (
+						inOverview &&
 						site &&
 						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
 						! item.points_to_wpcom &&

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -28,7 +28,7 @@ export const DEFAULT_VIEW = BASE_VIEW_PROPS;
 
 export const SITE_CONTEXT_VIEW = {
 	...BASE_VIEW_PROPS,
-	fields: [ 'type', 'ssl_status', 'expiry', 'domain_status' ],
+	fields: [ 'ssl_status', 'expiry', 'domain_status' ],
 };
 
 // Default layouts

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -80,18 +80,14 @@ const SiteDomainDataViews = ( {
 							<Button
 								variant="tertiary"
 								size="compact"
-								href={ addQueryArgs( `/domains/add/use-my-domain/${ site.slug }`, {
-									redirect_to: window.location.pathname,
-								} ) }
+								href={ addQueryArgs( '/setup/domain/use-my-domain', { siteSlug: site.slug } ) }
 							>
 								{ __( 'Transfer domain' ) }
 							</Button>
 							<Button
 								variant="secondary"
 								size="compact"
-								href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-									redirect_to: window.location.pathname,
-								} ) }
+								href={ addQueryArgs( '/setup/domain', { siteSlug: site.slug } ) }
 							>
 								{ __( 'Add domain' ) }
 							</Button>

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -33,6 +33,7 @@ const SiteDomainDataViews = ( {
 	const fields = useFields( {
 		site,
 		showPrimaryDomainBadge: type === 'table',
+		inOverview: true,
 	} );
 
 	const actions = useActions( { user, site } );


### PR DESCRIPTION
With the new design the type of the site is shown below the domain name if it's different than domain name registration. I've removed the type column and added the type below the domain name

It looks like this:
<img width="472" height="303" alt="Screenshot 2025-10-08 at 17 28 03" src="https://github.com/user-attachments/assets/e958d198-459f-4385-b15e-0422af00528a" />

Part of [DOMAINS-1701: Small updates in the Domains lists](https://linear.app/a8c/issue/DOMAINS-1701/small-updates-in-the-domains-lists)

## Proposed Changes

* Add the type of the domain below the domain name
* Fix the links to get a new domain or transfer a domain in the Site overview Domain section
* The "Free forever" expiration should only be displayed for the Default site address
* Don't show error in the expiration date in regular dataview (only in the site overview domain section)
* Don't show SSL status for transfers and also don't make unnecessary requests
* Add filter by type in the datagrid

## Why are these changes being made?

* Get more in line with the new design
* Optimize some things
* Also make it more consistent

## Testing Instructions

* Go the the Domains and Site domains lists and verify that the type is shown below the domain name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
