### PR TITLE
Increase execution timeout from 40 to 50 minutes in BuildBaseImages configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -225,7 +225,7 @@ object BuildBaseImages : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 40
+		executionTimeoutMin = 50
 	}
 
 	features {


### PR DESCRIPTION

## Proposed Changes

Increase the timeout of BuildBaseImages from 40m to 50m.

## Why are these changes being made?

BuildBaseImages is currently timing out at 40m. 


