### PR TITLE
e2e tests: add Slack notification for failed pre-release checks

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1006,12 +1006,26 @@ object PlaywrightTestPreReleaseMatrix : BuildType({
 				value("mobile", label = "Mobile"),
 			))
 		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#e2eflowtesting-notif"
+				messageFormat = verboseMessageFormat {
+					addStatusText = true
+				}
+			}
+			branchFilter = "+:<default>"
+			buildFailedToStart = true
+			buildFailed = true
+			buildFinishedSuccessfully = false
+			buildProbablyHanging = true
+		}
 	}
 
 	triggers {
 		vcs {
 			branchFilter = """
-				+:trunk
+				+:<default>
 			""".trimIndent()
 			triggerRules = """
 				-:**.md


### PR DESCRIPTION

Part of QAO-125
Followup of #106431 

## Proposed Changes

Configure a Slack alert for failing Pre-Release E2E Tests (Playwright Test) build configuration.

