### PR TITLE
Hosting Dashboard: Add receipt page

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -3,6 +3,7 @@ import {
 	userSettingsQuery,
 	userPurchasesQuery,
 	purchaseQuery,
+	receiptQuery,
 	sitesQuery,
 	queryClient,
 	accountRecoveryQuery,
@@ -127,9 +128,38 @@ export const billingHistoryRoute = createRoute( {
 	} ),
 	getParentRoute: () => billingRoute,
 	path: '/billing-history',
+} );
+
+export const billingHistoryIndexRoute = createRoute( {
+	getParentRoute: () => billingHistoryRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../me/billing-history' ).then( ( d ) =>
 		createLazyRoute( 'billing-history' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const receiptRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Receipt' ),
+			},
+		],
+	} ),
+	getParentRoute: () => billingHistoryRoute,
+	loader: async ( { params: { receiptId } } ) => {
+		const receipt = await queryClient.ensureQueryData( receiptQuery( parseInt( receiptId ) ) );
+		return {
+			receipt,
+		};
+	},
+	path: '$receiptId',
+} ).lazy( () =>
+	import( '../../me/billing-history/receipt' ).then( ( d ) =>
+		createLazyRoute( 'billing-history-receipt' )( {
 			component: d.default,
 		} )
 	)
@@ -688,7 +718,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 	meRoutes.push(
 		billingRoute.addChildren( [
 			billingIndexRoute,
-			billingHistoryRoute,
+			billingHistoryRoute.addChildren( [ billingHistoryIndexRoute, receiptRoute ] ),
 			monetizeSubscriptionsRoute.addChildren( [
 				monetizeSubscriptionsIndexRoute,
 				monetizeSubscriptionRoute,

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -1,7 +1,12 @@
 import { PaymentPartners } from '@automattic/api-core';
-import { receiptQuery } from '@automattic/api-queries';
+import {
+	receiptQuery,
+	sendReceiptEmailMutation,
+	userTaxDetailsQuery,
+} from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import {
 	Button,
 	Card,
@@ -13,6 +18,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -171,7 +177,109 @@ function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
 					</Text>
 				</VStack>
 			) }
+
+			<VatDetails receipt={ receipt } />
 		</VStack>
+	);
+}
+
+function UserVatDetails( { receipt }: { receipt: Receipt } ) {
+	const { data: vatDetails, isLoading, error } = useQuery( userTaxDetailsQuery() );
+	const sendEmailMutation = useMutation( {
+		...sendReceiptEmailMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'Your receipt was sent by email successfully.' ),
+				error: __(
+					'There was a problem sending your receipt. Please try again later or contact support.'
+				),
+			},
+		},
+	} );
+
+	const handleEmailReceipt = ( event: React.MouseEvent< HTMLButtonElement > ) => {
+		event.preventDefault();
+		sendEmailMutation.mutate( String( receipt.id ) );
+	};
+
+	if ( isLoading || error || ! vatDetails?.id ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 1 } alignment="flex-start">
+			<Text upperCase variant="muted" size={ 11 }>
+				{ __( 'VAT Details' ) }
+			</Text>
+			<VStack spacing={ 0.5 } alignment="flex-start">
+				<div>{ vatDetails.name }</div>
+				<div>{ vatDetails.address }</div>
+				<div>
+					{ sprintf(
+						/* translators: 1: VAT country code, 2: VAT ID number */
+						__( 'VAT #: %1$s %2$s' ),
+						vatDetails.country ?? '',
+						vatDetails.id
+					) }
+				</div>
+				<Text variant="muted" size={ 11 } className="receipt-vat-details-description">
+					{ createInterpolateElement(
+						__(
+							'You can edit your VAT details <vatDetailsLink>on this page</vatDetailsLink>. This is not an official VAT receipt. For an official VAT receipt, <emailReceiptButton>email yourself a copy</emailReceiptButton>.'
+						),
+						{
+							vatDetailsLink: <Link to="/me/billing/tax-details" />,
+							emailReceiptButton: (
+								<Button
+									className="receipt-email-button"
+									variant="link"
+									onClick={ handleEmailReceipt }
+									disabled={ sendEmailMutation.isPending }
+								/>
+							),
+						}
+					) }
+				</Text>
+			</VStack>
+		</VStack>
+	);
+}
+
+function VatVendorDetails( { receipt }: { receipt: Receipt } ) {
+	const vendorInfo = receipt.tax_vendor_info;
+	if ( ! vendorInfo ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 1 } alignment="flex-start">
+			<Text upperCase variant="muted" size={ 11 }>
+				{ sprintf(
+					/* translators: %s: tax name (e.g., "VAT", "GST") */
+					__( 'Vendor %s Details' ),
+					Object.keys( vendorInfo.tax_name_and_vendor_id_array ).join( '/' )
+				) }
+			</Text>
+			<VStack spacing={ 0.5 } alignment="flex-start">
+				{ vendorInfo.address.map( ( addressLine ) => (
+					<div key={ addressLine }>{ addressLine }</div>
+				) ) }
+				{ Object.entries( vendorInfo.tax_name_and_vendor_id_array ).map( ( [ taxName, taxID ] ) => (
+					<div key={ taxName }>
+						<strong>{ taxName }</strong> { taxID }
+					</div>
+				) ) }
+			</VStack>
+		</VStack>
+	);
+}
+
+function VatDetails( { receipt }: { receipt: Receipt } ) {
+	return (
+		<>
+			<UserVatDetails receipt={ receipt } />
+			<VatVendorDetails receipt={ receipt } />
+		</>
 	);
 }
 

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -1,0 +1,585 @@
+import { PaymentPartners } from '@automattic/api-core';
+import { receiptQuery } from '@automattic/api-queries';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Button,
+	Card,
+	CardBody,
+	Flex,
+	TextControl,
+	__experimentalDivider as Divider,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { receiptRoute } from '../../app/router/me';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import {
+	groupDomainProducts,
+	getTransactionTermLabel,
+	renderTransactionQuantitySummary,
+	DomainTransactionVolumeSummary,
+	transactionIncludesTax,
+	isTransactionJetpackSearch10kTier,
+	renderJetpackSearch10kTierBreakdown,
+	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
+} from './utils';
+import type { Receipt, ReceiptItem, ReceiptItemCostOverride } from '@automattic/api-core';
+import './styles.scss';
+
+export interface IntroductoryOfferTerms {
+	enabled: boolean;
+	interval_unit: string;
+	interval_count: number;
+	transition_after_renewal_count: number;
+}
+
+export interface LineItemCostOverrideForDisplay {
+	humanReadableReason: string;
+	overrideCode: string;
+	/**
+	 * The amount saved by this cost override in the currency's smallest unit.
+	 * If not set, a number will not be displayed.
+	 */
+	discountAmount?: number;
+}
+
+export default function Receipt() {
+	const params = receiptRoute.useParams();
+	const receiptId = params.receiptId;
+	const { data: receipt } = useSuspenseQuery( receiptQuery( receiptId ) );
+
+	const handlePrint = () => {
+		window.print();
+	};
+
+	const formattedDate = new Date( receipt.date ).toLocaleDateString( undefined, {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	} );
+
+	return (
+		<PageLayout
+			size="small"
+			header={ <PageHeader title={ __( 'Receipt' ) } prefix={ <Breadcrumbs length={ 2 } /> } /> }
+		>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<HStack justify="space-between">
+							<HStack spacing={ 4 } justify="flex-start">
+								<img src={ receipt.icon } alt={ receipt.service } className="receipt-icon" />
+								<VStack spacing={ 0.5 } alignment="flex-start">
+									<Text size={ 15 } weight={ 500 }>
+										{ receipt.service }
+									</Text>
+									<Text variant="muted" size={ 11 }>
+										{ receipt.service_slug === 'memberships'
+											? sprintf(
+													/* translators: %s: organization name */
+													__( 'Payment processed by %s' ),
+													receipt.org
+											  )
+											: sprintf(
+													/* translators: %s: organization name */
+													__( 'by %s' ),
+													receipt.org
+											  ) }
+									</Text>
+									{ receipt.address && (
+										<Text variant="muted" size={ 11 }>
+											{ receipt.address }
+										</Text>
+									) }
+								</VStack>
+							</HStack>
+							<Text variant="muted" size={ 11 } className="receipt-date">
+								{ formattedDate }
+							</Text>
+						</HStack>
+						<VStack spacing={ 6 }>
+							<ReceiptDetails receipt={ receipt } />
+							<ReceiptLineItems receipt={ receipt } />
+							<Flex gap={ 2 }>
+								<Button variant="primary" onClick={ handlePrint }>
+									{ __( 'Print Receipt' ) }
+								</Button>
+							</Flex>
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}
+
+function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
+	const [ billingDetailsText, setBillingDetailsText ] = useState(
+		receipt.cc_num !== 'XXXX' ? `${ receipt.cc_name }\n${ receipt.cc_email }` : ''
+	);
+
+	const paymentMethodText = getPaymentMethodText( receipt );
+
+	return (
+		<VStack spacing={ 3 } alignment="flex-start">
+			<VStack spacing={ 1 } alignment="flex-start">
+				<Text upperCase variant="muted" size={ 11 }>
+					{ __( 'Receipt ID' ) }
+				</Text>
+				<span className="receipt-monospace">{ receipt.id }</span>
+			</VStack>
+
+			{ receipt.pay_ref && (
+				<VStack spacing={ 1 } alignment="flex-start">
+					<Text upperCase variant="muted" size={ 11 }>
+						{ __( 'Transaction ID' ) }
+					</Text>
+					<span className="receipt-monospace">{ receipt.pay_ref }</span>
+				</VStack>
+			) }
+
+			{ paymentMethodText && (
+				<VStack spacing={ 1 } alignment="flex-start">
+					<Text upperCase variant="muted" size={ 11 }>
+						{ __( 'Payment Method' ) }
+					</Text>
+					<span>{ paymentMethodText }</span>
+				</VStack>
+			) }
+
+			{ receipt.cc_num !== 'XXXX' && ( receipt.cc_name || receipt.cc_email ) && (
+				<VStack spacing={ 1 } alignment="flex-start" className="receipt-billing-details">
+					<Text upperCase variant="muted" size={ 11 }>
+						{ __( 'Billing details' ) }
+					</Text>
+					<TextControl
+						value={ billingDetailsText }
+						onChange={ setBillingDetailsText }
+						className="receipt-text-control"
+						__nextHasNoMarginBottom
+					/>
+					<Text variant="muted" size={ 11 }>
+						{ __(
+							'Use this field to add your billing information (eg. business address) before printing.'
+						) }
+					</Text>
+				</VStack>
+			) }
+		</VStack>
+	);
+}
+
+function isUserVisibleCostOverride( costOverride: {
+	does_override_original_cost: boolean;
+	override_code: string;
+} ): boolean {
+	if ( costOverride.does_override_original_cost ) {
+		// We won't display original cost overrides since they are
+		// included in the original cost that's being displayed. They
+		// are not discounts.
+		return false;
+	}
+	return true;
+}
+
+function getPaymentMethodText( receipt: Receipt ): string | null {
+	if (
+		receipt.pay_part === PaymentPartners.PAYPAL_EXPRESS ||
+		receipt.pay_part === PaymentPartners.PAYPAL_PPCP
+	) {
+		return __( 'PayPal' );
+	}
+
+	if ( receipt.cc_num !== 'XXXX' ) {
+		const cardType =
+			receipt.cc_display_brand?.replace( '_', ' ' ).toUpperCase() ?? receipt.cc_type.toUpperCase();
+		/* translators: 1: card type (e.g., "VISA"), 2: last 4 digits of card */
+		return sprintf( __( '%1$s ending in %2$s' ), cardType, receipt.cc_num );
+	}
+
+	return null;
+}
+
+function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
+	const groupedItems = groupDomainProducts( receipt.items );
+
+	return (
+		<VStack spacing={ 4 } alignment="flex-start">
+			<Text weight={ 500 } size={ 15 }>
+				{ __( 'Order summary' ) }
+			</Text>
+			<VStack className="receipt-table">
+				<HStack justify="space-between" className="receipt-table-header">
+					<Text upperCase variant="muted" size={ 11 }>
+						{ __( 'Description' ) }
+					</Text>
+					<Text upperCase variant="muted" size={ 11 }>
+						{ __( 'Amount' ) }
+					</Text>
+				</HStack>
+				<Divider />
+				<VStack className="receipt-table-body">
+					<VStack spacing={ 4 }>
+						{ groupedItems.map( ( item ) => (
+							<ReceiptLineItem key={ item.id } item={ item } receipt={ receipt } />
+						) ) }
+					</VStack>
+					{ transactionIncludesTax( receipt ) && (
+						<VStack className="receipt-tax-row">
+							<HStack justify="space-between">
+								<span>{ __( 'Tax' ) }</span>
+								<span>
+									{ formatCurrency( receipt.tax_integer, receipt.currency, {
+										isSmallestUnit: true,
+										stripZeros: true,
+									} ) }
+								</span>
+							</HStack>
+						</VStack>
+					) }
+				</VStack>
+				<Divider />
+				<VStack className="receipt-total-row">
+					<HStack justify="space-between">
+						<Text weight={ 500 }>{ __( 'Total paid:' ) }</Text>
+						<Text weight={ 500 }>
+							{ formatCurrency( receipt.amount_integer, receipt.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ) }
+						</Text>
+					</HStack>
+				</VStack>
+			</VStack>
+		</VStack>
+	);
+}
+
+function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Receipt } ) {
+	const termLabel = getTransactionTermLabel( item );
+	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receipt.date );
+	const subtotalInteger = shouldShowDiscount
+		? getReceiptItemOriginalCost( item )
+		: item.subtotal_integer;
+	const formattedAmount = formatCurrency( subtotalInteger, item.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+
+	const shouldShowDomain = item.domain && ! item.domain.includes( 'a8cagency.blog' );
+
+	return (
+		<VStack className="receipt-line-item">
+			<HStack justify="space-between" alignment="flex-start">
+				<VStack className="receipt-line-item-cell">
+					<VStack spacing={ 1 } alignment="flex-start">
+						<Text weight={ 500 }>
+							{ item.variation } ({ item.type_localized.toLowerCase() })
+						</Text>
+						<VStack spacing={ 0 }>
+							{ termLabel && <Text>{ termLabel }</Text> }
+							{ shouldShowDomain && <Text variant="muted">{ item.domain }</Text> }
+							{ item.licensed_quantity && (
+								<Text>{ renderTransactionQuantitySummary( item ) }</Text>
+							) }
+							{ isTransactionJetpackSearch10kTier( item ) && (
+								<Text>{ renderJetpackSearch10kTierBreakdown( item, subtotalInteger ) }</Text>
+							) }
+							<DomainTransactionVolumeSummary item={ item } />
+						</VStack>
+					</VStack>
+				</VStack>
+				<VStack className="receipt-line-item-cell-price">
+					<Text>
+						{ doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+							item.cost_overrides,
+							item.introductory_offer_terms,
+							item.months_per_renewal_interval
+						) ? (
+							<s>{ formattedAmount }</s>
+						) : (
+							formattedAmount
+						) }
+					</Text>
+					{ receipt.credit && <Text>{ __( 'Refund' ) }</Text> }
+				</VStack>
+			</HStack>
+			{ shouldShowDiscount && (
+				<div className="receipt-discount-cell">
+					<ReceiptItemDiscounts item={ item } receiptDate={ receipt.date } />
+				</div>
+			) }
+		</VStack>
+	);
+}
+
+function ReceiptItemDiscounts( { item, receiptDate }: { item: ReceiptItem; receiptDate: string } ) {
+	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receiptDate );
+
+	return (
+		<ul className="receipt-discount-list">
+			{ filterCostOverridesForReceiptItem( item ).map( ( costOverride ) => {
+				const formattedDiscountAmount =
+					shouldShowDiscount && costOverride.discountAmount
+						? formatCurrency( -costOverride.discountAmount, item.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+						  } )
+						: '';
+
+				if (
+					doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+						item.cost_overrides,
+						item.introductory_offer_terms,
+						item.months_per_renewal_interval
+					)
+				) {
+					return (
+						<li key={ costOverride.humanReadableReason }>
+							<Text>{ costOverride.humanReadableReason }</Text>
+							{ item.introductory_offer_terms?.enabled && (
+								<Text>
+									{ sprintf(
+										/* translators: %s: formatted price */
+										__( 'Amount paid in transaction: %s' ),
+										formatCurrency( item.amount_integer, item.currency, {
+											isSmallestUnit: true,
+											stripZeros: true,
+										} )
+									) }
+								</Text>
+							) }
+						</li>
+					);
+				}
+
+				return (
+					<li key={ costOverride.humanReadableReason }>
+						<Flex justify="space-between">
+							<span>{ costOverride.humanReadableReason }</span>
+							<span>{ formattedDiscountAmount }</span>
+						</Flex>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+}
+
+function filterCostOverridesForReceiptItem( item: ReceiptItem ): LineItemCostOverrideForDisplay[] {
+	return item.cost_overrides
+		.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride ) )
+		.map( ( costOverride ) => makeIntroductoryOfferCostOverrideUnique( costOverride, item ) )
+		.map( ( costOverride ) => {
+			if (
+				doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+					item.cost_overrides,
+					item.introductory_offer_terms,
+					item.months_per_renewal_interval
+				)
+			) {
+				return {
+					humanReadableReason: costOverride.human_readable_reason,
+					overrideCode: costOverride.override_code,
+				};
+			}
+			return {
+				humanReadableReason: costOverride.human_readable_reason,
+				overrideCode: costOverride.override_code,
+				discountAmount: costOverride.old_price_integer - costOverride.new_price_integer,
+			};
+		} );
+}
+
+function makeIntroductoryOfferCostOverrideUnique(
+	costOverride: ReceiptItemCostOverride,
+	product: ReceiptItem
+): ReceiptItemCostOverride {
+	if ( 'introductory-offer' === costOverride.override_code && product.introductory_offer_terms ) {
+		return {
+			...costOverride,
+			human_readable_reason: getDiscountReasonForIntroductoryOffer(
+				product,
+				product.introductory_offer_terms,
+				true,
+				costOverride.new_price_integer > costOverride.old_price_integer
+			),
+		};
+	}
+	return costOverride;
+}
+
+function getIntroductoryOfferIntervalDisplay( {
+	intervalUnit,
+	intervalCount,
+	isFreeTrial,
+	isPriceIncrease,
+	context,
+	remainingRenewalsUsingOffer = 0,
+}: {
+	intervalUnit: string;
+	intervalCount: number;
+	isFreeTrial: boolean;
+	isPriceIncrease: boolean;
+	context: string;
+	remainingRenewalsUsingOffer: number;
+} ): string {
+	let text = isPriceIncrease ? __( 'First billing period' ) : __( 'Discount for first period' );
+
+	if ( isFreeTrial ) {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = __( 'First month free' );
+			} else {
+				text = sprintf(
+					/* translators: %d: number of months */
+					__( 'First %d months free' ),
+					intervalCount
+				);
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = __( 'First year free' );
+			} else {
+				text = sprintf(
+					/* translators: %d: number of years */
+					__( 'First %d years free' ),
+					intervalCount
+				);
+			}
+		}
+	} else {
+		if ( intervalUnit === 'month' ) {
+			if ( intervalCount === 1 ) {
+				text = isPriceIncrease ? __( 'Price for first month' ) : __( 'Discount for first month' );
+			} else {
+				text = isPriceIncrease
+					? sprintf(
+							/* translators: %d: number of months */
+							__( 'Price for first %d months' ),
+							intervalCount
+					  )
+					: sprintf(
+							/* translators: %d: number of months */
+							__( 'Discount for first %d months' ),
+							intervalCount
+					  );
+			}
+		}
+		if ( intervalUnit === 'year' ) {
+			if ( intervalCount === 1 ) {
+				text = isPriceIncrease ? __( 'Price for first year' ) : __( 'Discount for first year' );
+			} else {
+				text = isPriceIncrease
+					? sprintf(
+							/* translators: %d: number of years */
+							__( 'Price for first %d years' ),
+							intervalCount
+					  )
+					: sprintf(
+							/* translators: %d: number of years */
+							__( 'Discount for first %d years' ),
+							intervalCount
+					  );
+			}
+		}
+	}
+
+	if ( remainingRenewalsUsingOffer > 0 ) {
+		text += ' - ';
+		if ( context === 'checkout' ) {
+			if ( remainingRenewalsUsingOffer === 1 ) {
+				text += isPriceIncrease
+					? __( 'Applies for one renewal' )
+					: __( 'The first renewal is also discounted.' );
+			} else if ( isPriceIncrease ) {
+				text += sprintf(
+					/* translators: %d: number of renewals */
+					__( 'Applies for %d renewals' ),
+					remainingRenewalsUsingOffer
+				);
+			} else {
+				text +=
+					remainingRenewalsUsingOffer === 1
+						? __( 'The first renewal is also discounted.' )
+						: sprintf(
+								/* translators: %d: number of renewals */
+								__( 'The first %d renewals are also discounted.' ),
+								remainingRenewalsUsingOffer
+						  );
+			}
+		} else if ( isPriceIncrease ) {
+			text +=
+				remainingRenewalsUsingOffer === 1
+					? __( 'Applies for 1 renewal' )
+					: sprintf(
+							/* translators: %d: number of renewals */
+							__( 'Applies for %d renewals' ),
+							remainingRenewalsUsingOffer
+					  );
+		} else {
+			text +=
+				remainingRenewalsUsingOffer === 1
+					? __( '1 discounted renewal remaining.' )
+					: sprintf(
+							/* translators: %d: number of renewals */
+							__( '%d discounted renewals remaining.' ),
+							remainingRenewalsUsingOffer
+					  );
+		}
+	}
+
+	return text;
+}
+
+function getDiscountReasonForIntroductoryOffer(
+	product: ReceiptItem,
+	terms: IntroductoryOfferTerms,
+	allowFreeText: boolean,
+	isPriceIncrease: boolean
+): string {
+	return getIntroductoryOfferIntervalDisplay( {
+		intervalUnit: terms.interval_unit,
+		intervalCount: terms.interval_count,
+		isFreeTrial: product.amount_integer === 0 && allowFreeText,
+		isPriceIncrease,
+		context: 'checkout',
+		remainingRenewalsUsingOffer: terms.transition_after_renewal_count,
+	} );
+}
+
+function areReceiptItemDiscountsAccurate( receiptDate: string ): boolean {
+	const date = new Date( receiptDate );
+	const receiptDateUnix = date.getTime() / 1000;
+	const receiptTagsAccurateAsOf = 1704218040;
+	return receiptDateUnix > receiptTagsAccurateAsOf;
+}
+
+function getReceiptItemOriginalCost( item: ReceiptItem ): number {
+	if ( item.type === 'refund' ) {
+		return item.subtotal_integer;
+	}
+	const originalCostOverrides = item.cost_overrides.filter(
+		( override ) => override.does_override_original_cost
+	);
+	if ( originalCostOverrides.length > 0 ) {
+		const lastOriginalCostOverride = originalCostOverrides.pop();
+		if ( lastOriginalCostOverride ) {
+			return lastOriginalCostOverride.new_price_integer;
+		}
+	}
+	if ( item.cost_overrides.length > 0 ) {
+		const firstOverride = item.cost_overrides[ 0 ];
+		if ( firstOverride ) {
+			return firstOverride.old_price_integer;
+		}
+	}
+	return item.subtotal_integer;
+}

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -1,0 +1,36 @@
+.receipt-icon {
+	width: 68px;
+	height: 68px;
+}
+
+.receipt-date {
+	// This text is inside a flexbox (HStack) which has `min-width: 0` set on
+	// all its children, but this overrides the default of `min-width: auto`
+	// and allows elements to shrink beyond their minimum content size. This
+	// causes the text area to shrink slighly and the content overflows its
+	// padding on the right (due to `justify-content: flex-start`). This seems
+	// like a bug in `HStack` to me but for now this fixes it.
+	min-width: max-content;
+}
+
+.receipt-monospace {
+	font-family: monospace;
+}
+
+.receipt-billing-details {
+	width: 100%;
+}
+
+.receipt-text-control {
+	width: 100%;
+}
+
+.receipt-table {
+	width: 100%;
+}
+
+.receipt-discount-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -34,3 +34,7 @@
 	padding: 0;
 	margin: 0;
 }
