### PR TITLE
Add forms dashboard tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -83,7 +83,16 @@ export class FeedbackInboxPage {
 	 * @throws If the text is not found in the response.
 	 */
 	async validateTextInSubmission( text: string ): Promise< void > {
-		await this.page.locator( '.jp-forms__inbox-response' ).getByText( text ).first().waitFor();
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the response is in a full-screen modal
+			await this.page
+				.locator( '.jp-forms__inbox__response-mobile' )
+				.getByText( text )
+				.first()
+				.waitFor();
+		} else {
+			await this.page.locator( '.jp-forms__inbox-response' ).getByText( text ).first().waitFor();
+		}
 	}
 
 	/**
@@ -184,11 +193,16 @@ export class FeedbackInboxPage {
 	async clickNotSpamAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Not spam' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page
-			.getByText( 'Response marked as not spam.' )
-			.first()
-			.waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the modal closes after the action
+			await this.page.waitForTimeout( 1000 );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page
+				.getByText( 'Response marked as not spam.' )
+				.first()
+				.waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**
@@ -197,8 +211,13 @@ export class FeedbackInboxPage {
 	async clickMarkAsSpamAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Mark as spam' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page.getByText( 'Response marked as spam.' ).first().waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the modal closes after the action
+			await this.page.waitForTimeout( 1000 );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page.getByText( 'Response marked as spam.' ).first().waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**
@@ -207,8 +226,16 @@ export class FeedbackInboxPage {
 	async clickMarkAsReadAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Mark as read' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page.getByText( 'Response marked as read.' ).first().waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, read/unread actions keep the modal open, so wait for button state change
+			await this.page
+				.getByRole( 'button', { name: 'Mark as unread' } )
+				.last()
+				.waitFor( { timeout: 5000 } );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page.getByText( 'Response marked as read.' ).first().waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**
@@ -217,8 +244,19 @@ export class FeedbackInboxPage {
 	async clickMarkAsUnreadAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Mark as unread' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page.getByText( 'Response marked as unread.' ).first().waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, read/unread actions keep the modal open, so wait for button state change
+			await this.page
+				.getByRole( 'button', { name: 'Mark as read' } )
+				.last()
+				.waitFor( { timeout: 5000 } );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page
+				.getByText( 'Response marked as unread.' )
+				.first()
+				.waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**
@@ -227,8 +265,13 @@ export class FeedbackInboxPage {
 	async clickMoveToTrashAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Move to trash' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page.getByText( 'Response moved to trash.' ).first().waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the modal closes after the action
+			await this.page.waitForTimeout( 1000 );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page.getByText( 'Response moved to trash.' ).first().waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**
@@ -237,8 +280,13 @@ export class FeedbackInboxPage {
 	async clickRestoreAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
 		await this.page.getByRole( 'button', { name: 'Restore' } ).last().click();
-		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
-		await this.page.getByText( 'Response restored.' ).first().waitFor( { timeout: 5000 } );
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the modal closes after the action
+			await this.page.waitForTimeout( 1000 );
+		} else {
+			// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+			await this.page.getByText( 'Response restored.' ).first().waitFor( { timeout: 5000 } );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -44,7 +44,13 @@ export class FeedbackInboxPage {
 		await newResponseRowLocator.or( oldResponseRowLocator ).waitFor();
 		if ( await newResponseRowLocator.isVisible() ) {
 			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
-				await newResponseRowLocator.click();
+				// Check if the row is already selected to avoid de-selecting it
+				const isAlreadySelected = await newResponseRowLocator.evaluate( ( el ) =>
+					el.classList.contains( 'is-selected' )
+				);
+				if ( ! isAlreadySelected ) {
+					await newResponseRowLocator.click();
+				}
 				await this.page
 					.locator( '.jp-forms__inbox__dataviews .dataviews-view-table__row.is-selected' )
 					.filter( { hasText: text } )
@@ -84,8 +90,20 @@ export class FeedbackInboxPage {
 	 * Use the search input to search for a form response. Useful for filtering and triggering a data reload.
 	 *
 	 * @param {string} search The text to search for.
+	 * @param {boolean} skipWaiting Whether to skip waiting for the response request to complete.
 	 */
