### PR TITLE
Hosting Dashboard: Stop requesting performance report when API error returned.

### DIFF
--- a/packages/api-queries/src/site-performance.ts
+++ b/packages/api-queries/src/site-performance.ts
@@ -19,7 +19,6 @@ export const sitePerformanceInsightsQuery = ( url: string, token: string ) =>
 			if ( query.state.data?.pagespeed?.status === 'completed' || query.state.error ) {
 				return false;
 			}
-
 			return 5000;
 		},
 	} );

--- a/packages/api-queries/src/site-performance.ts
+++ b/packages/api-queries/src/site-performance.ts
@@ -16,9 +16,10 @@ export const sitePerformanceInsightsQuery = ( url: string, token: string ) =>
 		queryKey: [ 'performance', url, token ],
 		queryFn: () => fetchSitePerformanceInsights( url, token ),
 		refetchInterval: ( query ) => {
-			if ( query.state.data?.pagespeed?.status === 'completed' ) {
+			if ( query.state.data?.pagespeed?.status === 'completed' || query.state.error ) {
 				return false;
 			}
+
 			return 5000;
 		},
 	} );


### PR DESCRIPTION
Fixes: DOTCOM-14894.

## Proposed Changes

In testing #106344, the api returned a forbidden error but we continued to query the api for status. This PR kills the `refetchInterval` if an error is returned. The user can re-request a new report manually.

## Testing Instructions

1. Simulate an api error being returned from `/site-profiler/metrics/advanced/insights`.
2. Open your dev tools, see Network 
3. Load the performance page
4. Expect to see an error message on the page and no repeated api calls to `/site-profiler/metrics/advanced/insights`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
