### PR TITLE
Grid: add removeButton prop to Grid component

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -51,6 +51,7 @@ The main component exported by this package.
 - `minColumnWidth` (optional): Minimum width in pixels for each column; when provided, enables responsive mode that automatically adjusts columns based on container width
 - `editMode` (optional): Enables drag-and-drop reordering and resize functionality
 - `onChangeLayout` (optional): Callback fired when the layout changes (required when `editMode` is true)
+- `onRemoveItem` (optional): Callback fired when an item is removed from the grid. Receives the item's `key` as a string parameter. Use this to update your layout state when users remove items
 
 #### Child Components Props
 
@@ -69,6 +70,40 @@ Child components can accept special props that affect their behavior within the 
 	>
 		Card content
 	</Card>
+</Grid>
+```
+
+- `removeButton` (optional): A render prop function that receives an `onRemove` callback and returns React content. This allows you to create custom remove buttons with full control over styling and positioning. The function signature is: `(onRemove: () => void) => React.ReactNode`. When the user clicks your custom button, it will trigger the Grid's `onRemoveItem` callback with the item's key.
+
+```jsx
+// Example with custom remove button
+const [ layout, setLayout ] = useState( [
+	{ key: 'a', width: 2 },
+	{ key: 'b', width: 4 },
+] );
+
+<Grid
+	layout={ layout }
+	editMode
+	onChangeLayout={ setLayout }
+	onRemoveItem={ ( key ) => {
+		setLayout( ( prevLayout ) => prevLayout.filter( ( item ) => item.key !== key ) );
+	} }
+>
+	<Card
+		key="a"
+		removeButton={ ( onRemove ) => (
+			<button
+				onClick={ onRemove }
+				style={ { position: 'absolute', top: 8, right: 8, zIndex: 1 } }
+			>
+				×
+			</button>
+		) }
+	>
+		Card content
+	</Card>
+	<Card key="b">Another card</Card>
 </Grid>
 ```
 

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -46,7 +46,7 @@ type GridItemProps = {
 	/**
 	 * Callback fired when the item is being removed.
 	 */
-	onRemove?: ( id: GridLayoutItem ) => void;
+	onRemove?: ( key: string ) => void;
 
 	/**
 	 * Button to remove an item from the grid.
@@ -126,7 +126,7 @@ export function GridItem( {
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes }>
 			{ actionableArea }
-			{ removeButton && removeButton( () => onRemove?.( item ) ) }
+			{ removeButton && removeButton( () => onRemove?.( item.key ) ) }
 
 			<div { ...listeners } style={ { height: '100%' } }>
 				<div style={ contentStyle }>

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -42,6 +42,16 @@ type GridItemProps = {
 	 * Callback fired when resize operation ends.
 	 */
 	onResizeEnd: () => void;
+
+	/**
+	 * Callback fired when the item is being removed.
+	 */
+	onRemove?: ( id: GridLayoutItem ) => void;
+
+	/**
+	 * Button to remove an item from the grid.
+	 */
+	removeButton?: ( onRemove: () => void ) => React.ReactNode;
 };
 
 export function GridItem( {
@@ -52,6 +62,8 @@ export function GridItem( {
 	actionableArea = null,
 	onResize,
 	onResizeEnd,
+	onRemove,
+	removeButton,
 }: GridItemProps ) {
 	const [ previewDelta, setPreviewDelta ] = useState< { width: number; height: number } | null >(
 		null
@@ -114,6 +126,7 @@ export function GridItem( {
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes }>
 			{ actionableArea }
+			{ removeButton && removeButton( () => onRemove?.( item ) ) }
 
 			<div { ...listeners } style={ { height: '100%' } }>
 				<div style={ contentStyle }>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -16,6 +16,7 @@ export function Grid( {
 	minColumnWidth,
 	editMode = false,
 	onChangeLayout,
+	onRemoveItem,
 }: GridProps ) {
 	// Temporary layout to avoid updaing the layout while dragging
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
@@ -166,6 +167,8 @@ export function Grid( {
 							onResize={ ( delta ) => handleResize( id, delta ) }
 							onResizeEnd={ persistTemporaryLayout }
 							actionableArea={ childrenMap.get( id )?.props.actionableArea ?? null }
+							onRemove={ onRemoveItem }
+							removeButton={ childrenMap.get( id )?.props.removeButton }
 						>
 							{ childrenMap.get( id ) }
 						</GridItem>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -18,7 +18,7 @@ export function Grid( {
 	onChangeLayout,
 	onRemoveItem,
 }: GridProps ) {
-	// Temporary layout to avoid updaing the layout while dragging
+	// Temporary layout to avoid updating the layout while dragging
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
 		layout
 	);

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -73,16 +73,6 @@ export function Grid( {
 		return [ map, rest ];
 	}, [ children, layoutMap ] );
 
-	const actionableAreaMap = useMemo( () => {
-		const map = new Map< string, React.ReactNode >();
-		childrenMap.forEach( ( child, key ) => {
-			if ( child?.props.actionableArea ) {
-				map.set( key, child.props.actionableArea );
-			}
-		} );
-		return map;
-	}, [ childrenMap ] );
-
 	const sensors = useSensors(
 		useSensor( PointerSensor ),
 		useSensor( KeyboardSensor, {
@@ -175,7 +165,7 @@ export function Grid( {
 							disabled={ ! editMode }
 							onResize={ ( delta ) => handleResize( id, delta ) }
 							onResizeEnd={ persistTemporaryLayout }
-							actionableArea={ actionableAreaMap.get( id ) }
+							actionableArea={ childrenMap.get( id )?.props.actionableArea ?? null }
 						>
 							{ childrenMap.get( id ) }
 						</GridItem>

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -21,10 +21,14 @@ function Card( {
 	color,
 	children,
 	actionableArea,
+	removeButton,
+	onRemove,
 	...props
 }: {
 	color: string;
 	children: React.ReactNode;
+	onRemove?: ( id: string ) => void;
+	removeButton?: ( onRemove: () => void ) => React.ReactNode;
 	actionableArea?: React.ReactNode;
 } & HTMLAttributes< HTMLDivElement > ) {
 	return (
@@ -235,6 +239,10 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 				spacing={ 2 }
 				editMode
 				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
+				onRemoveItem={ ( key ) => {
+					// eslint-disable-next-line no-console
+					console.log( 'Grid.onRemoveItem: ', key );
+				} }
 			>
 				<Card
 					key="a"
@@ -250,7 +258,17 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 				>
 					Card A
 				</Card>
-				<Card key="b" color="#2196f3">
+				<Card
+					key="b"
+					color="#2196f3"
+					removeButton={ ( onRemove ) => {
+						return (
+							<div style={ { position: 'absolute', top: 2, right: 2, zIndex: 2 } }>
+								<button onClick={ onRemove }>x</button>
+							</div>
+						);
+					} }
+				>
 					Card B
 				</Card>
 				<Card
@@ -279,18 +297,7 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 				<Card key="g" color="#3f51b5">
 					Card G
 				</Card>
-				<Card
-					key="h"
-					color="#8bc34a"
-					actionableArea={
-						<WidgetActions
-							onClose={ () => {
-								// eslint-disable-next-line no-console
-								console.log( 'close card H' );
-							} }
-						/>
-					}
-				>
+				<Card key="h" color="#8bc34a">
 					Card H
 				</Card>
 				<Card key="i" color="#cddc39">

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -51,7 +51,7 @@ function Card( {
 	);
 }
 
-function WidgetActions( { onClose }: { onClose: () => void } ) {
+function WidgetActions( { onDuplicate }: { onDuplicate: () => void } ) {
 	return (
 		<div
 			style={ {
@@ -60,11 +60,11 @@ function WidgetActions( { onClose }: { onClose: () => void } ) {
 				alignItems: 'right',
 				justifyContent: 'right',
 				top: 2,
-				right: 2,
-				zIndex: 2,
+				left: 2,
+				zIndex: 1,
 			} }
 		>
-			<button onClick={ onClose }>x</button>
+			<button onClick={ onDuplicate }>duplicate</button>
 		</div>
 	);
 }
@@ -216,7 +216,7 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 /**
  * Example showing the Grid component with actionable area
  */
-export const WithActionableArea: StoryObj< typeof Grid > = {
+export const withActions: StoryObj< typeof Grid > = {
 	render: function EditableGrid() {
 		const [ layout, setLayout ] = useState< GridLayoutItem[] >( [
 			{ key: 'a', width: 1, height: 1 },
@@ -249,9 +249,9 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 					color="#f44336"
 					actionableArea={
 						<WidgetActions
-							onClose={ () => {
+							onDuplicate={ () => {
 								// eslint-disable-next-line no-console
-								console.log( 'close card A' );
+								console.log( 'duplicate card A' );
 							} }
 						/>
 					}
@@ -263,7 +263,7 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 					color="#2196f3"
 					removeButton={ ( onRemove ) => {
 						return (
-							<div style={ { position: 'absolute', top: 2, right: 2, zIndex: 2 } }>
+							<div style={ { position: 'absolute', top: 2, right: 2, zIndex: 1 } }>
 								<button onClick={ onRemove }>x</button>
 							</div>
 						);
@@ -276,9 +276,9 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 					color="#4caf50"
 					actionableArea={
 						<WidgetActions
-							onClose={ () => {
+							onDuplicate={ () => {
 								// eslint-disable-next-line no-console
-								console.log( 'close card C' );
+								console.log( 'duplicate card C' );
 							} }
 						/>
 					}
@@ -297,7 +297,18 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 				<Card key="g" color="#3f51b5">
 					Card G
 				</Card>
-				<Card key="h" color="#8bc34a">
+				<Card
+					key="h"
+					color="#8bc34a"
+					actionableArea={
+						<WidgetActions
+							onDuplicate={ () => {
+								// eslint-disable-next-line no-console
+								console.log( 'duplicate card H' );
+							} }
+						/>
+					}
+				>
 					Card H
 				</Card>
 				<Card key="i" color="#cddc39">

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -74,6 +74,11 @@ interface BaseGridProps {
 	 * Callback fired when layout changes due to item dragging
 	 */
 	onChangeLayout?: ( newLayout: GridLayoutItem[] ) => void;
+
+	/**
+	 * Callback fired when an item is removed from the grid.
+	 */
+	onRemoveItem?: ( key: GridLayoutItem ) => void;
 }
 
 interface StandardGridProps extends BaseGridProps {

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -78,7 +78,7 @@ interface BaseGridProps {
 	/**
 	 * Callback fired when an item is removed from the grid.
 	 */
-	onRemoveItem?: ( key: GridLayoutItem ) => void;
+	onRemoveItem?: ( key: string ) => void;
 }
 
 interface StandardGridProps extends BaseGridProps {


### PR DESCRIPTION
## Summary

Adds support for custom remove buttons in Grid items using the render props pattern. This enables consumers to implement item removal with full control over button styling and positioning.

### Changes

- Add `removeButton` prop to Grid child components (render prop pattern)
- Add `onRemoveItem` callback to Grid component
- Update Grid story with working remove button example
- Add comprehensive documentation to README

### API

**Consumer implementation:**

1. Define custom remove button via `removeButton` render prop:
```jsx
<Card
  removeButton={ ( onRemove ) => (
    <button onClick={ onRemove }>×</button>
  ) }
>
  Content
</Card>
```

2. Handle item removal in Grid's `onRemoveItem` callback:
```jsx
<Grid
  onRemoveItem={ ( key ) => {
    setLayout( prevLayout => prevLayout.filter( item => item.key !== key ) );
  } }
>
  {/* children */}
</Grid>
```

## Test plan

1. Open Storybook: `cd packages/grid && npm run storybook`
2. Navigate to "Grid > withActions" story
3. Verify Card B displays a remove button (×) in the top-right corner
4. Click the × button and verify Card B is removed from the grid
5. Verify other cards with `actionableArea` (duplicate buttons) still work correctly


https://github.com/user-attachments/assets/ec369361-e587-4b4c-b011-ee62e6c428cb

