### PR TITLE
Marketplace: delist the Snap Pixel plugin

### DIFF
--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -1,9 +1,5 @@
 import { CodeDeploymentData, HostingFeatures } from '@automattic/api-core';
-import {
-	siteBySlugQuery,
-	codeDeploymentsQuery,
-	githubInstallationsQuery,
-} from '@automattic/api-queries';
+import { siteBySlugQuery, codeDeploymentsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
@@ -36,15 +32,9 @@ function RepositoriesList() {
 	const router = useRouter();
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { error: githubInstallationsError, isLoading: isLoadingInstallations } = useQuery(
-		githubInstallationsQuery()
-	);
-
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
-	const { data: deployments = [], isLoading: isLoadingDeployments } = useQuery(
-		codeDeploymentsQuery( site.ID )
-	);
+	const { data: deployments = [], isLoading } = useQuery( codeDeploymentsQuery( site.ID ) );
 
 	const fields = useRepositoryFields();
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( deployments, view, fields );
@@ -110,12 +100,12 @@ function RepositoriesList() {
 	return (
 		<DataViewsCard>
 			<DataViews
-				data={ isLoadingInstallations || githubInstallationsError ? [] : filteredData }
+				data={ filteredData }
 				fields={ fields }
 				view={ view }
 				onChangeView={ setView }
 				actions={ actions }
-				isLoading={ isLoadingDeployments || isLoadingInstallations }
+				isLoading={ isLoading }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item ) => item.id.toString() }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -1,5 +1,9 @@
 import { CodeDeploymentData, HostingFeatures } from '@automattic/api-core';
-import { siteBySlugQuery, codeDeploymentsQuery } from '@automattic/api-queries';
+import {
+	siteBySlugQuery,
+	codeDeploymentsQuery,
+	githubInstallationsQuery,
+} from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
@@ -32,9 +36,15 @@ function RepositoriesList() {
 	const router = useRouter();
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { error: githubInstallationsError, isLoading: isLoadingInstallations } = useQuery(
+		githubInstallationsQuery()
+	);
+
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
-	const { data: deployments = [], isLoading } = useQuery( codeDeploymentsQuery( site.ID ) );
+	const { data: deployments = [], isLoading: isLoadingDeployments } = useQuery(
+		codeDeploymentsQuery( site.ID )
+	);
 
 	const fields = useRepositoryFields();
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( deployments, view, fields );
@@ -100,12 +110,12 @@ function RepositoriesList() {
 	return (
 		<DataViewsCard>
 			<DataViews
-				data={ filteredData }
+				data={ isLoadingInstallations || githubInstallationsError ? [] : filteredData }
 				fields={ fields }
 				view={ view }
 				onChangeView={ setView }
 				actions={ actions }
-				isLoading={ isLoading }
+				isLoading={ isLoadingDeployments || isLoadingInstallations }
 				defaultLayouts={ DEFAULT_LAYOUTS }
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item ) => item.id.toString() }

--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -87,6 +87,7 @@ export const UNLISTED_PLUGINS = [
 	'social-blend',
 	'wp-fusion-lite',
 	'wp-persistent-login',
+	'snap-pixel',
 ];
 
 export const WPBEGINNER_PLUGINS = [


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related thread p1759994894173759-slack-C029JEQRVRT

## Proposed Changes

* This PR hides the plugin page itself
* 193717-ghe-Automattic/wpcom removed the plugin from searches and browse pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Trust & Safety team received a trademark complaint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?