### PR TITLE
Performance v2: Use CustomSelect for the PageSelector

### DIFF
--- a/client/dashboard/sites/performance/page-selector.scss
+++ b/client/dashboard/sites/performance/page-selector.scss
@@ -1,6 +1,7 @@
 .performance-page-selector {
 	display: flex;
-	align-items: center;
+	align-items: baseline;
+	justify-content: end;
 	gap: 8px;
 	width: 240px;
 

--- a/client/dashboard/sites/performance/page-selector.scss
+++ b/client/dashboard/sites/performance/page-selector.scss
@@ -1,36 +1,10 @@
 .performance-page-selector {
-	position: relative;
-	width: 240px;
-	align-self: flex-start;
-}
-
-.performance-page-selector > * {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-}
-
-.performance-page-selector .components-combobox-control__suggestions-container {
-	background-color: #fff;
-}
-
-.performance-page-selector .components-base-control__field {
 	display: flex;
+	align-items: center;
 	gap: 8px;
-}
+	width: 240px;
 
-.performance-page-selector .components-base-control__field label {
-	line-height: 40px;
-	margin-bottom: 0; /* Override the default margin-bottom of the ComboboxControl */
-}
-
-.performance-page-selector .components-form-token-field__suggestions-list {
-	max-height: 300px;
-	z-index: 100;
-}
-
-.performance-page-selector li.is-selected .components-text {
-	// TODO Use the correct color variables for displaying white text on a blue background
-	filter: invert(1) brightness(1.6);
+	.components-custom-select-control__item-hint {
+		width: 100%;
+	}
 }

--- a/client/dashboard/sites/performance/page-selector.tsx
+++ b/client/dashboard/sites/performance/page-selector.tsx
@@ -1,38 +1,32 @@
-import { ComboboxControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { CustomSelectControl } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { Text } from '../../components/text';
 import type { SitePerformancePage } from '@automattic/api-core';
-
+import type { CSSProperties } from 'react';
 import './page-selector.scss';
 
 interface PageOption {
-	url: string;
-	path: string;
-	label: string;
-	value: string;
-	disabled: boolean;
-	wpcom_performance_report_hash: string;
+	key: string;
+	name: string;
+	hint?: string;
+	style?: CSSProperties;
 }
 
-/**
- * Map a PerformanceProfilerPage to a PageReport
- * @param page - The PerformanceProfilerPage to map
- * @param siteUrl - The URL of the site
- * @returns The PageReport
- */
+const defaultStyle = {
+	lineHeight: 1.2,
+};
+
 function mapPageToPageOption( page: SitePerformancePage, siteUrl: string ): PageOption {
-	let path = page.link.replace( siteUrl ?? '', '' );
-	path = path.length > 1 ? path.replace( /\/$/, '' ) : path;
+	const key = page.id.toString();
+	const name = page.title.rendered || __( 'No title' );
+	const path = page.link.replace( siteUrl ?? '', '' );
 
 	return {
-		url: page.link,
-		path,
-		label: page.title.rendered || __( 'No Title' ),
-		value: page.id.toString(),
-		disabled: false,
-		wpcom_performance_report_hash: page.wpcom_performance_report_hash,
+		key,
+		name,
+		hint: path.length > 1 ? path.replace( /\/$/, '' ) : path,
+		style: defaultStyle,
 	};
 }
 
@@ -48,11 +42,6 @@ export default function PageSelector( {
 	onChange: ( page_id: string | null | undefined ) => void;
 } ) {
 	const isDesktop = useViewportMatch( 'medium' );
-
-	const currentPageOption: PageOption | undefined = currentPage
-		? mapPageToPageOption( currentPage, siteUrl )
-		: undefined;
-
 	const pageOptions = useMemo( () => {
 		if ( ! pages ) {
 			return [];
@@ -62,39 +51,37 @@ export default function PageSelector( {
 			mapPageToPageOption( page, siteUrl )
 		);
 
-		return [ ...mappedPages, { label: '', value: '-1', path: '', disabled: true } ];
+		return [
+			...mappedPages,
+			{
+				key: '-1',
+				name: __( 'Performance testing is available for the 20 most popular pages.' ),
+				style: {
+					...defaultStyle,
+					color: '#949494',
+					pointerEvents: 'none' as const,
+				},
+			},
+		];
 	}, [ pages, siteUrl ] );
 
-	return (
-		<div className="performance-page-selector">
-			<ComboboxControl
-				label={ __( 'Page' ) }
-				allowReset={ false }
-				options={ pageOptions }
-				hideLabelFromVision={ isDesktop ? false : true }
-				value={ currentPageOption?.value }
-				onChange={ onChange }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				__experimentalRenderItem={ ( { item } ) => {
-					if ( item.value === '-1' ) {
-						return pages.length ? (
-							<Text variant="muted">
-								{ __( 'Performance testing is available for the 20 most popular pages.' ) }
-							</Text>
-						) : (
-							<Text variant="muted">{ __( 'No pages found.' ) }</Text>
-						);
-					}
+	const currentPageOption: PageOption | undefined = currentPage
+		? pageOptions.find( ( pageOptions ) => pageOptions.key === currentPage.id.toString() )
+		: undefined;
 
-					return (
-						<VStack spacing="0">
-							<Text>{ item.label }</Text>
-							<Text variant="muted">{ item.path }</Text>
-						</VStack>
-					);
-				} }
-			/>
-		</div>
+	const handleChange = ( { selectedItem }: { selectedItem: PageOption } ) => {
+		onChange( selectedItem.key );
+	};
+
+	return (
+		<CustomSelectControl
+			className="performance-page-selector"
+			label={ __( 'Page' ) }
+			value={ currentPageOption }
+			options={ pageOptions }
+			__next40pxDefaultSize
+			hideLabelFromVision={ isDesktop ? false : true }
+			onChange={ handleChange }
+		/>
 	);
 }

--- a/client/dashboard/sites/performance/page-selector.tsx
+++ b/client/dashboard/sites/performance/page-selector.tsx
@@ -24,7 +24,7 @@ function mapPageToPageOption( page: SitePerformancePage, siteUrl: string ): Page
 
 	return {
 		key,
-		name,
+		name: name.replace( /&nbsp;/g, ' ' ),
 		hint: path.length > 1 ? path.replace( /\/$/, '' ) : path,
 		style: defaultStyle,
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-599

## Proposed Changes

* Try using CustomSelect for the PageSelector to eliminate the need for custom CSS.
However, CustomSelect determines the selected option based on the name property. Since pages can have duplicate names, this approach may not work correctly for this use case.

| Before | After |
| - | - |
|<img width="411" height="365" alt="image" src="https://github.com/user-attachments/assets/5559ef98-ed61-4bac-b5b5-14b65023ea44" />|<img width="413" height="487" alt="image" src="https://github.com/user-attachments/assets/35a39773-5863-4e0f-af10-6bf4202e8875" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance
* Focus on the page selector
* Ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
