### PR TITLE
Reblogs: remove extra redirect logic, we only have 1 editor now

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -3,7 +3,6 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { stopEditingPost } from 'calypso/state/editor/actions';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -34,20 +33,13 @@ function getPostID( context ) {
 	return parseInt( context.params.post, 10 );
 }
 
-export const redirect = async ( context, next ) => {
+export const redirect = async ( context ) => {
 	const {
 		store: { getState },
 	} = context;
 
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
-	const isPostShare = context.query.is_post_share; // Added here https://github.com/Automattic/wp-calypso/blob/4b5fdb65b115e02baf743d2487eeca94fbd28a18/client/blocks/reader-share/index.jsx#L74
-
-	// Force load Gutenframe when choosing to share a post to a Simple site.
-	if ( isPostShare && isPostShare === 'true' && ! isAtomicSite( state, siteId ) ) {
-		return next();
-	}
-
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
 


### PR DESCRIPTION
Fixes CML-955

## Proposed Changes, why are these changes being made?

This needs to be updated following the changes in #106181.

## Testing Instructions

* Load http://calypso.localhost:3000/reader/feeds/160392520/posts/5833700728
* Click on the "Repost" button
* Attempt to repost to simple, WoA, and self-hosted sites
* You should get redirect to the wp-admin editor every time.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
