### PR TITLE
Domain Search Rewrite: Remove protocol (`http`, `https`) and `www` subdomain from domain searches

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -38,17 +38,8 @@ export const useQueryHandler = ( {
 	} );
 
 	const setQuery = useCallback( ( query: string ) => {
-		const normalizedQuery = query
-			.trim()
-			.toLowerCase()
-			.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
-			.replace( /^www[0-9]?\./, '' )
-			.replace( /[^a-zA-ZÀ-ÖÙ-öù-ÿĀ-žḀ-ỿ0-9-. ]/g, '' );
-
-		if ( normalizedQuery ) {
-			setLocalQuery( normalizedQuery );
-			setSessionStorageQuery( normalizedQuery );
-		}
+		setLocalQuery( query );
+		setSessionStorageQuery( query );
 	}, [] );
 
 	return {

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -38,8 +38,17 @@ export const useQueryHandler = ( {
 	} );
 
 	const setQuery = useCallback( ( query: string ) => {
-		setLocalQuery( query );
-		setSessionStorageQuery( query );
+		const normalizedQuery = query
+			.trim()
+			.toLowerCase()
+			.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
+			.replace( /^www[0-9]?\./, '' )
+			.replace( /[^a-zA-ZÀ-ÖÙ-öù-ÿĀ-žḀ-ỿ0-9-. ]/g, '' );
+
+		if ( normalizedQuery ) {
+			setLocalQuery( normalizedQuery );
+			setSessionStorageQuery( normalizedQuery );
+		}
 	}, [] );
 
 	return {

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -193,7 +193,15 @@ export const useDomainSearchContextValue = ( {
 			openFullCart,
 			query: externalQuery ?? '',
 			setQuery: ( query ) => {
-				normalizedEvents.onQueryChange( query );
+				const normalizedQuery = query
+					.trim()
+					.toLowerCase()
+					.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
+					.replace( /[^a-zA-ZÀ-ÖÙ-öù-ÿĀ-žḀ-ỿ0-9-. ]/g, '' );
+
+				if ( normalizedQuery ) {
+					normalizedEvents.onQueryChange( normalizedQuery );
+				}
 			},
 			slots,
 			currentSiteUrl,


### PR DESCRIPTION
Part of [DOMAINS-1699](https://linear.app/a8c/issue/DOMAINS-1699/)

## Proposed Changes

This PR updates the new domain search code to remove the protocol prefixes `http`/`https` and `www` subdomain when making domain searches and availability checks.

### Screenshots

| Before | After |
| --- | --- |
| <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 40 45" src="https://github.com/user-attachments/assets/824a2a81-c19b-4bd3-bb3e-4041759f37dc" /> | <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 39 57" src="https://github.com/user-attachments/assets/df46152f-7709-4cd5-a80c-6fbee514e151" /> |
| <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 40 58" src="https://github.com/user-attachments/assets/3d2bfa0e-4ce4-4d85-93f9-25cd98ef1aec" /> | <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 39 49" src="https://github.com/user-attachments/assets/ed5af418-fb0f-46ce-91a0-64ef78bf336b" /> |
| <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 41 07" src="https://github.com/user-attachments/assets/cc311f3b-7128-4be3-b3cf-0dcfb0415062" /> | <img width="954" height="1080" alt="Screenshot 2025-10-08 at 19 39 39" src="https://github.com/user-attachments/assets/c416ed55-aae0-4667-b810-40f80fed70f1" /> |

## Why are these changes being made?

This was reported in the CFT here (pdtkmj-40Z-p2#comment-7750).

In domain search, when a user inputs a domain name with the `www` subdomain and/or the `http` protocol parts, the availability check returns an error because that's not a valid domain (it's actually a URL). The previous behavior of the domain search was to remove these parts before doing an availability check or suggestions request. 

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain search flow (e.g. `/setup/onboarding`) with the `domain-search-rewrite` flag enabled
- Search for a domain with the `www` subdomain, e.g. `www.leotabatestdomainsearch.com`
- Ensure no availability error notice is shown, and the domain (`leotabatestdomainsearch.com`), if available, is shown in the suggestions list
- Search for a domain with the `http` protocol part, e.g. `http://leotabatestdomainsearch2.com`
- Ensure no availability error is shown
- Search for a domain with both the `http` protocol and `www` subdomain, e.g. `http://www.leotabatestdomainsearch3.com`
- Ensure no availability error is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
