### PR TITLE
Update copy for Contact details page

### DIFF
--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -87,8 +87,8 @@ export const getContactFormFields = (
 								{ createInterpolateElement(
 									sprintf(
 										/* translators: %s: "what is this?" link */
-										__( 'Opt-out of the 60-day transfer lock <link>%s</link>' ),
-										__( 'what is this?' )
+										__( 'Opt-out of the 60-day transfer lock. <link>%s</link>' ),
+										__( 'What is this?' )
 									),
 									{
 										link: <InlineSupportLink supportContext="60-day-transfer-lock" />,

--- a/client/dashboard/domains/domain-contact-details/contact-form.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form.tsx
@@ -169,7 +169,6 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 						>
 							{ __( 'Learn more' ) }
 						</ExternalLink>
-						.
 					</Text>
 				</VStack>
 			</Notice>
@@ -198,7 +197,7 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 								<Text as="p">
 									{ createInterpolateElement(
 										__(
-											'By clicking <strong>Save contact info</strong>, you agree to the applicable <agreementlink>Domain Registration Agreement</agreementlink> and confirm that the Transferee has agreed in writing to be bound by the same agreement. You authorize the respective registrar to act as your <agentlink>Designated Agent</agentlink>.'
+											'By clicking <strong>Save</strong>, you agree to the applicable <agreementlink>Domain Registration Agreement</agreementlink> and confirm that the Transferee has agreed in writing to be bound by the same agreement. You authorize the respective registrar to act as your <agentlink>Designated Agent</agentlink>.'
 										),
 										{
 											strong: <strong />,
@@ -221,7 +220,7 @@ export default function ContactForm( { domainName, initialData }: ContactFormPro
 									isBusy={ isSubmitting }
 									disabled={ ! canSave || ! isDirty || isSubmitting }
 								>
-									{ __( 'Save contact info' ) }
+									{ __( 'Save' ) }
 								</Button>
 							</ButtonStack>
 						</form>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

We want to have a consistent behavior on CTA name and copy across HD.

Part of pdtkmj-41C-p2#comment-7756

## Proposed Changes

* Changed the save CTA name from `Save contact info` to `Save`
* Improved copy

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of a design review

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Contact information for a domain and make sure it matches the requirements

<img width="772" height="300" alt="image" src="https://github.com/user-attachments/assets/23a41969-d913-471b-94e6-619bbdf1b2c8" />

<img width="757" height="252" alt="image" src="https://github.com/user-attachments/assets/5cf4208e-8ba1-4acb-b6ee-48cad3c589f8" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?