+
+.receipt-email-button {
+	font-size: 11px;
+}

--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -1,0 +1,346 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	isDIFMProduct,
+	isGoogleWorkspace,
+	isTitanMail,
+	isTieredVolumeSpaceAddon,
+	isJetpackSearch,
+} from '../../utils/purchase';
+import type { Receipt, ReceiptItem } from '@automattic/api-core';
+import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
+
+interface GroupedDomainProduct {
+	product: ReceiptItem;
+	groupCount: number;
+}
+
+export const groupDomainProducts = ( originalItems: ReceiptItem[] ) => {
+	const domainProducts: ReceiptItem[] = [];
+	const otherProducts: ReceiptItem[] = [];
+	originalItems.forEach( ( item ) => {
+		if ( item.product_slug === 'wp-domains' ) {
+			domainProducts.push( item );
+		} else {
+			otherProducts.push( item );
+		}
+	} );
+
+	const groupedDomainProductsMap = domainProducts.reduce<
+		Map< ReceiptItem[ 'domain' ], GroupedDomainProduct >
+	>( ( groups, product ) => {
+		const existingGroup = groups.get( product.domain );
+		if ( existingGroup ) {
+			existingGroup.product.amount_integer += product.amount_integer;
+			existingGroup.product.subtotal_integer += product.subtotal_integer;
+			existingGroup.product.tax_integer += product.tax_integer;
+			existingGroup.groupCount++;
+		} else {
+			const newGroup = {
+				product: { ...product },
+				groupCount: 1,
+			};
+			groups.set( product.domain, newGroup );
+		}
+
+		return groups;
+	}, new Map() );
+
+	const groupedDomainProducts: ReceiptItem[] = [];
+
+	groupedDomainProductsMap.forEach( ( value ) => {
+		if ( value.groupCount === 1 ) {
+			groupedDomainProducts.push( value.product );
+			return;
+		}
+		groupedDomainProducts.push( {
+			...value.product,
+			variation: __( 'Domain Registration' ),
+		} );
+	} );
+
+	return [ ...otherProducts, ...groupedDomainProducts ];
+};
+
+export function transactionIncludesTax( transaction: Receipt ) {
+	if ( ! transaction || ! transaction.tax_integer ) {
+		return false;
+	}
+
+	return transaction.items.some( ( item ) => item.tax_integer > 0 );
+}
+
+function renderTransactionQuantitySummaryForMailboxes(
+	licensedQuantity: number,
+	newQuantity: number,
+	isRenewal: boolean,
+	isUpgrade: boolean
+) {
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %d: number of mailboxes */
+			_n( 'Renewal for %d mailbox', 'Renewal for %d mailboxes', licensedQuantity ),
+			licensedQuantity
+		);
+	}
+
+	if ( isUpgrade ) {
+		return sprintf(
+			/* translators: %d: number of additional mailboxes */
+			_n( 'Purchase of %d additional mailbox', 'Purchase of %d additional mailboxes', newQuantity ),
+			newQuantity
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of mailboxes */
+		_n( 'Purchase of %d mailbox', 'Purchase of %d mailboxes', licensedQuantity ),
+		licensedQuantity
+	);
+}
+
+function renderDIFMTransactionQuantitySummary( licensedQuantity: number ) {
+	return sprintf(
+		/* translators: %d: number of pages */
+		_n( 'One-time fee includes %d page', 'One-time fee includes %d pages', licensedQuantity ),
+		licensedQuantity
+	);
+}
+
+function renderJetpackSearchQuantitySummary( licensedQuantity: number, isRenewal: boolean ) {
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %d: number of search records/requests */
+			__( 'Renewal for %d search records/requests' ),
+			licensedQuantity
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of search records/requests */
+		__( 'Purchase for %d search records/requests' ),
+		licensedQuantity
+	);
+}
+
+function renderSpaceAddOnquantitySummary( licensedQuantity: number, isRenewal: boolean ) {
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %d: number of gigabytes */
+			__( 'Renewal for %d GB' ),
+			licensedQuantity
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of gigabytes */
+		__( 'Purchase of %d GB' ),
+		licensedQuantity
+	);
+}
+
+export function DomainTransactionVolumeSummary( { item }: { item: ReceiptItem } ) {
+	if ( ! item.volume ) {
+		return null;
+	}
+
+	const isRenewal = 'recurring' === item.type;
+	const volume = parseInt( String( item.volume ) );
+
+	if ( 'wp-domains' !== item.product_slug || item.variation_slug === 'wp-domain-mapping' ) {
+		return null;
+	}
+
+	if ( isRenewal ) {
+		return (
+			<em>
+				{ sprintf(
+					/* translators: %d: number of years */
+					_n( 'Domain renewed for %d year', 'Domain renewed for %d years', volume ),
+					volume
+				) }
+			</em>
+		);
+	}
+
+	return (
+		<em>
+			{ sprintf(
+				/* translators: %d: number of years */
+				_n( 'Domain registered for %d year', 'Domain registered for %d years', volume ),
+				volume
+			) }
+		</em>
+	);
+}
+
+export function renderTransactionQuantitySummary( {
+	licensed_quantity,
+	new_quantity,
+	type,
+	wpcom_product_slug,
+}: ReceiptItem ) {
+	if ( ! licensed_quantity ) {
+		return null;
+	}
+
+	const licensedQuantity = parseInt( String( licensed_quantity ) );
+	const newQuantity = parseInt( String( new_quantity ) );
+	const product = { product_slug: wpcom_product_slug };
+	const isRenewal = 'recurring' === type;
+	const isUpgrade = 'new purchase' === type && newQuantity > 0;
+
+	if ( isJetpackSearch( product ) ) {
+		return renderJetpackSearchQuantitySummary( licensedQuantity, isRenewal );
+	}
+
+	if ( isGoogleWorkspace( product ) || isTitanMail( product ) ) {
+		return renderTransactionQuantitySummaryForMailboxes(
+			licensedQuantity,
+			newQuantity,
+			isRenewal,
+			isUpgrade
+		);
+	}
+
+	if ( isDIFMProduct( product ) ) {
+		return renderDIFMTransactionQuantitySummary( licensedQuantity );
+	}
+
+	if ( isTieredVolumeSpaceAddon( product ) ) {
+		return renderSpaceAddOnquantitySummary( licensedQuantity, isRenewal );
+	}
+
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %d: number of items */
+			_n( 'Renewal for %d item', 'Renewal for %d items', licensedQuantity ),
+			licensedQuantity
+		);
+	}
+
+	if ( isUpgrade ) {
+		return sprintf(
+			/* translators: %d: number of additional items */
+			_n( 'Purchase of %d additional item', 'Purchase of %d additional items', newQuantity ),
+			newQuantity
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of items */
+		_n( 'Purchase of %d item', 'Purchase of %d items', licensedQuantity ),
+		licensedQuantity
+	);
+}
+
+export function getTransactionTermLabel( transaction: ReceiptItem ) {
+	switch ( transaction.months_per_renewal_interval ) {
+		case 1:
+			return __( 'Monthly subscription' );
+		case 12:
+			return __( 'Annual subscription' );
+		case 24:
+			return __( 'Two year subscription' );
+		case 36:
+			return __( 'Three year subscription' );
+		case 100:
+			return __( 'Hundred year subscription' );
+		default:
+			return undefined;
+	}
+}
+
+export function isTransactionJetpackSearch10kTier( {
+	wpcom_product_slug,
+	licensed_quantity,
+	price_tier_slug,
+}: ReceiptItem ): boolean {
+	const product = { product_slug: wpcom_product_slug };
+	return (
+		isJetpackSearch( product ) &&
+		licensed_quantity !== null &&
+		price_tier_slug === 'additional_10k_queries_and_records'
+	);
+}
+
+export function renderJetpackSearch10kTierBreakdown(
+	{ licensed_quantity, currency }: ReceiptItem,
+	subtotalInteger: number
+) {
+	if ( ! licensed_quantity ) {
+		return null;
+	}
+
+	const numberOfUnits = Math.ceil( licensed_quantity / 10000 );
+	const pricePerUnit = subtotalInteger / numberOfUnits;
+	const formattedPricePerUnit = formatCurrency( pricePerUnit, currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+
+	return sprintf(
+		/* translators: 1: number of units, 2: formatted price per unit */
+		_n( '%1$d unit @ %2$s', '%1$d units @ %2$s', numberOfUnits ),
+		numberOfUnits,
+		formattedPricePerUnit
+	);
+}
+
+/**
+ * Returns the bill period in months for an introductory offer interval unit.
+ */
+function getBillPeriodMonthsForIntroductoryOfferInterval( interval: string ): number {
+	switch ( interval ) {
+		case 'month':
+			return 1;
+		case 'year':
+			return 12;
+		default:
+			return 0;
+	}
+}
+
+/**
+ * Returns true if the product has an introductory offer which is for a
+ * different term length than the term length of the product (eg: a 3 month
+ * discount for an annual plan).
+ */
+export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+	costOverrides: { override_code: string }[] | undefined,
+	introductoryOfferTerms: IntroductoryOfferTerms | undefined | null,
+	monthsPerBillPeriodForProduct: number | undefined | null
+): boolean {
+	if (
+		costOverrides?.some( ( costOverride ) => {
+			! isOverrideCodeIntroductoryOffer( costOverride.override_code );
+		} )
+	) {
+		return false;
+	}
+	if ( ! introductoryOfferTerms?.enabled ) {
+		return false;
+	}
+	if (
+		getBillPeriodMonthsForIntroductoryOfferInterval( introductoryOfferTerms.interval_unit ) ===
+		monthsPerBillPeriodForProduct
+	) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Checks if an override code represents an introductory offer.
+ */
+function isOverrideCodeIntroductoryOffer( overrideCode: string ): boolean {
+	switch ( overrideCode ) {
+		case 'introductory-offer':
+			return true;
+		case 'prorated-introductory-offer':
+			return true;
+		case 'quantity-upgrade-introductory-offer':
+			return true;
+	}
+	return false;
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -3,6 +3,9 @@ import {
 	AkismetPlans,
 	TitanMailSlugs,
 	GoogleWorkspaceSlugs,
+	WPCOM_DIFM_LITE,
+	PRODUCT_1GB_SPACE,
+	JETPACK_SEARCH_PRODUCTS,
 } from '@automattic/api-core';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
@@ -339,16 +342,45 @@ export function isJetpackCrmProduct( keyOrSlug: string ): boolean {
 	);
 }
 
-export function isTitanMail( purchase: Purchase ): boolean {
-	return ( Object.values( TitanMailSlugs ) as string[] ).includes( purchase.product_slug );
+type ObjectWithProductSlug = { product_slug?: string };
+
+export function isTitanMail( purchase: Purchase | ObjectWithProductSlug ): boolean {
+	return (
+		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ||
+		purchase.product_slug === TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG
+	);
 }
 
-export function isGoogleWorkspace( purchase: Purchase ): boolean {
-	return ( Object.values( GoogleWorkspaceSlugs ) as string[] ).includes( purchase.product_slug );
+export function isGoogleWorkspace( purchase: Purchase | ObjectWithProductSlug ): boolean {
+	return (
+		purchase.product_slug === GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY ||
+		purchase.product_slug === GoogleWorkspaceSlugs.GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY
+	);
 }
 
 export function isSiteRedirect( purchase: Purchase ): boolean {
 	return purchase.product_slug === 'offsite_redirect';
+}
+
+/**
+ * Checks if a product is a DIFM (Do It For Me) product.
+ */
+export function isDIFMProduct( product: ObjectWithProductSlug ): boolean {
+	return product.product_slug === WPCOM_DIFM_LITE;
+}
+
+/**
+ * Checks if a product is a tiered volume space addon.
+ */
+export function isTieredVolumeSpaceAddon( product: ObjectWithProductSlug ): boolean {
+	return product.product_slug === PRODUCT_1GB_SPACE;
+}
+
+/**
+ * Checks if a product is a Jetpack Search product.
+ */
+export function isJetpackSearch( product: ObjectWithProductSlug ): boolean {
+	return product.product_slug ? JETPACK_SEARCH_PRODUCTS.includes( product.product_slug ) : false;
 }
 
 function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -167,9 +167,17 @@ export const JetpackPlans = {
 	PLAN_JETPACK_GROWTH_MONTHLY: 'jetpack_growth_monthly',
 	PLAN_JETPACK_GROWTH_YEARLY: 'jetpack_growth_yearly',
 	PLAN_JETPACK_GROWTH_BI_YEARLY: 'jetpack_growth_bi_yearly',
+	PRODUCT_JETPACK_SEARCH_BI_YEARLY: 'jetpack_search_bi_yearly',
+	PRODUCT_JETPACK_SEARCH: 'jetpack_search',
+	PRODUCT_JETPACK_SEARCH_MONTHLY: 'jetpack_search_monthly',
+	PRODUCT_JETPACK_SEARCH_FREE: 'jetpack_search_free',
 } as const;
 
 export const WPCOM_DIFM_LITE = 'wp_difm_lite';
+
+export const PRODUCT_1GB_SPACE = 'wordpress_com_1gb_space_addon_yearly';
+export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
+export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 
 export const OFFSITE_REDIRECT = 'offsite_redirect';
 
@@ -270,3 +278,18 @@ export const getPlanNames = () => ( {
 	[ DotcomPlans.ECOMMERCE ]: __( 'Commerce' ),
 	[ DotcomPlans.PREMIUM ]: __( 'Premium' ),
 } );
+
+export const PaymentPartners = {
+	PAYPAL_EXPRESS: 'paypal_express',
+	PAYPAL_PPCP: 'paypal_ppcp',
+	RAZORPAY: 'razorpay',
+} as const;
+
+export const JETPACK_SEARCH_PRODUCTS = [
+	JetpackPlans.PRODUCT_JETPACK_SEARCH_BI_YEARLY,
+	JetpackPlans.PRODUCT_JETPACK_SEARCH,
+	JetpackPlans.PRODUCT_JETPACK_SEARCH_MONTHLY,
+	JetpackPlans.PRODUCT_JETPACK_SEARCH_FREE,
+	PRODUCT_WPCOM_SEARCH,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
+];

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -30,6 +30,7 @@ export * from './me';
 export * from './me-account';
 export * from './me-allowed-payment-methods';
 export * from './me-account-recovery';
+export * from './me-billing-history';
 export * from './me-blocked-sites';
 export * from './me-connected-applications';
 export * from './me-dpa';

--- a/packages/api-core/src/me-billing-history/fetchers.ts
+++ b/packages/api-core/src/me-billing-history/fetchers.ts
@@ -1,0 +1,13 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { Receipt } from './types';
+
+export async function fetchReceipt( receiptId: number ): Promise< Receipt > {
+	return wpcom.req.get( {
+		path: `/me/billing-history/receipt/${ receiptId }`,
+		apiVersion: '1.2',
+	} );
+}
+
+export async function sendBillingReceiptEmail( receiptId: string ): Promise< unknown > {
+	return wpcom.req.post( `/me/billing-history/receipt/${ receiptId }/email` );
+}

--- a/packages/api-core/src/me-billing-history/fetchers.ts
+++ b/packages/api-core/src/me-billing-history/fetchers.ts
@@ -9,5 +9,5 @@ export async function fetchReceipt( receiptId: number ): Promise< Receipt > {
 }
 
 export async function sendBillingReceiptEmail( receiptId: string ): Promise< unknown > {
-	return wpcom.req.post( `/me/billing-history/receipt/${ receiptId }/email` );
+	return wpcom.req.get( `/me/billing-history/receipt/${ receiptId }/email` );
 }

--- a/packages/api-core/src/me-billing-history/index.ts
+++ b/packages/api-core/src/me-billing-history/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -1,5 +1,35 @@
 import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
 
+export interface TaxVendorInfo {
+	/**
+	 * The country code for this info.
+	 */
+	country_code: string;
+
+	/**
+	 * The mailing address to display on receipts as a list of strings (each
+	 * string should be on its own line).
+	 */
+	address: string[];
+
+	/**
+	 * An object containing tax names and corresponding vendor ids that are used for the user's country
+	 *
+	 * This will deprecate the vat_id and tax_name properties
+	 * For now, those two properties will stay in place for backwards compatibility
+	 *
+	 * Key:   The localized name of the tax (eg: "VAT", "GST", etc.).
+	 * Value: A8c vendor id for that specific tax
+	 */
+	tax_name_and_vendor_id_array: Record< string, string >;
+
+	/**
+	 * The localized name of the tax (eg: "VAT", "GST", etc.).
+	 * @deprecated This is still in place for backwards compability with cached clients
+	 */
+	tax_name: string;
+}
+
 export interface ReceiptItemCostOverride {
 	id: number;
 	human_readable_reason: string;
@@ -59,5 +89,5 @@ export interface Receipt {
 	cc_email: string;
 	credit: string;
 	items: ReceiptItem[];
-	tax_vendor_info: string;
+	tax_vendor_info?: TaxVendorInfo;
 }

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -1,0 +1,63 @@
+import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
+
+export interface ReceiptItemCostOverride {
+	id: number;
+	human_readable_reason: string;
+	override_code: string;
+	does_override_original_cost: boolean;
+	old_price_integer: number;
+	new_price_integer: number;
+}
+
+export interface ReceiptItem {
+	id: number;
+	type: string;
+	type_localized: string;
+	domain: string | null;
+	site_id: number;
+	subtotal_integer: number;
+	tax_integer: number;
+	amount_integer: number;
+	currency: string;
+	licensed_quantity: number;
+	new_quantity: number;
+	product: string;
+	product_slug: string;
+	variation: string;
+	variation_slug: string;
+	months_per_renewal_interval: number;
+	wpcom_product_slug: string;
+	cost_overrides: ReceiptItemCostOverride[];
+	volume: number;
+	credits_used: number | null;
+	introductory_offer_terms: IntroductoryOfferTerms | null;
+	price_tier_slug: string;
+}
+
+export interface Receipt {
+	id: number;
+	service: string;
+	service_slug: string;
+	currency: string;
+	subtotal_integer: number;
+	tax_integer: number;
+	amount_integer: number;
+	tax_country_code: string;
+	date: string;
+	desc: string;
+	org: string;
+	address: string | null;
+	icon: string;
+	url: string;
+	support: string;
+	pay_ref: string;
+	pay_part: string;
+	cc_type: string;
+	cc_display_brand: string;
+	cc_num: string;
+	cc_name: string;
+	cc_email: string;
+	credit: string;
+	items: ReceiptItem[];
+	tax_vendor_info: string;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -24,6 +24,7 @@ export * from './marketplace-search';
 export * from './me-a8c';
 export * from './me-account';
 export * from './me-account-recovery';
+export * from './me-billing-history';
 export * from './me-blocked-sites';
 export * from './me-connected-applications';
 export * from './me-dpa';

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -1,5 +1,5 @@
-import { fetchReceipt } from '@automattic/api-core';
-import { queryOptions } from '@tanstack/react-query';
+import { fetchReceipt, sendBillingReceiptEmail } from '@automattic/api-core';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 
 export const receiptQueryKey = ( receiptId: number ) => [ 'receipt', receiptId ];
 
@@ -7,4 +7,9 @@ export const receiptQuery = ( receiptId: number ) =>
 	queryOptions( {
 		queryKey: receiptQueryKey( receiptId ),
 		queryFn: () => fetchReceipt( receiptId ),
+	} );
+
+export const sendReceiptEmailMutation = () =>
+	mutationOptions( {
+		mutationFn: ( receiptId: string ) => sendBillingReceiptEmail( receiptId ),
 	} );

--- a/packages/api-queries/src/me-billing-history.ts
+++ b/packages/api-queries/src/me-billing-history.ts
@@ -1,0 +1,10 @@
+import { fetchReceipt } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const receiptQueryKey = ( receiptId: number ) => [ 'receipt', receiptId ];
+
+export const receiptQuery = ( receiptId: number ) =>
+	queryOptions( {
+		queryKey: receiptQueryKey( receiptId ),
+		queryFn: () => fetchReceipt( receiptId ),
+	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-235

## Proposed Changes

This adds the single receipt page to the Hosting Dashboard Billing section.

Depends on 194056-ghe-Automattic/wpcom

Calypso             |  Hosting Dashboard
:-------------------------:|:-------------------------:
<img width="727" height="729" alt="Screenshot 2025-10-15 at 6 14 30 PM" src="https://github.com/user-attachments/assets/9d18ff4c-27e5-4e97-926b-9948ef8f6d26" /> | <img width="528" height="660" alt="Screenshot 2025-10-17 at 1 00 13 PM" src="https://github.com/user-attachments/assets/44b6b7e2-d4f9-44ee-abb2-0851754c19a9" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since the billing history page in the hosting dashboard is not yet ready, visit the old billing history page at https://wordpress.com/me/purchases/billing and click on a receipt. Copy the receipt ID from the URL and then visit http://calypso.localhost:3000/v2/me/billing/billing-history/RECEIPT_ID_HERE

Verify that the information on the receipt page matches the information on the existing receipt page.