### PR TITLE
Domain Search Rewrite: Refactor unavailable premium domain filtering logic

### DIFF
--- a/packages/domain-search/src/components/search-notice/index.tsx
+++ b/packages/domain-search/src/components/search-notice/index.tsx
@@ -2,6 +2,7 @@ import { DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-co
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getAvailabilityNotice } from '../../helpers/get-availability-notice';
+import { isSupportedPremiumDomain } from '../../helpers/is-supported-premium-domain';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchNotice } from '../../ui';
 
@@ -33,10 +34,7 @@ const shouldHideAvailabilityNotice = (
 		return true;
 	}
 
-	if (
-		availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM &&
-		availability.is_supported_premium_domain
-	) {
+	if ( isSupportedPremiumDomain( availability ) ) {
 		return true;
 	}
 

--- a/packages/domain-search/src/components/suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/test/index.tsx
@@ -29,7 +29,8 @@ describe( 'DomainSuggestionCTA', () => {
 
 			const availability = buildAvailability( {
 				domain_name: 'test-add-to-cart.com',
-				status: DomainAvailabilityStatus.AVAILABLE,
+				status: DomainAvailabilityStatus.AVAILABLE_PREMIUM,
+				is_supported_premium_domain: true,
 			} );
 
 			mockGetAvailabilityQuery( {

--- a/packages/domain-search/src/helpers/is-supported-premium-domain.ts
+++ b/packages/domain-search/src/helpers/is-supported-premium-domain.ts
@@ -1,0 +1,8 @@
+import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
+
+export const isSupportedPremiumDomain = ( availability: DomainAvailability ) => {
+	return (
+		availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM &&
+		!! availability.is_supported_premium_domain
+	);
+};


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/106369, we introduced some additional logic to filter out unavailable domains. While the logic works fine by now, there are some aspects of it that increase the bus factor, as the code [isn't clear enough for future code wranglers](https://github.com/Automattic/wp-calypso/pull/106369#discussion_r2420976872).

This PR refactors that logic, making it clearer and more fail-proof compared to the current version. It does so by iterating over a single array instead of taking the index of one array and querying a different one, which works today by coincidence, but future changes, both in how React Query works and our own business logic, might turn that into a debugging nightmare.

## Testing Instructions

Verify all unit tests are still passing, and the testing instructions from the previous PR linked above.