-	async searchResponses( search: string ): Promise< void > {
+	async searchResponses( search: string, skipWaiting: boolean = false ): Promise< void > {
+		if ( skipWaiting ) {
+			await this.page
+				.getByRole( 'searchbox', { name: 'Search' } )
+				.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
+				.fill( search );
+			await this.page
+				.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
+				.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\(\d+\)$/ } ) )
+				.waitFor();
+			return;
+		}
 		const responseRequestPromise = this.page.waitForResponse(
 			( response ) =>
 				// Atomic
@@ -110,12 +128,164 @@ export class FeedbackInboxPage {
 
 	/**
 	 * Clears the search input.
+	 *
+	 * @param {boolean} skipWaiting Whether to skip waiting for the response request to complete.
 	 */
-	async clearSearch(): Promise< void > {
+	async clearSearch( skipWaiting: boolean = false ): Promise< void > {
+		if ( skipWaiting ) {
+			// @todo Remove the `.or( ... )` once the DataView-based inbox is deployed everywhere.
+			await this.page
+				.getByRole( 'searchbox', { name: 'Search' } )
+				.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
+				.clear();
+			await this.page.waitForTimeout( 500 ); // Wait for the UI to update
+			return;
+		}
+		const responseRequestPromise = this.page.waitForResponse(
+			( response ) =>
+				// Atomic
+				( response.url().includes( '/wp-json/wp/v2/feedback' ) ||
+					// Simple
+					response.url().match( /\/wp\/v2\/sites\/[0-9]+\/feedback/ ) ||
+					// @todo Remove once once the DataView-based inbox is deployed everywhere.
+					response.url().includes( '/forms/responses' ) ) &&
+				! response.url().includes( 'search=' )
+		);
 		// @todo Remove the `.or( ... )` once the DataView-based inbox is deployed everywhere.
 		await this.page
 			.getByRole( 'searchbox', { name: 'Search' } )
 			.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
 			.clear();
+		await responseRequestPromise;
+		await this.page.waitForTimeout( 500 ); // Wait for the UI to update
+	}
+
+	/**
+	 * Clicks on a folder tab (Inbox, Spam, or Trash).
+	 *
+	 * @param {string} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash').
+	 */
+	async clickFolderTab( folderName: string ): Promise< void > {
+		// @todo Remove the `.or( ... )` once the DataView-based inbox is deployed everywhere.
+		await this.page
+			.getByRole( 'tab', { name: new RegExp( folderName, 'i' ) } )
+			.or(
+				this.page.getByRole( 'radio', {
+					name: new RegExp( `^${ folderName }\\s*\\(\\d+\\)$`, 'i' ),
+				} )
+			)
+			.click();
+		await this.page.waitForTimeout( 500 ); // Wait for the data to load
+	}
+
+	/**
+	 * Clicks the "Not spam" action button for the current response.
+	 */
+	async clickNotSpamAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Not spam' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page
+			.getByText( 'Response marked as not spam.' )
+			.first()
+			.waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Mark as spam" action button for the current response.
+	 */
+	async clickMarkAsSpamAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Mark as spam' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page.getByText( 'Response marked as spam.' ).first().waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Mark as read" action button for the current response.
+	 */
+	async clickMarkAsReadAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Mark as read' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page.getByText( 'Response marked as read.' ).first().waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Mark as unread" action button for the current response.
+	 */
+	async clickMarkAsUnreadAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Mark as unread' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page.getByText( 'Response marked as unread.' ).first().waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Move to trash" action button for the current response.
+	 */
+	async clickMoveToTrashAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Move to trash' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page.getByText( 'Response moved to trash.' ).first().waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Restore" action button for the current response.
+	 */
+	async clickRestoreAction(): Promise< void > {
+		// Use .last() to get the button in the side panel, not in the table row
+		await this.page.getByRole( 'button', { name: 'Restore' } ).last().click();
+		// Wait for the success notification (use .first() to avoid a11y-speak duplicate)
+		await this.page.getByText( 'Response restored.' ).first().waitFor( { timeout: 5000 } );
+	}
+
+	/**
+	 * Clicks the "Next" navigation button in the response view.
+	 */
+	async clickNextResponse(): Promise< void > {
+		// Use .last() to get the button in the side panel, not pagination buttons
+		await this.page.getByRole( 'button', { name: 'Next', exact: true } ).last().click();
+		await this.page.waitForTimeout( 1000 ); // Wait for the navigation to complete
+	}
+
+	/**
+	 * Clicks the "Previous" navigation button in the response view.
+	 */
+	async clickPreviousResponse(): Promise< void > {
+		// Use .last() to get the button in the side panel, not pagination buttons
+		await this.page.getByRole( 'button', { name: 'Previous', exact: true } ).last().click();
+		await this.page.waitForTimeout( 1000 ); // Wait for the navigation to complete
+	}
+
+	/**
+	 * Clicks the "Close" button in the response view.
+	 */
+	async clickCloseResponse(): Promise< void > {
+		await this.page.getByRole( 'button', { name: 'Close' } ).last().click();
+		await this.page.waitForTimeout( 300 ); // Wait for the panel to close
+	}
+
+	/**
+	 * Verifies that the Next navigation button is disabled.
+	 */
+	async verifyNextButtonDisabled(): Promise< void > {
+		// Use .last() to get the button in the side panel, not pagination buttons
+		await this.page
+			.getByRole( 'button', { name: 'Next', exact: true, disabled: true } )
+			.last()
+			.waitFor();
+	}
+
+	/**
+	 * Verifies that the Previous navigation button is disabled.
+	 */
+	async verifyPreviousButtonDisabled(): Promise< void > {
+		// Use .last() to get the button in the side panel, not pagination buttons
+		await this.page
+			.getByRole( 'button', { name: 'Previous', exact: true, disabled: true } )
+			.last()
+			.waitFor();
 	}
 }

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -245,6 +245,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.validateTextInSubmission( formData1.phone );
 			await feedbackInboxPage.validateTextInSubmission( formData1.hearAboutUsOption );
 			await feedbackInboxPage.validateTextInSubmission( formData1.otherDetails );
+			await feedbackInboxPage.clickCloseResponse();
 		} );
 	} );
 
