### PR TITLE
Switch to the new all-domains endpoint for all domains lists in the Hosting Dashboard

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -1,4 +1,4 @@
-import { SiteDomain } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import {
 	queryClient,
 	rawUserPreferencesQuery,
@@ -35,7 +35,7 @@ export const emailsRoute = createRoute( {
 		);
 
 		// 3) From those domains, identify ones with email capability and preload their mailboxes
-		const allDomains = domainsArrays.flat().filter( ( d: SiteDomain ) => d && ! d.wpcom_domain );
+		const allDomains = domainsArrays.flat().filter( ( d: Domain ) => ! d?.wpcom_domain );
 		const domainsWithEmails = allDomains.filter( ( d ) => domainHasEmail( d ) );
 
 		await Promise.all( [

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -1,4 +1,4 @@
-import { Domain } from '@automattic/api-core';
+import { Domain, DomainSubtype } from '@automattic/api-core';
 import {
 	queryClient,
 	rawUserPreferencesQuery,
@@ -35,7 +35,9 @@ export const emailsRoute = createRoute( {
 		);
 
 		// 3) From those domains, identify ones with email capability and preload their mailboxes
-		const allDomains = domainsArrays.flat().filter( ( d: Domain ) => ! d?.wpcom_domain );
+		const allDomains = domainsArrays
+			.flat()
+			.filter( ( d: Domain ) => d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
 		const domainsWithEmails = allDomains.filter( ( d ) => domainHasEmail( d ) );
 
 		await Promise.all( [

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -135,7 +135,8 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return (
-						item.current_user_is_owner && item.subtype.id === DomainSubtype.DOMAIN_REGISTRATION
+						item.current_user_is_owner === true &&
+						item.subtype.id === DomainSubtype.DOMAIN_REGISTRATION
 					);
 				},
 			},

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,4 +1,4 @@
-import { DomainTransferStatus, DomainSubtype } from '@automattic/api-core';
+import { DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -17,14 +17,7 @@ import {
 	domainTransferToAnyUserRoute,
 	domainTransferToOtherSiteRoute,
 } from '../../app/router/domains';
-import {
-	isRecentlyRegistered,
-	isDomainRenewable,
-	isDomainUpdatable,
-	isDomainInGracePeriod,
-	canSetAsPrimary,
-	getDomainRenewalUrl,
-} from '../../utils/domain';
+import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import type { DomainSummary, Site, User } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -53,7 +46,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 					const purchase = purchases?.find(
-						( p ) => p.ID === parseInt( domain.subscription_id, 10 )
+						( p ) => p.ID === parseInt( domain.subscription_id ?? '0', 10 )
 					);
 
 					if ( ! purchase ) {
@@ -80,7 +73,8 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					} );
 				},
 				isEligible: ( item: DomainSummary ) =>
-					item.subtype.id === DomainSubtype.DOMAIN_CONNECTION && ! item.points_to_wpcom,
+					item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
+					item.domain_status.id === 'connection_error',
 			},
 			{
 				id: 'manage-domain',
@@ -120,10 +114,8 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
-					return (
-						item.can_manage_dns_records &&
-						item.transfer_status !== DomainTransferStatus.PENDING_ASYNC &&
-						item.subtype.id !== DomainSubtype.SITE_REDIRECT
+					return [ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
+						item.subtype.id
 					);
 				},
 			},
@@ -143,11 +135,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return (
-						!! item.current_user_is_owner &&
-						item.can_update_contact_info &&
-						! item.wpcom_domain &&
-						item.has_registration &&
-						( isDomainUpdatable( item ) || isDomainInGracePeriod( item ) )
+						item.current_user_is_owner && item.subtype.id === DomainSubtype.DOMAIN_REGISTRATION
 					);
 				},
 			},
@@ -188,11 +176,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					);
 				},
 				isEligible: ( item: DomainSummary ) => {
-					return (
-						!! site &&
-						canSetAsPrimary( { domain: item, site, user } ) &&
-						! isRecentlyRegistered( item.registration_date )
-					);
+					return !! site && canSetAsPrimary( { domain: item, site, user } );
 				},
 				disabled: setPrimaryDomainMutation.isPending,
 			},

