### PR TITLE
Help Center: Avoid glitch on opening

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -31,6 +31,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
 import { HELP_CENTER_STORE } from '../stores';
+import PlaceholderLines from './placeholder-lines';
 import type { SearchResult } from '../types';
 import './help-center-search-results.scss';
 
@@ -179,6 +180,7 @@ interface HelpSearchResultsProps {
 		result: SearchResult
 	) => void;
 	searchQuery: string;
+	placeholderLines?: number;
 	openAdminInNewTab: boolean;
 	location: string;
 	isSearching: boolean;
@@ -190,6 +192,7 @@ function HelpSearchResults( {
 	externalLinks = false,
 	onSelect,
 	searchQuery = '',
+	placeholderLines = 4,
 	openAdminInNewTab = false,
 	location = 'inline-help-popover',
 	isSearching,
@@ -358,6 +361,7 @@ function HelpSearchResults( {
 
 	return (
 		<div className="help-center-search-results" aria-label={ resultsLabel }>
+			{ isSearching && ! hasAPIResults && <PlaceholderLines lines={ placeholderLines } /> }
 			{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
 				<div className="help-center-search-results__empty-results">
 					<p>

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -9,10 +9,10 @@ import {
 	SUPPORT_TYPE_API_HELP,
 	SUPPORT_TYPE_CONTEXTUAL_HELP,
 } from '@automattic/data-stores';
-import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { speak } from '@wordpress/a11y';
 import { Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import {
@@ -30,11 +30,8 @@ import React, { Fragment, useEffect, useMemo } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
-import { useHelpSearchQuery } from '../hooks/use-help-search-query';
 import { HELP_CENTER_STORE } from '../stores';
-import PlaceholderLines from './placeholder-lines';
 import type { SearchResult } from '../types';
-import type { HelpCenterSelect } from '@automattic/data-stores';
 import './help-center-search-results.scss';
 
 const MAX_VISIBLE_RESULTS = 8;
@@ -182,9 +179,10 @@ interface HelpSearchResultsProps {
 		result: SearchResult
 	) => void;
 	searchQuery: string;
-	placeholderLines: number;
 	openAdminInNewTab: boolean;
 	location: string;
+	isSearching: boolean;
+	searchData: SearchResult[];
 	currentRoute?: string;
 }
 
@@ -192,17 +190,15 @@ function HelpSearchResults( {
 	externalLinks = false,
 	onSelect,
 	searchQuery = '',
-	placeholderLines,
 	openAdminInNewTab = false,
 	location = 'inline-help-popover',
+	isSearching,
+	searchData,
 	currentRoute,
 }: HelpSearchResultsProps ) {
-	const { hasPurchases, sectionName, site, source } = useHelpCenterContext();
+	const { hasPurchases, sectionName, site } = useHelpCenterContext();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const contextTerm = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getContextTerm(),
-		[]
-	);
+	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
 
 	const isPurchasesSection = [ 'purchases', 'site-purchases' ].includes( sectionName );
 	const siteIntent = site?.options.site_intent;
@@ -211,20 +207,10 @@ function HelpSearchResults( {
 		[ sectionName, siteIntent ]
 	);
 
-	const locale = useLocale();
 	const contextualResults = rawContextualResults.filter(
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
 		filterManagePurchaseLink( hasPurchases, isPurchasesSection )
-	);
-
-	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
-
-	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery(
-		searchQuery || contextTerm || contextSearch, // If there's a query, we don't context search
-		locale,
-		currentRoute,
-		source
 	);
 
 	const searchResults = searchData ?? [];
@@ -261,8 +247,8 @@ function HelpSearchResults( {
 		queueMicrotask( () => {
 			recordTracksEvent( 'calypso_help_center_search_traintracks_interact', {
 				action: 'click',
-				railcar: result.railcar.railcar,
-				session_id: result.railcar.session_id,
+				railcar: result.railcar?.railcar,
+				session_id: result.railcar?.session_id,
 				href: result.link,
 				search_type: ! contextSearch && ! searchQuery ? 'tailored' : 'search',
 				location,
@@ -372,7 +358,6 @@ function HelpSearchResults( {
 
 	return (
 		<div className="help-center-search-results" aria-label={ resultsLabel }>
-			{ isSearching && ! searchResults.length && <PlaceholderLines lines={ placeholderLines } /> }
 			{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
 				<div className="help-center-search-results__empty-results">
 					<p>

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -26,7 +26,7 @@ type HelpCenterSearchProps = {
 
 export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSearchProps ) => {
 	const locale = useLocale();
-	const { sectionName, site, currentUser } = useHelpCenterContext();
+	const { sectionName, site, currentUser, source } = useHelpCenterContext();
 	const { searchQuery, setSearchQueryAndEmailSubject, redirectToArticle } =
 		useHelpCenterSearch( onSearchChange );
 
@@ -39,7 +39,8 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch, // If there's a query, we don't context search
 		locale,
-		currentRoute
+		currentRoute,
+		source
 	);
 
 	const isSiteOwner = site?.site_owner === currentUser?.ID;

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -1,13 +1,21 @@
 /* eslint-disable no-restricted-imports */
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useHelpCenterSearch } from '../hooks';
+import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
+import { useHelpSearchQuery } from '../hooks/use-help-search-query';
+import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterRecentConversations from './help-center-recent-conversations';
 import HelpCenterSearchResults from './help-center-search-results';
 import { BlockedZendeskNotice } from './notices';
+import PlaceholderLines from './placeholder-lines';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
 import './help-center-search.scss';
 import './help-center-launchpad.scss';
 
@@ -17,9 +25,22 @@ type HelpCenterSearchProps = {
 };
 
 export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSearchProps ) => {
+	const locale = useLocale();
 	const { sectionName, site, currentUser } = useHelpCenterContext();
 	const { searchQuery, setSearchQueryAndEmailSubject, redirectToArticle } =
 		useHelpCenterSearch( onSearchChange );
+
+	const contextTerm = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getContextTerm(),
+		[]
+	);
+	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
+
+	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery(
+		searchQuery || contextTerm || contextSearch, // If there's a query, we don't context search
+		locale,
+		currentRoute
+	);
 
 	const isSiteOwner = site?.site_owner === currentUser?.ID;
 	const launchpadEnabled = site?.options?.launchpad_screen === 'full' && isSiteOwner;
@@ -29,24 +50,28 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 			<HelpCenterRecentConversations />
 			<BlockedZendeskNotice />
 			{ launchpadEnabled && <HelpCenterLaunchpad /> }
-			<InlineHelpSearchCard
-				searchQuery={ searchQuery }
-				onSearch={ setSearchQueryAndEmailSubject }
-				location="help-center"
-				isVisible
-				placeholder={ __( 'Search guides…', __i18n_text_domain__ ) }
-				sectionName={ sectionName }
-				useSearchControl
-			/>
+			{ isSearching && <PlaceholderLines lines={ 4 } /> }
+			{ ! isSearching && (
+				<InlineHelpSearchCard
+					searchQuery={ searchQuery }
+					onSearch={ setSearchQueryAndEmailSubject }
+					location="help-center"
+					isVisible
+					placeholder={ __( 'Search guides…', __i18n_text_domain__ ) }
+					sectionName={ sectionName }
+					useSearchControl
+				/>
+			) }
 			<HelpCenterSearchResults
 				onSelect={ redirectToArticle }
 				searchQuery={ searchQuery || '' }
 				openAdminInNewTab
-				placeholderLines={ 4 }
 				location="help-center"
+				isSearching={ isSearching }
+				searchData={ searchData }
 				currentRoute={ currentRoute }
 			/>
-			{ ! searchQuery && <HelpCenterMoreResources /> }
+			{ ! searchQuery && ! isSearching && <HelpCenterMoreResources /> }
 		</div>
 	);
 };

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -13,7 +13,6 @@ import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterRecentConversations from './help-center-recent-conversations';
 import HelpCenterSearchResults from './help-center-search-results';
 import { BlockedZendeskNotice } from './notices';
-import PlaceholderLines from './placeholder-lines';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
 import './help-center-search.scss';
@@ -51,7 +50,6 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 			<HelpCenterRecentConversations />
 			<BlockedZendeskNotice />
 			{ launchpadEnabled && <HelpCenterLaunchpad /> }
-			{ isSearching && <PlaceholderLines lines={ 4 } /> }
 			{ ! isSearching && (
 				<InlineHelpSearchCard
 					searchQuery={ searchQuery }

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -53,7 +53,7 @@ export interface FeatureFlags {
 }
 
 export interface SearchResult {
-	railcar: {
+	railcar?: {
 		railcar?: string;
 		fetch_algo?: string;
 		fetch_lang?: string;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-314/fix-loading-issue

## What

Hide the search and more resources section while the other contents load.

### Before

https://github.com/user-attachments/assets/006285ae-396a-4e33-ac7a-36c9f259b351

### After

[Last 5 seconds]

https://github.com/user-attachments/assets/6ec3b971-8993-4d92-ab22-99e60717c31e



## Why

To avoid a glitch when loading the Help Center

## Testing 

1. Open the Help Center setting a slow connection in the developer tools
2. No glitch should happen, Search bar and More Resources should appear only after loading stops.
