### PR TITLE
A4A > Licenses: Update the buttons' position on the cancel license feedback modal & disabled button colors

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -214,22 +214,22 @@ const CancelLicenseFeedbackModal = ( {
 			extraActions={
 				<>
 					<Button
+						onClick={ onSpeakWithManager }
+						variant="secondary"
+						disabled={ isFetchingScheduleCallLink }
+						isBusy={ isFetchingScheduleCallLink }
+					>
+						{ translate( 'Speak with my Partner Manager' ) }
+					</Button>
+					<Button
 						isDestructive
 						onClick={ handleOnCancel }
-						variant="secondary"
+						variant="primary"
 						disabled={ isLoading || ( suggestion && ! suggestions.length ) }
 						isBusy={ isLoading }
 					>
 						{ translate( 'Cancel license' ) }
 						{ isAtomicSite && <Icon icon={ external } size={ 18 } /> }
-					</Button>
-					<Button
-						onClick={ onSpeakWithManager }
-						variant="primary"
-						disabled={ isFetchingScheduleCallLink }
-						isBusy={ isFetchingScheduleCallLink }
-					>
-						{ translate( 'Speak with my Partner Manager' ) }
 					</Button>
 				</>
 			}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -128,7 +128,9 @@
 	}
 
 	.components-button.is-primary:disabled {
-		background-color: var(--color-primary-50);
+		&:hover {
+			background-color: var(--color-accent-5);
+		}
 	}
 
 	.components-button.is-link {
@@ -181,13 +183,15 @@
 
 	.components-button.is-primary.is-destructive,
 	.button.is-primary.is-scary {
-		background-color: var(--color-scary-50);
-		color: var(--color-text-inverted);
-
-		&:hover,
-		&:focus-visible {
-			background-color: var(--color-scary-60);
+		&:not(:disabled) {
+			background-color: var(--color-scary-50);
 			color: var(--color-text-inverted);
+
+			&:hover,
+			&:focus-visible {
+				background-color: var(--color-scary-60);
+				color: var(--color-text-inverted);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1569/make-speak-to-my-partner-manager-a-secondary-button-and-switch

## Proposed Changes

This PR 
- Updates the buttons' position on the cancel license feedback modal.
- Fixes the disabled button colors 

## Why are these changes being made?

* As legal thinks this is like a dark pattern: pfk7UV-2jf-p2#comment-3816, we are switching buttons' placement

## Testing Instructions

* Open the A4A live link
* Go to Purchases: Licenses > Revoke any license
* Verify the buttons are interchanged now

Before:

<img width="788" height="645" alt="Screenshot 2025-10-15 at 12 37 38 PM" src="https://github.com/user-attachments/assets/39dcbe21-332e-4cc0-9250-091dd216816a" />

After:

<img width="788" height="645" alt="Screenshot 2025-10-15 at 12 52 56 PM" src="https://github.com/user-attachments/assets/e0450ed8-41f7-45a5-9f4d-18edf1ad0b2f" />

<img width="788" height="645" alt="Screenshot 2025-10-15 at 12 53 03 PM" src="https://github.com/user-attachments/assets/6ad3c64a-c6f8-4b1e-86ea-f67cff297628" />

* Go to WooPayments: Dashboard: Click the "Add WooPayments to site" button > Verify the disabled state is updated

<img width="788" height="645" alt="Screenshot 2025-10-15 at 12 56 39 PM" src="https://github.com/user-attachments/assets/7930053b-e084-4487-8805-630a8659202e" />

<img width="788" height="645" alt="Screenshot 2025-10-15 at 12 56 59 PM" src="https://github.com/user-attachments/assets/eb8f668e-1f1a-4202-9cf1-882d43ce7b59" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?