### PR TITLE
Warn when `useAnalytics` is used without the provider

### DIFF
--- a/client/dashboard/app/analytics/index.tsx
+++ b/client/dashboard/app/analytics/index.tsx
@@ -31,9 +31,7 @@ export function useAnalytics() {
 		context === defaultNoopAnalyticsClient
 	) {
 		// eslint-disable-next-line no-console
-		console.error(
-			'useAnalytics() hook expects the <AnalyticsProvider> to be available in the component tree'
-		);
+		console.error( 'useAnalytics() must be used with a <AnalyticsProvider>' );
 	}
 
 	return context;

--- a/client/dashboard/app/analytics/index.tsx
+++ b/client/dashboard/app/analytics/index.tsx
@@ -7,10 +7,12 @@ export type AnalyticsClient = {
 	recordPageView: ( url: string, title: string ) => void;
 };
 
-const AnalyticsContext = createContext< AnalyticsClient >( {
+const defaultNoopAnalyticsClient = {
 	recordTracksEvent() {},
 	recordPageView() {},
-} );
+};
+
+const AnalyticsContext = createContext< AnalyticsClient >( defaultNoopAnalyticsClient );
 
 interface AnalyticsProviderProps {
 	children: React.ReactNode;
@@ -22,7 +24,19 @@ export function AnalyticsProvider( { children, client }: AnalyticsProviderProps 
 }
 
 export function useAnalytics() {
-	return useContext( AnalyticsContext );
+	const context = useContext( AnalyticsContext );
+
+	if (
+		! config< string >( 'env_id' ).includes( 'production' ) &&
+		context === defaultNoopAnalyticsClient
+	) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'useAnalytics() hook expects the <AnalyticsProvider> to be available in the component tree'
+		);
+	}
+
+	return context;
 }
 
 export function bumpStat( group: string, name: string ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Console error (in non-prod builds) when `Analytics` is used without a `<AnalyticsProvider>`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The monitoring callout hasn't been sending tracks events p58i-nTx-p2#comment-70986
A warning may have alerted us earlier

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nav to `http://calypso.localhost:3000/site-monitoring/{{ site slug }}` using a non-business test site
* Check console for error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?