### PR TITLE
Hosting Dashboard: Fix performance recommendation section layout for small devices.

### DIFF
--- a/client/dashboard/sites/performance/llm-notice.tsx
+++ b/client/dashboard/sites/performance/llm-notice.tsx
@@ -1,4 +1,5 @@
 import { __experimentalHStack as HStack, Card, CardBody } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import AIIcon from 'calypso/assets/images/performance-profiler/ai-icon.svg';
@@ -16,6 +17,8 @@ const LLMNotice = ( {
 	isLoading?: boolean;
 	actions?: ReactNode;
 } ) => {
+	const isMediumScreen = useViewportMatch( 'medium', '<' );
+
 	return (
 		<Card
 			size="xSmall"
@@ -25,7 +28,10 @@ const LLMNotice = ( {
 			} }
 		>
 			<CardBody>
-				<HStack>
+				<HStack
+					direction={ isMediumScreen ? 'column' : 'row' }
+					alignment={ isMediumScreen ? 'flex-start' : 'center' }
+				>
 					<HStack
 						className={ clsx( 'llm-notice', { 'is-loading': isLoading } ) }
 						justify="flex-start"

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -45,13 +45,17 @@ export const PerformanceInsightTitle = ( {
 	const intent = insight.type === 'fail' ? 'error' : 'warning';
 
 	return (
-		<HStack style={ { minHeight: isMediumScreen ? '40px' : 'auto' } }>
+		<HStack
+			alignment={ isSmallScreen ? 'flex-start' : 'center' }
+			style={ {
+				minHeight: isMediumScreen ? '40px' : 'auto',
+				flexDirection: isSmallScreen ? 'column-reverse' : 'row',
+			} }
+		>
 			<HStack justify="flex-start" alignment={ isMediumScreen ? 'flex-start' : 'center' }>
-				{ ! isSmallScreen && (
-					<Text intent={ intent } size={ 15 } weight={ 500 }>
-						{ index }
-					</Text>
-				) }
+				<Text intent={ intent } size={ 15 } weight={ 500 }>
+					{ index }
+				</Text>
 				<HStack
 					justify="flex-start"
 					alignment={ isMediumScreen ? 'flex-start' : 'center' }
@@ -135,7 +139,7 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 		}
 
 		return (
-			<>
+			<HStack wrap>
 				<Text>{ __( 'How did we do?' ) }</Text>
 				<Button
 					icon={ thumbsUp }
@@ -188,7 +192,7 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 						</form>
 					</Modal>
 				) }
-			</>
+			</HStack>
 		);
 	};
 

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -40,21 +40,31 @@ export const PerformanceInsightTitle = ( {
 	index: number;
 	isHightImpact: boolean;
 } ) => {
+	const isMediumScreen = useViewportMatch( 'medium', '<' );
+	const isSmallScreen = useViewportMatch( 'small', '<' );
 	const intent = insight.type === 'fail' ? 'error' : 'warning';
 
 	return (
-		<HStack>
-			<HStack justify="flex-start">
-				<Text intent={ intent } size={ 15 } weight={ 500 }>
-					{ index }
-				</Text>
-				<Text>{ insight.title }</Text>
-				{ insight.displayValue && (
-					<>
-						<Text>&nbsp;&minus;&nbsp;</Text>
-						<Text intent={ intent }>{ insight.displayValue }</Text>
-					</>
+		<HStack style={ { minHeight: isMediumScreen ? '40px' : 'auto' } }>
+			<HStack justify="flex-start" alignment={ isMediumScreen ? 'flex-start' : 'center' }>
+				{ ! isSmallScreen && (
+					<Text intent={ intent } size={ 15 } weight={ 500 }>
+						{ index }
+					</Text>
 				) }
+				<HStack
+					justify="flex-start"
+					alignment={ isMediumScreen ? 'flex-start' : 'center' }
+					direction={ isMediumScreen ? 'column' : 'row' }
+				>
+					<Text lineHeight={ isMediumScreen ? '17px' : 'unset' }>{ insight.title }</Text>
+					{ insight.displayValue && (
+						<>
+							{ ! isMediumScreen && <Text>&nbsp;&minus;&nbsp;</Text> }
+							<Text intent={ intent }>{ insight.displayValue }</Text>
+						</>
+					) }
+				</HStack>
 			</HStack>
 			{ isHightImpact && (
 				<Badge intent="error" style={ { flexShrink: 0 } }>

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -46,14 +46,14 @@ export const PerformanceInsightTitle = ( {
 
 	return (
 		<HStack
+			direction={ isSmallScreen ? 'column' : 'row' }
 			alignment={ isSmallScreen ? 'flex-start' : 'center' }
 			style={ {
 				minHeight: isMediumScreen ? '40px' : 'auto',
-				flexDirection: isSmallScreen ? 'column-reverse' : 'row',
 			} }
 		>
 			<HStack justify="flex-start" alignment={ isMediumScreen ? 'flex-start' : 'center' }>
-				<Text intent={ intent } size={ 15 } weight={ 500 }>
+				<Text intent={ intent } size={ 15 } weight={ 500 } style={ { flexShrink: 0 } }>
 					{ index }
 				</Text>
 				<HStack
@@ -71,7 +71,7 @@ export const PerformanceInsightTitle = ( {
 				</HStack>
 			</HStack>
 			{ isHightImpact && (
-				<Badge intent="error" style={ { flexShrink: 0 } }>
+				<Badge intent="error" style={ { flexShrink: 0, marginInlineStart: '16px' } }>
 					{ __( 'High impact' ) }
 				</Badge>
 			) }

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -115,6 +115,7 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 	const { recordTracksEvent } = useAnalytics();
 	const [ isSent, setIsSent ] = useState( false );
 	const [ isFeedbackModalOpen, setIsFeedbackModalOpen ] = useState( false );
+	const isSmallScreen = useViewportMatch( 'small', '<' );
 	const [ formData, setFormData ] = useState( {
 		userFeedback: '',
 	} );
@@ -140,7 +141,9 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 
 		return (
 			<HStack wrap>
-				<Text>{ __( 'How did we do?' ) }</Text>
+				<Text style={ { flexBasis: isSmallScreen ? '100%' : 'auto' } }>
+					{ __( 'How did we do?' ) }
+				</Text>
 				<Button
 					icon={ thumbsUp }
 					iconSize={ 16 }

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -115,7 +115,6 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 	const { recordTracksEvent } = useAnalytics();
 	const [ isSent, setIsSent ] = useState( false );
 	const [ isFeedbackModalOpen, setIsFeedbackModalOpen ] = useState( false );
-	const isSmallScreen = useViewportMatch( 'small', '<' );
 	const [ formData, setFormData ] = useState( {
 		userFeedback: '',
 	} );
@@ -141,9 +140,7 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 
 		return (
 			<HStack wrap>
-				<Text style={ { flexBasis: isSmallScreen ? '100%' : 'auto' } }>
-					{ __( 'How did we do?' ) }
-				</Text>
+				<Text>{ __( 'How did we do?' ) }</Text>
 				<Button
 					icon={ thumbsUp }
 					iconSize={ 16 }


### PR DESCRIPTION
Part of DOTCOM-14931.


## Proposed Changes

This improves the mobile layout for the recommendation section. I don't think this perfects the layout, but it's an improvement for now. We should do another pass on the markdown section and AI results. 

| Before | After |
|--------|--------|
| <img width="1290" height="4037" alt="before" src="https://github.com/user-attachments/assets/9e026582-1268-490a-8d81-c4fb494c2f07" /> | <img width="1290" height="4770" alt="after" src="https://github.com/user-attachments/assets/44d07c51-9f28-44af-93fe-50dbf54c146d" /> | 
|  <img width="344" height="110" alt="Screenshot 2025-10-13 at 10 10 17 AM" src="https://github.com/user-attachments/assets/5b33dfa5-6898-4cb6-a60c-0f66f4d31df3" /> |  <img width="303" height="154" alt="Screenshot 2025-10-13 at 1 01 57 PM" src="https://github.com/user-attachments/assets/e309593c-5d2c-4570-be2c-7e4586883fb3" /> |
| <img width="554" height="636" alt="Screenshot 2025-10-13 at 10 17 25 AM" src="https://github.com/user-attachments/assets/169fef48-2bd3-4931-971e-0a8a26707d7d" /> | <img width="570" height="622" alt="Screenshot 2025-10-13 at 10 17 41 AM" src="https://github.com/user-attachments/assets/ad700a7e-3d41-456a-8219-b4777128680a" /> |
| <img width="1141" height="672" alt="Screenshot 2025-10-13 at 10 18 33 AM" src="https://github.com/user-attachments/assets/f730e10e-84f2-488b-a2f2-9dfdf55c9064" /> | <img width="1174" height="635" alt="Screenshot 2025-10-13 at 10 18 48 AM" src="https://github.com/user-attachments/assets/94780cb9-1b14-48c3-a222-ecb17a513ac8" /> |



## Testing Instructions

- Load the performance page on mobile.
- Run a test and interact with the bottom recommendation section. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
