### PR TITLE
Hosting Dashboard: Refactor usePerformanceData and fix inaccurate loading states.

### DIFF
--- a/client/dashboard/app/hooks/site-performance.ts
+++ b/client/dashboard/app/hooks/site-performance.ts
@@ -5,14 +5,12 @@ import type { SitePerformanceReport } from '@automattic/api-core';
 type ReportType = 'mobile' | 'desktop';
 
 interface PerformanceData {
-	refetch: () => void;
-	loadingState: ( reportType: ReportType ) => {
-		isLoading: boolean;
-		message: string | null;
-	} | null;
+	hasCompleted: boolean;
+	createNewReport: () => void;
 	getReport: ( type: ReportType ) => SitePerformanceReport | undefined;
 	hasError: ( type: ReportType ) => boolean;
-	hasCompleted: boolean;
+	isLoadingExistingReport: ( reportType: ReportType ) => boolean;
+	isLoadingNewReport: ( reportType: ReportType ) => boolean;
 }
 
 /**
@@ -41,7 +39,7 @@ export function usePerformanceData(
 		isLoading: isLoadingBasicMetrics,
 		isFetching: isFetchingBasicMetrics,
 		isError: isBasicMetricsError,
-		refetch,
+		refetch: createNewReport,
 	} = useQuery( {
 		...basicMetricsQuery( url as string ),
 		refetchOnWindowFocus: false,
@@ -63,36 +61,6 @@ export function usePerformanceData(
 		staleTime: 0,
 	} );
 
-	const desktop = performanceData?.pagespeed?.desktop;
-	const mobile = performanceData?.pagespeed?.mobile;
-	const desktopLoaded = typeof desktop === 'object';
-	const mobileLoaded = typeof mobile === 'object';
-
-	const getLoadingState = ( reportType: ReportType ) => {
-		// If we have loaded reports, never show loading
-		if ( reportType === 'desktop' ? desktopLoaded : mobileLoaded ) {
-			return { isLoading: false, message: null };
-		}
-
-		if ( shouldFetchToken ) {
-			if ( isLoadingBasicMetrics || isFetchingBasicMetrics ) {
-				return { isLoading: true, message: 'Generating new report token...' };
-			}
-
-			if ( isLoadingPerformanceInsights || isFetchingPerformanceInsights ) {
-				return { isLoading: true, message: 'Running new report...' };
-			}
-
-			if ( isReportRunning( reportType === 'desktop' ? desktop : mobile ) ) {
-				return { isLoading: true, message: 'Running new report...' };
-			}
-		} else if ( isLoadingPerformanceInsights || isFetchingPerformanceInsights ) {
-			return { isLoading: true, message: 'Loading your data...' };
-		}
-
-		return { isLoading: false, message: null };
-	};
-
 	const getReport = ( type: ReportType ): SitePerformanceReport | undefined => {
 		if ( typeof performanceData?.pagespeed[ type ] === 'string' ) {
 			return undefined;
@@ -101,12 +69,43 @@ export function usePerformanceData(
 		return performanceData?.pagespeed[ type ];
 	};
 
+	const isLoadingExistingReport = ( reportType: ReportType ) => {
+		if ( getReport( reportType ) !== undefined ) {
+			return false;
+		}
+
+		return ! shouldFetchToken && ( isLoadingPerformanceInsights || isFetchingPerformanceInsights );
+	};
+
+	const isLoadingNewReport = ( reportType: ReportType ) => {
+		if ( getReport( reportType ) !== undefined ) {
+			return false;
+		}
+
+		if ( shouldFetchToken ) {
+			if ( isLoadingBasicMetrics || isFetchingBasicMetrics ) {
+				return true;
+			}
+
+			if ( isLoadingPerformanceInsights || isFetchingPerformanceInsights ) {
+				return true;
+			}
+
+			if ( isReportRunning( performanceData?.pagespeed?.[ reportType ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
 	return {
+		createNewReport,
+		getReport,
+		hasCompleted: !! getReport( 'desktop' ) && !! getReport( 'mobile' ),
 		hasError: ( type: ReportType ) =>
 			isReportFailed( getReport( type ) ) || isBasicMetricsError || isInsightsError,
-		refetch,
-		loadingState: getLoadingState,
-		getReport: ( type: ReportType ) => getReport( type ),
-		hasCompleted: getReport( 'desktop' ) !== undefined && getReport( 'mobile' ) !== undefined,
+		isLoadingExistingReport,
+		isLoadingNewReport,
 	};
 }

--- a/client/dashboard/app/hooks/site-performance.ts
+++ b/client/dashboard/app/hooks/site-performance.ts
@@ -30,9 +30,9 @@ const isReportRunning = ( report: unknown ) => 'running' === report || 'queued' 
 export function usePerformanceData(
 	url: string | undefined,
 	hash: string | undefined,
-	runNewReport: boolean
+	runNewReport?: boolean
 ): PerformanceData {
-	const shouldFetchToken = runNewReport || ! hash;
+	const shouldFetchToken = runNewReport ?? ! hash;
 
 	const {
 		data: basicMetricsData,

--- a/client/dashboard/app/hooks/site-performance.ts
+++ b/client/dashboard/app/hooks/site-performance.ts
@@ -2,21 +2,17 @@ import { basicMetricsQuery, sitePerformanceInsightsQuery } from '@automattic/api
 import { useQuery } from '@tanstack/react-query';
 import type { SitePerformanceReport } from '@automattic/api-core';
 
+type ReportType = 'mobile' | 'desktop';
+
 interface PerformanceData {
-	hash: string | undefined;
-	mobileReport: SitePerformanceReport | undefined;
-	desktopReport: SitePerformanceReport | undefined;
-	desktopScore: number | undefined;
-	mobileScore: number | undefined;
-	desktopLoaded: boolean;
-	mobileLoaded: boolean;
-	isLoading: boolean;
-	isDesktopReportRunning: boolean;
-	isMobileReportRunning: boolean;
-	isDesktopReportError: boolean;
-	isMobileReportError: boolean;
-	isError: boolean;
 	refetch: () => void;
+	loadingState: ( reportType: ReportType ) => {
+		isLoading: boolean;
+		message: string | null;
+	} | null;
+	getReport: ( type: ReportType ) => SitePerformanceReport | undefined;
+	hasError: ( type: ReportType ) => boolean;
+	hasCompleted: boolean;
 }
 
 /**
@@ -35,17 +31,21 @@ const isReportRunning = ( report: unknown ) => 'running' === report || 'queued' 
 
 export function usePerformanceData(
 	url: string | undefined,
-	hash: string | undefined
+	hash: string | undefined,
+	runNewReport: boolean
 ): PerformanceData {
+	const shouldFetchToken = runNewReport || ! hash;
+
 	const {
 		data: basicMetricsData,
 		isLoading: isLoadingBasicMetrics,
+		isFetching: isFetchingBasicMetrics,
 		isError: isBasicMetricsError,
 		refetch,
 	} = useQuery( {
 		...basicMetricsQuery( url as string ),
 		refetchOnWindowFocus: false,
-		enabled: !! url && ! hash,
+		enabled: !! url && shouldFetchToken,
 	} );
 
 	const token = basicMetricsData?.token || hash;
@@ -53,12 +53,14 @@ export function usePerformanceData(
 	const {
 		data: performanceData,
 		isLoading: isLoadingPerformanceInsights,
+		isFetching: isFetchingPerformanceInsights,
 		isError: isInsightsError,
 	} = useQuery( {
 		...sitePerformanceInsightsQuery( url as string, token || '' ),
 		refetchOnWindowFocus: false,
 		retry: false,
 		enabled: !! url && !! token,
+		staleTime: 0,
 	} );
 
 	const desktop = performanceData?.pagespeed?.desktop;
@@ -66,20 +68,45 @@ export function usePerformanceData(
 	const desktopLoaded = typeof desktop === 'object';
 	const mobileLoaded = typeof mobile === 'object';
 
+	const getLoadingState = ( reportType: ReportType ) => {
+		// If we have loaded reports, never show loading
+		if ( reportType === 'desktop' ? desktopLoaded : mobileLoaded ) {
+			return { isLoading: false, message: null };
+		}
+
+		if ( shouldFetchToken ) {
+			if ( isLoadingBasicMetrics || isFetchingBasicMetrics ) {
+				return { isLoading: true, message: 'Generating new report token...' };
+			}
+
+			if ( isLoadingPerformanceInsights || isFetchingPerformanceInsights ) {
+				return { isLoading: true, message: 'Running new report...' };
+			}
+
+			if ( isReportRunning( reportType === 'desktop' ? desktop : mobile ) ) {
+				return { isLoading: true, message: 'Running new report...' };
+			}
+		} else if ( isLoadingPerformanceInsights || isFetchingPerformanceInsights ) {
+			return { isLoading: true, message: 'Loading your data...' };
+		}
+
+		return { isLoading: false, message: null };
+	};
+
+	const getReport = ( type: ReportType ): SitePerformanceReport | undefined => {
+		if ( typeof performanceData?.pagespeed[ type ] === 'string' ) {
+			return undefined;
+		}
+
+		return performanceData?.pagespeed[ type ];
+	};
+
 	return {
-		hash: token,
-		mobileReport: mobileLoaded ? mobile : undefined,
-		desktopReport: desktopLoaded ? desktop : undefined,
-		desktopScore: desktop?.overall_score,
-		mobileScore: mobile?.overall_score,
-		desktopLoaded,
-		mobileLoaded,
-		isLoading: isLoadingBasicMetrics || isLoadingPerformanceInsights,
-		isDesktopReportRunning: isReportRunning( desktop ),
-		isMobileReportRunning: isReportRunning( mobile ),
-		isDesktopReportError: isReportFailed( desktop ),
-		isMobileReportError: isReportFailed( mobile ),
-		isError: isBasicMetricsError || isInsightsError,
+		hasError: ( type: ReportType ) =>
+			isReportFailed( getReport( type ) ) || isBasicMetricsError || isInsightsError,
 		refetch,
+		loadingState: getLoadingState,
+		getReport: ( type: ReportType ) => getReport( type ),
+		hasCompleted: getReport( 'desktop' ) !== undefined && getReport( 'mobile' ) !== undefined,
 	};
 }

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -4,12 +4,12 @@ import { useQuery } from '@tanstack/react-query';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { usePerformanceData } from '../../app/hooks/site-performance';
 import { useTimeSince } from '../../components/time-since';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import OverviewCard from '../overview-card';
+import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
@@ -83,7 +83,7 @@ function PerformanceCardContentWithTests( {
 	site: Site;
 	page: SitePerformancePage;
 } ) {
-	const { getReport, hasCompleted } = usePerformanceData(
+	const { getReport, hasCompleted } = useSitePerformanceData(
 		page.link,
 		page.wpcom_performance_report_hash
 	);

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -83,18 +83,24 @@ function PerformanceCardContentWithTests( {
 	site: Site;
 	page: SitePerformancePage;
 } ) {
-	const { desktopReport, mobileReport, desktopScore, mobileScore } = usePerformanceData(
+	const { getReport, hasCompleted } = usePerformanceData(
 		page.link,
 		page.wpcom_performance_report_hash
 	);
 
-	if ( ! desktopReport || ! mobileReport ) {
+	if ( ! hasCompleted ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
 	}
 
-	if ( ! desktopScore || ! mobileScore ) {
+	const desktopReport = getReport( 'desktop' );
+	const mobileReport = getReport( 'mobile' );
+
+	if ( ! desktopReport || ! mobileReport ) {
 		return <PerformanceCardContentWithoutTests site={ site } />;
 	}
+
+	const desktopScore = desktopReport.overall_score;
+	const mobileScore = mobileReport.overall_score;
 
 	const report = desktopScore < mobileScore ? desktopReport : mobileReport;
 	const worseScore = Math.min( desktopScore, mobileScore );

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -39,6 +39,9 @@ const getPageFromID = ( pages: SitePerformancePage[] | undefined, pageId: string
 };
 
 function SitePerformanceContent( { site }: { site: Site } ) {
+	const [ deviceToggle, setDeviceToggle ] = useState< DeviceToggleType >( 'mobile' );
+	const [ runNewReport, setRunNewReport ] = useState( false );
+
 	const { data: siteSettings } = useSuspenseQuery( {
 		...siteSettingsQuery( site.ID ),
 		select: ( s ) => ( {
@@ -48,18 +51,17 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 	} );
 	const { data: pagesData, refetch: refetchPages } = useQuery( {
 		...sitePerformancePagesQuery( site.ID ),
-		refetchOnWindowFocus: false,
 	} );
 	const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
 	const currentPage = useMemo( () => {
 		return page_id ? getPageFromID( pagesData, page_id ) : pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
-	const [ deviceToggle, setDeviceToggle ] = useState< DeviceToggleType >( 'mobile' );
-	const [ runNewReport, setRunNewReport ] = useState( false );
+
 	const {
 		hasError,
-		refetch: refetchReport,
-		loadingState,
+		createNewReport,
+		isLoadingExistingReport,
+		isLoadingNewReport,
 		getReport,
 		hasCompleted,
 	} = usePerformanceData(
@@ -72,27 +74,22 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 
 	const handleReportRefetch = async () => {
 		setRunNewReport( true );
-		await refetchReport();
+		await createNewReport();
 		// Once we get a token back, we can refetch the pages to get the updated hash.
 		refetchPages();
 	};
 
-	const currentReport = getReport( deviceToggle );
-
 	useEffect( () => {
-		if ( ! hasCompleted ) {
-			return;
+		if ( hasCompleted ) {
+			setRunNewReport( false );
 		}
-
-		setRunNewReport( false );
 	}, [ hasCompleted ] );
 
 	if ( ! pagesData || ! currentPage ) {
 		return null;
 	}
 
-	console.log( 'loadingState', loadingState( deviceToggle ) );
-
+	const currentReport = getReport( deviceToggle );
 	const { gmtOffset, timezoneString } = siteSettings;
 
 	const renderContent = () => {
@@ -100,8 +97,12 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
 
-		if ( isFetchingReport || ! currentReport ) {
-			return <ReportLoading isSavedReport={ isFetchingReport } />;
+		if ( isLoadingNewReport( deviceToggle ) ) {
+			return <ReportLoading isSavedReport={ false } />;
+		}
+
+		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport ) {
+			return <ReportLoading isSavedReport />;
 		}
 
 		return (

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -10,7 +10,6 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { usePerformanceData } from '../../app/hooks/site-performance';
 import { sitePerformanceRoute, siteRoute } from '../../app/router/sites';
 import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -25,6 +24,7 @@ import ReportErrorNotice from './report-error-notice';
 import ReportExpiredNotice from './report-expired-notice';
 import ReportLoading from './report-loading';
 import Subtitle from './subtitle';
+import { useSitePerformanceData } from './use-site-performance-data';
 import type { DeviceToggleType } from './types';
 import type { Site, SitePerformancePage } from '@automattic/api-core';
 
@@ -64,7 +64,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		isLoadingNewReport,
 		getReport,
 		hasCompleted,
-	} = usePerformanceData(
+	} = useSitePerformanceData(
 		currentPage?.link,
 		currentPage?.wpcom_performance_report_hash,
 		runNewReport

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -8,7 +8,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { usePerformanceData } from '../../app/hooks/site-performance';
 import { sitePerformanceRoute, siteRoute } from '../../app/router/sites';
@@ -55,51 +55,53 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		return page_id ? getPageFromID( pagesData, page_id ) : pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
 	const [ deviceToggle, setDeviceToggle ] = useState< DeviceToggleType >( 'mobile' );
+	const [ runNewReport, setRunNewReport ] = useState( false );
 	const {
-		desktopReport,
-		mobileReport,
-		isLoading: isFetchingReport,
-		isDesktopReportRunning,
-		isMobileReportRunning,
-		desktopLoaded,
-		mobileLoaded,
-		isError,
-		isDesktopReportError,
-		isMobileReportError,
+		hasError,
 		refetch: refetchReport,
-	} = usePerformanceData( currentPage?.link, currentPage?.wpcom_performance_report_hash );
+		loadingState,
+		getReport,
+		hasCompleted,
+	} = usePerformanceData(
+		currentPage?.link,
+		currentPage?.wpcom_performance_report_hash,
+		runNewReport
+	);
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitePerformanceRoute.fullPath } );
 
 	const handleReportRefetch = async () => {
+		setRunNewReport( true );
 		await refetchReport();
 		// Once we get a token back, we can refetch the pages to get the updated hash.
 		refetchPages();
 	};
 
+	const currentReport = getReport( deviceToggle );
+
+	useEffect( () => {
+		if ( ! hasCompleted ) {
+			return;
+		}
+
+		setRunNewReport( false );
+	}, [ hasCompleted ] );
+
 	if ( ! pagesData || ! currentPage ) {
 		return null;
 	}
 
-	const isDesktopSelected = deviceToggle === 'desktop';
-	const currentReport = isDesktopSelected ? desktopReport : mobileReport;
-	const isRunningReport = isDesktopSelected ? isDesktopReportRunning : isMobileReportRunning;
-	const hasError = ( isDesktopSelected ? isDesktopReportError : isMobileReportError ) || isError;
+	console.log( 'loadingState', loadingState( deviceToggle ) );
+
 	const { gmtOffset, timezoneString } = siteSettings;
 
 	const renderContent = () => {
-		if ( hasError ) {
+		if ( hasError( deviceToggle ) ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
 
-		if ( isFetchingReport || isRunningReport || ! currentReport ) {
-			return (
-				<ReportLoading
-					isSavedReport={
-						isFetchingReport || ( ! currentReport && ( desktopLoaded || mobileLoaded ) )
-					}
-				/>
-			);
+		if ( isFetchingReport || ! currentReport ) {
+			return <ReportLoading isSavedReport={ isFetchingReport } />;
 		}
 
 		return (
@@ -136,6 +138,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 								currentPage={ currentPage }
 								pages={ pagesData }
 								onChange={ ( pageId ) => {
+									setRunNewReport( false );
 									recordTracksEvent(
 										'calypso_dashboard_performance_profiler_page_selector_change',
 										{

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -1,12 +1,13 @@
 import { basicMetricsQuery, sitePerformanceInsightsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import type { SitePerformanceReport } from '@automattic/api-core';
+import type { BasicMetricsData, SitePerformanceReport } from '@automattic/api-core';
+import type { QueryObserverResult } from '@tanstack/react-query';
 
 type ReportType = 'mobile' | 'desktop';
 
 interface PerformanceData {
 	hasCompleted: boolean;
-	createNewReport: () => void;
+	createNewReport: () => Promise< QueryObserverResult< BasicMetricsData, Error > >;
 	getReport: ( type: ReportType ) => SitePerformanceReport | undefined;
 	hasError: ( type: ReportType ) => boolean;
 	isLoadingExistingReport: ( reportType: ReportType ) => boolean;

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -58,7 +58,6 @@ export function useSitePerformanceData(
 		refetchOnWindowFocus: false,
 		retry: false,
 		enabled: !! url && !! token,
-		staleTime: 0,
 	} );
 
 	const getReport = ( type: ReportType ): SitePerformanceReport | undefined => {

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -27,7 +27,7 @@ const isReportFailed = ( report: unknown ) => report === 'failed';
  */
 const isReportRunning = ( report: unknown ) => 'running' === report || 'queued' === report;
 
