### PR TITLE
Hosting Dashboard: Fix: Make sure we run test for new pages.

### DIFF
--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -33,7 +33,7 @@ export function useSitePerformanceData(
 	hash: string | undefined,
 	runNewReport?: boolean
 ): PerformanceData {
-	const shouldFetchToken = ! hash || runNewReport === true;
+	const shouldFetchToken = ! hash || !! runNewReport;
 
 	const {
 		data: basicMetricsData,

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -33,7 +33,7 @@ export function useSitePerformanceData(
 	hash: string | undefined,
 	runNewReport?: boolean
 ): PerformanceData {
-	const shouldFetchToken = runNewReport ?? ! hash;
+	const shouldFetchToken = runNewReport || ! hash;
 
 	const {
 		data: basicMetricsData,

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -33,7 +33,7 @@ export function useSitePerformanceData(
 	hash: string | undefined,
 	runNewReport?: boolean
 ): PerformanceData {
-	const shouldFetchToken = runNewReport || ! hash;
+	const shouldFetchToken = ! hash || runNewReport === true;
 
 	const {
 		data: basicMetricsData,

--- a/packages/calypso-e2e/src/lib/pages/dashboard-performance-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/dashboard-performance-page.ts
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { Page } from 'playwright';
+
+/**
+ * Dashboard Performance page class for the site performance section.
+ *
+ * This Page Object represents the site performance page
+ * accessible under the /sites/{siteSlug}/performance path.
+ */
+export class DashboardPerformancePage {
+	/**
+	 * Reference to the Playwright page object.
+	 */
+	page: Page;
+
+	/**
+	 * Constructs a new DashboardPerformancePage instance.
+	 *
+	 * @param page - The Playwright page object.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Checks if the performance page shows the hosting feature gate.
+	 * This appears when the site doesn't have the performance feature.
+	 *
+	 * @returns Promise that resolves to true if the feature gate is visible.
+	 */
+	async isFeatureGateVisible(): Promise< boolean > {
+		// Lookthis.page.getByText( 'Performance monitoring'e's an SVG icon
+		return this.page.getByRole( 'button', { name: /upgrade plan/i } ).isVisible();
+	}
+
+	/**
+	 * Gets the device toggle (Mobile/Desktop) element.
+	 *
+	 * @returns Promise that resolves to the device toggle element.
+	 */
+	async getDeviceToggle(): Promise< any > {
+		return this.page.getByRole( 'button', { name: /mobile|desktop/i } );
+	}
+
+	/**
+	 * Switches the device toggle to the specified device.
+	 *
+	 * @param device - The device to switch to ('mobile' or 'desktop').
+	 * @returns Promise that resolves when the toggle is clicked.
+	 */
+	async switchDevice( device: 'mobile' | 'desktop' ): Promise< void > {
+		await this.page.getByRole( 'button', { name: device, exact: true } ).click();
+	}
+
+	/**
+	 * Gets the page selector dropdown element.
+	 *
+	 * @returns Promise that resolves to the page selector element.
+	 */
+	async getPageSelector(): Promise< any > {
+		return this.page.getByRole( 'combobox' );
+	}
+
+	/**
+	 * Selects a specific page from the page selector.
+	 *
+	 * @param pageName - The name of the page to select.
+	 * @returns Promise that resolves when the page is selected.
+	 */
+	async selectPage( pageName: string ): Promise< void > {
+		await this.page.getByRole( 'combobox' ).click();
+		await this.page.getByRole( 'option', { name: pageName } ).click();
+	}
+
+	/**
+	 * Gets the "Run new test" or "Retest" button.
+	 *
+	 * @returns Promise that resolves to the retest button element.
+	 */
+	async getRetestButton(): Promise< any > {
+		return this.page.getByRole( 'button', { name: /run new test|retest/i } );
+	}
+
+	/**
+	 * Clicks the retest button to run a new performance test.
+	 *
+	 * @returns Promise that resolves when the button is clicked.
+	 */
+	async clickRetest(): Promise< void > {
+		await this.page.getByRole( 'button', { name: /run new test|retest/i } ).click();
+	}
+
+	/**
+	 * Checks if the performance report is loading.
+	 *
+	 * @returns Promise that resolves to true if the loading state is visible.
+	 */
+	async isReportLoading(): Promise< boolean > {
+		return this.page.getByText( /checking for an existing report/i ).isVisible();
+	}
+
+	/**
+	 * Waits for the loading to finish.
+	 *
+	 * @param timeout - Maximum time to wait in milliseconds (default: 30000).
+	 * @returns Promise that resolves when loading is complete or times out.
+	 */
+	async waitForLoadingToFinish( timeout: number = 30000 ): Promise< void > {
+		await this.page.getByText( /checking for an existing report/i ).waitFor( {
+			state: 'hidden',
+			timeout,
+		} );
+	}
+
+	/**
+	 * Checks if the performance report has loaded and is visible.
+	 *
+	 * @returns Promise that resolves to true if the report is visible.
+	 */
+	async isReportVisible(): Promise< boolean > {
+		return await this.page
+			.getByText(
+				/first contentful paint|page load timeline|personalized recommendations|performance score/i
+			)
+			.first()
+			.isVisible();
+	}
+
+	/**
+	 * Checks if there's an error message visible on the performance page.
+	 *
+	 * @returns Promise that resolves to true if an error is visible.
+	 */
+	async hasError(): Promise< boolean > {
+		return this.page.getByText( /error|failed|unable to/i ).isVisible();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -3,6 +3,7 @@ export * from './add-people-page';
 export * from './cart-checkout-page';
 export * from './checkout-thank-you-page';
 export * from './dashboard-page';
+export * from './dashboard-performance-page';
 export * from './dashboard-visibility-settings-page';
 export * from './domains-page';
 export * from './editor-page';

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -27,6 +27,7 @@ import {
 	BlazeCampaignPage,
 	BlockWidgetEditorComponent,
 	DashboardPage,
+	DashboardPerformancePage,
 	DashboardVisibilitySettingsPage,
 	DataHelper,
 	EditorPage,
@@ -141,6 +142,10 @@ export const test = base.extend< {
 	 * Page object representing the WordPress.com dashboard.
 	 */
 	pageDashboard: DashboardPage;
+	/**
+	 * Page object representing the WordPress.com dashboard performance page.
+	 */
+	pageDashboardPerformance: DashboardPerformancePage;
 	/**
 	 * Page object representing the WordPress.com dashboard visibility settings page.
 	 */
@@ -291,6 +296,10 @@ export const test = base.extend< {
 	pageDashboard: async ( { page }, use ) => {
 		const dashboardPage = new DashboardPage( page );
 		await use( dashboardPage );
+	},
+	pageDashboardPerformance: async ( { page }, use ) => {
+		const dashboardPerformancePage = new DashboardPerformancePage( page );
+		await use( dashboardPerformancePage );
 	},
 	pageDashboardVisibilitySettings: async ( { page }, use ) => {
 		const dashboardVisibilitySettingsPage = new DashboardVisibilitySettingsPage( page );

--- a/test/e2e/specs/dashboard/dashboard__site-performance.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__site-performance.spec.ts
@@ -1,0 +1,58 @@
+import { DataHelper } from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+
+test.describe( 'Dashboard: Site Performance', { tag: [ tags.CALYPSO_PR ] }, () => {
+	test.skip(
+		DataHelper.isCalypsoProduction(),
+		'Skipping for WordPress.com as v2 dashboard is not enabled yet.'
+	);
+
+	test( 'As a WordPress.com user, I am offered the ability to upgrade to a paid plan to access the site performance page', async ( {
+		pageDashboard,
+		pageDashboardPerformance,
+		sitePublic,
+	} ) => {
+		await test.step( "Given I am on my public site's performance page", async function () {
+			await pageDashboard.visitPath( `sites/${ sitePublic.blog_details.site_slug }/performance` );
+		} );
+
+		await test.step( 'I see the feature upgrade window', async function () {
+			await expect
+				.poll( async () => await pageDashboardPerformance.isFeatureGateVisible() )
+				.toBe( true );
+		} );
+	} );
+
+	test( 'As a WordPress.com user, I am able to view my performance report.', async ( {
+		accountAtomic,
+		pageDashboard,
+		pageDashboardPerformance,
+		page,
+	} ) => {
+		await test.step( `Given I am authenticated as '${ accountAtomic.accountName }'`, async function () {
+			await accountAtomic.authenticate( page );
+		} );
+
+		await test.step( "Given I am on my public site's performance page", async function () {
+			await pageDashboard.visitPath(
+				`sites/${ accountAtomic.getSiteURL( { protocol: false } ) }/performance`
+			);
+		} );
+
+		await test.step( 'I see the loading indicator.', async function () {
+			await expect
+				.poll( async () => await pageDashboardPerformance.isReportLoading() )
+				.toBe( true );
+		} );
+
+		await test.step( 'I wait for loading to finish.', async function () {
+			await pageDashboardPerformance.waitForLoadingToFinish();
+		} );
+
+		await test.step( 'I see my report.', async function () {
+			await expect
+				.poll( async () => await pageDashboardPerformance.isReportVisible() )
+				.toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related to: #106389

## Proposed Changes

In #106389, I introduced a regression where we don't automatically run a report on pages that don't have a saved token. 

This PR fixes that, along with adding e2e tests to catch these issues in the future.


## Testing Instructions

**Test Existing Site**
With Hosting features activated:

- Create a new page on your site.
- Visit `/v2/sites/{site}/performance`
- Select that page in the Page Selector.
- Expect that to immediately trigger a test run.

**Test New Site**
- After activating hosting features
- Visit `/v2/sites/{site}/performance`
- Expect on page load that we run a new report. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
