### PR TITLE
GetBillingIntervalLabel: Fix rule of hooks error

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -754,10 +754,10 @@ export function LineItemSublabelAndPrice( {
 		isTitanMail( product )
 	) {
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			const billingInterval = GetBillingIntervalLabel( { product } );
 			return (
 				<>
-					<DefaultLineItemSublabel product={ product } />: { billingInterval }
+					<DefaultLineItemSublabel product={ product } />:{ ' ' }
+					<GetBillingIntervalLabel product={ product } />
 					<LineItemExpiryDates product={ product } />
 				</>
 			);
@@ -833,7 +833,9 @@ export function LineItemSublabelAndPrice( {
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
 				{ ! product.is_included_for_100yearplan && (
-					<>: { GetBillingIntervalLabel( { product } ) }</>
+					<>
+						: <GetBillingIntervalLabel product={ product } />
+					</>
 				) }
 				<LineItemExpiryDates product={ product } />
 			</>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -754,7 +754,7 @@ export function LineItemSublabelAndPrice( {
 		isTitanMail( product )
 	) {
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			const billingInterval = GetBillingIntervalLabel( translate, product );
+			const billingInterval = GetBillingIntervalLabel( { product } );
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
@@ -833,7 +833,7 @@ export function LineItemSublabelAndPrice( {
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
 				{ ! product.is_included_for_100yearplan && (
-					<>: { GetBillingIntervalLabel( translate, product ) }</>
+					<>: { GetBillingIntervalLabel( { product } ) }</>
 				) }
 				<LineItemExpiryDates product={ product } />
 			</>
@@ -1024,10 +1024,8 @@ function formatDate( isoDate: string ): string {
 	} );
 }
 
-function GetBillingIntervalLabel(
-	translate: ReturnType< typeof useTranslate >,
-	product: ResponseCartProduct
-) {
+function GetBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
 	if ( product.volume > 1 ) {
 		return translate( 'billed %(total_years)s years, then annually', {
 			args: { total_years: product.volume },

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -754,7 +754,7 @@ export function LineItemSublabelAndPrice( {
 		isTitanMail( product )
 	) {
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			const billingInterval = GetBillingIntervalLabel( { product } );
+			const billingInterval = GetBillingIntervalLabel( translate, product );
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
@@ -833,7 +833,7 @@ export function LineItemSublabelAndPrice( {
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
 				{ ! product.is_included_for_100yearplan && (
-					<>: { GetBillingIntervalLabel( { product } ) }</>
+					<>: { GetBillingIntervalLabel( translate, product ) }</>
 				) }
 				<LineItemExpiryDates product={ product } />
 			</>
@@ -1024,8 +1024,10 @@ function formatDate( isoDate: string ): string {
 	} );
 }
 
-function GetBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {
-	const translate = useTranslate();
+function GetBillingIntervalLabel(
+	translate: ReturnType< typeof useTranslate >,
+	product: ResponseCartProduct
+) {
 	if ( product.volume > 1 ) {
 		return translate( 'billed %(total_years)s years, then annually', {
 			args: { total_years: product.volume },


### PR DESCRIPTION
Attempt to fix a "Rule of Hooks" error seen in prod, https://react.dev/errors/310?invariant=310 Rendered more hooks than during the previous render.

For the original alert, see, p1759960082606319-slack-C096PD42U.

I think what's happening is `GetBillingIntervalLabel()` is being called as a regular function, but it calls a hook (useTranslate()). If the React component that's calling `GetBillingIntervalLabel()` switches between calling it and not calling it between renders, then the "Rules of hooks" are violated because the number of hooks run during a render changed.

Solution: Either turn `GetBillingIntervalLabel()` into a react component, or make it stop calling a hook. I changed it to not be a hook and to just have the translation function passed in. It seems to be used only in these places anyway.


## Proposed Changes

*

## Why are these changes being made?

*

## Reproduce the problem on trunk

* I was not able to do this. Logically, I think you need to add Google Workspace, Gsuite, or Titan Email, go to checkout, and flip between monthly and yearly to see the error. However, that doesn't seem to be doing it. 
  * If you're not also able to recreate it, you can at least verify this PR doesn't break anything and makes logical sense.

## Testing Instructions

* Modify locally to see the changes easier

```diff
diff --git a/packages/wpcom-checkout/src/checkout-line-items.tsx b/packages/wpcom-checkout/src/checkout-line-items.tsx
index 4ee6e5a8ed1..3122d16238a 100644
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1029,11 +1029,11 @@ function GetBillingIntervalLabel(
        product: ResponseCartProduct
 ) {
        if ( product.volume > 1 ) {
-               return translate( 'billed %(total_years)s years, then annually', {
+               return translate( 'b (dev check2) illed %(total_years)s years, then annually', {
                        args: { total_years: product.volume },
                } );
        }
-       return translate( 'billed annually' );
+       return translate( 'b (dev check) illed annually' );
 }

 export function LineItemBillingInterval( { product }: { product: ResponseCartProduct } ) {
```


* Have a site with a custom domain
* Add an email product like titan email or google email to cart
* Visit checkout and make sure the description line is still working

<img width="692" height="443" alt="Screenshot 2025-10-08 at 6 01 17 PM" src="https://github.com/user-attachments/assets/553520be-868e-477c-885d-4a896ff7bfc0" />


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?