### PR TITLE
Update mobile response view locator

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -51,7 +51,10 @@ export class FeedbackInboxPage {
 					.waitFor();
 			} else {
 				await newResponseRowLocator.getByRole( 'button', { name: 'View response' } ).click();
-				await this.page.getByRole( 'dialog', { name: 'Response' } ).waitFor();
+				await this.page
+					.getByRole( 'dialog' )
+					.filter( { has: this.page.getByRole( 'heading', { name: 'Response' } ) } )
+					.waitFor();
 			}
 		} else {
 			await oldResponseRowLocator.click();


### PR DESCRIPTION
This PR changes locator for mobile response dialog to match latest changes on JP Forms


## Proposed Changes

Change the locator since mobile dashboard is using a header-less modal now and that can't be found using the previous locator

## Why are these changes being made?
Because now the modal `dialog` doesn't hold a `{ name: 'Response' }`. While the structure is the same (`<modal><h1>response</h1></modal>`) the locator was only finding the right dialog based on the `aria-labeledby="[ID]"`, where `ID` is the `h1` element's id attribute, because the Modal component creates such element with a runtime assigned ID string. As we now use the header-less modal we're creating the `h1` element on our own and we can't go assigning the ID (Modal component will assign IDs through iteration suffixing with `*-[NUM]` depending on the NUM of modals opened.

## Testing Instructions
Run the test, the change is already in production and muted until we change this test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
