### PR TITLE
Hosting Dashboard: Replace me-purchases with upgrades endpoint

### DIFF
--- a/packages/api-core/src/me-purchases/fetchers.ts
+++ b/packages/api-core/src/me-purchases/fetchers.ts
@@ -2,14 +2,6 @@ import { normalizePurchase } from '../purchase';
 import { wpcom } from '../wpcom-fetcher';
 import type { Purchase } from '../purchase';
 
-export async function fetchUserPurchases(): Promise< Purchase[] > {
-	const data = await wpcom.req.get( {
-		path: '/me/purchases',
-		apiVersion: '1.2',
-	} );
-	return data.map( normalizePurchase );
-}
-
 export async function fetchUserTransferredPurchases(): Promise< Purchase[] > {
 	const data = await wpcom.req.get( {
 		path: '/me/purchases/transferred',

--- a/packages/api-core/src/upgrades/fetchers.ts
+++ b/packages/api-core/src/upgrades/fetchers.ts
@@ -2,6 +2,14 @@ import { normalizePurchase } from '../purchase';
 import { wpcom } from '../wpcom-fetcher';
 import type { Purchase } from '../purchase';
 
+export async function fetchUserPurchases(): Promise< Purchase[] > {
+	const data = await wpcom.req.get( {
+		path: '/upgrades',
+		apiVersion: '1.2',
+	} );
+	return data.map( normalizePurchase );
+}
+
 export async function fetchPurchase( purchaseId: number ): Promise< Purchase > {
 	const data = await wpcom.req.get( {
 		path: `/upgrades/${ purchaseId }`,

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -93,3 +93,4 @@ export * from './site-users';
 export * from './site-wordpress-version';
 export * from './site';
 export * from './sites';
+export * from './upgrades';

--- a/packages/api-queries/src/me-purchases.ts
+++ b/packages/api-queries/src/me-purchases.ts
@@ -1,17 +1,5 @@
-import {
-	fetchUserPurchases,
-	fetchUserTransferredPurchases,
-	setPurchaseAutoRenew,
-	fetchPurchase,
-} from '@automattic/api-core';
-import { queryOptions, mutationOptions } from '@tanstack/react-query';
-import { queryClient } from './query-client';
-
-export const userPurchasesQuery = () =>
-	queryOptions( {
-		queryKey: [ 'me', 'purchases' ],
-		queryFn: () => fetchUserPurchases(),
-	} );
+import { fetchUserTransferredPurchases } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
 
 export function userTransferredPurchasesQuery() {
 	return queryOptions( {
@@ -19,17 +7,3 @@ export function userTransferredPurchasesQuery() {
 		queryFn: () => fetchUserTransferredPurchases(),
 	} );
 }
-
-export const purchaseQuery = ( purchaseId: number ) =>
-	queryOptions( {
-		queryKey: [ 'me', 'purchases', purchaseId ],
-		queryFn: () => fetchPurchase( purchaseId ),
-	} );
-
-export const userPurchaseSetAutoRenewQuery = ( purchaseId: number ) =>
-	mutationOptions( {
-		mutationFn: ( autoRenew: boolean ) => setPurchaseAutoRenew( purchaseId, autoRenew ),
-		onSuccess: ( data ) => {
-			queryClient.setQueryData( purchaseQuery( purchaseId ).queryKey, data.upgrade );
-		},
-	} );

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -1,0 +1,23 @@
+import { fetchUserPurchases, setPurchaseAutoRenew, fetchPurchase } from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+
+export const userPurchasesQuery = () =>
+	queryOptions( {
+		queryKey: [ 'upgrades' ],
+		queryFn: () => fetchUserPurchases(),
+	} );
+
+export const purchaseQuery = ( purchaseId: number ) =>
+	queryOptions( {
+		queryKey: [ 'upgrades', purchaseId ],
+		queryFn: () => fetchPurchase( purchaseId ),
+	} );
+
+export const userPurchaseSetAutoRenewQuery = ( purchaseId: number ) =>
+	mutationOptions( {
+		mutationFn: ( autoRenew: boolean ) => setPurchaseAutoRenew( purchaseId, autoRenew ),
+		onSuccess: ( data ) => {
+			queryClient.setQueryData( purchaseQuery( purchaseId ).queryKey, data.upgrade );
+		},
+	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1115

## Proposed Changes

This PR refactors the user purchases list endpoint in the hosting dashboard to use `/upgrades` instead of `/me/purchases` (they are identical – see 193531-ghe-Automattic/wpcom). This more closely aligns the purchase list endpoint with the other purchase endpoints that all are under `/upgrades`.

After this, the only purchases endpoints still outside of the `/upgrades` path are `/sites/%s/purchases` and `/me/purchases/transferred`, which are both specialized versions of the user purchases list endpoint. I'll update both in a later PR.

(We might want to further clarify by renaming all the "purchase" terminology to "upgrade" in the types and function names but that's a much bigger change that can wait until a later date.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The purchases endpoints cover a wide range of paths, but most of them are under the `/upgrades` path, like `/upgrades/%s` and `/upgrades/%s/enable-auto-renew` and `/upgrades/%s/assign-payment-method`. For clarity and discoverability, it would be nice to align all of them into the same path, particularly for the hosting dashboard where they are organized by path and use the path as the query key.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/v2/me/billing/purchases and verify that you see a list of your purchases.

Since this doesn't change the exported function names, it should be safe.