### PR TITLE
Hosting Dashboard: Remove "Monetize Subscriptions" from MeMenu

### DIFF
--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -15,9 +15,6 @@ const MeMenu = () => {
 			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/preferences">{ __( 'Preferences' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to="/me/billing/monetize-subscriptions">
-				{ __( 'Monetize Subscriptions' ) }
-			</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/security">{ __( 'Security' ) }</ResponsiveMenu.Item>
 			{ hasAppSupport( supports, 'privacy' ) && (
 				<ResponsiveMenu.Item to="/me/privacy">{ __( 'Privacy' ) }</ResponsiveMenu.Item>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

When the "Monetize subscriptions" page was added to the hosting dashboard in #105695, it was accidentally added both to the billing page menu and also to the top-level user menu. Since it's in the billing menu, there's no need for it to also occupy the user menu. This PR removes it from there.

Before             |  After
:-------------------------:|:-------------------------:
<img width="912" height="159" alt="Screenshot 2025-10-08 at 11 08 38 AM" src="https://github.com/user-attachments/assets/753fa848-641a-4990-9f58-e46edfb0e859" /> | <img width="746" height="154" alt="Screenshot 2025-10-08 at 11 08 54 AM" src="https://github.com/user-attachments/assets/116cfe50-fa60-4406-bbf2-1df251528574" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/v2/me/billing and verify that you don't see "Monetize subscriptions" in the header menu but you do see it in the billing menu.
