### PR TITLE
Hosting Dashboard Emails: Add domain filter

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -45,6 +45,11 @@ export const emailsRoute = createRoute( {
 			),
 		] );
 	},
+	validateSearch: ( search ): { domainName: string | undefined } => {
+		return {
+			domainName: typeof search.domainName === 'string' ? search.domainName : undefined,
+		};
+	},
 } ).lazy( () =>
 	import( '../../emails' ).then( ( d ) =>
 		createLazyRoute( 'emails' )( {

--- a/client/dashboard/emails/dataviews.tsx
+++ b/client/dashboard/emails/dataviews.tsx
@@ -1,6 +1,6 @@
 import type { View } from '@wordpress/dataviews';
 
-export { emailFields } from './fields';
+export { getEmailFields } from './fields';
 
 export const DEFAULT_EMAILS_VIEW: View = {
 	type: 'table',
@@ -9,6 +9,7 @@ export const DEFAULT_EMAILS_VIEW: View = {
 	sort: { field: 'emailAddress', direction: 'asc' },
 	fields: [ 'domainName', 'type', 'status' ],
 	titleField: 'emailAddress',
+	search: '',
 };
 
 export { useEmailActions } from './actions';

--- a/client/dashboard/emails/fields/domain-name.ts
+++ b/client/dashboard/emails/fields/domain-name.ts
@@ -1,9 +1,11 @@
+import { SiteDomain } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import type { Email } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const domainNameField: Field< Email > = {
+export const getDomainNameField = ( domains: SiteDomain[] ): Field< Email > => ( {
 	id: 'domainName',
 	label: __( 'Domain' ),
 	getValue: ( { item }: { item: Email } ) => item.domainName,
-};
+	elements: domains.map( ( { domain } ) => ( { value: domain, label: domain } ) ),
+} );

--- a/client/dashboard/emails/fields/index.ts
+++ b/client/dashboard/emails/fields/index.ts
@@ -1,15 +1,14 @@
-import { domainNameField } from './domain-name';
+import { SiteDomain } from '@automattic/api-core';
+import { getDomainNameField } from './domain-name';
 import { emailAddressField } from './email-address';
 import { statusField } from './status';
 import { typeField } from './type';
 import type { Email } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const emailFields: Field< Email >[] = [
+export const getEmailFields = ( domains: SiteDomain[] ): Field< Email >[] => [
 	emailAddressField,
-	domainNameField,
+	getDomainNameField( domains ),
 	typeField,
 	statusField,
 ];
-
-export { emailAddressField, domainNameField, typeField, statusField };

--- a/client/dashboard/utils/persist-view-to-url.ts
+++ b/client/dashboard/utils/persist-view-to-url.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+import type { Operator, View } from '@wordpress/dataviews';
+
+function alterUrlForViewProp(
+	url: URL,
+	urlKey: string,
+	currentViewPropValue: string | number | string[] | number[] | undefined
+): void {
+	if ( currentViewPropValue ) {
+		url.searchParams.set( urlKey, String( currentViewPropValue ) );
+	} else {
+		url.searchParams.delete( urlKey );
+	}
+}
+
+export function persistViewToUrl(
+	view: View,
+	fieldName: string,
+	formatFieldValue?: ( fieldValue: string ) => string
+): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	// Only persist certain view settings to the URL for now.
+	const url = new URL( window.location.href );
+	const fieldValue = view.filters?.find( ( filter ) => filter.field === fieldName )?.value;
+	alterUrlForViewProp(
+		url,
+		fieldName,
+		formatFieldValue ? formatFieldValue( fieldValue ) : fieldValue
+	);
+	window.history.pushState( undefined, '', url );
+}
+
+export function updateViewFromField( view: View, fieldName: string, fieldValue: string ): View {
+	return {
+		...view,
+		filters: [
+			...( view.filters ?? [] ),
+			{
+				value: fieldValue,
+				operator: 'isAny' as Operator,
+				field: fieldName,
+			},
+		],
+	};
+}
+
+export function useSetInitialViewFromUrl( {
+	fieldName,
+	fieldValue,
+	setView,
+}: {
+	fieldName: string;
+	fieldValue: string | undefined;
+	setView: ( setter: View | ( ( view: View ) => View ) ) => void;
+} ): void {
+	const didUpdateViewFromUrl = useRef( false );
+	useEffect( () => {
+		if ( ! fieldValue ) {
+			return;
+		}
+		if ( didUpdateViewFromUrl.current ) {
+			return;
+		}
+		didUpdateViewFromUrl.current = true;
+		setView( ( view ) => updateViewFromField( view, fieldName, fieldValue ) );
+	}, [ fieldName, fieldValue, setView ] );
+}


### PR DESCRIPTION
Fixes DOTDASH-637

## Proposed Changes

- Adds the ability to filter emails by domain.
- Moves to a shared util the existing logic in Billing > Upgrades that persists the filtered view to the URL, so we can use it as well on Emails

<img width="1259" height="475" alt="Screenshot 2025-10-13 at 13 42 32" src="https://github.com/user-attachments/assets/b0b74549-940f-474c-b174-7043ae0897b1" />



## Why are these changes being made?

Because WP.com sites currently has a Upgrades/Hosting > Emails menu that only shows the existing emails for a given site, so we need a replacement for that when.

## Testing Instructions

- Use the Calypso live link below
- If you don't have any email on your WP.com sites, go first to `/email`, select a site, and follow the instructions to get an email
- Go to `/v2/emails`
- Make sure by default emails from all sites are listed
- Make sure there is a new "Domain" filter
- Use it to select a domain name
- Make sure only emails from the select domain are displayed
- Make sure the URL changes after filtering by a domain
- Reload the URL with the filter param
- Make sure the filter is initialized correctly
- Remove the filter using the UI
- Make sure all emails are displayed now
- Go to `/v2/me/billing/purchases`
- Make sure there are no regressions when filtering by site


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
