### PR TITLE
Dashboard v2: Add support links to hosting feature tabs

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -514,7 +514,7 @@ const contextLinks = {
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},
 	'site-monitoring-logs': {
-		link: 'https://developer.wordpress.com/docs/troubleshooting/site-monitoring/#php-logs-and-webserver-logs',
+		link: 'https://developer.wordpress.com/docs/troubleshooting/site-monitoring/#3-php-logs-and-web-server-logs',
 		post_id: 99421,
 		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
 	},

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -52,7 +52,7 @@ export const SectionHeader = ( {
 					<ButtonStack
 						justify="flex-end"
 						expanded={ false }
-						alignment="center"
+						alignment="flex-start"
 						className="dashboard-section-header__actions"
 					>
 						{ actions }

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -7,6 +7,7 @@ import { useSuspenseQuery, useQuery, useQueries } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, seen } from '@wordpress/icons';
 import { useState, useMemo } from 'react';
@@ -16,6 +17,7 @@ import {
 	siteDeploymentsListRoute,
 } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -160,6 +162,14 @@ function DeploymentsList() {
 			header={
 				<PageHeader
 					title={ __( 'Deployments' ) }
+					description={ createInterpolateElement(
+						__(
+							'Automate updates from GitHub to streamline workflows. <learnMoreLink>Learn more</learnMoreLink>'
+						),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="github-deployments" />,
+						}
+					) }
 					actions={
 						<>
 							<RouterLinkButton

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -9,6 +9,7 @@ import {
 	__experimentalVStack as VStack,
 	TabPanel,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useDateRange } from '../../app/hooks/use-date-range';
@@ -16,6 +17,7 @@ import { useLocale } from '../../app/locale';
 import { siteRoute } from '../../app/router/sites';
 import { DateRangePicker } from '../../components/date-range-picker';
 import { isLast7Days } from '../../components/date-range-picker/utils';
+import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -100,6 +102,14 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 			header={
 				<PageHeader
 					title={ __( 'Logs' ) }
+					description={ createInterpolateElement(
+						__(
+							'View and download various server logs. <learnMoreLink>Learn more</learnMoreLink>'
+						),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="site-monitoring-logs" />,
+						}
+					) }
 					actions={
 						shouldShowDateRangePicker ? (
 							<DateRangePicker

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -7,11 +7,13 @@ import {
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { usePerformanceData } from '../../app/hooks/site-performance';
 import { sitePerformanceRoute, siteRoute } from '../../app/router/sites';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -176,7 +178,18 @@ function SitePerformance() {
 			{ site.is_coming_soon || site.is_private ? (
 				<PageLayout
 					size="small"
-					header={ <PageHeader /> }
+					header={
+						<PageHeader
+							description={ createInterpolateElement(
+								__(
+									'Optimize your site for lightning-fast performance. <learnMoreLink>Learn more</learnMoreLink>'
+								),
+								{
+									learnMoreLink: <InlineSupportLink supportContext="site-performance" />,
+								}
+							) }
+						/>
+					}
 					notices={
 						<Notice
 							title={ __( 'Launch your site to start measuring performance' ) }

--- a/client/dashboard/sites/performance/subtitle.tsx
+++ b/client/dashboard/sites/performance/subtitle.tsx
@@ -28,10 +28,10 @@ export default function Subtitle( {
 	if ( ! timestamp ) {
 		return createInterpolateElement(
 			__(
-				'Optimize your site for lightning-fast performance. <supportLink>Learn more.</supportLink>'
+				'Optimize your site for lightning-fast performance. <learnMoreLink>Learn more</learnMoreLink>'
 			),
 			{
-				supportLink: <InlineSupportLink supportContext="site-performance" />,
+				learnMoreLink: <InlineSupportLink supportContext="site-performance" />,
 			}
 		);
 	}


### PR DESCRIPTION
Part of DOTDASH-602

## Proposed Changes

This PR adds support links to the following hosting features:

- Deployments
- Logs
- Performance (when the site is not launched yet)

For the other tabs, I think it needs designer's input; I commented on the Linear issue.

|v1|v2 after this PR|
|-|-|
|<img width="699" height="83" alt="image" src="https://github.com/user-attachments/assets/2cf94dc0-2c35-4e1c-801f-b49fb0ab043e" />|<img width="777" height="139" alt="image" src="https://github.com/user-attachments/assets/c51a2800-e05e-405c-bde6-cb3cc9d25dfa" />|
|<img width="788" height="83" alt="image" src="https://github.com/user-attachments/assets/f7997b91-fa8d-4362-a5e9-a28e3fe43ee3" />|<img width="776" height="140" alt="image" src="https://github.com/user-attachments/assets/2a6d4008-0533-46b8-b668-304518de4bd1" />|
|<img width="604" height="102" alt="image" src="https://github.com/user-attachments/assets/cfa25248-cf6e-420f-8d9f-40c172b52b0e" />|<img width="677" height="139" alt="image" src="https://github.com/user-attachments/assets/7eea7fff-6bba-4a5f-a3e5-e2c771e66a71" />


## Why are these changes being made?

Fit n finish.

## Testing Instructions

1. Go to `/v2/:siteSlug` of an Atomic site.
2. Go to the above tabs and verify you see the support links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