@@ -310,6 +311,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.validateTextInSubmission( formData2.phone );
 			await feedbackInboxPage.validateTextInSubmission( formData2.hearAboutUsOption );
 			await feedbackInboxPage.validateTextInSubmission( formData2.otherDetails );
+			await feedbackInboxPage.clickCloseResponse();
 		} );
 	} );
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -192,7 +192,6 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// The email is unique to every run, so will only ever return one response result when the search is successful.
 			// So we loop over a search attempt on the email, looking for a folder tab with a result in it!
 			const searchAndClickFolderWithResult = async () => {
-				await feedbackInboxPage.clearSearch();
 				await feedbackInboxPage.searchResponses( formData1.email );
 				const tabLocator = page
 					.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
@@ -363,6 +362,12 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 				await feedbackInboxPage.validateTextInSubmission( formData1.name );
 				await feedbackInboxPage.validateTextInSubmission( formData1.email );
+			}
+		} );
+
+		it( 'Close response modal', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+				await feedbackInboxPage.clickCloseResponse();
 			}
 		} );
 	} );

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -14,13 +14,22 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page, Browser, Locator } from 'playwright';
 
-const formData = {
+const formData1 = {
 	name: `${ DataHelper.getRandomPhrase() }`,
 	// Making the email unique to each run allows us to filter down to one in the inbox later.
 	email: `test${ DataHelper.getTimestamp() + DataHelper.getRandomInteger( 0, 100 ) }@example.com`,
 	phone: '(877) 273-3049',
 	hearAboutUsOption: 'Search Engine',
-	otherDetails: 'Test submission details',
+	otherDetails: 'Test submission details - First',
+};
+
+const formData2 = {
+	name: `${ DataHelper.getRandomPhrase() }`,
+	// Making the email unique for the second submission
+	email: `test${ DataHelper.getTimestamp() + DataHelper.getRandomInteger( 100, 200 ) }@example.com`,
+	phone: '(877) 273-3050',
+	hearAboutUsOption: 'Social Media',
+	otherDetails: 'Test submission details - Second',
 };
 
 const postTitle = DataHelper.getRandomPhrase();
@@ -46,7 +55,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		const postContent = `<!-- wp:jetpack/contact-form {"subject":"A new registration from your website","to":"","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
+		const postContent = `<!-- wp:jetpack/contact-form {"subject":"A new registration from your website","to":"","disableGoBack":false,"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
 						<div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:jetpack/field-name {"required":true,"requiredText":"(required)"} /-->
 
 						<!-- wp:jetpack/field-email {"required":true,"requiredText":"(required)"} /-->
@@ -73,38 +82,86 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		);
 	} );
 
