### PR TITLE
Domain Search Rewrite: Remove i18n-calypso dependency

### DIFF
--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -54,7 +54,6 @@
 		"@wordpress/icons": "^10.23.0",
 		"@wordpress/react-i18n": "^4.23.0",
 		"clsx": "^2.1.1",
-		"i18n-calypso": "workspace:^",
 		"moment": "^2.30.1",
 		"qs": "^6.11.2"
 	},

--- a/packages/domain-search/src/components/search-notice/test/index.tsx
+++ b/packages/domain-search/src/components/search-notice/test/index.tsx
@@ -544,12 +544,12 @@ describe( 'SearchNotice', () => {
 			expect( await screen.findByText( 'Information notice' ) ).toBeInTheDocument();
 
 			const [ notice ] = screen.getAllByText(
-				'test-mapped-other-site-same-user.com is already connected to your site other-site.com. If you want to connect it to this site instead, we will be happy to help you do that. Contact us.'
+				'test-mapped-other-site-same-user.com is already connected to your site other-site.com. If you want to connect it to this site instead, we will be happy to help you do that. Contact us .'
 			);
 
 			expect( notice ).toBeInTheDocument();
 
-			expect( screen.getByRole( 'link', { name: 'Contact us.' } ) ).toHaveAttribute(
+			expect( screen.getByRole( 'link', { name: 'Contact us' } ) ).toHaveAttribute(
 				'href',
 				'/help?help-center=home'
 			);
@@ -582,12 +582,12 @@ describe( 'SearchNotice', () => {
 			expect( await screen.findByText( 'Information notice' ) ).toBeInTheDocument();
 
 			const [ notice ] = screen.getAllByText(
-				'test-mapped-other-site-same-user-registrable.com is already connected to your site other-site.com. Register it to the connected site.'
+				'test-mapped-other-site-same-user-registrable.com is already connected to your site other-site.com. Register it to the connected site .'
 			);
 
 			expect( notice ).toBeInTheDocument();
 
-			const cta = screen.getByText( 'Register it to the connected site.' );
+			const cta = screen.getByText( 'Register it to the connected site' );
 
 			expect( cta ).toBeInTheDocument();
 
@@ -659,12 +659,12 @@ describe( 'SearchNotice', () => {
 			expect( await screen.findByText( 'Error notice' ) ).toBeInTheDocument();
 
 			const [ notice ] = screen.getAllByText(
-				"test-transfer-pending.com is pending transfer and can't be connected to WordPress.com right now. Learn More."
+				"test-transfer-pending.com is pending transfer and can't be connected to WordPress.com right now. Learn more ."
 			);
 
 			expect( notice ).toBeInTheDocument();
 
-			expect( screen.getByRole( 'link', { name: 'Learn More.' } ) ).toHaveAttribute(
+			expect( screen.getByRole( 'link', { name: 'Learn more' } ) ).toHaveAttribute(
 				'href',
 				'https://wordpress.com/support/incoming-domain-transfer/#step-4-check-the-transfer-status'
 			);

--- a/packages/domain-search/src/helpers/get-availability-notice.tsx
+++ b/packages/domain-search/src/helpers/get-availability-notice.tsx
@@ -7,7 +7,8 @@ import {
 	MAP_EXISTING_DOMAIN,
 	PREMIUM_DOMAINS,
 } from '@automattic/urls';
-import { translate } from 'i18n-calypso';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
 import { DomainSearchEvents } from '../page/types';
 
@@ -27,132 +28,196 @@ export const getAvailabilityNotice = (
 
 	switch ( availabilityData.status ) {
 		case DomainAvailabilityStatus.REGISTERED:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to a WordPress.com site.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__( '<strong>%(domain)s</strong> is already connected to a WordPress.com site.' ),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-					},
+					strong: <strong />,
 				}
 			);
+
 			break;
 		case DomainAvailabilityStatus.REGISTERED_SAME_SITE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{button}}Are you trying to make this the primary address for your site?{{/button}}',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						'<strong>%(domain)s</strong> is already registered on this site. <button>Are you trying to make this the primary address for your site?</button>'
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						button: <button onClick={ () => events.onMakePrimaryAddressClick( domain ) } />,
-					},
+					strong: <strong />,
+					button: <button onClick={ () => events.onMakePrimaryAddressClick( domain ) } />,
 				}
 			);
 			severity = 'info';
 			break;
 		case DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( availabilityData.other_site_domain ) {
-				const messageOptions = {
-					args: { domain, site: availabilityData.other_site_domain! },
-					components: {
-						strong: <strong />,
-						button: (
-							<button
-								onClick={ () =>
-									events.onMoveDomainToSiteClick( availabilityData.other_site_domain!, domain )
-								}
-							/>
-						),
-					},
-				};
 				if ( currentSiteUrl ) {
 					if ( availabilityData.other_site_domain_only ) {
-						message = translate(
-							'{{strong}}%(domain)s{{/strong}} is already registered as a domain-only site. Do you want to {{button}}move it to this site{{/button}}?',
-							messageOptions
+						message = createInterpolateElement(
+							sprintf(
+								/* translators: %(domain)s is the domain name */
+								__(
+									'<strong>%(domain)s</strong> is already registered as a domain-only site. Do you want to <button>move it to this site</button>?'
+								),
+								{
+									domain,
+								}
+							),
+							{
+								strong: <strong />,
+								button: (
+									<button
+										onClick={ () =>
+											events.onMoveDomainToSiteClick( availabilityData.other_site_domain!, domain )
+										}
+									/>
+								),
+							}
 						);
 					} else {
-						message = translate(
-							'{{strong}}%(domain)s{{/strong}} is already registered on your site %(site)s. Do you want to {{button}}move it to this site{{/button}}?',
-							messageOptions
+						message = createInterpolateElement(
+							sprintf(
+								/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
+								__(
+									'<strong>%(domain)s</strong> is already registered on your site %(site)s. Do you want to <button>move it to this site</button>?'
+								),
+								{
+									domain,
+									site: availabilityData.other_site_domain!,
+								}
+							),
+							{
+								strong: <strong />,
+								button: (
+									<button
+										onClick={ () =>
+											events.onMoveDomainToSiteClick( availabilityData.other_site_domain!, domain )
+										}
+									/>
+								),
+							}
 						);
 					}
 				} else if ( availabilityData.other_site_domain_only ) {
-					message = translate(
-						'{{strong}}%(domain)s{{/strong}} is already registered as a domain-only site.',
-						messageOptions
+					message = createInterpolateElement(
+						sprintf(
+							/* translators: %(domain)s is the domain name */
+							__( '<strong>%(domain)s</strong> is already registered as a domain-only site.' ),
+							{
+								domain,
+							}
+						),
+						{
+							strong: <strong />,
+						}
 					);
 				} else {
-					message = translate(
-						'{{strong}}%(domain)s{{/strong}} is already registered on your site %(site)s.',
-						messageOptions
+					message = createInterpolateElement(
+						sprintf(
+							/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
+							__( '<strong>%(domain)s</strong> is already registered on your site %(site)s.' ),
+							{
+								domain,
+								site: availabilityData.other_site_domain!,
+							}
+						),
+						{
+							strong: <strong />,
+						}
 					);
 				}
 			} else {
-				message = translate(
-					'{{strong}}%(domain)s{{/strong}} is already registered on another site you own.',
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is the domain name */
+						__( '<strong>%(domain)s</strong> is already registered on another site you own.' ),
+						{
+							domain,
+						}
+					),
 					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-						},
+						strong: <strong />,
 					}
 				);
 			}
 			severity = 'info';
 			break;
 		case DomainAvailabilityStatus.IN_REDEMPTION:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is not eligible to register or transfer since it is in {{redemptionLink}}redemption{{/redemptionLink}}. If you own this domain, please contact your current registrar to {{aboutRenewingLink}}redeem the domain{{/aboutRenewingLink}}.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						'<strong>%(domain)s</strong> is not eligible to register or transfer since it is in <redemptionLink>redemption</redemptionLink>. If you own this domain, please contact your current registrar to <aboutRenewingLink>redeem the domain</aboutRenewingLink>.'
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						redemptionLink: (
-							<a
-								target="_blank"
-								rel="noopener noreferrer"
-								href="https://www.icann.org/resources/pages/grace-2013-05-03-en"
-							/>
-						),
-						aboutRenewingLink: (
-							<a
-								target="_blank"
-								rel="noopener noreferrer"
-								href="https://www.icann.org/news/blog/do-you-have-a-domain-name-here-s-what-you-need-to-know-part-5"
-							/>
-						),
-					},
+					strong: <strong />,
+					redemptionLink: (
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href="https://www.icann.org/resources/pages/grace-2013-05-03-en"
+						/>
+					),
+					aboutRenewingLink: (
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href="https://www.icann.org/news/blog/do-you-have-a-domain-name-here-s-what-you-need-to-know-part-5"
+						/>
+					),
 				}
 			);
 			break;
 		case DomainAvailabilityStatus.CONFLICTING_CNAME_EXISTS:
-			message = translate(
-				'There is an existing CNAME for {{strong}}%(domain)s{{/strong}}. If you want to connect this subdomain, you should remove the conflicting CNAME DNS record first.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						'There is an existing CNAME for <strong>%(domain)s</strong>. If you want to connect this subdomain, you should remove the conflicting CNAME DNS record first.'
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-					},
+					strong: <strong />,
 				}
 			);
 			break;
 		case DomainAvailabilityStatus.MAPPED_SAME_SITE_TRANSFERRABLE:
 			if ( currentSiteUrl ) {
-				message = translate(
-					'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +
-						'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
-						'together? {{button}}Yes, transfer it to WordPress.com.{{/button}}',
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is the domain name */
+						__(
+							'<strong>%(domain)s</strong> is already connected to this site, but registered somewhere else. Do you want to move ' +
+								'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
+								'together? <button>Yes, transfer it to WordPress.com.</button>'
+						),
+						{
+							domain,
+						}
+					),
 					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-							button: (
-								<button
-									onClick={ () => events.onMoveDomainToSiteClick( currentSiteUrl!, domain ) }
-								/>
-							),
-						},
+						strong: <strong />,
+						button: (
+							<button onClick={ () => events.onMoveDomainToSiteClick( currentSiteUrl!, domain ) } />
+						),
 					}
 				);
 				severity = 'info';
