### PR TITLE
A4A > WooPayments: Add "See full terms" links to the overview cards

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
@@ -234,17 +234,22 @@ const WooPaymentsOverview = () => {
 		);
 	}, [ dispatch ] );
 
-	const onSeeFullTermsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_woopayments_overview_see_full_terms_click' ) );
-	}, [ dispatch ] );
+	const addWooPaymentsToSite = (
+		<Button __next40pxDefaultSize variant="primary" onClick={ handleAddWooPaymentsToSite }>
+			{ translate( 'Add WooPayments to site' ) }
+		</Button>
+	);
 
-	const addWooPaymentsToSite = useMemo( () => {
-		return (
-			<Button __next40pxDefaultSize variant="primary" onClick={ handleAddWooPaymentsToSite }>
-				{ translate( 'Add WooPayments to site' ) }
-			</Button>
-		);
-	}, [ translate, handleAddWooPaymentsToSite ] );
+	const seeFullTermsLink = (
+		<ExternalLink
+			onClick={ () => {
+				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_see_full_terms_click' ) );
+			} }
+			href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
+		>
+			{ translate( 'See full terms' ) }
+		</ExternalLink>
+	);
 
 	return (
 		<Layout className="woopayments-overview" title={ title } wide>
@@ -339,16 +344,7 @@ const WooPaymentsOverview = () => {
 									)
 								) }
 							</div>
-							<div>
-								<a
-									href="https://automattic.com/for-agencies/program-incentives/"
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ onSeeFullTermsClick }
-								>
-									{ translate( 'See full terms' ) }
-								</a>
-							</div>
+							<div>{ seeFullTermsLink }</div>
 						</div>
 					</PageSectionColumns.Column>
 					<PageSectionColumns.Column>
@@ -385,16 +381,7 @@ const WooPaymentsOverview = () => {
 									] }
 								/>
 							</div>
-							<div>
-								<a
-									href="https://automattic.com/for-agencies/program-incentives/"
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ onSeeFullTermsClick }
-								>
-									{ translate( 'See full terms' ) }
-								</a>
-							</div>
+							<div>{ seeFullTermsLink }</div>
 						</div>
 					</PageSectionColumns.Column>
 					<PageSectionColumns.Column heading={ translate( 'Commissions at a glance' ) } fullWidth>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -234,6 +234,10 @@ const WooPaymentsOverview = () => {
 		);
 	}, [ dispatch ] );
 
+	const onSeeFullTermsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_woopayments_overview_see_full_terms_click' ) );
+	}, [ dispatch ] );
+
 	const addWooPaymentsToSite = useMemo( () => {
 		return (
 			<Button __next40pxDefaultSize variant="primary" onClick={ handleAddWooPaymentsToSite }>
@@ -335,6 +339,16 @@ const WooPaymentsOverview = () => {
 									)
 								) }
 							</div>
+							<div>
+								<a
+									href="https://automattic.com/for-agencies/program-incentives/"
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ onSeeFullTermsClick }
+								>
+									{ translate( 'See full terms' ) }
+								</a>
+							</div>
 						</div>
 					</PageSectionColumns.Column>
 					<PageSectionColumns.Column>
@@ -370,6 +384,16 @@ const WooPaymentsOverview = () => {
 										),
 									] }
 								/>
+							</div>
+							<div>
+								<a
+									href="https://automattic.com/for-agencies/program-incentives/"
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ onSeeFullTermsClick }
+								>
+									{ translate( 'See full terms' ) }
+								</a>
 							</div>
 						</div>
 					</PageSectionColumns.Column>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
@@ -41,7 +41,7 @@ $alt-color: #FAF7F3;
 		margin-block-end: 16px;
 	}
 
-	a {
+	a:not(.components-external-link) {
 		text-decoration: underline;
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1568/add-link-to-terms-under-how-revenue-share-works-cards-on-woopayments

## Proposed Changes

This PR adds "See full terms" links to the overview cards on the WooPayments page.

## Why are these changes being made?

* To avoid confusion of our terms and conditions.

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Overview > Verify you see "See full terms" external links on the screen as displayed below

<img width="1554" height="442" alt="Screenshot 2025-10-14 at 1 21 06 PM" src="https://github.com/user-attachments/assets/2e3e831b-f653-4ef8-aca6-5b69514cfc8c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
