### PR TITLE
Hosting Dashboard: Replace more back buttons with breadcrumbs

### DIFF
--- a/client/dashboard/components/clipboard-input-control/index.tsx
+++ b/client/dashboard/components/clipboard-input-control/index.tsx
@@ -42,6 +42,7 @@ export default function ClipboardInputControl( {
 	return (
 		<InputControl
 			{ ...props }
+			__next40pxDefaultSize
 			suffix={
 				<InputControlSuffixWrapper variant="control">
 					<Button

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -21,7 +21,7 @@ import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-tab
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useRouter, Link } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -40,18 +40,18 @@ import {
 } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _n, isRTL, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	moreVertical,
-	chevronLeft,
-	chevronRight,
 	calendar,
+	chevronRight,
 	currencyDollar,
 	siteLogo,
 	commentAuthorAvatar,
 } from '@wordpress/icons';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
+import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
@@ -171,24 +171,6 @@ function shouldAllowExpiredAutoRenewToggle( purchase: Purchase ): boolean {
 function upgradePurchase( upgradeUrl: string ): void {
 	window.location.href = upgradeUrl;
 }
-
-const BackButton = () => {
-	const router = useRouter();
-
-	return (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( {
-					to: '/me/billing/purchases',
-				} );
-			} }
-		>
-			{ __( 'Purchases' ) }
-		</Button>
-	);
-};
 
 function ProductLink( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.is_plan && purchase.site_slug ) {
@@ -1097,7 +1079,7 @@ export default function PurchaseSettings() {
 			header={
 				<VStack>
 					<PageHeader
-						prefix={ <BackButton /> }
+						prefix={ <Breadcrumbs length={ 3 } /> }
 						title={ getTitleForDisplay( purchase ) }
 						actions={
 							site?.options?.admin_url && (

--- a/client/dashboard/me/monetize-subscriptions/dataviews.tsx
+++ b/client/dashboard/me/monetize-subscriptions/dataviews.tsx
@@ -59,7 +59,7 @@ export function getMonetizeFieldDefinitions(): Fields< MonetizeSubscription > {
 		},
 		{
 			id: 'description',
-			label: __( 'Product Description' ),
+			label: __( 'Product description' ),
 			type: 'text',
 			enableGlobalSearch: true,
 			enableSorting: true,

--- a/client/dashboard/me/monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/monetize-subscriptions/monetize-subscription.tsx
@@ -9,7 +9,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate, useRouter } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -21,26 +21,17 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
-import {
-	chevronRight,
-	chevronLeft,
-	calendar,
-	currencyDollar,
-	siteLogo,
-	rotateRight,
-} from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { calendar, currencyDollar, rotateRight, siteLogo } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { monetizeSubscriptionRoute } from '../../app/router/me';
 import ActionList from '../../components/action-list';
 import { addFlashMessage } from '../../components/flash-message';
 import { useFormattedTime } from '../../components/formatted-time';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import {
-	getMonetizeSubscriptionsUrl,
-	getMonetizeSubscriptionsPageTitle,
-} from '../../me/monetize-subscriptions/urls';
+import { getMonetizeSubscriptionsUrl } from '../../me/monetize-subscriptions/urls';
 import { formatDate } from '../../utils/datetime';
 import { PurchaseSettingsCard } from '../billing-purchases/purchase-settings';
 
@@ -219,24 +210,6 @@ function StopSubscriptionButton( {
 	);
 }
 
-const BackButton = () => {
-	const router = useRouter();
-
-	return (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( {
-					to: getMonetizeSubscriptionsUrl(),
-				} );
-			} }
-		>
-			{ getMonetizeSubscriptionsPageTitle() }
-		</Button>
-	);
-};
-
 export default function MonetizeSubscriptionDetails() {
 	const params = monetizeSubscriptionRoute.useParams();
 	const subscriptionId: string = params.subscriptionId ?? '';
@@ -276,8 +249,8 @@ export default function MonetizeSubscriptionDetails() {
 			size="small"
 			header={
 				<PageHeader
-					prefix={ <BackButton /> }
-					title={ isProduct ? __( 'Product Details' ) : __( 'Subscription Details' ) }
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ isProduct ? __( 'Product details' ) : __( 'Subscription details' ) }
 				/>
 			}
 		>
@@ -302,7 +275,7 @@ export default function MonetizeSubscriptionDetails() {
 							title={ expiryDateTitle }
 							heading={ ( () => {
 								if ( isOneTimePurchase ) {
-									return __( 'Never expires' );
+									return __( 'Never expires.' );
 								}
 								if ( isAutoRenewing ) {
 									return formattedRenewal;
@@ -311,9 +284,9 @@ export default function MonetizeSubscriptionDetails() {
 							} )() }
 							description={ ( () => {
 								if ( isAutoRenewing ) {
-									return __( 'Auto-renew is enabled' );
+									return __( 'Auto-renew is enabled.' );
 								}
-								return __( 'Auto-renew is disabled' );
+								return __( 'Auto-renew is disabled.' );
 							} )() }
 						/>
 					</HStack>

--- a/client/dashboard/me/security-two-step-auth-backup-codes/index.tsx
+++ b/client/dashboard/me/security-two-step-auth-backup-codes/index.tsx
@@ -1,37 +1,21 @@
 import { userSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import PrintBackupCodes from '../security-two-step-auth/common/print-backup-codes';
 
 export default function SecurityTwoStepAuthBackupCodes() {
-	const router = useRouter();
-
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const username = userSettings.user_login;
 
-	// TODO: Replace with breadcrumb
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: '/me/security/two-step-auth' } );
-			} }
-		>
-			{ __( 'Security' ) }
-		</Button>
-	);
 	return (
 		<PageLayout
 			size="small"
 			header={
 				<PageHeader
-					prefix={ backButton }
+					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Backup codes' ) }
 					description={ __(
 						'Backup codes let you access your account if you lose your phone or can’t use your authenticator app. Each code can only be used once. Store them in a safe place.'

--- a/client/dashboard/me/security-two-step-auth/common/page-layout.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/page-layout.tsx
@@ -1,7 +1,5 @@
-import { useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import Breadcrumbs from '../../../app/breadcrumbs';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 
@@ -10,25 +8,14 @@ export default function SecurityTwoStepAuthPageLayout( {
 }: {
 	children: React.ReactNode;
 } ) {
-	const router = useRouter();
-
-	// TODO: Replace with breadcrumb
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: '/me/security/two-step-auth' } );
-			} }
-		>
-			{ __( 'Security' ) }
-		</Button>
-	);
 	return (
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ backButton } title={ __( 'Set up two-step authentication' ) } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ __( 'Set up two-step authentication' ) }
+				/>
 			}
 		>
 			{ children }

--- a/client/dashboard/me/security-two-step-auth/common/print-backup-codes.tsx
+++ b/client/dashboard/me/security-two-step-auth/common/print-backup-codes.tsx
@@ -188,6 +188,7 @@ export default function PrintBackupCodes( {
 								</CardFooter>
 							</Card>
 							<CheckboxControl
+								__nextHasNoMarginBottom
 								checked={ isBackupCodesPrinted }
 								onChange={ setIsBackupCodesPrinted }
 								label={ __( 'I have printed or saved these codes' ) }

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -3,7 +3,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
-	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -12,11 +11,12 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
-import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
-import { siteBackupDownloadRoute, siteBackupsRoute } from '../../app/router/sites';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { siteBackupDownloadRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
@@ -138,22 +138,12 @@ function SiteBackupDownload() {
 		}
 	};
 
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug } } );
-			} }
-		>
-			{ __( 'Backups' ) }
-		</Button>
-	);
-
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ backButton } title={ __( 'Download backup' ) } /> }
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
+			}
 		>
 			{ currentStep !== 'success' ? (
 				<Card>

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -1,9 +1,7 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import {
-	Button,
 	Card,
 	CardBody,
 	CardHeader,
@@ -12,12 +10,13 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { __, isRTL, sprintf } from '@wordpress/i18n';
-import { Icon, cloud, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { useAnalytics } from '../../app/analytics';
-import { siteBackupRestoreRoute, siteBackupsRoute } from '../../app/router/sites';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { siteBackupRestoreRoute } from '../../app/router/sites';
 import { useFormattedTime } from '../../components/formatted-time';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
@@ -53,8 +52,6 @@ function SiteBackupRestore() {
 	const browserSelectedList = fileBrowserState.getSelectedList( Number( rewindId ) );
 	const hasSelectedFiles = browserSelectedList.length > 0;
 	const hasSelectedAllFiles = browserSelectedList[ 0 ]?.path === '//';
-
-	const router = useRouter();
 
 	const handleRestoreInitiate = ( newRestoreId: number ) => {
 		recordTracksEvent( 'calypso_dashboard_backups_restore_started' );
@@ -117,22 +114,12 @@ function SiteBackupRestore() {
 		}
 	};
 
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( { to: siteBackupsRoute.fullPath, params: { siteSlug } } );
-			} }
-		>
-			{ __( 'Backups' ) }
-		</Button>
-	);
-
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ backButton } title={ __( 'Site restore' ) } /> }
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Site restore' ) } />
+			}
 		>
 			{ currentStep !== 'success' ? (
 				<Card>


### PR DESCRIPTION
## Proposed Changes

This replaces more back buttons instances with breadcrumbs. After this, there are two more instances left that are less straightforward to replace:

https://github.com/Automattic/wp-calypso/blob/73b471700e997d5fad2405aff70c14aa94b5f7c0/client/dashboard/me/billing-purchases/change-payment-method.tsx#L27-L43

https://github.com/Automattic/wp-calypso/blob/73b471700e997d5fad2405aff70c14aa94b5f7c0/client/dashboard/sites/backups/index.tsx#L142-L153


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