@@ -160,129 +225,154 @@ export const getAvailabilityNotice = (
 			}
 		case DomainAvailabilityStatus.MAPPED_SAME_SITE_NOT_TRANSFERRABLE:
 			if ( availabilityData.cannot_transfer_due_to_unsupported_premium_tld ) {
-				message = translate(
-					'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com because premium domain transfers for the %(tld)s TLD are not supported. {{a}}Learn more{{/a}}.',
-					{
-						args: {
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is the domain name, %(tld)s is the TLD */
+						__(
+							'<strong>%(domain)s</strong> is already connected to this site and cannot be transferred to WordPress.com because premium domain transfers for the %(tld)s TLD are not supported. <a>Learn more</a>.'
+						),
+						{
 							domain,
 							tld: availabilityData.tld,
-						},
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									target="_blank"
-									rel="noopener noreferrer"
-									href={ localizeUrl( PREMIUM_DOMAINS ) }
-								/>
-							),
-						},
+						}
+					),
+					{
+						strong: <strong />,
+						a: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								href={ localizeUrl( PREMIUM_DOMAINS ) }
+							/>
+						),
 					}
 				);
 				break;
 			}
 
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com. {{a}}Learn more{{/a}}.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						'<strong>%(domain)s</strong> is already connected to this site and cannot be transferred to WordPress.com. <a>Learn more</a>.'
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								target="_blank"
-								rel="noopener noreferrer"
-								href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS ) }
-							/>
-						),
-					},
+					strong: <strong />,
+					a: (
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS ) }
+						/>
+					),
 				}
 			);
 			break;
 		case DomainAvailabilityStatus.MAPPED_OTHER_SITE_SAME_USER:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s. If you want to connect it to this site ' +
