### PR TITLE
HD redirects to log in screen when _any_ API says the user is logged out

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -110,7 +110,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				event.type === 'updated' &&
 				event.action.type === 'error' &&
 				isWpError( event.action.error ) &&
-				event.action.error.statusCode === 403 &&
+				[ 401, 403 ].includes( event.action.error.statusCode ) &&
 				event.action.error.error === 'authorization_required'
 			) {
 				const currentPath = window.location.pathname;

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -1,10 +1,15 @@
-import { fetchUser } from '@automattic/api-core';
+import { fetchUser, isWpError } from '@automattic/api-core';
 import { clearQueryClient, disablePersistQueryClient } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { isSupportUserSession } from '@automattic/calypso-support-session';
 import { magnificentNonEnLocales } from '@automattic/i18n-utils';
-import { useQuery } from '@tanstack/react-query';
-import { createContext, useContext, useMemo } from 'react';
+import {
+	useQuery,
+	useQueryClient,
+	type QueryCacheNotifyEvent,
+	type MutationCacheNotifyEvent,
+} from '@tanstack/react-query';
+import { createContext, useContext, useMemo, useEffect } from 'react';
 import type { User } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
@@ -47,11 +52,8 @@ async function initializeCurrentUser(): Promise< User > {
  * 4. Redirects to login if unauthorized
  */
 export function AuthProvider( { children }: { children: React.ReactNode } ) {
-	const {
-		data: user,
-		isLoading: userIsLoading,
-		isError: userIsError,
-	} = useQuery( {
+	const queryClient = useQueryClient();
+	const { data: user, isLoading: userIsLoading } = useQuery( {
 		queryKey: AUTH_QUERY_KEY,
 		queryFn: initializeCurrentUser,
 		staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
@@ -100,14 +102,29 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ user ] );
 
-	if ( userIsError ) {
-		if ( typeof window !== 'undefined' ) {
-			const currentPath = window.location.pathname;
-			const loginUrl = `/log-in?redirect_to=${ encodeURIComponent( currentPath ) }`;
-			window.location.href = loginUrl;
-		}
-		return null;
-	}
+	// Subscribe to network errors and when errors occur due to being logged
+	// out, redirect the user to the log in screen.
+	useEffect( () => {
+		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {
+			if (
+				event.type === 'updated' &&
+				event.action.type === 'error' &&
+				isWpError( event.action.error ) &&
+				event.action.error.statusCode === 403 &&
+				event.action.error.error === 'authorization_required'
+			) {
+				const currentPath = window.location.pathname;
+				const loginUrl = `/log-in?redirect_to=${ encodeURIComponent( currentPath ) }`;
+				window.location.href = loginUrl;
+			}
+		};
+		const unsubMutationCache = queryClient.getMutationCache().subscribe( handleEvent );
+		const unsubQueryCache = queryClient.getQueryCache().subscribe( handleEvent );
+		return () => {
+			unsubMutationCache();
+			unsubQueryCache();
+		};
+	}, [ queryClient ] );
 
 	if ( userIsLoading || ! user ) {
 		return null;

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -9,7 +9,7 @@ import {
 	type QueryCacheNotifyEvent,
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
-import { createContext, useContext, useMemo, useEffect } from 'react';
+import { createContext, useContext, useMemo, useEffect, useRef } from 'react';
 import type { User } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
@@ -52,6 +52,7 @@ async function initializeCurrentUser(): Promise< User > {
  * 4. Redirects to login if unauthorized
  */
 export function AuthProvider( { children }: { children: React.ReactNode } ) {
+	const authErrorHandled = useRef( false );
 	const queryClient = useQueryClient();
 	const { data: user, isLoading: userIsLoading } = useQuery( {
 		queryKey: AUTH_QUERY_KEY,
@@ -111,8 +112,10 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				event.action.type === 'error' &&
 				isWpError( event.action.error ) &&
 				[ 401, 403 ].includes( event.action.error.statusCode ) &&
-				event.action.error.error === 'authorization_required'
+				event.action.error.error === 'authorization_required' &&
+				! authErrorHandled.current // Prevents repeated calls to redirect
 			) {
+				authErrorHandled.current = true;
 				const currentPath = window.location.pathname;
 				const loginUrl = `/log-in?redirect_to=${ encodeURIComponent( currentPath ) }`;
 				window.location.href = loginUrl;

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -9,7 +9,7 @@ import {
 	type QueryCacheNotifyEvent,
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
-import { createContext, useContext, useMemo, useEffect, useRef } from 'react';
+import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
 import type { User } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
@@ -54,7 +54,11 @@ async function initializeCurrentUser(): Promise< User > {
 export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	const authErrorHandled = useRef( false );
 	const queryClient = useQueryClient();
-	const { data: user, isLoading: userIsLoading } = useQuery( {
+	const {
+		data: user,
+		isLoading: userIsLoading,
+		isError: userIsError,
+	} = useQuery( {
 		queryKey: AUTH_QUERY_KEY,
 		queryFn: initializeCurrentUser,
 		staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
@@ -103,6 +107,18 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ user ] );
 
+	const handleAuthError = useCallback( () => {
+		// Prevents repeated calls to redirect
+		if ( authErrorHandled.current ) {
+			return;
+		}
+
+		authErrorHandled.current = true;
+		const currentPath = window.location.pathname;
+		const loginUrl = `/log-in?redirect_to=${ encodeURIComponent( currentPath ) }`;
+		window.location.href = loginUrl;
+	}, [] );
+
 	// Subscribe to network errors and when errors occur due to being logged
 	// out, redirect the user to the log in screen.
 	useEffect( () => {
@@ -115,10 +131,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				event.action.error.error === 'authorization_required' &&
 				! authErrorHandled.current // Prevents repeated calls to redirect
 			) {
-				authErrorHandled.current = true;
-				const currentPath = window.location.pathname;
-				const loginUrl = `/log-in?redirect_to=${ encodeURIComponent( currentPath ) }`;
-				window.location.href = loginUrl;
+				handleAuthError();
 			}
 		};
 		const unsubMutationCache = queryClient.getMutationCache().subscribe( handleEvent );
@@ -127,7 +140,16 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			unsubMutationCache();
 			unsubQueryCache();
 		};
-	}, [ queryClient ] );
+	}, [ queryClient, handleAuthError ] );
+
+	// Handles _all_ errors fetching the user object, regardless of whether they are
+	// `authorization_required` errors or not.
+	if ( userIsError ) {
+		if ( typeof window !== 'undefined' ) {
+			handleAuthError();
+		}
+		return null;
+	}
 
 	if ( userIsLoading || ! user ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14911

## Proposed Changes

Previously hosting dashboard watched whether the initial user object request failed and redirected to the log in page if it failed.

Now it watches all API requests and if any of them fail for the reason of being logged out, it redirects to the log in page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is to address situations like DOTCOM-14911. If the user loses the cookie they are logged out, it should just be about the initial user object.

I'm looking to start bootstrap the user object using Calypso's `wpcom-user-bootstrap` mechanism, and at that point we can't simply rely on the initial user object request failing to detect that they have lost the cookie.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `calypso.localhost:3000/v2`
* Delete the `wordpress_sec` cookie
* Refresh
* You should be redirected to the log in screen

This is how the hosting dashboard already worked, but this PR will really come into its own once the user bootstrapping mechanism lands.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
