### PR TITLE
HelpCenter: force email support for users blocked from chat

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -32,7 +32,7 @@ export function HelpCenterChat( {
 	const siteUrl = params.get( 'siteUrl' );
 	const siteId = params.get( 'siteId' );
 
-	const { forceEmailSupport, isBlockedFromChat } = useChatStatus();
+	const { forceEmailSupport, isChatRestricted } = useChatStatus();
 
 	useEffect( () => {
 		if ( preventOdieAccess ) {
@@ -55,7 +55,7 @@ export function HelpCenterChat( {
 			userFieldFlowName={ userFieldFlowName ?? params.get( 'userFieldFlowName' ) }
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			forceEmailSupport={ Boolean( forceEmailSupport ) }
-			isBlockedFromChat={ Boolean( isBlockedFromChat ) }
+			isChatRestricted={ Boolean( isChatRestricted ) }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -32,7 +32,7 @@ export function HelpCenterChat( {
 	const siteUrl = params.get( 'siteUrl' );
 	const siteId = params.get( 'siteId' );
 
-	const { forceEmailSupport } = useChatStatus();
+	const { forceEmailSupport, isBlockedFromChat } = useChatStatus();
 
 	useEffect( () => {
 		if ( preventOdieAccess ) {
@@ -55,6 +55,7 @@ export function HelpCenterChat( {
 			userFieldFlowName={ userFieldFlowName ?? params.get( 'userFieldFlowName' ) }
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			forceEmailSupport={ Boolean( forceEmailSupport ) }
+			isBlockedFromChat={ Boolean( isBlockedFromChat ) }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -60,36 +60,39 @@ export const BlockedZendeskNotice: React.FC = () => {
 	);
 };
 
-export const EmailFallbackNotice: React.FC = () => {
+export const EmailFallbackNotice: React.FC< { isBlocked?: boolean } > = ( {
+	isBlocked = false,
+} ) => {
 	const navigate = useNavigate();
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	params.set( 'wapuuFlow', 'true' );
 	const url = '/contact-form?' + params.toString();
+
+	const title = isBlocked
+		? __( 'Live chat is currently unavailable.', __i18n_text_domain__ )
+		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
+
+	const message = __(
+				'Please reach out via <email>email</email> if you need immediate assistance.',
+				__i18n_text_domain__
+		  );
+
 	return (
 		<div className="help-center__notice email-fallback-notice">
 			<Icon icon={ info } className="help-center__notice-icon" />
 			<p>
-				{ __(
-					'Live chat is temporarily unavailable for scheduled maintenance.',
-					__i18n_text_domain__
-				) }
+				<strong>{ title }</strong>
 				&nbsp;
-				{ createInterpolateElement(
-					__(
-						'Please reach out via <email>email</email> if you need immediate assistance.',
-						__i18n_text_domain__
+				{ createInterpolateElement( message, {
+					email: (
+						<Button
+							variant="link"
+							className="help-center__notice-link"
+							onClick={ () => navigate( url ) }
+						/>
 					),
-					{
-						email: (
-							<Button
-								variant="link"
-								className="help-center__notice-link"
-								onClick={ () => navigate( url ) }
-							/>
-						),
-					}
-				) }
+				} ) }
 			</p>
 		</div>
 	);

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -9,6 +9,7 @@ import { Icon, info } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
+import { useSupportStatus } from '../data/use-support-status';
 import useChatStatus from '../hooks/use-chat-status';
 import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
@@ -60,21 +61,20 @@ export const BlockedZendeskNotice: React.FC = () => {
 	);
 };
 
-export const EmailFallbackNotice: React.FC< { isBlocked?: boolean } > = ( {
-	isBlocked = false,
-} ) => {
+export const EmailFallbackNotice: React.FC = () => {
 	const navigate = useNavigate();
 	const { search } = useLocation();
+	const { data: supportStatus } = useSupportStatus();
 	const params = new URLSearchParams( search );
 	params.set( 'wapuuFlow', 'true' );
 	const url = '/contact-form?' + params.toString();
 
-	const title = isBlocked
+	const title = supportStatus?.eligibility?.is_chat_restricted
 		? __( 'Live chat is currently unavailable.', __i18n_text_domain__ )
 		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
 
 	const message = __(
-		'Please reach out via <email>email</email> if you need immediate assistance.',
+		'Please reach out via <email>email</email> if you need assistance.',
 		__i18n_text_domain__
 	);
 

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -74,9 +74,9 @@ export const EmailFallbackNotice: React.FC< { isBlocked?: boolean } > = ( {
 		: __( 'Live chat is temporarily unavailable for scheduled maintenance.', __i18n_text_domain__ );
 
 	const message = __(
-				'Please reach out via <email>email</email> if you need immediate assistance.',
-				__i18n_text_domain__
-		  );
+		'Please reach out via <email>email</email> if you need immediate assistance.',
+		__i18n_text_domain__
+	);
 
 	return (
 		<div className="help-center__notice email-fallback-notice">

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -21,6 +21,6 @@ export function useSupportStatus( enabled = true ) {
 		enabled,
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
-		staleTime: 100, // 100  ms, just to prevent refreshing the data on every render.
+		staleTime: 180000, // 3mins.
 	} );
 }

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -29,5 +29,6 @@ export default function useChatStatus() {
 		supportActivity,
 		supportLevel: supportStatus?.eligibility?.support_level,
 		forceEmailSupport,
+		isBlockedFromChat: supportStatus?.eligibility?.is_blocked_from_chat,
 	};
 }

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -29,6 +29,6 @@ export default function useChatStatus() {
 		supportActivity,
 		supportLevel: supportStatus?.eligibility?.support_level,
 		forceEmailSupport,
-		isBlockedFromChat: supportStatus?.eligibility?.is_blocked_from_chat,
+		isBlockedFromChat: supportStatus?.eligibility?.is_chat_restricted,
 	};
 }

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -29,6 +29,6 @@ export default function useChatStatus() {
 		supportActivity,
 		supportLevel: supportStatus?.eligibility?.support_level,
 		forceEmailSupport,
-		isBlockedFromChat: supportStatus?.eligibility?.is_chat_restricted,
+		isChatRestricted: supportStatus?.eligibility?.is_chat_restricted,
 	};
 }

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -95,6 +95,7 @@ interface Availability {
 
 interface Eligibility {
 	is_user_eligible: boolean;
+	is_blocked_from_chat: boolean;
 	wapuu_assistant_enabled: boolean;
 	support_level:
 		| 'free'

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -95,7 +95,7 @@ interface Availability {
 
 interface Eligibility {
 	is_user_eligible: boolean;
-	is_blocked_from_chat: boolean;
+	is_chat_restricted: boolean;
 	wapuu_assistant_enabled: boolean;
 	support_level:
 		| 'free'

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -60,8 +60,14 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, canConnectToZendesk, forceEmailSupport, isBlockedFromChat, chat } =
-		useOdieAssistantContext();
+	const {
+		isUserEligibleForPaidSupport,
+		trackEvent,
+		canConnectToZendesk,
+		forceEmailSupport,
+		isBlockedFromChat,
+		chat,
+	} = useOdieAssistantContext();
 
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -27,6 +27,7 @@ const getDisplayMessage = (
 	messageContent: ReactNode,
 	hasCannedResponse?: boolean,
 	forceEmailSupport?: boolean,
+	isBlockedFromChat?: boolean,
 	isErrorMessage?: boolean
 ) => {
 	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk ) {
@@ -38,7 +39,7 @@ const getDisplayMessage = (
 	}
 
 	if ( isUserEligibleForPaidSupport && forceEmailSupport ) {
-		return getOdieEmailFallbackMessageContent();
+		return getOdieEmailFallbackMessageContent( { isBlockedFromChat } );
 	}
 
 	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
@@ -59,7 +60,7 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, canConnectToZendesk, forceEmailSupport, chat } =
+	const { isUserEligibleForPaidSupport, trackEvent, canConnectToZendesk, forceEmailSupport, isBlockedFromChat, chat } =
 		useOdieAssistantContext();
 
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
@@ -78,6 +79,7 @@ export const UserMessage = ( {
 				message.content,
 				hasCannedResponse,
 				forceEmailSupport,
+				isBlockedFromChat,
 				message?.context?.flags?.is_error_message
 		  )
 		: message.content;

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -27,7 +27,7 @@ const getDisplayMessage = (
 	messageContent: ReactNode,
 	hasCannedResponse?: boolean,
 	forceEmailSupport?: boolean,
-	isBlockedFromChat?: boolean,
+	isChatRestricted?: boolean,
 	isErrorMessage?: boolean
 ) => {
 	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk ) {
@@ -39,7 +39,7 @@ const getDisplayMessage = (
 	}
 
 	if ( isUserEligibleForPaidSupport && forceEmailSupport ) {
-		return getOdieEmailFallbackMessageContent( { isBlockedFromChat } );
+		return getOdieEmailFallbackMessageContent( isChatRestricted );
 	}
 
 	if ( isErrorMessage && ! isUserEligibleForPaidSupport ) {
@@ -65,7 +65,7 @@ export const UserMessage = ( {
 		trackEvent,
 		canConnectToZendesk,
 		forceEmailSupport,
-		isBlockedFromChat,
+		isChatRestricted,
 		chat,
 	} = useOdieAssistantContext();
 
@@ -85,7 +85,7 @@ export const UserMessage = ( {
 				message.content,
 				hasCannedResponse,
 				forceEmailSupport,
-				isBlockedFromChat,
+				isChatRestricted,
 				message?.context?.flags?.is_error_message
 		  )
 		: message.content;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -25,8 +25,7 @@ const getTextAreaPlaceholder = (
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const textareaRef = useRef< HTMLTextAreaElement >( null );
-	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport, isBlockedFromChat } =
-		useOdieAssistantContext();
+	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport } = useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
 			! canConnectToZendesk ) ??
@@ -176,7 +175,7 @@ export const OdieSendMessageButton = () => {
 		<>
 			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
 				{ isEmailFallback ? (
-					<EmailFallbackNotice isBlocked={ isBlockedFromChat } />
+					<EmailFallbackNotice />
 				) : (
 					<AgentUIFooter
 						value={ inputValue }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -25,7 +25,8 @@ const getTextAreaPlaceholder = (
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const textareaRef = useRef< HTMLTextAreaElement >( null );
-	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport } = useOdieAssistantContext();
+	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport, isBlockedFromChat } =
+		useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
 			! canConnectToZendesk ) ??
@@ -175,7 +176,7 @@ export const OdieSendMessageButton = () => {
 		<>
 			<div className="odie-chat-message-input-container agenttic" ref={ divContainerRef }>
 				{ isEmailFallback ? (
-					<EmailFallbackNotice />
+					<EmailFallbackNotice isBlocked={ isBlockedFromChat } />
 				) : (
 					<AgentUIFooter
 						value={ inputValue }

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -84,13 +84,13 @@ export const getOdieEmailFallbackMessageContent = ( {
 }: { isBlockedFromChat?: boolean } = {} ): string =>
 	isBlockedFromChat
 		? `${ __(
-		"I’m sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
-		__i18n_text_domain__
-	) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`
-		: __(
-				'We’re sorry, but live chat is temporarily unavailable for scheduled maintenance. Please feel free to reach out via email or check our Support Guides in the meantime.',
+				"I’m sorry, our human chat support is unavailable, but I'm here and ready to assist.",
 				__i18n_text_domain__
-		  );
+		  ) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`
+		: `${ __(
+				"I’m sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
+				__i18n_text_domain__
+		  ) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`;
 
 export const getOdieEmailFallbackMessage = (): Message => ( {
 	content: getOdieEmailFallbackMessageContent(),

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -79,10 +79,8 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		__i18n_text_domain__
 	) }`;
 
-export const getOdieEmailFallbackMessageContent = ( {
-	isBlockedFromChat = false,
-}: { isBlockedFromChat?: boolean } = {} ): string => {
-	const unavailableMessage = isBlockedFromChat
+export const getOdieEmailFallbackMessageContent = ( isChatRestricted = false ): string => {
+	const unavailableMessage = isChatRestricted
 		? __(
 				"I'm sorry, our human chat support is unavailable, but I'm here and ready to assist.",
 				__i18n_text_domain__

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -79,11 +79,18 @@ export const getOdieThirdPartyMessageContent = (): string =>
 		__i18n_text_domain__
 	) }`;
 
-export const getOdieEmailFallbackMessageContent = (): string =>
-	`${ __(
+export const getOdieEmailFallbackMessageContent = ( {
+	isBlockedFromChat = false,
+}: { isBlockedFromChat?: boolean } = {} ): string =>
+	isBlockedFromChat
+		? `${ __(
 		"I’m sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
 		__i18n_text_domain__
-	) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`;
+	) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`
+		: __(
+				'We’re sorry, but live chat is temporarily unavailable for scheduled maintenance. Please feel free to reach out via email or check our Support Guides in the meantime.',
+				__i18n_text_domain__
+		  );
 
 export const getOdieEmailFallbackMessage = (): Message => ( {
 	content: getOdieEmailFallbackMessageContent(),

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -81,16 +81,20 @@ export const getOdieThirdPartyMessageContent = (): string =>
 
 export const getOdieEmailFallbackMessageContent = ( {
 	isBlockedFromChat = false,
-}: { isBlockedFromChat?: boolean } = {} ): string =>
-	isBlockedFromChat
-		? `${ __(
-				"I’m sorry, our human chat support is unavailable, but I'm here and ready to assist.",
+}: { isBlockedFromChat?: boolean } = {} ): string => {
+	const unavailableMessage = isBlockedFromChat
+		? __(
+				"I'm sorry, our human chat support is unavailable, but I'm here and ready to assist.",
 				__i18n_text_domain__
-		  ) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`
-		: `${ __(
-				"I’m sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
+		  )
+		: __(
+				"I'm sorry, our human chat support is down for maintenance, but I'm here and ready to assist.",
 				__i18n_text_domain__
-		  ) } \n\n ${ __( 'What can I help you with?', __i18n_text_domain__ ) }`;
+		  );
+
+	const followUp = __( 'What can I help you with?', __i18n_text_domain__ );
+	return `${ unavailableMessage } \n\n ${ followUp }`;
+};
 
 export const getOdieEmailFallbackMessage = (): Message => ( {
 	content: getOdieEmailFallbackMessageContent(),

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -50,6 +50,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	setMessageLikedStatus: noop,
 	trackEvent: noop,
 	forceEmailSupport: false,
+	isBlockedFromChat: false,
 } );
 
 // Custom hook to access the OdieAssistantContext
@@ -73,6 +74,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	version = null,
 	currentUser,
 	forceEmailSupport = false,
+	isBlockedFromChat = false,
 	children,
 } ) => {
 	const { botNameSlug, isMinimized, isChatLoaded } = useSelect( ( select ) => {
@@ -204,6 +206,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				trackEvent,
 				version: overriddenVersion,
 				forceEmailSupport,
+				isBlockedFromChat,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -50,7 +50,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	setMessageLikedStatus: noop,
 	trackEvent: noop,
 	forceEmailSupport: false,
-	isBlockedFromChat: false,
+	isChatRestricted: false,
 } );
 
 // Custom hook to access the OdieAssistantContext
@@ -74,7 +74,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	version = null,
 	currentUser,
 	forceEmailSupport = false,
-	isBlockedFromChat = false,
+	isChatRestricted = false,
 	children,
 } ) => {
 	const { botNameSlug, isMinimized, isChatLoaded } = useSelect( ( select ) => {
@@ -206,7 +206,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				trackEvent,
 				version: overriddenVersion,
 				forceEmailSupport,
-				isBlockedFromChat,
+				isChatRestricted,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -21,6 +21,7 @@ export type OdieAssistantContextInterface = {
 	userFieldMessage?: string | null;
 	userFieldFlowName?: string | null;
 	forceEmailSupport: boolean;
+	isBlockedFromChat: boolean;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
@@ -43,6 +44,7 @@ export type OdieAssistantProviderProps = {
 	userFieldFlowName?: string | null;
 	version?: string | null;
 	forceEmailSupport?: boolean;
+	isBlockedFromChat?: boolean;
 	children?: ReactNode;
 	setChatStatus?: ( status: ChatStatus ) => void;
 } & PropsWithChildren;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -21,7 +21,7 @@ export type OdieAssistantContextInterface = {
 	userFieldMessage?: string | null;
 	userFieldFlowName?: string | null;
 	forceEmailSupport: boolean;
-	isBlockedFromChat: boolean;
+	isChatRestricted: boolean;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
@@ -44,7 +44,7 @@ export type OdieAssistantProviderProps = {
 	userFieldFlowName?: string | null;
 	version?: string | null;
 	forceEmailSupport?: boolean;
-	isBlockedFromChat?: boolean;
+	isChatRestricted?: boolean;
 	children?: ReactNode;
 	setChatStatus?: ( status: ChatStatus ) => void;
 } & PropsWithChildren;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTSUP-299

193719-ghe-Automattic/wpcom

## Proposed Changes

* Wire isChatBlocked based on the backend
* Display different notice in this case

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For users with blocked chat access, the chat should not be available. Only email support

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the related patch 193719-ghe-Automattic/wpcom
* Build this branch: `yarn && yarn start`
* Block your testing user from chat access in the RC
* When accessing an active chat with support there should be also a notice displayed
* When escalating to support via odie, it should happen via email not chat
* Revert the blocking of the user and test for regressions
* Switch force-email-support-test and test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
