### PR TITLE
e2e tests: run migrated tests on push to trunk

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -994,26 +994,28 @@ object PlaywrightTestPreReleaseMatrix : BuildType({
 	name = "Pre-Release E2E Tests (Playwright Test)"
 	description = "Runs Calypso pre-release e2e tests using Playwright Test runner with build matrix"
 
-	features {
-		matrix {
-			param("PROJECT", listOf(
-				value("desktop", label = "Desktop"),
-				value("mobile", label = "Mobile")
-			))
-		}
-	}
-
 	params {
 		text("TEST_GROUP", "@calypso-release")
 		param("CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
 	}
 
-	steps {
-		bashNodeScript {
-			name = "Test step"
-			scriptContent = """
-				echo "Running pre-release Playwright tests for project %PROJECT%"
-			"""
+	features {
+		matrix {
+			param("PROJECT", listOf(
+				value("desktop", label = "Desktop"),
+				value("mobile", label = "Mobile"),
+			))
+		}
+	}
+
+	triggers {
+		vcs {
+			branchFilter = """
+				+:trunk
+			""".trimIndent()
+			triggerRules = """
+				-:**.md
+			""".trimIndent()
 		}
 	}
 })


### PR DESCRIPTION
Part of QAO-125

## Proposed Changes

This is a pre step of running the e2e tests migrated to Playwright Test runner as part of the pre-release checks.

For now, run the build configuration on push to trunk, without any link to the deploy logic. 

## Testing Instructions

- Post merge, check the `Pre-Release E2E Tests (Playwright Test) (Web app)` in TeamCity
