### PR TITLE
100 year old product: Submit zendesk field after checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -1,8 +1,11 @@
 import { PLAN_100_YEARS, getPlan, domainProductSlugs } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, WordPressLogo } from '@automattic/components';
+import { FLOWS_ZENDESK_FLOWNAME } from '@automattic/help-center/src/constants';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW } from '@automattic/onboarding';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -175,12 +178,31 @@ export default function HundredYearThankYou( {
 			targetDomain = null;
 	}
 
+	const { mutateAsync: submitUserFields } = useUpdateZendeskUserFields();
+
 	useEffect( () => {
 		dispatch( hideMasterbar() );
 		if ( isReceiptLoading && receiptId ) {
 			dispatch( fetchReceipt( receiptId ) );
 		}
 	}, [ dispatch, isReceiptLoading, receiptId ] );
+
+	useEffect( () => {
+		if ( productSlug && submitUserFields && siteId ) {
+			submitUserFields( {
+				messaging_flow:
+					FLOWS_ZENDESK_FLOWNAME[
+						productSlug === PLAN_100_YEARS ? HUNDRED_YEAR_PLAN_FLOW : HUNDRED_YEAR_DOMAIN_FLOW
+					],
+				messaging_initial_message:
+					productSlug === PLAN_100_YEARS
+						? 'User purchased the 100 year plan.'
+						: 'User purchased the 100 year domain.',
+				messaging_site_id: siteId,
+				messaging_url: window.location.href,
+			} );
+		}
+	}, [ siteId, submitUserFields, productSlug ] );
 
 	if (
 		! isReceiptLoading &&

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -194,10 +194,6 @@ export default function HundredYearThankYou( {
 					FLOWS_ZENDESK_FLOWNAME[
 						productSlug === PLAN_100_YEARS ? HUNDRED_YEAR_PLAN_FLOW : HUNDRED_YEAR_DOMAIN_FLOW
 					],
-				messaging_initial_message:
-					productSlug === PLAN_100_YEARS
-						? 'User purchased the 100 year plan.'
-						: 'User purchased the 100 year domain.',
 				messaging_site_id: siteId,
 				messaging_url: window.location.href,
 			} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-228/add-messaging-flow-tag-to-100-year-product-purchases

When someone purchases a 100 Year Plan or 100 Year Domain, we'd like a User tag to be added to the customer's Zendesk customer record identifying them as a 100 year product customer.

100 year plan => messaging_flow_dotcom_100_year_plan
100 year domain => messaging_flow_dotcom_100_year_domain

## Testing steps

1. Buy a 100 year old domain
2. Check that the `/help/zendesk/update-user-fields` calls happen in the network tab in the developer tools
3. Check that the passed fields are correct