### PR TITLE
Hosting Dashboard: Fix "No Pages" message flash.

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -51,7 +51,11 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			timezoneString: s?.timezone_string || undefined,
 		} ),
 	} );
-	const { data: pagesData, refetch: refetchPages } = useQuery( {
+	const {
+		data: pagesData,
+		isFetching: isFetchingPages,
+		refetch: refetchPages,
+	} = useQuery( {
 		...sitePerformancePagesQuery( site.ID ),
 	} );
 	const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
@@ -96,10 +100,6 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 	const { gmtOffset, timezoneString } = siteSettings;
 
 	const renderContent = () => {
-		if ( ! pagesData || ! currentPage ) {
-			return <ReportNoPagesNotice />;
-		}
-
 		if ( hasError( deviceToggle ) ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
@@ -108,8 +108,12 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			return <ReportLoading isSavedReport={ false } />;
 		}
 
-		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport ) {
+		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport || isFetchingPages ) {
 			return <ReportLoading isSavedReport />;
+		}
+
+		if ( ! pagesData || ! currentPage ) {
+			return <ReportNoPagesNotice />;
 		}
 
 		return (

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -153,7 +153,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 							<PageSelector
 								siteUrl={ site.URL }
 								currentPage={ currentPage }
-								pages={ pagesData }
+								pages={ pagesData || [] }
 								onChange={ ( pageId ) => {
 									setRunNewReport( false );
 									recordTracksEvent(

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -108,7 +108,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			return <ReportLoading isLoadingPages />;
 		}
 
-		if ( ! pagesData?.length ) {
+		if ( ! pagesData?.length || ! currentPage ) {
 			return <ReportNoPagesNotice />;
 		}
 
@@ -117,7 +117,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		}
 
 		// Our default loading state is loading the existing report.
-		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport || ! currentPage ) {
+		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport ) {
 			return <ReportLoading isSavedReport />;
 		}
 
@@ -149,33 +149,30 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 						/>
 					}
 					actions={
-						pagesData &&
-						pagesData.length && (
-							<HStack>
-								<PageSelector
-									siteUrl={ site.URL }
-									currentPage={ currentPage }
-									pages={ pagesData }
-									onChange={ ( pageId ) => {
-										setRunNewReport( false );
-										recordTracksEvent(
-											'calypso_dashboard_performance_profiler_page_selector_change',
-											{
-												is_home: pageId === '0',
-											}
-										);
+						<HStack>
+							<PageSelector
+								siteUrl={ site.URL }
+								currentPage={ currentPage }
+								pages={ pagesData }
+								onChange={ ( pageId ) => {
+									setRunNewReport( false );
+									recordTracksEvent(
+										'calypso_dashboard_performance_profiler_page_selector_change',
+										{
+											is_home: pageId === '0',
+										}
+									);
 
-										navigate( {
-											search: ( prev: Record< string, string > ) => ( {
-												...prev,
-												page_id: Number( pageId ),
-											} ),
-										} );
-									} }
-								/>
-								<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
-							</HStack>
-						)
+									navigate( {
+										search: ( prev: Record< string, string > ) => ( {
+											...prev,
+											page_id: Number( pageId ),
+										} ),
+									} );
+								} }
+							/>
+							<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
+						</HStack>
 					}
 				/>
 			}

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -104,16 +104,17 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
 
+		if ( ! pagesData?.length && ! isFetchingPages ) {
+			return <ReportNoPagesNotice />;
+		}
+
 		if ( isLoadingNewReport( deviceToggle ) ) {
 			return <ReportLoading isSavedReport={ false } />;
 		}
 
-		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport || isFetchingPages ) {
+		// Our default loading state is loading the existing report.
+		if ( isLoadingExistingReport( deviceToggle ) || ! currentReport || ! currentPage ) {
 			return <ReportLoading isSavedReport />;
-		}
-
-		if ( ! pagesData || ! currentPage ) {
-			return <ReportNoPagesNotice />;
 		}
 
 		return (

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -53,7 +53,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 	} );
 	const {
 		data: pagesData,
-		isFetching: isFetchingPages,
+		isLoading: isLoadingPages,
 		refetch: refetchPages,
 	} = useQuery( {
 		...sitePerformancePagesQuery( site.ID ),
@@ -104,7 +104,11 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 			return <ReportErrorNotice onRetestClick={ handleReportRefetch } />;
 		}
 
-		if ( ! pagesData?.length && ! isFetchingPages ) {
+		if ( isLoadingPages ) {
+			return <ReportLoading isLoadingPages />;
+		}
+
+		if ( ! pagesData?.length ) {
 			return <ReportNoPagesNotice />;
 		}
 

--- a/client/dashboard/sites/performance/page-selector.tsx
+++ b/client/dashboard/sites/performance/page-selector.tsx
@@ -77,17 +77,14 @@ export default function PageSelector( {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				__experimentalRenderItem={ ( { item } ) => {
-					const hasPages = pageOptions.length > 1;
-					if ( hasPages && item.value === '-1' ) {
-						return (
+					if ( item.value === '-1' ) {
+						return pages.length ? (
 							<Text variant="muted">
 								{ __( 'Performance testing is available for the 20 most popular pages.' ) }
 							</Text>
+						) : (
+							<Text variant="muted">{ __( 'No pages found.' ) }</Text>
 						);
-					}
-
-					if ( ! hasPages && item.value === '-1' ) {
-						return <Text variant="muted">{ __( 'No pages found.' ) }</Text>;
 					}
 
 					return (

--- a/client/dashboard/sites/performance/page-selector.tsx
+++ b/client/dashboard/sites/performance/page-selector.tsx
@@ -77,13 +77,19 @@ export default function PageSelector( {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				__experimentalRenderItem={ ( { item } ) => {
-					if ( item.value === '-1' ) {
+					const hasPages = pageOptions.length > 1;
+					if ( hasPages && item.value === '-1' ) {
 						return (
 							<Text variant="muted">
 								{ __( 'Performance testing is available for the 20 most popular pages.' ) }
 							</Text>
 						);
 					}
+
+					if ( ! hasPages && item.value === '-1' ) {
+						return <Text variant="muted">{ __( 'No pages found.' ) }</Text>;
+					}
+
 					return (
 						<VStack spacing="0">
 							<Text>{ item.label }</Text>

--- a/client/dashboard/sites/performance/report-loading.tsx
+++ b/client/dashboard/sites/performance/report-loading.tsx
@@ -9,9 +9,18 @@ import { border, published } from '@wordpress/icons';
 import { Text } from '../../components/text';
 import useLoadingSteps from './use-loading-steps';
 
-export default function ReportLoading( { isSavedReport }: { isSavedReport: boolean } ) {
-	const { step, steps } = useLoadingSteps( {
-		steps: isSavedReport
+export default function ReportLoading( {
+	isSavedReport = true,
+	isLoadingPages = false,
+}: {
+	isSavedReport?: boolean;
+	isLoadingPages?: boolean;
+} ) {
+	const getSteps = () => {
+		if ( isLoadingPages ) {
+			return [ __( 'Getting your site pages.' ) ];
+		}
+		return isSavedReport
 			? [ __( 'Checking for an existing report.' ) ]
 			: [
 					__( 'Running a new report.' ),
@@ -20,7 +29,11 @@ export default function ReportLoading( { isSavedReport }: { isSavedReport: boole
 					__( 'Fetching historic data.' ),
 					__( 'Identifying performance improvements.' ),
 					__( 'Finalizing your results.' ),
-			  ],
+			  ];
+	};
+
+	const { step, steps } = useLoadingSteps( {
+		steps: getSteps(),
 		duration: 5000, // 5 seconds
 	} );
 


### PR DESCRIPTION
Related to #106421.

## Proposed Changes

In #106421, I introduced a "No Pages" error message that is displayed when we can't find pages. What I neglected to test was what happens when there is no cache. 

The problem is, when there is no cache, the page flashes the banner temporarily.

Therefore, we need a proper loading state. 

The existing [performance page had one](https://github.com/Automattic/wp-calypso/blob/9d968faa36e14c47cb90247b69ac2b61c6e8d355/client/performance-profiler/pages/loading-screen/progress.tsx#L117). I've reintroduced it here in this PR.


## Screenshots
| Context | Before | After |
|--------|--------|--------|
| No Cache | ![Screen Recording on 2025-10-17 at 09-31-20](https://github.com/user-attachments/assets/110e8d94-e940-448d-ad53-a2d04992fd94) | ![Screen Recording on 2025-10-17 at 09-23-06](https://github.com/user-attachments/assets/6d2842f3-978c-438a-b97c-06e3be369882) |
| From cache | ![Screen Recording on 2025-10-17 at 09-32-06](https://github.com/user-attachments/assets/8e6ba92c-7777-4edb-8eae-8318154f629f) | ![Screen Recording on 2025-10-17 at 09-25-11](https://github.com/user-attachments/assets/d980545c-6d21-4d65-860a-582c18a361df) |
| No Pages (No cache) | ![Screen Recording on 2025-10-17 at 09-33-04](https://github.com/user-attachments/assets/acd5240f-954f-4d48-a071-41bcf2d887c4) | ![Screen Recording on 2025-10-17 at 09-27-05](https://github.com/user-attachments/assets/c762a8f6-a293-47d0-a306-3d4f54438570) |
| No Pages ( With cache) | ![Screen Recording on 2025-10-17 at 09-33-23](https://github.com/user-attachments/assets/cf18315f-dd42-4017-9d86-246e1259c021) | ![Screen Recording on 2025-10-17 at 09-27-27](https://github.com/user-attachments/assets/61d81220-0bd3-4ff2-8c1e-865db1647f69) |


As mentioned in https://github.com/Automattic/wp-calypso/pull/106506#issue-3521546393, a follow-up PR with E2e is incoming.


## Testing Instructions

**Test with no pages**

Update [fetchSitePerformancePages](https://github.com/Automattic/wp-calypso/blob/9d968faa36e14c47cb90247b69ac2b61c6e8d355/packages/api-core/src/site-performance-pages/fetchers.) to return an empty array.

1. Visit `v2/sites/{sites}/performance`
1. Expect to see the "No Pages" error message.


**Test with empty cache**
1. Delete your `REACT_QUERY_OFFLINE_CACHE` key from localStorage
1. Visit `v2/sites/{sites}/performance`
1. Expect to not see the "No Pages" error message and see the report loading message.
1. Expect the report to load 

**Test with full cache**
1. Visit `v2/sites/{sites}/performance`
1. Expect to not see the "No Pages" error message and see the report loading message.
1. Expect the report to load

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
