### PR TITLE
Staging Sites: Update staging site creation notification message

### DIFF
--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -337,7 +337,9 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 		}
 
 		createSuccessNotice(
-			__( 'We are adding your staging site. We will send you an email when it is done.' ),
+			__(
+				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.'
+			),
 			{
 				type: 'snackbar',
 			}

--- a/client/dashboard/sites/site/test/environment-switcher.test.tsx
+++ b/client/dashboard/sites/site/test/environment-switcher.test.tsx
@@ -290,7 +290,7 @@ describe( 'EnvironmentSwitcher', () => {
 			await user.click( screen.getByText( 'Add staging site' ) );
 
 			expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
-				'We are adding your staging site. We will send you an email when it is done.',
+				'Setting up your staging site — this may take a few minutes. We’ll email you when it’s ready.',
 				{ type: 'snackbar' }
 			);
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-247

## Proposed Changes

- update staging site creation notification message

<img width="1208" height="128" alt="Markup on 2025-10-15 at 14:49:44" src="https://github.com/user-attachments/assets/9cb256fa-971f-47be-84f3-1491513df771" />

ℹ️ The proposed copy is the shortest one I could think of - that also includes the information the process can take several minutes - while also keeping the message in one line (at least in the English locale). If you have better ideas, I will be happy to adjust the copy further. 🙂 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make it clear the staging site creation process can take several minutes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. Navigate to the Overview tab of a test WoA site that does not have a staging site created in the new Hosting Dashboard (`http://calypso.localhost:3000/v2/sites/{site-slug}`).
3. Trigger new staging site creation.
4. Review the snack-bar notification displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
