### PR TITLE
Hosting Dashboard domains: review and add InlineSupportLink to all the pages

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -211,6 +211,14 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/manage-my-profile/',
 		post_id: 19775,
 	},
+	'map-domain-change-name-servers': {
+		link: 'https://wordpress.com/support/domains/connect-existing-domain/#step-2-change-your-domains-name-servers',
+		post_id: 2789,
+	},
+	'map-domain-update-a-records': {
+		link: 'https://wordpress.com/support/domains/connect-a-domain-alternative-method/',
+		post_id: 219751,
+	},
 	mcp: {
 		link: 'https://wordpress.com/support/model-context-protocol-mcp-settings/',
 		post_id: 418160,

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -8,6 +8,7 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import DnsDescription from '../domain-dns/dns-description';
 import DNSRecordForm from './form';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
@@ -50,7 +51,12 @@ export default function DomainAddDNS() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
+			}
+		>
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -8,6 +8,7 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import DnsDescription from '../domain-dns/dns-description';
 import DNSRecordForm from './form';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import { getProcessedRecord } from './utils';
@@ -59,7 +60,12 @@ export default function DomainEditDNS() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
+			}
+		>
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -134,10 +134,21 @@ export default function DNSRecordForm( {
 							} }
 						/>
 						<ButtonStack justify="flex-start">
-							<Button variant="primary" type="submit" isBusy={ isBusy } disabled={ isBusy }>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isBusy }
+								disabled={ isBusy }
+							>
 								{ submitButtonText }
 							</Button>
-							<Button type="button" disabled={ isBusy } onClick={ handleCancel }>
+							<Button
+								__next40pxDefaultSize
+								type="button"
+								disabled={ isBusy }
+								onClick={ handleCancel }
+							>
 								{ __( 'Cancel' ) }
 							</Button>
 						</ButtonStack>

--- a/client/dashboard/domains/domain-connection-setup/components/help-message.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/help-message.tsx
@@ -2,28 +2,24 @@ import {
 	DomainConnectionSetupMode,
 	type DomainConnectionSetupModeValue,
 } from '@automattic/api-core';
-import { localizeUrl } from '@automattic/i18n-utils';
-import {
-	MAP_DOMAIN_CHANGE_NAME_SERVERS,
-	MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS,
-} from '@automattic/urls';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	Icon,
 } from '@wordpress/components';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { help } from '@wordpress/icons';
