### PR TITLE
Add some spacing to the last element to give room.

### DIFF
--- a/client/dashboard/sites/performance/screenshot-timeline.tsx
+++ b/client/dashboard/sites/performance/screenshot-timeline.tsx
@@ -62,6 +62,7 @@ export default function ScreenshotTimeline( { screenshots }: Props ) {
 											width: '100px',
 											flexShrink: 0,
 											padding: '2px', // Accomodate button focus box-shadow
+											paddingInlineEnd: index === screenshots.length - 1 ? '16px' : '0',
 										} }
 										key={ index }
 										spacing={ 2 }


### PR DESCRIPTION
## Proposed Changes

I have applied `paddingInlineEnd` to the CardBody to allow the scrollable container to appear cut off as an affordance to the user that they can scroll. That works well, but there isn't a space after the last item, and it therefore looks rather tight with the parent container. This PR adds a space to the last item in the HStack to give it some extra space.

| Before | After |
|--------|--------|
| <img width="939" height="345" alt="Screenshot 2025-10-13 at 10 43 48 AM" src="https://github.com/user-attachments/assets/29362dc9-23a3-4928-b240-2d310acb88e6" /> | <img width="937" height="346" alt="Screenshot 2025-10-13 at 10 41 59 AM" src="https://github.com/user-attachments/assets/3996b3fa-6db3-4800-bdf0-ca67072145ad" /> | 
| <img width="482" height="348" alt="Screenshot 2025-10-13 at 10 50 56 AM" src="https://github.com/user-attachments/assets/5827e165-2862-4381-a002-05beb7c71c0c" /> | <img width="480" height="338" alt="Screenshot 2025-10-13 at 10 50 34 AM" src="https://github.com/user-attachments/assets/6b1c8c1c-f237-4b9e-a839-0e7d9b15acec" /> |



## Testing Instructions

- Visit Performance page on a mobile device
- Scroll to the right in the screenshot panel.
- Expect there to be space after that last item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
