### PR TITLE
Use the full path of the route variable in the GitHub deployments form

### DIFF
--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -14,7 +14,11 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { siteRoute } from '../../app/router/sites';
+import {
+	siteRoute,
+	siteSettingsRepositoriesRoute,
+	siteSettingsRepositoriesManageRoute,
+} from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -27,13 +31,13 @@ export default function ConfigureRepository() {
 		codeDeploymentQuery( site.ID, deploymentId )
 	);
 	const { data: installations } = useSuspenseQuery( githubInstallationsQuery() );
-	const navigateFrom = '/sites/$siteSlug/settings/repositories/manage/$deploymentId';
+	const navigateFrom = siteSettingsRepositoriesManageRoute.fullPath;
 	const navigate = useNavigate( {
 		from: navigateFrom,
 	} );
 
 	const handleCancel = () => {
-		navigate( { to: '/sites/$siteSlug/settings/repositories' } );
+		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
 	};
 
 	const updateMutation = useMutation( updateCodeDeploymentMutation( site.ID, deploymentId ?? 0 ) );

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -14,7 +14,11 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { siteRoute, siteSettingsRepositoriesRoute } from '../../app/router/sites';
+import {
+	siteRoute,
+	siteSettingsRepositoriesConnectRoute,
+	siteSettingsRepositoriesRoute,
+} from '../../app/router/sites';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -25,7 +29,7 @@ export default function ConnectRepository() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: installations } = useSuspenseQuery( githubInstallationsQuery() );
-	const navigateFrom = siteSettingsRepositoriesRoute.fullPath;
+	const navigateFrom = siteSettingsRepositoriesConnectRoute.fullPath;
 	const navigate = useNavigate( { from: navigateFrom } );
 
 	const handleCancel = () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/106299#discussion_r2412938177

## Proposed Changes

* Use full path route variable instead of variables

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's optimal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use Calypso live
* Navigate to `/v2/sites/$siteSlug/settings/repositories`.
* Click on a Connect repository and click on cancel
* Observe everything worked correctly
* Click on the actions three dots menu > Configure repository
* Click on cancel button
* Observe that you navigated correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
