### PR TITLE
Add error handler for manual deployments

### DIFF
--- a/client/dashboard/sites/deployments-list/trigger-deployment-modal-form.tsx
+++ b/client/dashboard/sites/deployments-list/trigger-deployment-modal-form.tsx
@@ -58,7 +58,7 @@ export function TriggerDeploymentModalForm( {
 	repositoryId,
 	onSuccess,
 }: TriggerDeploymentModalFormProps ) {
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ deploymentFormData, setDeploymentFormData ] = useState< DeploymentFormData >( {
 		selectedDeploymentId: repositoryId ?? '',
 	} );
@@ -108,6 +108,9 @@ export function TriggerDeploymentModalForm( {
 					createSuccessNotice( __( 'Deployment run created.' ), { type: 'snackbar' } );
 					onClose?.();
 					onSuccess?.();
+				},
+				onError: ( error ) => {
+					createErrorNotice( error.message, { type: 'snackbar' } );
 				},
 			}
 		);


### PR DESCRIPTION
## Proposed Changes

With this PR we are starting render erorr if manual deployment failed

## Testing Instructions
1. Connect `http://calypso.localhost:3000/v2/sites`
2. Select a seit and Deployments tab
3. Connect a repo
4. Open https://github.com/settings/installations
5. Click on Configure and uninstall a repo
6. Open Settings -> Repositories in Calypso
7. Trigger manual deployment<br /><img width="679" height="100" alt="Screenshot 2025-10-10 at 13 21 29" src="https://github.com/user-attachments/assets/88bbd19f-62a0-4254-b657-e5632ab6edd8" />
8. Assert taht you see error<br /><img width="513" height="55" alt="Screenshot 2025-10-10 at 13 21 59" src="https://github.com/user-attachments/assets/f1de30a3-a319-406d-9b78-187f4cce5325" />
