### PR TITLE
Domain Search Rewrite: List domain transfers and connections in the cart

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -1,5 +1,10 @@
 /* eslint-disable no-restricted-imports */
-import { isPlan } from '@automattic/calypso-products';
+import {
+	isDomainMoveInternal,
+	isDomainRegistration,
+	isDomainTransfer,
+	isPlan,
+} from '@automattic/calypso-products';
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -9,7 +14,6 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import { ComponentProps, useMemo } from 'react';
-import { getDomainsInCart } from '../../../lib/cart-values/cart-items';
 
 const wpcomCartToDomainSearchCart = (
 	domain: ResponseCartProduct,
@@ -65,7 +69,14 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 	const { responseCart, addProductsToCart, removeProductFromCart } = useShoppingCart( cartKey );
 
 	return useMemo( () => {
-		const domainItems = flowAllowsMultipleDomainsInCart ? getDomainsInCart( responseCart ) : [];
+		const domainItems = flowAllowsMultipleDomainsInCart
+			? responseCart.products.filter(
+					( product ) =>
+						isDomainRegistration( product ) ||
+						isDomainTransfer( product ) ||
+						isDomainMoveInternal( product )
+			  )
+			: [];
 		const isPlanInCart =
 			responseCart.products.find( ( product ) => isPlan( product ) ) !== undefined;
 		// If there's an annual plan in the cart, the backend will already set the first domain as free.

--- a/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-shopping-cart-for-domain-search.ts
@@ -1,10 +1,4 @@
-/* eslint-disable no-restricted-imports */
-import {
-	isDomainMoveInternal,
-	isDomainRegistration,
-	isDomainTransfer,
-	isPlan,
-} from '@automattic/calypso-products';
+import { isDomainProduct, isDomainTransfer, isPlan } from '@automattic/calypso-products';
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -71,10 +65,7 @@ export const useWPCOMShoppingCartForDomainSearch = ( {
 	return useMemo( () => {
 		const domainItems = flowAllowsMultipleDomainsInCart
 			? responseCart.products.filter(
-					( product ) =>
-						isDomainRegistration( product ) ||
-						isDomainTransfer( product ) ||
-						isDomainMoveInternal( product )
+					( product ) => isDomainProduct( product ) || isDomainTransfer( product )
 			  )
 			: [];
 		const isPlanInCart =


### PR DESCRIPTION
Addresses pdtkmj-40Z-p2#comment-7769.

## Proposed Changes

If there's a transfer or a connection in the cart for a given site, we should list it, as it's related to the domain purchase process.

I'm also wondering if, after submitting the "use a domain I own" step, we should continue redirecting the user to the plans step, or go back to the domain search in case they want to add more.


## Testing Instructions

Make sure your existing site has a domain transfer and/or connection item in the cart, then enter `/domains/add/%s`. You should see the transfer item when clicking "View cart". You might need to refresh the page to get the most recent information if coming from checkout:

<img width="441" height="283" alt="image" src="https://github.com/user-attachments/assets/e019719c-7c34-48f0-bf12-d2db67c8e451" />