-	describe( 'Fill and submit form', function () {
+	describe( 'Fill and submit first form', function () {
 		it( 'View the published post', async function () {
 			await page.goto( newPostDetails.URL );
 		} );
 
-		it( 'Fill out form', async function () {
+		it( 'Fill out first form', async function () {
 			publishedFormLocator = page.locator( "[data-test='contact-form']" );
 
-			await publishedFormLocator.getByRole( 'textbox', { name: 'Name' } ).fill( formData.name );
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Name' } ).fill( formData1.name );
 
-			await publishedFormLocator.getByRole( 'textbox', { name: 'Email' } ).fill( formData.email );
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Email' } ).fill( formData1.email );
 
-			await publishedFormLocator.getByRole( 'textbox', { name: 'Phone' } ).fill( formData.phone );
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Phone' } ).fill( formData1.phone );
 
 			await publishedFormLocator
 				.getByRole( 'combobox', { name: 'How did you hear about us?' } )
-				.selectOption( { label: formData.hearAboutUsOption } );
+				.selectOption( { label: formData1.hearAboutUsOption } );
 
 			await publishedFormLocator
 				.getByRole( 'textbox', { name: 'Other details' } )
-				.fill( formData.otherDetails );
+				.fill( formData1.otherDetails );
 		} );
 
-		it( 'Submit form', async function () {
+		it( 'Submit first form', async function () {
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
 
 			await page.getByText( 'Your message has been sent' ).waitFor( { timeout: 20 * 1000 } );
 		} );
+
+		it( 'Verify "Go back" link appears', async function () {
+			// The "Go back" can be either a link or button depending on the implementation
+			await page.getByText( 'Go back', { exact: true } ).waitFor();
+		} );
+
+		it( 'Click "Go back" to return to form', async function () {
+			await page.getByText( 'Go back', { exact: true } ).click();
+			// Verify the form is visible again and the success message is hidden
+			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).waitFor();
+			// Wait for the success message to be hidden
+			await page.waitForTimeout( 500 );
+		} );
 	} );
 
-	describe( 'Validate response', function () {
+	describe( 'Fill and submit second form', function () {
+		it( 'Reload the page to get a fresh form', async function () {
+			await page.reload();
+			publishedFormLocator = page.locator( "[data-test='contact-form']" );
+			// Wait for the form to be ready
+			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).waitFor();
+		} );
+
+		it( 'Fill out second form', async function () {
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Name' } ).fill( formData2.name );
+
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Email' } ).fill( formData2.email );
+
+			await publishedFormLocator.getByRole( 'textbox', { name: 'Phone' } ).fill( formData2.phone );
+
+			await publishedFormLocator
+				.getByRole( 'combobox', { name: 'How did you hear about us?' } )
+				.selectOption( { label: formData2.hearAboutUsOption } );
+
+			await publishedFormLocator
+				.getByRole( 'textbox', { name: 'Other details' } )
+				.fill( formData2.otherDetails );
+		} );
+
+		it( 'Submit second form', async function () {
+			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
+
+			// Wait for the success message to become visible (not just exist)
+			await page
+				.getByText( 'Your message has been sent' )
+				.waitFor( { state: 'visible', timeout: 20 * 1000 } );
+		} );
+	} );
+
+	describe( 'Validate first response', function () {
 		let feedbackInboxPage: FeedbackInboxPage;
+		let isInSpam = false;
 
 		beforeAll( async function () {
 			await testAccount.authenticate( page );
@@ -127,7 +184,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		} );
 
-		it( 'Search for unique response email until result shows up', async function () {
+		it( 'Search for first response email until result shows up', async function () {
 			// There's a lot we have to account for to stably find the right response!
 			// First, there may be a delay in the response showing up.
 			// Second, the response may be in the spam folder!
@@ -136,11 +193,14 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// So we loop over a search attempt on the email, looking for a folder tab with a result in it!
 			const searchAndClickFolderWithResult = async () => {
 				await feedbackInboxPage.clearSearch();
-				await feedbackInboxPage.searchResponses( formData.email );
-				await page
+				await feedbackInboxPage.searchResponses( formData1.email );
+				const tabLocator = page
 					.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
-					.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) )
-					.click( { timeout: 4000 } );
+					.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
+				await tabLocator.click( { timeout: 4000 } );
+				// Check if we're in spam folder
+				const tabText = await tabLocator.textContent();
+				isInSpam = tabText?.toLowerCase().includes( 'spam' ) || false;
 			};
 
 			const MAX_ATTEMPTS = 3;
@@ -156,16 +216,229 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			}
 		} );
 
-		it( 'Click response row', async () => {
-			await feedbackInboxPage.clickResponseRowByText( formData.name );
+		it( 'Click first response row', async () => {
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 		} );
 
-		it( 'Validate response data', async () => {
-			await feedbackInboxPage.validateTextInSubmission( formData.name );
-			await feedbackInboxPage.validateTextInSubmission( formData.email );
-			await feedbackInboxPage.validateTextInSubmission( formData.phone );
-			await feedbackInboxPage.validateTextInSubmission( formData.hearAboutUsOption );
-			await feedbackInboxPage.validateTextInSubmission( formData.otherDetails );
+		it( 'If in Spam, mark as not spam', async function () {
+			if ( isInSpam ) {
+				await feedbackInboxPage.clickNotSpamAction();
+			}
+		} );
+
+		it( 'Navigate to Inbox tab', async function () {
+			if ( isInSpam ) {
+				// Clear search first to show all responses
+				await feedbackInboxPage.clearSearch( true );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
+				// Wait for folder change to complete and data to reload
+				await page.waitForTimeout( 2000 );
+				// Search again for the first response in Inbox
+				await feedbackInboxPage.searchResponses( formData1.name );
+				await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			}
+		} );
+
+		it( 'Validate first response data', async () => {
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.email );
+			await feedbackInboxPage.validateTextInSubmission( formData1.phone );
+			await feedbackInboxPage.validateTextInSubmission( formData1.hearAboutUsOption );
+			await feedbackInboxPage.validateTextInSubmission( formData1.otherDetails );
+		} );
+	} );
+
+	describe( 'Validate second response', function () {
+		let feedbackInboxPage: FeedbackInboxPage;
+		let isInSpam = false;
+
+		it( 'Search for second response email until result shows up', async function () {
+			feedbackInboxPage = new FeedbackInboxPage( page );
+
+			const searchAndClickFolderWithResult = async () => {
+				// Don't clear/wait as it won't happen, results are cached.
+				await feedbackInboxPage.clearSearch( true );
+				await feedbackInboxPage.searchResponses( formData2.email );
+				const tabLocator = page
+					.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
+					.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
+				await tabLocator.click( { timeout: 4000 } );
+				// Check if we're in spam folder
+				const tabText = await tabLocator.textContent();
+				isInSpam = tabText?.toLowerCase().includes( 'spam' ) || false;
+			};
+
+			const MAX_ATTEMPTS = 3;
+			for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
+				try {
+					await searchAndClickFolderWithResult();
+					return;
+				} catch ( err ) {
+					if ( attempt === MAX_ATTEMPTS ) {
+						throw err;
+					}
+				}
+			}
+		} );
+
+		it( 'Click second response row', async () => {
+			await feedbackInboxPage.clickResponseRowByText( formData2.name );
+		} );
+
+		it( 'If in Spam, mark as not spam', async function () {
+			if ( isInSpam ) {
+				await feedbackInboxPage.clickNotSpamAction();
+			}
+		} );
+
+		it( 'Navigate to Inbox tab', async function () {
+			if ( isInSpam ) {
+				// Clear search first to show all responses
+				await feedbackInboxPage.clearSearch( true );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
+				// Wait for folder change to complete
+				await page.waitForTimeout( 1000 );
+				// Search again for the second response in Inbox
+				await feedbackInboxPage.searchResponses( formData2.name );
+				await feedbackInboxPage.clickResponseRowByText( formData2.name );
+			}
+		} );
+
+		it( 'Validate second response data', async () => {
+			await feedbackInboxPage.validateTextInSubmission( formData2.name );
+			await feedbackInboxPage.validateTextInSubmission( formData2.email );
+			await feedbackInboxPage.validateTextInSubmission( formData2.phone );
+			await feedbackInboxPage.validateTextInSubmission( formData2.hearAboutUsOption );
+			await feedbackInboxPage.validateTextInSubmission( formData2.otherDetails );
+		} );
+	} );
+
+	describe( 'Test response navigation', function () {
+		let feedbackInboxPage: FeedbackInboxPage;
+
+		it( 'Clear search to show both responses', async function () {
+			feedbackInboxPage = new FeedbackInboxPage( page );
+			await feedbackInboxPage.clearSearch( true );
+			// Wait for the data to reload
+			await page.waitForTimeout( 1000 );
+		} );
+
+		it( 'Click on first response', async function () {
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+		} );
+
+		it( 'Verify first response data is visible', async function () {
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.email );
+		} );
+
+		it( 'Click Previous to navigate to second response', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+				await feedbackInboxPage.clickPreviousResponse();
+			}
+		} );
+
+		it( 'Verify second response data is visible', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+				await feedbackInboxPage.validateTextInSubmission( formData2.name );
+				await feedbackInboxPage.validateTextInSubmission( formData2.email );
+			}
+		} );
+
+		it( 'Verify Previous button is disabled (no newer responses)', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+				await feedbackInboxPage.verifyPreviousButtonDisabled();
+			}
+		} );
+
+		it( 'Click Next to navigate back to first response', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+				await feedbackInboxPage.clickNextResponse();
+			}
+		} );
+
+		it( 'Verify first response data is visible again', async function () {
+			if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+				await feedbackInboxPage.validateTextInSubmission( formData1.name );
+				await feedbackInboxPage.validateTextInSubmission( formData1.email );
+			}
+		} );
+	} );
+
+	describe( 'Test response actions', function () {
+		let feedbackInboxPage: FeedbackInboxPage;
+
+		it( 'Ensure first response is selected', async function () {
+			feedbackInboxPage = new FeedbackInboxPage( page );
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+		} );
+
+		it( 'Mark first response as unread', async function () {
+			await feedbackInboxPage.clickMarkAsUnreadAction();
+		} );
+
+		it( 'Mark first response as read', async function () {
+			// Re-select the response after the action
+			// await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.clickMarkAsReadAction();
+		} );
+
+		it( 'Mark first response as spam', async function () {
+			// Re-select the response after the action
+			// await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.clickMarkAsSpamAction();
+		} );
+
+		it( 'Navigate to Spam folder', async function () {
+			await feedbackInboxPage.clickFolderTab( 'Spam' );
+		} );
+
+		it( 'Verify first response is in Spam', async function () {
+			await feedbackInboxPage.searchResponses( formData1.email );
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
+		} );
+
+		it( 'Mark first response as not spam', async function () {
+			await feedbackInboxPage.clickNotSpamAction();
+		} );
+
+		it( 'Navigate back to Inbox', async function () {
+			await feedbackInboxPage.clickFolderTab( 'Inbox' );
+		} );
+
+		it( 'Verify first response is back in Inbox', async function () {
+			await feedbackInboxPage.searchResponses( formData1.email, true );
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
+		} );
+
+		it( 'Move first response to trash', async function () {
+			await feedbackInboxPage.clickMoveToTrashAction();
+		} );
+
+		it( 'Navigate to Trash folder', async function () {
+			await feedbackInboxPage.clickFolderTab( 'Trash' );
+		} );
+
+		it( 'Verify first response is in Trash', async function () {
+			await feedbackInboxPage.searchResponses( formData1.email, true );
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
+		} );
+
+		it( 'Restore first response from trash', async function () {
+			await feedbackInboxPage.clickRestoreAction();
+		} );
+
+		it( 'Navigate back to Inbox to confirm', async function () {
+			await feedbackInboxPage.clickFolderTab( 'Inbox' );
+		} );
+
+		it( 'Verify first response is restored in Inbox', async function () {
+			await feedbackInboxPage.searchResponses( formData1.email, true );
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
 	} );
 } );


