### PR TITLE
New Hosted Site Flow: Clear store and signup information upon entering the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -19,7 +19,6 @@ import {
 	clearSignupCompleteSlug,
 	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../../../hooks/use-query';
@@ -37,6 +36,13 @@ async function initialize( reduxStore: Store ) {
 	const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;
 
 	await resetOnboardStore();
+	// @ts-expect-error We're using the thunk middleware but TS doesn't know that.
+	reduxStore.dispatch( setSelectedSiteId( null ) );
+	clearStepPersistedState( NEW_HOSTED_SITE_FLOW );
+	clearSignupDestinationCookie();
+	clearSignupCompleteFlowName();
+	clearSignupCompleteSlug();
+	clearSignupCompleteSiteID();
 
 	const queryParams = getCurrentQueryParams();
 	const showDomainStep = queryParams.has( 'showDomainStep' );
@@ -244,26 +250,6 @@ const hosting: FlowV2< typeof initialize > = {
 		};
 	},
 	useSideEffect( currentStepSlug ) {
-		const reduxDispatch = useReduxDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-
-		/**
-		 * Clears every state we're persisting during the flow
-		 * when entering it. This is to ensure that the user
-		 * starts on a clean slate.
-		 */
-		useEffect( () => {
-			if ( ! currentStepSlug ) {
-				resetOnboardStore();
-				reduxDispatch( setSelectedSiteId( null ) );
-				clearStepPersistedState( this.name );
-				clearSignupDestinationCookie();
-				clearSignupCompleteFlowName();
-				clearSignupCompleteSlug();
-				clearSignupCompleteSiteID();
-			}
-		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
-
 		const studioSiteId = useQuery().get( 'studioSiteId' );
 
 		useEffect( () => {

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -1,5 +1,5 @@
 import { isFreeHostingTrial, isDotComPlan } from '@automattic/calypso-products';
-import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
+import { clearStepPersistedState, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -14,8 +14,14 @@ import {
 	getSignupCompleteSiteID,
 	setSignupCompleteSiteID,
 	getSignupCompleteSlug,
+	clearSignupDestinationCookie,
+	clearSignupCompleteFlowName,
+	clearSignupCompleteSlug,
+	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { getCurrentQueryParams } from '../../../utils/get-current-query-params';
@@ -238,6 +244,26 @@ const hosting: FlowV2< typeof initialize > = {
 		};
 	},
 	useSideEffect( currentStepSlug ) {
+		const reduxDispatch = useReduxDispatch();
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		/**
+		 * Clears every state we're persisting during the flow
+		 * when entering it. This is to ensure that the user
+		 * starts on a clean slate.
+		 */
+		useEffect( () => {
+			if ( ! currentStepSlug ) {
+				resetOnboardStore();
+				reduxDispatch( setSelectedSiteId( null ) );
+				clearStepPersistedState( this.name );
+				clearSignupDestinationCookie();
+				clearSignupCompleteFlowName();
+				clearSignupCompleteSlug();
+				clearSignupCompleteSiteID();
+			}
+		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+
 		const studioSiteId = useQuery().get( 'studioSiteId' );
 
 		useEffect( () => {


### PR DESCRIPTION
Closes DOTOBRD-338.

## Proposed Changes

During testing we observed that going through the flow multiple times resulted in the domains in the cart being lost.

This happens because the create site step remembers the site that was just created, so we need to reset the state when the user enters the flow to prevent that from happening.

## Testing Instructions

Enter `/setup/new-hosted-site?showDomainStep`, pick one or more domains and the Business plan. Verify you end up with the new site, the plan and the domains at checkout.

Do it again, and verify you get a new site, plan and domains.

Verify `/setup/new-hosted-site` without the domains step also works. Verify `/setup/new-hosted-site?plan=business-bundle` also works. You should get a new site at checkout in both cases. Try the flow with the domains step again and verify it's still working.