### PR TITLE
Create a flow for building a new Flex site

### DIFF
--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -17,7 +17,7 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser ) as any;
+	const user = useSelector( getCurrentUser ) as User;
 
 	return (
 		<Dropdown

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,9 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { AuthContext } from '../../dashboard/app/auth';
+import { AuthProvider } from '../../dashboard/app/auth';
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
@@ -17,33 +15,32 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser ) as User;
 
 	return (
-		<Dropdown
-			popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
-			focusOnMount
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<AddNewSiteButton
-					showMainButtonLabel={ ! showCompact }
-					mainButtonLabelText={ translate( 'Add new site' ) }
-					isMenuVisible={ isOpen }
-					isPrimary={ ! showCompact }
-					toggleMenu={ onToggle }
-				/>
-			) }
-			renderContent={ () => (
-				<div className="sites-add-new-site__popover-content">
-					<AuthContext.Provider value={ { user } }>
+		<AuthProvider>
+			<Dropdown
+				popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<AddNewSiteButton
+						showMainButtonLabel={ ! showCompact }
+						mainButtonLabelText={ translate( 'Add new site' ) }
+						isMenuVisible={ isOpen }
+						isPrimary={ ! showCompact }
+						toggleMenu={ onToggle }
+					/>
+				) }
+				renderContent={ () => (
+					<div className="sites-add-new-site__popover-content">
 						<AsyncContent context={ context } />
-					</AuthContext.Provider>
-				</div>
-			) }
-			onToggle={ ( isOpen ) => {
-				if ( isOpen ) {
-					recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
-				}
-			} }
-		/>
+					</div>
+				) }
+				onToggle={ ( isOpen ) => {
+					if ( isOpen ) {
+						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
+					}
+				} }
+			/>
+		</AuthProvider>
 	);
 };

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,6 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { AuthContext } from '../../dashboard/app/auth';
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
@@ -14,6 +17,7 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
+	const user = useSelector( getCurrentUser ) as any;
 
 	return (
 		<Dropdown
@@ -30,7 +34,9 @@ export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 			) }
 			renderContent={ () => (
 				<div className="sites-add-new-site__popover-content">
-					<AsyncContent context={ context } />
+					<AuthContext.Provider value={ { user } }>
+						<AsyncContent context={ context } />
+					</AuthContext.Provider>
 				</div>
 			) }
 			onToggle={ ( isOpen ) => {

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -12,9 +12,12 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { useContext } from 'react';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import { useAnalytics } from '../../app/analytics';
+import { AuthContext } from '../../app/auth';
 import { useHelpCenter } from '../../app/help-center';
+import { userHasFlag } from '../../utils/user';
 import Column from './column';
 import MenuItem from './menu-item';
 import type { AddNewSiteProps } from './types';
@@ -22,6 +25,9 @@ import './style.scss';
 
 function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 	const { recordTracksEvent } = useAnalytics();
+	const auth = useContext( AuthContext );
+	const user = auth?.user;
+	const isFlexEligible = user ? userHasFlag( user, 'wpcom-flex' ) : false;
 
 	const wordpressClick = () => {
 		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
@@ -67,6 +73,20 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 	return (
 		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 6 }>
 			<Column title={ __( 'Add new site' ) }>
+				{ isFlexEligible && (
+					<MenuItem
+						icon={ <WordPressLogo /> }
+						title={ __( 'Create a Flex Site' ) }
+						description={ __( 'Provision a flexible WordPress.com environment.' ) }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+								action: 'flex-site',
+							} );
+						} }
+						href={ `/setup/flex-site?source=${ context }&ref=new-site-popover` }
+						aria-label={ __( 'Create a Flex Site' ) }
+					/>
+				) }
 				<MenuItem
 					icon={ <WordPressLogo /> }
 					title="WordPress.com"

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -76,7 +76,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 				{ isFlexEligible && (
 					<MenuItem
 						icon={ <WordPressLogo /> }
-						title={ __( 'Create a Flex Site' ) }
+						title={ __( 'Create a Flex site' ) }
 						description={ __( 'Provision a flexible WordPress.com environment.' ) }
 						onClick={ () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
@@ -84,7 +84,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 							} );
 						} }
 						href={ `/setup/flex-site?source=${ context }&ref=new-site-popover` }
-						aria-label={ __( 'Create a Flex Site' ) }
+						aria-label={ __( 'Create a Flex site' ) }
 					/>
 				) }
 				<MenuItem

--- a/client/landing/stepper/declarative-flow/flows/flex-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/README.md
@@ -1,46 +1,56 @@
 # Flex Site Flow
 
-This flow allows users to create new flex sites with custom configuration options.
+This flow allows users to quickly create new flex sites with a simple site name form.
+
+## Flow Configuration
+
+- **Flow Name**: `flex-site`
+- **Uses Sessions**: Yes (`__experimentalUseSessions`)
+- **Built-in Authentication**: Yes (`__experimentalUseBuiltinAuth`)
+- **Signup Flow**: Yes
+- **Requires Login**: All steps require authentication
 
 ## Flow Steps
 