-					'instead, we will be happy to help you do that. {{a}}Contact us.{{/a}}',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
+					__(
+						'<strong>%(domain)s</strong> is already connected to your site %(site)s. If you want to connect it to this site ' +
+							'instead, we will be happy to help you do that. <a>Contact us</a>.'
+					),
+					{
+						domain,
+						site: availabilityData.other_site_domain!,
+					}
+				),
 				{
-					args: { domain, site: availabilityData.other_site_domain! },
-					components: {
-						strong: <strong />,
-						a: (
-							<a target="_blank" rel="noopener noreferrer" href={ CALYPSO_HELP_WITH_HELP_CENTER } />
-						),
-					},
+					strong: <strong />,
+					a: <a target="_blank" rel="noopener noreferrer" href={ CALYPSO_HELP_WITH_HELP_CENTER } />,
 				}
 			);
 			severity = 'info';
 			break;
 		case DomainAvailabilityStatus.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s.' +
-					' {{button}}Register it to the connected site.{{/button}}',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
+					__(
+						'<strong>%(domain)s</strong> is already connected to your site %(site)s.' +
+							' <button>Register it to the connected site</button>.'
+					),
+					{
+						domain,
+						site: availabilityData.other_site_domain!,
+					}
+				),
 				{
-					args: { domain, site: availabilityData.other_site_domain! },
-					components: {
-						strong: <strong />,
-						button: (
-							<button
-								onClick={ () =>
-									events.onRegisterDomainClick( availabilityData.other_site_domain!, domain )
-								}
-							/>
-						),
-					},
+					strong: <strong />,
+					button: (
+						<button
+							onClick={ () =>
+								events.onRegisterDomainClick( availabilityData.other_site_domain!, domain )
+							}
+						/>
+					),
 				}
 			);
 			severity = 'info';
 			break;
 		case DomainAvailabilityStatus.TRANSFER_PENDING_SAME_USER:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is pending transfer. {{button}}Check the transfer status{{/button}} to learn more.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						'<strong>%(domain)s</strong> is pending transfer. <button>Check the transfer status</button> to learn more.'
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						button: <button onClick={ () => events.onCheckTransferStatusClick( domain ) } />,
-					},
+					strong: <strong />,
+					button: <button onClick={ () => events.onCheckTransferStatusClick( domain ) } />,
 				}
 			);
 			severity = 'info';
 			break;
 		case DomainAvailabilityStatus.TRANSFER_PENDING:
