### PR TITLE
Scheduled updates: Fix group by field value

### DIFF
--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -37,7 +37,7 @@ This `docs` directory contains comprehensive design documentation for the `/clie
 ## Hacks
 
 - We want to use the core `Badge` component but there are limitations in its functionality right now. Specifically we want a way to apply the colors (by `intent` prop), but sometimes override the used `icon`. For now we are using `TrendComparisonBadge` with some hacky css to hide the icon.
-
+- Grouping by a field in the core `DataViews` component uses `getValue` to display the grouping header. To group by a value but display something else in the header, we're generating an ID containing a unique number of zero-width space characters in `scheduled-updates`. This should be removed once we're able to edit the header value.
 ## E2E testing
 
 ### Currently

--- a/client/dashboard/plugins/scheduled-updates/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/helpers.ts
@@ -1,5 +1,5 @@
-import { __ } from '@wordpress/i18n';
-import type { TimeSlot, Frequency, Weekday, ScheduleCollisions } from './types';
+import { __, sprintf } from '@wordpress/i18n';
+import { TimeSlot, Frequency, Weekday, ScheduleCollisions, ScheduledUpdateRow } from './types';
 import type { Site } from '@automattic/api-core';
 
 export function prepareTimestamp(
@@ -197,4 +197,42 @@ export function formatScheduleCollisionsErrorMulti( {
 export function normalizeScheduleId( id: string ): string {
 	const m = id.match( /^(.*)-(daily|weekly)-(\d+)-(\d{2}:\d{2})$/ );
 	return m ? m[ 1 ] : id;
+}
+
+export function prepareScheduleName( locale: string, schedule: ScheduledUpdateRow ) {
+	const time = new Intl.DateTimeFormat( locale, { timeStyle: 'short' } ).format(
+		schedule.nextUpdate * 1000
+	);
+	const dayNumber = new Date( schedule.nextUpdate * 1000 ).getDay();
+
+	if ( schedule.schedule === 'daily' ) {
+		/* translators: Daily at 10 am. */
+		return sprintf( __( 'Daily at %s' ), time );
+	} else if ( schedule.schedule === 'weekly' ) {
+		switch ( dayNumber ) {
+			case 0:
+				/* translators: Sundays at 10 am. */
+				return sprintf( __( 'Sundays at %s' ), time );
+			case 1:
+				/* translators: Mondays at 10 am. */
+				return sprintf( __( 'Mondays at %s' ), time );
+			case 2:
+				/* translators: Tuesdays at 10 am. */
+				return sprintf( __( 'Tuesdays at %s' ), time );
+			case 3:
+				/* translators: Wednesdays at 10 am. */
+				return sprintf( __( 'Wednesdays at %s' ), time );
+			case 4:
+				/* translators: Thursdays at 10 am. */
+				return sprintf( __( 'Thursdays at %s' ), time );
+			case 5:
+				/* translators: Fridays at 10 am. */
+				return sprintf( __( 'Fridays at %s' ), time );
+			case 6:
+				/* translators: Saturdays at 10 am. */
+				return sprintf( __( 'Saturdays at %s' ), time );
+		}
+	}
+
+	return '';
 }

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -20,93 +20,112 @@ import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { SiteIconLink } from '../../sites/site-fields';
 import { formatDate } from '../../utils/datetime';
+import { prepareScheduleName } from './helpers';
 import { useScheduledUpdates } from './hooks/use-scheduled-updates';
 import { ScheduledUpdateRow } from './types';
 
-const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => [
-	{
-		id: 'site',
-		type: 'text',
-		label: __( 'Site' ),
-		getValue: ( { item } ) => item.site.name,
-	},
-	{
-		id: 'lastUpdate',
-		type: 'integer',
-		label: __( 'Last Update' ),
-		render: ( { item } ) =>
-			item.lastUpdate
-				? formatDate( new Date( item.lastUpdate * 1000 ), locale, {
-						dateStyle: 'medium',
-						timeStyle: 'short',
-				  } )
-				: '-',
-	},
-	{
-		id: 'nextUpdate',
-		type: 'integer',
-		label: __( 'Next Update' ),
-		render: ( { item } ) =>
-			formatDate( new Date( item.nextUpdate * 1000 ), locale, {
-				dateStyle: 'medium',
-				timeStyle: 'short',
-			} ),
-	},
-	{
-		id: 'schedule',
-		type: 'text',
-		label: __( 'Frequency' ),
-		render: ( { item } ) => ( item.schedule === 'daily' ? __( 'Daily' ) : __( 'Weekly' ) ),
-	},
-	{
-		id: 'plugins',
-		type: 'text',
-		label: __( 'Plugins' ),
-		render: ( { item } ) => (
-			<span
-				style={ {
-					alignItems: 'center',
-					display: 'flex',
-				} }
-			>
-				{ item.plugins.length }&nbsp;
-				<Tooltip text={ item.plugins.join( ', ' ) }>
-					<span
-						style={ {
-							alignItems: 'center',
-							display: 'flex',
-						} }
-					>
-						<Icon icon={ info } size={ 16 } />
-					</span>
-				</Tooltip>
-			</span>
-		),
-	},
-	{
-		id: 'active',
-		type: 'text',
-		label: __( 'Active' ),
-		render: ( { item } ) => <FormToggle checked={ item.active } onChange={ () => {} } />,
-	},
-	{
-		id: 'actions',
-		type: 'text',
-		label: __( 'Actions' ),
-	},
-	{
-		id: 'scheduleId',
-		type: 'text',
-		label: __( 'Schedule' ),
-	},
-	{
-		id: 'icon.ico',
-		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIconLink site={ item.site } />,
-		enableSorting: false,
-		enableGlobalSearch: false,
-	},
-];
+const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
+	// Create stable mapping outside of getValue calls
+	const getUniqueScheduleName = ( () => {
+		const scheduleIdMap = new Map< string, number >();
+		let counter = 0;
+
+		return ( item: ScheduledUpdateRow ) => {
+			if ( ! scheduleIdMap.has( item.scheduleId ) ) {
+				scheduleIdMap.set( item.scheduleId, ++counter );
+			}
+			const uniqueNumber = scheduleIdMap.get( item.scheduleId )!;
+			const invisibleId = '\u200B'.repeat( uniqueNumber );
+			return prepareScheduleName( locale, item ) + invisibleId;
+		};
+	} )();
+
+	return [
+		{
+			id: 'site',
+			type: 'text',
+			label: __( 'Site' ),
+			getValue: ( { item } ) => item.site.name,
+		},
+		{
+			id: 'lastUpdate',
+			type: 'integer',
+			label: __( 'Last Update' ),
+			render: ( { item } ) =>
+				item.lastUpdate
+					? formatDate( new Date( item.lastUpdate * 1000 ), locale, {
+							dateStyle: 'medium',
+							timeStyle: 'short',
+					  } )
+					: '-',
+		},
+		{
+			id: 'nextUpdate',
+			type: 'integer',
+			label: __( 'Next Update' ),
+			render: ( { item } ) =>
+				formatDate( new Date( item.nextUpdate * 1000 ), locale, {
+					dateStyle: 'medium',
+					timeStyle: 'short',
+				} ),
+		},
+		{
+			id: 'schedule',
+			type: 'text',
+			label: __( 'Frequency' ),
+			render: ( { item } ) => ( item.schedule === 'daily' ? __( 'Daily' ) : __( 'Weekly' ) ),
+		},
+		{
+			id: 'plugins',
+			type: 'text',
+			label: __( 'Plugins' ),
+			render: ( { item } ) => (
+				<span
+					style={ {
+						alignItems: 'center',
+						display: 'flex',
+					} }
+				>
+					{ item.plugins.length }&nbsp;
+					<Tooltip text={ item.plugins.join( ', ' ) }>
+						<span
+							style={ {
+								alignItems: 'center',
+								display: 'flex',
+							} }
+						>
+							<Icon icon={ info } size={ 16 } />
+						</span>
+					</Tooltip>
+				</span>
+			),
+		},
+		{
+			id: 'active',
+			type: 'text',
+			label: __( 'Active' ),
+			render: ( { item } ) => <FormToggle checked={ item.active } onChange={ () => {} } />,
+		},
+		{
+			id: 'actions',
+			type: 'text',
+			label: __( 'Actions' ),
+		},
+		{
+			id: 'scheduleId',
+			type: 'text',
+			label: __( 'Schedule' ),
+			getValue: ( { item } ) => getUniqueScheduleName( item ),
+		},
+		{
+			id: 'icon.ico',
+			label: __( 'Site icon' ),
+			render: ( { item } ) => <SiteIconLink site={ item.site } />,
+			enableSorting: false,
+			enableGlobalSearch: false,
+		},
+	];
+};
 
 export const defaultView: View = {
 	type: 'table',

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -24,22 +24,22 @@ import { prepareScheduleName } from './helpers';
 import { useScheduledUpdates } from './hooks/use-scheduled-updates';
 import { ScheduledUpdateRow } from './types';
 
+// Create stable mapping for unique schedule names with invisible suffixes
+const getUniqueScheduleName = ( () => {
+	const scheduleIdMap = new Map< string, number >();
+	let counter = 0;
+
+	return ( locale: string, item: ScheduledUpdateRow ) => {
+		if ( ! scheduleIdMap.has( item.scheduleId ) ) {
+			scheduleIdMap.set( item.scheduleId, ++counter );
+		}
+		const uniqueNumber = scheduleIdMap.get( item.scheduleId )!;
+		const invisibleId = '\u200B'.repeat( uniqueNumber );
+		return prepareScheduleName( locale, item ) + invisibleId;
+	};
+} )();
+
 const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
-	// Create stable mapping outside of getValue calls
-	const getUniqueScheduleName = ( () => {
-		const scheduleIdMap = new Map< string, number >();
-		let counter = 0;
-
-		return ( item: ScheduledUpdateRow ) => {
-			if ( ! scheduleIdMap.has( item.scheduleId ) ) {
-				scheduleIdMap.set( item.scheduleId, ++counter );
-			}
-			const uniqueNumber = scheduleIdMap.get( item.scheduleId )!;
-			const invisibleId = '\u200B'.repeat( uniqueNumber );
-			return prepareScheduleName( locale, item ) + invisibleId;
-		};
-	} )();
-
 	return [
 		{
 			id: 'site',
@@ -115,7 +115,7 @@ const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
 			id: 'scheduleId',
 			type: 'text',
 			label: __( 'Schedule' ),
-			getValue: ( { item } ) => getUniqueScheduleName( item ),
+			getValue: ( { item } ) => getUniqueScheduleName( locale, item ),
 		},
 		{
 			id: 'icon.ico',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-213

## Proposed Changes

Update the schedule name to only display the formatted name and remove the `scheduleId`. 

<img width="1162" height="335" alt="image" src="https://github.com/user-attachments/assets/cdf33d8d-05bf-43de-aaf6-ee8cdf6e6c92" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When multiple scheduled updates have identical names, DataViews grouping fails to create distinct groups since it relies on the `getValue` function return value for both uniqueness and display.

To keep the value unique while also being able to display it, the implmentation adds invisible Unicode characters (zero-width spaces \u200B) as suffixes to schedule names, with each unique scheduleId getting a different number of invisible characters. 

This hack should be removed once we're able to alter the grouping render code in the core component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `v2/plugins/scheduled-updates`
* Confirm the headers no longer contain the schedule IDs. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
