### PR TITLE
Domain Search Rewrite: Add unavailable search result tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -111,6 +111,7 @@ const DomainSearchStep: StepType< {
 				isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow )
 					? HUNDRED_YEAR_DOMAIN_TLDS
 					: allowedTlds,
+			includeOwnedDomainInSuggestions: true,
 			allowsUsingOwnDomain:
 				! isAIBuilderFlow( flow ) &&
 				! isNewHostedSiteCreationFlow( flow ) &&

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -56,6 +56,7 @@ export default function DomainSearch() {
 			} ),
 			allowedTlds,
 			skippable: false,
+			allowsUsingOwnDomain: true,
 		};
 	}, [ tldQuery ] );
 

--- a/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
+++ b/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
@@ -1,0 +1,286 @@
+import { DomainAvailabilityStatus } from '@automattic/api-core';
+import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UnavailableSearchResult } from '..';
+import { buildAvailability } from '../../../test-helpers/factories/availability';
+import { buildSuggestion } from '../../../test-helpers/factories/suggestions';
+import { mockGetAvailabilityQuery } from '../../../test-helpers/queries/availability';
+import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
+import { TestDomainSearchWithSuggestions } from '../../../test-helpers/renderer';
+
+const GENERIC_STATUSES = [
+	DomainAvailabilityStatus.TRANSFERRABLE,
+	DomainAvailabilityStatus.TRANSFERRABLE_PREMIUM,
+	DomainAvailabilityStatus.MAPPABLE,
+	DomainAvailabilityStatus.MAPPED,
+];
+
+const SPECIAL_STATUSES = [
+	DomainAvailabilityStatus.TLD_NOT_SUPPORTED,
+	DomainAvailabilityStatus.TLD_NOT_SUPPORTED_TEMPORARILY,
+	DomainAvailabilityStatus.UNKNOWN,
+];
+
+const STATUSES_WITH_MESSAGES = [ ...GENERIC_STATUSES, ...SPECIAL_STATUSES ];
+
+const ALL_OTHER_STATUSES = Object.values( DomainAvailabilityStatus ).filter(
+	( status ) => ! STATUSES_WITH_MESSAGES.includes( status )
+);
+
+describe( 'UnavailableSearchResult', () => {
+	it.each( GENERIC_STATUSES )(
+		'renders the already registered message if the availability status is %s',
+		async ( status ) => {
+			mockGetSuggestionsQuery( {
+				params: { query: `test-${ status }.com` },
+				suggestions: [ buildSuggestion( { domain_name: `test-${ status }.com` } ) ],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: `test-${ status }.com` },
+				availability: buildAvailability( {
+					domain_name: `test-${ status }.com`,
+					tld: 'com',
+					status,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestions
+					query={ `test-${ status }.com` }
+					config={ { allowsUsingOwnDomain: true } }
+				>
+					<UnavailableSearchResult />
+				</TestDomainSearchWithSuggestions>
+			);
+
+			await waitFor( () => screen.getByText( /is already registered./ ) );
+
+			expect( screen.getByText( /is already registered./ ) ).toHaveTextContent(
+				`test-${ status }.com is already registered.`
+			);
+		}
+	);
+
+	it( 'renders the tld not supported message if the availability status is tld_not_supported', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'woo.test.boston' },
+			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],
+		} );
+
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'woo.test.boston' },
+			availability: buildAvailability( {
+				domain_name: 'woo.test.boston',
+				tld: 'boston',
+				status: DomainAvailabilityStatus.TLD_NOT_SUPPORTED,
+			} ),
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions
+				query="woo.test.boston"
+				config={ { allowsUsingOwnDomain: true } }
+			>
+				<UnavailableSearchResult />
+			</TestDomainSearchWithSuggestions>
+		);
+
+		await waitFor( () => screen.getByText( /domains are not available/i ) );
+
+		expect( screen.getByText( /domains are not available/i ) ).toHaveTextContent(
+			'.boston domains are not available for registration on WordPress.com.'
+		);
+	} );
+
+	it( 'renders the tld not supported message if the availability status is unknown', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'woo.test.boston' },
+			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],
+		} );
+
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'woo.test.boston' },
+			availability: buildAvailability( {
+				domain_name: 'woo.test.boston',
+				tld: 'boston',
+				status: DomainAvailabilityStatus.UNKNOWN,
+			} ),
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions
+				query="woo.test.boston"
+				config={ { allowsUsingOwnDomain: true } }
+			>
+				<UnavailableSearchResult />
+			</TestDomainSearchWithSuggestions>
+		);
+
+		await waitFor( () => screen.getByText( /domains are not available/i ) );
+
+		expect( screen.getByText( /domains are not available/i ) ).toHaveTextContent(
+			'.boston domains are not available for registration on WordPress.com.'
+		);
+	} );
+
+	it( 'renders the tld not supported temporarily message if the availability status is tld_not_supported_temporarily', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'woo.test.boston' },
+			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],
+		} );
+
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'woo.test.boston' },
+			availability: buildAvailability( {
+				domain_name: 'woo.test.boston',
+				tld: 'boston',
+				status: DomainAvailabilityStatus.TLD_NOT_SUPPORTED_TEMPORARILY,
+			} ),
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions
+				query="woo.test.boston"
+				config={ { allowsUsingOwnDomain: true } }
+			>
+				<UnavailableSearchResult />
+			</TestDomainSearchWithSuggestions>
+		);
+
+		await waitFor( () => screen.getByText( /domains are temporarily not offered/i ) );
+
+		expect( screen.getByText( /domains are temporarily not offered/i ) ).toHaveTextContent(
+			'.boston domains are temporarily not offered on WordPress.com. Please try again later or choose a different extension.'
+		);
+	} );
+
+	describe( 'bring it over cta', () => {
+		it( 'calls onExternalDomainClick if config.allowsUsingOwnDomain is true', async () => {
+			const onExternalDomainClick = jest.fn();
+			const user = userEvent.setup();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'woo.test.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'woo.test.com' },
+				availability: buildAvailability( {
+					domain_name: 'woo.test.com',
+					tld: 'com',
+					status: DomainAvailabilityStatus.TRANSFERRABLE,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestions
+					query="woo.test.com"
+					config={ { allowsUsingOwnDomain: true } }
+					events={ { onExternalDomainClick } }
+				>
+					<UnavailableSearchResult />
+				</TestDomainSearchWithSuggestions>
+			);
+
+			await user.click( await screen.findByText( 'Bring it over' ) );
+
+			expect( onExternalDomainClick ).toHaveBeenCalledWith( 'test.com' );
+		} );
+
+		it( 'does not expose bring it over cta if config.allowsUsingOwnDomain is false', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'woo.test.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'woo.test.com' },
+				availability: buildAvailability( {
+					domain_name: 'woo.test.com',
+					tld: 'com',
+					status: DomainAvailabilityStatus.TRANSFERRABLE,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearchWithSuggestions
+					query="woo.test.com"
+					config={ { allowsUsingOwnDomain: false } }
+				>
+					<UnavailableSearchResult />
+				</TestDomainSearchWithSuggestions>
+			);
+
+			await waitFor( () => screen.getByText( /is already registered./ ) );
+
+			expect( screen.queryByText( 'Bring it over' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders root domain name when the queried domain is a subdomain', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'woo.test.com' },
+			suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+		} );
+
+		mockGetAvailabilityQuery( {
+			params: { domainName: 'woo.test.com' },
+			availability: buildAvailability( {
+				domain_name: 'woo.test.com',
+				tld: 'com',
+				status: DomainAvailabilityStatus.TRANSFERRABLE,
+			} ),
+		} );
+
+		render(
+			<TestDomainSearchWithSuggestions query="woo.test.com">
+				<UnavailableSearchResult />
+			</TestDomainSearchWithSuggestions>
+		);
+
+		expect( await screen.findByText( /is already registered./ ) ).toHaveTextContent(
+			'test.com is already registered.'
+		);
+	} );
+
+	describe( 'no unavailable search result message', () => {
+		it( 'renders nothing if the availability query was not retrieved', async () => {
+			const { container } = render(
+				<TestDomainSearchWithSuggestions query="test">
+					<UnavailableSearchResult />
+				</TestDomainSearchWithSuggestions>
+			);
+
+			await waitForElementToBeRemoved( () => screen.getByText( 'LOADING_TEST_CONTENT' ) );
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		it.each( ALL_OTHER_STATUSES )(
+			'renders nothing if the availability status is %s',
+			async ( status ) => {
+				mockGetSuggestionsQuery( {
+					params: { query: `test-${ status }.com` },
+					suggestions: [ buildSuggestion( { domain_name: `test-${ status }.com` } ) ],
+				} );
+
+				const availabilityQuery = mockGetAvailabilityQuery( {
+					params: { domainName: `test-${ status }.com` },
+					availability: buildAvailability( { status } ),
+				} );
+
+				const { container } = render(
+					<TestDomainSearchWithSuggestions query={ `test-${ status }.com` }>
+						<UnavailableSearchResult />
+					</TestDomainSearchWithSuggestions>
+				);
+
+				await waitFor( () => expect( availabilityQuery.isDone() ).toBe( true ) );
+
+				expect( container ).toBeEmptyDOMElement();
+			}
+		);
+	} );
+} );

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -14,6 +14,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	events: {
 		onContinue: noop,
 		onSkip: noop,
+		onExternalDomainClick: noop,
 		onMakePrimaryAddressClick: noop,
 		onMoveDomainToSiteClick: noop,
 		onTransferDomainToWordPressComClick: noop,
@@ -60,8 +61,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		skippable: false,
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
-		allowsUsingOwnDomain: true,
-		includeOwnedDomainInSuggestions: true,
+		allowsUsingOwnDomain: false,
+		includeOwnedDomainInSuggestions: false,
 		allowedTlds: [],
 		priceRules: {
 			hidePrice: false,

--- a/packages/domain-search/src/page/test/initial-state.tsx
+++ b/packages/domain-search/src/page/test/initial-state.tsx
@@ -36,16 +36,6 @@ describe( 'InitialState', () => {
 		expect( screen.queryByText( /already have a domain/i ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'does not render the already own domain CTA when onExternalDomainClick is not provided', () => {
-		render(
-			<TestDomainSearch config={ { allowsUsingOwnDomain: true } }>
-				<InitialState />
-			</TestDomainSearch>
-		);
-
-		expect( screen.queryByText( /already have a domain/i ) ).not.toBeInTheDocument();
-	} );
-
 	it( 'calls onExternalDomainClick when CTA is clicked', () => {
 		const onExternalDomainClick = jest.fn();
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -34,7 +34,7 @@ export interface DomainSearchCart {
 export interface DomainSearchEvents {
 	onContinue: () => void;
 	onSkip: ( suggestion?: FreeDomainSuggestion ) => void;
-	onExternalDomainClick?: ( domainName?: string ) => void;
+	onExternalDomainClick: ( domainName?: string ) => void;
 	onMakePrimaryAddressClick: ( domainName: string ) => void;
 	onMoveDomainToSiteClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onTransferDomainToWordPressComClick: ( domainName: string ) => void;

--- a/packages/domain-search/src/test-helpers/queries/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/queries/suggestions.ts
@@ -20,7 +20,7 @@ export const mockGetSuggestionsQuery = ( {
 		quantity: 30,
 		vendor: 'variation2_front',
 		exact_sld_matches_only: false,
-		include_internal_move_eligible: true,
+		include_internal_move_eligible: false,
 		...rawParams,
 	};
 


### PR DESCRIPTION
Part of DOMAINS-1634.

## Proposed Changes

Adds tests to and reviews the unavailable search result logic. This banner is shown below the search bar if the domain isn't available:

<img width="1222" height="427" alt="image" src="https://github.com/user-attachments/assets/270062cb-e3cf-4b29-b230-2da4ad355e45" />

## Testing Instructions

Verify the tests are green!