### PR TITLE
Deployments: Add warning copy to install workflow for me button

### DIFF
--- a/client/dashboard/sites/settings-repositories/advanced-workflow-style.tsx
+++ b/client/dashboard/sites/settings-repositories/advanced-workflow-style.tsx
@@ -92,6 +92,7 @@ export const AdvancedWorkflowStyle = ( {
 				disabled={ isLoading }
 				options={ workflowOptions }
 				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 			/>
 
 			<Text variant="muted">

--- a/client/dashboard/sites/settings-repositories/new-workflow-wizard.tsx
+++ b/client/dashboard/sites/settings-repositories/new-workflow-wizard.tsx
@@ -51,7 +51,7 @@ export const NewWorkflowWizard = ( {
 			{ errorMessage && <Text>{ errorMessage }</Text> }
 			<Text variant="muted">
 				{ __(
-					'Proceeding will commit a new workflow configuration file to your repository‘s default branch, no other files will be affected.'
+					'Proceeding will commit a new workflow configuration file to your repository‘s default branch. No other files will be affected.'
 				) }
 			</Text>
 

--- a/client/dashboard/sites/settings-repositories/new-workflow-wizard.tsx
+++ b/client/dashboard/sites/settings-repositories/new-workflow-wizard.tsx
@@ -49,6 +49,11 @@ export const NewWorkflowWizard = ( {
 			<CodeHighlighter content={ exampleTemplate } />
 
 			{ errorMessage && <Text>{ errorMessage }</Text> }
+			<Text variant="muted">
+				{ __(
+					'Proceeding will commit a new workflow configuration file to your repository‘s default branch, no other files will be affected.'
+				) }
+			</Text>
 
 			<Button
 				type="button"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTDASH-655

## Proposed Changes

* Add a warning copy on top of the Install Workflow for me button notifying that a new workflow file will be committed to the repository

|Before | After|
|-------|------|
|<img width="2150" height="3681" alt="CleanShot 2025-10-16 at 12 05 59@2x" src="https://github.com/user-attachments/assets/28a5c972-1b1f-4663-80ee-769f4e652297" />|<img width="2148" height="3744" alt="CleanShot 2025-10-16 at 12 05 33@2x" src="https://github.com/user-attachments/assets/5468e538-d1cc-4c8d-8987-9a75adebe811" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To explain to users what is happening when clicking the button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run Calypso locally or open the Calypso Live link below
* Using a Business or Commerce site, navigate to a `/v2/sites/:siteSlug/settings/repositories` and select `Connect repository` or use an existing repository and select `Configure repository` on the three dots menu
* On the bottom of the form, select `Advanced` radio button
* Expand the `Deployment Workflow` dropdown  <img width="533" height="200" alt="CleanShot 2025-10-16 at 11 59 52@2x" src="https://github.com/user-attachments/assets/cbfeada0-9883-4c18-96cc-1251979188ae" />
* Select `Create new workflow` <img width="533" height="200" alt="CleanShot 2025-10-16 at 11 59 36@2x" src="https://github.com/user-attachments/assets/e5789260-2a01-4a7c-9474-6410ce21f2d7" />
* Check that there is a text above the `Install workflow for me` explaining that the new workflow will be committed, please see screenshot in the `Proposed Changes` section above. 
* Check the copy 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