-			message = translate(
-				"{{strong}}%(domain)s{{/strong}} is pending transfer and can't be connected to WordPress.com right now. " +
-					'{{a}}Learn More.{{/a}}',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						"<strong>%(domain)s</strong> is pending transfer and can't be connected to WordPress.com right now. <a>Learn more</a>."
+					),
+					{
+						domain,
+					}
+				),
 				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								target="_blank"
-								rel="noopener noreferrer"
-								href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS ) }
-							/>
-						),
-					},
+					strong: <strong />,
+					a: (
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS ) }
+						/>
+					),
 				}
 			);
 			break;
 		case DomainAvailabilityStatus.NOT_REGISTRABLE:
 			if ( availabilityData.tld ) {
-				message = translate(
-					'To use this domain on your site, you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
+				message = createInterpolateElement(
+					__(
+						'To use this domain on your site, you can register it elsewhere first and then add it here. <a>Learn more</a>.'
+					),
 					{
-						args: { tld: availabilityData.tld },
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									target="_blank"
-									rel="noopener noreferrer"
-									href={ localizeUrl( MAP_EXISTING_DOMAIN ) }
-								/>
-							),
-						},
+						a: (
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								href={ localizeUrl( MAP_EXISTING_DOMAIN ) }
+							/>
+						),
 					}
 				);
 				severity = 'info';
