### PR TITLE
Domain Search Rewrite: Prevent triggering `calypso_domain_search_results_suggestions_receive` event twice when loading domain search page

### DIFF
--- a/packages/domain-search/src/hooks/use-request-tracking.ts
+++ b/packages/domain-search/src/hooks/use-request-tracking.ts
@@ -7,9 +7,11 @@ export const useRequestTracking = () => {
 	const { query, events, queries } = useDomainSearch();
 	const lastQueryChangeTime = useRef( 0 );
 
-	const { data: suggestions = [], isLoading: isLoadingSuggestions } = useQuery(
-		queries.domainSuggestions( query )
-	);
+	const {
+		data: suggestions = [],
+		isLoading: isLoadingSuggestions,
+		isPending: isPendingSuggestions,
+	} = useQuery( queries.domainSuggestions( query ) );
 
 	const { data: availabilityData, isLoading: isLoadingQueryAvailability } = useQuery(
 		queries.domainAvailability( query )
@@ -29,10 +31,10 @@ export const useRequestTracking = () => {
 	} );
 
 	useEffect( () => {
-		if ( ! isLoadingSuggestions ) {
+		if ( ! isLoadingSuggestions && ! isPendingSuggestions ) {
 			triggerSuggestionsReceiveEvent();
 		}
-	}, [ triggerSuggestionsReceiveEvent, isLoadingSuggestions ] );
+	}, [ triggerSuggestionsReceiveEvent, isLoadingSuggestions, isPendingSuggestions ] );
 
 	const triggerQueryAvailabilityCheckEvent = useEvent( () => {
 		const availabilityCheckResponseTime = Date.now() - lastQueryChangeTime.current;


### PR DESCRIPTION
Fixes [DOMAINS-1705](https://linear.app/a8c/issue/DOMAINS-1705/)

## Proposed Changes

This PR fixes triggering the `calypso_domain_search_results_suggestions_receive` Tracks event twice when loading the domain search page.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot 2025-10-10 at 18 29 48" src="https://github.com/user-attachments/assets/e899a494-a85c-47e8-8042-de39f7b9f45a" /> | <img width="1920" height="1080" alt="Screenshot 2025-10-10 at 18 28 35" src="https://github.com/user-attachments/assets/6d22b31f-a358-4abb-8a6d-20b3e9bfe7cd" /> |

## Why are these changes being made?

The event should be triggered once per request to the `suggestions` endpoint. It was being called twice, once when the page loaded and twice when the suggestions request was actually finished.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Open your browser's network inspection and listen for the `calypso_domain_search_results_suggestions_receive` Tracks event
- Go to a domain search page (e.g. `/setup/domain`) with the `domain-search-rewrite` flag enabled
- Do a domain search and ensure only one event is triggered
- Reload the page and ensure only one event is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
