### PR TITLE
Domain Search Rewrite: Remove premium suggestion from suggestions list if user searched for a premium FQDN

### DIFF
--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -23,19 +23,22 @@ export const useSuggestionsList = () => {
 		enabled: !! getTld( query ),
 	} );
 
-	const premiumSuggestions = useMemo(
+	// We need to check the availability not only of all premium suggestions, but also of the suggestion
+	// that's the same as the query. That's because sometimes we get suggestions that are premium but
+	// are not marked as such, and we might need to remove that from the suggestions list.
+	const suggestionsNeedingAvailabilityCheck = useMemo(
 		() =>
 			suggestions
-				.filter( ( suggestion ) => suggestion.is_premium )
+				.filter( ( suggestion ) => suggestion.is_premium || suggestion.domain_name === query )
 				.map( ( suggestion ) => suggestion.domain_name ),
-		[ suggestions ]
+		[ suggestions, query ]
 	);
 
 	const unavailablePremiumDomainsCombinator = useCallback(
 		( results: UseQueryResult< DomainAvailability, Error >[] ) => {
 			return {
 				isLoadingUnavailablePremiumDomains: results.some( ( result ) => result.isLoading ),
-				unavailablePremiumDomains: premiumSuggestions.filter( ( _, index ) => {
+				unavailablePremiumDomains: suggestionsNeedingAvailabilityCheck.filter( ( _, index ) => {
 					const availabilityQuery = results[ index ];
 
 					if ( availabilityQuery?.error || ! availabilityQuery?.data ) {
@@ -50,11 +53,11 @@ export const useSuggestionsList = () => {
 				} ),
 			};
 		},
-		[ premiumSuggestions ]
+		[ suggestionsNeedingAvailabilityCheck ]
 	);
 
 	const { isLoadingUnavailablePremiumDomains, unavailablePremiumDomains } = useQueries( {
-		queries: premiumSuggestions.map( ( suggestion ) => ( {
+		queries: suggestionsNeedingAvailabilityCheck.map( ( suggestion ) => ( {
 			...queries.domainAvailability( suggestion ),
 			enabled: true,
 		} ) ),

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -47,6 +47,11 @@ export const useSuggestionsList = () => {
 
 					const { status, is_supported_premium_domain } = availabilityQuery.data;
 
+					// Non-premium domains don't need to be filtered out
+					if ( DomainAvailabilityStatus.AVAILABLE === status ) {
+						return false;
+					}
+
 					return (
 						DomainAvailabilityStatus.AVAILABLE_PREMIUM !== status || ! is_supported_premium_domain
 					);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOMAINS-1703](https://linear.app/a8c/issue/DOMAINS-1703/)

## Proposed Changes

This PR removes a premium suggestion from the suggestions result list if the user searched for that FQDN and it is premium.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="954" height="1080" alt="Screenshot 2025-10-08 at 16 41 00" src="https://github.com/user-attachments/assets/32fc9b01-f700-48f4-86fe-1812a4baeaab" /> | <img width="954" height="1080" alt="Screenshot 2025-10-08 at 16 41 31" src="https://github.com/user-attachments/assets/bdce676b-040e-4ec1-ba53-2f9003d299e8" /> |

## Why are these changes being made?

This was reported here (pdtkmj-40Z-p2#comment-7750).

Sometimes we get suggestions from our domain suggestion providers that are premium but not marked as such. This is a problem in onboarding, for example, where we don't offer premium domains. It was confusing for users because if they search for a FQDN, we run an availability check and show an error notice if the domain is premium. However, that domain remained in the results list as available.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to a domain search flow with the `domain-search-rewrite` flag enabled, e.g. `/setup/onboarding`
- Search for a FQDN that's premium but not returned as such by our suggestion providers, e.g. `eduardo.work`
- Ensure the availability notice is shown ("Sorry, eduardo.work is a premium domain ...")
- Ensure the searched domain is not shown in the suggestions list
- Search for a FQDN that's not premium (e.g. `asdfhqwkhrkjdshafkjhsdkjf.com`)
- Ensure that suggestion is shown in the suggestions list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?