### PR TITLE
Hosting Dashboard: Add a notice when no pages are found.

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -25,6 +25,7 @@ import Report from './report';
 import ReportErrorNotice from './report-error-notice';
 import ReportExpiredNotice from './report-expired-notice';
 import ReportLoading from './report-loading';
+import ReportNoPagesNotice from './report-no-pages-notice';
 import Subtitle from './subtitle';
 import { useSitePerformanceData } from './use-site-performance-data';
 import type { DeviceToggleType } from './types';
@@ -87,14 +88,14 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		}
 	}, [ hasCompleted ] );
 
-	if ( ! pagesData || ! currentPage ) {
-		return null;
-	}
-
 	const currentReport = getReport( deviceToggle );
 	const { gmtOffset, timezoneString } = siteSettings;
 
 	const renderContent = () => {
+		if ( ! pagesData || ! currentPage ) {
+			return <ReportNoPagesNotice />;
+		}
+
 		if ( hasError( deviceToggle ) ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
@@ -135,30 +136,33 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 						/>
 					}
 					actions={
-						<HStack>
-							<PageSelector
-								siteUrl={ site.URL }
-								currentPage={ currentPage }
-								pages={ pagesData }
-								onChange={ ( pageId ) => {
-									setRunNewReport( false );
-									recordTracksEvent(
-										'calypso_dashboard_performance_profiler_page_selector_change',
-										{
-											is_home: pageId === '0',
-										}
-									);
+						pagesData &&
+						pagesData.length && (
+							<HStack>
+								<PageSelector
+									siteUrl={ site.URL }
+									currentPage={ currentPage }
+									pages={ pagesData }
+									onChange={ ( pageId ) => {
+										setRunNewReport( false );
+										recordTracksEvent(
+											'calypso_dashboard_performance_profiler_page_selector_change',
+											{
+												is_home: pageId === '0',
+											}
+										);
 
-									navigate( {
-										search: ( prev: Record< string, string > ) => ( {
-											...prev,
-											page_id: Number( pageId ),
-										} ),
-									} );
-								} }
-							/>
-							<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
-						</HStack>
+										navigate( {
+											search: ( prev: Record< string, string > ) => ( {
+												...prev,
+												page_id: Number( pageId ),
+											} ),
+										} );
+									} }
+								/>
+								<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
+							</HStack>
+						)
 					}
 				/>
 			}

--- a/client/dashboard/sites/performance/report-no-pages-notice.tsx
+++ b/client/dashboard/sites/performance/report-no-pages-notice.tsx
@@ -7,9 +7,11 @@ export default function ReportNoPagesNotice() {
 		<Notice variant="error" title={ __( 'No pages found' ) }>
 			<Text as="p">
 				{ __(
-					'We couldn’t find any pages to test yet. If you just activated hosting features, they should appear soon.'
+					'We couldn’t find any pages to test yet. If you just activated hosting features, they should appear soon. If the issue persists, please contact support.'
 				) }
 			</Text>
+
+			<Text as="p">{ __( 'If the issue persists, please contact support.' ) }</Text>
 		</Notice>
 	);
 }

--- a/client/dashboard/sites/performance/report-no-pages-notice.tsx
+++ b/client/dashboard/sites/performance/report-no-pages-notice.tsx
@@ -7,7 +7,7 @@ export default function ReportNoPagesNotice() {
 		<Notice variant="error" title={ __( 'No pages found' ) }>
 			<Text as="p">
 				{ __(
-					'We couldn’t find any pages yet. If you just activated hosting features, they should appear soon.'
+					'We couldn’t find any pages to test yet. If you just activated hosting features, they should appear soon.'
 				) }
 			</Text>
 		</Notice>

--- a/client/dashboard/sites/performance/report-no-pages-notice.tsx
+++ b/client/dashboard/sites/performance/report-no-pages-notice.tsx
@@ -1,0 +1,15 @@
+import { __experimentalText as Text } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+
+export default function ReportNoPagesNotice() {
+	return (
+		<Notice variant="error" title={ __( 'No pages found' ) }>
+			<Text as="p">
+				{ __(
+					'We couldn’t find any pages yet. If you just activated hosting features, they should appear soon.'
+				) }
+			</Text>
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/performance/report-no-pages-notice.tsx
+++ b/client/dashboard/sites/performance/report-no-pages-notice.tsx
@@ -1,17 +1,19 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
 
 export default function ReportNoPagesNotice() {
 	return (
 		<Notice variant="error" title={ __( 'No pages found' ) }>
-			<Text as="p">
-				{ __(
-					'We couldn’t find any pages to test yet. If you just activated hosting features, they should appear soon. If the issue persists, please contact support.'
-				) }
-			</Text>
+			<VStack>
+				<Text as="p">
+					{ __(
+						'We couldn’t find any pages to test yet. If you just activated hosting features, they should appear soon.'
+					) }
+				</Text>
 
-			<Text as="p">{ __( 'If the issue persists, please contact support.' ) }</Text>
+				<Text as="p">{ __( 'If the issue persists, please contact support.' ) }</Text>
+			</VStack>
 		</Notice>
 	);
 }


### PR DESCRIPTION
Part of DOTCOM-14933

## Proposed Changes

Add an error notice if we don't have pages. Handles broken API issues as well.

We've made some changes to the API to make sure they return, but this adds an extra layer of safety.

The error notice is tailored to the use case identified in DOTCOM-14933, which seems okay to me.

**Screenshot**

<img width="1094" height="694" alt="Screenshot 2025-10-14 at 3 50 10 PM" src="https://github.com/user-attachments/assets/ee2e9cfd-78dc-402d-8153-906d7c3e7ce0" />


## Testing Instructions

**Test no pages returned **
Apply patch:
```diff
diff --git a/packages/api-core/src/site-performance-pages/fetchers.ts b/packages/api-core/src/site-performance-pages/fetchers.ts
index 75de78defd3..68a683268b0 100644
--- a/packages/api-core/src/site-performance-pages/fetchers.ts
+++ b/packages/api-core/src/site-performance-pages/fetchers.ts
@@ -4,8 +4,5 @@ import { SitePerformancePage } from './types';
 export const fetchSitePerformancePages = async (
        siteId: number
 ): Promise< SitePerformancePage[] > => {
-       return wpcom.req.get( {
-               path: `/sites/${ siteId }/site-profiler/pages`,
-               apiNamespace: 'wpcom/v2',
-       } );
+       return Promise.resolve( [] );
 };
```

- Visit `/v2/{site}/performance`
- Expect to see the error.

<hr>

**Test Missing Endpoint**
Apply patch:

```diff
diff --git a/packages/api-core/src/site-performance-pages/fetchers.ts b/packages/api-core/src/site-performance-pages/fetchers.ts
index 75de78defd3..a1b1449b039 100644
--- a/packages/api-core/src/site-performance-pages/fetchers.ts
+++ b/packages/api-core/src/site-performance-pages/fetchers.ts
@@ -5,7 +5,7 @@ export const fetchSitePerformancePages = async (
        siteId: number
 ): Promise< SitePerformancePage[] > => {
        return wpcom.req.get( {
-               path: `/sites/${ siteId }/site-profiler/pages`,
+               path: `/sites/${ siteId }/site-profilser/pages`,
                apiNamespace: 'wpcom/v2',
        } );
 };
```

- Visit `/v2/{site}/performance`
- Expect to see the error.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
