### PR TITLE
Give the chart a height and remove its contrained width.

### DIFF
--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -209,55 +209,54 @@ export default function CoreMetricsChart( {
 					value={ formatThresholdValue( isOverall, 'bad' ) }
 				/>
 			</HStack>
-			<div style={ { maxWidth: '500px' } }>
-				{ lineChartData ? (
-					<LineChart
-						data={ lineChartData.seriesData }
-						withGradientFill={ false }
-						curveType="linear"
-						options={ {
-							yScale: lineChartData.yScale,
-							axis: {
-								y: {
-									tickFormat: ( value ) => `${ getFormattedNumber( value ) }`,
-								},
+			{ lineChartData ? (
+				<LineChart
+					height={ 300 }
+					data={ lineChartData.seriesData }
+					withGradientFill={ false }
+					curveType="linear"
+					options={ {
+						yScale: lineChartData.yScale,
+						axis: {
+							y: {
+								tickFormat: ( value ) => `${ getFormattedNumber( value ) }`,
 							},
-						} }
-						renderGlyph={ ( { key, x, y, datum } ) => {
-							const data = datum as { value: number };
-							const value = [ 'lcp', 'fcp', 'ttfb', 'inp', 'tbt' ].includes( metric )
-								? data.value * 1000
-								: data.value;
-							const valuation = mapThresholdsToStatus( metric, value );
-							const color = getColorForStatus( valuation );
-							const label = getStatusText( valuation );
-							if ( ! label.includes( key ) ) {
-								return null;
-							}
-							const GlyphComponent = StatusGlyph[ valuation ];
-							return <GlyphComponent top={ y } left={ x } size={ 100 } fill={ color } />;
-						} }
-						renderTooltip={ ( { tooltipData } ) => {
-							const nearestDatum = tooltipData?.nearestDatum?.datum;
-							if ( ! nearestDatum ) {
-								return null;
-							}
+						},
+					} }
+					renderGlyph={ ( { key, x, y, datum } ) => {
+						const data = datum as { value: number };
+						const value = [ 'lcp', 'fcp', 'ttfb', 'inp', 'tbt' ].includes( metric )
+							? data.value * 1000
+							: data.value;
+						const valuation = mapThresholdsToStatus( metric, value );
+						const color = getColorForStatus( valuation );
+						const label = getStatusText( valuation );
+						if ( ! label.includes( key ) ) {
+							return null;
+						}
+						const GlyphComponent = StatusGlyph[ valuation ];
+						return <GlyphComponent top={ y } left={ x } size={ 100 } fill={ color } />;
+					} }
+					renderTooltip={ ( { tooltipData } ) => {
+						const nearestDatum = tooltipData?.nearestDatum?.datum;
+						if ( ! nearestDatum ) {
+							return null;
+						}
 
-							const formattedDate = nearestDatum.date?.toLocaleDateString( undefined, {
-								month: 'short',
-								day: 'numeric',
-							} );
-							return [ formattedDate, nearestDatum.value ].join( ': ' );
-						} }
-					/>
-				) : (
-					<Notice title={ __( 'No history available' ) }>
-						{ __(
-							'The Chrome User Experience Report collects speed data from real site visits. Sites with low-traffic don‘t provide enough data to generate historical trends.'
-						) }
-					</Notice>
-				) }
-			</div>
+						const formattedDate = nearestDatum.date?.toLocaleDateString( undefined, {
+							month: 'short',
+							day: 'numeric',
+						} );
+						return [ formattedDate, nearestDatum.value ].join( ': ' );
+					} }
+				/>
+			) : (
+				<Notice title={ __( 'No history available' ) }>
+					{ __(
+						'The Chrome User Experience Report collects speed data from real site visits. Sites with low-traffic don‘t provide enough data to generate historical trends.'
+					) }
+				</Notice>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
This is branched from #106344, adding some non-agreed-upon changes yet.

## Proposed Changes

This includes a number of changes:
- Removes maxWidth on chart
- Restricts height to 300px.

| Before | After |
|--------|--------|
| <img width="1373" height="609" alt="Screenshot 2025-10-10 at 1 10 01 PM" src="https://github.com/user-attachments/assets/abb7ccc0-8154-4ce3-8745-2d04c208b8d5" /> | <img width="1393" height="690" alt="Screenshot 2025-10-10 at 1 09 37 PM" src="https://github.com/user-attachments/assets/e8e09f5d-aff3-4e28-a651-92c0b4ace872" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
