### PR TITLE
Scheduled updates: Handle schedule toggle

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,4 +1,7 @@
-import { hostingUpdateScheduleDeleteMutation } from '@automattic/api-queries';
+import {
+	hostingUpdateScheduleDeleteMutation,
+	hostingUpdateScheduleToggleActiveMutation,
+} from '@automattic/api-queries';
 import { useLocale } from '@automattic/i18n-utils';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -39,93 +42,101 @@ const getUniqueScheduleName = ( () => {
 	};
 } )();
 
-const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
-	return [
-		{
-			id: 'site',
-			type: 'text',
-			label: __( 'Site' ),
-			getValue: ( { item } ) => item.site.name,
-		},
-		{
-			id: 'lastUpdate',
-			type: 'integer',
-			label: __( 'Last Update' ),
-			render: ( { item } ) =>
-				item.lastUpdate
-					? formatDate( new Date( item.lastUpdate * 1000 ), locale, {
-							dateStyle: 'medium',
-							timeStyle: 'short',
-					  } )
-					: '-',
-		},
-		{
-			id: 'nextUpdate',
-			type: 'integer',
-			label: __( 'Next Update' ),
-			render: ( { item } ) =>
-				formatDate( new Date( item.nextUpdate * 1000 ), locale, {
-					dateStyle: 'medium',
-					timeStyle: 'short',
-				} ),
-		},
-		{
-			id: 'schedule',
-			type: 'text',
-			label: __( 'Frequency' ),
-			render: ( { item } ) => ( item.schedule === 'daily' ? __( 'Daily' ) : __( 'Weekly' ) ),
-		},
-		{
-			id: 'plugins',
-			type: 'text',
-			label: __( 'Plugins' ),
-			render: ( { item } ) => (
-				<span
-					style={ {
-						alignItems: 'center',
-						display: 'flex',
-					} }
-				>
-					{ item.plugins.length }&nbsp;
-					<Tooltip text={ item.plugins.join( ', ' ) }>
-						<span
-							style={ {
-								alignItems: 'center',
-								display: 'flex',
-							} }
-						>
-							<Icon icon={ info } size={ 16 } />
-						</span>
-					</Tooltip>
-				</span>
-			),
-		},
-		{
-			id: 'active',
-			type: 'text',
-			label: __( 'Active' ),
-			render: ( { item } ) => <FormToggle checked={ item.active } onChange={ () => {} } />,
-		},
-		{
-			id: 'actions',
-			type: 'text',
-			label: __( 'Actions' ),
-		},
-		{
-			id: 'scheduleId',
-			type: 'text',
-			label: __( 'Schedule' ),
-			getValue: ( { item } ) => getUniqueScheduleName( locale, item ),
-		},
-		{
-			id: 'icon.ico',
-			label: __( 'Site icon' ),
-			render: ( { item } ) => <SiteIconLink site={ item.site } />,
-			enableSorting: false,
-			enableGlobalSearch: false,
-		},
-	];
-};
+const getFields = (
+	locale: string,
+	onToggleActive: ( item: ScheduledUpdateRow ) => void,
+	isToggling: boolean
+): Field< ScheduledUpdateRow >[] => [
+	{
+		id: 'site',
+		type: 'text',
+		label: __( 'Site' ),
+		getValue: ( { item } ) => item.site.name,
+	},
+	{
+		id: 'lastUpdate',
+		type: 'integer',
+		label: __( 'Last Update' ),
+		render: ( { item } ) =>
+			item.lastUpdate
+				? formatDate( new Date( item.lastUpdate * 1000 ), locale, {
+						dateStyle: 'medium',
+						timeStyle: 'short',
+				  } )
+				: '-',
+	},
+	{
+		id: 'nextUpdate',
+		type: 'integer',
+		label: __( 'Next Update' ),
+		render: ( { item } ) =>
+			formatDate( new Date( item.nextUpdate * 1000 ), locale, {
+				dateStyle: 'medium',
+				timeStyle: 'short',
+			} ),
+	},
+	{
+		id: 'schedule',
+		type: 'text',
+		label: __( 'Frequency' ),
+		render: ( { item } ) => ( item.schedule === 'daily' ? __( 'Daily' ) : __( 'Weekly' ) ),
+	},
+	{
+		id: 'plugins',
+		type: 'text',
+		label: __( 'Plugins' ),
+		render: ( { item } ) => (
+			<span
+				style={ {
+					alignItems: 'center',
+					display: 'flex',
+				} }
+			>
+				{ item.plugins.length }&nbsp;
+				<Tooltip text={ item.plugins.join( ', ' ) }>
+					<span
+						style={ {
+							alignItems: 'center',
+							display: 'flex',
+						} }
+					>
+						<Icon icon={ info } size={ 16 } />
+					</span>
+				</Tooltip>
+			</span>
+		),
+	},
+	{
+		id: 'active',
+		type: 'text',
+		label: __( 'Active' ),
+		render: ( { item } ) => (
+			<FormToggle
+				checked={ item.active }
+				disabled={ isToggling }
+				onChange={ () => onToggleActive( item ) }
+			/>
+		),
+	},
+	{
+		id: 'actions',
+		type: 'text',
+		label: __( 'Actions' ),
+	},
+	{
+		id: 'scheduleId',
+		type: 'text',
+		label: __( 'Schedule' ),
+		getValue: ( { item } ) => getUniqueScheduleName( locale, item ),
+	},
+	{
+		id: 'icon.ico',
+		label: __( 'Site icon' ),
+		render: ( { item } ) => <SiteIconLink site={ item.site } />,
+		enableSorting: false,
+		enableGlobalSearch: false,
+	},
+];
 
 export const defaultView: View = {
 	type: 'table',
@@ -146,12 +157,43 @@ export default function PluginsScheduledUpdates() {
 	const [ scheduleToDelete, setScheduleToDelete ] = useState< ScheduledUpdateRow | null >( null );
 	const locale = useLocale();
 	const navigate = useNavigate();
-	const fields = useMemo( () => getFields( locale ), [ locale ] );
-
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutate: deleteSchedule, isPending: isDeletingSchedule } = useMutation(
 		hostingUpdateScheduleDeleteMutation()
+	);
+	const { mutate: toggleActive, isPending: isTogglingActive } = useMutation(
+		hostingUpdateScheduleToggleActiveMutation()
+	);
+
+	const handleToggleActive = ( schedule: ScheduledUpdateRow ) => {
+		toggleActive(
+			{
+				siteId: schedule.site.ID,
+				scheduleId: schedule.scheduleId,
+				active: ! schedule.active,
+			},
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						schedule.active
+							? __( 'Schedule deactivated successfully.' )
+							: __( 'Schedule activated successfully.' ),
+						{ type: 'snackbar' }
+					);
+				},
+				onError: ( error: Error ) => {
+					createErrorNotice( error.message || __( 'Failed to update schedule.' ), {
+						type: 'snackbar',
+					} );
+				},
+			}
+		);
+	};
+
+	const fields = useMemo(
+		() => getFields( locale, handleToggleActive, isTogglingActive ),
+		[ locale, isTogglingActive ]
 	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );

