### PR TITLE
v2 log out is now an async button to ensure local state is cleared

### DIFF
--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -128,8 +128,10 @@ function UserProfile() {
 								logout().catch( () => setIsLoggingOut( false ) );
 							} }
 						>
-							{ __( 'Log out' ) }
-							{ isLoggingOut && <Spinner /> }
+							<HStack>
+								<span>{ __( 'Log out' ) }</span>
+								{ isLoggingOut && <Spinner style={ { margin: 0 } } /> }
+							</HStack>
 						</MenuItem>
 					</MenuGroup>
 				</VStack>

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -129,8 +129,10 @@ function UserProfile() {
 							} }
 						>
 							<HStack>
-								<span>{ __( 'Log out' ) }</span>
-								{ isLoggingOut && <Spinner style={ { margin: 0 } } /> }
+								<span>{ isLoggingOut ? __( 'Logging out…' ) : __( 'Log out' ) }</span>
+								{ isLoggingOut && (
+									<Spinner style={ { width: 24, height: 24, padding: 4, margin: 0 } } />
+								) }
 							</HStack>
 						</MenuItem>
 					</MenuGroup>

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -7,10 +7,11 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	Spinner,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { help, commentAuthorAvatar } from '@wordpress/icons';
-import { Suspense, lazy, useCallback } from 'react';
+import { Suspense, lazy, useCallback, useState } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
@@ -62,9 +63,10 @@ function Help() {
 
 // User profile dropdown component
 function UserProfile() {
-	const { user, logoutUrl, handleLogout } = useAuth();
+	const { user, logout } = useAuth();
 	const { supports } = useAppContext();
 	const openCommandPalette = useOpenCommandPalette();
+	const [ isLoggingOut, setIsLoggingOut ] = useState( false );
 
 	return (
 		<DropdownMenu
@@ -119,9 +121,16 @@ function UserProfile() {
 						</MenuGroup>
 					) }
 					<MenuGroup>
-						<RouterLinkMenuItem onClick={ handleLogout } reloadDocument to={ logoutUrl }>
+						<MenuItem
+							disabled={ isLoggingOut }
+							onClick={ () => {
+								setIsLoggingOut( true );
+								logout().catch( () => setIsLoggingOut( false ) );
+							} }
+						>
 							{ __( 'Log out' ) }
-						</RouterLinkMenuItem>
+							{ isLoggingOut && <Spinner /> }
+						</MenuItem>
 					</MenuGroup>
 				</VStack>
 			) }

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -11,7 +11,7 @@ const userId = 1;
 function render( ui: React.ReactElement ) {
 	return testingLibraryRender(
 		<AuthContext.Provider
-			value={ { user: { ID: userId } as User, logoutUrl: '', handleLogout: () => {} } }
+			value={ { user: { ID: userId } as User, logout: () => Promise.resolve() } }
 		>
 			{ ui }
 		</AuthContext.Provider>

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -11,7 +11,7 @@ const userId = 1;
 function render( ui: React.ReactElement ) {
 	return testingLibraryRender(
 		<AuthContext.Provider
-			value={ { user: { ID: userId } as User, logoutUrl: '', handleLogout: () => {} } }
+			value={ { user: { ID: userId } as User, logout: () => Promise.resolve() } }
 		>
 			{ ui }
 		</AuthContext.Provider>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDASH-652

## Proposed Changes

* `useAuth` returns an all-in-one `logout` function
* v1 store clearing code only loaded when it is needed
* Prevent DOTDASH-652 bug by using a `<button>` instead of a `<a>`
* Show a loading state to the log out button
  * I didn't like that when you clicked it it looked like nothing was happening (previously the browser went into a loading state, now nothing)

<img width="317" alt="CleanShot 2025-10-15 at 11 20 24@2x" src="https://github.com/user-attachments/assets/85f505ae-bc92-4b40-a2d5-b8e4d08279ed" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes DOTDASH-652

## Testing Instructions

**To reproduce**

* Log in
* `calypso.localhost:3000/v2`
* Right click the "Log out" menu item
* Open in a new tab
* Observe that react query client has not been removed from the local storage

**To confirm fix**

* Log in
* `calypso.localhost:3000/v2`
* Right click to open in new tab is no longer an option
* Observe that react query client has not been removed after log out
* Observe that `calypso_store` IndexedDB data is also cleared after log out

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
