### PR TITLE
Adapting Contact details to reuse PhoneNumberInput

### DIFF
--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -71,7 +71,7 @@ export default function PhoneNumberInput( {
 				type="tel"
 				label={ __( 'Phone number' ) }
 				value={ data.phoneNumber ?? '' }
-				onChange={ ( value ) => {
+				onChange={ ( value: string | undefined ) => {
 					return onChange( {
 						...data,
 						phoneNumber: value ?? '',

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -15,12 +15,12 @@ export type SecuritySMSNumber = {
 export default function PhoneNumberInput( {
 	data,
 	onChange,
-	isDisabled,
+	isDisabled = false,
 	customValidity,
 }: {
 	data: SecuritySMSNumber;
 	onChange: ( value: Partial< SecuritySMSNumber > ) => void;
-	isDisabled: boolean;
+	isDisabled?: boolean;
 	customValidity:
 		| {
 				type: 'invalid';

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -25,7 +25,6 @@ export default function PhoneNumberInput( {
 	isDisabled: boolean;
 } ) {
 	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
-
 	const countryCodes =
 		smsCountryCodes?.map( ( countryCode ) => ( {
 			label: countryCode.name,
@@ -66,6 +65,7 @@ export default function PhoneNumberInput( {
 					return onChange( {
 						...data,
 						phoneNumber: value ?? '',
+						countryNumericCode: data.countryNumericCode,
 					} );
 				} }
 				disabled={ isDisabled }

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -21,12 +21,10 @@ export default function PhoneNumberInput( {
 	data: SecuritySMSNumber;
 	onChange: ( value: Partial< SecuritySMSNumber > ) => void;
 	isDisabled?: boolean;
-	customValidity:
-		| {
-				type: 'invalid';
-				message: string;
-		  }
-		| undefined;
+	customValidity?: {
+		type: 'invalid';
+		message: string;
+	};
 } ) {
 	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -1,11 +1,8 @@
 import { smsCountryCodesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import {
-	__experimentalHStack as HStack,
-	__experimentalInputControl as InputControl,
-	SelectControl,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, privateApis, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 import './style.scss';
 
@@ -19,11 +16,23 @@ export default function PhoneNumberInput( {
 	data,
 	onChange,
 	isDisabled,
+	customValidity,
 }: {
 	data: SecuritySMSNumber;
 	onChange: ( value: Partial< SecuritySMSNumber > ) => void;
 	isDisabled: boolean;
+	customValidity:
+		| {
+				type: 'invalid';
+				message: string;
+		  }
+		| undefined;
 } ) {
+	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/components'
+	);
+	const { ValidatedInputControl } = unlock( privateApis );
 	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
 	const countryCodes =
 		smsCountryCodes?.map( ( countryCode ) => ( {
@@ -45,7 +54,7 @@ export default function PhoneNumberInput( {
 	};
 
 	return (
-		<HStack>
+		<HStack className="phone-number-input">
 			<SelectControl
 				label={ __( 'Country code' ) }
 				value={ data.countryCode ?? '' }
@@ -54,9 +63,10 @@ export default function PhoneNumberInput( {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				disabled={ isDisabled }
+				className="phone-number-input__country-code-input"
 			/>
-			<InputControl
-				className="phone-number-input__number-input"
+			<ValidatedInputControl
+				customValidity={ customValidity }
 				__next40pxDefaultSize
 				type="tel"
 				label={ __( 'Phone number' ) }

--- a/client/dashboard/components/phone-number-input/index.tsx
+++ b/client/dashboard/components/phone-number-input/index.tsx
@@ -65,7 +65,6 @@ export default function PhoneNumberInput( {
 					return onChange( {
 						...data,
 						phoneNumber: value ?? '',
-						countryNumericCode: data.countryNumericCode,
 					} );
 				} }
 				disabled={ isDisabled }

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -1,3 +1,11 @@
-.phone-number-input__number-input {
-	width: 100%;
+.phone-number-input {
+	align-items: baseline;
+
+	.phone-number-input__country-code-input {
+		width: 35%;
+	}
+
+	.components-validated-control {
+		width: 65%;
+	}
 }

--- a/client/dashboard/components/phone-number-input/style.scss
+++ b/client/dashboard/components/phone-number-input/style.scss
@@ -1,5 +1,6 @@
 .phone-number-input {
 	align-items: baseline;
+	gap: calc( 4px * 4 );
 
 	.phone-number-input__country-code-input {
 		width: 35%;

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -90,7 +90,6 @@ export const getContactFormFields = (
 								phone: formattedPhone,
 							} );
 						} }
-						isDisabled={ false }
 					/>
 				);
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -58,10 +58,10 @@ export const getContactFormFields = (
 			Edit: ( { field, data, onChange } ) => {
 				const { getValue } = field;
 				const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
-				const phoneValue = getValue ? getValue( { item: data } ) : '';
+				const phoneValue = getValue( { item: data } );
 
 				// Our backend stores phone number in the format: +country_code.phone_number
-				const [ countryNumericCode, phoneNumber ] = phoneValue?.split( '.' ) ?? [ '', '' ];
+				const [ countryNumericCode, phoneNumber ] = phoneValue.split( '.' ) ?? [ '', '' ];
 
 				// Find country code from the numeric code using SMS country codes
 				const smsCountry = smsCountryCodes?.find(

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -100,8 +100,15 @@ export const getContactFormFields = (
 					if ( ! raw ) {
 						return null;
 					}
-					const phoneNumber = String( raw ).split( '.' ).join( '' );
-					const result = validatePhone( phoneNumber );
+					const fullPhoneNumber = String( raw ).split( '.' ).join( '' );
+					const [ , phoneNumberOnly ] = String( raw ).split( '.' ) ?? [ '', '' ];
+					const result = validatePhone( fullPhoneNumber );
+
+					if ( 'error' in result && result.error === 'phone_number_too_short' ) {
+						const resultWithoutCountryCode = validatePhone( phoneNumberOnly );
+						return 'error' in resultWithoutCountryCode ? resultWithoutCountryCode.message : null;
+					}
+
 					return 'error' in result ? result.message : null;
 				},
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -15,50 +15,6 @@ import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
 
-// Custom phone field component that handles SMS country codes
-function DomainContactDetailsPhoneField( {
-	field,
-	data,
-	onChange,
-}: {
-	field: Field< DomainContactDetails >;
-	data: DomainContactDetails;
-	onChange: ( edits: Partial< DomainContactDetails > ) => void;
-} ) {
-	const { getValue } = field;
-	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
-	const phoneValue = getValue ? getValue( { item: data } ) : '';
-
-	const [ countryNumericCode, phoneNumber ] = phoneValue?.split( '.' ) ?? [ '', '' ];
-
-	// Find country code from the numeric code using SMS country codes
-	const smsCountry = smsCountryCodes?.find(
-		( country ) => country.numeric_code === countryNumericCode
-	);
-
-	return (
-		<PhoneNumberInput
-			data={ {
-				countryCode: smsCountry?.code || '',
-				phoneNumber: phoneNumber,
-				countryNumericCode: countryNumericCode,
-			} }
-			onChange={ ( edits ) => {
-				// Format the phone value back to the expected format
-				// Keep countryNumericCode even if phoneNumber is empty to preserve the country selection
-				const formattedPhone = edits.countryNumericCode
-					? `${ edits.countryNumericCode }.${ edits.phoneNumber || '' }`
-					: '';
-
-				onChange( {
-					phone: formattedPhone,
-				} );
-			} }
-			isDisabled={ false }
-		/>
-	);
-}
-
 export const getContactFormFields = (
 	countryList: CountryListItem[] | undefined,
 	statesList: StatesListItem[] | undefined,
@@ -98,7 +54,40 @@ export const getContactFormFields = (
 			id: 'phone',
 			label: __( 'Phone' ),
 			type: 'text',
-			Edit: DomainContactDetailsPhoneField,
+			Edit: ( { field, data, onChange } ) => {
+				const { getValue } = field;
+				const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
+				const phoneValue = getValue ? getValue( { item: data } ) : '';
+
+				// Our backend stores phone number in the format: +country_code.phone_number
+				const [ countryNumericCode, phoneNumber ] = phoneValue?.split( '.' ) ?? [ '', '' ];
+
+				// Find country code from the numeric code using SMS country codes
+				const smsCountry = smsCountryCodes?.find(
+					( country ) => country.numeric_code === countryNumericCode
+				);
+
+				return (
+					<PhoneNumberInput
+						data={ {
+							countryCode: smsCountry?.code || '',
+							phoneNumber: phoneNumber,
+							countryNumericCode: countryNumericCode,
+						} }
+						onChange={ ( edits ) => {
+							// Format the phone value back to the expected format: +country_code.phone_number
+							const formattedPhone = edits.countryNumericCode
+								? `${ edits.countryNumericCode }.${ edits.phoneNumber || '' }`
+								: '';
+
+							onChange( {
+								phone: formattedPhone,
+							} );
+						} }
+						isDisabled={ false }
+					/>
+				);
+			},
 			isValid: {
 				required: true,
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -1,3 +1,5 @@
+import { smsCountryCodesQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	CheckboxControl,
 	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
@@ -7,10 +9,60 @@ import {
 import { type Field } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
+import PhoneNumberInput from '../../components/phone-number-input';
 import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
+
+// Custom phone field component that handles SMS country codes
+function PhoneField( {
+	field,
+	data,
+	onChange,
+}: {
+	field: Field< DomainContactDetails >;
+	data: DomainContactDetails;
+	onChange: ( edits: Partial< DomainContactDetails > ) => void;
+} ) {
+	const { getValue } = field;
+	const { data: smsCountryCodes } = useSuspenseQuery( smsCountryCodesQuery() );
+	const phoneValue = getValue ? getValue( { item: data } ) : '';
+
+	const [ countryNumericCode, phoneNumber ] = phoneValue?.split( '.' ) ?? [ '', '' ];
+
+	// Find country code from the numeric code using SMS country codes
+	const smsCountry = smsCountryCodes?.find(
+		( country ) => country.numeric_code === countryNumericCode
+	);
+
+	const [ countryCode, setCountryCode ] = useState( smsCountry?.code || '' );
+
+	return (
+		<PhoneNumberInput
+			data={ {
+				countryCode: countryCode,
+				phoneNumber: phoneNumber,
+				countryNumericCode: countryNumericCode,
+			} }
+			onChange={ ( edits ) => {
+				// Format the phone value back to the expected format
+				const formattedPhone =
+					edits.countryNumericCode && edits.phoneNumber
+						? `${ edits.countryNumericCode }.${ edits.phoneNumber }`
+						: '';
+
+				setCountryCode( edits.countryCode || '' );
+
+				onChange( {
+					phone: formattedPhone,
+				} );
+			} }
+			isDisabled={ false }
+		/>
+	);
+}
 
 export const getContactFormFields = (
 	countryList: CountryListItem[] | undefined,
@@ -51,6 +103,7 @@ export const getContactFormFields = (
 			id: 'phone',
 			label: __( 'Phone' ),
 			type: 'text',
+			Edit: PhoneField,
 			isValid: {
 				required: true,
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -11,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import InlineSupportLink from '../../components/inline-support-link';
 import PhoneNumberInput from '../../components/phone-number-input';
+import { validatePhone } from '../../utils/phone-number';
 import { RegionAddressFieldsets } from './region-address-fieldsets';
 import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
@@ -67,8 +68,13 @@ export const getContactFormFields = (
 					( country ) => country.numeric_code === countryNumericCode
 				);
 
+				const validationMessage = field.isValid?.custom?.( data, field );
+
 				return (
 					<PhoneNumberInput
+						customValidity={
+							validationMessage ? { type: 'invalid', message: validationMessage } : undefined
+						}
 						data={ {
 							countryCode: smsCountry?.code || '',
 							phoneNumber: phoneNumber,
@@ -90,6 +96,15 @@ export const getContactFormFields = (
 			},
 			isValid: {
 				required: true,
+				custom: ( item, field ) => {
+					const raw = field.getValue ? field.getValue( { item } ) : '';
+					if ( ! raw ) {
+						return null;
+					}
+					const phoneNumber = String( raw ).replace( '+', '' ).split( '.' ).join( '' );
+					const result = validatePhone( phoneNumber, countryCode );
+					return 'error' in result ? result.message : null;
+				},
 			},
 		},
 		{

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -9,7 +9,6 @@ import {
 import { type Field } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
 import PhoneNumberInput from '../../components/phone-number-input';
 import { RegionAddressFieldsets } from './region-address-fieldsets';
@@ -17,7 +16,7 @@ import type { CountryListItem } from './custom-form-fieldsets/types';
 import type { DomainContactDetails, StatesListItem } from '@automattic/api-core';
 
 // Custom phone field component that handles SMS country codes
-function PhoneField( {
+function DomainContactDetailsPhoneField( {
 	field,
 	data,
 	onChange,
@@ -37,23 +36,19 @@ function PhoneField( {
 		( country ) => country.numeric_code === countryNumericCode
 	);
 
-	const [ countryCode, setCountryCode ] = useState( smsCountry?.code || '' );
-
 	return (
 		<PhoneNumberInput
 			data={ {
-				countryCode: countryCode,
+				countryCode: smsCountry?.code || '',
 				phoneNumber: phoneNumber,
 				countryNumericCode: countryNumericCode,
 			} }
 			onChange={ ( edits ) => {
 				// Format the phone value back to the expected format
-				const formattedPhone =
-					edits.countryNumericCode && edits.phoneNumber
-						? `${ edits.countryNumericCode }.${ edits.phoneNumber }`
-						: '';
-
-				setCountryCode( edits.countryCode || '' );
+				// Keep countryNumericCode even if phoneNumber is empty to preserve the country selection
+				const formattedPhone = edits.countryNumericCode
+					? `${ edits.countryNumericCode }.${ edits.phoneNumber || '' }`
+					: '';
 
 				onChange( {
 					phone: formattedPhone,
@@ -103,7 +98,7 @@ export const getContactFormFields = (
 			id: 'phone',
 			label: __( 'Phone' ),
 			type: 'text',
-			Edit: PhoneField,
+			Edit: DomainContactDetailsPhoneField,
 			isValid: {
 				required: true,
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -100,8 +100,8 @@ export const getContactFormFields = (
 					if ( ! raw ) {
 						return null;
 					}
-					const phoneNumber = String( raw ).replace( '+', '' ).split( '.' ).join( '' );
-					const result = validatePhone( phoneNumber, countryCode );
+					const phoneNumber = String( raw ).split( '.' ).join( '' );
+					const result = validatePhone( phoneNumber );
 					return 'error' in result ? result.message : null;
 				},
 			},

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -15,7 +15,6 @@ import {
 	Card,
 	CardBody,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, Field, isItemValid, FormField } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -38,7 +37,6 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: countryList } = useQuery( countryListQuery() );
-	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ formData, setFormData ] = useState< DomainContactDetails >(
 		initialData ?? { optOutTransferLock: false }
 	);
@@ -116,15 +114,8 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 				children: [ 'firstName', 'lastName' ],
 			} as FormField,
 			'organization',
-			{
-				id: 'contact-row',
-				layout: {
-					type: 'row' as const,
-					alignment: 'start' as const,
-				},
-				children: isMobileViewport ? [ 'email' ] : [ 'email', 'phone' ],
-			} as FormField,
-			...( isMobileViewport ? [ 'phone' ] : [] ),
+			'email',
+			'phone',
 			'countryCode',
 			...RegionAddressFieldsLayout( {
 				statesList,

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -15,6 +15,7 @@ import {
 	Card,
 	CardBody,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, Field, isItemValid, FormField } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -37,6 +38,7 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: countryList } = useQuery( countryListQuery() );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ formData, setFormData ] = useState< DomainContactDetails >(
 		initialData ?? { optOutTransferLock: false }
 	);
@@ -120,8 +122,9 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 					type: 'row' as const,
 					alignment: 'start' as const,
 				},
-				children: [ 'email', 'phone' ],
+				children: isMobileViewport ? [ 'email' ] : [ 'email', 'phone' ],
 			} as FormField,
+			...( isMobileViewport ? [ 'phone' ] : [] ),
 			'countryCode',
 			...RegionAddressFieldsLayout( {
 				statesList,

--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -11,17 +11,17 @@ export function validatePhone( phoneNumber: string, countryCode: string | null )
 		};
 	}
 
-	if ( phoneNumberWithoutPlus.length < 8 ) {
-		return {
-			error: 'phone_number_too_short',
-			message: __( 'This number is too short' ),
-		};
-	}
-
 	if ( phoneNumber.search( /[a-z,A-Z]/ ) > -1 ) {
 		return {
 			error: 'phone_number_contains_letters',
 			message: __( 'Phone numbers cannot contain letters' ),
+		};
+	}
+
+	if ( phoneNumberWithoutPlus.length < 8 ) {
+		return {
+			error: 'phone_number_too_short',
+			message: __( 'This number is too short' ),
 		};
 	}
 

--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import phone from 'phone';
 
-export function validatePhone( phoneNumber: string ) {
+export function validatePhone( phoneNumber: string, countryCode: string | null ) {
 	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
 
 	if ( phoneNumberWithoutPlus.length === 0 ) {
@@ -33,7 +33,7 @@ export function validatePhone( phoneNumber: string ) {
 	}
 
 	// phone module validates mobile numbers
-	if ( ! phone( phoneNumber ).isValid ) {
+	if ( ! phone( phoneNumber, { country: countryCode ?? undefined } ).isValid ) {
 		return {
 			error: 'phone_number_invalid',
 			message: __( 'That phone number does not appear to be valid' ),

--- a/client/dashboard/utils/phone-number.ts
+++ b/client/dashboard/utils/phone-number.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import phone from 'phone';
 
-export function validatePhone( phoneNumber: string, countryCode: string | null ) {
+export function validatePhone( phoneNumber: string ) {
 	const phoneNumberWithoutPlus = phoneNumber.replace( /\+/, '' );
 
 	if ( phoneNumberWithoutPlus.length === 0 ) {
@@ -33,7 +33,7 @@ export function validatePhone( phoneNumber: string, countryCode: string | null )
 	}
 
 	// phone module validates mobile numbers
-	if ( ! phone( phoneNumber, { country: countryCode ?? undefined } ).isValid ) {
+	if ( ! phone( phoneNumber ).isValid ) {
 		return {
 			error: 'phone_number_invalid',
 			message: __( 'That phone number does not appear to be valid' ),

--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -1,0 +1,135 @@
+import { validatePhone } from '../phone-number';
+
+describe( 'validatePhone', () => {
+	describe( 'basic validation errors', () => {
+		it( 'should return error for empty phone number', () => {
+			const result = validatePhone( '', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_empty',
+				message: 'Please enter a phone number',
+			} );
+		} );
+
+		it( 'should return error for phone number containing letters', () => {
+			const result = validatePhone( '123abc456', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_letters',
+				message: 'Phone numbers cannot contain letters',
+			} );
+		} );
+
+		it( 'should return error for phone number that is too short', () => {
+			const result = validatePhone( '1234567', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_too_short',
+				message: 'This number is too short',
+			} );
+		} );
+
+		it( 'should return error for phone number with special characters', () => {
+			const result = validatePhone( '123-456-7890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_special_characters',
+				message: 'Phone numbers cannot contain special characters',
+			} );
+		} );
+	} );
+
+	describe( 'valid phone numbers', () => {
+		it( 'should return success for valid US phone number', () => {
+			const result = validatePhone( '2025551234', 'US' );
+			expect( result ).toEqual( {
+				info: 'phone_number_valid',
+				message: 'Valid phone number',
+			} );
+		} );
+
+		it( 'should return success for valid US phone number with plus sign', () => {
+			const result = validatePhone( '+12025551234', 'US' );
+			expect( result ).toEqual( {
+				info: 'phone_number_valid',
+				message: 'Valid phone number',
+			} );
+		} );
+
+		it( 'should return success for valid phone number without country code', () => {
+			const result = validatePhone( '2025551234', null );
+			expect( result ).toEqual( {
+				info: 'phone_number_valid',
+				message: 'Valid phone number',
+			} );
+		} );
+
+		it( 'should return success for valid international phone number', () => {
+			const result = validatePhone( '+447911123456', 'GB' );
+			expect( result ).toEqual( {
+				info: 'phone_number_valid',
+				message: 'Valid phone number',
+			} );
+		} );
+	} );
+
+	describe( 'invalid phone numbers', () => {
+		it( 'should return error for invalid phone number that passes basic validation', () => {
+			const result = validatePhone( '1234567890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_invalid',
+				message: 'That phone number does not appear to be valid',
+			} );
+		} );
+
+		it( 'should return error for invalid area code', () => {
+			const result = validatePhone( '9995551234', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_invalid',
+				message: 'That phone number does not appear to be valid',
+			} );
+		} );
+
+		it( 'should return error for phone number too long', () => {
+			const result = validatePhone( '12345678901234567890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_invalid',
+				message: 'That phone number does not appear to be valid',
+			} );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'should handle phone number with multiple plus signs', () => {
+			const result = validatePhone( '++1234567890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_invalid',
+				message: 'That phone number does not appear to be valid',
+			} );
+		} );
+
+		it( 'should handle phone number with plus sign in the middle', () => {
+			const result = validatePhone( '123+4567890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_invalid',
+				message: 'That phone number does not appear to be valid',
+			} );
+		} );
+
+		it( 'should handle phone number with commas (bug in regex)', () => {
+			const result = validatePhone( '123,456,7890', 'US' );
+			expect( result ).toEqual( {
+				error: 'phone_number_contains_letters',
+				message: 'Phone numbers cannot contain letters',
+			} );
+		} );
+	} );
+
+	describe( 'validation order', () => {
+		it( 'should check validations in correct order', () => {
+			expect( validatePhone( '', 'US' ).error ).toBe( 'phone_number_empty' );
+			expect( validatePhone( 'abc', 'US' ).error ).toBe( 'phone_number_contains_letters' );
+			expect( validatePhone( '123', 'US' ).error ).toBe( 'phone_number_too_short' );
+			expect( validatePhone( '1234567890-', 'US' ).error ).toBe(
+				'phone_number_contains_special_characters'
+			);
+			expect( validatePhone( '1234567890', 'GB' ).error ).toBe( 'phone_number_invalid' );
+		} );
+	} );
+} );

--- a/client/dashboard/utils/test/phone-number.ts
+++ b/client/dashboard/utils/test/phone-number.ts
@@ -3,7 +3,7 @@ import { validatePhone } from '../phone-number';
 describe( 'validatePhone', () => {
 	describe( 'basic validation errors', () => {
 		it( 'should return error for empty phone number', () => {
-			const result = validatePhone( '', 'US' );
+			const result = validatePhone( '' );
 			expect( result ).toEqual( {
 				error: 'phone_number_empty',
 				message: 'Please enter a phone number',
@@ -11,7 +11,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return error for phone number containing letters', () => {
-			const result = validatePhone( '123abc456', 'US' );
+			const result = validatePhone( '123abc456' );
 			expect( result ).toEqual( {
 				error: 'phone_number_contains_letters',
 				message: 'Phone numbers cannot contain letters',
@@ -19,7 +19,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return error for phone number that is too short', () => {
-			const result = validatePhone( '1234567', 'US' );
+			const result = validatePhone( '1234567' );
 			expect( result ).toEqual( {
 				error: 'phone_number_too_short',
 				message: 'This number is too short',
@@ -27,7 +27,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return error for phone number with special characters', () => {
-			const result = validatePhone( '123-456-7890', 'US' );
+			const result = validatePhone( '123-456-7890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_contains_special_characters',
 				message: 'Phone numbers cannot contain special characters',
@@ -37,7 +37,7 @@ describe( 'validatePhone', () => {
 
 	describe( 'valid phone numbers', () => {
 		it( 'should return success for valid US phone number', () => {
-			const result = validatePhone( '2025551234', 'US' );
+			const result = validatePhone( '2025551234' );
 			expect( result ).toEqual( {
 				info: 'phone_number_valid',
 				message: 'Valid phone number',
@@ -45,7 +45,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return success for valid US phone number with plus sign', () => {
-			const result = validatePhone( '+12025551234', 'US' );
+			const result = validatePhone( '+12025551234' );
 			expect( result ).toEqual( {
 				info: 'phone_number_valid',
 				message: 'Valid phone number',
@@ -53,7 +53,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return success for valid phone number without country code', () => {
-			const result = validatePhone( '2025551234', null );
+			const result = validatePhone( '2025551234' );
 			expect( result ).toEqual( {
 				info: 'phone_number_valid',
 				message: 'Valid phone number',
@@ -61,7 +61,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return success for valid international phone number', () => {
-			const result = validatePhone( '+447911123456', 'GB' );
+			const result = validatePhone( '+447911123456' );
 			expect( result ).toEqual( {
 				info: 'phone_number_valid',
 				message: 'Valid phone number',
@@ -71,7 +71,7 @@ describe( 'validatePhone', () => {
 
 	describe( 'invalid phone numbers', () => {
 		it( 'should return error for invalid phone number that passes basic validation', () => {
-			const result = validatePhone( '1234567890', 'US' );
+			const result = validatePhone( '1234567890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_invalid',
 				message: 'That phone number does not appear to be valid',
@@ -79,7 +79,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return error for invalid area code', () => {
-			const result = validatePhone( '9995551234', 'US' );
+			const result = validatePhone( '9995551234' );
 			expect( result ).toEqual( {
 				error: 'phone_number_invalid',
 				message: 'That phone number does not appear to be valid',
@@ -87,7 +87,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should return error for phone number too long', () => {
-			const result = validatePhone( '12345678901234567890', 'US' );
+			const result = validatePhone( '12345678901234567890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_invalid',
 				message: 'That phone number does not appear to be valid',
@@ -97,7 +97,7 @@ describe( 'validatePhone', () => {
 
 	describe( 'edge cases', () => {
 		it( 'should handle phone number with multiple plus signs', () => {
-			const result = validatePhone( '++1234567890', 'US' );
+			const result = validatePhone( '++1234567890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_invalid',
 				message: 'That phone number does not appear to be valid',
@@ -105,7 +105,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should handle phone number with plus sign in the middle', () => {
-			const result = validatePhone( '123+4567890', 'US' );
+			const result = validatePhone( '123+4567890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_invalid',
 				message: 'That phone number does not appear to be valid',
@@ -113,7 +113,7 @@ describe( 'validatePhone', () => {
 		} );
 
 		it( 'should handle phone number with commas (bug in regex)', () => {
-			const result = validatePhone( '123,456,7890', 'US' );
+			const result = validatePhone( '123,456,7890' );
 			expect( result ).toEqual( {
 				error: 'phone_number_contains_letters',
 				message: 'Phone numbers cannot contain letters',
@@ -123,13 +123,13 @@ describe( 'validatePhone', () => {
 
 	describe( 'validation order', () => {
 		it( 'should check validations in correct order', () => {
-			expect( validatePhone( '', 'US' ).error ).toBe( 'phone_number_empty' );
-			expect( validatePhone( 'abc', 'US' ).error ).toBe( 'phone_number_contains_letters' );
-			expect( validatePhone( '123', 'US' ).error ).toBe( 'phone_number_too_short' );
-			expect( validatePhone( '1234567890-', 'US' ).error ).toBe(
+			expect( validatePhone( '' ).error ).toBe( 'phone_number_empty' );
+			expect( validatePhone( 'abc' ).error ).toBe( 'phone_number_contains_letters' );
+			expect( validatePhone( '123' ).error ).toBe( 'phone_number_too_short' );
+			expect( validatePhone( '1234567890-' ).error ).toBe(
 				'phone_number_contains_special_characters'
 			);
-			expect( validatePhone( '1234567890', 'GB' ).error ).toBe( 'phone_number_invalid' );
+			expect( validatePhone( '1234567890' ).error ).toBe( 'phone_number_invalid' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to [DOTDASH-259](https://linear.app/a8c/issue/DOTDASH-259/create-a-phone-component)

## Proposed Changes

* We're reusing [HD PhoneNumberInput](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/components/phone-number-input/index.tsx#L18) in Dompain Contact details screen
* Ensure we send it in the expected format:  `+country_code.phone_number`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to ensure the best experience for users and reuse the code to achive that

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the new cphone contact information work as expected:

	<img width="754" height="967" alt="image" src="https://github.com/user-attachments/assets/eb76edb4-b04d-4d3d-9f81-8331fcbc184a" />


* Also test its mobile version:

	<img width="479" height="1122" alt="image" src="https://github.com/user-attachments/assets/413f4468-7855-448e-955a-47e6316d3d54" />

* Make sure the "[Account Recovery](http://calypso.localhost:3000/v2/me/security/account-recovery)" works as expected

	<img width="772" height="658" alt="image" src="https://github.com/user-attachments/assets/1b70be36-3a5b-4649-81b4-754d6d224832" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
