### PR TITLE
v2 HD - Scheduled Updates: Reuse `useDeleteSchedules` hook for deletions

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
@@ -29,7 +29,7 @@ export function useDeleteSchedules() {
 			let rollbackHosting: ( () => void ) | undefined;
 
 			// Apply optional optimistic update to hosting aggregate cache
-			if ( options?.optimisticHosting && siteIds.length && normalizedId ) {
+			if ( options?.optimisticHosting ) {
 				const hostingQuery = hostingUpdateSchedulesQuery();
 				const prevData = queryClient.getQueryData( hostingQuery.queryKey );
 				if ( prevData && typeof prevData === 'object' && 'sites' in prevData ) {

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
@@ -9,15 +9,18 @@ import { useAnalytics } from '../../../app/analytics';
 import { normalizeScheduleId } from '../helpers';
 import { useEligibleSites } from './use-eligible-sites';
 
+type UseDeleteSchedulesOptions = {
+	/**
+	 * Whether to apply optimistic updates to the hosting aggregate cache.
+	 */
+	optimistic?: boolean;
+};
+
 /**
  * Batch delete an existing schedule across multiple sites and track analytics.
  * @param {number[]} siteIds Sites to delete from
  * @param {string} scheduleId Base schedule ID to delete
  */
-type UseDeleteSchedulesOptions = {
-	optimisticHosting?: boolean;
-};
-
 export function useDeleteSchedules(
 	siteIds: number[],
 	scheduleId: string,
@@ -32,7 +35,7 @@ export function useDeleteSchedules(
 		let rollbackHosting: ( () => void ) | undefined;
 
 		// Apply optional optimistic update to hosting aggregate cache
-		if ( options?.optimisticHosting && siteIds.length && normalizedId ) {
+		if ( options?.optimistic && siteIds.length && normalizedId ) {
 			const hostingQuery = hostingUpdateSchedulesQuery();
 			const prevData = queryClient.getQueryData( hostingQuery.queryKey );
 			if ( prevData && typeof prevData === 'object' && 'sites' in prevData ) {

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
@@ -1,5 +1,9 @@
 import { deleteSiteUpdateSchedule, type Site } from '@automattic/api-core';
-import { queryClient, siteUpdateSchedulesQuery } from '@automattic/api-queries';
+import {
+	queryClient,
+	siteUpdateSchedulesQuery,
+	hostingUpdateSchedulesQuery,
+} from '@automattic/api-queries';
 import { useCallback } from '@wordpress/element';
 import { useAnalytics } from '../../../app/analytics';
 import { normalizeScheduleId } from '../helpers';
@@ -10,35 +14,71 @@ import { useEligibleSites } from './use-eligible-sites';
  * @param {number[]} siteIds Sites to delete from
  * @param {string} scheduleId Base schedule ID to delete
  */
-export function useDeleteSchedules( siteIds: number[], scheduleId: string ) {
+type UseDeleteSchedulesOptions = {
+	optimisticHosting?: boolean;
+};
+
+export function useDeleteSchedules() {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: eligibleSites = [] } = useEligibleSites();
-	const normalizedId = normalizeScheduleId( scheduleId );
-	const mutateAsync = useCallback( async () => {
-		const errors: string[] = [];
-		const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
+	const mutateAsync = useCallback(
+		async ( siteIds: number[], scheduleId: string, options?: UseDeleteSchedulesOptions ) => {
+			const normalizedId = normalizeScheduleId( scheduleId );
+			const errors: string[] = [];
+			const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
+			let rollbackHosting: ( () => void ) | undefined;
 
-		await Promise.all(
-			siteIds.map( async ( siteId ) => {
-				try {
-					await deleteSiteUpdateSchedule( siteId, normalizedId );
-					await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
-					const site = siteMap.get( siteId );
-					if ( site ) {
-						recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
-							site_slug: site.slug,
-						} );
-					}
-				} catch ( e ) {
-					errors.push( `Delete failed for site ${ siteId }` );
+			// Apply optional optimistic update to hosting aggregate cache
+			if ( options?.optimisticHosting && siteIds.length && normalizedId ) {
+				const hostingQuery = hostingUpdateSchedulesQuery();
+				const prevData = queryClient.getQueryData( hostingQuery.queryKey );
+				if ( prevData && typeof prevData === 'object' && 'sites' in prevData ) {
+					const cloned = JSON.parse( JSON.stringify( prevData ) );
+					siteIds.forEach( ( id ) => {
+						const key = String( id );
+						if ( cloned.sites?.[ key ]?.[ normalizedId ] ) {
+							delete cloned.sites[ key ][ normalizedId ];
+						}
+					} );
+					queryClient.setQueryData( hostingQuery.queryKey, cloned );
+					rollbackHosting = () => {
+						queryClient.setQueryData( hostingQuery.queryKey, prevData );
+					};
 				}
-			} )
-		);
+			}
 
-		if ( errors.length ) {
-			throw new Error( errors.join( '\n' ) );
-		}
-	}, [ siteIds, normalizedId, eligibleSites, recordTracksEvent ] );
+			await Promise.all(
+				siteIds.map( async ( siteId ) => {
+					try {
+						await deleteSiteUpdateSchedule( siteId, normalizedId );
+						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+						const site = siteMap.get( siteId );
+						if ( site ) {
+							recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+								site_slug: site.slug,
+							} );
+						}
+					} catch ( e ) {
+						errors.push( `Delete failed for site ${ siteId }` );
+					}
+				} )
+			);
+
+			if ( errors.length ) {
+				// Rollback optimistic changes on error
+				try {
+					rollbackHosting?.();
+				} catch {
+					// no-op
+				}
+				throw new Error( errors.join( '\n' ) );
+			}
+
+			// Invalidate hosting aggregate to refresh list view
+			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+		},
+		[ eligibleSites, recordTracksEvent ]
+	);
 
 	return { mutateAsync } as const;
 }

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-delete-schedules.ts
@@ -18,67 +18,68 @@ type UseDeleteSchedulesOptions = {
 	optimisticHosting?: boolean;
 };
 
-export function useDeleteSchedules() {
+export function useDeleteSchedules(
+	siteIds: number[],
+	scheduleId: string,
+	options?: UseDeleteSchedulesOptions
+) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: eligibleSites = [] } = useEligibleSites();
-	const mutateAsync = useCallback(
-		async ( siteIds: number[], scheduleId: string, options?: UseDeleteSchedulesOptions ) => {
-			const normalizedId = normalizeScheduleId( scheduleId );
-			const errors: string[] = [];
-			const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
-			let rollbackHosting: ( () => void ) | undefined;
+	const normalizedId = normalizeScheduleId( scheduleId );
+	const mutateAsync = useCallback( async () => {
+		const errors: string[] = [];
+		const siteMap = new Map( ( eligibleSites as Site[] ).map( ( s ) => [ s.ID, s ] ) );
+		let rollbackHosting: ( () => void ) | undefined;
 
-			// Apply optional optimistic update to hosting aggregate cache
-			if ( options?.optimisticHosting ) {
-				const hostingQuery = hostingUpdateSchedulesQuery();
-				const prevData = queryClient.getQueryData( hostingQuery.queryKey );
-				if ( prevData && typeof prevData === 'object' && 'sites' in prevData ) {
-					const cloned = JSON.parse( JSON.stringify( prevData ) );
-					siteIds.forEach( ( id ) => {
-						const key = String( id );
-						if ( cloned.sites?.[ key ]?.[ normalizedId ] ) {
-							delete cloned.sites[ key ][ normalizedId ];
-						}
-					} );
-					queryClient.setQueryData( hostingQuery.queryKey, cloned );
-					rollbackHosting = () => {
-						queryClient.setQueryData( hostingQuery.queryKey, prevData );
-					};
-				}
-			}
-
-			await Promise.all(
-				siteIds.map( async ( siteId ) => {
-					try {
-						await deleteSiteUpdateSchedule( siteId, normalizedId );
-						await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
-						const site = siteMap.get( siteId );
-						if ( site ) {
-							recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
-								site_slug: site.slug,
-							} );
-						}
-					} catch ( e ) {
-						errors.push( `Delete failed for site ${ siteId }` );
+		// Apply optional optimistic update to hosting aggregate cache
+		if ( options?.optimisticHosting && siteIds.length && normalizedId ) {
+			const hostingQuery = hostingUpdateSchedulesQuery();
+			const prevData = queryClient.getQueryData( hostingQuery.queryKey );
+			if ( prevData && typeof prevData === 'object' && 'sites' in prevData ) {
+				const cloned = JSON.parse( JSON.stringify( prevData ) );
+				siteIds.forEach( ( id ) => {
+					const key = String( id );
+					if ( cloned.sites?.[ key ]?.[ normalizedId ] ) {
+						delete cloned.sites[ key ][ normalizedId ];
 					}
-				} )
-			);
-
-			if ( errors.length ) {
-				// Rollback optimistic changes on error
-				try {
-					rollbackHosting?.();
-				} catch {
-					// no-op
-				}
-				throw new Error( errors.join( '\n' ) );
+				} );
+				queryClient.setQueryData( hostingQuery.queryKey, cloned );
+				rollbackHosting = () => {
+					queryClient.setQueryData( hostingQuery.queryKey, prevData );
+				};
 			}
+		}
 
-			// Invalidate hosting aggregate to refresh list view
-			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
-		},
-		[ eligibleSites, recordTracksEvent ]
-	);
+		await Promise.all(
+			siteIds.map( async ( siteId ) => {
+				try {
+					await deleteSiteUpdateSchedule( siteId, normalizedId );
+					await queryClient.invalidateQueries( siteUpdateSchedulesQuery( siteId ) );
+					const site = siteMap.get( siteId );
+					if ( site ) {
+						recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
+							site_slug: site.slug,
+						} );
+					}
+				} catch ( e ) {
+					errors.push( `Delete failed for site ${ siteId }` );
+				}
+			} )
+		);
+
+		if ( errors.length ) {
+			// Rollback optimistic changes on error
+			try {
+				rollbackHosting?.();
+			} catch {
+				// no-op
+			}
+			throw new Error( errors.join( '\n' ) );
+		}
+
+		// Invalidate hosting aggregate to refresh list view
+		await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+	}, [ eligibleSites, recordTracksEvent, siteIds, normalizedId, options ] );
 
 	return { mutateAsync } as const;
 }

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
@@ -55,7 +55,7 @@ export function useReconcileSchedules(
 
 	const { mutateAsync: runCreate } = useCreateSchedules( toCreate );
 	const { mutateAsync: runEdit } = useEditSchedules( toEdit, scheduleId );
-	const { mutateAsync: runDelete } = useDeleteSchedules( toDelete, scheduleId );
+	const { mutateAsync: runDelete } = useDeleteSchedules();
 
 	const mutateAsync = useCallback(
 		async ( { plugins, frequency, weekday, time }: Inputs ) => {
@@ -67,13 +67,13 @@ export function useReconcileSchedules(
 				tasks.push( runEdit( { plugins, frequency, weekday, time } ) );
 			}
 			if ( toDelete.length ) {
-				tasks.push( runDelete() );
+				tasks.push( runDelete( toDelete, scheduleId ) );
 			}
 
 			await Promise.all( tasks );
 			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
 		},
-		[ toCreate, toEdit, toDelete, runCreate, runEdit, runDelete ]
+		[ toCreate, toEdit, toDelete, runCreate, runEdit, runDelete, scheduleId ]
 	);
 
 	return { mutateAsync } as const;

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-reconcile-schedules.ts
@@ -55,7 +55,7 @@ export function useReconcileSchedules(
 
 	const { mutateAsync: runCreate } = useCreateSchedules( toCreate );
 	const { mutateAsync: runEdit } = useEditSchedules( toEdit, scheduleId );
-	const { mutateAsync: runDelete } = useDeleteSchedules();
+	const { mutateAsync: runDelete } = useDeleteSchedules( toDelete, scheduleId );
 
 	const mutateAsync = useCallback(
 		async ( { plugins, frequency, weekday, time }: Inputs ) => {
@@ -67,13 +67,13 @@ export function useReconcileSchedules(
 				tasks.push( runEdit( { plugins, frequency, weekday, time } ) );
 			}
 			if ( toDelete.length ) {
-				tasks.push( runDelete( toDelete, scheduleId ) );
+				tasks.push( runDelete() );
 			}
 
 			await Promise.all( tasks );
 			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
 		},
-		[ toCreate, toEdit, toDelete, runCreate, runEdit, runDelete, scheduleId ]
+		[ toCreate, toEdit, toDelete, runCreate, runEdit, runDelete ]
 	);
 
 	return { mutateAsync } as const;

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,4 +1,4 @@
-import { hostingUpdateSchedulesQuery, queryClient } from '@automattic/api-queries';
+// no imports from api-queries needed here
 import { useLocale } from '@automattic/i18n-utils';
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
@@ -151,10 +151,7 @@ export default function PluginsScheduledUpdates() {
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { mutateAsync: deleteSchedules } = useDeleteSchedules(
-		scheduleToDelete ? [ scheduleToDelete.site.ID ] : [],
-		scheduleToDelete?.scheduleId ?? ''
-	);
+	const { mutateAsync: deleteSchedules } = useDeleteSchedules();
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );
 	}, [ scheduledUpdates, view, fields ] );
@@ -169,8 +166,9 @@ export default function PluginsScheduledUpdates() {
 		}
 		try {
 			setIsDeletingSchedule( true );
-			await deleteSchedules();
-			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+			await deleteSchedules( [ scheduleToDelete.site.ID ], scheduleToDelete.scheduleId, {
+				optimisticHosting: true,
+			} );
 			createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
 		} catch ( e ) {
 			const message = e instanceof Error ? e.message : __( 'Failed to delete schedule.' );

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -154,7 +154,7 @@ export default function PluginsScheduledUpdates() {
 	const { mutateAsync: deleteSchedules } = useDeleteSchedules(
 		scheduleToDelete ? [ scheduleToDelete.site.ID ] : [],
 		scheduleToDelete?.scheduleId ?? '',
-		{ optimisticHosting: true }
+		{ optimisticHosting: false }
 	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -154,7 +154,7 @@ export default function PluginsScheduledUpdates() {
 	const { mutateAsync: deleteSchedules } = useDeleteSchedules(
 		scheduleToDelete ? [ scheduleToDelete.site.ID ] : [],
 		scheduleToDelete?.scheduleId ?? '',
-		{ optimisticHosting: false }
+		{ optimistic: false }
 	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,6 +1,5 @@
-import { hostingUpdateScheduleDeleteMutation } from '@automattic/api-queries';
+import { hostingUpdateSchedulesQuery, queryClient } from '@automattic/api-queries';
 import { useLocale } from '@automattic/i18n-utils';
-import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -21,6 +20,7 @@ import RouterLinkButton from '../../components/router-link-button';
 import { SiteIconLink } from '../../sites/site-fields';
 import { formatDate } from '../../utils/datetime';
 import { prepareScheduleName } from './helpers';
+import { useDeleteSchedules } from './hooks/use-delete-schedules';
 import { useScheduledUpdates } from './hooks/use-scheduled-updates';
 import { ScheduledUpdateRow } from './types';
 
@@ -144,14 +144,16 @@ export const defaultView: View = {
 export default function PluginsScheduledUpdates() {
 	const [ view, setView ] = useState( defaultView );
 	const [ scheduleToDelete, setScheduleToDelete ] = useState< ScheduledUpdateRow | null >( null );
+	const [ isDeletingSchedule, setIsDeletingSchedule ] = useState( false );
 	const locale = useLocale();
 	const navigate = useNavigate();
 	const fields = useMemo( () => getFields( locale ), [ locale ] );
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { mutate: deleteSchedule, isPending: isDeletingSchedule } = useMutation(
-		hostingUpdateScheduleDeleteMutation()
+	const { mutateAsync: deleteSchedules } = useDeleteSchedules(
+		scheduleToDelete ? [ scheduleToDelete.site.ID ] : [],
+		scheduleToDelete?.scheduleId ?? ''
 	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );
@@ -161,27 +163,21 @@ export default function PluginsScheduledUpdates() {
 		setScheduleToDelete( schedule );
 	};
 
-	const handleDeleteConfirm = () => {
-		if ( scheduleToDelete ) {
-			deleteSchedule(
-				{
-					siteId: scheduleToDelete.site.ID,
-					scheduleId: scheduleToDelete.scheduleId,
-				},
-				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
-					},
-					onError: ( error: Error ) => {
-						createErrorNotice( error.message || __( 'Failed to delete schedule.' ), {
-							type: 'snackbar',
-						} );
-					},
-					onSettled: () => {
-						setScheduleToDelete( null );
-					},
-				}
-			);
+	const handleDeleteConfirm = async () => {
+		if ( ! scheduleToDelete ) {
+			return;
+		}
+		try {
+			setIsDeletingSchedule( true );
+			await deleteSchedules();
+			await queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
+			createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
+		} catch ( e ) {
+			const message = e instanceof Error ? e.message : __( 'Failed to delete schedule.' );
+			createErrorNotice( message, { type: 'snackbar' } );
+		} finally {
+			setScheduleToDelete( null );
+			setIsDeletingSchedule( false );
 		}
 	};
 

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -151,7 +151,11 @@ export default function PluginsScheduledUpdates() {
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { mutateAsync: deleteSchedules } = useDeleteSchedules();
+	const { mutateAsync: deleteSchedules } = useDeleteSchedules(
+		scheduleToDelete ? [ scheduleToDelete.site.ID ] : [],
+		scheduleToDelete?.scheduleId ?? '',
+		{ optimisticHosting: true }
+	);
 	const { data: filtered, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( scheduledUpdates, view, fields );
 	}, [ scheduledUpdates, view, fields ] );
@@ -166,9 +170,7 @@ export default function PluginsScheduledUpdates() {
 		}
 		try {
 			setIsDeletingSchedule( true );
-			await deleteSchedules( [ scheduleToDelete.site.ID ], scheduleToDelete.scheduleId, {
-				optimisticHosting: true,
-			} );
+			await deleteSchedules();
 			createSuccessNotice( __( 'Schedule deleted successfully.' ), { type: 'snackbar' } );
 		} catch ( e ) {
 			const message = e instanceof Error ? e.message : __( 'Failed to delete schedule.' );

--- a/packages/api-core/src/hosting-update-schedules/index.ts
+++ b/packages/api-core/src/hosting-update-schedules/index.ts
@@ -1,3 +1,2 @@
 export * from './fetchers';
-export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/hosting-update-schedules/mutators.ts
+++ b/packages/api-core/src/hosting-update-schedules/mutators.ts
@@ -1,1 +1,0 @@
-// Removed duplicate deleteHostingUpdateSchedule; use site-update-schedules delete instead.

--- a/packages/api-core/src/hosting-update-schedules/mutators.ts
+++ b/packages/api-core/src/hosting-update-schedules/mutators.ts
@@ -1,9 +1,1 @@
-import { wpcom } from '../wpcom-fetcher';
-
-export function deleteHostingUpdateSchedule( siteId: number, scheduleId: string ): Promise< void > {
-	return wpcom.req.get( {
-		path: `/sites/${ siteId }/update-schedules/${ encodeURIComponent( scheduleId ) }`,
-		method: 'DELETE',
-		apiNamespace: 'wpcom/v2',
-	} );
-}
+// Removed duplicate deleteHostingUpdateSchedule; use site-update-schedules delete instead.

--- a/packages/api-queries/src/hosting-update-schedules.ts
+++ b/packages/api-queries/src/hosting-update-schedules.ts
@@ -1,45 +1,9 @@
-import { fetchHostingUpdateSchedules, deleteHostingUpdateSchedule } from '@automattic/api-core';
-import { mutationOptions, queryOptions } from '@tanstack/react-query';
-import { queryClient } from './query-client';
+import { fetchHostingUpdateSchedules } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
 
 // Query: hosting (multi-site) schedules
 export const hostingUpdateSchedulesQuery = () =>
 	queryOptions( {
 		queryKey: [ 'hosting', 'update-schedules' ],
 		queryFn: () => fetchHostingUpdateSchedules(),
-	} );
-
-// Mutation: delete hosting update schedule
-export const hostingUpdateScheduleDeleteMutation = () =>
-	mutationOptions( {
-		mutationFn: ( variables: { siteId: number; scheduleId: string } ) =>
-			deleteHostingUpdateSchedule( variables.siteId, variables.scheduleId ),
-		onMutate: ( variables: { siteId: number; scheduleId: string } ) => {
-			// Optimistically update the cache
-			const data = queryClient.getQueryData( hostingUpdateSchedulesQuery().queryKey );
-			if ( data && typeof data === 'object' && 'sites' in data ) {
-				const prevData = JSON.parse( JSON.stringify( data ) ); // deep copy
-				const sites = ( data as any ).sites || {};
-
-				// Remove the schedule from the site
-				if ( sites[ variables.siteId ] ) {
-					delete sites[ variables.siteId ][ variables.scheduleId ];
-				}
-
-				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, { ...data, sites } );
-				return { prevData };
-			}
-		},
-		onError: ( error, variables, context ) => {
-			// Rollback on error
-			if ( context?.prevData ) {
-				queryClient.setQueryData( hostingUpdateSchedulesQuery().queryKey, context.prevData );
-			}
-		},
-		onSuccess: () => {
-			// Delay cache invalidation to allow server to process the deletion and get fresh data
-			setTimeout( () => {
-				queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
-			}, 5000 );
-		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-213/schedule-updates-overview
Part of https://linear.app/a8c/issue/DSGCOM-215/implement-edit-of-existing-schedules-in-v2-hd

## Proposed Changes

The PR follows up from https://github.com/Automattic/wp-calypso/pull/106392 to do some cleanup, remove duplicated code in the api-core/query packages, and align with existing hooks added for reconciling schedules (as that also involves deleting per-site schedules).

The PR adds opt-in optimistic updates to `useDeleteSchedules` hook. If this logic (complex) proves to be unnecessary, then we can strip it out. In testing, I don't see much value in it. The delete operation, right now at least, is done through a confirmation modal that obscures the list view; so updating the list before cache invalidation is mostly updating something in the background. See imgs below.

### Without optimistic

https://github.com/user-attachments/assets/8d691f92-f838-4fea-bab6-527f038decf6 

### With optimistic

https://github.com/user-attachments/assets/1a217257-4e03-44cd-95ff-146347c9eabd

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-213/schedule-updates-overview
Part of https://linear.app/a8c/issue/DSGCOM-215/implement-edit-of-existing-schedules-in-v2-hd

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/v2/plugins/scheduled-updates/new` and create a schedule (try for multiple sites)
- Go to `/v2/plugins/scheduled-updates` and delete any schedule

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
