### PR TITLE
V1 Dashboard: Vertical align callout relative to its container

### DIFF
--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -12,6 +12,8 @@ import { areHostingFeaturesSupported } from './features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
 import type { ComponentType } from 'react';
 
+import './style.scss';
+
 export function hostingFeatures( context: PageJSContext, next: () => void ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
@@ -84,11 +86,7 @@ export function hostingFeaturesCallout(
 					</HostingFeatureCallout>
 				);
 
-			context.primary = (
-				<PageLayout>
-					<CalloutOverlay callout={ callout } />
-				</PageLayout>
-			);
+			context.primary = <div className="hosting-features-callout">{ callout }</div>;
 		}
 
 		next();

--- a/client/sites/hosting/style.scss
+++ b/client/sites/hosting/style.scss
@@ -1,0 +1,10 @@
+.hosting-features-callout {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	height: 100%;
+
+	.dashboard-callout {
+		max-width: 600px;
+	}
+}


### PR DESCRIPTION
Fixes DOTDASH-615

## Proposed Changes

This PR updates the callout so that vertically aligned with its parent container instead of position absolute.

| Before | After |
| ---| --- |
| <img width="1618" height="695" alt="SCR-20251016-jzmc" src="https://github.com/user-attachments/assets/fe481425-dcd1-4712-a85a-16187e146c9f" /> |  <img width="1622" height="695" alt="SCR-20251016-jzou" src="https://github.com/user-attachments/assets/f9fd5fc0-5d44-4ef2-bbe9-817f449fb4e1" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI improvement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites
* Select a Simple site, and click on the Deployments tab
* Ensure that the callout is vertically aligned with its parent container

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
