### PR TITLE
Reader - Feed stream - reintroduce reader back button

### DIFF
--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -6,6 +6,7 @@ import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { useSiteTags } from 'calypso/data/site-tags/use-site-tags';
 import withDimensions from 'calypso/lib/with-dimensions';
+import ReaderBackButton from 'calypso/reader/components/back-button';
 import FeedError from 'calypso/reader/feed-error';
 import { getFollowerCount, getSiteName } from 'calypso/reader/get-helpers';
 import SiteBlocked from 'calypso/reader/site-blocked';
@@ -85,6 +86,7 @@ const FeedStream = ( props ) => {
 					comment: '%s is the section name. For example: "My Likes"',
 				} ) }
 			/>
+			<ReaderBackButton />
 			<ReaderFeedHeader feed={ feed } site={ site } streamKey={ props.streamKey } />
 			{ siteId && <QueryPostCounts siteId={ siteId } type="post" /> }
 			{ ! feed && <QueryReaderFeed feedId={ feedId } /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-960/reader-feed-blog-page-does-not-include-a-back-button

## Proposed Changes

Re-introduces the reader back button to the feed/blog stream.
* Previously, we removed reader back buttons from 'top level' reader pages as they seemed cluttery and unnecessary. On top of that we considered removing the in-app back buttons from the reader altogether but decided to keep them on nested pages. In the process of removing the back button from 'top level' reader pages, it was also removed from the feed/blog stream. While a stream, and most streams are top level, this feed/blog page is never accessible directly from the sidebar therefore fits the criteria we have been using in the reader for requiring a back button.


Before
<img width="731" height="315" alt="Screenshot 2025-10-16 at 8 01 10 AM" src="https://github.com/user-attachments/assets/a5925c22-a2ea-4801-b80d-c9d1bf6f0a31" />


After
<img width="904" height="333" alt="Screenshot 2025-10-16 at 7 58 18 AM" src="https://github.com/user-attachments/assets/47ab518f-03aa-4d05-b134-e2cb4416b38d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* user report, previous development error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader
* go to discover
* click into a post
* from full post, in the author details, click the blog stream
* verify the blog stream now has a back button. this should be styled and positioned identically to other pages, at various breakpoints.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
