### PR TITLE
Hosting Dashboard: Create and link to "Add payment method" page

### DIFF
--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -50,18 +50,20 @@ function ChangePaymentMethod() {
 	if ( isNaN( numericId ) ) {
 		throw new Error( 'Invalid purchase ID' );
 	}
-	const { data: purchase } = useSuspenseQuery( purchaseQuery( numericId ) );
+	const { data: purchase, isLoading: isLoadingPurchase } = useSuspenseQuery(
+		purchaseQuery( numericId )
+	);
 	const { isLoading: isLoadingStoredCards } = useQuery(
 		userPaymentMethodsQuery( { type: 'card' } )
 	);
 	const { isStripeLoading } = useStripe();
 
 	const paymentMethods = useCreateAssignablePaymentMethods( purchase );
-	const isDataLoading = isLoadingStoredCards || isStripeLoading;
+	const isDataLoading = isLoadingStoredCards || isStripeLoading || isLoadingPurchase;
 
 	useEffect( () => {
 		if ( ! isDataLoading && ! purchase ) {
-			// Redirect if invalid data
+			// Redirect if the purchase does not exist
 			navigate( { to: '/me/billing/purchases' } );
 		}
 	}, [ isDataLoading, purchase, navigate ] );
@@ -80,7 +82,11 @@ function ChangePaymentMethod() {
 			header={
 				<PageHeader
 					prefix={ <BackButton purchase={ purchase } /> }
-					title={ __( 'Update payment method' ) }
+					title={
+						! purchase.payment_type || purchase.payment_type === 'credits'
+							? __( 'Add payment method' )
+							: __( 'Update payment method' )
+					}
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, Link } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isExpired, isRenewing, isAkismetFreeProduct } from '../../utils/purchase';
@@ -40,7 +40,7 @@ export function PurchasePaymentMethod( {
 	) {
 		return (
 			<div>
-				<a href={ getAddPaymentMethodUrlFor( purchase ) }>{ __( 'Add payment method' ) }</a>
+				<Link to={ getAddPaymentMethodUrlFor( purchase ) }>{ __( 'Add payment method' ) }</Link>
 			</div>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -354,7 +354,7 @@ function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 					}
 				),
 				{
-					link: <a href={ changePaymentMethodPath } />,
+					link: <Link to={ changePaymentMethodPath } />,
 				}
 			) }
 		</Notice>

--- a/client/dashboard/me/billing-purchases/urls.ts
+++ b/client/dashboard/me/billing-purchases/urls.ts
@@ -14,7 +14,7 @@ export function getPurchaseUrlForId( id: number | string ) {
 }
 
 export function getAddPaymentMethodUrlFor( purchase: Purchase ): string {
-	return `/me/purchases/${ purchase.site_slug ?? 'unknown' }/${ purchase.ID }/payment-method/add`;
+	return `/me/billing/purchases/${ purchase.ID }/payment-method/change`;
 }
 
 export function getChangePaymentMethodUrlFor( purchase: Purchase ): string {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-236/hosting-dashboard-migrate-existing-addchange-payment-screens-to

## Proposed Changes

This PR re-uses the "Update payment method" page added in https://github.com/Automattic/wp-calypso/pull/106190 to serve as the "Add payment method" page for upgrades with no payment method attached.

## Testing Instructions

1. First: add a subscription without a payment method to a site. You can do this either by using the backend admin tools or by purchasing a subscription using WPCOM credits.
2. Now visit http://calypso.localhost:3000/v2/me/billing/purchases/ and select your upgrade (or click "Add payment method" right in the list).
3. If you clicked through to the purchase settings page, click "Add payment method" in the central card.
4. Select or create a payment method for the upgrade and save it.
5. Verify that the payment method has been set. You should see it on the purchase settings page.
