### PR TITLE
Hosting Dashboard Emails: domain step

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -53,6 +53,94 @@ export const emailsRoute = createRoute( {
 	)
 );
 
+export const chooseDomainRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Choose a domain' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'emails/choose-domain',
+	loader: async () => {
+		// 1) Preload sites
+		const sites = await queryClient.ensureQueryData( sitesQuery() );
+		const managedSites = ( sites ?? [] ).filter( ( site ) => site.capabilities?.manage_options );
+
+		// 2) Preload domains for each managed site
+		await Promise.all(
+			managedSites.map( ( site ) => queryClient.ensureQueryData( siteDomainsQuery( site.ID ) ) )
+		);
+	},
+} ).lazy( () =>
+	import( '../../emails/choose-domain' ).then( ( d ) =>
+		createLazyRoute( 'choose-domain' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const chooseEmailSolutionRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Choose email solution' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'emails/choose-email-solution/$domain',
+} ).lazy( () =>
+	import( '../../emails/choose-email-solution' ).then( ( d ) =>
+		createLazyRoute( 'choose-email-solution' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const addTitanmailMailboxRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add Titan Mail mailbox' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'emails/add-titan-mailbox',
+} ).lazy( () =>
+	import( '../../emails/add-titan-mailbox' ).then( ( d ) =>
+		createLazyRoute( 'add-titan-mailbox' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const addGoogleMailboxRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add Google mailbox' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'emails/add-google-mailbox',
+} ).lazy( () =>
+	import( '../../emails/add-google-mailbox' ).then( ( d ) =>
+		createLazyRoute( 'add-google-mailbox' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createEmailsRoutes = () => {
-	return [ emailsRoute ];
+	return [
+		emailsRoute,
+		chooseDomainRoute,
+		chooseEmailSolutionRoute,
+		addTitanmailMailboxRoute,
+		addGoogleMailboxRoute,
+	];
 };

--- a/client/dashboard/emails/add-google-mailbox/index.tsx
+++ b/client/dashboard/emails/add-google-mailbox/index.tsx
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+
+export default function AddGoogleMailbox() {
+	return (
+		<PageLayout header={ <PageHeader /> } size="small">
+			<Text size={ 18 }>{ __( 'Add a Google mailbox' ) }</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/emails/add-titan-mailbox/index.tsx
+++ b/client/dashboard/emails/add-titan-mailbox/index.tsx
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+
+export default function AddTitanmailMailbox() {
+	return (
+		<PageLayout header={ <PageHeader /> } size="small">
+			<Text size={ 18 }>{ __( 'Add a Titan Mail mailbox' ) }</Text>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -1,0 +1,182 @@
+import { SiteDomain } from '@automattic/api-core';
+import { siteDomainsQuery, sitesQuery } from '@automattic/api-queries';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	__experimentalItem as Item,
+	__experimentalItemGroup as ItemGroup,
+	__experimentalVStack as VStack,
+	FlexBlock,
+	SearchControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { arrowLeft, chevronRight, Icon, plus } from '@wordpress/icons';
+import { useMemo, useState } from 'react';
+import { domainsRoute } from '../../app/router/domains';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import { Text } from '../../components/text';
+import { domainHasEmail, hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
+import './styles.css';
+
+const isJetpackSlug = ( slug: unknown ): boolean =>
+	typeof slug === 'string' && String( slug ).startsWith( 'jetpack_' );
+
+export default function ChooseDomain() {
+	const router = useRouter();
+	const { data: allSites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const sites = ( allSites ?? [] )
+		.filter( ( site ) => {
+			const product = site?.plan?.product_slug ?? null;
+			if ( product === null ) {
+				return true;
+			}
+
+			return ! isJetpackSlug( product );
+		} )
+		.filter( ( site ) => site.capabilities.manage_options );
+	const siteIds = sites.map( ( site ) => site.ID );
+
+	// Fetch site domains for each managed site ID
+	const domainsQueries = useQueries( {
+		queries: siteIds.map( ( id ) => ( {
+			...siteDomainsQuery( id ),
+			enabled: Boolean( id ),
+		} ) ),
+	} );
+	const isLoadingDomains = domainsQueries.some( ( q ) => q.isLoading );
+
+	// Aggregate all domains into a single array
+	const { eligibleDomains } = useMemo( () => {
+		if ( isLoadingDomains ) {
+			return { eligibleDomains: [] };
+		}
+
+		const domains = domainsQueries
+			.flatMap( ( q ) => ( q.data as SiteDomain[] ) ?? [] )
+			.filter( ( domain ) => ! domain.wpcom_domain );
+		const eligibleDomains = domains.filter(
+			( domain ) =>
+				! domainHasEmail( domain ) || hasGSuiteWithUs( domain ) || hasTitanMailWithUs( domain )
+		) as SiteDomain[];
+
+		return { eligibleDomains };
+	}, [ domainsQueries, isLoadingDomains ] );
+	// Prepare domain lists and search state
+	const firstTen = eligibleDomains.slice( 0, 10 );
+	const remaining = eligibleDomains.slice( 10 );
+	const [ search, setSearch ] = useState( '' );
+	const filteredRemaining = useMemo( () => {
+		const q = search.trim().toLowerCase();
+		if ( ! q ) {
+			return [] as SiteDomain[];
+		}
+		return eligibleDomains.filter( ( d ) => d.domain.toLowerCase().includes( q ) );
+	}, [ eligibleDomains, search ] );
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					prefix={
+						<RouterLinkButton
+							className="add-forwarder__back-button"
+							icon={ arrowLeft }
+							iconSize={ 12 }
+							to="/emails"
+						>
+							<Text variant="muted">{ __( 'Emails' ) }</Text>
+						</RouterLinkButton>
+					}
+				/>
+			}
+			size="small"
+		>
+			<Text size={ 16 }>{ __( 'Which domain name would you like to add a mailbox for?' ) }</Text>
+			<VStack spacing={ 6 }>
+				{ isLoadingSites || isLoadingDomains ? (
+					<Text variant="muted">{ __( 'Loading domains…' ) }</Text>
+				) : (
+					<>
+						<ItemGroup className="choose-domain__itemlist" isBordered isSeparated>
+							{ remaining.length > 0 && (
+								<Item>
+									<SearchControl
+										className="searchbox"
+										value={ search }
+										onChange={ setSearch }
+										placeholder={ __( 'Search' ) }
+									/>
+								</Item>
+							) }
+							{ ! search.trim() &&
+								firstTen.map( ( d ) => (
+									<Item
+										key={ d.blog_id + '-' + d.domain }
+										onClick={ () => {
+											// Navigate based on existing email solution
+											if ( hasTitanMailWithUs( d ) ) {
+												router.navigate( { to: '/emails/add-titan-mailbox' } );
+												return;
+											}
+											if ( hasGSuiteWithUs( d ) ) {
+												router.navigate( { to: '/emails/add-google-mailbox' } );
+												return;
+											}
+											router.navigate( {
+												to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
+											} );
+										} }
+									>
+										<HStack justify="flex-start">
+											<FlexBlock>{ d.domain }</FlexBlock>
+											<Icon className="choose-domain__icon" icon={ chevronRight } />
+										</HStack>
+									</Item>
+								) ) }
+							{ remaining.length > 0 &&
+								search.trim() &&
+								filteredRemaining.map( ( d: SiteDomain ) => (
+									<Item
+										key={ d.blog_id + '-' + d.domain }
+										onClick={ () => {
+											if ( hasTitanMailWithUs( d ) ) {
+												router.navigate( { to: '/emails/add-titan-mailbox' } );
+												return;
+											}
+											if ( hasGSuiteWithUs( d ) ) {
+												router.navigate( { to: '/emails/add-google-mailbox' } );
+												return;
+											}
+											router.navigate( {
+												to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
+											} );
+										} }
+									>
+										<HStack justify="flex-start">
+											<FlexBlock>{ d.domain }</FlexBlock>
+											<Icon className="choose-domain__icon" icon={ chevronRight } />
+										</HStack>
+									</Item>
+								) ) }
+						</ItemGroup>
+						<ItemGroup className="choose-domain__itemlist" isBordered isSeparated>
+							<Item
+								onClick={ () => {
+									router.navigate( { to: domainsRoute.fullPath } );
+								} }
+							>
+								<HStack justify="flex-start">
+									<FlexBlock>{ __( 'Add a new domain' ) }</FlexBlock>
+									<Icon className="choose-domain__icon" icon={ plus } />
+								</HStack>
+							</Item>
+						</ItemGroup>
+					</>
+				) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -18,7 +18,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
-import { domainHasEmail, hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
+import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
 import './styles.css';
 
 const isJetpackSlug = ( slug: unknown ): boolean =>
@@ -57,12 +57,8 @@ export default function ChooseDomain() {
 		const domains = domainsQueries
 			.flatMap( ( q ) => ( q.data as SiteDomain[] ) ?? [] )
 			.filter( ( domain ) => ! domain.wpcom_domain );
-		const eligibleDomains = domains.filter(
-			( domain ) =>
-				! domainHasEmail( domain ) || hasGSuiteWithUs( domain ) || hasTitanMailWithUs( domain )
-		) as SiteDomain[];
 
-		return { eligibleDomains };
+		return { eligibleDomains: domains };
 	}, [ domainsQueries, isLoadingDomains ] );
 	// Prepare domain lists and search state
 	const firstTen = eligibleDomains.slice( 0, 10 );

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -72,6 +72,21 @@ export default function ChooseDomain() {
 		return eligibleDomains.filter( ( d ) => d.domain.toLowerCase().includes( q ) );
 	}, [ eligibleDomains, search ] );
 
+	const handleDomainClick = ( d: SiteDomain ) => {
+		// Navigate based on existing email solution
+		if ( hasTitanMailWithUs( d ) ) {
+			router.navigate( { to: '/emails/add-titan-mailbox' } );
+			return;
+		}
+		if ( hasGSuiteWithUs( d ) ) {
+			router.navigate( { to: '/emails/add-google-mailbox' } );
+			return;
+		}
+		router.navigate( {
+			to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
+		} );
+	};
+
 	return (
 		<PageLayout
 			header={
@@ -109,23 +124,7 @@ export default function ChooseDomain() {
 							) }
 							{ ! search.trim() &&
 								firstTen.map( ( d ) => (
-									<Item
-										key={ d.blog_id + '-' + d.domain }
-										onClick={ () => {
-											// Navigate based on existing email solution
-											if ( hasTitanMailWithUs( d ) ) {
-												router.navigate( { to: '/emails/add-titan-mailbox' } );
-												return;
-											}
-											if ( hasGSuiteWithUs( d ) ) {
-												router.navigate( { to: '/emails/add-google-mailbox' } );
-												return;
-											}
-											router.navigate( {
-												to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
-											} );
-										} }
-									>
+									<Item key={ d.blog_id + '-' + d.domain } onClick={ () => handleDomainClick( d ) }>
 										<HStack justify="flex-start">
 											<FlexBlock>{ d.domain }</FlexBlock>
 											<Icon className="choose-domain__icon" icon={ chevronRight } />
@@ -135,22 +134,7 @@ export default function ChooseDomain() {
 							{ remaining.length > 0 &&
 								search.trim() &&
 								filteredRemaining.map( ( d: SiteDomain ) => (
-									<Item
-										key={ d.blog_id + '-' + d.domain }
-										onClick={ () => {
-											if ( hasTitanMailWithUs( d ) ) {
-												router.navigate( { to: '/emails/add-titan-mailbox' } );
-												return;
-											}
-											if ( hasGSuiteWithUs( d ) ) {
-												router.navigate( { to: '/emails/add-google-mailbox' } );
-												return;
-											}
-											router.navigate( {
-												to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
-											} );
-										} }
-									>
+									<Item key={ d.blog_id + '-' + d.domain } onClick={ () => handleDomainClick( d ) }>
 										<HStack justify="flex-start">
 											<FlexBlock>{ d.domain }</FlexBlock>
 											<Icon className="choose-domain__icon" icon={ chevronRight } />

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -21,8 +21,7 @@ import { Text } from '../../components/text';
 import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
 import './styles.css';
 
-const isJetpackSlug = ( slug: unknown ): boolean =>
-	typeof slug === 'string' && String( slug ).startsWith( 'jetpack_' );
+const isJetpackSlug = ( slug: string ): boolean => String( slug ).startsWith( 'jetpack_' );
 
 export default function ChooseDomain() {
 	const router = useRouter();

--- a/client/dashboard/emails/choose-domain/styles.css
+++ b/client/dashboard/emails/choose-domain/styles.css
@@ -1,0 +1,26 @@
+.choose-domain__itemlist {
+	background: #fff;
+	border-radius: 8px;
+}
+
+/* Ensure the text inside each item is 16px */
+.choose-domain__itemlist .components-item {
+	height: 56px;
+	display: flex;
+	padding: 0 24px;
+	font-size: 14px;
+}
+
+/* Chevron icon color */
+.choose-domain__icon {
+	color: #757575;
+	fill: #757575; /* fallback for SVGs not using currentColor */
+	stroke: #757575; /* extra safety for stroke-based icons */
+}
+
+/* Ensure SearchControl input spans full width */
+.choose-domain__itemlist .components-item .searchbox {
+	width: 100%;
+	padding-top: 8px;
+	box-sizing: border-box;
+}

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+
+export default function ChooseEmailSolution() {
+	const router = useRouter();
+	// Extract params from the current match for this route
+	const match = router.state.matches[ router.state.matches.length - 1 ];
+	const params = ( match?.params ?? {} ) as { domain?: string; type?: string };
+	const { domain = '' } = params;
+
+	return (
+		<PageLayout header={ <PageHeader /> } size="small">
+			<Text size={ 18 } as="h1">
+				{ __( 'Choose email solution' ) }
+			</Text>
+			<div style={ { marginTop: 12 } }>
+				<Text>
+					{ __( 'Domain:' ) } { domain }
+				</Text>
+			</div>
+		</PageLayout>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-478/hosting-dashboard-emails-mailbox-flow-domain-step

## Proposed Changes

* Added the domain step of the flow for when we want to add a mailbox to a new or existing domain.
* Created mock routes for the 3 next steps.


https://github.com/user-attachments/assets/457a9af2-8d92-44fc-9899-38f5f3683d0e



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link (or checkout locally)
* Go to: `/v2/emails/choose-domain`
* There are 2 main scenarios to test, when you have less than 10 domains and when you have more than 10 (you can change the code to just re-add the domains until you reach 10)
* When you have 10 or less, you should see al the domains and no search bar
* When you have more than 10, you should see 10 domains and the search bar.
* Domains with forwards should go to the choose provider step.
* Domains with no accounts should go to the choose provider step.
* Domains with a Google account should go to the add Google mailbox step.
* Domains with Titan Mail accounts should go to the add TitanMail mailbox step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
