### PR TITLE
Hosting Dashboard: Replace more back buttons with breadcrumbs

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -135,24 +135,6 @@ export const billingHistoryRoute = createRoute( {
 	)
 );
 
-export const changePaymentMethodRoute = createRoute( {
-	head: () => ( {
-		meta: [
-			{
-				title: __( 'Change payment method' ),
-			},
-		],
-	} ),
-	getParentRoute: () => billingRoute,
-	path: '/purchases/$purchaseId/payment-method/change',
-} ).lazy( () =>
-	import( '../../me/billing-purchases/change-payment-method' ).then( ( d ) =>
-		createLazyRoute( 'purchases-purchase-settings-change-payment-method' )( {
-			component: d.default,
-		} )
-	)
-);
-
 export const purchasesRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -203,9 +185,32 @@ export const purchaseSettingsRoute = createRoute( {
 		};
 	},
 	path: '$purchaseId',
+} );
+
+export const purchaseSettingsIndexRoute = createRoute( {
+	getParentRoute: () => purchaseSettingsRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../me/billing-purchases/purchase-settings' ).then( ( d ) =>
 		createLazyRoute( 'purchases-purchase-settings' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const changePaymentMethodRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Change payment method' ),
+			},
+		],
+	} ),
+	getParentRoute: () => purchaseSettingsRoute,
+	path: 'payment-method/change',
+} ).lazy( () =>
+	import( '../../me/billing-purchases/change-payment-method' ).then( ( d ) =>
+		createLazyRoute( 'purchases-purchase-settings-change-payment-method' )( {
 			component: d.default,
 		} )
 	)
@@ -688,8 +693,13 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				monetizeSubscriptionsIndexRoute,
 				monetizeSubscriptionRoute,
 			] ),