+import InlineSupportLink from '../../../components/inline-support-link';
 
 type HelpMessageProps = {
 	mode: DomainConnectionSetupModeValue;
 };
 export default function HelpMessage( { mode }: HelpMessageProps ) {
 	const supportLink: Partial< Record< DomainConnectionSetupModeValue, string > > = {
-		[ DomainConnectionSetupMode.SUGGESTED ]: MAP_DOMAIN_CHANGE_NAME_SERVERS,
-		[ DomainConnectionSetupMode.ADVANCED ]: MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS,
-		[ DomainConnectionSetupMode.DONE ]: MAP_DOMAIN_CHANGE_NAME_SERVERS,
+		[ DomainConnectionSetupMode.SUGGESTED ]: 'map-domain-change-name-servers',
+		[ DomainConnectionSetupMode.ADVANCED ]: 'map-domain-update-a-records',
+		[ DomainConnectionSetupMode.DONE ]: 'map-domain-change-name-servers',
 	};
 
 	if ( ! supportLink[ mode ] ) {
@@ -35,9 +31,11 @@ export default function HelpMessage( { mode }: HelpMessageProps ) {
 			<Icon icon={ help } size={ 16 } />
 			<Text variant="muted">
 				{ createInterpolateElement(
-					__( 'Not finding your way? You can read our detailed <a>support documentation</a>.' ),
+					__(
+						'Not finding your way? You can read our detailed <link>support documentation</link>.'
+					),
 					{
-						a: createElement( 'a', { href: localizeUrl( supportLink[ mode ] ), target: '_blank' } ),
+						link: <InlineSupportLink supportContext={ supportLink[ mode ] } />,
 					}
 				) }
 			</Text>

--- a/client/dashboard/domains/domain-connection-setup/steps/done.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/done.tsx
@@ -70,7 +70,7 @@ export function Done( {
 				</Text>
 				<Text as="p" align="center">
 					{ __(
-						"If your site isn't loading at your custom domain after a few hours, check that your DNS changes have been saved correctly at your domain provider."
+						'If your site isn’t loading at your custom domain after a few hours, check that your DNS changes have been saved correctly at your domain provider.'
 					) }
 				</Text>
 			</>
@@ -88,12 +88,12 @@ export function Done( {
 				</HStack>
 				<Text as="p" align="center">
 					{ __(
-						"We're checking if your domain is properly connected to WordPress.com. This may take a few moments."
+						'We’re checking if your domain is properly connected to WordPress.com. This may take a few moments.'
 					) }
 				</Text>
 				<Text as="p" align="center">
 					{ __(
-						"DNS changes can take up to 72 hours to fully propagate. If the verification doesn't complete immediately, that's normal."
+						'DNS changes can take up to 72 hours to fully propagate. If the verification doesn’t complete immediately, that’s normal.'
 					) }
 				</Text>
 			</>

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
@@ -96,7 +96,7 @@ export function TransferAuthCode( { domainName, siteId }: TransferStepComponentP
 
 						<Text as="p">
 							{ __(
-								"Once you've entered the authorization code, click on the button below to proceed."
+								'Once you’ve entered the authorization code, click on the button below to proceed.'
 							) }
 						</Text>
 

--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-unlock.tsx
@@ -54,11 +54,11 @@ export function TransferUnlock( {
 	const getErrorMessage = () => {
 		if ( allowSkip ) {
 			return __(
-				"Can't get the domain's lock status. If you've already unlocked it, wait a few minutes and try again."
+				'Can’t get the domain’s lock status. If you’ve already unlocked it, wait a few minutes and try again.'
 			);
 		}
 		return __(
-			"Your domain is still locked. If you've already unlocked it, wait a few minutes and try again."
+			'Your domain is still locked. If you’ve already unlocked it, wait a few minutes and try again.'
 		);
 	};
 
@@ -73,7 +73,7 @@ export function TransferUnlock( {
 		if ( isInitiallyUnknown || allowSkip ) {
 			return __( 'Skip domain lock verification' );
 		}
-		return __( "I've unlocked my domain" );
+		return __( 'I’ve unlocked my domain' );
 	};
 
 	return (
@@ -93,7 +93,7 @@ export function TransferUnlock( {
 								<>{ __( 'Please check that your domain is unlocked.' ) } </>
 							) }
 							{ __(
-								"Domain providers lock domains to prevent unauthorized transfers. You'll need to unlock it on your domain provider's settings page. Some domain providers require you to contact them via their customer support to unlock it."
+								'Domain providers lock domains to prevent unauthorized transfers. You’ll need to unlock it on your domain provider’s settings page. Some domain providers require you to contact them via their customer support to unlock it.'
 							) }
 						</Text>
 						<Text as="p">

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -209,6 +209,7 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 						<form onSubmit={ handleSubmit }>
 							<ButtonStack justify="flex-start">
 								<Button
+									__next40pxDefaultSize
 									variant="primary"
 									type="submit"
 									isBusy={ isSubmitting }

--- a/client/dashboard/domains/domain-dns/dns-description.tsx
+++ b/client/dashboard/domains/domain-dns/dns-description.tsx
@@ -1,0 +1,12 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../components/inline-support-link';
+
+export default function DnsDescription() {
+	return createInterpolateElement(
+		__( 'DNS records change how your domain works. <link>Learn more</link>' ),
+		{
+			link: <InlineSupportLink supportContext="manage-your-dns-records" />,
+		}
+	);
+}

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -170,10 +170,15 @@ export default function DnsImportDialog( {
 				) }
 
 				<ButtonStack justify="flex-end">
-					<Button onClick={ onCancel } disabled={ updateDnsMutation.isPending }>
+					<Button
+						__next40pxDefaultSize
+						onClick={ onCancel }
+						disabled={ updateDnsMutation.isPending }
+					>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
+						__next40pxDefaultSize
 						variant="primary"
 						isBusy={ updateDnsMutation.isPending }
 						onClick={ handleConfirm }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -23,6 +23,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { useDnsActions } from './actions';
 import DnsActionsMenu from './dns-actions-menu';
+import DnsDescription from './dns-description';
 import DnsImportDialog from './dns-import-dialog';
 import EmailSetup from './email-setup';
 import { useDnsFields } from './fields';
@@ -319,12 +320,7 @@ export default function DomainDns() {
 								/>
 							</>
 						}
-						description={ createInterpolateElement(
-							__( 'DNS records change how your domain works. <link>Learn more</link>' ),
-							{
-								link: <InlineSupportLink supportContext="manage-your-dns-records" />,
-							}
-						) }
+						description={ <DnsDescription /> }
 					/>
 				</VStack>
 			}

--- a/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
@@ -33,10 +33,10 @@ export default function RestoreDefaultARecords( {
 			<VStack spacing={ 6 }>
 				<Text>{ targetPlatformMessage }</Text>
 				<ButtonStack justify="flex-end">
-					<Button onClick={ onCancel } isBusy={ isBusy }>
+					<Button __next40pxDefaultSize onClick={ onCancel } isBusy={ isBusy }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
+					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
@@ -28,8 +28,10 @@ export default function RestoreDefaultCnameRecord( {
 			<VStack spacing={ 6 }>
 				<Text>{ __( 'In case a www CNAME record already exists, it will be deleted.' ) }</Text>
 				<ButtonStack justify="flex-end">
-					<Button onClick={ onCancel }>{ __( 'Cancel' ) }</Button>
-					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
+					<Button __next40pxDefaultSize onClick={ onCancel }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button __next40pxDefaultSizevariant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
@@ -31,7 +31,7 @@ export default function RestoreDefaultCnameRecord( {
 					<Button __next40pxDefaultSize onClick={ onCancel }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button __next40pxDefaultSizevariant="primary" isBusy={ isBusy } onClick={ onConfirm }>
+					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
@@ -30,8 +30,10 @@ export default function RestoreDefaultEmailRecords( {
 					{ __( 'This will restore SPF, DKIM and DMARC records to their default configurations.' ) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button onClick={ onCancel }>{ __( 'Cancel' ) }</Button>
-					<Button variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
+					<Button __next40pxDefaultSize onClick={ onCancel }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>
 						{ __( 'Restore' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -1,4 +1,3 @@
-import { CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from '@automattic/urls';
 import {
 	Button,
 	__experimentalText as Text,
@@ -179,7 +178,7 @@ export default function NameServersForm( {
 										__( '<link>Look up</link> the name servers for popular hosts.' ),
 										{
 											link: (
-												<InlineSupportLink supportLink={ CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } />
+												<InlineSupportLink supportContext="change-name-servers-finding-out-new-ns" />
 											),
 										}
 									) }


### PR DESCRIPTION
Closes [DOTDASH-503](https://linear.app/a8c/issue/DOTDASH-503/review-and-add-inlinesupportlink-to-all-the-pages)

## Proposed Changes
This PR makes sure every support link in Domains HD is using `InlineSupportLink` component. It's also fixes a few style and copy bugs. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions
Check that all the links are using `InlineSupportLink` with the correct support context.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
