### PR TITLE
A4A: Update commission % on Hosting > Enterprise

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
@@ -59,7 +59,7 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 						<div>
 							{ isReferMode && isVipPartnerOpportunityReferralsEnabled
 								? translate(
-										"Successfully refer your client to WordPress VIP and you'll earn a one-time 5% commission"
+										"Successfully refer your client to WordPress VIP and you'll earn up to a one-time 20% commission"
 								  )
 								: translate(
 										'Combine the ease of WordPress with enterprise-grade security and scalability.'
@@ -132,7 +132,7 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 					{ isVipPartnerOpportunityReferralsEnabled && (
 						<div className="enterprise-agency-hosting__top-details-subheading">
 							{ translate(
-								'Earn a one-time 5% commission on client referrals to WordPress VIP. {{a}}Full Terms{{/a}} ↗',
+								'Earn up to a 20% one-time commission on client referrals to WordPress VIP. {{a}}Full Terms{{/a}} ↗',
 								{
 									components: {
 										a: (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
@@ -59,7 +59,7 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 						<div>
 							{ isReferMode && isVipPartnerOpportunityReferralsEnabled
 								? translate(
-										"Successfully refer your client to WordPress VIP and you'll earn up to a one-time 20% commission"
+										"Successfully refer your client to WordPress VIP and you'll earn up to a 20% one-time commission"
 								  )
 								: translate(
 										'Combine the ease of WordPress with enterprise-grade security and scalability.'

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/enterprise-agency-hosting/index.tsx
@@ -15,6 +15,7 @@ import NewsCorpLogo from 'calypso/assets/images/logos/news-corp.svg';
 import SalesforceLogo from 'calypso/assets/images/logos/salesforce.svg';
 import SlackLogo from 'calypso/assets/images/logos/slack.svg';
 import SpotifyLogo from 'calypso/assets/images/logos/spotify.svg';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
@@ -22,6 +23,8 @@ import HostingTestimonialsSection from '../../../common/hosting-testimonials-sec
 import HostingPlanSection from '../common/hosting-plan-section';
 
 import './style.scss';
+
+const VIP_PARTNER_OPPORTUNITY_COMMISSION_PERCENTAGE = 20;
 
 export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode: boolean } ) {
 	const translate = useTranslate();
@@ -58,8 +61,15 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 
 						<div>
 							{ isReferMode && isVipPartnerOpportunityReferralsEnabled
-								? translate(
-										"Successfully refer your client to WordPress VIP and you'll earn up to a 20% one-time commission"
+								? preventWidows(
+										translate(
+											"Successfully refer your client to WordPress VIP and you'll earn up to a %(commission)s%% one-time commission",
+											{
+												args: {
+													commission: VIP_PARTNER_OPPORTUNITY_COMMISSION_PERCENTAGE,
+												},
+											}
+										)
 								  )
 								: translate(
 										'Combine the ease of WordPress with enterprise-grade security and scalability.'
@@ -132,7 +142,7 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 					{ isVipPartnerOpportunityReferralsEnabled && (
 						<div className="enterprise-agency-hosting__top-details-subheading">
 							{ translate(
-								'Earn up to a 20% one-time commission on client referrals to WordPress VIP. {{a}}Full Terms{{/a}} ↗',
+								'Earn up to a %(commission)s%% one-time commission on client referrals to WordPress VIP. {{a}}Full Terms{{/a}} ↗',
 								{
 									components: {
 										a: (
@@ -142,6 +152,9 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 												rel="noopener noreferrer"
 											/>
 										),
+									},
+									args: {
+										commission: VIP_PARTNER_OPPORTUNITY_COMMISSION_PERCENTAGE,
 									},
 								}
 							) }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1583/update-commission-percent-on-hosting-enterprise

## Proposed Changes

This PR updates the commission displayed on the Enterprise tab in the Hosting page.

## Why are these changes being made?

* To display the accurate commission percentage

## Testing Instructions

* Open the live link
* Go to Marketplace: Enterprise > Verify the below changes are done

| Before | After |
|--------|--------|
| <img width="1462" height="326" alt="Screenshot 2025-10-14 at 12 24 58 PM" src="https://github.com/user-attachments/assets/7f1b3d30-b5c7-44c5-a599-360862e5445f" /> | <img width="1462" height="356" alt="Screenshot 2025-10-14 at 12 39 51 PM" src="https://github.com/user-attachments/assets/d211811f-3d88-40e7-87a0-f80ca0311132" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
