### PR TITLE
Add `domainName` query param to the Emails links in the Domain overview screen

### DIFF
--- a/client/dashboard/domains/domain-menu/index.tsx
+++ b/client/dashboard/domains/domain-menu/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
@@ -5,6 +6,7 @@ import ResponsiveMenu from '../../components/responsive-menu';
 
 const DomainMenu = ( { domainName }: { domainName: string } ) => {
 	const { supports } = useAppContext();
+	const router = useRouter();
 
 	return (
 		<ResponsiveMenu label={ __( 'Domain Menu' ) }>
@@ -12,7 +14,11 @@ const DomainMenu = ( { domainName }: { domainName: string } ) => {
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>
 			{ supports.emails && (
-				<ResponsiveMenu.Item to={ emailsRoute.fullPath }>{ __( 'Emails' ) }</ResponsiveMenu.Item>
+				<ResponsiveMenu.Item
+					to={ router.buildLocation( { to: emailsRoute.fullPath, search: { domainName } } ).href }
+				>
+					{ __( 'Emails' ) }
+				</ResponsiveMenu.Item>
 			) }
 		</ResponsiveMenu>
 	);

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,6 +1,7 @@
 import { Domain } from '@automattic/api-core';
 import { mailboxesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
@@ -54,11 +55,18 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 		: // translators: %s is the mailbox name: youremail@example.com
 		  sprintf( __( 'youremail@%s' ), domain.domain );
 
+	const router = useRouter();
+
 	return (
 		<OverviewCard
 			title={ __( 'Emails' ) }
 			heading={ <span style={ { wordBreak: 'break-all' } }>{ email }</span> }
-			link={ emailsRoute.fullPath }
+			link={
+				router.buildLocation( {
+					to: emailsRoute.fullPath,
+					search: { domainName: domain.domain },
+				} ).href
+			}
 			icon={ <Icon icon={ envelope } /> }
 			description={ getDescription( mailboxes ) }
 		/>


### PR DESCRIPTION
The /v2/emails route can filter the emails by domain using `domainName` query param (see #106413) so here's a fix to all the domain in all links from the Domains overview screen

Part of [DOMAINS-1710: Change the links to /v2/emails to include a `domain` query param](https://linear.app/a8c/issue/DOMAINS-1710/change-the-links-to-v2emails-to-include-a-domain-query-param)

## Proposed Changes

* Add `domainName` as query param to the emails route so you can see the emails filtered by domain name

## Why are these changes being made?

* Well otherwise you'll see all emails that the customer has access to

## Testing Instructions

* Go to a domain overview page and verify that the links from the Emails overview card and the Emails subnavigation menu have a `domainName=example.com` query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
