### PR TITLE
Revert "Domain Search Rewrite Cleanup: Remove domainAndPlanPackage (#106480)"

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -75,6 +75,7 @@ const DomainUpsellCardContent = ( {
 				siteSlug: site.slug,
 				backUrl,
 				step: 'plans',
+				domain: true,
 			} );
 		} else {
 			window.location.href = addQueryArgs( `/checkout/${ site.slug }`, {
@@ -87,6 +88,7 @@ const DomainUpsellCardContent = ( {
 	const chooseYourOwnUrl = getDomainAndPlanUpsellUrl( {
 		siteSlug: site.slug,
 		backUrl,
+		domain: true,
 	} );
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -175,13 +175,15 @@ const Sidebar = ( {
 			return '';
 		}
 
+		if ( isStartWritingFlow( siteIntentOption ) ) {
+			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;
+		}
+
 		if ( ! site?.plan?.is_free ) {
 			return `/domains/manage/${ siteSlug }`;
 		}
 
-		const backUrl = `/setup/${ siteIntentOption }/launchpad?siteSlug=${ siteSlug }`;
-
-		return getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+		return getDomainAndPlanUpsellUrl( { siteSlug } );
 	}
 
 	function showDomainUpgradeBadge() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,8 +1,9 @@
 import { Task } from '@automattic/launchpad';
-import { isStartWritingFlow } from '@automattic/onboarding';
+import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
-import { isDomainUpsellCompleted } from '../../task-helper';
+import { getSiteIdOrSlug, isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -14,12 +15,22 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 			return '';
 		}
 
+		if ( isStartWritingFlow( flow ) || isReadymadeFlow( flow ) ) {
+			return addQueryArgs( `/setup/${ flow }/domains`, {
+				...getSiteIdOrSlug( flow, site, siteSlug ),
+				flowToReturnTo: flow,
+				new: site?.name,
+				domainAndPlanPackage: true,
+			} );
+		}
+
 		const backUrl = `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;
 
 		const purchaseDomainUrl = getDomainAndPlanUpsellUrl( {
 			siteSlug,
 			backUrl,
 			suggestion: site?.name,
+			forceStepperFlow: true,
 		} );
 
 		return domainUpsellCompleted ? `/domains/manage/${ siteSlug }` : purchaseDomainUrl;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -29,7 +29,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/domain-and-plan?siteSlug=site.wordpress.com&back_to=%2Fsetup%2Fstart-writing%2Flaunchpad%3FsiteSlug%3Dsite.wordpress.com&new=site.wordpress.com',
+				'/setup/start-writing/domains?siteId=211078228&flowToReturnTo=start-writing&new=site.wordpress.com&domainAndPlanPackage=true',
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -79,7 +79,7 @@ const sidebarDomain = buildDomainResponse( {
 } );
 
 const upgradeDomainBadgeText = 'Pick a custom domain';
-const upgradeDomainBadgeLink = `/setup/domain-and-plan?siteSlug=${ sidebarDomain.domain }&back_to=%2Fsetup%2Fnewsletter%2Flaunchpad%3FsiteSlug%3D${ siteSlug }`;
+const upgradeDomainBadgeLink = `/setup/domain-and-plan?siteSlug=${ sidebarDomain.domain }`;
 
 const props = {
 	sidebarDomain,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,6 +39,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -357,6 +358,7 @@ export default withCurrentRoute(
 		const siteId = getSelectedSiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
+		const isDomainAndPlanPackageFlow = !! getCurrentQueryArguments( state )?.domainAndPlanPackage;
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
@@ -379,6 +381,7 @@ export default withCurrentRoute(
 		const noMasterbarForRoute =
 			isJetpackLogin ||
 			currentRoute === '/me/account/closed' ||
+			isDomainAndPlanPackageFlow ||
 			isReaderTagEmbedPage( window?.location );
 		const noMasterbarForSection =
 			// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
@@ -401,7 +404,7 @@ export default withCurrentRoute(
 		const isEligibleForJITM = [ 'home', 'plans', 'themes', 'plugins', 'comments' ].includes(
 			sectionName
 		);
-		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
 		const isGlobalSidebarVisible = shouldShowGlobalSidebar && ! sidebarIsHidden;
 
 		const colorScheme = isWooJPC

--- a/client/lib/domains/get-domain-and-plan-upsell-url.ts
+++ b/client/lib/domains/get-domain-and-plan-upsell-url.ts
@@ -1,10 +1,17 @@
 import { addQueryArgs } from '@wordpress/url';
+import { shouldRenderRewrittenDomainSearch } from './should-render-rewritten-domain-search';
 
 interface GetDomainUpsellUrlParams {
 	siteSlug: string;
 	step?: 'domains' | 'plans';
 	suggestion?: string;
 	backUrl?: string;
+	domain?: boolean;
+	/**
+	 * This is necessary while we don't remove the feature flag and ?domainAndPlanPackage=true entirely.
+	 * Some entrypoints currently link to the domain and package plan flow instead of the domains/add page.
+	 */
+	forceStepperFlow?: boolean;
 }
 
 export const getDomainAndPlanUpsellUrl = ( {
@@ -12,17 +19,35 @@ export const getDomainAndPlanUpsellUrl = ( {
 	backUrl,
 	step = 'domains',
 	suggestion,
+	domain,
+	forceStepperFlow,
 }: GetDomainUpsellUrlParams ) => {
 	if ( step === 'domains' ) {
-		return addQueryArgs( '/setup/domain-and-plan', {
-			siteSlug,
+		if ( shouldRenderRewrittenDomainSearch() || forceStepperFlow ) {
+			return addQueryArgs( '/setup/domain-and-plan', {
+				siteSlug,
+				back_to: backUrl,
+				new: suggestion,
+			} );
+		}
+
+		return addQueryArgs( `/domains/add/${ siteSlug }`, {
+			domainAndPlanPackage: true,
+			domain,
 			back_to: backUrl,
-			new: suggestion,
 		} );
 	}
 
-	return addQueryArgs( '/setup/domain-and-plan/plans', {
-		siteSlug,
+	if ( shouldRenderRewrittenDomainSearch() || forceStepperFlow ) {
+		return addQueryArgs( '/setup/domain-and-plan/plans', {
+			siteSlug,
+			back_to: backUrl,
+		} );
+	}
+
+	return addQueryArgs( `/plans/yearly/${ siteSlug }`, {
+		domain,
+		domainAndPlanPackage: true,
 		back_to: backUrl,
 	} );
 };

--- a/client/me/domain-upsell/index.jsx
+++ b/client/me/domain-upsell/index.jsx
@@ -123,7 +123,7 @@ export function RenderDomainUpsell( {
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_profile_domain_upsell_search_click', {
@@ -137,6 +137,7 @@ export function RenderDomainUpsell( {
 		siteSlug,
 		backUrl,
 		step: 'plans',
+		domain: true,
 	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -127,7 +127,7 @@ export function RenderDomainUpsell( {
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
 	const getSearchClickHandler = () => {
 		recordTracksEvent( 'calypso_my_home_domain_upsell_search_click', {
@@ -141,6 +141,7 @@ export function RenderDomainUpsell( {
 		siteSlug,
 		backUrl,
 		step: 'plans',
+		domain: true,
 	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -110,12 +110,13 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 
-	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl } );
+	const searchLink = getDomainAndPlanUpsellUrl( { siteSlug, backUrl, domain: true } );
 
 	const plansPageLink = getDomainAndPlanUpsellUrl( {
 		siteSlug,
 		backUrl,
 		step: 'plans',
+		domain: true,
 	} );
 
 	const purchaseLink = ! isFreePlan && ! isMonthlyPlan ? `/checkout/${ siteSlug }` : plansPageLink;

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { get, includes, map } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -73,6 +74,29 @@ const domainSearch = ( context, next ) => {
 			</CalypsoShoppingCartProvider>
 		</Main>
 	);
+	next();
+};
+
+/**
+ * If the user enters /domains/add/:domain?domainAndPlanPackage=true,
+ * we redirect them to the domain upsell flow.
+ *
+ * This is necessary because we have some back-end logic that sends the user directly,
+ * and the concept of feature flags don't exist there. So we need to redirect here.
+ *
+ * Once the feature flag is removed and the back-end logic is updated, this can be removed.
+ *
+ * Remove this when working on DOMAINS-1590.
+ */
+const redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled = ( context, next ) => {
+	const isBrowsingDomainAndPlanPackageFlow = context.query.domainAndPlanPackage === 'true';
+
+	if ( shouldRenderRewrittenDomainSearch() && isBrowsingDomainAndPlanPackageFlow ) {
+		return window.location.replace(
+			addQueryArgs( '/setup/domain-and-plan', { siteSlug: context.params.domain } )
+		);
+	}
+
 	next();
 };
 
@@ -324,6 +348,7 @@ export default {
 	siteRedirect,
 	mapDomain,
 	mapDomainSetup,
+	redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled,
 	redirectToDomainSearchSuggestion,
 	redirectIfNoSite,
 	redirectToUseYourDomainIfVipSite,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -294,6 +294,7 @@ export default function () {
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		domainsController.redirectToDomainUpsellFlowIfRewrittenDomainSearchIsEnabled,
 		domainsController.domainSearch,
 		makeLayout,
 		clientRender

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -532,14 +532,22 @@ const PlansFeaturesMain = ( {
 		};
 
 		const handlePlanIntervalUpdate = ( interval: SupportedUrlFriendlyTermType ) => {
+			let isDomainAndPlanFlow: string | null = '';
+			let isDomainAndPlanPackageFlow: string | null = '';
 			let isJetpackAppFlow: string | null = '';
 
 			if ( typeof window !== 'undefined' ) {
+				isDomainAndPlanFlow = new URLSearchParams( window.location.search ).get( 'domain' );
+				isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
+					'domainAndPlanPackage'
+				);
 				isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
 			}
 
 			const pathOrQueryParam = getPlanTypeDestination( props, {
 				intervalType: interval,
+				domain: isDomainAndPlanFlow,
+				domainAndPlanPackage: isDomainAndPlanPackageFlow,
 				jetpackAppPlans: isJetpackAppFlow,
 			} );
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -59,6 +59,7 @@ export function plans( context, next ) {
 					? context.query.addDomainFlow === 'true'
 					: undefined
 			}
+			domainAndPlanPackage={ context.query.domainAndPlanPackage === 'true' }
 			jetpackAppPlans={ context.query.jetpackAppPlans === 'true' }
 		/>
 	);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -15,23 +15,29 @@ import {
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Plans } from '@automattic/data-stores';
+import { WpcomPlansUI, Plans } from '@automattic/data-stores';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { addQueryArgs } from '@wordpress/url';
-import { localize } from 'i18n-calypso';
+import { useDispatch } from '@wordpress/data';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import { isPartnerPurchase } from 'calypso/lib/purchases';
+import { isExternal } from 'calypso/lib/url';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -42,6 +48,7 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -52,6 +59,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import withCartKey from '../checkout/with-cart-key';
+import DomainAndPlanPackageNavigation from '../domains/components/domain-and-plan-package/navigation';
 import DomainUpsellDialog from './components/domain-upsell-dialog';
 import PlansHeader from './components/plans-header';
 import ECommerceTrialPlansPage from './ecommerce-trial';
@@ -61,16 +69,105 @@ import WooExpressPlansPage from './woo-express-plans-page';
 
 import './style.scss';
 
+function DomainAndPlanUpsellNotice() {
+	const translate = useTranslate();
+	const noticeTitle = translate( 'Almost done' );
+	const noticeDescription = translate( 'Upgrade today to claim your free domain name!' );
+	return (
+		<Banner
+			title={ noticeTitle }
+			description={ noticeDescription }
+			icon="star"
+			showIcon
+			disableHref
+		/>
+	);
+}
+function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteSlug } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	if ( ! isDomainUpsell ) {
+		return (
+			<>
+				<p>
+					{ translate(
+						'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}.',
+						{
+							args: {
+								domainName: yourDomainName,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You’ll also unlock advanced features that make it easy to build and grow your site.'
+					) }
+				</p>
+			</>
+		);
+	}
+
+	const skipPlan = () => {
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
+		// show Warning only on free plans.
+		isFreePlan
+			? dispatch( WpcomPlansUI.store ).setShowDomainUpsellDialog( true )
+			: page( `/checkout/${ siteSlug }` );
+	};
+
+	const subtitle = isFreePlan
+		? translate( 'See and compare the features available on each WordPress.com plan' )
+		: translate( 'All of our annual plans include a free domain name for one year.' );
+
+	const subtitle2 = isFreePlan
+		? ''
+		: translate(
+				'Upgrade to a yearly plan and claim {{strong}}%(domainName)s for free{{/strong}}.',
+				{
+					args: {
+						domainName: yourDomainName,
+					},
+					components: {
+						strong: <strong />,
+						br: <br />,
+					},
+				}
+		  );
+
+	const skipText = isFreePlan
+		? translate( 'Or continue with the free plan.' )
+		: translate( 'Or continue with your monthly plan.' );
+
+	return (
+		<>
+			<p>{ subtitle }</p>
+			{ subtitle2 && <p>{ subtitle2 }</p> }
+			<p>
+				<button onClick={ skipPlan }>{ skipText }</button>
+			</p>
+		</>
+	);
+}
+
 class PlansComponent extends Component {
 	static propTypes = {
 		context: PropTypes.object.isRequired,
 		coupon: PropTypes.string,
 		redirectToAddDomainFlow: PropTypes.bool,
+		domainAndPlanPackage: PropTypes.bool,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
 		redirectTo: PropTypes.string,
 		selectedSite: PropTypes.object,
+		isDomainAndPlanPackageFlow: PropTypes.bool,
+		isDomainUpsell: PropTypes.bool,
+		isDomainUpsellSuggested: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -84,9 +181,19 @@ class PlansComponent extends Component {
 			this.props.fetchSitePlans( selectedSite.ID );
 		}
 
+		if ( this.props.isDomainAndPlanPackageFlow ) {
+			document.body.classList.add( 'is-domain-plan-package-flow' );
+		}
+
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( document.body.classList.contains( 'is-domain-plan-package-flow' ) ) {
+			document.body.classList.remove( 'is-domain-plan-package-flow' );
 		}
 	}
 
@@ -140,7 +247,7 @@ class PlansComponent extends Component {
 	};
 
 	renderPlansMain() {
-		const { selectedSite, isUntangled, isWPForTeamsSite } = this.props;
+		const { selectedSite, isUntangled, isWPForTeamsSite, currentPlanIntervalType } = this.props;
 
 		if ( isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ) {
 			return (
@@ -156,13 +263,20 @@ class PlansComponent extends Component {
 			);
 		}
 
+		const hideFreePlan = this.props.isDomainAndPlanPackageFlow;
 		// The Jetpack mobile app wants to display a specific selection of plans
 		const plansIntent = this.props.jetpackAppPlans ? 'plans-jetpack-app' : null;
+		const hidePlanTypeSelector =
+			this.props.domainAndPlanPackage &&
+			( ! this.props.isDomainUpsell ||
+				( this.props.isDomainUpsell && currentPlanIntervalType === 'monthly' ) );
 
 		return (
 			<PlansFeaturesMain
 				isInSiteDashboard={ isUntangled }
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
+				hidePlanTypeSelector={ hidePlanTypeSelector }
+				hideFreePlan={ hideFreePlan }
 				customerType={ this.props.customerType }
 				intervalType={ this.props.intervalType }
 				selectedFeature={ this.props.selectedFeature }
@@ -172,9 +286,10 @@ class PlansComponent extends Component {
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }
 				plansWithScroll={ false }
+				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
 				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
 				intent={ plansIntent }
-				isSpotlightOnCurrentPlan={ ! isUntangled }
+				isSpotlightOnCurrentPlan={ ! isUntangled && ! this.props.isDomainAndPlanPackageFlow }
 				showPlanTypeSelectorDropdown={ isEnabled( 'onboarding/interval-dropdown' ) }
 			/>
 		);
@@ -273,6 +388,20 @@ class PlansComponent extends Component {
 		);
 	}
 
+	getBackLink() {
+		const backTo = getQueryArg( window.location.href, 'back_to' ) ?? '';
+		if ( ! isExternal( backTo ) ) {
+			return backTo;
+		}
+
+		const { selectedSite, isDomainUpsell, isDomainUpsellSuggested } = this.props;
+		return isDomainUpsell && isDomainUpsellSuggested
+			? addQueryArgs( `/home/${ selectedSite.slug }` )
+			: addQueryArgs( `/domains/add/${ selectedSite.slug }`, {
+					domainAndPlanPackage: true,
+			  } );
+	}
+
 	renderContent() {
 		const {
 			selectedSite,
@@ -280,9 +409,14 @@ class PlansComponent extends Component {
 			canAccessPlans,
 			isUntangled,
 			currentPlan,
+			domainAndPlanPackage,
+			isDomainAndPlanPackageFlow,
 			isJetpackNotAtomic,
+			isDomainUpsell,
 			isFreePlan,
+			currentPlanIntervalType,
 			domainFromHomeUpsellFlow,
+			jetpackAppPlans,
 			purchase,
 		} = this.props;
 
@@ -322,6 +456,16 @@ class PlansComponent extends Component {
 			subHeaderText = isWooExpressTrial ? wooExpressSubHeaderText : entrepreneurTrialSubHeaderText;
 		}
 
+		const allDomains = isDomainAndPlanPackageFlow ? getDomainRegistrations( this.props.cart ) : [];
+		const yourDomainName = allDomains.length
+			? allDomains.slice( -1 )[ 0 ]?.meta
+			: translate( 'your domain name' );
+
+		const headline =
+			currentPlanIntervalType === 'monthly'
+				? translate( 'Get your domain’s first year for free' )
+				: translate( 'Choose the perfect plan' );
+
 		// Hide for WooExpress plans and Entrepreneur trials that are not WooExpress trials
 		const isEntrepreneurTrial = isEcommerceTrial && ! purchase?.isWooExpressTrial;
 		const showPlansNavigation = ! isUntangled && ! ( isWooExpressPlan || isEntrepreneurTrial );
@@ -340,19 +484,42 @@ class PlansComponent extends Component {
 						is_site_on_paid_plan: !! ( currentPlanSlug && ! isFreePlan ),
 					} }
 				/>
-				{ domainFromHomeUpsellFlow && <DomainUpsellDialog domain={ selectedSite.slug } /> }
+				{ ( isDomainUpsell || domainFromHomeUpsellFlow ) && (
+					<DomainUpsellDialog domain={ selectedSite.slug } />
+				) }
 				{ canAccessPlans && (
 					<div>
 						{ isUntangled && <CurrentPlanPanel /> }
-						{ ! isUntangled && (
+						{ ! isUntangled && ! isDomainAndPlanPackageFlow && (
 							<PlansHeader
 								domainFromHomeUpsellFlow={ domainFromHomeUpsellFlow }
 								subHeaderText={ subHeaderText }
 							/>
 						) }
+						{ isDomainAndPlanPackageFlow && (
+							<>
+								<div className="plans__header">
+									{ ! jetpackAppPlans && (
+										<DomainAndPlanPackageNavigation goBackLink={ this.getBackLink() } step={ 2 } />
+									) }
+
+									<FormattedHeader brandFont headerText={ headline } align="center" />
+
+									<DescriptionMessage
+										isFreePlan={ isFreePlan }
+										yourDomainName={ yourDomainName }
+										siteSlug={ selectedSite.slug }
+										isDomainUpsell={ isDomainUpsell }
+									/>
+								</div>
+							</>
+						) }
 						<div id={ isUntangled ? 'site-plans' : 'plans' } className="plans plans__has-sidebar">
 							{ showPlansNavigation && <PlansNavigation path={ this.props.context.path } /> }
 							<Main fullWidthLayout={ ! isWooExpressTrial } wideLayout={ isWooExpressTrial }>
+								{ ! isDomainAndPlanPackageFlow && domainAndPlanPackage && (
+									<DomainAndPlanUpsellNotice />
+								) }
 								{ this.renderMainContent( {
 									isEcommerceTrial,
 									isBusinessTrial,
@@ -376,18 +543,27 @@ class PlansComponent extends Component {
 const ConnectedPlans = connect(
 	( state, props ) => {
 		const { currentPlan, selectedSiteId } = props;
+		const currentPlanIntervalType = getIntervalTypeForTerm(
+			getPlan( currentPlan?.productSlug )?.term
+		);
 
 		return {
 			currentPlan,
+			currentPlanIntervalType,
 			purchase: currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null,
 			selectedSite: getSelectedSite( state ),
 			canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 			isUntangled: isPlansPageUntangled( state ),
 			isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 			isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
+			isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
 			isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, {
 				treatAtomicAsJetpackSite: false,
 			} ),
+			isDomainUpsell:
+				!! getCurrentQueryArguments( state )?.domainAndPlanPackage &&
+				!! getCurrentQueryArguments( state )?.domain,
+			isDomainUpsellSuggested: getCurrentQueryArguments( state )?.domain === 'true',
 			isFreePlan: isFreePlanProduct( currentPlan ),
 			domainFromHomeUpsellFlow: getDomainFromHomeUpsellInQuery( state ),
 			siteHasLegacyStorage: siteHasFeature( state, selectedSiteId, FEATURE_LEGACY_STORAGE_200GB ),

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -66,4 +66,59 @@ body.is-section-plans {
 		}
 	}
 }
+body.is-section-plans.is-domain-plan-package-flow {
+	background: var(--color-body-background);
 
+	.layout__content {
+		padding-top: 0 !important;
+		padding-left: 0 !important;
+	}
+
+	.plans__has-sidebar {
+		.section-nav {
+			display: none;
+		}
+	}
+
+	.plans__header {
+		display: block;
+		overflow: auto;
+
+		.formatted-header__title,
+		.formatted-header__subtitle {
+			max-width: unset;
+		}
+
+		h1 {
+			font-family: $brand-serif;
+			font-size: $font-headline-small;
+		}
+
+		p {
+			font-size: $font-body;
+			color: var(--color-text-subtle);
+			text-align: center;
+			padding: 0 10px;
+			margin-bottom: 0;
+			&:last-child {
+				margin-bottom: 1.5em;
+			}
+			button {
+				font-size: $font-body;
+				text-decoration: underline;
+				cursor: pointer;
+			}
+		}
+	}
+
+	@include break-small {
+		.plans__header {
+			h1 {
+				font-size: $font-headline-medium;
+			}
+			p {
+				padding: 0 80px;
+			}
+		}
+	}
+}

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -1,14 +1,15 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains.ts';
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import { successNotice } from 'calypso/state/notices/actions';
 import {
@@ -21,9 +22,9 @@ import {
 
 const DomainUpsellCard = ( { siteId } ) => {
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const linkUrl = getDomainAndPlanUpsellUrl( {
-		siteSlug: domain,
-		step: 'domains',
+	const linkUrl = addQueryArgs( domainAddNew( domain ), {
+		domainAndPlanPackage: 'true',
+		upsell: 'activitypub',
 	} );
 	const translate = useTranslate();
 	const recordClick = () => {

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -59,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 		sidebarComponent = new SidebarComponent( page );
 		await sidebarComponent.openNotice(
 			'Upgrade',
-			`**/setup/domain-and-plan?siteSlug=${ siteSlug }`
+			`**/domains/add/${ siteSlug }?domainAndPlanPackage=true`
 		);
 	} );
 


### PR DESCRIPTION
This reverts commit 668693dd9d4bb3c5c0c7463e128ea5048891b4d5.

## Proposed Changes

We cannot use `/setup/domain-and-plan` when coming from the Launchpad because the pick domain task should be skippable so they can return to it.


## Testing Instructions

Verify Pre-release E2E tests are still passing.