### PR TITLE
Domain search rewrite: Rework "move suggestion" card

### DIFF
--- a/packages/domain-search/src/components/featured-search-results/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/item.tsx
@@ -28,12 +28,16 @@ export const FeaturedSearchResultsItem = ( {
 	const suggestion = useSuggestion( domainName );
 
 	const matchReasons = useMemo( () => {
-		if ( ! suggestion.match_reasons || query !== domainName ) {
+		if (
+			! suggestion.match_reasons ||
+			query !== domainName ||
+			suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE
+		) {
 			return;
 		}
 
 		return parseMatchReasons( domainName, suggestion.match_reasons );
-	}, [ domainName, suggestion.match_reasons, query ] );
+	}, [ domainName, suggestion.match_reasons, query, suggestion.price_rule ] );
 
 	const suggestionBadges = useDomainSuggestionBadges( domainName );
 	const policyBadges = usePolicyBadges( domainName );

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -1,9 +1,9 @@
 import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { envelope } from '@wordpress/icons';
+import { envelope, shuffle } from '@wordpress/icons';
 import { useState } from 'react';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
-import { useSuggestion } from '../../hooks/use-suggestion';
+import { DomainPriceRule, useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainSearchTrademarkClaimsModal,
@@ -102,16 +102,25 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 		);
 	}
 
+	const existingDomainLabel =
+		suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE
+			? __( 'Move your existing domain' )
+			: undefined;
+
 	return (
 		<>
 			<DomainSuggestionPrimaryCTA
 				disabled={ isMutating }
+				label={ existingDomainLabel }
+				icon={ suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE ? shuffle : undefined }
 				isBusy={ isPending }
 				onClick={ () => {
 					events.onSuggestionInteract( suggestion );
 					addToCart( { acceptedTrademarkClaim: false } );
 				} }
-			/>
+			>
+				{ existingDomainLabel }
+			</DomainSuggestionPrimaryCTA>
 			{ availability?.trademark_claims_notice_info && trademarkClaimModalOpen && (
 				<DomainSearchTrademarkClaimsModal
 					domainName={ domainName }

--- a/packages/domain-search/src/components/suggestion-cta/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/index.tsx
@@ -1,6 +1,6 @@
 import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { envelope, shuffle } from '@wordpress/icons';
+import { envelope, moveTo } from '@wordpress/icons';
 import { useState } from 'react';
 import { useIsCurrentMutation } from '../../hooks/use-is-current-mutation';
 import { DomainPriceRule, useSuggestion } from '../../hooks/use-suggestion';
@@ -112,7 +112,7 @@ export const DomainSuggestionCTA = ( { domainName }: DomainSuggestionCTAProps ) 
 			<DomainSuggestionPrimaryCTA
 				disabled={ isMutating }
 				label={ existingDomainLabel }
-				icon={ suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE ? shuffle : undefined }
+				icon={ suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE ? moveTo : undefined }
 				isBusy={ isPending }
 				onClick={ () => {
 					events.onSuggestionInteract( suggestion );

--- a/packages/domain-search/src/components/suggestion-price/index.tsx
+++ b/packages/domain-search/src/components/suggestion-price/index.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { useQuery } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
 import { DomainPriceRule, useSuggestion } from '../../hooks/use-suggestion';
 import { useDomainSearch } from '../../page/context';
 import { DomainSuggestionPrice as DomainSuggestionPriceComponent } from '../../ui';
@@ -15,16 +14,15 @@ export const DomainSuggestionPrice = ( { domainName }: DomainSuggestionPriceProp
 
 	const priceSource = availability ?? suggestion;
 
-	if ( suggestion.price_rule === DomainPriceRule.HIDE_PRICE ) {
+	if (
+		suggestion.price_rule === DomainPriceRule.HIDE_PRICE ||
+		suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE
+	) {
 		return null;
 	}
 
 	if ( suggestion.price_rule === DomainPriceRule.ONE_TIME_PRICE ) {
 		return <DomainSuggestionPriceComponent price={ priceSource.cost } />;
-	}
-
-	if ( suggestion.price_rule === DomainPriceRule.DOMAIN_MOVE_PRICE ) {
-		return <DomainSuggestionPriceComponent price={ __( 'Move your existing domain' ) } />;
 	}
 
 	if ( suggestion.price_rule === DomainPriceRule.FREE_FOR_FIRST_YEAR ) {


### PR DESCRIPTION
Addresses pdtkmj-40Z-p2#comment-7750 and pdtkmj-40Z-p2#comment-7768.

## Proposed Changes

During the CfT, @eduardozulian and @mdza8c raised that the "move your existing domain" card is a bit weird. He argued that we could hide the message and change the button label. This PR explores that proposal.

| Version with shuffle icon | Version with moveTo icon |
| --- | --- |
| <img width="1087" height="495" alt="image" src="https://github.com/user-attachments/assets/8d75cfa2-ed9e-4c3a-ad83-381fe81b9ac7" /> | <img width="1096" height="504" alt="image" src="https://github.com/user-attachments/assets/3deca9a4-f625-4185-b46a-edc9df5941e3" /> |

@ramynasr @ollierozdarz, please let me know if we want to change that, and which version we are picking. Once we decide which one we're going to stick with, I'll update the tests.

## Testing Instructions

Enter `/setup/onboarding` and verify you don't see match reasons and the "Move your existing domain" label, just the CTA with different wording and icon.