### PR TITLE
Signup: Remove StepWrapper logo if using StepContainerV2

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -272,7 +272,7 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
 	--color-accent: var(--studio-wordpress-blue-50);
 	--color-accent-60: var(--studio-wordpress-blue-60);
 
-	.signup-header {
+	&:not(:has(.step-container-v2)) .signup-header {
 		.wordpress-logo {
 			position: absolute;
 			inset-inline-start: 20px;


### PR DESCRIPTION
Closes DOMAINS-1711.

## Proposed Changes

Because the OneLoginLayout component uses StepContainerV2, some flows on Start might render the StepWrapper, which includes the WordPress logo absolutely positioned.

This PR detects StepContainerV2 and removes the duplicated logo.

| Before | After |
| --- | --- |
| <img width="500" height="127" alt="image" src="https://github.com/user-attachments/assets/74b347ed-5179-4258-8b64-4c3fd4035b8d" /> | <img width="540" height="175" alt="image" src="https://github.com/user-attachments/assets/0abb7917-bc1a-48d7-9ee7-744e2433c631" /> |

## Testing Instructions

Enter `/start/domain` as a logged-out user. Add a domain to the cart and pick "New site" in the following step. Pick a plan and verify you see the user step. In production you should see the "Before" version. On this branch you should see the "After" version.