### PR TITLE
Signup: Fix some errors not showing when social signup fails

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -44,6 +44,10 @@ $breakpoint-mobile: 660px;
 			padding-right: 0;
 		}
 	}
+
+	.dashboard-notice {
+		margin-bottom: 2rem;
+	}
 }
 
 .step-route.user:not(:has(.step-container-v2--user)) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import Notice from 'calypso/components/notice';
+import Notice from 'calypso/dashboard/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -52,35 +52,26 @@ export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptP
 			);
 		} else if ( errorResponse.error === '2FA_enabled' ) {
 			noticeText = (
-				<span>
-					<p>
-						{ errorResponse.message }
-						&nbsp;
-						{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
-							components: {
-								a: (
-									<a
-										href={ loginLink }
-										onClick={ () =>
-											dispatch( recordTracksEventWithClientId( 'calypso_signup_login_midflow' ) )
-										}
-									/>
-								),
-							},
-						} ) }
-					</p>
-				</span>
+				<>
+					{ errorResponse.message }
+					&nbsp;
+					{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
+						components: {
+							a: (
+								<a
+									href={ loginLink }
+									onClick={ () =>
+										dispatch( recordTracksEventWithClientId( 'calypso_signup_login_midflow' ) )
+									}
+								/>
+							),
+						},
+					} ) }
+				</>
 			);
 		}
 
-		return (
-			<Notice
-				className="signup-form__notice signup-form__span-columns"
-				showDismiss={ false }
-				status="is-transparent-info"
-				text={ noticeText }
-			/>
-		);
+		return <Notice variant="error">{ noticeText }</Notice>;
 	}
 
 	return false;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
@@ -18,72 +18,70 @@ export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptP
 		signupUrl: window.location.pathname + window.location.search,
 		redirectTo: window.location.pathname + window.location.search,
 	} );
+
 	if ( errorResponse && 'error' in errorResponse ) {
+		let noticeText =
+			errorResponse?.message || translate( 'Something went wrong. Please try again.' );
+
 		if ( errorResponse.error === 'user_exists' ) {
-			return (
-				<Notice
-					className="signup-form__notice signup-form__span-columns"
-					showDismiss={ false }
-					status="is-transparent-info"
-					text={ translate(
-						'We found a WordPress.com account with the email "%(email)s". ' +
-							'{{a}}Log in to connect it{{/a}}, or use a different email to sign up.',
-						{
-							args: { email: errorResponse.data?.email },
+			noticeText = translate(
+				'We found a WordPress.com account with the email "%(email)s". ' +
+					'{{a}}Log in to connect it{{/a}}, or use a different email to sign up.',
+				{
+					args: { email: errorResponse.data?.email },
+					components: {
+						a: (
+							<a
+								href={ loginLink }
+								onClick={ ( event ) => {
+									event.preventDefault();
+									recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
+									window.location.href = addQueryArgs(
+										{
+											service: recentSocialAuthAttemptParams?.service,
+											access_token: recentSocialAuthAttemptParams?.access_token,
+											id_token: recentSocialAuthAttemptParams?.id_token,
+										},
+										loginLink
+									);
+								} }
+							/>
+						),
+					},
+				}
+			);
+		} else if ( errorResponse.error === '2FA_enabled' ) {
+			noticeText = (
+				<span>
+					<p>
+						{ errorResponse.message }
+						&nbsp;
+						{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
 							components: {
 								a: (
 									<a
 										href={ loginLink }
-										onClick={ ( event ) => {
-											event.preventDefault();
-											recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
-											window.location.href = addQueryArgs(
-												{
-													service: recentSocialAuthAttemptParams?.service,
-													access_token: recentSocialAuthAttemptParams?.access_token,
-													id_token: recentSocialAuthAttemptParams?.id_token,
-												},
-												loginLink
-											);
-										} }
+										onClick={ () =>
+											dispatch( recordTracksEventWithClientId( 'calypso_signup_login_midflow' ) )
+										}
 									/>
 								),
 							},
-						}
-					) }
-				/>
-			);
-		} else if ( errorResponse.error === '2FA_enabled' ) {
-			return (
-				<Notice
-					className="signup-form__notice signup-form__span-columns"
-					showDismiss={ false }
-					status="is-transparent-info"
-					text={
-						<span>
-							<p>
-								{ errorResponse.message }
-								&nbsp;
-								{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
-									components: {
-										a: (
-											<a
-												href={ loginLink }
-												onClick={ () =>
-													dispatch(
-														recordTracksEventWithClientId( 'calypso_signup_login_midflow' )
-													)
-												}
-											/>
-										),
-									},
-								} ) }
-							</p>
-						</span>
-					}
-				/>
+						} ) }
+					</p>
+				</span>
 			);
 		}
+
+		return (
+			<Notice
+				className="signup-form__notice signup-form__span-columns"
+				showDismiss={ false }
+				status="is-transparent-info"
+				text={ noticeText }
+			/>
+		);
 	}
+
 	return false;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
@@ -20,7 +20,7 @@ export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptP
 	} );
 
 	if ( errorResponse && 'error' in errorResponse ) {
-		let noticeText =
+		let noticeText: React.ReactNode =
 			errorResponse?.message || translate( 'Something went wrong. Please try again.' );
 
 		if ( errorResponse.error === 'user_exists' ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Solves DOTOBRD-330
Relates to 193871-ghe-Automattic/wpcom

## Proposed Changes

* Update the `useErrorNotice` hook, used for showing errors for the social auth, to show all error messages.
* Update the Notice component to the newer one. The old Notice component is [deprecated](https://github.com/Automattic/wp-calypso/blob/302e56a5c766e790e10941e410d75d6670b36150/client/components/notice/index.tsx#L67).

| Old Notice      | New Notice |
| ----------- | ----------- |
| <img width="485" height="530" alt="image" src="https://github.com/user-attachments/assets/5d6a8256-875a-4375-9c54-b7cbb34af605" />      | <img width="495" height="560" alt="image" src="https://github.com/user-attachments/assets/70b7701c-a3d0-42fb-ac67-1e52bd0c1814" />       |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are cases where users see no error when trying to signup/login using social auth.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Map `wordpress.com`, `public-api.wordpress.com`, and `s1.wp.com` to your sandbox.
* Map `wpcalypso.wordpress.com` to `127.0.0.1`.
* Checkout 193871-ghe-Automattic/wpcom.
* In your sandbox, open `wp-content/plugins/landpack/src/blocks/custom-html/html/google-one-tap-auth.php` and search and replace `window.location.href = '/...` with `window.location.href = 'https://wpcalypso.wordpress.com/...`.
* In the sandbox CLI, go to the `public_html` folder and run `wp landing-pages render-hp 2024-jul`.
* Edit `wpmu_validate_user_signup` and force it to return an error.
* In your local calypso folder, run `NODE_ENV=production CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build`.
* Start Calypso using the following command: `HOST=wpcalypso.wordpress.com PORT=443 PROTOCOL=https yarn && yarn start`
* Test if `wpcalypso.wordpress.com` is working as expected. If not, check the "Running Calypso locally under wordpress.com or wpcalypso.wordpress.com" section in this field guide on how to fix it: PCYsg-5YE-p2
* In an incognito window, authenticate to your Google account.
* Go to the LOHP and use the Google One Tap Auth.
* Make sure you see the error notice generated by `wpmu_validate_user_signup`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?