### PR TITLE
Add flex sites to both V1 and V2 dashboards

### DIFF
--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,7 +1,13 @@
 import type { Site } from '@automattic/api-core';
 
+type SiteWithFlex = Site & { is_wpcom_flex?: boolean };
+
+export function isWpcomFlex( site: Site ) {
+	return !! ( site as SiteWithFlex ).is_wpcom_flex;
+}
+
 export function isSelfHostedJetpackConnected( site: Site ) {
-	return site.jetpack_connection && ! site.is_wpcom_atomic;
+	return site.jetpack_connection && ! site.is_wpcom_atomic && ! isWpcomFlex( site );
 }
 
 export function isP2( site: Site ) {

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,13 +1,7 @@
 import type { Site } from '@automattic/api-core';
 
-type SiteWithFlex = Site & { is_wpcom_flex?: boolean };
-
-export function isWpcomFlex( site: Site ) {
-	return !! ( site as SiteWithFlex ).is_wpcom_flex;
-}
-
 export function isSelfHostedJetpackConnected( site: Site ) {
-	return site.jetpack_connection && ! site.is_wpcom_atomic && ! isWpcomFlex( site );
+	return site.jetpack_connection && ! site.is_wpcom_atomic && ! site.is_wpcom_flex;
 }
 
 export function isP2( site: Site ) {


### PR DESCRIPTION
This PR makes both V1 and V2 dashboards semi-functional for Flex sites
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-19

## Proposed Changes

Two ifs will enable us to see the Hosting Dashboards with a Flex site. 

Flex sites are WPCOM sites that have the Jetpack site type, placing them in the middle in a normally undefined state, pointing all admin links to wp-admin. We, however, want to enable the Hosting Dashboard for them much like WPCOM Business sites, with which they have many commons, except the platform.

Given that the REST API endpoints will not function for Flex sites, the dashboards, once enabled, will trigger a variety of REST API failures, primarily 403 errors. These will later be fixed one by one.

## Why are these changes being made?

*

## Testing Instructions

* You'll need a new Flex site
* Then go to both V1 and V2 dashboards and make sure you see the overview screen and some fragments of the other Hosting Dashboard for Atomic screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
