### PR TITLE
Garden: CIAB hosting dashboard updates

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -8,6 +8,7 @@ import {
 	domainsQuery,
 	mailboxesQuery,
 	siteByIdQuery,
+	sitesQuery,
 	queryClient,
 	domainTransferRequestQuery,
 	domainWhoisQuery,
@@ -47,6 +48,7 @@ export const domainsRoute = createRoute( {
 	path: 'domains',
 	loader: async () => {
 		queryClient.ensureQueryData( domainsQuery() );
+		queryClient.ensureQueryData( sitesQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 } ).lazy( () =>

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -31,7 +31,7 @@ const SiteChangeAddressContent = lazy(
 
 const noop = () => {};
 
-export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
+export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) => {
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
@@ -146,11 +146,12 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				label: __( 'Make primary site address' ),
 				supportsBulk: false,
 				callback: ( domains: DomainSummary[] ) => {
+					const domain = domains[ 0 ];
+					const site = sites?.find( ( s ) => s.ID === domain.blog_id );
+
 					if ( ! site ) {
 						return;
 					}
-
-					const domain = domains[ 0 ];
 					setPrimaryDomainMutation.mutate(
 						{ siteId: site.ID, domain: domain.domain },
 						{
@@ -178,6 +179,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					);
 				},
 				isEligible: ( item: DomainSummary ) => {
+					const site = sites?.find( ( s ) => s.ID === item.blog_id );
 					return !! site && canSetAsPrimary( { domain: item, site, user } );
 				},
 				disabled: setPrimaryDomainMutation.isPending,
@@ -222,10 +224,12 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 				supportsBulk: false,
 				callback: () => {},
 				isEligible: ( item: DomainSummary ) => {
+					const site = sites?.find( ( s ) => s.ID === item.blog_id );
 					return !! site && ! site?.is_wpcom_atomic && isFreeUrlDomainName( item.domain );
 				},
-				RenderModal: ( { items, closeModal = noop } ) =>
-					site ? (
+				RenderModal: ( { items, closeModal = noop } ) => {
+					const site = sites?.find( ( s ) => s.ID === items[ 0 ].blog_id );
+					return site ? (
 						<Suspense fallback={ null }>
 							<SiteChangeAddressContent
 								site={ site }
@@ -233,7 +237,8 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 								onClose={ closeModal }
 							/>
 						</Suspense>
-					) : null,
+					) : null;
+				},
 			},
 			{
 				id: 'manage-auto-renew',
@@ -245,7 +250,7 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 		],
 		[
 			user,
-			site,
+			sites,
 			router,
 			purchases,
 			setPrimaryDomainMutation,

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -36,6 +36,16 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
+	let sitesByBlogId: Record< number, Site > = {};
+	if ( sites ) {
+		sitesByBlogId = sites.reduce(
+			( acc, site ) => {
+				acc[ site.ID ] = site;
+				return acc;
+			},
+			{} as Record< number, Site >
+		);
+	}
 	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{
@@ -147,7 +157,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				supportsBulk: false,
 				callback: ( domains: DomainSummary[] ) => {
 					const domain = domains[ 0 ];
-					const site = sites?.find( ( s ) => s.ID === domain.blog_id );
+					const site = sitesByBlogId[ domain.blog_id ];
 
 					if ( ! site ) {
 						return;
@@ -179,7 +189,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 					);
 				},
 				isEligible: ( item: DomainSummary ) => {
-					const site = sites?.find( ( s ) => s.ID === item.blog_id );
+					const site = sitesByBlogId[ item.blog_id ];
 					return !! site && canSetAsPrimary( { domain: item, site, user } );
 				},
 				disabled: setPrimaryDomainMutation.isPending,
@@ -224,11 +234,11 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				supportsBulk: false,
 				callback: () => {},
 				isEligible: ( item: DomainSummary ) => {
-					const site = sites?.find( ( s ) => s.ID === item.blog_id );
+					const site = sitesByBlogId[ item.blog_id ];
 					return !! site && ! site?.is_wpcom_atomic && isFreeUrlDomainName( item.domain );
 				},
 				RenderModal: ( { items, closeModal = noop } ) => {
-					const site = sites?.find( ( s ) => s.ID === items[ 0 ].blog_id );
+					const site = sitesByBlogId[ items[ 0 ].blog_id ];
 					return site ? (
 						<Suspense fallback={ null }>
 							<SiteChangeAddressContent
@@ -250,12 +260,12 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 		],
 		[
 			user,
-			sites,
 			router,
 			purchases,
 			setPrimaryDomainMutation,
 			createSuccessNotice,
 			createErrorNotice,
+			sitesByBlogId,
 		]
 	);
 

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -36,16 +36,18 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
-	let sitesByBlogId: Record< number, Site > = {};
-	if ( sites ) {
-		sitesByBlogId = sites.reduce(
+	const sitesByBlogId: Record< number, Site > = useMemo( () => {
+		if ( ! sites ) {
+			return {};
+		}
+		return sites.reduce(
 			( acc, site ) => {
 				acc[ site.ID ] = site;
 				return acc;
 			},
 			{} as Record< number, Site >
 		);
-	}
+	}, [ sites ] );
 	const actions: Action< DomainSummary >[] = useMemo(
 		() => [
 			{

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,5 +1,5 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainsQuery } from '@automattic/api-queries';
+import { domainsQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +21,8 @@ export function getDomainId( domain: DomainSummary ): string {
 function Domains() {
 	const { user } = useAuth();
 	const fields = useFields();
-	const actions = useActions( { user } );
+	const { data: sites } = useQuery( sitesQuery() );
+	const actions = useActions( { user, sites } );
 	const [ view, setView ] = useState< DomainsView >( () => ( {
 		...DEFAULT_VIEW,
 		type: 'table',

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -38,7 +38,7 @@ function SiteDomains() {
 		site,
 	} );
 
-	const actions = useActions( { user, site } );
+	const actions = useActions( { user, sites: [ site ] } );
 
 	const [ view, setView ] = useState< DomainsView >( () => ( {
 		...SITE_CONTEXT_VIEW,

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -104,7 +104,8 @@ export function shouldUpgradeToMakeDomainPrimary( {
 		! domain.primary_domain &&
 		userHasFlag( user, 'calypso_allow_nonprimary_domains_without_plan' ) &&
 		!! site.plan?.is_free &&
-		! hasPlanFeature( site, DotcomFeatures.SET_PRIMARY_CUSTOM_DOMAIN )
+		! hasPlanFeature( site, DotcomFeatures.SET_PRIMARY_CUSTOM_DOMAIN ) &&
+		! site.is_garden
 	);
 }
 

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -8,10 +8,8 @@ import { addPlanToCart, addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automat
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
-import wpcom from 'calypso/lib/wp';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
-import { useSite } from '../../../hooks/use-site';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
@@ -33,7 +31,6 @@ const domainUpsell: Flow = {
 		const backTo = useQuery().get( 'back_to' );
 		const flowName = this.name;
 		const siteSlug = useSiteSlug()!;
-		const site = useSite();
 		const { getDomainCartItem, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
@@ -112,27 +109,6 @@ const domainUpsell: Flow = {
 							initialQuery: providedDependencies.domain,
 						} );
 						return navigate( destination as typeof currentStep );
-					}
-
-					// For garden sites with domain mapping, skip plans and map directly
-					const domainCartItem = providedDependencies?.domainCartItem as
-						| MinimalRequestCartProduct
-						| undefined;
-
-					if (
-						site &&
-						( site as { is_garden?: boolean } ).is_garden &&
-						domainCartItem &&
-						domainCartItem.product_slug === 'domain_map'
-					) {
-						const domain = domainCartItem.meta as string;
-
-						try {
-							await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
-							return window.location.assign( `/ciab/sites/${ domain }` );
-						} catch ( error ) {
-							// If mapping fails, fall through to plans step
-						}
 					}
 
 					submittedDomains.current = true;

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -8,8 +8,10 @@ import { addPlanToCart, addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automat
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
+import wpcom from 'calypso/lib/wp';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
+import { useSite } from '../../../hooks/use-site';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
@@ -31,6 +33,7 @@ const domainUpsell: Flow = {
 		const backTo = useQuery().get( 'back_to' );
 		const flowName = this.name;
 		const siteSlug = useSiteSlug()!;
+		const site = useSite();
 		const { getDomainCartItem, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
@@ -109,6 +112,27 @@ const domainUpsell: Flow = {
 							initialQuery: providedDependencies.domain,
 						} );
 						return navigate( destination as typeof currentStep );
+					}
+
+					// For garden sites with domain mapping, skip plans and map directly
+					const domainCartItem = providedDependencies?.domainCartItem as
+						| MinimalRequestCartProduct
+						| undefined;
+
+					if (
+						site &&
+						( site as { is_garden?: boolean } ).is_garden &&
+						domainCartItem &&
+						domainCartItem.product_slug === 'domain_map'
+					) {
+						const domain = domainCartItem.meta as string;
+
+						try {
+							await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
+							return window.location.assign( `/ciab/sites/${ domain }` );
+						} catch ( error ) {
+							// If mapping fails, fall through to plans step
+						}
 					}
 
 					submittedDomains.current = true;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-1093

## Proposed Changes

This fills in various gaps with the `/ciab` hosting dashboard for garden sites.

* (Part of ARC-1094) Ensure that `Make primary site address` appears for garden sites (when appropriate)
* (Part of ARC-1099) Update the use-your-own-domain flow for garden sites. We skip the plans page and checkout, map the external domain, and continue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 194223-ghe-Automattic/wpcom on your sandbox if it hasn't been merged yet and sandbox the public api.
* Use `/tools/garden/` in MC to create a garden site.
* Once the site is provisioned, use the link in the MC tool to visit the wp-admin. For now, this is necessary to ensure that the required capabilities are synced to the Jetpack site.
* Run this PR locally and visit http://calypso.localhost:3000/ciab/sites.
* You should see your garden site in the list.
* Click "Actions" and "Settings". Then click "Overview" on the settings page.
* The domains list should have the "The perfect domain awaits" CTA.
* Click "choose your own", then "Use a domain I already own", then enter a domain name. (I've been using `random-subdomain.biek.dev` but it doesn't really matter since we're not configuring DNS for the domain).
* Click "Continue", then click "Select" under "Connect your domain".
* Your should return to the site overview.

* Click the "Domains" link at the top of the page.
* Click on the "..." Actions menu for the newly mapped domain.
* Click "Make primary site address".
  - Note that there's a 30 minute delay before you can set a new domain to primary. You can skip this by modifying [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/domains/dataviews/actions.tsx#L194) from `! isRecentlyRegistered( item.registration_date )` to `( true || ! isRecentlyRegistered( item.registration_date ) )`. You may also need to comment out line 1244 of `class.wpcom-store-domains-api-endpoints.php` on your sandbox and sandbox the public-api.
* The domain should be made primary

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?