### PR TITLE
Hosting Dashboard: /plugins minor fixes

### DIFF
--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -32,7 +32,7 @@ export const pluginsIndexRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Sites' ),
+				title: __( 'Plugins' ),
 			},
 		],
 	} ),

--- a/client/dashboard/plugins/manage/fields/update-available.ts
+++ b/client/dashboard/plugins/manage/fields/update-available.ts
@@ -4,7 +4,7 @@ import type { Field } from '@wordpress/dataviews';
 
 export const updateAvailableField: Field< PluginListRow > = {
 	id: 'updateAvailable',
-	label: __( 'Update Available' ),
+	label: __( 'Update available' ),
 	getValue: ( { item } ) => {
 		if ( item.areAutoUpdatesAllowed === 'none' ) {
 			return 0;

--- a/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
@@ -39,6 +39,7 @@ export default function FieldActionToggle( {
 
 	return (
 		<ToggleControl
+			__nextHasNoMarginBottom
 			label={ label }
 			checked={ checked }
 			onClick={ ( e ) => {

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { pluginRoute } from '../../app/router/plugins';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
@@ -17,9 +18,12 @@ export default function Plugin() {
 
 	if ( ! isLoading && ! plugin ) {
 		return (
-			<PageLayout size="large" header={ <PageHeader title={ __( 'Plugin Not Found' ) } /> }>
-				<div>{ __( 'Plugin not found' ) }</div>
-			</PageLayout>
+			<PageLayout
+				size="large"
+				header={
+					<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Plugin not found' ) } />
+				}
+			/>
 		);
 	}
 
@@ -28,11 +32,8 @@ export default function Plugin() {
 			size="large"
 			header={
 				<VStack spacing={ 2 }>
-					<Text as="p" variant="muted">
-						{ __( 'Manage plugins' ) }
-					</Text>
-
 					<PageHeader
+						prefix={ <Breadcrumbs length={ 2 } /> }
 						decoration={ icon && <img src={ icon } alt={ plugin?.name } /> }
 						title={
 							plugin ? (

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -88,7 +88,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							} }
 							successOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( '%s has been successfully activated.' ),
+								__( '%s has been activated.' ),
 								plugin?.name ?? ''
 							) }
 							errorOn={ sprintf(
@@ -98,7 +98,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							) }
 							successOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( '%s has been successfully deactivated.' ),
+								__( '%s has been deactivated.' ),
 								plugin?.name ?? ''
 							) }
 							errorOff={ sprintf(
@@ -141,7 +141,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							} }
 							successOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Auto‑updates for %s have been successfully enabled.' ),
+								__( 'Auto‑updates for %s have been enabled.' ),
 								plugin?.name ?? ''
 							) }
 							errorOn={ sprintf(
@@ -151,7 +151,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							) }
 							successOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Auto‑updates for %s have been successfully disabled.' ),
+								__( 'Auto‑updates for %s have been disabled.' ),
 								plugin?.name ?? ''
 							) }
 							errorOff={ sprintf(

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -88,22 +88,22 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							} }
 							successOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Activated %s' ),
+								__( '%s has been successfully activated.' ),
 								plugin?.name ?? ''
 							) }
 							errorOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Failed to activate %s' ),
+								__( 'Failed to activate %s.' ),
 								plugin?.name ?? ''
 							) }
 							successOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Deactivated %s' ),
+								__( '%s has been successfully deactivated.' ),
 								plugin?.name ?? ''
 							) }
 							errorOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Failed to deactivate %s' ),
+								__( 'Failed to deactivate %s.' ),
 								plugin?.name ?? ''
 							) }
 							actionId="activate"
@@ -141,22 +141,22 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							} }
 							successOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Enabled auto‑updates for %s' ),
+								__( 'Auto‑updates for %s have been successfully enabled.' ),
 								plugin?.name ?? ''
 							) }
 							errorOn={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Failed to enable auto‑updates for %s' ),
+								__( 'Failed to enable auto‑updates for %s.' ),
 								plugin?.name ?? ''
 							) }
 							successOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Disabled auto‑updates for %s' ),
+								__( 'Auto‑updates for %s have been successfully disabled.' ),
 								plugin?.name ?? ''
 							) }
 							errorOff={ sprintf(
 								// translators: %s is the name of the plugin.
-								__( 'Failed to disable auto‑updates for %s' ),
+								__( 'Failed to disable auto‑updates for %s.' ),
 								plugin?.name ?? ''
 							) }
 							actionId="autoupdate"

--- a/client/dashboard/plugins/scheduled-updates/components/frequency-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/frequency-selection.tsx
@@ -41,6 +41,8 @@ function ScheduledUpdatesFrequencySelection( { frequency, weekday, time, onChang
 						<HStack spacing={ 6 } justify="space-between" alignment="start">
 							<VStack spacing={ 2 } style={ { flex: 1 } }>
 								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
 									label={ __( 'Select day' ) }
 									value={ weekday }
 									onChange={ ( val: string ) =>
@@ -59,6 +61,8 @@ function ScheduledUpdatesFrequencySelection( { frequency, weekday, time, onChang
 							</VStack>
 							<VStack spacing={ 2 } style={ { flex: 1 } }>
 								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
 									label={ __( 'Select time' ) }
 									value={ time }
 									onChange={ ( val: string ) => onChange( { frequency, weekday, time: val } ) }
@@ -68,6 +72,8 @@ function ScheduledUpdatesFrequencySelection( { frequency, weekday, time, onChang
 						</HStack>
 					) : (
 						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Select time' ) }
 							value={ time }
 							onChange={ ( val: string ) => onChange( { frequency, weekday, time: val } ) }

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -50,7 +50,7 @@ const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
 		{
 			id: 'lastUpdate',
 			type: 'integer',
-			label: __( 'Last Update' ),
+			label: __( 'Last update' ),
 			render: ( { item } ) =>
 				item.lastUpdate
 					? formatDate( new Date( item.lastUpdate * 1000 ), locale, {
@@ -62,7 +62,7 @@ const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
 		{
 			id: 'nextUpdate',
 			type: 'integer',
-			label: __( 'Next Update' ),
+			label: __( 'Next update' ),
 			render: ( { item } ) =>
 				formatDate( new Date( item.nextUpdate * 1000 ), locale, {
 					dateStyle: 'medium',


### PR DESCRIPTION
## Proposed Changes

Mostly copy consistency changes and warning supressions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
