### PR TITLE
Performance v2: Adjust LineChart to show multiple dataset based on the valuation

### DIFF
--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -62,20 +62,21 @@ const MetricLabel = ( {
 	);
 };
 
-const useMetricData = (
-	metric: Metrics,
-	valuation: Valuation,
-	history?: SitePerformanceHistory
-) => {
+const useMetricData = ( metric: Metrics, history?: SitePerformanceHistory ) => {
 	const dates = history?.collection_period ?? [];
 	const values = history?.metrics[ metric ] ?? [];
 	if ( ! dates.length || ! values.length ) {
 		return null;
 	}
 
-	const color = getColorForStatus( valuation );
 	const weeksToShow = 8;
-	const data = [];
+	const metricData: Array< {
+		label: string;
+		data: Array< { date: Date; value: number } >;
+		options: { stroke: string };
+	} > = [];
+	const allData = [];
+	let currentValuation;
 	for ( let i = dates.length - 1; i > Math.max( 0, dates.length - 1 - weeksToShow ); i-- ) {
 		const date = dates[ i ];
 		const formattedDate =
@@ -87,20 +88,35 @@ const useMetricData = (
 						date.day.toString().padStart( 2, '0' ),
 				  ].join( '-' );
 
-		data.push( {
+		const nextValuation = mapThresholdsToStatus( metric, values[ i ] );
+		if ( nextValuation !== currentValuation ) {
+			const lastData = metricData[ metricData.length - 1 ]?.data?.slice().pop();
+			currentValuation = nextValuation;
+			metricData.push( {
+				// The label should be unique.
+				label: `${ getStatusText( currentValuation ) } - ${ metricData.length }`,
+				data: ( lastData ? [ lastData ] : [] ) as Array< { date: Date; value: number } >,
+				options: {
+					stroke: getColorForStatus( currentValuation ),
+				},
+			} );
+		}
+
+		const data = {
 			date: new Date( formattedDate ),
 			value: getFormattedValue( metric, values[ i ] ),
-		} );
+		};
+		metricData[ metricData.length - 1 ].data.push( data );
+		allData.push( data );
 	}
 
 	return [
+		// Use all data to maintain the range of the x axis.
 		{
-			label: getStatusText( valuation ),
-			data,
-			options: {
-				stroke: color,
-			},
+			label: '',
+			data: allData,
 		},
+		...metricData,
 	];
 };
 
@@ -116,8 +132,7 @@ export default function CoreMetricsChart( {
 } ) {
 	const { good, needsImprovement, bad } = metricsThresholds[ metric ];
 	const isDesktop = useViewportMatch( 'medium' );
-	const currentValuation = mapThresholdsToStatus( metric, report[ metric ] );
-	const data = useMetricData( metric, currentValuation, report.history );
+	const data = useMetricData( metric, report.history );
 
 	const formatThresholdValue = ( isOverall: boolean, valuation: Valuation ) => {
 		const unit = getDisplayUnit( metric );
@@ -179,8 +194,18 @@ export default function CoreMetricsChart( {
 						data={ data }
 						withGradientFill={ false }
 						smoothing={ false }
-						renderGlyph={ ( { color, x, y } ) => {
-							const GlyphComponent = StatusGlyph[ currentValuation ];
+						renderGlyph={ ( { key, x, y, datum } ) => {
+							const data = datum as { value: number };
+							const value = [ 'lcp', 'fcp', 'ttfb', 'inp', 'tbt' ].includes( metric )
+								? data.value * 1000
+								: data.value;
+							const valuation = mapThresholdsToStatus( metric, value );
+							const color = getColorForStatus( valuation );
+							const label = getStatusText( valuation );
+							if ( ! label.includes( key ) ) {
+								return null;
+							}
+							const GlyphComponent = StatusGlyph[ valuation ];
 							return <GlyphComponent top={ y } left={ x } size={ 100 } fill={ color } />;
 						} }
 						renderTooltip={ ( { tooltipData } ) => {
@@ -189,7 +214,11 @@ export default function CoreMetricsChart( {
 								return null;
 							}
 
-							return nearestDatum.value;
+							const formattedDate = nearestDatum.date?.toLocaleDateString( undefined, {
+								month: 'short',
+								day: 'numeric',
+							} );
+							return [ formattedDate, nearestDatum.value ].join( ': ' );
 						} }
 					/>
 				) : (

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -9,12 +9,15 @@ import {
 	Valuation,
 	getColorForStatus,
 	getDisplayUnit,
+	getFormattedNumber,
 	getFormattedValue,
 	getStatusText,
 	mapThresholdsToStatus,
 } from '../../utils/site-performance';
 import type { SitePerformanceReport, SitePerformanceHistory, Metrics } from '@automattic/api-core';
 import '@automattic/charts/line-chart/style.css';
+
+const WEEK_TO_SHOW = 8;
 
 const StatusGlyph = {
 	good: GlyphCircle,
@@ -62,22 +65,21 @@ const MetricLabel = ( {
 	);
 };
 
-const useMetricData = ( metric: Metrics, history?: SitePerformanceHistory ) => {
+const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) => {
 	const dates = history?.collection_period ?? [];
 	const values = history?.metrics[ metric ] ?? [];
 	if ( ! dates.length || ! values.length ) {
 		return null;
 	}
 
-	const weeksToShow = 8;
-	const metricData: Array< {
+	const seriesData: Array< {
 		label: string;
 		data: Array< { date: Date; value: number } >;
 		options: { stroke: string };
 	} > = [];
 	const allData = [];
 	let currentValuation;
-	for ( let i = dates.length - 1; i > Math.max( 0, dates.length - 1 - weeksToShow ); i-- ) {
+	for ( let i = dates.length - 1; i > Math.max( 0, dates.length - 1 - WEEK_TO_SHOW ); i-- ) {
 		const date = dates[ i ];
 		const formattedDate =
 			typeof date === 'string'
@@ -90,11 +92,11 @@ const useMetricData = ( metric: Metrics, history?: SitePerformanceHistory ) => {
 
 		const nextValuation = mapThresholdsToStatus( metric, values[ i ] );
 		if ( nextValuation !== currentValuation ) {
-			const lastData = metricData[ metricData.length - 1 ]?.data?.slice().pop();
+			const lastData = seriesData[ seriesData.length - 1 ]?.data?.slice().pop();
 			currentValuation = nextValuation;
-			metricData.push( {
+			seriesData.push( {
 				// The label should be unique.
-				label: `${ getStatusText( currentValuation ) } - ${ metricData.length }`,
+				label: `${ getStatusText( currentValuation ) } - ${ seriesData.length }`,
 				data: ( lastData ? [ lastData ] : [] ) as Array< { date: Date; value: number } >,
 				options: {
 					stroke: getColorForStatus( currentValuation ),
@@ -106,18 +108,25 @@ const useMetricData = ( metric: Metrics, history?: SitePerformanceHistory ) => {
 			date: new Date( formattedDate ),
 			value: getFormattedValue( metric, values[ i ] ),
 		};
-		metricData[ metricData.length - 1 ].data.push( data );
+		seriesData[ seriesData.length - 1 ].data.push( data );
 		allData.push( data );
 	}
 
-	return [
-		// Use all data to maintain the range of the x axis.
-		{
-			label: '',
-			data: allData,
+	const maxY = Math.max( ...allData.map( ( d ) => d.value ) );
+
+	return {
+		seriesData: [
+			// Use all data to maintain the range of the x axis.
+			{
+				label: '',
+				data: allData,
+			},
+			...seriesData,
+		],
+		yScale: {
+			domain: [ 0, maxY === 0 ? maxY : maxY * 1.5 ] as [ number, number ],
 		},
-		...metricData,
-	];
+	};
 };
 
 export default function CoreMetricsChart( {
@@ -132,7 +141,7 @@ export default function CoreMetricsChart( {
 } ) {
 	const { good, needsImprovement, bad } = metricsThresholds[ metric ];
 	const isDesktop = useViewportMatch( 'medium' );
-	const data = useMetricData( metric, report.history );
+	const lineChartData = useLineChartData( metric, report.history );
 
 	const formatThresholdValue = ( isOverall: boolean, valuation: Valuation ) => {
 		const unit = getDisplayUnit( metric );
@@ -189,11 +198,18 @@ export default function CoreMetricsChart( {
 				/>
 			</HStack>
 			<div style={ { maxWidth: '500px' } }>
-				{ data ? (
+				{ lineChartData ? (
 					<LineChart
-						data={ data }
+						data={ lineChartData.seriesData }
 						withGradientFill={ false }
-						smoothing={ false }
+						options={ {
+							yScale: lineChartData.yScale,
+							axis: {
+								y: {
+									tickFormat: ( value ) => `${ getFormattedNumber( value ) }`,
+								},
+							},
+						} }
 						renderGlyph={ ( { key, x, y, datum } ) => {
 							const data = datum as { value: number };
 							const value = [ 'lcp', 'fcp', 'ttfb', 'inp', 'tbt' ].includes( metric )

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -202,6 +202,7 @@ export default function CoreMetricsChart( {
 					<LineChart
 						data={ lineChartData.seriesData }
 						withGradientFill={ false }
+						curveType="linear"
 						options={ {
 							yScale: lineChartData.yScale,
 							axis: {

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -50,10 +50,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		...sitePerformancePagesQuery( site.ID ),
 		refetchOnWindowFocus: false,
 	} );
-	const { page_id, url } = useSearch( { from: sitePerformanceRoute.fullPath } ) as {
-		page_id?: string;
-		url?: string;
-	};
+	const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
 	const currentPage = useMemo( () => {
 		return page_id ? getPageFromID( pagesData, page_id ) : pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
@@ -70,7 +67,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		isDesktopReportError,
 		isMobileReportError,
 		refetch: refetchReport,
-	} = usePerformanceData( url ?? currentPage?.link, currentPage?.wpcom_performance_report_hash );
+	} = usePerformanceData( currentPage?.link, currentPage?.wpcom_performance_report_hash );
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitePerformanceRoute.fullPath } );
 

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -50,7 +50,10 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		...sitePerformancePagesQuery( site.ID ),
 		refetchOnWindowFocus: false,
 	} );
-	const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
+	const { page_id, url } = useSearch( { from: sitePerformanceRoute.fullPath } ) as {
+		page_id?: string;
+		url?: string;
+	};
 	const currentPage = useMemo( () => {
 		return page_id ? getPageFromID( pagesData, page_id ) : pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
@@ -67,7 +70,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		isDesktopReportError,
 		isMobileReportError,
 		refetch: refetchReport,
-	} = usePerformanceData( currentPage?.link, currentPage?.wpcom_performance_report_hash );
+	} = usePerformanceData( url ?? currentPage?.link, currentPage?.wpcom_performance_report_hash );
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitePerformanceRoute.fullPath } );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-577

## Proposed Changes

* Show multiple dataset based on the valuation of the value
* Adjust the domain of y axis to align with v1

| Before | After |
| - | - |
|<img width="609" height="492" alt="image" src="https://github.com/user-attachments/assets/9422687f-8949-4da5-bccb-65fe93aef7bb" />|<img width="605" height="488" alt="image" src="https://github.com/user-attachments/assets/b70572a6-4416-4bfc-834a-9d0bbd8aa4b7" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/:site/performance?url=https://wordpress.com for testing
* Ensure the line chart can display different valuations

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
