### PR TITLE
e2e tests: Handle cookie banner in page fixture

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -223,6 +223,18 @@ export const test = base.extend< {
 	 */
 	sitePublic: NewSiteResponse;
 } >( {
+	page: async ( { page }, use ) => {
+		await page.context().addCookies( [
+			{
+				name: 'sensitive_pixel_options',
+				value: '{"ok":true,"buckets":{"essential":true,"analytics":false,"advertising":false}}',
+				domain: '.wordpress.com',
+				path: '/',
+			},
+		] );
+
+		await use( page );
+	},
 	accountAtomic: async ( { page }, use ) => {
 		const testAccount = await getAccount( page, 'atomicUser' );
 		await use( testAccount );


### PR DESCRIPTION


## Proposed Changes

The cookie banner can get in the way. Adding the right cookies in the page fixture should hide the banner

## Testing Instructions

```
yarn test:pw
```


