### PR TITLE
Domain Search Rewrite: Enable feature flag globally

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -79,7 +79,7 @@ const sidebarDomain = buildDomainResponse( {
 } );
 
 const upgradeDomainBadgeText = 'Pick a custom domain';
-const upgradeDomainBadgeLink = `/domains/add/${ sidebarDomain.domain }?domainAndPlanPackage=true`;
+const upgradeDomainBadgeLink = `/setup/domain-and-plan?siteSlug=${ sidebarDomain.domain }`;
 
 const props = {
 	sidebarDomain,

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -86,11 +86,9 @@ describe( 'index', () => {
 
 		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
 		expect( searchLink ).toBeInTheDocument();
-		expect(
-			searchLink.href.includes(
-				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
-			)
-		).toBeTruthy();
+		expect( searchLink.href ).toContain(
+			'/setup/domain-and-plan?siteSlug=example.wordpress.com&back_to=%2F'
+		);
 	} );
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
@@ -133,8 +131,8 @@ describe( 'index', () => {
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
 		await waitFor( () => {
-			expect( pageLink ).toMatch(
-				/\/plans\/yearly\/example\.wordpress\.com\?domain=true&domainAndPlanPackage=true/
+			expect( pageLink ).toEqual(
+				'/setup/domain-and-plan/plans?siteSlug=example.wordpress.com&back_to=%2F'
 			);
 		} );
 	} );
@@ -241,11 +239,9 @@ describe( 'index', () => {
 
 		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
 		expect( searchLink ).toBeInTheDocument();
-		expect(
-			searchLink.href.includes(
-				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
-			)
-		).toBeTruthy();
+		expect( searchLink.href ).toContain(
+			'/setup/domain-and-plan?siteSlug=example.wordpress.com&back_to=%2F'
+		);
 	} );
 
 	test( 'Should NOT show Home domain upsell if paid plan with > 0 custom domains', async () => {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
@@ -88,11 +88,9 @@ describe( 'index', () => {
 
 		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
 		expect( searchLink ).toBeInTheDocument();
-		expect(
-			searchLink.href.includes(
-				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
-			)
-		).toBeTruthy();
+		expect( searchLink.href ).toContain(
+			'/setup/domain-and-plan?siteSlug=example.wordpress.com&back_to=%2F'
+		);
 	} );
 
 	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
@@ -136,8 +134,8 @@ describe( 'index', () => {
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
 		await waitFor( () => {
-			expect( pageLink ).toMatch(
-				/\/plans\/yearly\/example\.wordpress\.com\?domain=true&domainAndPlanPackage=true/
+			expect( pageLink ).toContain(
+				'/setup/domain-and-plan/plans?siteSlug=example.wordpress.com&back_to=%2F'
 			);
 		} );
 	} );
@@ -246,11 +244,9 @@ describe( 'index', () => {
 
 		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
 		expect( searchLink ).toBeInTheDocument();
-		expect(
-			searchLink.href.includes(
-				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
-			)
-		).toBeTruthy();
+		expect( searchLink.href ).toContain(
+			'/setup/domain-and-plan?siteSlug=example.wordpress.com&back_to=%2F'
+		);
 	} );
 
 	test( 'Should NOT show Home domain upsell if paid plan with > 0 custom domains', async () => {

--- a/config/development.json
+++ b/config/development.json
@@ -62,7 +62,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domain-search-rewrite": false,
+		"domain-search-rewrite": true,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": false,
 		"google-drive": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": true,
-		"domain-search-rewrite": false,
+		"domain-search-rewrite": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,7 +39,7 @@
 		"dashboard/v2/backport/site-overview": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
-		"domain-search-rewrite": false,
+		"domain-search-rewrite": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,7 +38,7 @@
 		"current-site/notice": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domain-search-rewrite": false,
+		"domain-search-rewrite": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,
 		"help": true,


### PR DESCRIPTION
Closes DOMAINS-1709.

## Proposed Changes

After a successful CfT, it's time to roll out the rewritten Domain Search UI to all users.

This PR enables the feature flag in all environments, including production.

## Testing Instructions

Verify all tests, including Pre-Release E2E tests, are green. Do some smoke testing in `/setup`. Verify you can:
- Search for a domain
- Add it to the cart
- Add a different domain to the cart
- Filter for a specific TLD
- Remove a domain from the cart
- Continue to the next step
- See the domain (s) at checkout