### PR TITLE
Allow individual V1 dashboard screens for Flex sites by recognizing they are Flex

### DIFF
--- a/client/sites/hosting/features.ts
+++ b/client/sites/hosting/features.ts
@@ -7,11 +7,11 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
 export function areHostingFeaturesSupported( site?: SiteExcerptData | null ) {
-	const isAtomicOrStagingSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
-	const isFlexSite = !! site?.is_wpcom_flex;
+	const isWoAOrStagingOrFlexSite =
+		!! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site || !! site?.is_wpcom_flex;
 	const isPlanExpired = site?.plan?.expired;
 
-	return ( isAtomicOrStagingSite || isFlexSite ) && ! isPlanExpired;
+	return isWoAOrStagingOrFlexSite && ! isPlanExpired;
 }
 
 export function useAreHostingFeaturesSupported() {

--- a/client/sites/hosting/features.ts
+++ b/client/sites/hosting/features.ts
@@ -7,10 +7,11 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
 export function areHostingFeaturesSupported( site?: SiteExcerptData | null ) {
-	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+	const isAtomicOrStagingSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+	const isFlexSite = !! site?.is_wpcom_flex;
 	const isPlanExpired = site?.plan?.expired;
 
-	return isAtomicSite && ! isPlanExpired;
+	return ( isAtomicOrStagingSite || isFlexSite ) && ! isPlanExpired;
 }
 
 export function useAreHostingFeaturesSupported() {

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -17,6 +17,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'jetpack',
 	'jetpack_connection',
 	'is_wpcom_atomic',
+	'is_wpcom_flex',
 	'is_wpcom_staging_site',
 	'user_interactions',
 	'lang',


### PR DESCRIPTION
Part of DOTMART-19

## Proposed Changes

* The individual V1 Hosting Dashboard screens would display an upsell after the merge of https://github.com/Automattic/wp-calypso/pull/106411
* We would like them to show up and trigger multiple REST API endpoints that will fail with 403 instead. This way we can work on the REST API endpoints and fix them one by one

We split #106411 in two because the code is too unrelated to combine the change

Before and after:

<img width="45%" alt="Screenshot 2025-10-16 at 15 31 58" src="https://github.com/user-attachments/assets/f44fb4ea-39bd-487b-a3c8-f737e7ae1594" /> <img width="45%" alt="Screenshot 2025-10-16 at 15 31 34" src="https://github.com/user-attachments/assets/6a8fc450-0d3c-474d-b0ab-44413f6e3b40" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Create a flex site, following the instructions in #106411
* Visit /sites and select the flex site
* The individual v1 screens should become available and click-able, although not functioning due to missing endpoints

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
