### PR TITLE
Domain Search Rewrite: Use no-user cart key if browsing as a guest

### DIFF
--- a/client/components/domains/wpcom-domain-search/index.tsx
+++ b/client/components/domains/wpcom-domain-search/index.tsx
@@ -4,8 +4,9 @@ import { DomainSearch, getTld } from '@automattic/domain-search';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { useDebounce } from '@wordpress/compose';
 import { useCallback, useMemo, useRef, type ComponentProps } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { submitDomainStepSelection } from 'calypso/signup/steps/domains/legacy';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordAddDomainButtonClick } from 'calypso/state/domains/actions';
 import { recordUseYourDomainButtonClick } from '../../domain-search-v2/register-domain-step/analytics';
 import { WPCOMDomainSearchCartProvider } from './domain-search-cart-provider';
@@ -35,7 +36,9 @@ const DomainSearchWithCart = ( {
 	...props
 }: DomainSearchProps ) => {
 	const dispatch = useDispatch();
-	const cartKey = currentSiteId ?? 'no-site';
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const sitelessCartKey = isLoggedIn ? 'no-site' : 'no-user';
+	const cartKey = currentSiteId ?? sitelessCartKey;
 	const railcarId = useRef( getNewRailcarId( 'domain-suggestion' ) );
 
 	const { query } = props;


### PR DESCRIPTION
## Proposed Changes

Fixes a problem where we were using the `no-site` cart key when the user was logged out. That doesn't work because that particular cart key is reserved for authenticated users.

For guests, we need to use `no-user`.

## Testing Instructions

- Enter `/start/domain` as a guest (incognito browser window) and verify you can add domains to the cart and continue to checkout
- Enter `/start/domain` as a logged-in user and verify you can add domains to the cart and continue to checkout