### PR TITLE
A4A: Replace all External link icons with arrow icon.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -1,6 +1,6 @@
 import { FormLabel } from '@automattic/components';
 import { Button, CheckboxControl } from '@wordpress/components';
-import { Icon, external, info } from '@wordpress/icons';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
@@ -228,8 +228,7 @@ const CancelLicenseFeedbackModal = ( {
 						disabled={ isLoading || ( suggestion && ! suggestions.length ) }
 						isBusy={ isLoading }
 					>
-						{ translate( 'Cancel license' ) }
-						{ isAtomicSite && <Icon icon={ external } size={ 18 } /> }
+						{ isAtomicSite ? translate( 'Cancel license ↗' ) : translate( 'Cancel license' ) }
 					</Button>
 				</>
 			}

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, chevronDown, external } from '@wordpress/icons';
+import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -57,8 +57,7 @@ const MigrationOfferV2 = () => {
 							className="a4a-migration-offer-v2__button"
 							href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT }
 						>
-							{ translate( 'Contact us to learn more' ) }
-							<Icon icon={ external } size={ 18 } />
+							{ translate( 'Contact us to learn more ↗' ) }
 						</Button>
 					</div>
 				) }

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -35,7 +35,7 @@ export function A4ARequestWPAdminAccess() {
 					onClick={ onLearnMoreClick }
 					target="_blank"
 				>
-					<>{ translate( 'Learn more about team member permissions ↗' ) }</>
+					{ translate( 'Learn more about team member permissions ↗' ) }
 				</Button>
 			</div>
 			<div className="a4a-request-wp-admin-access__illustration">

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import illustration from 'calypso/assets/images/a8c-for-agencies/request-wp-admin-access-illustration.svg';
 import { useDispatch } from 'calypso/state';
@@ -36,10 +35,7 @@ export function A4ARequestWPAdminAccess() {
 					onClick={ onLearnMoreClick }
 					target="_blank"
 				>
-					<>
-						{ translate( 'Learn more about team member permissions' ) }
-						<Icon icon={ external } size={ 18 } />
-					</>
+					<>{ translate( 'Learn more about team member permissions ↗' ) }</>
 				</Button>
 			</div>
 			<div className="a4a-request-wp-admin-access__illustration">

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/banner/index.tsx
@@ -1,6 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { Icon, chevronDown, external } from '@wordpress/icons';
+import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -67,14 +67,12 @@ export default function PressablePremiumPlanMigrationBanner( {
 			<Button
 				className="pressable-premium-plan-migration__chat-to-us-button"
 				variant="secondary"
-				icon={ external }
-				iconPosition="right"
 				iconSize={ 16 }
 				onClick={ handleChatToUs }
 				isBusy={ isLoading }
 				disabled={ isLoading }
 			>
-				{ translate( 'Chat to us about this offer' ) }
+				{ translate( 'Chat to us about this offer ↗' ) }
 			</Button>
 		</>
 	);

--- a/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-premium-plan-migration/card/index.tsx
@@ -1,6 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Card, Button } from '@wordpress/components';
-import { close, external } from '@wordpress/icons';
+import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -99,14 +99,12 @@ export default function PressablePremiumPlanMigrationCard() {
 					<Button
 						className="is-light pressable-premium-plan-migration-card__chat-to-us-button"
 						variant="secondary"
-						icon={ external }
-						iconPosition="right"
 						iconSize={ 16 }
 						onClick={ handleChatToUs }
 						isBusy={ isLoading }
 						disabled={ isLoading }
 					>
-						{ translate( 'Chat to us about this offer' ) }
+						{ translate( 'Chat to us about this offer ↗' ) }
 					</Button>
 				</div>
 

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -100,8 +99,7 @@ export const PressableUsageLimitNotice = () => {
 							);
 						} }
 					>
-						{ translate( 'Learn more' ) }
-						<Icon icon={ external } size={ 18 } />
+						{ translate( 'Learn more ↗' ) }
 					</Button>
 				) }
 			</div>

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
@@ -34,8 +33,7 @@ export function SubscriptionPurchase( {
 					href="https://my.pressable.com/agency/auth"
 					variant="link"
 				>
-					{ translate( 'Manage in Pressable' ) }
-					<Icon icon={ external } size={ 18 } />
+					{ translate( 'Manage in Pressable ↗' ) }
 				</Button>
 			) }
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { VIPLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { BackgroundType11 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import { A4A_MARKETPLACE_HOSTING_REFER_ENTERPRISE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -96,12 +95,10 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 									onClick={ onRequestDemoClick }
 									target="_blank"
 									variant="secondary"
-									icon={ external }
-									iconPosition="right"
 									iconSize={ 16 }
 									__next40pxDefaultSize
 								>
-									{ translate( 'Request a Demo' ) }
+									{ translate( 'Request a Demo ↗' ) }
 								</Button>
 							</>
 						) : (
@@ -112,12 +109,10 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 									onClick={ onRequestDemoClick }
 									target="_blank"
 									variant="primary"
-									icon={ external }
-									iconPosition="right"
 									iconSize={ 16 }
 									__next40pxDefaultSize
 								>
-									{ translate( 'Request a Demo' ) }
+									{ translate( 'Request a Demo ↗' ) }
 								</Button>
 
 								{ isVipPartnerOpportunityReferralsEnabled && (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -1,7 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
-import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
@@ -72,16 +71,14 @@ export default function PremiumPlanSection( {
 							className="premium-plan-section__cta-button"
 							onClick={ onTalkToUsClick }
 							variant="secondary"
-							icon={ external }
-							iconPosition="right"
 							iconSize={ 16 }
 							__next40pxDefaultSize
 							isBusy={ isLoading }
 							disabled={ isLoading }
 						>
 							{ isDesktop
-								? translate( 'Buying for your agency? Talk to us' )
-								: translate( 'For your agency? Talk to us' ) }
+								? translate( 'Buying for your agency? Talk to us ↗' )
+								: translate( 'For your agency? Talk to us ↗' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value';
@@ -83,12 +82,9 @@ export default function PressablePlanSelectorCard( {
 					target="_blank"
 					rel="norefferer nooppener"
 					href="https://my.pressable.com/agency/auth"
-					icon={ external }
-					iconSize={ 18 }
-					iconPosition="right"
 					__next40pxDefaultSize
 				>
-					{ translate( 'Manage in Pressable' ) }
+					{ translate( 'Manage in Pressable ↗' ) }
 				</Button>
 			) : (
 				<Button

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,6 +1,5 @@
 import { Button, Tooltip } from '@automattic/components';
 import { formatCurrency, formatNumber, formatNumberCompact } from '@automattic/number-formatters';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
@@ -160,7 +159,7 @@ export default function PlanSelectionDetails( {
 							href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
 							primary
 						>
-							{ translate( 'Contact support' ) } <Icon icon={ external } size={ 16 } />
+							{ translate( 'Contact support ↗' ) }
 						</Button>
 					</div>
 				) : (
@@ -184,9 +183,8 @@ export default function PlanSelectionDetails( {
 											disabled={ ! isOwner }
 										>
 											{ isOwner
-												? translate( 'Manage in Pressable' )
+												? translate( 'Manage in Pressable ↗' )
 												: translate( 'Managed by agency owner' ) }
-											{ isOwner && <Icon icon={ external } size={ 18 } /> }
 										</Button>
 									</div>
 								) : (
@@ -219,7 +217,7 @@ export default function PlanSelectionDetails( {
 								href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
 								primary
 							>
-								{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
+								{ translate( 'Contact us ↗' ) }
 							</Button>
 						) }
 					</>
@@ -249,7 +247,7 @@ export default function PlanSelectionDetails( {
 					href={ PRESSABLE_CONTACT_LINK }
 					target="_blank"
 				>
-					{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
+					{ translate( 'Schedule a Demo ↗' ) }
 				</Button>
 			</div>
 			<div className="pressable-overview-plan-selection__details-hint">

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Card } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
@@ -146,7 +145,7 @@ export default function MigrationsHostingOptions() {
 							rel="noopener noreferrer"
 							onClick={ onSchedulePressableDemoClick }
 						>
-							{ translate( 'Schedule a demo' ) } <Icon icon={ external } size={ 16 } />
+							{ translate( 'Schedule a demo ↗' ) }
 						</Button>,
 					] }
 				/>

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
@@ -3,7 +3,6 @@ import { Button, FoldableCard, Gridicon } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -96,8 +95,7 @@ const PressableOffering = () => {
 						rel="norefferer nooppener"
 						href={ pressableUrl }
 					>
-						{ translate( 'View your dashboard' ) }
-						<Icon icon={ external } size={ 18 } />
+						{ translate( 'View your dashboard ↗' ) }
 					</Button>
 				)
 			) }

--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { external, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -39,8 +38,7 @@ export default function OverviewSidebarGrowthAcceleratorCta( {
 			isBusy={ isFetchingScheduleCallLink }
 			onClick={ onRequestCallClick }
 		>
-			{ translate( 'Schedule a call' ) }
-			<Icon icon={ external } size={ 16 } />
+			{ translate( 'Schedule a call ↗' ) }
 		</Button>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
 import CancelLicenseFeedbackModal from 'calypso/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal';
@@ -135,7 +134,7 @@ export default function LicenseDetailsActions( {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ translate( 'Manage in Pressable' ) } <Icon icon={ external } size={ 18 } />
+					{ translate( 'Manage in Pressable ↗' ) }
 				</Button>
 			) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
-import { Icon, external } from '@wordpress/icons';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -82,8 +81,7 @@ export const ManageInPressable = ( { attachedAt }: { attachedAt: string | null }
 				}
 			} }
 		>
-			{ translate( 'Manage in Pressable' ) }
-			<Icon className="gridicon" icon={ external } size={ 18 } />
+			{ translate( 'Manage in Pressable ↗' ) }
 		</a>
 	) : (
 		translate( 'Managed by agency owner' )

--- a/client/a8c-for-agencies/sections/reports/reports-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/reports-survey/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { Button, Modal } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -68,15 +67,8 @@ export default function ReportsSurvey() {
 				) }
 			</p>
 			<div className="reports-survey-modal__buttons">
-				<Button
-					variant="primary"
-					href={ SURVEY_URL }
-					target="_blank"
-					onClick={ handleSurveyClick }
-					icon={ <Icon icon={ external } /> }
-					iconPosition="right"
-				>
-					{ translate( 'Take 2 minute survey' ) }
+				<Button variant="primary" href={ SURVEY_URL } target="_blank" onClick={ handleSurveyClick }>
+					{ translate( 'Take 2 minute survey ↗' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
@@ -1,6 +1,6 @@
 import { Button, CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Icon, external, trash } from '@wordpress/icons';
+import { Icon, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
@@ -111,8 +111,7 @@ export default function SiteErrorPreview( {
 							rel="noopener noreferrer"
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_confirm' ) }
 						>
-							{ translate( 'Confirm now' ) }
-							<Icon icon={ external } />
+							{ translate( 'Confirm now ↗' ) }
 						</Button>
 					</FormattedHeader>
 				</CompactCard>
@@ -141,8 +140,7 @@ export default function SiteErrorPreview( {
 							rel="noopener noreferrer"
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' ) }
 						>
-							{ translate( 'View guide' ) }
-							<Icon icon={ external } />
+							{ translate( 'View guide ↗' ) }
 						</Button>
 					</FormattedHeader>
 				</CompactCard>
@@ -171,8 +169,7 @@ export default function SiteErrorPreview( {
 							rel="noopener noreferrer"
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_disconnect' ) }
 						>
-							{ translate( 'Disconnect' ) }
-							<Icon icon={ external } />
+							{ translate( 'Disconnect ↗' ) }
 						</Button>
 					</FormattedHeader>
 				</CompactCard>

--- a/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
@@ -1,6 +1,5 @@
 import { WordPressLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -74,8 +73,7 @@ const HostingOverviewPreview = ( { site }: Props ) => {
 										href="https://my.pressable.com/agency/auth"
 										variant="link"
 									>
-										{ translate( 'Manage all Pressable sites' ) }
-										<Icon icon={ external } size={ 18 } />
+										{ translate( 'Manage all Pressable sites ↗' ) }
 									</Button>
 								</div>
 							</div>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-plugins.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { external, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 
@@ -20,13 +19,7 @@ export function JetpackPluginsPreview( { featureText, link, linkLabel, captionTe
 				<p className="site-preview-pane__plugins-caption">{ captionText }</p>
 				<div style={ { marginTop: '24px' } }>
 					<Button href={ link } primary target="_blank">
-						{ linkLabel }
-						<Icon
-							icon={ external }
-							size={ 16 }
-							className="site-preview-pane__plugins-icon"
-							viewBox="0 0 20 20"
-						/>
+						{ linkLabel } ↗
 					</Button>
 				</div>
 			</div>

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -1,6 +1,5 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -94,8 +93,7 @@ export default function GetStarted() {
 						href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members"
 						onClick={ onLearnMoreClick }
 					>
-						{ translate( 'Team members Knowledge Base article' ) }
-						<Icon icon={ external } size={ 18 } />
+						{ translate( 'Team members Knowledge Base article ↗' ) }
 					</Button>
 					<br />
 				</StepSection>

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import {
 	A4A_OVERVIEW_LINK,
@@ -106,8 +105,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 					href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#accepting-an-invitation-a-team-member-s-guide"
 					onClick={ onLearnMoreClick }
 				>
-					{ translate( 'Team members Knowledge Base article' ) }
-					<Icon icon={ external } size={ 18 } />
+					{ translate( 'Team members Knowledge Base article ↗' ) }
 				</Button>
 				<br />
 				<Button
@@ -117,8 +115,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 					href={ `${ A4A_OVERVIEW_LINK }#contact-support` }
 					onClick={ onContactSupportClick }
 				>
-					{ translate( 'Contact support' ) }
-					<Icon icon={ external } size={ 18 } />
+					{ translate( 'Contact support ↗' ) }
 				</Button>
 			</StepSection>
 		</>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -120,7 +120,7 @@ export const WooPaymentsStatusColumn = ( {
 				) }
 				target="_blank"
 			>
-				<>{ translate( 'Learn more about the incentive ↗' ) }</>
+				{ translate( 'Learn more about the incentive ↗' ) }
 			</Button>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -2,7 +2,6 @@ import { BadgeType, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { memo, useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
@@ -121,10 +120,7 @@ export const WooPaymentsStatusColumn = ( {
 				) }
 				target="_blank"
 			>
-				<>
-					{ translate( 'Learn more about the incentive' ) }
-					<Icon icon={ external } size={ 18 } />
-				</>
+				<>{ translate( 'Learn more about the incentive ↗' ) }</>
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
This PR replaces all external link icons with the Arrow icon in the A4A dashboard.

Example

| Before | After |
|--------|--------|
| <img width="449" height="209" alt="Screenshot 2025-10-08 at 4 57 28 PM" src="https://github.com/user-attachments/assets/63e4def0-9b26-4681-88b1-37349d511a00" /> | <img width="443" height="223" alt="Screenshot 2025-10-08 at 4 57 34 PM" src="https://github.com/user-attachments/assets/4755d3b0-222a-4f25-a56c-a8a776928c58" /> | 

## Proposed Changes

* Refactor the A4A codebase and replace all external link icons with a simple arrow icon.

## Why are these changes being made?

* For consistency, we should use the correct icon.

## Testing Instructions

* Use the A4A live link and navigate to `/` page.
* Audit the pages to see that all affected buttons are properly replaced.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
