### PR TITLE
Scheduled updates: Add delete action

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -6,8 +6,8 @@ import { FormToggle, Icon, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, type Field, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { info } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import {
 	pluginsScheduledUpdatesEditRoute,

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,14 +1,19 @@
+import { hostingUpdateScheduleDeleteMutation } from '@automattic/api-queries';
 import { useLocale } from '@automattic/i18n-utils';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { DataViews, type Field, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { info } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
 import {
 	pluginsScheduledUpdatesEditRoute,
 	pluginsScheduledUpdatesNewRoute,
 } from '../../app/router/plugins';
+import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -119,72 +124,134 @@ export const defaultView: View = {
 
 export default function PluginsScheduledUpdates() {
 	const [ view, setView ] = useState( defaultView );
+	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
+	const [ scheduleToDelete, setScheduleToDelete ] = useState< ScheduledUpdateRow | null >( null );
 	const locale = useLocale();
 	const navigate = useNavigate();
 	const fields = useMemo( () => getFields( locale ), [ locale ] );
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const deleteMutation = useMutation( hostingUpdateScheduleDeleteMutation() );
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );
 	}, [ scheduledUpdates, view, fields ] );
 
+	const handleDeleteClick = ( schedule: ScheduledUpdateRow ) => {
+		setScheduleToDelete( schedule );
+		setIsDeleteDialogOpen( true );
+	};
+
+	const handleDeleteConfirm = () => {
+		if ( scheduleToDelete ) {
+			deleteMutation.mutate(
+				{
+					siteId: scheduleToDelete.site.ID,
+					scheduleId: scheduleToDelete.scheduleId,
+				},
+				{
+					onSuccess: () => {
+						createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
+					},
+					onError: ( error: Error ) => {
+						createErrorNotice( error.message || __( 'Failed to delete schedule.' ), {
+							type: 'snackbar',
+						} );
+					},
+					onSettled: () => {
+						setIsDeleteDialogOpen( false );
+						setScheduleToDelete( null );
+					},
+				}
+			);
+		} else {
+			setIsDeleteDialogOpen( false );
+			setScheduleToDelete( null );
+		}
+	};
+
+	const handleDeleteCancel = () => {
+		setIsDeleteDialogOpen( false );
+		setScheduleToDelete( null );
+	};
+
 	return (
-		<PageLayout
-			size="large"
-			header={
-				<PageHeader
-					title={ __( 'Scheduled updates' ) }
-					actions={
-						<RouterLinkButton
-							variant="primary"
-							to={ pluginsScheduledUpdatesNewRoute.to }
-							__next40pxDefaultSize
-						>
-							{ __( 'New schedule' ) }
-						</RouterLinkButton>
-					}
-				/>
-			}
-		>
-			<DataViewsCard>
-				<DataViews
-					paginationInfo={ paginationInfo }
-					fields={ fields }
-					data={ filtered }
-					defaultLayouts={ { table: {} } }
-					view={ view }
-					onChangeView={ setView }
-					isLoading={ isLoading }
-					empty={
-						<p>
-							{ scheduledUpdates.length === 0
-								? __( 'No scheduled updates yet.' )
-								: __(
-										'We couldn’t find any schedules based on your search criteria. You might want to check your search terms and try again.'
-								  ) }
-						</p>
-					}
-					actions={ [
-						{
-							id: 'edit',
-							label: __( 'Edit' ),
-							isPrimary: true,
-							callback: ( items ) => {
-								const item = items[ 0 ];
-								navigate( {
-									to: pluginsScheduledUpdatesEditRoute.fullPath,
-									params: { scheduleId: item?.scheduleId },
-								} );
+		<>
+			<PageLayout
+				size="large"
+				header={
+					<PageHeader
+						title={ __( 'Scheduled updates' ) }
+						actions={
+							<RouterLinkButton
+								variant="primary"
+								to={ pluginsScheduledUpdatesNewRoute.to }
+								__next40pxDefaultSize
+							>
+								{ __( 'New schedule' ) }
+							</RouterLinkButton>
+						}
+					/>
+				}
+			>
+				<DataViewsCard>
+					<DataViews
+						paginationInfo={ paginationInfo }
+						fields={ fields }
+						data={ filtered }
+						defaultLayouts={ { table: {} } }
+						view={ view }
+						onChangeView={ setView }
+						isLoading={ isLoading }
+						empty={
+							<p>
+								{ scheduledUpdates.length === 0
+									? __( 'No scheduled updates yet.' )
+									: __(
+											"We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
+									  ) }
+							</p>
+						}
+						actions={ [
+							{
+								id: 'edit',
+								label: __( 'Edit' ),
+								isPrimary: true,
+								callback: ( items ) => {
+									const item = items[ 0 ];
+									navigate( {
+										to: pluginsScheduledUpdatesEditRoute.fullPath,
+										params: { scheduleId: item?.scheduleId },
+									} );
+								},
 							},
-						},
-						{
-							id: 'remove',
-							label: __( 'Remove' ),
-							callback: () => {},
-						},
-					] }
-				/>
-			</DataViewsCard>
-		</PageLayout>
+							{
+								id: 'remove',
+								label: __( 'Remove' ),
+								callback: ( items ) => {
+									const item = items[ 0 ];
+									if ( item ) {
+										handleDeleteClick( item );
+									}
+								},
+							},
+						] }
+					/>
+				</DataViewsCard>
+			</PageLayout>
+
+			<ConfirmModal
+				isOpen={ isDeleteDialogOpen }
+				confirmButtonProps={ {
+					label: __( 'Delete schedule' ),
+					isBusy: deleteMutation.isPending,
+					disabled: deleteMutation.isPending,
+				} }
+				onCancel={ handleDeleteCancel }
+				onConfirm={ handleDeleteConfirm }
+			>
+				{ __( 'Are you sure you want to delete this schedule?' ) }
+			</ConfirmModal>
+		</>
 	);
 }

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -124,7 +124,6 @@ export const defaultView: View = {
 
 export default function PluginsScheduledUpdates() {
 	const [ view, setView ] = useState( defaultView );
-	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
 	const [ scheduleToDelete, setScheduleToDelete ] = useState< ScheduledUpdateRow | null >( null );
 	const locale = useLocale();
 	const navigate = useNavigate();
@@ -132,19 +131,20 @@ export default function PluginsScheduledUpdates() {
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const deleteMutation = useMutation( hostingUpdateScheduleDeleteMutation() );
+	const { mutate: deleteSchedule, isPending: isDeletingSchedule } = useMutation(
+		hostingUpdateScheduleDeleteMutation()
+	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );
 	}, [ scheduledUpdates, view, fields ] );
 
 	const handleDeleteClick = ( schedule: ScheduledUpdateRow ) => {
 		setScheduleToDelete( schedule );
-		setIsDeleteDialogOpen( true );
 	};
 
 	const handleDeleteConfirm = () => {
 		if ( scheduleToDelete ) {
-			deleteMutation.mutate(
+			deleteSchedule(
 				{
 					siteId: scheduleToDelete.site.ID,
 					scheduleId: scheduleToDelete.scheduleId,
@@ -159,19 +159,14 @@ export default function PluginsScheduledUpdates() {
 						} );
 					},
 					onSettled: () => {
-						setIsDeleteDialogOpen( false );
 						setScheduleToDelete( null );
 					},
 				}
 			);
-		} else {
-			setIsDeleteDialogOpen( false );
-			setScheduleToDelete( null );
 		}
 	};
 
 	const handleDeleteCancel = () => {
-		setIsDeleteDialogOpen( false );
 		setScheduleToDelete( null );
 	};
 
@@ -228,6 +223,7 @@ export default function PluginsScheduledUpdates() {
 							{
 								id: 'remove',
 								label: __( 'Remove' ),
+								isEligible: () => ! isDeletingSchedule,
 								callback: ( items ) => {
 									const item = items[ 0 ];
 									if ( item ) {
@@ -241,11 +237,11 @@ export default function PluginsScheduledUpdates() {
 			</PageLayout>
 
 			<ConfirmModal
-				isOpen={ isDeleteDialogOpen }
+				isOpen={ !! scheduleToDelete }
 				confirmButtonProps={ {
 					label: __( 'Delete schedule' ),
-					isBusy: deleteMutation.isPending,
-					disabled: deleteMutation.isPending,
+					isBusy: isDeletingSchedule,
+					disabled: isDeletingSchedule,
 				} }
 				onCancel={ handleDeleteCancel }
 				onConfirm={ handleDeleteConfirm }

--- a/packages/api-core/src/hosting-update-schedules/index.ts
+++ b/packages/api-core/src/hosting-update-schedules/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
+export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/hosting-update-schedules/mutators.ts
+++ b/packages/api-core/src/hosting-update-schedules/mutators.ts
@@ -1,0 +1,9 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export function deleteHostingUpdateSchedule( siteId: number, scheduleId: string ): Promise< void > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/update-schedules/${ encodeURIComponent( scheduleId ) }`,
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-queries/src/hosting-update-schedules.ts
+++ b/packages/api-queries/src/hosting-update-schedules.ts
@@ -14,7 +14,32 @@ export const hostingUpdateScheduleDeleteMutation = () =>
 	mutationOptions( {
 		mutationFn: ( variables: { siteId: number; scheduleId: string } ) =>
 			deleteHostingUpdateSchedule( variables.siteId, variables.scheduleId ),
+		onMutate: ( variables: { siteId: number; scheduleId: string } ) => {
+			// Optimistically update the cache
+			const data = queryClient.getQueryData( hostingUpdateSchedulesQuery().queryKey );
+			if ( data && typeof data === 'object' && 'sites' in data ) {
+				const prevData = JSON.parse( JSON.stringify( data ) ); // deep copy
+				const sites = ( data as any ).sites || {};
+
+				// Remove the schedule from the site
+				if ( sites[ variables.siteId ] ) {
+					delete sites[ variables.siteId ][ variables.scheduleId ];
+				}
+
+				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, { ...data, sites } );
+				return { prevData };
+			}
+		},
+		onError: ( error, variables, context ) => {
+			// Rollback on error
+			if ( context?.prevData ) {
+				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, context.prevData );
+			}
+		},
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'hosting', 'update-schedules' ] } );
+			// Delay cache invalidation to allow server to process the deletion and get fresh data
+			setTimeout( () => {
+				queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+			}, 5000 );
 		},
 	} );

--- a/packages/api-queries/src/hosting-update-schedules.ts
+++ b/packages/api-queries/src/hosting-update-schedules.ts
@@ -1,9 +1,20 @@
-import { fetchHostingUpdateSchedules } from '@automattic/api-core';
-import { queryOptions } from '@tanstack/react-query';
+import { fetchHostingUpdateSchedules, deleteHostingUpdateSchedule } from '@automattic/api-core';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
 
 // Query: hosting (multi-site) schedules
 export const hostingUpdateSchedulesQuery = () =>
 	queryOptions( {
 		queryKey: [ 'hosting', 'update-schedules' ],
 		queryFn: () => fetchHostingUpdateSchedules(),
+	} );
+
+// Mutation: delete hosting update schedule
+export const hostingUpdateScheduleDeleteMutation = () =>
+	mutationOptions( {
+		mutationFn: ( variables: { siteId: number; scheduleId: string } ) =>
+			deleteHostingUpdateSchedule( variables.siteId, variables.scheduleId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'hosting', 'update-schedules' ] } );
+		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-211

## Proposed Changes

Add the delete functionality, deleting the scheduled update from a selected site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To be able to delete the scheduled update for a site in the list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `v2/plugins/scheduled-updates`
* Expand the actions menu and select remove 
* Confirm the scheduled update for the site is correctly deleted. 


Notes:  `/hosting/update-schedules` has delay when deleting a scheduled update, if we're fetching the list after deletion we'd get the results including the deleted scheduled update. 

This is handled in the previous implementation with a 5 second delay, I've kept the approach here while also optimistically updating the cache.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