-1. **Flex Site Creation** (`flex-site-creation`): A form where users can configure a new flex site with the following options:
+1. **Flex Site Creation** (`flex-site-creation`): A simple form where users enter the site name to create a new flex site:
 
-   - Site Name (required)
-   - Site Type (Production, Staging, Development)
-   - Data Center (optional)
-   - PHP Version (8.3, 8.2, 8.1, 8.0, 7.4)
-   - WordPress Version (Latest, 6.5, 6.4, 6.3)
+   - **Site Name** (required): Text field with autofocus
+   - **Create a site** button: Disabled until a site name is entered
+   - **Migration link**: "Already have an existing site? Migrate it to WordPress.com" redirects to `/setup/site-migration-flow`
+   - **Back button**: Returns to `/sites` dashboard
 
-2. **Create Site** (`create-site`): Sets up the site creation pending action:
+   On submission, the site name is stored in ONBOARD_STORE and the flow navigates to the site creation step.
+
+2. **Site Creation** (`SITE_CREATION_STEP`): Sets up the site creation pending action:
 
    - Stores the site creation function in ONBOARD_STORE as a pending action
-   - Uses the site title stored in ONBOARD_STORE
+   - Uses the site title stored in ONBOARD_STORE from the previous step
    - Shows a "Creating your site" loading indicator
-   - Immediately navigates to the processing step
+   - Immediately navigates to the processing step (step is removed from history for proper back button behavior)
 
 3. **Processing** (`processing`): Executes the site creation:
 
-   - Runs the pending action set by the create-site step
+   - Runs the pending action set by the site creation step
    - Calls the `/sites/new` endpoint with the stored configuration
    - Backend determines flex site creation based on user attributes
-   - After successful creation, redirects to the new site or sites dashboard
+   - After successful creation, redirects to the flex site's wp-admin with `logmein=direct` parameter for automatic login
+   - If site creation fails, falls back to redirecting to the sites dashboard at `/sites`
 
 ## Backend Integration
 
-The flex site creation is handled on the backend by checking user attributes. The frontend simply:
+The flex site creation is handled on the backend by checking user attributes. The frontend:
 
-- Collects the site name and configuration preferences (for future use)
+- Collects the site name
 - Stores the site title in ONBOARD_STORE
-- Uses the standard `create-site` step
-- The backend `/sites/new` endpoint will detect eligible users and create a flex site accordingly
+- Uses the standard `SITE_CREATION_STEP`
+- The backend `/sites/new` endpoint detects eligible users and creates a flex site accordingly
 
 ## Future Enhancements
 
-- Pass flex configuration options (PHP version, WordPress version, etc.) to backend
+- Add configuration options form (Site Type, Data Center, PHP version, WordPress version, etc.) and pass to backend
 - Add checkout step for paid plans (when applicable)
 - Add domain selection step (when applicable)
-- Add success/launchpad step after site creation
+- Add success/launchpad step after site creation instead of direct redirect to wp-admin
 
 ## Testing
 
@@ -52,40 +62,47 @@ To test this flow, navigate to:
 
 ### Test Cases
 
-1. **Basic Site Creation**
+1. **Successful Site Creation**
 
    - Navigate to `/setup/flex-site`
-   - Enter a site name
-   - Keep default selections
+   - Enter a site name (e.g., "My Test Site")
    - Click "Create a site"
-   - Verify the data is submitted correctly
+   - Verify the button shows loading state
+   - After creation, verify redirect to the new site's wp-admin with automatic login via `logmein=direct`
 
-2. **Custom Configuration**
+2. **Validation - Empty Site Name**
 
    - Navigate to `/setup/flex-site`
+   - Leave the site name field empty
+   - Verify the "Create a site" button is disabled
    - Enter a site name
-   - Change Site Type to "Staging"
-   - Select a different Data Center
-   - Change PHP Version to 8.2
-   - Change WordPress Version to 6.4
-   - Click "Create a site"
-   - Verify all selections are submitted correctly
+   - Verify the button becomes enabled
 
-3. **Migration Link**
+3. **Validation - Whitespace Only**
 
    - Navigate to `/setup/flex-site`
-   - Click "Migrate it to WordPress.com" link
-   - Verify redirect to migration flow
+   - Enter only spaces in the site name field
+   - Verify the "Create a site" button remains disabled
+   - Enter actual text
+   - Verify the button becomes enabled
 
-4. **Validation**
+4. **Migration Link**
+
    - Navigate to `/setup/flex-site`
-   - Try to submit without entering a site name
-   - Verify the button is disabled
-   - Enter a site name
-   - Verify the button is enabled
+   - Click "Migrate it to WordPress.com" link in the footer
+   - Verify redirect to `/setup/site-migration-flow`
+   - Verify tracks event `calypso_flex_site_creation_migration_link_click` is fired
+
+5. **Back Button**
+
+   - Navigate to `/setup/flex-site`
+   - Click the "Back to sites" button in the top bar
+   - Verify redirect to `/sites` dashboard
 
 ## Notes
 
-- This flow currently requires user authentication
+- This flow requires user authentication for all steps
 - No checkout or domains are included in this initial version
-- Site creation backend integration is pending
+- After successful site creation, users are automatically logged into their new flex site's wp-admin
+- The flow uses experimental session and built-in authentication features
+- Back button navigation is handled properly by removing the site creation step from history

