### PR TITLE
Hosting Dashboard: Move the "Testing will take 30 seconds" copy into the subtitle.

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -137,6 +137,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 							timezoneString={ timezoneString }
 							gmtOffset={ gmtOffset }
 							onClick={ handleReportRefetch }
+							isLoadingNewReport={ isRunningReport }
 						/>
 					}
 					actions={

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -137,7 +137,6 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 							timezoneString={ timezoneString }
 							gmtOffset={ gmtOffset }
 							onClick={ handleReportRefetch }
-							isLoadingNewReport={ isRunningReport }
 						/>
 					}
 					actions={

--- a/client/dashboard/sites/performance/report-loading.tsx
+++ b/client/dashboard/sites/performance/report-loading.tsx
@@ -66,9 +66,6 @@ export default function ReportLoading( { isSavedReport }: { isSavedReport: boole
 					</HStack>
 				) ) }
 			</VStack>
-			{ ! isSavedReport && (
-				<Text variant="muted">{ __( 'Testing your site may take around 30 seconds.' ) }</Text>
-			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/performance/subtitle.tsx
+++ b/client/dashboard/sites/performance/subtitle.tsx
@@ -2,19 +2,16 @@ import { __experimentalText as Text, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useFormattedTime } from '../../components/formatted-time';
-import InlineSupportLink from '../../components/inline-support-link';
 
 export default function Subtitle( {
 	timestamp,
 	timezoneString,
 	gmtOffset,
-	isLoadingNewReport,
 	onClick,
 }: {
 	timestamp: string | undefined;
 	timezoneString?: string;
 	gmtOffset?: number;
-	isLoadingNewReport?: boolean;
 	onClick: () => void;
 } ) {
 	const formattedTime = useFormattedTime(
@@ -27,19 +24,8 @@ export default function Subtitle( {
 		gmtOffset
 	);
 
-	if ( isLoadingNewReport ) {
-		return <Text variant="muted">{ __( 'Testing your site may take around 30 seconds.' ) }</Text>;
-	}
-
 	if ( ! timestamp ) {
-		return createInterpolateElement(
-			__(
-				'Optimize your site for lightning-fast performance. <learnMoreLink>Learn more</learnMoreLink>'
-			),
-			{
-				learnMoreLink: <InlineSupportLink supportContext="site-performance" />,
-			}
-		);
+		return <Text variant="muted">{ __( 'Testing your site may take around 30 seconds.' ) }</Text>;
 	}
 
 	return createInterpolateElement(

--- a/client/dashboard/sites/performance/subtitle.tsx
+++ b/client/dashboard/sites/performance/subtitle.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { __experimentalText as Text, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useFormattedTime } from '../../components/formatted-time';
@@ -8,11 +8,13 @@ export default function Subtitle( {
 	timestamp,
 	timezoneString,
 	gmtOffset,
+	isLoadingNewReport,
 	onClick,
 }: {
 	timestamp: string | undefined;
 	timezoneString?: string;
 	gmtOffset?: number;
+	isLoadingNewReport?: boolean;
 	onClick: () => void;
 } ) {
 	const formattedTime = useFormattedTime(
@@ -24,6 +26,10 @@ export default function Subtitle( {
 		timezoneString,
 		gmtOffset
 	);
+
+	if ( isLoadingNewReport ) {
+		return <Text variant="muted">{ __( 'Testing your site may take around 30 seconds.' ) }</Text>;
+	}
 
 	if ( ! timestamp ) {
 		return createInterpolateElement(


### PR DESCRIPTION
Fixes DOTDASH-572
Related to https://github.com/Automattic/wp-calypso/pull/106389

## Proposed Changes

Move the "Testing your site may take around 30 seconds." into the subtitle when tests are running and remove "Optimize your site for lightning-fast performance".

## Why are these changes being made?

The current (V1 & V2) experience is distracting. 

When we have a report, we display:
`Tested on October 12, 2025 at 12:27 PM. [Test again]`

If you click [Test again], we move back to the default state of:
`Optimize your site for lightning-fast performance. <supportLink>Learn more.</supportLink>`

Then once complete:
`Tested on October 12, 2025 at 1:27 PM. [Test again]`

That change is distracting. It's meant to give the user something to do while they wait; however, it doesn't feel like the right place. They don't have enough time to interact with it.

However, the relevant information about how long the test can take, setting expectations, is buried below the loading state.

| Header | Header |
|--------|--------|
| ![Screen Recording on 2025-10-12 at 09-43-48](https://github.com/user-attachments/assets/17936b67-ee1f-45a5-9958-15d74b988aba) | ![Screen Recording on 2025-10-12 at 09-42-45](https://github.com/user-attachments/assets/c623407e-28f7-4e63-b91a-32af3eee3b42) | 

> [!NOTE]
> I recognize this is my opinion. We don't track the events here, so I can't validate. This is in the spirit of less is more. If we don't agree with this change, that's fine.


## Testing Instructions

1. On your performance page.
2. Click retest.
3. Expect to see "Testing your site may take around 30 seconds."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