@@ -290,46 +380,48 @@ export const getAvailabilityNotice = (
 			break;
 		case DomainAvailabilityStatus.MAINTENANCE:
 			if ( availabilityData.tld ) {
-				let maintenanceEnd = translate( 'shortly', {
-					comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
-				} );
+				let maintenanceEnd = __( 'shortly' );
 				if ( availabilityData.maintenance_end_time ) {
 					maintenanceEnd = moment
 						.unix( parseInt( availabilityData.maintenance_end_time, 10 ) )
 						.fromNow();
 				}
 
-				message = translate(
-					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please ' +
-						'try a different extension or check back %(maintenanceEnd)s.',
-					{
-						args: {
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(tld)s is the TLD */
+						__(
+							'Domains ending with <strong>.%(tld)s</strong> are undergoing maintenance. Please ' +
+								'try a different extension or check back %(maintenanceEnd)s.'
+						),
+						{
 							tld: availabilityData.tld,
 							maintenanceEnd,
-						},
-						components: {
-							strong: <strong />,
-						},
+						}
+					),
+					{
+						strong: <strong />,
 					}
 				);
 				severity = 'info';
 			}
 			break;
 		case DomainAvailabilityStatus.PURCHASES_DISABLED: {
-			let maintenanceEnd = translate( 'shortly', {
-				comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
-			} );
+			let maintenanceEnd = __( 'shortly' );
 			if ( availabilityData.maintenance_end_time ) {
 				maintenanceEnd = moment
 					.unix( parseInt( availabilityData.maintenance_end_time, 10 ) )
 					.fromNow();
 			}
 
-			message = translate(
-				'Domain registration is unavailable at this time. Please select a free subdomain ' +
-					'or check back %(maintenanceEnd)s.',
+			message = sprintf(
+				/* translators: %(maintenanceEnd)s is the maintenance end time */
+				__(
+					'Domain registration is unavailable at this time. Please select a free subdomain ' +
+						'or check back %(maintenanceEnd)s.'
+				),
 				{
-					args: { maintenanceEnd },
+					maintenanceEnd,
 				}
 			);
 			severity = 'info';
@@ -337,85 +429,106 @@ export const getAvailabilityNotice = (
 		}
 
 		case DomainAvailabilityStatus.EMPTY_RESULTS:
-			message = translate(
+			message = __(
 				"Sorry, we weren't able to generate any domain name suggestions for that search term. Please try a different set of keywords."
 			);
 			break;
 
 		case DomainAvailabilityStatus.INVALID_TLD:
 		case DomainAvailabilityStatus.INVALID:
-			message = translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
-				args: { domain: domain },
-			} );
+			message = sprintf(
+				/* translators: %(domain)s is the domain name */
+				__( 'Sorry, %(domain)s does not appear to be a valid domain name.' ),
+				{
+					domain,
+				}
+			);
 			break;
 
 		case DomainAvailabilityStatus.RECENTLY_EXPIRED:
-			message = translate(
-				'This domain expired recently. To get it back please {{a}}contact support{{/a}}.',
+			message = createInterpolateElement(
+				__( 'This domain expired recently. To get it back please <a>contact support</a>.' ),
 				{
-					components: {
-						a: <a target="_blank" href={ CALYPSO_HELP_WITH_HELP_CENTER } rel="noreferrer" />,
-					},
+					a: <a target="_blank" href={ CALYPSO_HELP_WITH_HELP_CENTER } rel="noreferrer" />,
 				}
 			);
 			break;
 
 		case DomainAvailabilityStatus.DOMAIN_SUGGESTIONS_THROTTLED:
-			message = translate(
+			message = __(
 				'You have made too many domain suggestions requests in a short time. Please wait a few minutes and try again.'
 			);
 			break;
 
 		case DomainAvailabilityStatus.AVAILABLE_PREMIUM:
 			if ( currentSiteUrl ) {
-				message = translate(
-					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can {{button}}connect it to your site{{/button}}.",
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is the domain name */
+						__(
+							"Sorry, <strong>%(domain)s</strong> is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can <button>connect it to your site</button>."
+						),
+						{
+							domain,
+						}
+					),
 					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-							button: <button onClick={ () => events.onMapDomainClick( domain ) } />,
-						},
+						strong: <strong />,
+						button: <button onClick={ () => events.onMapDomainClick( domain ) } />,
 					}
 				);
 			} else {
-				message = translate(
-					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com.",
+				message = createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is the domain name */
+						__(
+							"Sorry, <strong>%(domain)s</strong> is a premium domain. We don't support purchasing this premium domain on WordPress.com."
+						),
+						{
+							domain,
+						}
+					),
 					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-						},
+						strong: <strong />,
 					}
 				);
 			}
 			break;
 
 		case DomainAvailabilityStatus.AVAILABLE_RESERVED:
