### PR TITLE
A4A > Sites: Fix restore and content links for Backup

### DIFF
--- a/client/components/activity-card/toolbar/actions/restore-button.tsx
+++ b/client/components/activity-card/toolbar/actions/restore-button.tsx
@@ -38,6 +38,7 @@ const RestoreButton: FunctionComponent< RestoreButtonProps > = ( {
 				href={ ! isRestoreDisabled && backupRestorePath( siteSlug, rewindId ) }
 				label={ buttonLabel }
 				onClick={ onRestoreClick }
+				allowEventBubbling
 				primary
 				whiteSeparator
 			>

--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -142,3 +142,13 @@ Menu children to be rendered.
 </table>
 
 If `true`, then the menu icon will be displayed in light gray and will not be clickable.
+
+### `allowEventBubbling`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>false</code></td></tr>
+</table>
+
+If `true`, then the event won't be prevented from bubbling up to parent elements, allowing natural link navigation when href is provided. This is useful for navigation buttons that need to work with client-side routing. If `false` (default), event propagation is stopped to prevent interference with parent elements like FoldableCard.

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -27,6 +27,7 @@ class SplitButton extends PureComponent {
 		popoverClassName: PropTypes.string,
 		href: PropTypes.string,
 		whiteSeparator: PropTypes.bool,
+		allowEventBubbling: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -42,6 +43,7 @@ class SplitButton extends PureComponent {
 		primary: false,
 		scary: false,
 		whiteSeparator: false,
+		allowEventBubbling: false,
 	};
 
 	state = {
@@ -50,13 +52,19 @@ class SplitButton extends PureComponent {
 
 	popoverContext = createRef();
 
+	handleStopPropagation = ( event ) => {
+		if ( ! this.props.allowEventBubbling ) {
+			event.stopPropagation();
+		}
+	};
+
 	handleMainClick = ( event ) => {
-		event.stopPropagation();
+		this.handleStopPropagation( event );
 		return this.props.onClick( event );
 	};
 
 	handleMenuClick = ( event ) => {
-		event.stopPropagation();
+		this.handleStopPropagation( event );
 		return this.toggleMenu( ! this.state.isMenuVisible );
 	};
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1621/a4a-dashboard-specific-backups-are-not-working-404-error
Fixes https://linear.app/a8c/issue/A4A-1620/a4a-dashboard-view-files-in-backup-is-inaccesable

## Proposed Changes

This PR fixes the restore, and content links for Backup on the A4A dashboard.

## Why are these changes being made?

* To allow A4A users to view backup files and restore as these links are currently broken. 

## Testing Instructions

* Open the A4A live link
* Go to Sites > Open the site details of a site that has a backup > Go to a date that has a backup 

<img width="1194" height="413" alt="Screenshot 2025-10-16 at 10 34 01 AM" src="https://github.com/user-attachments/assets/f973050f-e4bd-4fe0-954a-73c66001e14e" />

* Click the `Restore to this point` button > Verify it works as expected, and the page loads
* Click the `View files` option > Verify the page loads and you can see the files

<img width="1191" height="490" alt="Screenshot 2025-10-16 at 10 34 13 AM" src="https://github.com/user-attachments/assets/bd5dc9b8-7805-4258-994c-7a38f46e06e4" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
