### PR TITLE
Hosting Dashboard: Expand date range, check to make sure we have data.

### DIFF
--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -83,7 +83,7 @@ const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) =
 	const dataValues = [];
 	// Start from the most recent data and go backwards until we have enough data points or reach the start of available data.
 	for ( let i = dates.length - 1; i >= 0; i-- ) {
-		if ( values[ i ] != null ) {
+		if ( values[ i ] !== null && values[ i ] !== undefined ) {
 			dataValues.push( { date: dates[ i ], value: values[ i ] } );
 			if ( dataValues.length >= WEEK_TO_SHOW ) {
 				break;

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -124,7 +124,7 @@ const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) =
 			...seriesData,
 		],
 		yScale: {
-			domain: [ 0, maxY === 0 ? maxY : maxY * 1.5 ] as [ number, number ],
+			domain: [ 0, maxY === 0 ? 1 : maxY * 1.5 ] as [ number, number ],
 		},
 	};
 };

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -79,8 +79,20 @@ const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) =
 	} > = [];
 	const allData = [];
 	let currentValuation;
-	for ( let i = dates.length - 1; i > Math.max( 0, dates.length - 1 - WEEK_TO_SHOW ); i-- ) {
-		const date = dates[ i ];
+
+	const dataValues = [];
+	// Start from the most recent data and go backwards until we have enough data points or reach the start of available data.
+	for ( let i = dates.length - 1; i >= 0; i-- ) {
+		if ( values[ i ] != null ) {
+			dataValues.push( { date: dates[ i ], value: values[ i ] } );
+			if ( dataValues.length >= WEEK_TO_SHOW ) {
+				break;
+			}
+		}
+	}
+
+	// Loop through the date range
+	for ( const { date, value } of dataValues ) {
 		const formattedDate =
 			typeof date === 'string'
 				? date
@@ -90,7 +102,7 @@ const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) =
 						date.day.toString().padStart( 2, '0' ),
 				  ].join( '-' );
 
-		const nextValuation = mapThresholdsToStatus( metric, values[ i ] );
+		const nextValuation = mapThresholdsToStatus( metric, value );
 		if ( nextValuation !== currentValuation ) {
 			const lastData = seriesData[ seriesData.length - 1 ]?.data?.slice().pop();
 			currentValuation = nextValuation;
@@ -106,7 +118,7 @@ const useLineChartData = ( metric: Metrics, history?: SitePerformanceHistory ) =
 
 		const data = {
 			date: new Date( formattedDate ),
-			value: getFormattedValue( metric, values[ i ] ),
+			value: getFormattedValue( metric, value ),
 		};
 		seriesData[ seriesData.length - 1 ].data.push( data );
 		allData.push( data );


### PR DESCRIPTION
Fixes DOTCOM-14932

## Proposed Changes

A site may have recordings, but not of the latest date range. The current code will grab the latest dates and build the chart with `0` values. That's a bug.

We have two choices:
1. Fix the bug, and simply show no data for that PR
2. Expand the date range to include any data return in the collection..

I've implemented 2, by expanding the date range until we have the max weeks or we reach the start of the collection.

I feel like if we have data, even if its old, we should show it.


| Before | After |
|--------|--------|
| <img width="533" height="459" alt="Screenshot 2025-10-13 at 1 54 18 PM" src="https://github.com/user-attachments/assets/4421dfcd-9c7a-4b7d-8fb1-1728c70c0a95" /> | <img width="536" height="460" alt="Screenshot 2025-10-13 at 1 52 44 PM" src="https://github.com/user-attachments/assets/a02bb93a-21d7-4df9-bbb6-d896af0f88d7" /> | 



## Testing Instructions

- Apply this patch:
```diff
diff --git a/client/dashboard/sites/performance/index.tsx b/client/dashboard/sites/performance/index.tsx
index 38850896d04..be20256e7b6 100644
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -50,7 +50,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
                ...sitePerformancePagesQuery( site.ID ),
                refetchOnWindowFocus: false,
        } );
-       const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
+       const { page_id, url } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string, url?: string };
        const currentPage = useMemo( () => {
                return page_id ? getPageFromID( pagesData, page_id ) : pagesData?.[ 0 ];
        }, [ page_id, pagesData ] );
@@ -67,7 +67,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
                isDesktopReportError,
                isMobileReportError,
                refetch: refetchReport,
-       } = usePerformanceData( currentPage?.link, currentPage?.wpcom_performance_report_hash );
+       } = usePerformanceData( url ?? currentPage?.link, currentPage?.wpcom_performance_report_hash );
        const { recordTracksEvent } = useAnalytics();
        const navigate = useNavigate( { from: sitePerformanceRoute.fullPath } );
```
- Load a site [this link](http://calypso.localhost:3000/v2/sites/abstracting.blog/performance?url=https://onik.io).
- Click CLS or Time to first byte and expect to see historical data.

Test with wordpress.com.
- Expect it to include the last week's result.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