-			message = translate(
-				'Sorry, {{strong}}%(domain)s{{/strong}} is reserved by the .%(tld)s registry and cannot be registered without permission.',
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name, %(tld)s is the TLD */
+					__(
+						'Sorry, <strong>%(domain)s</strong> is reserved by the .%(tld)s registry and cannot be registered without permission.'
+					),
+					{
+						domain,
+						tld: availabilityData.tld,
+					}
+				),
 				{
-					args: { domain, tld: availabilityData.tld },
-					components: {
-						strong: <strong />,
-					},
+					strong: <strong />,
 				}
 			);
 			break;
 
 		case DomainAvailabilityStatus.INVALID_LENGTH:
-			message = translate( 'The domain name is too long.' );
+			message = __( 'The domain name is too long.' );
 			break;
 
 		case DomainAvailabilityStatus.DOMAIN_AVAILABILITY_THROTTLED:
-			message = translate(
-				"Unfortunately we're unable to check the status of {{strong}}%(domain)s{{/strong}} at this moment. Please log in first or try again later.",
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-					},
-				}
+			message = createInterpolateElement(
+				sprintf(
+					/* translators: %(domain)s is the domain name */
+					__(
+						"Unfortunately we're unable to check the status of <strong>%(domain)s</strong> at this moment. Please log in first or try again later."
+					),
+					{
+						domain,
+					}
+				),
+				{ strong: <strong /> }
 			);
 			break;
 	}

--- a/packages/domain-search/src/helpers/parse-match-reasons.ts
+++ b/packages/domain-search/src/helpers/parse-match-reasons.ts
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 import { getTld } from './get-tld';
 
 const SLD_EXACT_MATCH = 'exact-match';
@@ -26,19 +26,22 @@ function getMatchReasonPhrasesMap( tld: string ) {
 	return new Map( [
 		[
 			TLD_EXACT_MATCH,
-			translate( 'Extension ".%(tld)s" matches your query', { args: { tld } } ) as string,
+			/* translators: %(tld)s is the TLD */
+			sprintf( __( 'Extension ".%(tld)s" matches your query' ), { tld } ),
 		],
 		[
 			TLD_SIMILAR,
-			translate( 'Extension ".%(tld)s" closely matches your query', { args: { tld } } ) as string,
+			/* translators: %(tld)s is the TLD */
+			sprintf( __( 'Extension ".%(tld)s" closely matches your query' ), { tld } ),
 		],
-		[ 'exact-match', translate( 'Exact match' ) as string ],
-		[ SIMILAR_MATCH, translate( 'Close match' ) as string ],
+		[ 'exact-match', __( 'Exact match' ) ],
+		[ SIMILAR_MATCH, __( 'Close match' ) ],
 		[
 			TLD_COMMON,
 			tld === 'com'
-				? ( translate( '".com" is the most common extension' ) as string )
-				: ( translate( '".%(tld)s" is a common extension', { args: { tld } } ) as string ),
+				? __( '".com" is the most common extension' )
+				: /* translators: %(tld)s is the TLD */
+				  sprintf( __( '".%(tld)s" is a common extension' ), { tld } ),
 		],
 	] );
 }

--- a/packages/domain-search/tsconfig.json
+++ b/packages/domain-search/tsconfig.json
@@ -8,5 +8,9 @@
 		"resolveJsonModule": true
 	},
 	"include": [ "src", "src/**/*.json" ],
-	"references": [ { "path": "../components" }, { "path": "../api-core" } ]
+	"references": [
+		{ "path": "../components" },
+		{ "path": "../api-core" },
+		{ "path": "../api-queries" }
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,7 +1240,6 @@ __metadata:
     "@wordpress/react-i18n": "npm:^4.23.0"
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
-    i18n-calypso: "workspace:^"
     moment: "npm:^2.30.1"
     nock: "npm:^13.5.6"
     qs: "npm:^6.11.2"


### PR DESCRIPTION
Closes DOMAINS-1708.

## Proposed Changes

In order to save time during the first iterations, we took a shortcut to have internationalized sentences within `@packages/domain-search` by importing `translate` from `i18n-calypso`, which is a function specific to Calypso and shouldn't be used in agnostic packages, in which `@wordpress/i18n` is preferred.

This PR performs this cleanup to ensure the domain search package stays truly agnostic.

## Testing Instructions

No manual testing needed as all paths are covered with tests. But you can verify the match reasons still show up by searching for an available FQDN, and the availability notices show up by going to `/start/domain` and searching for a domain registered in one of your sites.