### PR TITLE
Calypso logs the siutation where the cookie-auth-missing message is sent from iframe

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -17,16 +17,21 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { addQueryArgs, getSiteFragment } from 'calypso/lib/route';
+import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
 import {
 	getProductSlugFromContext,
 	isContextSourceMyJetpack,
 } from 'calypso/my-sites/checkout/utils';
-import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	isUserLoggedIn,
+	getCurrentUser,
+	getCurrentUserId,
+} from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
 	getImmediateLoginLocale,
@@ -142,10 +147,7 @@ export function redirectLoggedOut( context, next ) {
 		return next();
 	}
 
-	if (
-		isUserLoggedIn( state ) &&
-		( ! config.isEnabled( 'cookie-missing-redirect' ) || ! isCookieAuthMissing() )
-	) {
+	if ( isUserLoggedIn( state ) && ! isCookieAuthMissing() ) {
 		next();
 		return;
 	}
@@ -180,15 +182,28 @@ export function redirectLoggedOut( context, next ) {
 		loginParameters.redirectTo = 'https://wordpress.com' + loginParameters.redirectTo;
 	}
 
-	// If there is an issue with the auth cookie then we need to do more than
-	// just redirect to the login page. Otherwise that page may just detect that
-	// the user has already logged in. We fully log out to get fresh cookies.
-	if (
-		config.isEnabled( 'cookie-missing-redirect' ) &&
-		state.currentUser &&
-		isCookieAuthMissing()
-	) {
-		context.store.dispatch( redirectToLogout( login( loginParameters ) ) );
+	// Log if there is anything wrong with the auth cookie. We may add logout code in this scenario.
+	// See #106394
+	if ( isCookieAuthMissing() ) {
+		// Logic used by redirectToLogout() to get the path to redirect to
+		const userData = getCurrentUser( state );
+		const logoutUrl = getLogoutUrl( userData, login( loginParameters ) );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Proxy iframe has cookie-auth-missing error',
+			severity: 'debug',
+			user_id: getCurrentUserId( state ), // isUserLoggedIn() might be true, in which case we can match the ID with other records.
+			properties: {
+				env: config( 'env_id' ),
+				logout_url: logoutUrl.replace( /(nonce=)\w*/, '$1SECRET' ),
+				pathname: context.pathname,
+			},
+		} );
+	}
+
+	if ( isUserLoggedIn( state ) ) {
+		next();
 		return;
 	}
 

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -25,6 +25,7 @@ import {
 	getProductSlugFromContext,
 	isContextSourceMyJetpack,
 } from 'calypso/my-sites/checkout/utils';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
@@ -177,6 +178,18 @@ export function redirectLoggedOut( context, next ) {
 	) {
 		loginParameters.isJetpack = true;
 		loginParameters.redirectTo = 'https://wordpress.com' + loginParameters.redirectTo;
+	}
+
+	// If there is an issue with the auth cookie then we need to do more than
+	// just redirect to the login page. Otherwise that page may just detect that
+	// the user has already logged in. We fully log out to get fresh cookies.
+	if (
+		config.isEnabled( 'cookie-missing-redirect' ) &&
+		state.currentUser &&
+		isCookieAuthMissing()
+	) {
+		context.store.dispatch( redirectToLogout( login( loginParameters ) ) );
+		return;
 	}
 
 	// force full page reload to avoid SSR hydration issues.

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -10,6 +10,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { removeQueryArgs } from '@wordpress/url';
 import { translate, fixMe } from 'i18n-calypso';
 import { Provider as ReduxProvider } from 'react-redux';
+import { isCookieAuthMissing } from 'wpcom-proxy-request';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
 import MomentProvider from 'calypso/components/localized-moment/provider';
@@ -140,7 +141,7 @@ export function redirectLoggedOut( context, next ) {
 		return next();
 	}
 
