### PR TITLE
Hosting Dashboard Emails: Improved Dataview padding

### DIFF
--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -101,23 +101,21 @@ function Emails() {
 	return (
 		<PageLayout header={ <PageHeader /> } notices={ <OptInWelcome tracksContext="emails" /> }>
 			<DataViewsCard>
-				<div className="emails__dataviews">
-					<DataViews
-						data={ filteredData }
-						isLoading={ isLoadingDomains || isLoadingMailboxes }
-						fields={ emailFields }
-						view={ view }
-						onChangeView={ onChangeView }
-						selection={ selection.map( ( item ) => item.id ) }
-						onChangeSelection={ ( ids ) =>
-							setSelection( emails.filter( ( email ) => ids.includes( email.id ) ) )
-						}
-						actions={ actions }
-						defaultLayouts={ { table: {} } }
-						paginationInfo={ paginationInfo }
-						empty={ emptyState }
-					/>
-				</div>
+				<DataViews
+					data={ filteredData }
+					isLoading={ isLoadingDomains || isLoadingMailboxes }
+					fields={ emailFields }
+					view={ view }
+					onChangeView={ onChangeView }
+					selection={ selection.map( ( item ) => item.id ) }
+					onChangeSelection={ ( ids ) =>
+						setSelection( emails.filter( ( email ) => ids.includes( email.id ) ) )
+					}
+					actions={ actions }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ paginationInfo }
+					empty={ emptyState }
+				/>
 			</DataViewsCard>
 		</PageLayout>
 	);

--- a/client/dashboard/emails/style.scss
+++ b/client/dashboard/emails/style.scss
@@ -1,32 +1,30 @@
-.emails__dataviews {
-	.email-redirect-field {
-		gap: 1px;
-	}
+.email-redirect-field {
+	gap: 1px;
+}
 
-	.email-icon-wrapper {
-		border: 1px solid var(--color-border, #ddd);
-		border-radius: 4px;
-		width: 36px;
-		height: 36px;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		overflow: hidden;
-	}
+.email-icon-wrapper {
+	border: 1px solid var(--color-border, #ddd);
+	border-radius: 4px;
+	width: 36px;
+	height: 36px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+}
 
-	.professional-email-icon {
-		stroke: none;
-		fill: var(--wp-admin-theme-color);
-	}
+.professional-email-icon {
+	stroke: none;
+	fill: var(--wp-admin-theme-color);
+}
 
-	.email-forwarder-icon {
-		stroke: none;
-		fill: #959595;
-	}
+.email-forwarder-icon {
+	stroke: none;
+	fill: #959595;
+}
 
-	.mailbox--icon {
-		width: 16px;
-	}
+.mailbox--icon {
+	width: 16px;
 }
 
 .add-forwarder__back-button {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-651/padding-in-email-dataview-appears-incorrect

## Proposed Changes

* Removed a div that was causing a style to not be applied (the style that removes the padding)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to Emails
* The Dataview padding should be the same as the other Dataviews.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
