### PR TITLE
Update calls to purchase list endpoints to 1.2

### DIFF
--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -35,7 +35,10 @@ export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 	} );
 
 	return wpcom.req
-		.get( `/sites/${ siteId }/purchases` )
+		.get( {
+			path: `/sites/${ siteId }/purchases`,
+			apiVersion: '1.2',
+		} )
 		.then( ( data ) => {
 			dispatch( {
 				type: PURCHASES_SITE_FETCH_COMPLETED,
@@ -57,7 +60,10 @@ export const fetchUserPurchases = ( userId ) => ( dispatch ) => {
 	} );
 
 	return wpcom.req
-		.get( '/me/purchases' )
+		.get( {
+			path: '/me/purchases',
+			apiVersion: '1.2',
+		} )
 		.then( ( data ) => {
 			dispatch( {
 				type: PURCHASES_USER_FETCH_COMPLETED,

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -39,7 +39,7 @@ describe( 'actions', () => {
 	describe( '#fetchSitePurchases', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( `/rest/v1.1/sites/${ siteId }/purchases` )
+				.get( `/rest/v1.2/sites/${ siteId }/purchases` )
 				.reply( 200, purchases );
 		} );
 
@@ -64,7 +64,7 @@ describe( 'actions', () => {
 	describe( '#fetchUserPurchases', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/me/purchases' )
+				.get( '/rest/v1.2/me/purchases' )
 				.reply( 200, purchases );
 		} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes SHILL-1057

## Proposed Changes

In 191236-ghe-Automattic/wpcom and 193428-ghe-Automattic/wpcom, we made new versions of the purchases endpoints that have a more organized return data type. This PR switches the fetch functions in calypso to use those new endpoints. There should be no change in behavior.

This was already done for the Hosting Dashboard in https://github.com/Automattic/wp-calypso/pull/106257

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/me/purchases`. Verify that your purchases appear as they did without this PR.