### PR DESCRIPTION
Add Comprehensive E2E Tests for Jetpack Forms Submissions and Inbox Management

NOTE: we might do good and wait until next AT deploy, currently all these tests run fine except on AT mobile, as it still doesn't have latest changes that alter the close button markup.

(Claude summary)

## Summary

  Adds comprehensive end-to-end tests for Jetpack Forms covering form submissions, spam detection, inbox navigation, and response management
  actions (43 test cases total).

  ## Changes

  ### Tests (`test/e2e/specs/published-content/forms__submissions.ts`)
  - Form submission with "Go back" button functionality
  - Spam folder detection and "Mark as not spam" action
  - Response navigation (Previous/Next/Close buttons)
  - Response actions (read/unread, spam, trash, restore)
  - Folder navigation between Inbox, Spam, and Trash

  ### Page Object (`packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts`)

  **New methods:**
  - Folder navigation: `clickFolderTab()`
  - Response actions: `clickNotSpamAction()`, `clickMarkAsSpamAction()`, `clickMarkAsReadAction()`, `clickMarkAsUnreadAction()`,
  `clickMoveToTrashAction()`, `clickRestoreAction()`
  - Response navigation: `clickNextResponse()`, `clickPreviousResponse()`, `clickCloseResponse()`, `verifyNextButtonDisabled()`,
  `verifyPreviousButtonDisabled()`

  **Bug fixes:**
  - `clickResponseRowByText()`: Now checks if row is already selected before clicking to prevent de-selection
  - `clearSearch()`: Now waits for API response to complete
  - All action buttons use `.last()` to avoid strict mode violations (multiple matching elements)
  - All notifications use `.first()` to avoid matching hidden a11y-speak regions

