### PR TITLE
Domain Search Rewrite: Check if site has available domain credit to show the "Free for the first year" discount

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -76,6 +76,7 @@ const DomainSearchStep: StepType< {
 	const tldQuery = useQuery().get( 'tld' );
 	const source = useQuery().get( 'source' );
 	const backTo = useQuery().get( 'back_to' );
+	const sourceSlug = useQuery().get( 'sourceSlug' );
 
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
@@ -250,6 +251,21 @@ const DomainSearchStep: StepType< {
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
 	}, [ flow ] );
 
+	// For /setup flows, we want to show the free domain for a year discount for all flows
+	// except if we're in a site context or in the 100-year plan or domain flow
+	const isFirstDomainFreeForFirstYear = useMemo( () => {
+		if (
+			siteSlug ||
+			siteId ||
+			sourceSlug ||
+			isHundredYearPlanFlow( flow ) ||
+			isHundredYearDomainFlow( flow )
+		) {
+			return false;
+		}
+		return true;
+	}, [ flow, siteSlug, siteId, sourceSlug ] );
+
 	const domainSearchElement = (
 		<WPCOMDomainSearch
 			className={
@@ -262,9 +278,7 @@ const DomainSearchStep: StepType< {
 			flowName={ flow }
 			config={ config }
 			query={ query }
-			isFirstDomainFreeForFirstYear={
-				! isHundredYearDomainFlow( flow ) && ! isHundredYearPlanFlow( flow )
-			}
+			isFirstDomainFreeForFirstYear={ isFirstDomainFreeForFirstYear }
 			events={ events }
 			flowAllowsMultipleDomainsInCart={
 				isOnboardingFlow( flow ) ||

--- a/client/signup/steps/domains/rewritten/index.tsx
+++ b/client/signup/steps/domains/rewritten/index.tsx
@@ -352,6 +352,15 @@ const DomainSearchUI = (
 		);
 	};
 
+	// For /start flows, we want to show the free domain for a year discount for all flows
+	// except if we're in a site context or in the free or monthly plan flows
+	const isFirstDomainFreeForFirstYear = useMemo( () => {
+		if ( siteSlug || siteId || isMonthlyOrFreeFlow( flowName ) ) {
+			return false;
+		}
+		return true;
+	}, [ flowName, siteSlug, siteId ] );
+
 	return (
 		<StepWrapper
 			{ ...props }
@@ -375,7 +384,7 @@ const DomainSearchUI = (
 					config={ config }
 					flowAllowsMultipleDomainsInCart={ flowAllowsMultipleDomainsInCart }
 					slots={ slots }
-					isFirstDomainFreeForFirstYear={ ! isMonthlyOrFreeFlow( flowName ) }
+					isFirstDomainFreeForFirstYear={ isFirstDomainFreeForFirstYear }
 					analyticsSection={ isDomainOnlyFlow ? 'domain-first' : 'signup' }
 				/>
 			}


### PR DESCRIPTION
This is a copy of #106454 which for some reason fails E2E tests constantly.

Addresses https://github.com/Automattic/wp-calypso/pull/106377#issuecomment-3397032502

## Proposed Changes

This PR updates the conditions to enforce the "Free for the first year" discount in the domain search step.

For `/setup` flows, we'll always show the discount except if we're in a site context or in a hundred year domain or plan flow. In these cases, we rely on the shopping cart's `next_domain_is_free` property, which is true if there's a plan in the cart or if the site has a plan with unused domain credit.

For `/start` flows, we'll always show the discount, except if we're in a site context, in `/start/free` or the monthly plan flows (e.g. `/start/personal-monthly`), where we'll rely on the cart's `next_domain_is_free` property.

There are no changes in `/domains/add/%s` since in that case we're always checking the `next_domain_is_free` property which is correct.

### Screenshots

| | Screenshot |
| --- | --- |
| Site with plan with used domain credit | <img width="954" height="1080" alt="Screenshot 2025-10-14 at 16 51 41" src="https://github.com/user-attachments/assets/798074a7-c5d8-4c3d-9fc1-2e8db7e8e1c5" /> |
| Site with plan with available domain credit | <img width="954" height="1080" alt="Screenshot 2025-10-14 at 16 52 39" src="https://github.com/user-attachments/assets/46439167-a0c0-4fcf-a129-50856cec0b36" /> |
| No site | <img width="954" height="1080" alt="Screenshot 2025-10-14 at 16 52 49" src="https://github.com/user-attachments/assets/44fc61b1-fca9-4908-aa0e-2e021c84e8e0" /> |

## Why are these changes being made?

We don't want to show the discount for sites with plans that already used their domain credit.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Visit `/setup/domain?siteSlug=<site_slug>` with the site slug of a site that has a plan that has already used its domain credit
- Ensure the "Free for the first year" discount is not shown
- Visit `/setup/domain?siteSlug=<site_slug>` with the site slug of a site that has a plan with available domain credit
- Ensure the "Free for the first year" discount is shown
- Visit `/setup/domain`
- Ensure the "Free for the first year" discount is shown
- Visit the launch site flow (`/start/launch-site/domains-launch?siteSlug=<site_slug>&hide_initial_query=yes`) for a site that has a plan with available domain credit
- Ensure the "Free for the first year" discount is shown
- Visit the launch site flow for a site that has a plan with used domain credit
- Ensure the "Free for the first year" discount is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?