### PR TITLE
Prefer crux score over the overall score.

### DIFF
--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -34,6 +34,7 @@ const CoreMetricsTabs = ( {
 	compact?: boolean;
 } ) => {
 	const isSmall = useViewportMatch( 'small' );
+	const performanceValue = report.crux_score ? report.crux_score : report.overall_score;
 
 	return (
 		<Tabs.TabList style={ { maxWidth: '100%' } }>
@@ -43,9 +44,9 @@ const CoreMetricsTabs = ( {
 				</Text>
 				<OverallScore
 					lineHeight="32px"
-					status={ mapThresholdsToStatus( 'overall_score', report.overall_score ) }
+					status={ mapThresholdsToStatus( 'overall_score', performanceValue ) }
 					size={ isSmall ? 20 : 16 }
-					value={ report.overall_score }
+					value={ performanceValue }
 				/>
 			</Tab>
 			{ Object.entries( metricsNames ).map(

--- a/packages/api-core/src/site-performance/types.ts
+++ b/packages/api-core/src/site-performance/types.ts
@@ -2,7 +2,15 @@ export interface BasicMetricsData {
 	token?: string;
 }
 
-export type Metrics = 'cls' | 'lcp' | 'fcp' | 'ttfb' | 'inp' | 'tbt' | 'overall_score';
+export type Metrics =
+	| 'cls'
+	| 'lcp'
+	| 'fcp'
+	| 'ttfb'
+	| 'inp'
+	| 'tbt'
+	| 'overall_score'
+	| 'crux_score';
 
 export type SitePerformanceHistory = {
 	collection_period: Array< string | { year: number; month: number; day: number } >;


### PR DESCRIPTION
## Proposed Changes

If the `crux_score` is available, prefer that.

See: #95913


## Why are these changes being made?

This was missed in the rebuild. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
