### PR TITLE
Hosting Dashboard: Disable 'Save' button in User Profile if the username field fails validation

### DIFF
--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -36,6 +36,7 @@ export default function PersonalDetailsSection( {
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	const [ edits, setEdits ] = useState< Partial< UserSettings > >( {} );
+	const [ hasUsernameError, setHasUsernameError ] = useState( false );
 
 	const mutation = useMutation( {
 		...userSettingsMutation(),
@@ -110,7 +111,7 @@ export default function PersonalDetailsSection( {
 		id: 'is_dev_account',
 		label: __( 'I am a developer' ),
 		type: 'boolean',
-		description: __( 'Opt in to previews of new developer-focused features.' ),
+		description: __( 'Opt in to previews of new developer—focused features.' ),
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 			const { id, getValue, description } = field;
 			return (
@@ -172,6 +173,7 @@ export default function PersonalDetailsSection( {
 							isEmailVerified={ isEmailVerified }
 							canChangeUsername={ canChangeUsername }
 							onCancel={ handleUsernameCancel }
+							onValidationChange={ setHasUsernameError }
 						/>
 
 						{ /* Email address */ }
@@ -195,7 +197,7 @@ export default function PersonalDetailsSection( {
 								variant="primary"
 								type="submit"
 								isBusy={ isSaving }
-								disabled={ isSaving || ! isDirty }
+								disabled={ isSaving || ! isDirty || hasUsernameError }
 							>
 								{ __( 'Save' ) }
 							</Button>

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -111,7 +111,7 @@ export default function PersonalDetailsSection( {
 		id: 'is_dev_account',
 		label: __( 'I am a developer' ),
 		type: 'boolean',
-		description: __( 'Opt in to previews of new developer—focused features.' ),
+		description: __( 'Opt in to previews of new developer-focused features.' ),
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 			const { id, getValue, description } = field;
 			return (

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -13,14 +13,7 @@ import {
 } from '../../profile/__mocks__/user-settings';
 import PersonalDetailsSection from '../index';
 
-// Mock the username validation utils
-jest.mock( '../update-username/username-validation-utils', () => ( {
-	validateUsernameDebounced: jest.fn(),
-	isUsernameValid: jest.fn(),
-	getUsernameValidationMessage: jest.fn(),
-	getAllowedActions: jest.fn( () => ( {} ) ),
-	updateUsername: jest.fn(),
-} ) );
+const API_BASE = 'https://public-api.wordpress.com';
 
 // Mock the API queries (return query configurations, not data)
 jest.mock( '@automattic/api-queries', () => ( {
@@ -84,6 +77,14 @@ const renderWithUserData = ( userData = mockUserSettings ) => {
 };
 
 describe( 'PersonalDetailsSection', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+
+	afterAll( () => {
+		nock.enableNetConnect();
+	} );
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockCreateSuccessNotice.mockClear();
@@ -252,6 +253,120 @@ describe( 'PersonalDetailsSection', () => {
 
 			expect( updateUsernameMutation ).toHaveBeenCalledWith();
 			expect( updateUsernameMutation().meta.snackbar.error ).toBe( 'Failed to update username.' );
+		} );
+	} );
+
+	describe( 'Save button validation', () => {
+		it( 'disables Save button when username has validation error', async () => {
+			const user = userEvent.setup();
+			const eligibleUserData = {
+				...mockUserSettings,
+				email_verified: true,
+				user_login_can_be_changed: true,
+			};
+
+			renderWithUserData( eligibleUserData );
+
+			await waitFor( () => {
+				expect( screen.getByLabelText( 'Username' ) ).toBeEnabled();
+			} );
+
+			const firstNameInput = screen.getByLabelText( 'First name' );
+			await user.clear( firstNameInput );
+			await user.type( firstNameInput, 'Updated' );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/ab' ).reply( 200, {
+				error: 'invalid_input',
+				message: 'Usernames must be at least 4 characters.',
+			} );
+
+			const usernameInput = screen.getByLabelText( 'Username' );
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'ab' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeDisabled();
+			} );
+		} );
+
+		it( 'enables Save button when username validation passes', async () => {
+			const user = userEvent.setup();
+			const eligibleUserData = {
+				...mockUserSettings,
+				email_verified: true,
+				user_login_can_be_changed: true,
+			};
+
+			renderWithUserData( eligibleUserData );
+
+			await waitFor( () => {
+				expect( screen.getByLabelText( 'Username' ) ).toBeEnabled();
+			} );
+
+			const firstNameInput = screen.getByLabelText( 'First name' );
+			await user.clear( firstNameInput );
+			await user.type( firstNameInput, 'Updated' );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/validusername' ).reply( 200, {
+				success: true,
+				message: 'Nice username!',
+			} );
+
+			const usernameInput = screen.getByLabelText( 'Username' );
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'validusername' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
+		it( 'enables Save button when username error is cleared', async () => {
+			const user = userEvent.setup();
+			const eligibleUserData = {
+				...mockUserSettings,
+				email_verified: true,
+				user_login_can_be_changed: true,
+			};
+
+			renderWithUserData( eligibleUserData );
+
+			await waitFor( () => {
+				expect( screen.getByLabelText( 'Username' ) ).toBeEnabled();
+			} );
+
+			const firstNameInput = screen.getByLabelText( 'First name' );
+			await user.clear( firstNameInput );
+			await user.type( firstNameInput, 'Updated' );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/ab' ).reply( 200, {
+				error: 'invalid_input',
+				message: 'Usernames must be at least 4 characters.',
+			} );
+
+			const usernameInput = screen.getByLabelText( 'Username' );
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'ab' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeDisabled();
+			} );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/newvalidusername' ).reply( 200, {
+				success: true,
+				message: 'Nice username!',
+			} );
+
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'newvalidusername' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeEnabled();
+			} );
 		} );
 	} );
 

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -257,6 +257,87 @@ describe( 'PersonalDetailsSection', () => {
 	} );
 
 	describe( 'Save button validation', () => {
+		it( 'disables Save button when username confirmation does not match', async () => {
+			const user = userEvent.setup();
+			const eligibleUserData = {
+				...mockUserSettings,
+				email_verified: true,
+				user_login_can_be_changed: true,
+			};
+
+			renderWithUserData( eligibleUserData );
+
+			await waitFor( () => {
+				expect( screen.getByLabelText( 'Username' ) ).toBeEnabled();
+			} );
+
+			const firstNameInput = screen.getByLabelText( 'First name' );
+			await user.clear( firstNameInput );
+			await user.type( firstNameInput, 'Updated' );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/newusername' ).reply( 200, {
+				success: true,
+				message: 'Nice username!',
+			} );
+
+			const usernameInput = screen.getByLabelText( 'Username' );
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'newusername' );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Confirm new username' ) ).toBeInTheDocument();
+			} );
+
+			const confirmInput = screen.getByLabelText( 'Confirm new username' );
+			await user.type( confirmInput, 'wrongusername' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeDisabled();
+				expect( screen.getByText( 'Usernames do not match.' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'enables Save button when username confirmation matches', async () => {
+			const user = userEvent.setup();
+			const eligibleUserData = {
+				...mockUserSettings,
+				email_verified: true,
+				user_login_can_be_changed: true,
+			};
+
+			renderWithUserData( eligibleUserData );
+
+			await waitFor( () => {
+				expect( screen.getByLabelText( 'Username' ) ).toBeEnabled();
+			} );
+
+			const firstNameInput = screen.getByLabelText( 'First name' );
+			await user.clear( firstNameInput );
+			await user.type( firstNameInput, 'Updated' );
+
+			nock( API_BASE ).get( '/rest/v1.1/me/username/validate/newusername' ).reply( 200, {
+				success: true,
+				message: 'Nice username!',
+			} );
+
+			const usernameInput = screen.getByLabelText( 'Username' );
+			await user.clear( usernameInput );
+			await user.type( usernameInput, 'newusername' );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Confirm new username' ) ).toBeInTheDocument();
+			} );
+
+			const confirmInput = screen.getByLabelText( 'Confirm new username' );
+			await user.type( confirmInput, 'newusername' );
+
+			await waitFor( () => {
+				const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( saveButton ).toBeEnabled();
+			} );
+		} );
+
 		it( 'disables Save button when username has validation error', async () => {
 			const user = userEvent.setup();
 			const eligibleUserData = {

--- a/client/dashboard/me/profile-personal-details/username-section.tsx
+++ b/client/dashboard/me/profile-personal-details/username-section.tsx
@@ -25,6 +25,7 @@ interface UsernameSectionProps {
 	isEmailVerified: boolean;
 	canChangeUsername: boolean;
 	onCancel: () => void;
+	onValidationChange?: ( hasError: boolean ) => void;
 }
 /*
 	Username section:
@@ -40,11 +41,14 @@ export default function UsernameSection( {
 	isEmailVerified,
 	canChangeUsername,
 	onCancel,
+	onValidationChange,
 }: UsernameSectionProps ) {
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ userLoginConfirm, setUserLoginConfirm ] = useState( '' );
 	const [ usernameAction, setUsernameAction ] = useState< string >( 'none' );
-	const [ validationResult, setValidationResult ] = useState< ValidationResult | null >( null );
+	const [ validationResultState, setValidationResultState ] = useState< ValidationResult | null >(
+		null
+	);
 
 	const { mutate: updateUsername, isPending } = useMutation( {
 		...updateUsernameMutation(),
@@ -62,6 +66,19 @@ export default function UsernameSection( {
 	} );
 
 	const hasUsernameChange = !! ( value && value !== currentUsername );
+
+	const setValidationResult = useCallback(
+		( result: ValidationResult | null ) => {
+			setValidationResultState( result );
+			if ( onValidationChange ) {
+				const hasError = hasUsernameChange && result !== null && ! isUsernameValid( result );
+				onValidationChange( hasError );
+			}
+		},
+		[ hasUsernameChange, onValidationChange ]
+	);
+
+	const validationResult = validationResultState;
 
 	// Input field helper text
 	const getHelpText = useCallback( () => {
@@ -118,7 +135,7 @@ export default function UsernameSection( {
 		setUserLoginConfirm( '' );
 		setUsernameAction( 'none' );
 		onCancel();
-	}, [ onChange, currentUsername, onCancel ] );
+	}, [ onChange, currentUsername, onCancel, setValidationResult ] );
 
 	const handleUsernameChange = ( newValue: string | undefined ) => {
 		onChange( newValue );

--- a/client/dashboard/me/profile-personal-details/username-section.tsx
+++ b/client/dashboard/me/profile-personal-details/username-section.tsx
@@ -46,7 +46,7 @@ export default function UsernameSection( {
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ userLoginConfirm, setUserLoginConfirm ] = useState( '' );
 	const [ usernameAction, setUsernameAction ] = useState< string >( 'none' );
-	const [ validationResultState, setValidationResultState ] = useState< ValidationResult | null >(
+	const [ validationResult, setValidationResultState ] = useState< ValidationResult | null >(
 		null
 	);
 
@@ -94,12 +94,10 @@ export default function UsernameSection( {
 	const handleConfirmChange = useCallback(
 		( confirmValue: string ) => {
 			setUserLoginConfirm( confirmValue );
-			notifyValidationChange( validationResultState, confirmValue );
+			notifyValidationChange( validationResult, confirmValue );
 		},
-		[ notifyValidationChange, validationResultState ]
+		[ notifyValidationChange, validationResult ]
 	);
-
-	const validationResult = validationResultState;
 
 	// Input field helper text
 	const getHelpText = useCallback( () => {

--- a/client/dashboard/me/profile-personal-details/username-section.tsx
+++ b/client/dashboard/me/profile-personal-details/username-section.tsx
@@ -67,15 +67,36 @@ export default function UsernameSection( {
 
 	const hasUsernameChange = !! ( value && value !== currentUsername );
 
+	const notifyValidationChange = useCallback(
+		( result: ValidationResult | null, confirmValue: string ) => {
+			if ( ! onValidationChange ) {
+				return;
+			}
+
+			const hasValidationError =
+				hasUsernameChange && result !== null && ! isUsernameValid( result );
+			const hasConfirmError =
+				hasUsernameChange && !! value && confirmValue.length > 0 && confirmValue !== value;
+
+			onValidationChange( hasValidationError || hasConfirmError );
+		},
+		[ hasUsernameChange, value, onValidationChange ]
+	);
+
 	const setValidationResult = useCallback(
 		( result: ValidationResult | null ) => {
 			setValidationResultState( result );
-			if ( onValidationChange ) {
-				const hasError = hasUsernameChange && result !== null && ! isUsernameValid( result );
-				onValidationChange( hasError );
-			}
+			notifyValidationChange( result, userLoginConfirm );
 		},
-		[ hasUsernameChange, onValidationChange ]
+		[ notifyValidationChange, userLoginConfirm ]
+	);
+
+	const handleConfirmChange = useCallback(
+		( confirmValue: string ) => {
+			setUserLoginConfirm( confirmValue );
+			notifyValidationChange( validationResultState, confirmValue );
+		},
+		[ notifyValidationChange, validationResultState ]
 	);
 
 	const validationResult = validationResultState;
@@ -214,7 +235,7 @@ export default function UsernameSection( {
 					usernameToConfirm={ value }
 					validationResult={ validationResult }
 					usernameAction={ usernameAction }
-					onConfirmChange={ setUserLoginConfirm }
+					onConfirmChange={ handleConfirmChange }
 					onActionChange={ setUsernameAction }
 					onShowConfirmModal={ () => setShowConfirmModal( true ) }
 					onCancel={ cancelUsernameChange }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-611.

## Proposed Changes

* Add onValidationChange props for sending back validation status (simple true/false) to consuming component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For consistency purposes - the 'Save' button sounds generic, and hence it has to react to the form generically. Unfortunately however, pressing Save does not change the username - this inconsistency shall remain.

## What doesn't this PR fix?

* If you click 'Change Username' and proceed, **all your changes in other fields will be lost**. This is an unrelated issue and has been there since a while - and we'd probably have to create a client-only mutation and state to store a global form data temporarily to fix this.
* If you leave the email empty, or if you leave the 'Username' field empty, the 'Save' button doesn't get disabled. Somewhat related, but this issue exists before this PR. Also, no hints showing that these fields are empty upon pressing the enabled Save field. Fixing this probably deserves its own PR - I'm guessing we didn't enable empty field validation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Steps to test:**

1. Create a new/utilize your testing, WordPress.com account, using a different browser/user profile to do so. Incognito is quirky because of 3rd party cookie restrictions so don't use it. Log into it in wordpress.com
2. Head on over to http://calypso.localhost:3000/v2/me/profile and try to change your username. Try making an error hint appear i.e. confirm username field not matching with the new username, username too short, or username is already in use, or try a blank username field in the confirmation box. Not sure what other scenarios I've missed.
3. Then, edit your first name or last name.
4. 'Save Button' should be disabled :) . NOTE: If there are no changes made to other fields i.e. first name, last name, email, the save button would be disabled also.

| Before | After |
|--------|--------|
| <img width="678" height="720" alt="image" src="https://github.com/user-attachments/assets/c908f3bb-32cf-41a6-afad-9df85e7162fd" /> _I changed my first name, and then caused an error in the username fields_ | <img width="679" height="715" alt="image" src="https://github.com/user-attachments/assets/7cf052d3-0b90-4dc9-8f27-60019e34912d" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