-	if ( isUserLoggedIn( state ) ) {
+	if ( isUserLoggedIn( state ) && ! isCookieAuthMissing() ) {
 		next();
 		return;
 	}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -141,7 +141,10 @@ export function redirectLoggedOut( context, next ) {
 		return next();
 	}
 
-	if ( isUserLoggedIn( state ) && ! isCookieAuthMissing() ) {
+	if (
+		isUserLoggedIn( state ) &&
+		( ! config.isEnabled( 'cookie-missing-redirect' ) || ! isCookieAuthMissing() )
+	) {
 		next();
 		return;
 	}

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -398,7 +398,8 @@ function onmessage( e ) {
 		return;
 	}
 
-	// Alert listeners that there is
+	// Allows packages consumers to check whether the iframe had a cookie
+	// error. See the isCookieAuthMissing() function.
 	if ( data === 'cookie-auth-missing' ) {
 		_isCookieAuthMissing = true;
 		return;

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -569,7 +569,7 @@ function canAccessWpcomApis() {
 /**
  * Returns whether the iframe has ever sent the "cookie-auth-missing" event, signalling
  * that something is wrong with the user's cookie.
- * @returns boolean
+ * @returns {boolean}
  */
 function isCookieAuthMissing() {
 	return _isCookieAuthMissing;

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -76,6 +76,12 @@ let buffered;
 const requests = {};
 
 /**
+ * A flag which stores whether the iframe has sent a cookie-auth-missing event.
+ * @type boolean
+ */
+let _isCookieAuthMissing = false;
+
+/**
  * Performs a "proxied REST API request". This happens by calling
  * `iframe.postMessage()` on the proxy iframe instance, which from there
  * takes care of WordPress.com user authentication (via the currently
@@ -392,6 +398,12 @@ function onmessage( e ) {
 		return;
 	}
 
+	// Alert listeners that there is
+	if ( data === 'cookie-auth-missing' ) {
+		_isCookieAuthMissing = true;
+		return;
+	}
+
 	if ( postStrings && 'string' === typeof data ) {
 		data = JSON.parse( data );
 	}
@@ -554,7 +566,16 @@ function canAccessWpcomApis() {
 }
 
 /**
+ * Returns whether the iframe has ever sent the "cookie-auth-missing" event, signalling
+ * that something is wrong with the user's cookie.
+ * @returns boolean
+ */
+function isCookieAuthMissing() {
+	return _isCookieAuthMissing;
+}
+
+/**
  * Export `request` function.
  */
 export default request;
-export { reloadProxy, canAccessWpcomApis };
+export { reloadProxy, canAccessWpcomApis, isCookieAuthMissing };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14911

## Proposed Changes

* Add a `isCookieAuthMissing()` function to `wpcom-proxy-request`
  * Returns true when the proxy iframe has sent this error message
* Add an `isCookieAuthMissing` check to the existing "is logged in" middleware
  * If there's something wrong with the cookie then we log to logstash

There are technical discussions at DOTDASH-623 DOTCOM-14911

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When the `wpcom-user-bootstrap` flag is disabled (e.g. `calypso.localhost` and `.live`) the user data is fetched client side via `public-api`. That means a missing/invalid `wordpress_sec` cookie is detected and redirects the user to the log in screen. But when the `wpcom-user-bootstrap` flag is _enabled_ (e.g. `production` and `wpcalypso`) the user data will be injected by the server and the client doesn't find out that `wordpress_sec` is invalid.

This adds a log so that even when `wpcom-user-bootstrap` _is_ enabled, and the proxy iframe reports an issue with the cookie, we get the log so we can decide whether we want to start logging users out in this situation.

The proxy iframe sends the message about the invalid auth here: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Qcebkl%2Scebivqre%2Qi2.0.wf%3Se%3Qqr0q2rq4%23955-og

| You used to see an error like this | If we were to log the user out they would see |
| --- | --- |
|  <img width="1462" height="307" alt="image" src="https://github.com/user-attachments/assets/505035a7-a321-4fb6-aada-0bf1ad683e4a" /> |  <img width="2540" height="1492" alt="CleanShot 2025-10-30 at 18 43 43@2x" src="https://github.com/user-attachments/assets/29233ce2-aa64-4562-a9fc-dc418052ee84" /> |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The key to testing this locally is enabling the user object bootstrap behaviour. The FG has instructions PCYsg-5YE-p2
After doing the above:
* Enable the `wpcom-user-bootstrap` flag in `development.json`
* Restart the node server
* Sandbox `public-api`
* Confirm that `calypso.localhost:3000/sites` loads fine, and that the bootstrap user object is available at `window.currentUser`
* In the dev tools, delete the `wordpress_sec` cookie
  * The Calypso node server will still think you're logged in, since it is never sent the `wordpress_sec` cookie anyway (it uses `wordpress_logged_in`). But the proxy iframe will notice that the cookie is missing and will stop giving you a valid JWT
* Refresh the page
* Check the network tools for a request to the `/logstash` endpoint
* Check logs here 39738-pb (remember to update the `host` to your own sandbox)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?