### PR TITLE
Hosting Dashboard: Add default tax location data for PaymentMethodEditDialog

### DIFF
--- a/client/dashboard/me/billing-payment-methods/payment-method-edit-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-edit-dialog.tsx
@@ -91,6 +91,17 @@ function calculateTaxLocationFields( {
 	return fields;
 }
 
+const defaultTaxLocation: StoredPaymentMethod[ 'tax_location' ] = {
+	country_code: '',
+	postal_code: '',
+	subdivision_code: '',
+	ip_address: '',
+	vat_id: '',
+	organization: '',
+	address: '',
+	city: '',
+};
+
 export function PaymentMethodEditDialog( {
 	paymentMethod,
 	isVisible,
@@ -104,7 +115,7 @@ export function PaymentMethodEditDialog( {
 } ) {
 	const { data: countryList } = useQuery( countryListQuery() );
 	const [ formData, setFormData ] = useState< StoredPaymentMethod[ 'tax_location' ] >(
-		paymentMethod.tax_location
+		paymentMethod.tax_location ?? defaultTaxLocation
 	);
 
 	const selectedCountryCode = formData?.country_code;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-231

## Proposed Changes

This fixes a bug in https://github.com/Automattic/wp-calypso/pull/105388 which added the ability to view and edit payment methods in the hosting dashboard. If a payment method did not already have tax information set, then the edit form would crash. This PR adds a fallback default for a payment method that has no tax information.

<img width="1248" height="98" alt="Screenshot 2025-10-08 at 5 33 36 PM" src="https://github.com/user-attachments/assets/46a426c2-9bfb-404b-9806-0dccd79b19a1" />

Before             |  After
:-------------------------:|:-------------------------:
<img width="1267" height="285" alt="Screenshot 2025-10-08 at 5 33 49 PM" src="https://github.com/user-attachments/assets/37f71d28-fff2-4335-b46a-412f53a9b5ac" /> | <img width="1262" height="701" alt="Screenshot 2025-10-08 at 5 38 17 PM" src="https://github.com/user-attachments/assets/91dce351-1358-4f8c-9c75-b61ab84f76c0" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use an account that has a payment method which is missing its tax data. The easiest way to do this is to have a payment method which was added before we started requiring tax data, but there's probably also a way to manually create the situation by manually editing the tax data on the server (ping me if you'd like help to figure out how to do this).

Visit http://calypso.localhost:3000/v2/me/billing/payment-methods and find a payment method that reads "Missing information" in the "Billing information" column of the table.

Click the actions menu for that payment method and select "Edit billing information".

Verify that you are presented with an edit form.