-export function usePerformanceData(
+export function useSitePerformanceData(
 	url: string | undefined,
 	hash: string | undefined,
 	runNewReport?: boolean

--- a/packages/api-queries/src/site-performance.ts
+++ b/packages/api-queries/src/site-performance.ts
@@ -16,9 +16,10 @@ export const sitePerformanceInsightsQuery = ( url: string, token: string ) =>
 		queryKey: [ 'performance', url, token ],
 		queryFn: () => fetchSitePerformanceInsights( url, token ),
 		refetchInterval: ( query ) => {
-			if ( query.state.data?.pagespeed?.status === 'completed' ) {
+			if ( query.state.data?.pagespeed?.status === 'completed' || query.state.error ) {
 				return false;
 			}
+
 			return 5000;
 		},
 	} );

--- a/packages/api-queries/src/site-performance.ts
+++ b/packages/api-queries/src/site-performance.ts
@@ -16,10 +16,9 @@ export const sitePerformanceInsightsQuery = ( url: string, token: string ) =>
 		queryKey: [ 'performance', url, token ],
 		queryFn: () => fetchSitePerformanceInsights( url, token ),
 		refetchInterval: ( query ) => {
-			if ( query.state.data?.pagespeed?.status === 'completed' || query.state.error ) {
+			if ( query.state.data?.pagespeed?.status === 'completed' ) {
 				return false;
 			}
-
 			return 5000;
 		},
 	} );


