### PR TITLE
Deployments: Update `Back to Deployments` button

### DIFF
--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -10,6 +10,6 @@
 	margin: $grid-unit-20;
 }
 
-body:has( .repositories-back-link ) .dashboard-snackbars {
+body:has( .repositories-back-button ) .dashboard-snackbars {
 	margin-bottom: calc( $grid-unit-20 + 52px );
 }

--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -1,4 +1,4 @@
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/variables';
 
 .dashboard-snackbars {
 	position: fixed;
@@ -8,4 +8,8 @@
 	flex-direction: column;
 	align-items: flex-start;
 	margin: $grid-unit-20;
+}
+
+body:has( .repositories-back-link ) .dashboard-snackbars {
+	margin-bottom: calc( $grid-unit-20 + 52px );
 }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -6,11 +6,11 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { keyboardReturn, Icon } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
@@ -190,24 +190,34 @@ function SiteRepositories() {
 				</HostingFeatureGatedWithCallout>
 			</PageLayout>
 			{ showBackToDeployments && (
-				<HStack className="dashboard-snackbars">
-					<Snackbar
-						icon={ <Icon icon={ keyboardReturn } style={ { fill: 'currentcolor' } } /> }
-						actions={ [
-							{
-								label: __( 'Navigate' ),
-								onClick: () => {
-									navigate( {
-										to: siteDeploymentsListRoute.fullPath,
-										params: { siteSlug },
-									} );
-								},
-							},
-						] }
+				<div
+					className="repositories-back-link"
+					style={ {
+						position: 'fixed',
+						bottom: '16px',
+						insetInlineStart: '16px',
+					} }
+				>
+					<Button
+						variant="secondary"
+						icon={ chevronLeft }
+						iconPosition="left"
+						onClick={ () => {
+							navigate( {
+								to: siteDeploymentsListRoute.fullPath,
+								params: { siteSlug },
+							} );
+						} }
+						style={ {
+							backgroundColor: '#1e1e1e',
+							color: '#ffffff',
+							borderColor: '#1e1e1e',
+							boxShadow: 'none',
+						} }
 					>
 						{ __( 'Back to Deployments' ) }
-					</Snackbar>
-				</HStack>
+					</Button>
+				</div>
 			) }
 		</>
 	);

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -9,8 +9,8 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
@@ -200,7 +200,7 @@ function SiteRepositories() {
 				>
 					<Button
 						variant="secondary"
-						icon={ chevronLeft }
+						icon={ isRTL() ? chevronRight : chevronLeft }
 						iconPosition="left"
 						onClick={ () => {
 							navigate( {

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -191,7 +191,7 @@ function SiteRepositories() {
 			</PageLayout>
 			{ showBackToDeployments && (
 				<div
-					className="repositories-back-link"
+					className="repositories-back-button"
 					style={ {
 						position: 'fixed',
 						bottom: '16px',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-624

## Proposed Changes

* update the `Back to Deployments` button on the _Repositories_ page

| Before | After |
|--------|--------|
| <img width="622" height="152" alt="Markup on 2025-10-16 at 16:22:11" src="https://github.com/user-attachments/assets/bf25985d-aff6-409e-bd33-22f2bf700c08" /> | <img width="422" height="136" alt="Markup on 2025-10-16 at 16:21:16" src="https://github.com/user-attachments/assets/82e227af-7f3e-4ec4-91fa-5999c27d632d" /> | 

Notifications rendered above:

https://github.com/user-attachments/assets/047726c4-f4ef-423b-a917-afa7f18d37d8

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current button isn't fully clickable, which may be confusing to our users. The Snackbar notifications overlap with it as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. Navigate to the _Repositories_ page in the V2 Hosting Dashboard on one of your WoA sites: `http://calypso.localhost:3000/v2/sites/{site-slug}/settings/repositories?from=deployments`.
3. Observe the `Back to Deployments` button and ensure it works as expected.
4. While still on the _Repositories_ page, trigger some error. For example:
  - When you have your GitHub account connected already, navigate to the [Installed GitHub Applications](https://github.com/settings/installations) page.
  - Open the _WordPress.com for Developers_ app and suspend it temporarily.
  - Trigger manual deployment from the Repositories page.
5. As the error notification displays, confirm it is not overlapping with the `Back to Deployments` button.
6. Try to trigger some other error / success notification outside the Repositories page. For example:
  - Go to the _Overview_ tab and try to create a new staging site.
  - As the notification renders, it should display as before - right at the bottom-left corner of the screen.
7. If you like, you may also test the behavior with the RTL locale and confirm all is looking good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
