### PR TITLE
Domain Search Rewrite: Add regular search results tests

### DIFF
--- a/packages/domain-search/src/components/search-results/test/index.tsx
+++ b/packages/domain-search/src/components/search-results/test/index.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SearchResults } from '..';
+import { buildSuggestion } from '../../../test-helpers/factories/suggestions';
+import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
+import { mockGetAvailableTldsQuery } from '../../../test-helpers/queries/tlds';
+import { TestDomainSearchWithSuggestionsList } from '../../../test-helpers/renderer';
+import { Filter } from '../../search-bar/filter';
+
+describe( 'SearchResults', () => {
+	it( 'renders the search results', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'test' },
+			suggestions: [
+				buildSuggestion( { domain_name: 'test-regular.com' } ),
+				buildSuggestion( { domain_name: 'test-regular.net' } ),
+			],
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestionsList query="test">
+				<SearchResults suggestions={ [ 'test-regular.com', 'test-regular.net' ] } />
+			</TestDomainSearchWithSuggestionsList>
+		);
+
+		expect( await screen.findByTitle( 'test-regular.com' ) ).toBeInTheDocument();
+		expect( await screen.findByTitle( 'test-regular.net' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing if there are no suggestions and no active filters', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-no-suggestions' },
+			suggestions: [],
+		} );
+
+		const { container } = render(
+			<TestDomainSearchWithSuggestionsList query="test-no-suggestions">
+				<SearchResults suggestions={ [] } />
+			</TestDomainSearchWithSuggestionsList>
+		);
+
+		await waitForElementToBeRemoved( () => screen.getByText( 'LOADING_TEST_CONTENT' ) );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'allows resetting filters if there are no suggestions but the exact match filter is active', async () => {
+		const user = userEvent.setup();
+		const onFilterReset = jest.fn();
+
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-no-suggestions' },
+			suggestions: [],
+		} );
+
+		mockGetAvailableTldsQuery( {
+			params: { query: 'test-no-suggestions' },
+			tlds: [ 'com', 'net', 'org' ],
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestionsList query="test-no-suggestions" events={ { onFilterReset } }>
+				<Filter />
+				<SearchResults suggestions={ [] } />
+			</TestDomainSearchWithSuggestionsList>
+		);
+
+		const filterButton = await screen.findByLabelText( 'Filter, no filters applied' );
+
+		// Not sure why we need to double click here.
+		await user.dblClick( filterButton );
+
+		await user.click(
+			screen.getByRole( 'checkbox', {
+				name: 'Show exact matches only',
+			} )
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+
+		const disableFiltersButton = screen.getByRole( 'button', { name: 'Disable filters' } );
+		expect( disableFiltersButton ).toBeInTheDocument();
+
+		await user.click( disableFiltersButton );
+		expect( onFilterReset ).toHaveBeenCalled();
+	} );
+
+	it( 'allows resetting filters if there are no suggestions but the TLD filter is active', async () => {
+		const user = userEvent.setup();
+		const onFilterReset = jest.fn();
+
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-no-suggestions' },
+			suggestions: [],
+		} );
+
+		mockGetAvailableTldsQuery( {
+			params: { query: 'test-no-suggestions' },
+			tlds: [ 'com', 'net', 'org' ],
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestionsList query="test-no-suggestions" events={ { onFilterReset } }>
+				<Filter />
+				<SearchResults suggestions={ [] } />
+			</TestDomainSearchWithSuggestionsList>
+		);
+
+		const filterButton = await screen.findByLabelText( 'Filter, no filters applied' );
+
+		// Not sure why we need to double click here.
+		await user.dblClick( filterButton );
+
+		await user.click(
+			screen.getByRole( 'option', {
+				name: '.com',
+			} )
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+
+		const disableFiltersButton = screen.getByRole( 'button', { name: 'Disable filters' } );
+		expect( disableFiltersButton ).toBeInTheDocument();
+
+		await user.click( disableFiltersButton );
+		expect( onFilterReset ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/domain-search/src/components/search-results/test/item.tsx
+++ b/packages/domain-search/src/components/search-results/test/item.tsx
@@ -1,0 +1,290 @@
+import { DomainAvailabilityStatus } from '@automattic/api-core';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { HTTPS_SSL } from '@automattic/urls';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DomainPriceRule } from '../../../hooks/use-suggestion';
+import { buildAvailability } from '../../../test-helpers/factories/availability';
+import { buildCartItem } from '../../../test-helpers/factories/cart';
+import { buildSuggestion } from '../../../test-helpers/factories/suggestions';
+import { mockGetAvailabilityQuery } from '../../../test-helpers/queries/availability';
+import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
+import { TestDomainSearchWithSuggestionsList } from '../../../test-helpers/renderer';
+import { SearchResultsItem } from '../item';
+
+describe( 'SearchResultsItem', () => {
+	describe( 'badges', () => {
+		it( 'renders the policy badges', async () => {
+			const user = userEvent.setup();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-policy-badges.app' },
+				suggestions: [
+					buildSuggestion( {
+						domain_name: 'test-policy-badges.app',
+						policy_notices: [
+							{
+								type: 'hsts',
+								message:
+									'All domains with this ending require an SSL certificate to host a website.',
+								label: 'HSTS required',
+							},
+							{
+								type: 'another-one',
+								message: 'Another message',
+								label: 'Another badge',
+							},
+						],
+					} ),
+				],
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-policy-badges.app">
+					<SearchResultsItem domainName="test-policy-badges.app" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-policy-badges.app' ) );
+
+			const hstsBadge = screen.getByText( 'HSTS required' );
+			expect( hstsBadge ).toBeInTheDocument();
+
+			await user.click( within( hstsBadge ).getByRole( 'button' ) );
+			const popoverContent = screen.getByText(
+				/All domains with this ending require an SSL certificate to host a website/
+			);
+			expect( popoverContent ).toBeInTheDocument();
+			expect( within( popoverContent ).getByRole( 'link' ) ).toHaveAttribute(
+				'href',
+				localizeUrl( HTTPS_SSL )
+			);
+
+			const anotherOneBadge = screen.getByText( 'Another badge' );
+			expect( anotherOneBadge ).toBeInTheDocument();
+
+			await user.click( within( anotherOneBadge ).getByRole( 'button' ) );
+			const anotherOnePopoverContent = screen.getByText( 'Another message' );
+			expect( anotherOnePopoverContent ).toBeInTheDocument();
+		} );
+
+		it( 'renders the sale badge if there is a sale cost in the suggestion and the price rule is PRICE', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-sale.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-sale.com', sale_cost: 10 } ) ],
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-sale.com">
+					<SearchResultsItem domainName="test-sale.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-sale.com' ) );
+
+			expect( screen.getByText( 'Sale' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the sale badge if there is a sale cost in the availability and the price rule is PRICE', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-sale-availability.com' },
+				suggestions: [
+					buildSuggestion( {
+						domain_name: 'test-sale-availability.com',
+						sale_cost: undefined,
+					} ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-sale-availability.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-sale-availability.com',
+					status: DomainAvailabilityStatus.AVAILABLE,
+					sale_cost: 10,
+					currency_code: 'USD',
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-sale-availability.com">
+					<SearchResultsItem domainName="test-sale-availability.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-sale-availability.com' ) );
+
+			expect( screen.getByText( 'Sale' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the premium badge if the suggestion is premium and the price does not exceed the limit', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-premium-normal-price.com' },
+				suggestions: [
+					buildSuggestion( {
+						domain_name: 'test-premium-normal-price.com',
+						is_premium: true,
+					} ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-premium-normal-price.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-premium-normal-price.com',
+					status: DomainAvailabilityStatus.AVAILABLE_PREMIUM,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-premium-normal-price.com">
+					<SearchResultsItem domainName="test-premium-normal-price.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-premium-normal-price.com' ) );
+
+			expect( screen.getByText( 'Premium' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the restricted premium badge if the suggestion is premium and the price exceeds the limit', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-premium-price-limit-exceeded.com' },
+				suggestions: [
+					buildSuggestion( {
+						domain_name: 'test-premium-price-limit-exceeded.com',
+						is_premium: true,
+					} ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-premium-price-limit-exceeded.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-premium-price-limit-exceeded.com',
+					status: DomainAvailabilityStatus.AVAILABLE_PREMIUM,
+					is_price_limit_exceeded: true,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-premium-price-limit-exceeded.com">
+					<SearchResultsItem domainName="test-premium-price-limit-exceeded.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-premium-price-limit-exceeded.com' ) );
+
+			expect( screen.getByText( 'Restricted premium' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'cta', () => {
+		it( 'renders the add to cart cta as secondary and without text', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-add-to-cart.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-add-to-cart.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-add-to-cart.com">
+					<SearchResultsItem domainName="test-add-to-cart.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-add-to-cart.com' ) );
+
+			const cta = screen.getByRole( 'button', { name: 'Add to Cart' } );
+
+			expect( cta ).toBeInTheDocument();
+			expect( cta ).toHaveClass( 'is-secondary' );
+			expect( cta ).toHaveTextContent( '' );
+		} );
+
+		it( 'renders continue cta with text', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-continue.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-continue.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList
+					initialCartItems={ [ buildCartItem( { domain: 'test-continue', tld: 'com' } ) ] }
+					query="test-continue.com"
+				>
+					<SearchResultsItem domainName="test-continue.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-continue.com' ) );
+
+			const cta = screen.getByRole( 'button', { name: 'Continue' } );
+
+			expect( cta ).toBeInTheDocument();
+			expect( cta ).toHaveClass( 'is-pressed' );
+			expect( cta ).toHaveTextContent( '' );
+		} );
+
+		it( 'renders contact support cta as secondary and without text', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-contact-support.com' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test-contact-support.com', is_premium: true } ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-contact-support.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-contact-support.com',
+					status: DomainAvailabilityStatus.AVAILABLE_PREMIUM,
+					is_price_limit_exceeded: true,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestionsList query="test-contact-support.com">
+					<SearchResultsItem domainName="test-contact-support.com" />
+				</TestDomainSearchWithSuggestionsList>
+			);
+
+			await waitFor( () => screen.getByTitle( 'test-contact-support.com' ) );
+
+			const cta = screen.getByRole( 'link', {
+				name: 'Interested in this domain? Contact support',
+			} );
+
+			expect( cta ).toBeInTheDocument();
+			expect( cta ).toHaveClass( 'is-secondary' );
+			expect( cta ).toHaveTextContent( '' );
+		} );
+	} );
+
+	it( 'triggers the suggestion render event when the suggestion is rendered', async () => {
+		const suggestion = buildSuggestion( { domain_name: 'test-suggestion-render.com' } );
+
+		mockGetSuggestionsQuery( {
+			params: { query: 'test-suggestion-render.com' },
+			suggestions: [ suggestion ],
+		} );
+
+		const onSuggestionRender = jest.fn();
+
+		render(
+			<TestDomainSearchWithSuggestionsList
+				events={ { onSuggestionRender } }
+				query="test-suggestion-render.com"
+			>
+				<SearchResultsItem domainName="test-suggestion-render.com" />
+			</TestDomainSearchWithSuggestionsList>
+		);
+
+		await waitFor( () => {
+			expect( onSuggestionRender ).toHaveBeenCalledWith( {
+				...suggestion,
+				position: 0,
+				price_rule: DomainPriceRule.PRICE,
+			} );
+		} );
+	} );
+} );

--- a/packages/domain-search/src/test-helpers/queries/tlds.ts
+++ b/packages/domain-search/src/test-helpers/queries/tlds.ts
@@ -1,0 +1,16 @@
+import nock from 'nock';
+
+export const mockGetAvailableTldsQuery = ( {
+	params: { query },
+	tlds,
+}: {
+	params: { query: string };
+	tlds: string[];
+} ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/domains/suggestions/tlds' )
+		.query( {
+			search: query,
+		} )
+		.reply( 200, tlds );
+};

--- a/packages/domain-search/src/test-helpers/renderer.tsx
+++ b/packages/domain-search/src/test-helpers/renderer.tsx
@@ -93,7 +93,7 @@ export const TestDomainSearchWithSuggestionsList: typeof TestDomainSearchWithCar
 	const Content = () => {
 		const { isLoading } = useSuggestionsList();
 
-		return isLoading ? null : props.children;
+		return isLoading ? 'LOADING_TEST_CONTENT' : props.children;
 	};
 
 	return (


### PR DESCRIPTION
Part of DOMAINS-1634.

## Proposed Changes

Similar to https://github.com/Automattic/wp-calypso/pull/106334, this PR focuses on parts specific to the regular search results. The price and CTA components will be tested on a follow-up PR.

## Testing Instructions

Verify tests are still 🟢.
