### PR TITLE
Clear v2 dashboard cache when logging out of v1

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -1,4 +1,8 @@
 import accessibleFocus from '@automattic/accessible-focus';
+import {
+	clearQueryClient as clearHostingDashboardQueryClient,
+	disablePersistQueryClient as disablePersistHostingDashboardQueryClient,
+} from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
@@ -323,6 +327,10 @@ const boot = async ( currentUser, registerRoutes ) => {
 	setStore( reduxStore, getStateFromCache( currentUser?.ID ) );
 	onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
 	onDisablePersistence( unsubscribePersister );
+	onDisablePersistence( () => {
+		disablePersistHostingDashboardQueryClient();
+		clearHostingDashboardQueryClient();
+	} );
 	setupLocale( currentUser, reduxStore );
 	setupCountryCode();
 	configureReduxStore( currentUser, reduxStore );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-636

## Proposed Changes

* When logging out from the v1 interface, Calypso needs to clear the v2 query client.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Security/privacy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in
* Go to `calypso.localhost:3000/v2` to populate the local storage
* Check the `REACT_QUERY_OFFLINE_CACHE` data is indeed in local storage
* Go to `calypso.localhost:3000/sites`
* Log out via the masterbar menu
* After log out go to `calypso.localhost:3000` and check local storage
* `REACT_QUERY_OFFLINE_CACHE` should be empty
* Test again but this time log out from the button on `/me`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
