### PR TITLE
Domain Search Rewrite: Preserve start writing domain upsell task destination

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,8 +1,9 @@
 import { Task } from '@automattic/launchpad';
 import { isStartWritingFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
-import { isDomainUpsellCompleted } from '../../task-helper';
+import { getSiteIdOrSlug, isDomainUpsellCompleted } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -12,6 +13,14 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const getDestionationUrl = () => {
 		if ( ! siteSlug ) {
 			return '';
+		}
+
+		if ( isStartWritingFlow( flow ) ) {
+			return addQueryArgs( `/setup/${ flow }/domains`, {
+				...getSiteIdOrSlug( flow, site, siteSlug ),
+				flowToReturnTo: flow,
+				new: site?.name,
+			} );
 		}
 
 		const backUrl = `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/test/index.ts
@@ -29,7 +29,7 @@ describe( 'getDesignEditedTask', () => {
 		expect( getDomainUpSellTask( task, START_WRITING_FLOW, context ) ).toMatchObject( {
 			useCalypsoPath: true,
 			calypso_path:
-				'/setup/domain-and-plan?siteSlug=site.wordpress.com&back_to=%2Fsetup%2Fstart-writing%2Flaunchpad%3FsiteSlug%3Dsite.wordpress.com&new=site.wordpress.com',
+				'/setup/start-writing/domains?siteId=211078228&flowToReturnTo=start-writing&new=site.wordpress.com',
 		} );
 	} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/106480#discussion_r2434089660.

## Proposed Changes

In the mentioned PR, we're setting all domain upsell Launchpad tasks to `/setup/domain-and-plan` but that flow not being skippable means the user will not get their task ticked, which is not what we want. We can revisit that later, but let's move forward with the previous behavior of sending the user to `/setup/start-writing/domains` to have E2E tests passing.

## Testing Instructions

None - watch the E2E tests pass.