--- a/client/landing/stepper/declarative-flow/flows/flex-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/README.md
@@ -1,0 +1,91 @@
+# Flex Site Flow
+
+This flow allows users to create new flex sites with custom configuration options.
+
+## Flow Steps
+
+1. **Flex Site Creation** (`flex-site-creation`): A form where users can configure a new flex site with the following options:
+
+   - Site Name (required)
+   - Site Type (Production, Staging, Development)
+   - Data Center (optional)
+   - PHP Version (8.3, 8.2, 8.1, 8.0, 7.4)
+   - WordPress Version (Latest, 6.5, 6.4, 6.3)
+
+2. **Create Site** (`create-site`): Sets up the site creation pending action:
+
+   - Stores the site creation function in ONBOARD_STORE as a pending action
+   - Uses the site title stored in ONBOARD_STORE
+   - Shows a "Creating your site" loading indicator
+   - Immediately navigates to the processing step
+
+3. **Processing** (`processing`): Executes the site creation:
+
+   - Runs the pending action set by the create-site step
+   - Calls the `/sites/new` endpoint with the stored configuration
+   - Backend determines flex site creation based on user attributes
+   - After successful creation, redirects to the new site or sites dashboard
+
+## Backend Integration
+
+The flex site creation is handled on the backend by checking user attributes. The frontend simply:
+
+- Collects the site name and configuration preferences (for future use)
+- Stores the site title in ONBOARD_STORE
+- Uses the standard `create-site` step
+- The backend `/sites/new` endpoint will detect eligible users and create a flex site accordingly
+
+## Future Enhancements
+
+- Pass flex configuration options (PHP version, WordPress version, etc.) to backend
+- Add checkout step for paid plans (when applicable)
+- Add domain selection step (when applicable)
+- Add success/launchpad step after site creation
+
+## Testing
+
+To test this flow, navigate to:
+
+```
+/setup/flex-site
+```
+
+### Test Cases
+
+1. **Basic Site Creation**
+
+   - Navigate to `/setup/flex-site`
+   - Enter a site name
+   - Keep default selections
+   - Click "Create a site"
+   - Verify the data is submitted correctly
+
+2. **Custom Configuration**
+
+   - Navigate to `/setup/flex-site`
+   - Enter a site name
+   - Change Site Type to "Staging"
+   - Select a different Data Center
+   - Change PHP Version to 8.2
+   - Change WordPress Version to 6.4
+   - Click "Create a site"
+   - Verify all selections are submitted correctly
+
+3. **Migration Link**
+
+   - Navigate to `/setup/flex-site`
+   - Click "Migrate it to WordPress.com" link
+   - Verify redirect to migration flow
+
+4. **Validation**
+   - Navigate to `/setup/flex-site`
+   - Try to submit without entering a site name
+   - Verify the button is disabled
+   - Enter a site name
+   - Verify the button is enabled
+
+## Notes
+
+- This flow currently requires user authentication
+- No checkout or domains are included in this initial version
+- Site creation backend integration is pending

--- a/client/landing/stepper/declarative-flow/flows/flex-site/README.md
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/README.md
@@ -1,4 +1,4 @@
-# Flex Site Flow
+# Flex site Flow
 
 This flow allows users to quickly create new flex sites with a simple site name form.
 
@@ -12,7 +12,7 @@ This flow allows users to quickly create new flex sites with a simple site name 
 
 ## Flow Steps
 