--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -22,7 +22,7 @@ export const DomainExpiryField = ( {
 
 	const isAutoRenewing = Boolean( domain.auto_renewing );
 	const isExpired = new Date( domain.expiry ) < new Date();
-	const isHundredYearDomain = Boolean( domain.is_hundred_year_domain );
+	const isHundredYearDomain = Boolean( domain.tags.includes( 'hundred_year_domain' ) );
 	const renderExpiry = () => {
 		if ( isHundredYearDomain ) {
 			return sprintf(

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -156,7 +156,11 @@ export const useFields = ( {
 				render: ( { item } ) => {
 					// Site Overview does not show the Status column, so we use this column for error messages.
 					// TODO: move this inside the DomainExpiryField component?
-					if ( inOverview ) {
+					if (
+						inOverview &&
+						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
+						item.domain_status.id === 'connection_error'
+					) {
 						return <Text intent={ item.domain_status.type }>{ item.domain_status.label }</Text>;
 					}
 

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -5,7 +5,6 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { Text } from '../../components/text';
-import { isRecentlyRegistered } from '../../utils/domain';
 import { DomainNameField } from './field-domain-name';
 import { DomainSiteField } from './field-domain-site';
 import { DomainExpiryField } from './field-expiry';
@@ -13,7 +12,6 @@ import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
-const THREE_DAYS_IN_MINUTES = 3 * 1440;
 
 export const useFields = ( {
 	site,
@@ -78,7 +76,7 @@ export const useFields = ( {
 					field.getValue( { item } ) ? <Text>{ __( 'Primary' ) }</Text> : <IneligibleIndicator />,
 			},
 			{
-				id: 'type',
+				id: 'subtype',
 				label: __( 'Type' ),
 				enableHiding: false,
 				enableSorting: false,
@@ -86,11 +84,12 @@ export const useFields = ( {
 					{ value: DomainSubtype.DOMAIN_REGISTRATION, label: __( 'Domain name registration' ) },
 					{ value: DomainSubtype.DOMAIN_TRANSFER, label: __( 'Domain name transfer' ) },
 					{ value: DomainSubtype.DOMAIN_CONNECTION, label: __( 'Domain name connection' ) },
+					{ value: DomainSubtype.DEFAULT_ADDRESS, label: __( 'Default site address' ) },
 				],
 				filterBy: {
 					operators: [ 'isAny' as Operator ],
 				},
-				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.id ?? '',
+				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.id,
 			},
 			// {
 			// 	id: 'owner',
@@ -157,14 +156,8 @@ export const useFields = ( {
 				render: ( { item } ) => {
 					// Site Overview does not show the Status column, so we use this column for error messages.
 					// TODO: move this inside the DomainExpiryField component?
-					if (
-						inOverview &&
-						site &&
-						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
-						! item.points_to_wpcom &&
-						! isRecentlyRegistered( item.registration_date, THREE_DAYS_IN_MINUTES )
-					) {
-						return <Text intent="error">{ __( 'Connection error' ) }</Text>;
+					if ( inOverview ) {
+						return <Text intent={ item.domain_status.type }>{ item.domain_status.label }</Text>;
 					}
 
 					return (
@@ -189,9 +182,9 @@ export const useFields = ( {
 				filterBy: {
 					operators: [ 'isAny' as Operator ],
 				},
-				getValue: ( { item } ) => item.domain_status?.status_type,
+				getValue: ( { item } ) => item.domain_status.label,
 				render: ( { item } ) => {
-					return item.domain_status?.status || <IneligibleIndicator />;
+					return <Text intent={ item.domain_status.type }>{ item.domain_status.label }</Text>;
 				},
 			},
 		],

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -40,7 +40,7 @@ export default function Actions() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: purchase } = useQuery(
-		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
+		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
 	const { mutate: disconnectDomain, isPending: isDisconnecting } = useMutation(
 		disconnectDomainMutation( domainName )

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -15,7 +15,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 	const locale = useLocale();
 	const date = domain.auto_renewing ? domain.auto_renewal_date : domain.expiry;
 
-	if ( ! date ) {
+	if ( ! date || domain.subscription_id === null ) {
 		return null;
 	}
 

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -23,7 +23,7 @@ export default function DomainOverview() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: purchase } = useSuspenseQuery(
-		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id, 10 ) )
+		sitePurchaseQuery( domain.blog_id, parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
 
 	const wrappableDomainName = useMemo( () => {

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -24,7 +24,6 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 		domain_status: { status: 'active' },
 		expired: false,
 		expiry: false,
-		has_registration: true,
 		is_dnssec_enabled: false,
 		is_dnssec_supported: true,
 		is_eligible_for_inbound_transfer: false,

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -44,7 +44,6 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 		registration_date: '2023-01-01',
 		subscription_id: 'sub123',
 		transfer_status: null,
-		type: 'wpcom',
 		wpcom_domain: true,
 		subtype: {
 			id: DomainSubtype.DOMAIN_REGISTRATION,

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -24,6 +25,17 @@ function Domains() {
 	const [ view, setView ] = useState< DomainsView >( () => ( {
 		...DEFAULT_VIEW,
 		type: 'table',
+		filters: [
+			{
+				field: 'subtype',
+				operator: 'isAny',
+				value: [
+					DomainSubtype.DOMAIN_REGISTRATION,
+					DomainSubtype.DOMAIN_TRANSFER,
+					DomainSubtype.DOMAIN_CONNECTION,
+				],
+			},
+		],
 	} ) );
 
 	const { data: domains, isLoading } = useQuery( domainsQuery() );

--- a/client/dashboard/domains/name-servers/utils.ts
+++ b/client/dashboard/domains/name-servers/utils.ts
@@ -15,11 +15,8 @@ export const shouldShowUpsellNudge = ( user: User, domain: Domain, site?: Site )
 		! user.meta.data.flags.active_flags.includes(
 			'calypso_allow_nonprimary_domains_without_plan'
 		) ||
-		! domain.points_to_wpcom ||
-		domain.wpcom_domain ||
 		domain.primary_domain ||
-		domain.is_domain_only_site ||
-		domain.is_wpcom_staging_domain
+		domain.is_domain_only_site
 	) {
 		return false;
 	}

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -1,4 +1,4 @@
-import { SiteDomain } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
@@ -37,12 +37,12 @@ export default function ChooseDomain() {
 	const filteredRemaining = useMemo( () => {
 		const q = search.trim().toLowerCase();
 		if ( ! q ) {
-			return [] as SiteDomain[];
+			return [] as Domain[];
 		}
 		return eligibleDomains.filter( ( d ) => d.domain.toLowerCase().includes( q ) );
 	}, [ eligibleDomains, search ] );
 
-	const handleDomainClick = ( d: SiteDomain ) => {
+	const handleDomainClick = ( d: Domain ) => {
 		router.navigate( {
 			to: chooseEmailSolutionRoute.to,
 			params: { domain: d.domain },
@@ -95,7 +95,7 @@ export default function ChooseDomain() {
 								) ) }
 							{ remaining.length > 0 &&
 								search.trim() &&
-								filteredRemaining.map( ( d: SiteDomain ) => (
+								filteredRemaining.map( ( d: Domain ) => (
 									<Item key={ d.blog_id + '-' + d.domain } onClick={ () => handleDomainClick( d ) }>
 										<HStack justify="flex-start">
 											<FlexBlock>{ d.domain }</FlexBlock>

--- a/client/dashboard/emails/fields/domain-name.ts
+++ b/client/dashboard/emails/fields/domain-name.ts
@@ -1,9 +1,9 @@
-import { SiteDomain } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import type { Email } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const getDomainNameField = ( domains: SiteDomain[] ): Field< Email > => ( {
+export const getDomainNameField = ( domains: Domain[] ): Field< Email > => ( {
 	id: 'domainName',
 	label: __( 'Domain' ),
 	getValue: ( { item }: { item: Email } ) => item.domainName,

--- a/client/dashboard/emails/fields/index.ts
+++ b/client/dashboard/emails/fields/index.ts
@@ -1,4 +1,4 @@
-import { SiteDomain } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import { getDomainNameField } from './domain-name';
 import { emailAddressField } from './email-address';
 import { statusField } from './status';
@@ -6,7 +6,7 @@ import { typeField } from './type';
 import type { Email } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const getEmailFields = ( domains: SiteDomain[] ): Field< Email >[] => [
+export const getEmailFields = ( domains: Domain[] ): Field< Email >[] => [
 	emailAddressField,
 	getDomainNameField( domains ),
 	typeField,

--- a/client/dashboard/emails/hooks/use-domains.ts
+++ b/client/dashboard/emails/hooks/use-domains.ts
@@ -1,9 +1,9 @@
-import { SiteDomain } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import { siteDomainsQuery, sitesQuery } from '@automattic/api-queries';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 
-export const useDomains = (): { domains: SiteDomain[]; isLoading: boolean } => {
+export const useDomains = (): { domains: Domain[]; isLoading: boolean } => {
 	const { data: allSites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
 	const sites = ( allSites ?? [] )
 		.filter( ( site ) => {
@@ -25,7 +25,7 @@ export const useDomains = (): { domains: SiteDomain[]; isLoading: boolean } => {
 	} );
 
 	// Aggregate all domains into a single array
-	const domains = domainsQueries.flatMap( ( q ) => ( q.data as SiteDomain[] ) ?? [] );
+	const domains = domainsQueries.flatMap( ( q ) => ( q.data as Domain[] ) ?? [] );
 
 	return {
 		domains,

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -1,4 +1,4 @@
-import { EmailAccount, EmailBox, SiteDomain, DomainSubtype } from '@automattic/api-core';
+import { EmailAccount, EmailBox, Domain, DomainSubtype } from '@automattic/api-core';
 import { mailboxAccountsQuery } from '@automattic/api-queries';
 import { useQueries } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -33,16 +33,16 @@ function Emails() {
 			( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 		);
 
-		const domainsWithEmails = nonWpcomDomains.filter( domainHasEmail ) as SiteDomain[];
+		const domainsWithEmails = nonWpcomDomains.filter( domainHasEmail ) as Domain[];
 		const domainsWithoutEmails = nonWpcomDomains.filter(
 			( domain ) => ! domainHasEmail( domain )
-		) as SiteDomain[];
+		) as Domain[];
 
 		return { domainsWithEmails, domainsWithoutEmails };
 	}, [ domains, isLoadingDomains ] );
 
 	const mailboxQueries = useQueries( {
-		queries: domainsWithEmails.map( ( domain: SiteDomain ) =>
+		queries: domainsWithEmails.map( ( domain: Domain ) =>
 			mailboxAccountsQuery( domain.blog_id, domain.domain )
 		),
 	} );

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -1,4 +1,4 @@
-import { EmailAccount, EmailBox, SiteDomain } from '@automattic/api-core';
+import { EmailAccount, EmailBox, SiteDomain, DomainSubtype } from '@automattic/api-core';
 import { mailboxAccountsQuery } from '@automattic/api-queries';
 import { useQueries } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -29,7 +29,9 @@ function Emails() {
 		}
 
 		// We filter the same way v1 does.
-		const nonWpcomDomains = domains.filter( ( domain ) => ! domain.wpcom_domain );
+		const nonWpcomDomains = domains.filter(
+			( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
+		);
 
 		const domainsWithEmails = nonWpcomDomains.filter( domainHasEmail ) as SiteDomain[];
 		const domainsWithoutEmails = nonWpcomDomains.filter(

--- a/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
+++ b/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
@@ -1,4 +1,4 @@
-import { EmailAccount, EmailBox, SiteDomain } from '@automattic/api-core';
+import { EmailAccount, EmailBox, Domain } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { accountHasWarningWithSlug } from '../../utils/email-utils';
 import type { Email } from '../types';
@@ -6,7 +6,7 @@ import type { Email } from '../types';
 export const mapMailboxToEmail = (
 	box: EmailBox,
 	emailAccount: EmailAccount,
-	domain: SiteDomain
+	domain: Domain
 ): Email => {
 	const provider = emailAccount.account_type;
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -9,7 +9,7 @@ import {
 	DomainTransferStatus,
 } from '@automattic/api-core';
 import {
-	domainsQuery,
+	domainQuery,
 	purchaseQuery,
 	userPurchaseSetAutoRenewQuery,
 	siteDifmWebsiteContentQuery,
@@ -809,11 +809,13 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 
 function DomainTransferInfo( { purchase }: { purchase: Purchase } ) {
 	const locale = useLocale();
-	const domains = useQuery( domainsQuery() ).data;
+	const { data: domain } = useQuery( {
+		...domainQuery( purchase?.meta ?? '' ),
+		enabled: Boolean( purchase.meta ),
+	} );
 	if ( purchase.product_slug !== DomainProductSlugs.TRANSFER_IN ) {
 		return null;
 	}
-	const domain = domains?.find( ( domain ) => domain.domain === purchase.meta );
 	if ( ! domain ) {
 		return null;
 	}

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,4 +1,4 @@
-import { siteDomainsQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, domainsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -23,14 +23,9 @@ function SiteDomains() {
 	const { user } = useAuth();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: siteDomains, isLoading } = useQuery( {
-		...siteDomainsQuery( site.ID ),
+		...domainsQuery(),
 		select: ( data ) => {
-			// If the site has *.wpcomstaging.com domain, exclude *.wordpress.com
-			if ( data && data.find( ( domain ) => domain.is_wpcom_staging_domain ) ) {
-				return data.filter( ( domain ) => ! domain.wpcom_domain || domain.is_wpcom_staging_domain );
-			}
-
-			return data;
+			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},
 	} );
 

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -12,9 +12,9 @@ import { AddDomainButton } from '../../domains/add-domain-button';
 import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
 import PrimaryDomainSelector from './primary-domain-selector';
 import type { DomainsView } from '../../domains/dataviews';
-import type { SiteDomain } from '@automattic/api-core';
+import type { DomainSummary } from '@automattic/api-core';
 
-function getDomainId( domain: SiteDomain ) {
+function getDomainId( domain: DomainSummary ) {
 	return `${ domain.domain }-${ domain.blog_id }`;
 }
 
@@ -59,7 +59,7 @@ function SiteDomains() {
 				<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />
 			) }
 			<DataViewsCard>
-				<DataViews< SiteDomain >
+				<DataViews< DomainSummary >
 					data={ filteredData || [] }
 					fields={ fields }
 					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -1,4 +1,4 @@
-import { type SiteDomain, type Site, type User, DomainSubtype } from '@automattic/api-core';
+import { type DomainSummary, type Site, type User, DomainSubtype } from '@automattic/api-core';
 import { siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
@@ -19,7 +19,7 @@ import { userHasFlag } from '../../utils/user';
 import type { Field } from '@wordpress/dataviews';
 
 interface PrimaryDomainSelectorProps {
-	domains: SiteDomain[];
+	domains: DomainSummary[];
 	site: Site;
 	user: User;
 }
@@ -41,23 +41,17 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		if ( ! domains || ! site ) {
 			return [];
 		}
-		const hasWpcomStagingDomain = domains.find( ( domain ) => domain.is_wpcom_staging_domain );
 		return domains.filter( ( domain ) => {
 			// Basic eligibility criteria
 			const isEligible =
 				( domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION ||
-					domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) &&
+					domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
+					domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) &&
 				domain.can_set_as_primary &&
-				! domain.primary_domain &&
-				! domain.aftermarket_auction;
+				! domain.primary_domain;
 
 			if ( ! isEligible ) {
 				return false;
-			}
-
-			// Additional filtering for wpcom staging domains
-			if ( hasWpcomStagingDomain && domain.wpcom_domain ) {
-				return domain.is_wpcom_staging_domain;
 			}
 
 			return true;

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,10 +1,11 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
 import DomainUpsellCard from '../overview-domain-upsell-card';
-import type { Site, DomainSubtype } from '@automattic/api-core';
+import type { Site } from '@automattic/api-core';
 
 export default function DomainsCard( { site }: { site: Site } ) {
 	const { data: siteDomains } = useQuery( {

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,4 +1,4 @@
-import { siteDomainsQuery } from '@automattic/api-queries';
+import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -8,14 +8,9 @@ import type { Site } from '@automattic/api-core';
 
 export default function DomainsCard( { site }: { site: Site } ) {
 	const { data: siteDomains } = useQuery( {
-		...siteDomainsQuery( site.ID ),
+		...domainsQuery(),
 		select: ( data ) => {
-			// If the site has *.wpcomstaging.com domain, exclude *.wordpress.com
-			if ( data && data.find( ( domain ) => domain.is_wpcom_staging_domain ) ) {
-				return data.filter( ( domain ) => ! domain.wpcom_domain || domain.is_wpcom_staging_domain );
-			}
-
-			return data;
+			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},
 	} );
 

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -4,7 +4,7 @@ import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
 import DomainUpsellCard from '../overview-domain-upsell-card';
-import type { Site } from '@automattic/api-core';
+import type { Site, DomainSubtype } from '@automattic/api-core';
 
 export default function DomainsCard( { site }: { site: Site } ) {
 	const { data: siteDomains } = useQuery( {
@@ -29,7 +29,7 @@ export default function DomainsCard( { site }: { site: Site } ) {
 		return <DomainTransferUpsellCard />;
 	}
 
-	if ( ! siteDomains.find( ( domain ) => ! domain.wpcom_domain ) ) {
+	if ( ! siteDomains.find( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS ) ) {
 		return <DomainUpsellCard site={ site } />;
 	}
 

--- a/client/dashboard/utils/domain-types.ts
+++ b/client/dashboard/utils/domain-types.ts
@@ -2,7 +2,5 @@ import { DomainSubtype } from '@automattic/api-core';
 import type { SiteDomain } from '@automattic/api-core';
 
 export function isTransferrableToWpcom( domain: SiteDomain ) {
-	return (
-		domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION && domain.is_eligible_for_inbound_transfer
-	);
+	return domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION;
 }

--- a/client/dashboard/utils/domain-types.ts
+++ b/client/dashboard/utils/domain-types.ts
@@ -1,6 +1,6 @@
 import { DomainSubtype } from '@automattic/api-core';
-import type { SiteDomain } from '@automattic/api-core';
+import type { DomainSummary } from '@automattic/api-core';
 
-export function isTransferrableToWpcom( domain: SiteDomain ) {
+export function isTransferrableToWpcom( domain: DomainSummary ) {
 	return domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION;
 }

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -11,7 +11,6 @@ import type {
 	Site,
 	User,
 	WhoisDataEntry,
-	Domain as FullDomain,
 } from '@automattic/api-core';
 
 export function getDomainSiteSlug( domain: DomainSummary ) {
@@ -129,17 +128,17 @@ export function canSetAsPrimary( {
 	);
 }
 
-export function hasGSuiteWithUs( domain: Domain | FullDomain ) {
+export function hasGSuiteWithUs( domain: Domain ) {
 	const status = domain.google_apps_subscription?.status;
 	return !! status && ! [ 'no_subscription', 'other_provider' ].includes( status );
 }
 
-export function hasTitanMailWithUs( domain: Domain | FullDomain ) {
+export function hasTitanMailWithUs( domain: Domain ) {
 	const subscriptionStatus = domain.titan_mail_subscription?.status;
 	return subscriptionStatus === 'active' || subscriptionStatus === 'suspended';
 }
 
-export function hasEmailForwards( domain: Domain | FullDomain ) {
+export function hasEmailForwards( domain: Domain ) {
 	return domain?.email_forwards_count ?? 0;
 }
 

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -102,10 +102,7 @@ export function shouldUpgradeToMakeDomainPrimary( {
 		[ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
 			domain.subtype.id
 		) &&
-		! domain.current_user_can_create_site_from_domain_only &&
 		! domain.primary_domain &&
-		! domain.wpcom_domain &&
-		! domain.is_wpcom_staging_domain &&
 		userHasFlag( user, 'calypso_allow_nonprimary_domains_without_plan' ) &&
 		!! site.plan?.is_free &&
 		! hasPlanFeature( site, DotcomFeatures.SET_PRIMARY_CUSTOM_DOMAIN )
@@ -124,7 +121,6 @@ export function canSetAsPrimary( {
 	return (
 		domain.can_set_as_primary &&
 		! domain.primary_domain &&
-		! domain.aftermarket_auction &&
 		! shouldUpgradeToMakeDomainPrimary( {
 			domain,
 			site,

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -1,4 +1,4 @@
-import { DotcomFeatures, WhoisType, DomainSubtype } from '@automattic/api-core';
+import { DotcomFeatures, WhoisType, DomainSubtype, DomainStatus } from '@automattic/api-core';
 import { addQueryArgs } from '@wordpress/url';
 import { isAfter, subMinutes, subDays } from 'date-fns';
 import { getRenewalUrlFromPurchase } from './purchase';
@@ -46,17 +46,17 @@ export function isDomainRenewable( domain: DomainSummary ) {
 
 	return (
 		!! domain.subscription_id &&
-		! domain.pending_renewal &&
-		! domain.pending_registration_at_registry &&
-		! domain.pending_registration &&
-		domain.current_user_can_manage &&
-		( domain.is_renewable || domain.is_redeemable ) &&
-		! domain.aftermarket_auction
+		! [
+			DomainStatus.PENDING_RENEWAL,
+			DomainStatus.PENDING_TRANSFER,
+			DomainStatus.PENDING_REGISTRATION,
+			DomainStatus.EXPIRED_IN_AUCTION,
+		].includes( domain.domain_status.id )
 	);
 }
 
 export function isDomainUpdatable( domain: DomainSummary ) {
-	return ! domain.pending_transfer && ! domain.expired;
+	return domain.domain_status.id !== DomainStatus.PENDING_TRANSFER && ! domain.expired;
 }
 
 export function isDomainInGracePeriod( domain: DomainSummary ) {

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -6,7 +6,7 @@ import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
 import type {
 	Purchase,
-	SiteDomain,
+	Domain,
 	DomainSummary,
 	Site,
 	User,
@@ -129,21 +129,21 @@ export function canSetAsPrimary( {
 	);
 }
 
-export function hasGSuiteWithUs( domain: SiteDomain | FullDomain ) {
+export function hasGSuiteWithUs( domain: Domain | FullDomain ) {
 	const status = domain.google_apps_subscription?.status;
 	return !! status && ! [ 'no_subscription', 'other_provider' ].includes( status );
 }
 
-export function hasTitanMailWithUs( domain: SiteDomain | FullDomain ) {
+export function hasTitanMailWithUs( domain: Domain | FullDomain ) {
 	const subscriptionStatus = domain.titan_mail_subscription?.status;
 	return subscriptionStatus === 'active' || subscriptionStatus === 'suspended';
 }
 
-export function hasEmailForwards( domain: SiteDomain | FullDomain ) {
+export function hasEmailForwards( domain: Domain | FullDomain ) {
 	return domain?.email_forwards_count ?? 0;
 }
 
-export const domainHasEmail = ( domain: SiteDomain ) =>
+export const domainHasEmail = ( domain: Domain ) =>
 	hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) || hasEmailForwards( domain );
 
 export function findRegistrantWhois( whoisContacts: WhoisDataEntry[] | undefined ) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@automattic/calypso-typescript-config/mixed-package.json",
 	"compilerOptions": {
-		"incremental": true,
 		"rootDir": ".",
 		"noEmit": true,
 		"types": [

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@automattic/calypso-typescript-config/mixed-package.json",
 	"compilerOptions": {
+		"incremental": true,
 		"rootDir": ".",
 		"noEmit": true,
 		"types": [

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -39,6 +39,7 @@ export interface Domain extends DomainSummary {
 	is_dnssec_enabled: boolean;
 	is_dnssec_supported: boolean;
 	is_domain_only_site: boolean;
+	is_eligible_for_inbound_transfer: boolean;
 	is_gravatar_domain: boolean;
 	is_gravatar_restricted_domain: boolean;
 	is_locked: boolean;

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -1,4 +1,4 @@
-import type { DomainSummary } from '../domains';
+import type { DomainSummary, DomainTransferStatus } from '../domains';
 
 export const EmailSubscriptionStatus = {
 	NO_SUBSCRIPTION: 'no_subscription',
@@ -17,10 +17,17 @@ export type EmailSubscription = {
 
 export interface Domain extends DomainSummary {
 	auth_code_required: boolean;
+	aftermarket_auction: boolean;
 	auto_renewal_date: string;
 	can_manage_name_servers: boolean;
+	can_manage_dns_records: boolean;
+	can_update_contact_info: boolean;
 	can_transfer_to_any_user: boolean;
 	can_transfer_to_other_site: boolean;
+	cannot_manage_name_servers_reason: string | null;
+	cannot_manage_dns_records_reason: string | null;
+	cannot_update_contact_info_reason: string | null;
+	current_user_can_manage: boolean;
 	contact_info_disclosure_available: boolean;
 	contact_info_disclosed: boolean;
 	dnssec_records?: {
@@ -35,7 +42,10 @@ export interface Domain extends DomainSummary {
 	is_gravatar_domain: boolean;
 	is_gravatar_restricted_domain: boolean;
 	is_locked: boolean;
+	is_pending_whois_update: boolean;
 	is_root_domain_registered_with_automattic: boolean;
+	is_redeemable: boolean;
+	is_hundred_year_domain: boolean;
 	is_subdomain: boolean;
 	is_pending_icann_verification: boolean;
 	move_to_new_site_pending: boolean;
@@ -46,10 +56,17 @@ export interface Domain extends DomainSummary {
 	is_pending_registration_at_registry: boolean;
 	private_domain: boolean;
 	privacy_available: boolean;
+	points_to_wpcom: boolean;
+	pending_registration: boolean;
+	pending_registration_at_registry: boolean;
+	pending_transfer: boolean;
 	renewable_until: string;
 	ssl_status: 'active' | 'inactive' | 'newly_registered' | 'pending';
 	subdomain_part: string;
+	transfer_status: DomainTransferStatus | null;
 	transfer_away_eligible_at: string;
+	registration_date: string;
+	email_forwards_count?: number;
 	google_apps_subscription: EmailSubscription;
 	titan_mail_subscription: EmailSubscription;
 }

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -10,10 +10,15 @@ export const EmailSubscriptionStatus = {
 export type EmailSubscriptionStatus =
 	( typeof EmailSubscriptionStatus )[ keyof typeof EmailSubscriptionStatus ];
 
-export type EmailSubscription = {
-	status: EmailSubscriptionStatus;
-	is_eligible_for_introductory_offer: boolean;
-};
+interface EmailSubscription {
+	status: 'active' | 'pending' | 'suspended' | 'no_subscription';
+}
+
+export interface GoogleEmailSubscription extends EmailSubscription {}
+
+export interface TitanEmailSubscription extends EmailSubscription {
+	order_id: number;
+}
 
 export interface Domain extends DomainSummary {
 	auth_code_required: boolean;
@@ -49,6 +54,7 @@ export interface Domain extends DomainSummary {
 	is_hundred_year_domain: boolean;
 	is_subdomain: boolean;
 	is_pending_icann_verification: boolean;
+	is_wpcom_staging_domain?: boolean;
 	move_to_new_site_pending: boolean;
 	nominet_pending_contact_verification_request: boolean;
 	nominet_domain_suspended: boolean;
@@ -69,8 +75,9 @@ export interface Domain extends DomainSummary {
 	wpcom_domain?: boolean;
 	registration_date: string;
 	email_forwards_count?: number;
-	google_apps_subscription: EmailSubscription;
-	titan_mail_subscription: EmailSubscription;
+	google_apps_subscription?: GoogleEmailSubscription | null;
+	titan_mail_subscription?: TitanEmailSubscription | null;
 	transfer_start_date?: string;
 	last_transfer_error: string;
+	current_user_can_add_email: boolean;
 }

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -66,8 +66,11 @@ export interface Domain extends DomainSummary {
 	subdomain_part: string;
 	transfer_status: DomainTransferStatus | null;
 	transfer_away_eligible_at: string;
+	wpcom_domain?: boolean;
 	registration_date: string;
 	email_forwards_count?: number;
 	google_apps_subscription: EmailSubscription;
 	titan_mail_subscription: EmailSubscription;
+	transfer_start_date?: string;
+	last_transfer_error: string;
 }

--- a/packages/api-core/src/domains/fetchers.ts
+++ b/packages/api-core/src/domains/fetchers.ts
@@ -2,9 +2,12 @@ import { wpcom } from '../wpcom-fetcher';
 import type { DomainSummary } from './types';
 
 export async function fetchDomains(): Promise< DomainSummary[] > {
-	const { domains } = await wpcom.req.get( '/all-domains', {
-		no_wpcom: true,
-		resolve_status: true,
-	} );
+	const { domains } = await wpcom.req.get(
+		{ path: '/all-domains', apiVersion: '1.2' },
+		{
+			no_wpcom: true,
+			resolve_status: true,
+		}
+	);
 	return domains;
 }

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -26,10 +26,32 @@ export enum DomainSubtype {
 }
 
 export interface DomainSummary {
-	aftermarket_auction: boolean;
-	auto_renewing: boolean;
+	domain: string;
+	subtype: {
+		id: DomainSubtype;
+		label: string;
+	};
 	blog_id: number;
 	blog_name: string;
+	site_slug: string;
+	auto_renewing: boolean;
+	current_user_is_owner: boolean | null;
+	is_domain_only_site: boolean;
+	expiry: string | false;
+	expired: boolean;
+	primary_domain: boolean;
+	can_set_as_primary: boolean;
+	domain_status: {
+		id: string;
+		label: string;
+		type: 'success' | 'warning' | 'error';
+		cta: string;
+	};
+	subscription_id: string | null;
+	tags: string[];
+
+	/*
+	aftermarket_auction: boolean;
 	can_manage_dns_records: boolean;
 	can_update_contact_info: boolean;
 	can_set_as_primary: boolean;
@@ -39,17 +61,8 @@ export interface DomainSummary {
 	current_user_can_add_email: boolean;
 	current_user_can_create_site_from_domain_only: boolean;
 	current_user_can_manage: boolean;
-	current_user_is_owner: boolean | null;
-	domain: string;
-	domain_status?: {
-		status: string;
-		status_type: 'success' | 'neutral' | 'error';
-	};
 	email_forwards_count: number;
 	expired: boolean;
-	expiry: string | false;
-	has_registration: boolean;
-	is_domain_only_site: boolean;
 	is_eligible_for_inbound_transfer: boolean;
 	is_hundred_year_domain: boolean;
 	is_pending_whois_update: boolean;
@@ -63,15 +76,10 @@ export interface DomainSummary {
 	points_to_wpcom: boolean;
 	primary_domain: boolean;
 	registration_date: string;
-	site_slug: string;
-	subscription_id: string;
-	subtype: {
-		id: DomainSubtype;
-		label: string;
-	};
 	transfer_status: DomainTransferStatus | null;
 	type: DomainTypes;
 	wpcom_domain: boolean;
 	last_transfer_error?: string;
 	transfer_start_date?: string;
+	*/
 }

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -64,37 +64,4 @@ export interface DomainSummary {
 	};
 	subscription_id: string | null;
 	tags: string[];
-
-	/*
-	aftermarket_auction: boolean;
-	can_manage_dns_records: boolean;
-	can_update_contact_info: boolean;
-	can_set_as_primary: boolean;
-	cannot_update_contact_info_reason: string | null;
-	cannot_manage_name_servers_reason: string | null;
-	cannot_manage_dns_records_reason: string | null;
-	current_user_can_add_email: boolean;
-	current_user_can_create_site_from_domain_only: boolean;
-	current_user_can_manage: boolean;
-	email_forwards_count: number;
-	expired: boolean;
-	is_eligible_for_inbound_transfer: boolean;
-	is_hundred_year_domain: boolean;
-	is_pending_whois_update: boolean;
-	is_redeemable: boolean;
-	is_renewable: boolean;
-	is_wpcom_staging_domain: boolean;
-	pending_registration: boolean;
-	pending_registration_at_registry: boolean;
-	pending_renewal: boolean;
-	pending_transfer: boolean;
-	points_to_wpcom: boolean;
-	primary_domain: boolean;
-	registration_date: string;
-	transfer_status: DomainTransferStatus | null;
-	type: DomainTypes;
-	wpcom_domain: boolean;
-	last_transfer_error?: string;
-	transfer_start_date?: string;
-	*/
 }

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -25,6 +25,21 @@ export enum DomainSubtype {
 	SITE_REDIRECT = 'site_redirect',
 }
 
+export enum DomainStatus {
+	ACTIVE = 'active',
+	IN_PROGRESS = 'in_progress',
+	EXPIRED = 'expired',
+	EXPIRED_IN_AUCTION = 'expired_in_auction',
+	PENDING_RENEWAL = 'pending_renewal',
+	PENDING_TRANSFER = 'pending_transfer',
+	EXPIRING_SOON = 'expiring_soon',
+	TRANSFER_COMPLETED = 'transfer_completed',
+	CONNECTION_ERROR = 'connection_error',
+	TRANSFER_PENDING = 'transfer_pending',
+	TRANSFER_ERROR = 'transfer_error',
+	PENDING_REGISTRATION = 'pending_registration',
+}
+
 export interface DomainSummary {
 	domain: string;
 	subtype: {
@@ -42,7 +57,7 @@ export interface DomainSummary {
 	primary_domain: boolean;
 	can_set_as_primary: boolean;
 	domain_status: {
-		id: string;
+		id: DomainStatus;
 		label: string;
 		type: 'success' | 'warning' | 'error';
 		cta: string;

--- a/packages/api-core/src/site-domains/fetchers.ts
+++ b/packages/api-core/src/site-domains/fetchers.ts
@@ -1,7 +1,7 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SiteDomain } from './types';
+import type { Domain } from '../domain/types';
 
-export async function fetchSiteDomains( siteId: number ): Promise< SiteDomain[] > {
+export async function fetchSiteDomains( siteId: number ): Promise< Domain[] > {
 	const { domains } = await wpcom.req.get(
 		{
 			path: `/sites/${ siteId }/domains`,

--- a/packages/api-core/src/site-domains/index.ts
+++ b/packages/api-core/src/site-domains/index.ts
@@ -1,3 +1,2 @@
 export * from './fetchers';
 export * from './mutators';
-export * from './types';

--- a/packages/api-core/src/site-domains/mutators.ts
+++ b/packages/api-core/src/site-domains/mutators.ts
@@ -1,6 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SiteDomain } from './types';
 
-export async function setPrimaryDomain( siteId: number, domain: string ): Promise< SiteDomain > {
-	return wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
+export async function setPrimaryDomain( siteId: number, domain: string ): Promise< void > {
+	await wpcom.req.post( `/sites/${ siteId }/domains/primary`, { domain } );
 }

--- a/packages/api-core/src/site-domains/types.ts
+++ b/packages/api-core/src/site-domains/types.ts
@@ -1,3 +1,0 @@
-export type SiteDomain = {
-	email_forwards_count?: number;
-};

--- a/packages/api-core/src/site-domains/types.ts
+++ b/packages/api-core/src/site-domains/types.ts
@@ -11,6 +11,7 @@ export interface TitanEmailSubscription extends EmailSubscription {
 }
 
 export type SiteDomain = DomainSummary & {
+	email_forwards_count?: number;
 	google_apps_subscription?: GoogleEmailSubscription | null;
 	titan_mail_subscription?: TitanEmailSubscription | null;
 };

--- a/packages/api-core/src/site-domains/types.ts
+++ b/packages/api-core/src/site-domains/types.ts
@@ -1,17 +1,3 @@
-import type { DomainSummary } from '../domains';
-
-interface EmailSubscription {
-	status: 'active' | 'pending' | 'suspended' | 'no_subscription';
-}
-
-export interface GoogleEmailSubscription extends EmailSubscription {}
-
-export interface TitanEmailSubscription extends EmailSubscription {
-	order_id: number;
-}
-
-export type SiteDomain = DomainSummary & {
+export type SiteDomain = {
 	email_forwards_count?: number;
-	google_apps_subscription?: GoogleEmailSubscription | null;
-	titan_mail_subscription?: TitanEmailSubscription | null;
 };


### PR DESCRIPTION
We want to use a new endpoint that returns the data for all domains in a single request + the domain status.

In order to do that we need to:
* Remove all the properties from the DomainSummary type
* Add only the properties the endpoint exposes
* Update the code that gets the list of site domains to use the all-domains endpoint
* Change all the places where the removed properties are used to use the new properties

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDASH-502: Review and add all missing info, warnings and errors](https://linear.app/a8c/issue/DOTDASH-502/review-and-add-all-missing-info-warnings-and-errors)

## Proposed Changes

* Move to the new all-domains endpoint and update the DomainSummary type to match the endpoint data

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to use the new REST API endpoint (v1.2) to fetch all domains lists (both for a single site and for all domains). The new endpoint exposes only the necessary data for those lists including the domain status

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the all domains list or click on a site and verify that you can see the domains in the site overview domain screen or if you click on the domains list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