--- a/packages/api-core/src/hosting-update-schedules/mutators.ts
+++ b/packages/api-core/src/hosting-update-schedules/mutators.ts
@@ -7,3 +7,15 @@ export function deleteHostingUpdateSchedule( siteId: number, scheduleId: string 
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+export function updateActiveStatusHostingUpdateSchedule(
+	siteId: number,
+	scheduleId: string,
+	active: boolean
+): Promise< unknown > {
+	return wpcom.req.put( {
+		path: `/sites/${ siteId }/update-schedules/${ encodeURIComponent( scheduleId ) }/active`,
+		apiNamespace: 'wpcom/v2',
+		body: { active },
+	} );
+}

--- a/packages/api-queries/src/hosting-update-schedules.ts
+++ b/packages/api-queries/src/hosting-update-schedules.ts
@@ -1,4 +1,8 @@
-import { fetchHostingUpdateSchedules, deleteHostingUpdateSchedule } from '@automattic/api-core';
+import {
+	fetchHostingUpdateSchedules,
+	deleteHostingUpdateSchedule,
+	updateActiveStatusHostingUpdateSchedule,
+} from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -38,6 +42,48 @@ export const hostingUpdateScheduleDeleteMutation = () =>
 		},
 		onSuccess: () => {
 			// Delay cache invalidation to allow server to process the deletion and get fresh data
+			setTimeout( () => {
+				queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+			}, 5000 );
+		},
+	} );
+
+// Mutation: toggle hosting update schedule activation
+export const hostingUpdateScheduleToggleActiveMutation = () =>
+	mutationOptions( {
+		mutationFn: ( variables: { siteId: number; scheduleId: string; active: boolean } ) =>
+			updateActiveStatusHostingUpdateSchedule(
+				variables.siteId,
+				variables.scheduleId,
+				variables.active
+			),
+		onMutate: ( variables: { siteId: number; scheduleId: string; active: boolean } ) => {
+			// Optimistically update the cache
+			const data = queryClient.getQueryData( hostingUpdateSchedulesQuery().queryKey );
+			if ( data && typeof data === 'object' && 'sites' in data ) {
+				const prevData = JSON.parse( JSON.stringify( data ) ); // deep copy
+				const sites = ( data as any ).sites || {};
+
+				// Update the schedule active status in the site
+				if ( sites[ variables.siteId ] && sites[ variables.siteId ][ variables.scheduleId ] ) {
+					sites[ variables.siteId ][ variables.scheduleId ] = {
+						...sites[ variables.siteId ][ variables.scheduleId ],
+						active: variables.active,
+					};
+				}
+
+				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, { ...data, sites } );
+				return { prevData };
+			}
+		},
+		onError: ( error, variables, context ) => {
+			// Rollback on error
+			if ( context?.prevData ) {
+				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, context.prevData );
+			}
+		},
+		onSuccess: () => {
+			// Delay cache invalidation to allow server to process the activation change and get fresh data
 			setTimeout( () => {
 				queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
 			}, 5000 );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
