### PR TITLE
Staging Sites: Display shared quota message for production and staging sites

### DIFF
--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -51,7 +51,7 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 				progressLabel={ `${ storageUsagePercent }%` }
 			/>
 			{ isSharedQuota && (
-				<Text variant="muted">
+				<Text variant="muted" lineHeight="16px" size={ 12 }>
 					{ sprintf(
 						// translators: %s is the total storage quota (e.g., "53 GB")
 						__( 'Production and staging share a total storage quota of %s.' ),

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,10 +1,16 @@
 import { siteMediaStorageQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import {
+	ExternalLink,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
 import filesize from 'filesize';
 import { Stat } from '../../components/stat';
+import { hasStagingSite } from '../../utils/site-staging-site';
 import { getStorageAlertLevel } from '../../utils/site-storage';
+import { isStagingSite } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
@@ -31,6 +37,8 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 		storageWarningColor = 'alert-yellow' as const;
 	}
 
+	const isSharedQuota = isStagingSite( site ) || hasStagingSite( site );
+
 	return (
 		<VStack spacing={ 2 }>
 			<Stat
@@ -42,6 +50,15 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 				progressColor={ storageWarningColor }
 				progressLabel={ `${ storageUsagePercent }%` }
 			/>
+			{ isSharedQuota && (
+				<Text variant="muted">
+					{ sprintf(
+						// translators: %s is the total storage quota (e.g., "53 GB")
+						__( 'Production and staging share a total storage quota of %s.' ),
+						filesize( mediaStorage.max_storage_bytes * 2, { round: 0 } )
+					) }
+				</Text>
+			) }
 			{ alertLevel !== 'none' && (
 				<ExternalLink href={ `/add-ons/${ site.slug }` }>{ __( 'Add more storage' ) }</ExternalLink>
 			) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-246

## Proposed Changes

* add information that the storage is shared between staging and production environments

<img width="2850" height="1048" alt="Markup on 2025-10-14 at 14:42:27" src="https://github.com/user-attachments/assets/1cd99fab-894a-414c-9545-28bbba4d4944" />

The original text used previously was `Storage quota is shared between production and staging.`, but I think displaying the actual max storage adds more clarity.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The information used to be displayed in the old storage design. We already received a ticket where the user was confused why they don't have full plan storage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link below).
2. Head over to the Overview tab of a WoA site with staging site created, in both V1 and V2 dashboards:
  - V2: `/v2/sites/{site-slug}`
  - V1: `/sites/{site-slug}`
3. A new message should render in the card (as can be seen in the screenshot above).
4. Switch to a different site that does not have a staging site.
5. The new message should not render there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
