### PR TITLE
Dashboard v2: Make the account deletion links redirect to v2 urls

### DIFF
--- a/client/dashboard/me/profile-deletion/alternatives-modal.tsx
+++ b/client/dashboard/me/profile-deletion/alternatives-modal.tsx
@@ -37,11 +37,13 @@ export default function AlternativesModal( {
 						text: __( 'Change your site’s address' ),
 						to: '/domains',
 						supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
+						useRouterButton: true,
 					},
 					{
 						text: __( 'Delete a site' ),
 						to: '/sites',
 						supportLink: localizeUrl( 'https://wordpress.com/support/delete-site/' ),
+						useRouterButton: true,
 					},
 			  ]
 			: [] ),
@@ -53,13 +55,15 @@ export default function AlternativesModal( {
 		},
 		{
 			text: __( 'Change your username' ),
-			to: '/me/account',
+			to: '/me/profile',
 			supportLink: localizeUrl( 'https://wordpress.com/support/change-your-username/' ),
+			useRouterButton: true,
 		},
 		{
 			text: __( 'Change your password' ),
 			to: '/me/security',
 			supportLink: localizeUrl( 'https://wordpress.com/support/passwords/' ),
+			useRouterButton: true,
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-609

## Proposed Changes

* Change the links to use the `ButtonRouterLink` to redirect to Dashboard v2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous links were linking to the v1 (Calypso Blue) dashboard. Since this page lives in the Dashboard v2 it makes sense for them to land on the same dashboard. We're using the `ButtonRouterLink` so that it avoids a full page reload/render.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go into `/v2/me/profile` and click `Delete account` (you can change the purchases [here](https://github.com/Automattic/wp-calypso/blob/a4feaee344c598d6ab337488e479dc6c14782146/client/dashboard/me/profile-deletion/index.tsx#L73-L74) to an empty array to trigger the modal in case you have purchases on your account)
* Check that the following links all link to the Dashboard v2, with the exception of the `Start a new site`
<img width="1382" height="1172" alt="CleanShot 2025-10-10 at 17 36 13@2x" src="https://github.com/user-attachments/assets/6521b6ef-cf27-40ab-87fc-cf773ce81c93" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
