### PR TITLE
Dashboard v1: ensure hosting upsell callout events are fired

### DIFF
--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -1,9 +1,11 @@
 import { FEATURE_SFTP } from '@automattic/calypso-products';
+import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
 import { CalloutOverlay } from 'calypso/dashboard/components/callout-overlay';
 import PageLayout from 'calypso/dashboard/components/page-layout';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getRouteFromContext } from 'calypso/utils';
+import { useAnalyticsClient } from '../v2/hooks/use-analytics-client';
 import { HostingActivationCallout, HostingUpsellCallout } from './components/hosting-callout';
 import HostingFeatures from './components/hosting-features';
 import { areHostingFeaturesSupported } from './features';
@@ -55,6 +57,11 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 	next();
 }
 
+function HostingFeatureCallout( { children }: { children: React.ReactNode } ) {
+	const analyticsClient = useAnalyticsClient();
+	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
+}
+
 export function hostingFeaturesCallout(
 	CalloutComponent: ComponentType< {
 		siteSlug: string;
@@ -72,7 +79,9 @@ export function hostingFeaturesCallout(
 				site.plan?.features.active.includes( FEATURE_SFTP ) ? (
 					<HostingActivationCallout siteId={ site.ID } />
 				) : (
-					<CalloutComponent siteSlug={ site.slug } titleAs="h3" />
+					<HostingFeatureCallout>
+						<CalloutComponent siteSlug={ site.slug } titleAs="h3" />
+					</HostingFeatureCallout>
 				);
 
 			context.primary = (

--- a/client/sites/v2/hooks/use-analytics-client.ts
+++ b/client/sites/v2/hooks/use-analytics-client.ts
@@ -4,13 +4,13 @@ import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actio
 import type { AnyRouter } from '@tanstack/react-router';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 
-export const useAnalyticsClient = ( router: AnyRouter ) => {
+export const useAnalyticsClient = ( router?: AnyRouter ) => {
 	const dispatch = useDispatch();
 
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				const path = router.state.matches.at( -1 )?.fullPath;
+				const path = router?.state.matches.at( -1 )?.fullPath;
 				dispatch(
 					recordTracksEvent( eventName, {
 						path,


### PR DESCRIPTION
Fixes p1760458487519749/1760436813.336839-slack-CRWCHQGUB

## Proposed Changes

This PR actually allow the Tracks events around hosting feature upsells in Dashboard v1 to fire, by providing the required `analyticsClient`.

It was missed in the first implementation.

|Action|Event|
|-|-|
|Impression<br><br><img width="450"  alt="image" src="https://github.com/user-attachments/assets/1ba6ff71-30b7-47e6-a66a-936b7122b433" />|<img width="466" height="194" alt="image" src="https://github.com/user-attachments/assets/d04a83e4-7a2a-4405-9c11-abd1a4ecef1c" />|
|Click CTA<br><br><img width="450" alt="image" src="https://github.com/user-attachments/assets/46280d4f-5311-47a1-9922-e7ba53e33c2d" />|<img width="498" height="199" alt="image" src="https://github.com/user-attachments/assets/c863e5c0-c0af-44c2-bb35-692295025b9c" />|



## Testing Instructions

1. Prepare a Simple site.
2. Go to `/sites/:siteSlug`.
3. Click Monitoring (or any other hosting feature tab).
4. Verify you see the callout and the impression event as shown above.
5. Click the CTA button.
6. Verify you see the click event as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?