### PR TITLE
Themes/Plugins: Enable global version only when the hosting-dashboard-opt-in is enabled

### DIFF
--- a/client/controller/preferences.js
+++ b/client/controller/preferences.js
@@ -1,0 +1,19 @@
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+
+export async function setupPreferences( context, next ) {
+	const state = context.store.getState();
+	if ( ! isUserLoggedIn( state ) || hasReceivedRemotePreferences( state ) ) {
+		next();
+		return;
+	}
+
+	try {
+		await context.store.dispatch( fetchPreferences() );
+	} catch {
+		// if the fetching of preferences fails, do nothing.
+	}
+
+	next();
+}

--- a/client/controller/preferences.js
+++ b/client/controller/preferences.js
@@ -4,6 +4,8 @@ import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selector
 
 export async function setupPreferences( context, next ) {
 	const state = context.store.getState();
+
+	// If the preferences have been fetched, we don't need to re-fetch again.
 	if ( ! isUserLoggedIn( state ) || hasReceivedRemotePreferences( state ) ) {
 		next();
 		return;
@@ -12,7 +14,7 @@ export async function setupPreferences( context, next ) {
 	try {
 		await context.store.dispatch( fetchPreferences() );
 	} catch {
-		// if the fetching of preferences fails, do nothing.
+		// If the fetching of preferences fails, do nothing.
 	}
 
 	next();

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -46,6 +46,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
@@ -426,17 +427,20 @@ export default withCurrentRoute(
 			currentRoute.startsWith( '/start/domain-for-gravatar' ) ||
 			( isCheckoutSection && hasGravatarDomainQueryParam( state ) );
 
+		const hostingDashboardOptIn = hasHostingDashboardOptIn( state );
+
 		const hasUniversalHeader =
-			( config.isEnabled( 'themes/universal-header' ) &&
+			hostingDashboardOptIn &&
+			( ( config.isEnabled( 'themes/universal-header' ) &&
 				! siteId &&
 				[ 'themes', 'theme' ].includes( sectionName ) ) ||
-			( config.isEnabled( 'plugins/universal-header' ) &&
-				! siteId &&
-				[ 'plugins' ].includes( sectionName ) &&
-				! (
-					currentRoute.startsWith( '/plugins/manage' ) ||
-					currentRoute.startsWith( '/plugins/scheduled-updates' )
-				) );
+				( config.isEnabled( 'plugins/universal-header' ) &&
+					! siteId &&
+					[ 'plugins' ].includes( sectionName ) &&
+					! (
+						currentRoute.startsWith( '/plugins/manage' ) ||
+						currentRoute.startsWith( '/plugins/scheduled-updates' )
+					) ) );
 
 		return {
 			masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -429,18 +429,22 @@ export default withCurrentRoute(
 
 		const hostingDashboardOptIn = hasHostingDashboardOptIn( state );
 
+		const isEnabledThemeUniversalHeader =
+			config.isEnabled( 'themes/universal-header' ) &&
+			[ 'themes', 'theme' ].includes( sectionName );
+
+		const isEnabledPluginsUniversalHeader =
+			config.isEnabled( 'plugins/universal-header' ) &&
+			[ 'plugins' ].includes( sectionName ) &&
+			! (
+				currentRoute.startsWith( '/plugins/manage' ) ||
+				currentRoute.startsWith( '/plugins/scheduled-updates' )
+			);
+
 		const hasUniversalHeader =
 			hostingDashboardOptIn &&
-			( ( config.isEnabled( 'themes/universal-header' ) &&
-				! siteId &&
-				[ 'themes', 'theme' ].includes( sectionName ) ) ||
-				( config.isEnabled( 'plugins/universal-header' ) &&
-					! siteId &&
-					[ 'plugins' ].includes( sectionName ) &&
-					! (
-						currentRoute.startsWith( '/plugins/manage' ) ||
-						currentRoute.startsWith( '/plugins/scheduled-updates' )
-					) ) );
+			! siteId &&
+			( isEnabledThemeUniversalHeader || isEnabledPluginsUniversalHeader );
 
 		return {
 			masterbarIsHidden,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -83,6 +83,7 @@ import {
 	getSitePlanSlug,
 	getSiteSlug,
 } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -938,9 +939,11 @@ export function hideNavigationIfLoggedInWithNoSites( context, next ) {
 export function addNavigationIfLoggedIn( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-	const shouldShowNavigation = config.isEnabled( 'themes/universal-header' )
-		? selectedSite
-		: isUserLoggedIn( state );
+	const hostingDashboardOptIn = hasHostingDashboardOptIn( state );
+	const shouldShowNavigation =
+		config.isEnabled( 'themes/universal-header' ) && hostingDashboardOptIn
+			? selectedSite
+			: isUserLoggedIn( state );
 	if ( shouldShowNavigation ) {
 		navigation( context, next );
 	}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -16,6 +16,7 @@ import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
 import { UNLISTED_PLUGINS } from './constants';
@@ -383,6 +384,7 @@ export function maybeRedirectLoggedOut( context, next ) {
 export function renderPluginsSidebar( context, next ) {
 	const state = context.store.getState();
 	const siteUrl = getSiteFragment( context.path );
+	const hostingDashboardOptIn = hasHostingDashboardOptIn( state );
 
 	if ( ! isUserLoggedIn( state ) ) {
 		next();
@@ -391,6 +393,7 @@ export function renderPluginsSidebar( context, next ) {
 	if ( ! siteUrl ) {
 		context.secondary =
 			isEnabled( 'plugins/universal-header' ) &&
+			hostingDashboardOptIn &&
 			! (
 				context.path.startsWith( '/plugins/manage' ) ||
 				context.path.startsWith( '/plugins/scheduled-updates' )

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -2,6 +2,7 @@ import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { JSDOM } from 'jsdom';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { overrideSanitizeSectionRoot } from 'calypso/lib/plugins/sanitize-section-content';
 import { browsePlugins, browsePluginsOrPlugin } from './controller';
 import {
@@ -21,6 +22,7 @@ export default function ( router ) {
 		[ `/${ langParam }/plugins` ],
 		skipIfLoggedIn,
 		ssrSetupLocale,
+		setupPreferences,
 		fetchPlugins,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
@@ -32,6 +34,7 @@ export default function ( router ) {
 		`/${ langParam }/plugins/browse/:category`,
 		skipIfLoggedIn,
 		ssrSetupLocale,
+		setupPreferences,
 		fetchCategoryPlugins,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
@@ -44,6 +47,7 @@ export default function ( router ) {
 		skipIfLoggedIn,
 		validatePlugin,
 		ssrSetupLocale,
+		setupPreferences,
 		fetchPlugin,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -7,6 +7,7 @@ import {
 	render as clientRender,
 	redirectIfCurrentUserCannot,
 } from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { noSite, navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	renderPluginsDashboard,
@@ -62,6 +63,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		setupPreferences,
 		renderPluginsSidebar,
 		browsePlugins,
 		makeLayout,
@@ -98,6 +100,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
+		setupPreferences,
 		renderPluginsSidebar,
 		browsePlugins,
 		makeLayout,
@@ -170,6 +173,7 @@ export default function ( router ) {
 		navigation,
 		redirectTrialSites,
 		jetpackCanUpdate,
+		setupPreferences,
 		renderPluginsSidebar,
 		plugins,
 		makeLayout,
@@ -216,6 +220,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		setupPreferences,
 		renderPluginsSidebar,
 		relatedPlugins,
 		makeLayout,
@@ -243,6 +248,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		setupPreferences,
 		renderPluginsSidebar,
 		browsePluginsOrPlugin,
 		makeLayout,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -25,6 +25,7 @@ import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-s
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSitePlan, isJetpackSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -109,7 +110,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 		? category.charAt( 0 ).toUpperCase() + category.slice( 1 )
 		: __( 'Plugins' );
 	const categoryName = categories[ category ]?.menu || fallbackCategoryName;
-	const shouldUseLoggedInView = isEnabled( 'plugins/universal-header' ) ? siteId : isLoggedIn;
+	const hostingDashboardOptIn = useSelector( ( state ) => hasHostingDashboardOptIn( state ) );
+	const shouldUseLoggedInView =
+		isEnabled( 'plugins/universal-header' ) && hostingDashboardOptIn ? siteId : isLoggedIn;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {

--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Icon, link, linkOff, trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	ACTIVATE_PLUGIN,
@@ -12,12 +13,14 @@ import { PluginActionTypes } from 'calypso/my-sites/plugins/plugin-management-v2
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { Plugin, PluginSite } from 'calypso/state/plugins/installed/types';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { PluginActions } from '../hooks/types';
 
 export function useActions(
 	bulkActionDialog: ( action: string, plugins: Array< Plugin > ) => void
 ) {
 	const dispatch = useDispatch();
+	const hostingDashboardOptIn = useSelector( ( state ) => hasHostingDashboardOptIn( state ) );
 	const recordIntentionEvent = ( plugins: Array< Plugin >, action: string ) => {
 		/**
 		 * There's currently no better way to differentiate between bulk and single action clicks.
@@ -49,16 +52,17 @@ export function useActions(
 				const pluginSlug = plugins?.[ 0 ]?.slug;
 				if ( pluginSlug ) {
 					const url = `/plugins/${ pluginSlug }`;
-					if ( isEnabled( 'plugins/universal-header' ) ) {
+					if ( isEnabled( 'plugins/universal-header' ) && hostingDashboardOptIn ) {
 						window.open( url, '_blank' );
 					} else {
 						navigate( url );
 					}
 				}
 			},
-			label: isEnabled( 'plugins/universal-header' )
-				? translate( 'Manage plugin ↗' )
-				: translate( 'Manage plugin' ),
+			label:
+				isEnabled( 'plugins/universal-header' ) && hostingDashboardOptIn
+					? translate( 'Manage plugin ↗' )
+					: translate( 'Manage plugin' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: false,

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -11,6 +11,7 @@ import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
 import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { AppState } from 'calypso/types';
 import { SidebarIconPlugins } from '../../sidebar/static-data/global-sidebar-menu';
 import { SidebarIconCalendar } from './icons';
@@ -22,7 +23,7 @@ interface Props {
 }
 const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
 
-const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
+const PluginsSidebar = ( { path, isCollapsed, hasOptIn }: Props ) => {
 	const translate = useTranslate();
 
 	const [ previousPath, setPreviousPath ] = useState( path );
@@ -47,7 +48,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			footer={ isEnabled( 'dashboard/v2' ) && ! isCollapsed && <HostingDashboardOptInBanner /> }
 		>
 			<SidebarMenu>
-				{ ! isEnabled( 'plugins/universal-header' ) && (
+				{ ! ( isEnabled( 'plugins/universal-header' ) && hasOptIn ) && (
 					<SidebarItem
 						className="sidebar__menu-item--plugins"
 						link="/plugins"
@@ -82,7 +83,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					customIcon={ <SidebarIconCalendar /> }
 				/>
 
-				{ isEnabled( 'plugins/universal-header' ) && (
+				{ isEnabled( 'plugins/universal-header' ) && hasOptIn && (
 					<SidebarItem
 						className="sidebar__menu-item--plugins"
 						link="/plugins"
@@ -113,8 +114,10 @@ export default withCurrentRoute(
 			section: currentSection,
 			route: currentRoute,
 		} );
+
 		return {
 			isCollapsed: shouldShowCollapsedGlobalSidebar,
+			hasOptIn: hasHostingDashboardOptIn( state ),
 		};
 	} )( PluginsSidebar )
 );

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -20,6 +20,7 @@ import './style.scss';
 interface Props {
 	path: string;
 	isCollapsed: boolean;
+	hasOptIn: boolean;
 }
 const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
 

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -23,7 +23,7 @@ export const SidebarIconPlugins = () => (
 /**
  * Menu items that support all sites screen.
  */
-export default function globalSidebarMenu( { showP2s = false } = {} ) {
+export default function globalSidebarMenu( { showP2s = false, hasOptIn = false } = {} ) {
 	return [
 		{
 			icon: <Icon icon={ category } className="sidebar__menu-icon svg_all-sites" size={ 24 } />,
@@ -60,7 +60,7 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 			navigationLabel: translate( 'Themes' ),
 			type: 'menu-item',
 			url: '/themes',
-			forceExternalLink: isEnabled( 'themes/universal-header' ),
+			forceExternalLink: isEnabled( 'themes/universal-header' ) && hasOptIn,
 		},
 		{
 			icon: <SidebarIconPlugins />,
@@ -68,7 +68,8 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'Plugins' ),
 			type: 'menu-item',
-			url: isEnabled( 'plugins/universal-header' ) ? '/plugins/manage/sites' : '/plugins',
+			url:
+				isEnabled( 'plugins/universal-header' ) && hasOptIn ? '/plugins/manage/sites' : '/plugins',
 			forceChevronIcon: true,
 		},
 	];

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -14,6 +14,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
@@ -68,8 +69,13 @@ const useSiteMenuItems = () => {
 
 	const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
+	const hostingDashboardOptIn = useSelector( ( state ) => hasHostingDashboardOptIn( state ) );
+
 	if ( shouldShowGlobalSidebar ) {
-		return globalSidebarMenu( { showP2s: showP2s } );
+		return globalSidebarMenu( {
+			showP2s: showP2s,
+			hasOptIn: hostingDashboardOptIn,
+		} );
 	}
 
 	/**

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -1,6 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { details, fetchThemeDetailsData, fetchThemeFilters, notFoundError } from './controller';
 
 export default function ( router ) {
@@ -10,6 +11,7 @@ export default function ( router ) {
 	router(
 		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id?`,
 		ssrSetupLocale,
+		setupPreferences,
 		fetchThemeFilters,
 		fetchThemeDetailsData,
 		details,

--- a/client/my-sites/themes/controller-logged-in.jsx
+++ b/client/my-sites/themes/controller-logged-in.jsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { setBackPath } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getProps, loggedOut } from './controller';
@@ -46,9 +47,11 @@ export function upload( context, next ) {
 export function renderThemes( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSiteId( state );
-	const shouldUseLoggedIn = isEnabled( 'themes/universal-header' )
-		? selectedSite
-		: isUserLoggedIn( state );
+	const hostingDashboardOptIn = hasHostingDashboardOptIn( state );
+	const shouldUseLoggedIn =
+		isEnabled( 'themes/universal-header' ) && hostingDashboardOptIn
+			? selectedSite
+			: isUserLoggedIn( state );
 	if ( shouldUseLoggedIn ) {
 		return loggedIn( context, next );
 	}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -1,6 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
+import { setupPreferences } from 'calypso/controller/preferences';
 import {
 	fetchThemeData,
 	fetchThemeFilters,
@@ -33,6 +34,7 @@ export default function ( router ) {
 	router(
 		showcaseRoutes,
 		ssrSetupLocale,
+		setupPreferences,
 		fetchThemeFilters,
 		validateVertical,
 		validateFilters,
@@ -62,5 +64,5 @@ export default function ( router ) {
 			redirectToThemeDetails( res.redirect, site, theme, section, next )
 	);
 	// The following route definition is needed so direct hits on `/themes/<mysite>` don't result in a 404.
-	router( '/themes/*', fetchThemeData, renderThemes, makeLayout );
+	router( '/themes/*', setupPreferences, fetchThemeData, renderThemes, makeLayout );
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,6 +6,7 @@ import {
 	redirectWithoutLocaleParamIfLoggedIn,
 	render as clientRender,
 } from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import {
 	addNavigationIfLoggedIn,
 	navigation,
@@ -73,6 +74,7 @@ export default function ( router ) {
 		redirectWithoutLocaleParamIfLoggedIn,
 		fetchAndValidateVerticalsAndFilters,
 		noSite,
+		setupPreferences,
 		renderThemes,
 		addNavigationIfLoggedIn,
 		makeLayout,
@@ -91,5 +93,5 @@ export default function ( router ) {
 			redirectToThemeDetails( page.redirect, site_id, theme, section, next )
 	);
 
-	router( '/themes/*', fetchThemeData, renderThemes, makeLayout );
+	router( '/themes/*', setupPreferences, fetchThemeData, renderThemes, makeLayout );
 }

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -6,6 +6,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallThemeButton from './install-theme-button';
 import useThemeShowcaseDescription from './use-theme-showcase-description';
@@ -34,9 +35,9 @@ export default function ThemeShowcaseHeader( {
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const skipTitleFormatting = shouldSkipTitleFormatting( { filter, tier } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
-	const shouldUseLoggedInHeader = isEnabled( 'themes/universal-header' )
-		? selectedSiteId
-		: isLoggedIn;
+	const hostingDashboardOptIn = useSelector( ( state ) => hasHostingDashboardOptIn( state ) );
+	const shouldUseLoggedInHeader =
+		isEnabled( 'themes/universal-header' ) && hostingDashboardOptIn ? selectedSiteId : isLoggedIn;
 
 	const {
 		title: documentHeadTitle,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Enable global header on both Theme Showcase and Plugins Marketplace only when the user has enabled the HD opt-in

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disable HD opt-in
* Go to /themes or /plugins
* Ensure it works as before
* Select any theme or plugin
* Ensure it works as before
* Go to /sites
* Ensure the Themes on the sidebar doesn't have the external icon
* Click "Plugins"
* Ensure it opens the Plugins Marketplace
* Enable HD opt-in
* Go to /themes or /plugins
* Ensure it displays the global header like the logged-out view
* Select any theme or plugin
* Ensure it displays the global header like the logged-out view as well
* Go to /sites
* Ensure the Themes on the sidebar has the external icon
* Click "Plugins"
* Ensure it opens the "Manage plugins"
* Click "Marketplace" icon on the sidebar
* Ensure it opens the Plugins Marketplace on the new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