-			purchasesRoute.addChildren( [ purchasesIndexRoute, purchaseSettingsRoute ] ),
-			changePaymentMethodRoute,
+			purchasesRoute.addChildren( [
+				purchasesIndexRoute,
+				purchaseSettingsRoute.addChildren( [
+					purchaseSettingsIndexRoute,
+					changePaymentMethodRoute,
+				] ),
+			] ),
 			paymentMethodsRoute,
 			taxDetailsRoute,
 		] )

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -411,7 +411,7 @@ export const siteBackupsIndexRoute = createRoute( {
 	path: '/',
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>
-		createLazyRoute( 'site-backups-index' )( {
+		createLazyRoute( 'site-backups' )( {
 			component: d.BackupsListPage,
 		} )
 	)
@@ -434,7 +434,7 @@ export const siteBackupDetailIndexRoute = createRoute( {
 	path: '/',
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>
-		createLazyRoute( 'site-backup-detail-index' )( {
+		createLazyRoute( 'site-backup-detail' )( {
 			component: d.BackupsListPage,
 		} )
 	)

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -411,7 +411,7 @@ export const siteBackupsIndexRoute = createRoute( {
 	path: '/',
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>
-		createLazyRoute( 'site-backups' )( {
+		createLazyRoute( 'site-backups-index' )( {
 			component: d.BackupsListPage,
 		} )
 	)

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -418,11 +418,23 @@ export const siteBackupsIndexRoute = createRoute( {
 );
 
 export const siteBackupDetailRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Backups' ),
+			},
+		],
+	} ),
 	getParentRoute: () => siteBackupsRoute,
 	path: '$rewindId',
+} );
+
+export const siteBackupDetailIndexRoute = createRoute( {
+	getParentRoute: () => siteBackupDetailRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>
-		createLazyRoute( 'site-backup-detail' )( {
+		createLazyRoute( 'site-backup-detail-index' )( {
 			component: d.BackupsListPage,
 		} )
 	)
@@ -436,8 +448,8 @@ export const siteBackupRestoreRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => siteBackupsRoute,
-	path: '$rewindId/restore',
+	getParentRoute: () => siteBackupDetailRoute,
+	path: 'restore',
 } ).lazy( () =>
 	import( '../../sites/backup-restore' ).then( ( d ) =>
 		createLazyRoute( 'site-backup-restore' )( {
@@ -450,12 +462,12 @@ export const siteBackupDownloadRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Sites' ),
+				title: __( 'Download backup' ),
 			},
 		],
 	} ),
-	getParentRoute: () => siteBackupsRoute,
-	path: '$rewindId/download',
+	getParentRoute: () => siteBackupDetailRoute,
+	path: 'download',
 	validateSearch: ( search ) => {
 		const downloadId = Number( search.downloadId );
 		return {
@@ -1131,10 +1143,12 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 	if ( config.supports.sites.backups ) {
 		siteRoutes.push(
 			siteBackupsRoute.addChildren( [
-				siteBackupDetailRoute,
 				siteBackupsIndexRoute,
-				siteBackupRestoreRoute,
-				siteBackupDownloadRoute,
+				siteBackupDetailRoute.addChildren( [
+					siteBackupDetailIndexRoute,
+					siteBackupRestoreRoute,
+					siteBackupDownloadRoute,
+				] ),
 			] )
 		);
 	}

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -5,14 +5,6 @@
 	position: relative;
 	z-index: 1;
 
-	.components-button.dashboard-page-header__back-button {
-		padding-inline: 0;
-
-		svg {
-			margin-inline: -4px;
-		}
-	}
-
 	.dashboard-section-header__heading-row {
 		min-height: 32px;
 	}

--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -9,38 +9,19 @@ import {
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useRouter, useNavigate } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useNavigate } from '@tanstack/react-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useCallback } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { changePaymentMethodRoute } from '../../app/router/me';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { PaymentMethodSelector } from './payment-method-selector';
 import { useCreateAssignablePaymentMethods } from './payment-method-selector/use-create-assignable-payment-methods';
 import { getPurchaseUrl } from './urls';
-import type { Purchase } from '@automattic/api-core';
 
 import './style.scss';
-
-function BackButton( { purchase }: { purchase: Purchase } ) {
-	const router = useRouter();
-
-	return (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				router.navigate( {
-					to: getPurchaseUrl( purchase ),
-				} );
-			} }
-		>
-			{ __( 'Cancel' ) }
-		</Button>
-	);
-}
 
 function ChangePaymentMethod() {
 	const { purchaseId } = changePaymentMethodRoute.useParams();
@@ -81,7 +62,7 @@ function ChangePaymentMethod() {
 			size="small"
 			header={
 				<PageHeader
-					prefix={ <BackButton purchase={ purchase } /> }
+					prefix={ <Breadcrumbs length={ 4 } /> }
 					title={
 						! purchase.payment_type || purchase.payment_type === 'credits'
 							? __( 'Add payment method' )

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -152,13 +152,13 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 					<Text size={ 14 } weight={ 500 }>
 						{ backup.content.text }
 					</Text>
-					<HStack alignment="left" spacing={ 4 }>
+					<HStack alignment="left" spacing={ 1 }>
 						<Text variant="muted">{ formattedTime }</Text>
 						{ backup.actor?.name && (
 							<Text variant="muted">
 								{
 									/* translators: %s is the name of the person/system who performed the backup */
-									sprintf( __( 'By %s' ), backup.actor.name )
+									sprintf( __( 'by %s' ), backup.actor.name )
 								}
 							</Text>
 						) }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -2,14 +2,15 @@ import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, useParams, useRouter } from '@tanstack/react-router';
-import { __experimentalGrid as Grid, Button } from '@wordpress/components';
+import { __experimentalGrid as Grid } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { __, isRTL } from '@wordpress/i18n';
-import { backup, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { backup } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect, useCallback } from 'react';
 import { FileBrowserProvider } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { useDateRange } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
 import { siteRoute, siteBackupsIndexRoute, siteBackupDetailRoute } from '../../app/router/sites';
@@ -127,7 +128,7 @@ export function BackupsListPage() {
 		handleDateRangeChange( next );
 		setSelectedBackup( null, false );
 	};
-	const [ showDetails, setShowDetails ] = useState( false );
+	const [ showDetails, setShowDetails ] = useState( Boolean( rewindId ) );
 	const columns = isSmallViewport ? 1 : 2;
 
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
@@ -138,19 +139,6 @@ export function BackupsListPage() {
 			setShowDetails( true );
 		}
 	};
-
-	const backButton = (
-		<Button
-			className="dashboard-page-header__back-button"
-			icon={ isRTL() ? chevronRight : chevronLeft }
-			onClick={ () => {
-				setShowDetails( false );
-				setSelectedBackup( null );
-			} }
-		>
-			{ __( 'Backups' ) }
-		</Button>
-	);
 
 	const renderMobileView = () => {
 		if ( showDetails && selectedBackup ) {
@@ -203,7 +191,7 @@ export function BackupsListPage() {
 			header={
 				<PageHeader
 					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
-					prefix={ isMobileDetailsView ? backButton : undefined }
+					prefix={ isMobileDetailsView && rewindId ? <Breadcrumbs length={ 2 } /> : undefined }
 					actions={ shouldShowActions ? actions : undefined }
 				/>
 			}

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -19,6 +19,10 @@ jest.mock( '../../../app/auth', () => ( {
 	} ),
 } ) );
 
+jest.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: jest.fn(),
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: jest.fn(),


### PR DESCRIPTION
## Proposed Changes

This PR replaces the remaining back buttons with breadcrumbs, that is:

* /purchases/$purchaseId/payment-method/change

<img width="1686" height="1124" alt="SCR-20251015-onmg" src="https://github.com/user-attachments/assets/501fd8aa-2ddb-40d3-8fd7-c296c512611c" />

* /sites/$siteSlug/backups/$rewindId

<img width="1686" height="949" alt="SCR-20251015-onum" src="https://github.com/user-attachments/assets/130f0fec-a969-4111-928b-1332594b9146" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Use breadcrumbs in all instances.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test that breadcrumbs in the screens above work as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
