### PR TITLE
Setup Domain: Preserve existing site when going through plans

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -7,7 +7,7 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 	const onSearchClick = () => {
 		window.location.href = siteSlug
 			? addQueryArgs( '/setup/domain', { siteSlug } )
-			: '/start/domain';
+			: '/setup/domain';
 		return false;
 	};
 

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -71,6 +71,20 @@ const domain: FlowV2< typeof initialize > = {
 			[]
 		);
 
+		const goToCheckout = ( siteSlug: string ) => {
+			const destination = `/v2/sites/${ siteSlug }/domains`;
+
+			// replace the location to delete processing step from history.
+			return window.location.replace(
+				addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
+					redirect_to: destination,
+					signup: 1,
+					cancel_to: new URL( addQueryArgs( '/setup/domain', { siteSlug } ), window.location.href )
+						.href,
+				} )
+			);
+		};
+
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -90,7 +104,7 @@ const domain: FlowV2< typeof initialize > = {
 						return navigate( useMyDomainURL as typeof currentStepSlug );
 					}
 
-					setSiteUrl( providedDependencies.siteUrl as string );
+					setSiteUrl( siteSlug ?? ( providedDependencies.siteUrl as string ) );
 					setDomainCartItem( providedDependencies.domainItem as MinimalRequestCartProduct );
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
@@ -239,6 +253,27 @@ const domain: FlowV2< typeof initialize > = {
 						} else {
 							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
 						}
+
+						if ( siteSlug ) {
+							return goToCheckout( siteSlug );
+						}
+					} else if ( siteSlug ) {
+						setPendingAction( async () => {
+							if ( pickedPlan ) {
+								await addProductsToCart( siteSlug, this.name, [
+									pickedPlan,
+									...products.filter( ( product ) => product !== null ),
+								] );
+							}
+
+							return {
+								siteSlug,
+								goToCheckout: true,
+								siteCreated: false,
+							};
+						} );
+
+						return navigate( STEPS.PROCESSING.slug );
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
@@ -258,23 +293,11 @@ const domain: FlowV2< typeof initialize > = {
 						setSignupCompleteSlug( providedDependencies.siteSlug );
 
 						if ( providedDependencies.goToCheckout ) {
-							const siteSlug = providedDependencies.siteSlug as string;
-
-							// replace the location to delete processing step from history.
-							window.location.replace(
-								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									redirect_to: destination,
-									signup: 1,
-									cancel_to: new URL(
-										addQueryArgs( '/setup/domain', { siteSlug } ),
-										window.location.href
-									).href,
-								} )
-							);
-						} else {
-							// replace the location to delete processing step from history.
-							window.location.replace( destination );
+							return goToCheckout( providedDependencies.siteSlug as string );
 						}
