### PR TITLE
Hosting Dashboard: Update /plugins routes

### DIFF
--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -43,28 +43,6 @@ export const pluginsIndexRoute = createRoute( {
 	},
 } );
 
-export const pluginRoute = createRoute( {
-	head: ( { params } ) => ( {
-		meta: [
-			{
-				title: params.pluginId,
-			},
-		],
-	} ),
-	getParentRoute: () => pluginsRoute,
-	path: '$pluginId',
-	loader: async () => {
-		queryClient.ensureQueryData( marketplacePluginsQuery() );
-		await queryClient.ensureQueryData( pluginsQuery() );
-	},
-} ).lazy( () =>
-	import( '../../plugins/plugin' ).then( ( d ) =>
-		createLazyRoute( 'plugin' )( {
-			component: d.default,
-		} )
-	)
-);
-
 export const pluginsManageRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -80,9 +58,36 @@ export const pluginsManageRoute = createRoute( {
 		queryClient.ensureQueryData( pluginsQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
+} );
+
+export const pluginsManageIndexRoute = createRoute( {
+	getParentRoute: () => pluginsManageRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../plugins/manage' ).then( ( d ) =>
 		createLazyRoute( 'plugins-manage' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const pluginRoute = createRoute( {
+	head: ( { params } ) => ( {
+		meta: [
+			{
+				title: params.pluginId,
+			},
+		],
+	} ),
+	getParentRoute: () => pluginsManageRoute,
+	path: '$pluginId',
+	loader: async () => {
+		queryClient.ensureQueryData( marketplacePluginsQuery() );
+		await queryClient.ensureQueryData( pluginsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../plugins/plugin' ).then( ( d ) =>
+		createLazyRoute( 'plugin' )( {
 			component: d.default,
 		} )
 	)
@@ -98,6 +103,11 @@ export const pluginsScheduledUpdatesRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsRoute,
 	path: 'scheduled-updates',
+} );
+
+export const pluginsScheduledUpdatesIndexRoute = createRoute( {
+	getParentRoute: () => pluginsScheduledUpdatesRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates' ).then( ( d ) =>
 		createLazyRoute( 'plugins-scheduled-updates' )( {
@@ -114,8 +124,8 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => pluginsRoute,
-	path: 'scheduled-updates/new',
+	getParentRoute: () => pluginsScheduledUpdatesRoute,
+	path: '/new',
 	loader: () => {
 		queryClient.ensureQueryData( sitesQuery() );
 	},
@@ -135,8 +145,8 @@ export const pluginsScheduledUpdatesEditRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => pluginsRoute,
-	path: 'scheduled-updates/edit/$scheduleId',
+	getParentRoute: () => pluginsScheduledUpdatesRoute,
+	path: '/edit/$scheduleId',
 	loader: () => {
 		queryClient.ensureQueryData( sitesQuery() );
 	},
@@ -151,11 +161,13 @@ export const pluginsScheduledUpdatesEditRoute = createRoute( {
 export const createPluginsRoutes = () => {
 	const childRoutes: AnyRoute[] = [
 		pluginsIndexRoute,
-		pluginRoute,
-		pluginsManageRoute,
-		pluginsScheduledUpdatesRoute,
-		pluginsScheduledUpdatesNewRoute,
-		pluginsScheduledUpdatesEditRoute,
+		pluginsManageRoute.addChildren( [ pluginsManageIndexRoute, pluginRoute ] ),
+		pluginsScheduledUpdatesRoute.addChildren( [
+			pluginsScheduledUpdatesIndexRoute,
+			pluginsScheduledUpdatesNewRoute,
+			pluginsScheduledUpdatesEditRoute,
+		] ),
 	];
+
 	return [ pluginsRoute.addChildren( childRoutes ) ];
 };

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -4,9 +4,7 @@ import ResponsiveMenu from '../../components/responsive-menu';
 const PluginsMenu = () => {
 	return (
 		<ResponsiveMenu>
-			<ResponsiveMenu.Item to="/plugins/manage" activeOptions={ { exact: true } }>
-				{ __( 'Manage plugins' ) }
-			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
 				{ __( 'Scheduled updates' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../../app/breadcrumbs';
 import {
 	pluginsScheduledUpdatesEditRoute,
 	pluginsScheduledUpdatesRoute,
@@ -27,7 +28,7 @@ export default function PluginsScheduledUpdatesEdit() {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader /> }
+			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }
 			notices={
 				error && (
 					<Notice status="error" isDismissible={ false }>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from 'react';
+import Breadcrumbs from '../../../app/breadcrumbs';
 import {
 	pluginsScheduledUpdatesNewRoute,
 	pluginsScheduledUpdatesRoute,
@@ -35,6 +36,7 @@ function ScheduledUpdatesNew() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'New schedule' ) }
 					description={ __(
 						'First, choose the sites you want. Next, select the plugins to update. Finally, set how often the updates should run.'


### PR DESCRIPTION
## Proposed Changes

This PR updates the /plugins route structure, mainly moving /plugins/$pluginId to /plugins/manage/$pluginId

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