### PR DESCRIPTION
Fixes DOTCOM-14912

## Proposed Changes

This refactors the `usePerformanceData`, which simplifies its public API and improves report status tracking overall, allowing for more accurate loading states.


**Case 1:**
| Before | After |
|--------|--------|
| ![Screen Recording on 2025-10-12 at 07-50-04](https://github.com/user-attachments/assets/28404fa9-9c62-4f46-b8ac-a3c0c79e14ee) | ![Screen Recording on 2025-10-12 at 07-50-26](https://github.com/user-attachments/assets/de0d729f-7fd5-464b-8d24-678a4ddec096) |

**Case 2:**
| Before | After |
|--------|--------|
| ![Screen Recording on 2025-10-12 at 08-00-37](https://github.com/user-attachments/assets/168b6e89-7032-4aec-a5fa-3fe4df242df2) | ![Screen Recording on 2025-10-12 at 08-02-35](https://github.com/user-attachments/assets/9665575a-2f37-4662-a126-e3f020e116c9) |

### Changes:
- Moves hook into `/performance`, renamed to `use-site-performance-data`.
- Renames hook to `useSitePerformanceData` to match other naming conventions.
- Removes `refetchOnWindowFocus` from `sitePerformancePagesQuery` to better keep pages + token in sync. 
  - Corrects cases where users create pages or run performance reports in different windows.

## Known issues

There is a delay from when you click "retest" and the loading state. 

I've logged that as a separate issue: DOTCOM-14929

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
