### PR TITLE
Scheduled updates: Add edit action

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,9 +1,13 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { useNavigate } from '@tanstack/react-router';
 import { FormToggle } from '@wordpress/components';
 import { DataViews, type Field, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
-import { pluginsScheduledUpdatesNewRoute } from '../../app/router/plugins';
+import {
+	pluginsScheduledUpdatesEditRoute,
+	pluginsScheduledUpdatesNewRoute,
+} from '../../app/router/plugins';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -90,7 +94,7 @@ export const defaultView: View = {
 export default function PluginsScheduledUpdates() {
 	const [ view, setView ] = useState( defaultView );
 	const locale = useLocale();
-
+	const navigate = useNavigate();
 	const fields = useMemo( () => getFields( locale ), [ locale ] );
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
@@ -139,7 +143,13 @@ export default function PluginsScheduledUpdates() {
 							id: 'edit',
 							label: __( 'Edit' ),
 							isPrimary: true,
-							callback: () => {},
+							callback: ( items ) => {
+								const item = items[ 0 ];
+								navigate( {
+									to: pluginsScheduledUpdatesEditRoute.fullPath,
+									params: { scheduleId: item?.scheduleId },
+								} );
+							},
 						},
 						{
 							id: 'remove',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-211

## Proposed Changes

Update the edit action to redirect to the correct route.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

WIth the Edit functionality now implemented, the table should link to the correct edit page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `v2/plugins/scheduled-updates`
* Expand the settings menu for an entry and click the Edit option
* Confirm you're correctly redirected to the Edit Schedule page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