-1. **Flex Site Creation** (`flex-site-creation`): A simple form where users enter the site name to create a new flex site:
+1. **Flex site Creation** (`flex-site-creation`): A simple form where users enter the site name to create a new flex site:
 
    - **Site Name** (required): Text field with autofocus
    - **Create a site** button: Disabled until a site name is entered

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -1,0 +1,53 @@
+import { FLEX_SITE_FLOW } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { STEPS } from '../../internals/steps';
+import type { FlowV2, SubmitHandler } from '../../internals/types';
+
+async function initialize() {
+	// Add the flex site creation form step, create-site step, and processing step
+	return stepsWithRequiredLogin( [
+		STEPS.FLEX_SITE_CREATION,
+		STEPS.SITE_CREATION_STEP,
+		STEPS.PROCESSING,
+	] );
+}
+
+const flexSite: FlowV2< typeof initialize > = {
+	name: FLEX_SITE_FLOW,
+	get title() {
+		return translate( 'Create a Flex Site' );
+	},
+	__experimentalUseSessions: true,
+	__experimentalUseBuiltinAuth: true,
+	isSignupFlow: true,
+	initialize,
+	useStepNavigation( _currentStep, navigate ) {
+		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
+			const { slug, providedDependencies } = submittedStep;
+
+			switch ( slug ) {
+				case 'flex-site-creation':
+					// After user fills out the form, navigate to create-site step
+					// The create-site step will use the data stored in the onboard store
+					return navigate( STEPS.SITE_CREATION_STEP.slug );
+
+				case 'create-site':
+					// Navigate to processing step which will execute the site creation
+					// Pass true to remove create-site from history so back button works properly
+					return navigate( STEPS.PROCESSING.slug, undefined, true );
+
+				case 'processing':
+					if ( providedDependencies?.siteSlug ) {
+						return ( window.location.href = `/sites/${ providedDependencies.siteSlug }` );
+					}
+					// Fallback to sites dashboard
+					return ( window.location.href = '/sites' );
+			}
+		};
+
+		return { submit };
+	},
+};
+
+export default flexSite;

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -51,7 +51,10 @@ const flexSite: FlowV2< typeof initialize > = {
 						providedDependencies?.processingResult === ProcessingResult.SUCCESS &&
 						typeof providedDependencies.siteSlug === 'string'
 					) {
-						return window.location.replace( `/sites/${ providedDependencies.siteSlug }` );
+						// Redirect to the Flex site's wp-admin with logmein parameter for direct login
+						return window.location.replace(
+							`https://${ providedDependencies.siteSlug }/wp-admin/?logmein=direct`
+						);
 					}
 					// Fallback to sites dashboard
 					return window.location.replace( '/sites' );

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -19,7 +19,7 @@ async function initialize() {
 const flexSite: FlowV2< typeof initialize > = {
 	name: FLEX_SITE_FLOW,
 	get title() {
-		return translate( 'Create a Flex Site' );
+		return translate( 'Create a Flex site' );
 	},
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -2,6 +2,7 @@ import { FLEX_SITE_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
+import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import type { FlowV2, SubmitHandler } from '../../internals/types';
 
 async function initialize() {
@@ -37,12 +38,16 @@ const flexSite: FlowV2< typeof initialize > = {
 					// Pass true to remove create-site from history so back button works properly
 					return navigate( STEPS.PROCESSING.slug, undefined, true );
 
-				case 'processing':
-					if ( providedDependencies?.siteSlug ) {
-						return ( window.location.href = `/sites/${ providedDependencies.siteSlug }` );
+				case 'processing': {
+					if (
+						providedDependencies?.processingResult === ProcessingResult.SUCCESS &&
+						typeof providedDependencies.siteSlug === 'string'
+					) {
+						return window.location.replace( `/sites/${ providedDependencies.siteSlug }` );
 					}
 					// Fallback to sites dashboard
-					return ( window.location.href = '/sites' );
+					return window.location.replace( '/sites' );
+				}
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -1,5 +1,7 @@
 import { FLEX_SITE_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
@@ -24,11 +26,17 @@ const flexSite: FlowV2< typeof initialize > = {
 	isSignupFlow: true,
 	initialize,
 	useStepNavigation( _currentStep, navigate ) {
+		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
+
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 
 			switch ( slug ) {
 				case 'flex-site-creation':
+					// Store site title in ONBOARD_STORE so create-site step can use it
+					if ( providedDependencies?.siteName ) {
+						setSiteTitle( providedDependencies.siteName );
+					}
 					// After user fills out the form, navigate to create-site step
 					// The create-site step will use the data stored in the onboard store
 					return navigate( STEPS.SITE_CREATION_STEP.slug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -1,11 +1,10 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Step } from '@automattic/onboarding';
 import { TextControl, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -16,7 +15,6 @@ const FlexSiteCreation: StepType< {
 } > = function FlexSiteCreation( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 
 	const [ siteName, setSiteName ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -29,9 +27,6 @@ const FlexSiteCreation: StepType< {
 		}
 
 		setIsLoading( true );
-
-		// Store site title in ONBOARD_STORE so create-site step can use it
-		setSiteTitle( siteName );
 
 		submit?.( {
 			siteName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -33,14 +33,12 @@ const FlexSiteCreation: StepType< {
 		} );
 	};
 
-	const isSiteNameEmpty = ! siteName.trim();
-
 	return (
 		<>
 			<DocumentHead title={ __( 'Create a new site' ) } />
 			<Step.CenteredColumnLayout
 				className="flex-site-creation"
-				columnWidth={ 5 }
+				columnWidth={ 6 }
 				topBar={
 					<Step.TopBar
 						leftElement={
@@ -69,13 +67,11 @@ const FlexSiteCreation: StepType< {
 							/>
 						</FormFieldset>
 
-						<div className="flex-site-creation__form-row" />
-
 						<Button
 							className="flex-site-creation__submit-button"
 							variant="primary"
 							type="submit"
-							disabled={ isSiteNameEmpty || isLoading }
+							disabled={ isLoading }
 						>
 							{ __( 'Create a site' ) }
 						</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -1,0 +1,201 @@
+import { Step } from '@automattic/onboarding';
+import { SelectControl, TextControl, Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { FormEvent, useState } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step as StepType } from '../../types';
+import './style.scss';
+
+const FlexSiteCreation: StepType< {
+	submits: {
+		siteName: string;
+		siteType: string;
+		dataCenter: string;
+		phpVersion: string;
+		wordpressVersion: string;
+	};
+} > = function FlexSiteCreation( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
+
+	const [ siteName, setSiteName ] = useState( '' );
+	const [ siteType, setSiteType ] = useState( 'production' );
+	const [ dataCenter, setDataCenter ] = useState( 'default' );
+	const [ phpVersion, setPhpVersion ] = useState( '8.3' );
+	const [ wordpressVersion, setWordpressVersion ] = useState( 'latest' );
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	const siteTypeOptions = [
+		{ label: __( 'Production' ), value: 'production' },
+		{ label: __( 'Staging' ), value: 'staging' },
+		{ label: __( 'Development' ), value: 'development' },
+	];
+
+	const dataCenterOptions = [
+		{ label: __( 'Default' ), value: 'default' },
+		{ label: __( 'US East' ), value: 'us-east' },
+		{ label: __( 'US West' ), value: 'us-west' },
+		{ label: __( 'Europe' ), value: 'europe' },
+		{ label: __( 'Asia' ), value: 'asia' },
+	];
+
+	const phpVersionOptions = [
+		{ label: '8.3', value: '8.3' },
+		{ label: '8.2', value: '8.2' },
+		{ label: '8.1', value: '8.1' },
+		{ label: '8.0', value: '8.0' },
+		{ label: '7.4', value: '7.4' },
+	];
+
+	const wordpressVersionOptions = [
+		{ label: __( 'Latest' ), value: 'latest' },
+		{ label: '6.5', value: '6.5' },
+		{ label: '6.4', value: '6.4' },
+		{ label: '6.3', value: '6.3' },
+	];
+
+	const handleSubmit = ( event: FormEvent ) => {
+		event.preventDefault();
+
+		if ( ! siteName.trim() ) {
+			return;
+		}
+
+		setIsLoading( true );
+
+		// Store site title in ONBOARD_STORE so create-site step can use it
+		setSiteTitle( siteName );
+
+		recordTracksEvent( 'calypso_flex_site_creation_submit', {
+			site_name: siteName,
+			site_type: siteType,
+			data_center: dataCenter,
+			php_version: phpVersion,
+			wordpress_version: wordpressVersion,
+		} );
+
+		submit?.( {
+			siteName,
+			siteType,
+			dataCenter,
+			phpVersion,
+			wordpressVersion,
+		} );
+	};
+
+	const isSiteNameEmpty = ! siteName.trim();
+
+	return (
+		<>
+			<DocumentHead title={ __( 'Create a new site' ) } />
+			<Step.CenteredColumnLayout
+				className="flex-site-creation"
+				columnWidth={ 5 }
+				topBar={
+					<Step.TopBar
+						leftElement={
+							<Step.BackButton href="/sites">{ __( 'Back to sites' ) }</Step.BackButton>
+						}
+					/>
+				}
+				heading={
+					<Step.Heading
+						text={ __( 'Create a new site' ) }
+						subText={ __( 'No-hassle WordPress install in one click.' ) }
+					/>
+				}
+			>
+				<form className="flex-site-creation__form" onSubmit={ handleSubmit }>
+					<div className="flex-site-creation__card">
+						<FormFieldset>
+							<TextControl
+								label={ __( 'Site name' ) }
+								value={ siteName }
+								onChange={ ( value: string ) => setSiteName( value ) }
+								placeholder={ __( 'Enter site name' ) }
+								// eslint-disable-next-line jsx-a11y/no-autofocus
+								autoFocus
+								__nextHasNoMarginBottom
+							/>
+						</FormFieldset>
+
+						<div className="flex-site-creation__form-row">
+							<FormFieldset className="flex-site-creation__form-field">
+								<SelectControl
+									label={ __( 'Site type' ) }
+									value={ siteType }
+									options={ siteTypeOptions }
+									onChange={ ( value: string ) => setSiteType( value ) }
+									__nextHasNoMarginBottom
+								/>
+							</FormFieldset>
+
+							<FormFieldset className="flex-site-creation__form-field">
+								<SelectControl
+									label={ __( 'Data center (optional)' ) }
+									value={ dataCenter }
+									options={ dataCenterOptions }
+									onChange={ ( value: string ) => setDataCenter( value ) }
+									__nextHasNoMarginBottom
+								/>
+							</FormFieldset>
+						</div>
+
+						<div className="flex-site-creation__form-row">
+							<FormFieldset className="flex-site-creation__form-field">
+								<SelectControl
+									label={ __( 'PHP version' ) }
+									value={ phpVersion }
+									options={ phpVersionOptions }
+									onChange={ ( value: string ) => setPhpVersion( value ) }
+									__nextHasNoMarginBottom
+								/>
+							</FormFieldset>
+
+							<FormFieldset className="flex-site-creation__form-field">
+								<SelectControl
+									label={ __( 'WordPress version' ) }
+									value={ wordpressVersion }
+									options={ wordpressVersionOptions }
+									onChange={ ( value: string ) => setWordpressVersion( value ) }
+									__nextHasNoMarginBottom
+								/>
+							</FormFieldset>
+						</div>
+
+						<Button
+							className="flex-site-creation__submit-button"
+							variant="primary"
+							type="submit"
+							disabled={ isSiteNameEmpty || isLoading }
+						>
+							{ isLoading ? __( 'Creating...' ) : __( 'Create a site' ) }
+						</Button>
+					</div>
+
+					<div className="flex-site-creation__footer">
+						<span className="flex-site-creation__footer-text">
+							{ __( 'Already have an existing site?' ) }{ ' ' }
+						</span>
+						<a
+							href="/setup/site-migration-flow"
+							className="flex-site-creation__footer-link"
+							onClick={ () => {
+								recordTracksEvent( 'calypso_flex_site_creation_migration_link_click' );
+							} }
+						>
+							{ __( 'Migrate it to WordPress.com' ) }
+						</a>
+					</div>
+				</form>
+			</Step.CenteredColumnLayout>
+		</>
+	);
+};
+
+export default FlexSiteCreation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -6,7 +6,6 @@ import { FormEvent, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -33,10 +32,6 @@ const FlexSiteCreation: StepType< {
 
 		// Store site title in ONBOARD_STORE so create-site step can use it
 		setSiteTitle( siteName );
-
-		recordTracksEvent( 'calypso_flex_site_creation_submit', {
-			site_name: siteName,
-		} );
 
 		submit?.( {
 			siteName,
@@ -93,7 +88,7 @@ const FlexSiteCreation: StepType< {
 
 					<div className="flex-site-creation__footer">
 						<span className="flex-site-creation__footer-text">
-							{ __( 'Already have an existing site?' ) }{ ' ' }
+							{ __( 'Already have an existing site?' ) }
 						</span>
 						<a
 							href="/setup/site-migration-flow"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -1,5 +1,5 @@
 import { Step } from '@automattic/onboarding';
-import { SelectControl, TextControl, Button } from '@wordpress/components';
+import { TextControl, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useState } from 'react';
@@ -13,10 +13,6 @@ import './style.scss';
 const FlexSiteCreation: StepType< {
 	submits: {
 		siteName: string;
-		siteType: string;
-		dataCenter: string;
-		phpVersion: string;
-		wordpressVersion: string;
 	};
 } > = function FlexSiteCreation( { navigation } ) {
 	const { submit } = navigation;
@@ -24,40 +20,7 @@ const FlexSiteCreation: StepType< {
 	const { setSiteTitle } = useDispatch( ONBOARD_STORE );
 
 	const [ siteName, setSiteName ] = useState( '' );
-	const [ siteType, setSiteType ] = useState( 'production' );
-	const [ dataCenter, setDataCenter ] = useState( 'default' );
-	const [ phpVersion, setPhpVersion ] = useState( '8.3' );
-	const [ wordpressVersion, setWordpressVersion ] = useState( 'latest' );
 	const [ isLoading, setIsLoading ] = useState( false );
-
-	const siteTypeOptions = [
-		{ label: __( 'Production' ), value: 'production' },
-		{ label: __( 'Staging' ), value: 'staging' },
-		{ label: __( 'Development' ), value: 'development' },
-	];
-
-	const dataCenterOptions = [
-		{ label: __( 'Default' ), value: 'default' },
-		{ label: __( 'US East' ), value: 'us-east' },
-		{ label: __( 'US West' ), value: 'us-west' },
-		{ label: __( 'Europe' ), value: 'europe' },
-		{ label: __( 'Asia' ), value: 'asia' },
-	];
-
-	const phpVersionOptions = [
-		{ label: '8.3', value: '8.3' },
-		{ label: '8.2', value: '8.2' },
-		{ label: '8.1', value: '8.1' },
-		{ label: '8.0', value: '8.0' },
-		{ label: '7.4', value: '7.4' },
-	];
-
-	const wordpressVersionOptions = [
-		{ label: __( 'Latest' ), value: 'latest' },
-		{ label: '6.5', value: '6.5' },
-		{ label: '6.4', value: '6.4' },
-		{ label: '6.3', value: '6.3' },
-	];
 
 	const handleSubmit = ( event: FormEvent ) => {
 		event.preventDefault();
@@ -73,18 +36,10 @@ const FlexSiteCreation: StepType< {
 
 		recordTracksEvent( 'calypso_flex_site_creation_submit', {
 			site_name: siteName,
-			site_type: siteType,
-			data_center: dataCenter,
-			php_version: phpVersion,
-			wordpress_version: wordpressVersion,
 		} );
 
 		submit?.( {
 			siteName,
-			siteType,
-			dataCenter,
-			phpVersion,
-			wordpressVersion,
 		} );
 	};
 
@@ -124,49 +79,7 @@ const FlexSiteCreation: StepType< {
 							/>
 						</FormFieldset>
 
-						<div className="flex-site-creation__form-row">
-							<FormFieldset className="flex-site-creation__form-field">
-								<SelectControl
-									label={ __( 'Site type' ) }
-									value={ siteType }
-									options={ siteTypeOptions }
-									onChange={ ( value: string ) => setSiteType( value ) }
-									__nextHasNoMarginBottom
-								/>
-							</FormFieldset>
-
-							<FormFieldset className="flex-site-creation__form-field">
-								<SelectControl
-									label={ __( 'Data center (optional)' ) }
-									value={ dataCenter }
-									options={ dataCenterOptions }
-									onChange={ ( value: string ) => setDataCenter( value ) }
-									__nextHasNoMarginBottom
-								/>
-							</FormFieldset>
-						</div>
-
-						<div className="flex-site-creation__form-row">
-							<FormFieldset className="flex-site-creation__form-field">
-								<SelectControl
-									label={ __( 'PHP version' ) }
-									value={ phpVersion }
-									options={ phpVersionOptions }
-									onChange={ ( value: string ) => setPhpVersion( value ) }
-									__nextHasNoMarginBottom
-								/>
-							</FormFieldset>
-
-							<FormFieldset className="flex-site-creation__form-field">
-								<SelectControl
-									label={ __( 'WordPress version' ) }
-									value={ wordpressVersion }
-									options={ wordpressVersionOptions }
-									onChange={ ( value: string ) => setWordpressVersion( value ) }
-									__nextHasNoMarginBottom
-								/>
-							</FormFieldset>
-						</div>
+						<div className="flex-site-creation__form-row" />
 
 						<Button
 							className="flex-site-creation__submit-button"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -87,7 +87,7 @@ const FlexSiteCreation: StepType< {
 							type="submit"
 							disabled={ isSiteNameEmpty || isLoading }
 						>
-							{ isLoading ? __( 'Creating...' ) : __( 'Create a site' ) }
+							{ __( 'Create a site' ) }
 						</Button>
 					</div>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/style.scss
@@ -1,63 +1,50 @@
 .flex-site-creation {
-	.step-container-v2__content {
-		max-width: 680px;
+	.flex-site-creation__form {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
 	}
-}
 
-.flex-site-creation__form {
-	display: flex;
-	flex-direction: column;
-	gap: 24px;
-}
-
-.flex-site-creation__card {
-	background: #fff;
-	border: 1px solid #dcdcde;
-	border-radius: 4px;
-	padding: 32px;
-	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
-}
-
-.flex-site-creation__form-row {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 16px;
-	margin-block-start: 16px;
-
-	@media ( max-width: 600px ) {
-		grid-template-columns: 1fr;
+	.flex-site-creation__card {
+		background: #fff;
+		border: 1px solid var(--gray-200, #E0E0E0);
+		border-radius: 8px;
+		padding: 24px;
 	}
-}
 
-.flex-site-creation__form-field {
-	margin-block-end: 0;
-}
+	.components-text-control__input {
+		padding: 8px 12px;
+		line-height: 20px;
+		height: auto;
+	}
 
-.flex-site-creation__submit-button {
-	margin-block-start: 24px;
-	width: 100%;
-	justify-content: center;
-	height: 44px;
-	font-size: 16px;
-}
+	.flex-site-creation__submit-button {
+		margin-inline-end: auto;
+		justify-content: center;
+		height: 44px;
+		font-size: 13px;
+	}
 
-.flex-site-creation__footer {
-	text-align: center;
-	font-size: 14px;
-	color: #646970;
-}
+	.flex-site-creation__footer {
+		text-align: left;
+		font-size: 13px;
+		color: var( --studio-gray-50, #646970 );
+	}
 
-.flex-site-creation__footer-text {
-	margin-inline-end: 4px;
-}
-
-.flex-site-creation__footer-link {
-	color: #3858e9;
-	text-decoration: none;
-	font-weight: 500;
-
-	&:hover {
+	.flex-site-creation__footer-text {
+		margin-inline-end: 4px;
+	}
+	.flex-site-creation__footer-link {
+		color: #3858e9;
 		text-decoration: underline;
 	}
 }
 
+.step-container-v2__heading {
+	text-align: left;
+
+}
+.step-container-v2__heading p {
+	color: var( --studio-gray-50, #646970 );
+	font-size: 13px;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/style.scss
@@ -1,0 +1,63 @@
+.flex-site-creation {
+	.step-container-v2__content {
+		max-width: 680px;
+	}
+}
+
+.flex-site-creation__form {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.flex-site-creation__card {
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 32px;
+	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+}
+
+.flex-site-creation__form-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+	margin-block-start: 16px;
+
+	@media ( max-width: 600px ) {
+		grid-template-columns: 1fr;
+	}
+}
+
+.flex-site-creation__form-field {
+	margin-block-end: 0;
+}
+
+.flex-site-creation__submit-button {
+	margin-block-start: 24px;
+	width: 100%;
+	justify-content: center;
+	height: 44px;
+	font-size: 16px;
+}
+
+.flex-site-creation__footer {
+	text-align: center;
+	font-size: 14px;
+	color: #646970;
+}
+
+.flex-site-creation__footer-text {
+	margin-inline-end: 4px;
+}
+
+.flex-site-creation__footer-link {
+	color: #3858e9;
+	text-decoration: none;
+	font-weight: 500;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -63,6 +63,11 @@ export const STEPS = {
 
 	ERROR: { slug: 'error', asyncComponent: () => import( './steps-repository/error-step' ) },
 
+	FLEX_SITE_CREATION: {
+		slug: 'flex-site-creation',
+		asyncComponent: () => import( './steps-repository/flex-site-creation' ),
+	},
+
 	NEWSLETTER_SETUP: {
 		slug: 'newsletterSetup',
 		asyncComponent: () => import( './steps-repository/newsletter-setup' ),

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -19,6 +19,7 @@ import {
 	ONBOARDING_UNIFIED_FLOW,
 	DOMAIN_AND_PLAN_FLOW,
 	PLAN_UPGRADE_FLOW,
+	FLEX_SITE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow, FlowV2 } from '../declarative-flow/internals/types';
 
@@ -52,6 +53,9 @@ const availableFlows: Record< string, () => Promise< { default: FlowV2< any > } 
 		),
 	[ PLAN_UPGRADE_FLOW ]: () =>
 		import( /* webpackChunkName: "plan-upgrade-flow" */ './flows/plan-upgrade/plan-upgrade' ),
+
+	[ FLEX_SITE_FLOW ]: () =>
+		import( /* webpackChunkName: "flex-site-flow" */ './flows/flex-site/flex-site' ),
 };
 
 /**

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -12,6 +12,9 @@ import { SitesAddNewSitePopover } from 'calypso/components/sites-add-new-site';
 import SplitButton from 'calypso/components/split-button';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
+import { useSelector } from 'calypso/state';
+import { WPCOM_FLEX } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { LinkWithRedirect } from './link-with-redirect';
 import './sites-dashboard-header.scss';
@@ -113,7 +116,7 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
 		ref: 'topbar',
 	} );
-
+	const isFlexEligible = useSelector( ( state ) => currentUserHasFlag( state, WPCOM_FLEX ) );
 	return (
 		<PageHeader className="sites-dashboard-header">
 			<HeaderControls>
@@ -133,6 +136,16 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 						toggleIcon={ isMobile ? 'plus' : undefined }
 						isMobile={ isMobile }
 					>
+						{ isFlexEligible && (
+							<PopoverMenuItem
+								onClick={ () => {
+									recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_flex' );
+								} }
+								href="/setup/flex-site"
+							>
+								<span>{ translate( 'Create a Flex Site' ) }</span>
+							</PopoverMenuItem>
+						) }
 						<PopoverMenuItem
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -144,7 +144,7 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 								href="/setup/flex-site"
 							>
 								<WordPressLogo className="gridicon" size={ 18 } />
-								<span>{ translate( 'Create a Flex Site' ) }</span>
+								<span>{ translate( 'Create a Flex site' ) }</span>
 							</PopoverMenuItem>
 						) }
 						<PopoverMenuItem

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { JetpackLogo } from '@automattic/components';
+import { JetpackLogo, WordPressLogo } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
@@ -143,6 +143,7 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 								} }
 								href="/setup/flex-site"
 							>
+								<WordPressLogo className="gridicon" size={ 18 } />
 								<span>{ translate( 'Create a Flex Site' ) }</span>
 							</PopoverMenuItem>
 						) }

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,4 +1,6 @@
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
+// Flex eligibility user flag returned in /me meta.flags.active_flags
+export const WPCOM_FLEX = 'wpcom-flex';
 
 export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'price_2020_q2_test_1';

--- a/packages/api-core/src/me/types.ts
+++ b/packages/api-core/src/me/types.ts
@@ -1,4 +1,4 @@
-export type UserFlags = 'calypso_allow_nonprimary_domains_without_plan';
+export type UserFlags = 'calypso_allow_nonprimary_domains_without_plan' | 'wpcom-flex';
 
 export interface SocialLoginConnection {
 	service: string;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -39,6 +39,7 @@ export const AI_SITE_BUILDER_FLOW = 'ai-site-builder';
 export const AI_SITE_BUILDER_SPEC_FLOW = 'ai-site-builder-spec';
 export const PLAYGROUND_FLOW = 'playground';
 export const PLAN_UPGRADE_FLOW = 'plan-upgrade';
+export const FLEX_SITE_FLOW = 'flex-site';
 
 export const isNewsletterFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && NEWSLETTER_FLOW === flowName );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTMART-17](https://linear.app/a8c/issue/DOTMART-17/create-a-flow-for-building-a-new-flex-site)

## Proposed Changes

* adds a simplified flow, with no checkout to create Flex sites
* adds dedicated button in the `Add new site` popover for creating Flex sites, only visible for Flex users

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of an effort to create a flow for building Flex sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Flex site
* Follow instructions from 193934-ghe-Automattic/wpcom
* Go to `/sites`
* You should see the in `Create a Flex site` in the `Add new site` popover
<img width="480" alt="Screenshot 2025-10-16 at 16 10 56" src="https://github.com/user-attachments/assets/61707b64-47ce-4aa1-9f6c-8736efe68421" />

* Select the `Create a Flex site`
* Enter a `Site Title` and submit
<img width="480" alt="Screenshot 2025-10-16 at 16 13 27" src="https://github.com/user-attachments/assets/4c13be82-23bd-4182-a630-178eece18a75" />

* A new wpcomstaging site should be created with the specified `Site Title` and you should land on the login screen
<img width="480" alt="Screenshot 2025-10-16 at 16 14 25" src="https://github.com/user-attachments/assets/fde6f5f1-e9d0-4866-ba75-6aaea91eddc8" />

##### Normal site
* Go to `/site`
* Choosing should take you through the onboarding flow and result in a normal wpcom site.

##### Non Flex user
* Create a new user or remove the attribute added in 193934-ghe-Automattic/wpcom
* Go to `/site`
* You should not see `Create a Flex site` option
<img width="480" alt="Screenshot 2025-10-16 at 16 29 54" src="https://github.com/user-attachments/assets/8d7a50d3-276a-4b11-9a82-46d289bd0aad" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?