### PR TITLE
Domain search rewrite: Remove unavailable FQDN from the domain suggestions

### DIFF
--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -25,7 +25,7 @@ export interface DomainAvailability {
 	/**
 	 * Whether the domain is a supported premium domain
 	 */
-	is_supported_premium_domain?: true;
+	is_supported_premium_domain?: boolean;
 
 	/**
 	 * Whether the domain price exceeds the limit

--- a/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
+++ b/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
@@ -62,7 +62,7 @@ describe( 'UnavailableSearchResult', () => {
 		}
 	);
 
-	it( 'renders the tld not supported message if the availability status is tld_not_supported', async () => {
+	it( 'renders the TLD not supported message if the availability status is tld_not_supported', async () => {
 		mockGetSuggestionsQuery( {
 			params: { query: 'woo.test.boston' },
 			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],
@@ -93,7 +93,7 @@ describe( 'UnavailableSearchResult', () => {
 		);
 	} );
 
-	it( 'renders the tld not supported message if the availability status is unknown', async () => {
+	it( 'renders the TLD not supported message if the availability status is unknown', async () => {
 		mockGetSuggestionsQuery( {
 			params: { query: 'woo.test.boston' },
 			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],
@@ -124,7 +124,7 @@ describe( 'UnavailableSearchResult', () => {
 		);
 	} );
 
-	it( 'renders the tld not supported temporarily message if the availability status is tld_not_supported_temporarily', async () => {
+	it( 'renders the TLD not supported temporarily message if the availability status is tld_not_supported_temporarily', async () => {
 		mockGetSuggestionsQuery( {
 			params: { query: 'woo.test.boston' },
 			suggestions: [ buildSuggestion( { domain_name: 'test.boston' } ) ],

--- a/packages/domain-search/src/helpers/test/parse-domain-against-tld-list.ts
+++ b/packages/domain-search/src/helpers/test/parse-domain-against-tld-list.ts
@@ -7,19 +7,19 @@ describe( 'parseDomainAgainstTldList', () => {
 		expect( parseDomainAgainstTldList( '', tldList ) ).toEqual( '' );
 	} );
 
-	test( 'should return an empty string if the tld is not a known one', () => {
+	test( 'should return an empty string if the TLD is not a known one', () => {
 		expect( parseDomainAgainstTldList( 'example.co.yz', tldList ) ).toEqual( '' );
 	} );
 
-	test( 'should return domain fragment if it exists in the list of known tlds', () => {
+	test( 'should return domain fragment if it exists in the list of known TLDs', () => {
 		expect( parseDomainAgainstTldList( 'co.uk', tldList ) ).toEqual( 'co.uk' );
 	} );
 
-	test( 'should return the right multi-level tld with a subdomain', () => {
+	test( 'should return the right multi-level TLD with a subdomain', () => {
 		expect( parseDomainAgainstTldList( 'example.co.uk', tldList ) ).toEqual( 'co.uk' );
 	} );
 
-	test( 'should return the right multi-level tld with a sub-subdomain', () => {
+	test( 'should return the right multi-level TLD with a sub-subdomain', () => {
 		expect( parseDomainAgainstTldList( 'test.example.co.uk', tldList ) ).toEqual( 'co.uk' );
 	} );
 } );


### PR DESCRIPTION
Addresses pdtkmj-40Z-p2#comment-7750.

## Proposed Changes

We were not filtering out unavailable suggestions, including unavailable premium, if the user searched for a FQDN.

@leonardost @ramynasr, one thing I don't understand is why `premium: true` isn't returned from the API for the `eduardo.work` suggestion, which clearly is a premium domain. This PR could be much simpler if it did.

## Testing Instructions

Search for `eduardo.work`, which is an unsupported premium domain, and you should see just the error message:

<img width="1064" height="423" alt="image" src="https://github.com/user-attachments/assets/bf7824d6-666e-469f-b7c7-7d5f09543ee2" />

Search for `eduardo.live`, which is a supported premium domain, and verify you see it on the list:

<img width="1112" height="363" alt="image" src="https://github.com/user-attachments/assets/cd286cdc-ae6d-4da5-8b93-4817545139d7" />

Non-premium domains should show up as normal:

<img width="1092" height="402" alt="image" src="https://github.com/user-attachments/assets/6d3177f0-8c37-409e-aa8b-e78b045fd4a1" />

Move suggestions should not show up in `/start/domain`:

<img width="1093" height="435" alt="image" src="https://github.com/user-attachments/assets/3effb0ee-ae6c-4de2-91ac-be7ff7e63590" />

Move suggestion should show up in `/setup/onboarding`:

<img width="1098" height="487" alt="image" src="https://github.com/user-attachments/assets/a9b85e13-87bc-4497-9ddf-41a99c081d4c" />
