### PR TITLE
Deployments: dont render repos if github is not authorized

### DIFF
--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Card, CardBody, ExternalLink } from '@wordpress/components';
+import { Card, CardBody, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -70,15 +70,15 @@ export default function ConfigureRepository() {
 						formTitle={ __( 'Update connection details' ) }
 						formDescription={ createInterpolateElement(
 							__(
-								'Update the connection used to deploy a GitHub repository to your WordPress.com site. Missing GitHub repositories? <adjustPermissions />'
+								'Update the connection used to deploy a GitHub repository to your WordPress.com site. Missing GitHub repositories? <a>Adjust permissions on GitHub</a>'
 							),
 							{
-								adjustPermissions: (
-									<ExternalLink
+								a: (
+									<Button
+										variant="link"
+										target="_blank"
 										href={ `https://github.com/settings/installations/${ selectedInstallation?.external_id }` }
-									>
-										{ __( 'Adjust permissions on GitHub' ) }
-									</ExternalLink>
+									/>
 								),
 							}
 						) }

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Card, CardBody, ExternalLink } from '@wordpress/components';
+import { Card, CardBody, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -59,15 +59,15 @@ export default function ConnectRepository() {
 						formTitle={ __( 'Configure repository connection' ) }
 						formDescription={ createInterpolateElement(
 							__(
-								'Configure a repository connection to deploy a GitHub repository to your WordPress.com site. Missing GitHub repositories? <adjustPermissions />'
+								'Configure a repository connection to deploy a GitHub repository to your WordPress.com site. Missing GitHub repositories? <a>Adjust permissions on GitHub</a>'
 							),
 							{
-								adjustPermissions: (
-									<ExternalLink
+								a: (
+									<Button
+										variant="link"
+										target="_blank"
 										href={ `https://github.com/settings/installations/${ installations[ 0 ]?.external_id }` }
-									>
-										{ __( 'Adjust permissions on GitHub' ) }
-									</ExternalLink>
+									/>
 								),
 							}
 						) }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -1,5 +1,9 @@
 import { CodeDeploymentData, HostingFeatures } from '@automattic/api-core';
-import { siteBySlugQuery, codeDeploymentsQuery } from '@automattic/api-queries';
+import {
+	siteBySlugQuery,
+	codeDeploymentsQuery,
+	githubInstallationsQuery,
+} from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
@@ -32,9 +36,15 @@ function RepositoriesList() {
 	const router = useRouter();
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { error: githubInstallationsError, isLoading: isLoadingInstallations } = useQuery(
+		githubInstallationsQuery()
+	);
+
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
-	const { data: deployments = [], isLoading } = useQuery( codeDeploymentsQuery( site.ID ) );
+	const { data: deployments = [], isLoading: isLoadingDeployments } = useQuery(
+		codeDeploymentsQuery( site.ID )
+	);
 
 	const fields = useRepositoryFields();
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( deployments, view, fields );
@@ -100,12 +110,12 @@ function RepositoriesList() {
 	return (
 		<DataViewsCard>
 			<DataViews
-				data={ filteredData }
+				data={ isLoadingInstallations || githubInstallationsError ? [] : filteredData }
 				fields={ fields }
 				view={ view }
 				onChangeView={ setView }
 				actions={ actions }
-				isLoading={ isLoading }
+				isLoading={ isLoadingDeployments || isLoadingInstallations }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item ) => item.id.toString() }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -8,6 +8,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keyboardReturn, Icon } from '@wordpress/icons';
 import { useState } from 'react';
@@ -102,10 +103,28 @@ function RepositoriesList() {
 		},
 	];
 
+	let emptyTitle;
 	const hasFilterOrSearch = ( view.filters && view.filters.length > 0 ) || view.search;
-	const emptyTitle = hasFilterOrSearch
-		? __( 'No repositories found' )
-		: __( 'No repositories connected' );
+
+	if ( githubInstallationsError ) {
+		emptyTitle = createInterpolateElement(
+			__( 'No repositories available. <a>Check your GitHub connection</a>.' ),
+			{
+				a: (
+					<Button
+						variant="link"
+						onClick={ () =>
+							router.navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } )
+						}
+					/>
+				),
+			}
+		);
+	} else if ( hasFilterOrSearch ) {
+		emptyTitle = __( 'No repositories found' );
+	} else {
+		emptyTitle = __( 'No repositories connected' );
+	}
 
 	return (
 		<DataViewsCard>


### PR DESCRIPTION
Fixes: DOTDASH-628

## Why are these changes being made?
If user has connected repos but revoiked github installation, then we should not render repos.

## Testing Instructions
1. Open Settings -> Repositories
2. Click Connect repository
3. Authorize and cvonnect a few repos
4. Open https://github.com/settings/apps/authorizations
5. Revoke WordPress.com 
6. Open Settings -> Repositories
7. Assert that you don't see connected repos<br /><img width="719" height="304" alt="Screenshot 2025-10-09 at 16 41 42" src="https://github.com/user-attachments/assets/54cd6b1b-a8e4-4d45-9e42-2ffee73a014f" />
8. Click on Connect repository and Install wordpress.com app
9. Open Settings -> Repositories
10. Assert that you see connected repos again