Summary of Mobile Support Changes

  The same 43 tests now work on both desktop and mobile viewports with minimal code changes:

  Key Changes to FeedbackInboxPage (packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts):

  1. Action methods now handle mobile differently:
    - Mobile: Actions that change status (spam, trash, restore) close the modal immediately, so we wait for timeout instead of notification
    - Mobile: Read/unread actions keep the modal open, so we wait for the button state to change
    - Desktop: Wait for success notifications as before
  2. Updated methods:
    - clickNotSpamAction(), clickMarkAsSpamAction(), clickMoveToTrashAction(), clickRestoreAction(): Wait for modal close on mobile (1000ms
  timeout)
    - clickMarkAsReadAction(), clickMarkAsUnreadAction(): Wait for opposite button to appear on mobile (indicates state changed)
    - validateTextInSubmission(): Look for .jp-forms__inbox__response-mobile container on mobile instead of .jp-forms__inbox-response
  3. Test file adjustment:
    - Added "Close response modal" test at the end of navigation tests (mobile-only) to ensure modal is closed before next test suite


## Testing

```bash
# Desktop
VIEWPORT_NAME='desktop' yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts

# Mobile
VIEWPORT_NAME='mobile' yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts

# AT desktop
ATOMIC_VARIATION=default TEST_ON_ATOMIC=true VIEWPORT_NAME=desktop yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts

# AT mobile
ATOMIC_VARIATION=default TEST_ON_ATOMIC=true VIEWPORT_NAME=mobile yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```