+
+						// replace the location to delete processing step from history.
+						window.location.replace( destination );
 					} else {
 						// TODO: Handle errors
 						// navigate( 'error' );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -1,5 +1,10 @@
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
-import { DOMAIN_FLOW, addProductsToCart, clearStepPersistedState } from '@automattic/onboarding';
+import {
+	DOMAIN_FLOW,
+	addPlanToCart,
+	addProductsToCart,
+	clearStepPersistedState,
+} from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
@@ -177,6 +182,12 @@ const domain: FlowV2< typeof initialize > = {
 						setHideFreePlan( true );
 						setSignupCompleteFlowName( this.name );
 						setSignupCompleteSlug( siteSlug );
+						setDomainCartItem( providedDependencies.domainCartItem );
+						setDomainCartItems( [ providedDependencies.domainCartItem ] );
+
+						if ( ! siteHasPaidPlan( site ) ) {
+							return navigate( STEPS.UNIFIED_PLANS.slug );
+						}
 
 						setPendingAction( async () => {
 							await addProductsToCart( siteSlug, this.name, [
@@ -196,10 +207,8 @@ const domain: FlowV2< typeof initialize > = {
 					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
 						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 						setHideFreePlan( true );
-						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
-						setDomainCartItems( [
-							providedDependencies.domainCartItem as MinimalRequestCartProduct,
-						] );
+						setDomainCartItem( providedDependencies.domainCartItem );
+						setDomainCartItems( [ providedDependencies.domainCartItem ] );
 					}
 
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
@@ -231,7 +240,9 @@ const domain: FlowV2< typeof initialize > = {
 
 				case STEPS.SITE_PICKER.slug: {
 					if ( ! siteHasPaidPlan( providedDependencies.site ) ) {
-						return navigate( STEPS.UNIFIED_PLANS.slug );
+						return navigate(
+							`${ STEPS.UNIFIED_PLANS.slug }?siteSlug=${ providedDependencies.siteSlug }`
+						);
 					}
 
 					setPendingAction( async () => {
@@ -253,7 +264,11 @@ const domain: FlowV2< typeof initialize > = {
 					const cartItems = providedDependencies.cartItems;
 					const [ pickedPlan, ...products ] = cartItems ?? [];
 
+					const addOns = products.filter( ( product ) => product !== null );
+
 					setPlanCartItem( pickedPlan );
+					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
+					setProductCartItems( addOns );
 
 					if ( ! pickedPlan ) {
 						// Since we're removing the paid domain, it means that the user chose to continue
@@ -272,10 +287,15 @@ const domain: FlowV2< typeof initialize > = {
 					} else if ( siteSlug ) {
 						setPendingAction( async () => {
 							if ( pickedPlan ) {
-								await addProductsToCart( siteSlug, this.name, [
-									pickedPlan,
-									...products.filter( ( product ) => product !== null ),
-								] );
+								await addPlanToCart( siteSlug, this.name, true, '', pickedPlan );
+							}
+
+							if ( addOns.length > 0 ) {
+								await addProductsToCart( siteSlug, this.name, addOns );
+							}
+
+							if ( domainCartItems ) {
+								await addProductsToCart( siteSlug, this.name, domainCartItems );
 							}
 
 							return {
@@ -287,9 +307,6 @@ const domain: FlowV2< typeof initialize > = {
 
 						return navigate( STEPS.PROCESSING.slug );
 					}
-
-					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
-					setProductCartItems( products.filter( ( product ) => product !== null ) );
 
 					setSignupCompleteFlowName( this.name );
 					return navigate( STEPS.SITE_CREATION_STEP.slug, undefined, false );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -23,7 +23,7 @@ import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
-import { type FlowV2, type SubmitHandler } from '../../internals/types';
+import { AssertConditionState, type FlowV2, type SubmitHandler } from '../../internals/types';
 
 function initialize() {
 	const steps = [
@@ -49,6 +49,15 @@ const domain: FlowV2< typeof initialize > = {
 	isSignupFlow: false,
 	__experimentalUseBuiltinAuth: true,
 	initialize,
+	useAssertConditions() {
+		const { site, siteSlug } = useSiteData();
+
+		if ( ! siteSlug ) {
+			return { state: AssertConditionState.SUCCESS };
+		}
+
+		return { state: site ? AssertConditionState.SUCCESS : AssertConditionState.CHECKING };
+	},
 	useStepNavigation( currentStepSlug, navigate ) {
 		const {
 			setDomainCartItem,

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -197,6 +197,9 @@ const domain: FlowV2< typeof initialize > = {
 						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 						setHideFreePlan( true );
 						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
+						setDomainCartItems( [
+							providedDependencies.domainCartItem as MinimalRequestCartProduct,
+						] );
 					}
 
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -270,15 +270,20 @@ function UnifiedPlansStep( {
 
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 
-	const { siteUrl, domainItem, siteTitle, username, coupon, selectedThemeType } =
-		signupDependencies;
+	const { domainItem, siteTitle, username, coupon, selectedThemeType } = signupDependencies;
 
-	const { domainCartItem } = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
-		const { getDomainCartItem } = select( ONBOARD_STORE );
-		return {
-			domainCartItem: getDomainCartItem(),
-		};
-	}, [] );
+	const { domainCartItem, siteUrl: onboardingStoreSiteUrl } = useSelect(
+		( select: ( key: string ) => OnboardSelect ) => {
+			const { getDomainCartItem, getSiteUrl } = select( ONBOARD_STORE );
+			return {
+				domainCartItem: getDomainCartItem(),
+				siteUrl: getSiteUrl(),
+			};
+		},
+		[]
+	);
+
+	const siteUrl = onboardingStoreSiteUrl ?? signupDependencies.siteUrl;
 
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 

--- a/test/e2e/specs/flows/setup-domain__existing-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__existing-free-site.ts
@@ -14,6 +14,7 @@ import {
 	NewUserResponse,
 	NewSiteResponse,
 	RestAPIClient,
+	PlansPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared/api-close-account';
@@ -98,7 +99,7 @@ describe(
 			} );
 
 			it( `Select ${ domainAdditionPlan } plan`, async function () {
-				const plansPage = new SignupPickPlanPage( page );
+				const plansPage = new PlansPage( page );
 
 				await plansPage.selectPlan( domainAdditionPlan );
 			} );

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -80,7 +80,10 @@ describe(
 			it( `Select ${ planName } plan`, async function () {
 				const plansPage = new PlansPage( page );
 
-				await plansPage.selectPlan( planName );
+				await Promise.all( [
+					plansPage.selectPlan( planName ),
+					page.waitForURL( /.*\/checkout\/.*/, { timeout: 30 * 1000 } ),
+				] );
 			} );
 
 			it( 'See plan and domain at checkout', async function () {

--- a/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
+++ b/test/e2e/specs/flows/setup-domain__preselected-free-site.ts
@@ -12,6 +12,7 @@ import {
 	SignupPickPlanPage,
 	UserSignupPage,
 	NewUserResponse,
+	PlansPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared/api-close-account';
@@ -77,7 +78,7 @@ describe(
 			} );
 
 			it( `Select ${ planName } plan`, async function () {
-				const plansPage = new SignupPickPlanPage( page );
+				const plansPage = new PlansPage( page );
 
 				await plansPage.selectPlan( planName );
 			} );


### PR DESCRIPTION
Addresses pdtkmj-40Z-p2#comment-7769.

## Proposed Changes

Choosing either the free or paid plans in the plans step of `/setup/domain?siteSlug=%s` resulted in creating a new site instead of preserving the existing one passed as a query parameter.

## Testing Instructions

Enter `/setup/domain?siteSlug=%s` and add a domain to the cart. Click continue to see the plans step, then pick "Personal." You should go to checkout with your site slug preserved and the domain and plan added to the cart of the existing site.

Clear the checkout.

Enter `/setup/domain?siteSlug=%s` and add a domain to the cart. Click continue to see the plans step, then choose to continue with the free plan. You should go to checkout with your site slug preserved and the domain added to the cart of the existing site, without the plan.

Leave the checkout and you should be redirected to `/setup/domain?siteSlug=%s` with your domain still in the cart. Click "Use a domain I already own" at the top-right corner and transfer an external domain. You should go to checkout with your site slug preserved and the domain and transfer added to the cart of the existing site, without the plan.
 

Finally, enter `/setup/domain`, go through the flow, and verify a new site gets created with the domain in the cart.