### PR TITLE
Hosting dashboard uses the bootstrapped user object where available

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -30,6 +30,7 @@ async function initializeCurrentUser(): Promise< User > {
 			// - client/lib/user/user.d.ts
 			return window.currentUser as any;
 		}
+		throw new Error( 'Failed to bootstrap user object' );
 	}
 
 	return fetchUser();

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -22,10 +22,13 @@ async function initializeCurrentUser(): Promise< User > {
 	const useBootstrap = ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
 
 	if ( useBootstrap ) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if ( ( window as any ).currentUser ) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			return ( window as any ).currentUser;
+		if ( window.currentUser ) {
+			// TODO: align the various `currentUser` types. The different types have
+			// different opinions on which fields are required and optional.
+			// - packages/api-core/src/me/types.ts
+			// - packages/data-stores/src/user/types.ts
+			// - client/lib/user/user.d.ts
+			return window.currentUser as any;
 		}
 	}
 

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -22,13 +22,16 @@ async function initializeCurrentUser(): Promise< User > {
 	const useBootstrap = ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
 
 	if ( useBootstrap ) {
-		if ( window.currentUser ) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		if ( ( window as any ).currentUser ) {
 			// TODO: align the various `currentUser` types. The different types have
 			// different opinions on which fields are required and optional.
 			// - packages/api-core/src/me/types.ts
 			// - packages/data-stores/src/user/types.ts
 			// - client/lib/user/user.d.ts
-			return window.currentUser as any;
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return ( window as any ).currentUser;
 		}
 		throw new Error( 'Failed to bootstrap user object' );
 	}

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -1,6 +1,7 @@
 import { fetchUser } from '@automattic/api-core';
 import { clearQueryClient, disablePersistQueryClient } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
+import { isSupportUserSession } from '@automattic/calypso-support-session';
 import { magnificentNonEnLocales } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { createContext, useContext, useMemo } from 'react';
@@ -13,6 +14,23 @@ interface AuthContextType {
 	logout: () => Promise< void >;
 }
 export const AuthContext = createContext< AuthContextType | undefined >( undefined );
+
+async function initializeCurrentUser(): Promise< User > {
+	// In support user session the `currentUser` refers to the wrong person so we should request
+	// the user object. Note we do not check `isSupportNextSession()` because in "next" support
+	// sessions the server does bootstrap the correct `currentUser`.
+	const useBootstrap = ! isSupportUserSession() && config.isEnabled( 'wpcom-user-bootstrap' );
+
+	if ( useBootstrap ) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		if ( ( window as any ).currentUser ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return ( window as any ).currentUser;
+		}
+	}
+
+	return fetchUser();
+}
 
 /**
  * This component:
@@ -28,7 +46,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		isError: userIsError,
 	} = useQuery( {
 		queryKey: AUTH_QUERY_KEY,
-		queryFn: fetchUser,
+		queryFn: initializeCurrentUser,
 		staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
 		retry: false, // Don't retry on 401 errors
 		meta: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

Adds the existing `wpcom-user-bootstrap` feature to the hosting dashboard. If the node server places the user object in the `window.currentUser` global, then we should use it in the hosting dashboard to start rendering our UI faster.

This can not be done locally unfortunately, it is only possible in environments where the `wpcom-user-bootstrap` feature is enabled.

The equivalent V1 code is here.

https://github.com/Automattic/wp-calypso/blob/32599d702ce04b1c9e0de5a9c1975353cf3b9964/client/lib/user/shared-utils/initialize-current-user.ts#L29

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `wpcom-user-bootstrap` feature is primarily a performance optimisation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This one is tricky to test without merging. We can't test locally because our local calypso servers don't have a secret key needed to access fetch user data.

Please confirm that localhost still works as it did before, but the final test will need to be done on staging, and a quick revert prepared for.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
