### PR TITLE
Hosting Dashboard Emails: Verfication email link

### DIFF
--- a/client/dashboard/emails/actions/delete-email-forward.tsx
+++ b/client/dashboard/emails/actions/delete-email-forward.tsx
@@ -13,17 +13,16 @@ import type { Email } from '../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useDeleteEmailForwardAction = (): Action< Email > => {
-	const { mutateAsync: deleteEmailForward, isPending } = useMutation(
-		deleteEmailForwardMutation()
-	);
-
 	return {
 		id: 'delete-email-forward',
 		label: __( 'Delete forwarder' ),
 		isDestructive: true,
 		callback: () => {},
 		RenderModal: ( { items, closeModal, onActionPerformed } ) => {
-			const { createErrorNotice } = useDispatch( noticesStore );
+			const { mutateAsync: deleteEmailForward, isPending } = useMutation(
+				deleteEmailForwardMutation()
+			);
+			const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 			const email = items[ 0 ];
 
 			const mailbox = email.emailAddress.split( '@' )[ 0 ];
@@ -34,6 +33,15 @@ export const useDeleteEmailForwardAction = (): Action< Email > => {
 						mailbox,
 						destination: email.forwardingTo as string,
 					} );
+					createSuccessNotice(
+						sprintf(
+							/* translators: %1$s is the email and %2$s is the forwarding destination address. */
+							__( 'Forwarder from %1$s to %2$s has been removed.' ),
+							email.emailAddress,
+							email.forwardingTo as string
+						),
+						{ type: 'snackbar' }
+					);
 					onActionPerformed?.( items );
 					closeModal?.();
 				} catch ( _e ) {

--- a/client/dashboard/emails/actions/delete-titan-mailbox.tsx
+++ b/client/dashboard/emails/actions/delete-titan-mailbox.tsx
@@ -13,10 +13,6 @@ import type { Email } from '../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useDeleteTitanMailboxAction = (): Action< Email > => {
-	const { mutateAsync: deleteTitanMailbox, isPending } = useMutation(
-		deleteTitanMailboxMutation()
-	);
-
 	return {
 		id: 'delete-titan-mailbox',
 		label: __( 'Delete mailbox' ),
@@ -24,6 +20,9 @@ export const useDeleteTitanMailboxAction = (): Action< Email > => {
 		// Using a modal to confirm deletion
 		callback: () => {},
 		RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+			const { mutateAsync: deleteTitanMailbox, isPending } = useMutation(
+				deleteTitanMailboxMutation()
+			);
 			const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 			const email = items[ 0 ];
 

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -9,6 +9,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { arrowLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
+import { useAppContext } from '../../app/context';
+import { emailsRoute } from '../../app/router/emails';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -30,6 +32,7 @@ export interface FormData {
 }
 
 function AddEmailForwarder() {
+	const { basePath } = useAppContext();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { mutate: addEmailForwarder, isPending: isAddingEmailForwarder } = useMutation(
 		addEmailForwarderMutation()
@@ -145,11 +148,18 @@ function AddEmailForwarder() {
 
 		const { localPart, domain, forwardingAddresses } = formData;
 
+		const redirectPath = `${ ( basePath || '' ).replace( /\/$/, '' ) }${ emailsRoute.to }`;
+		const redirectUrl =
+			typeof window !== 'undefined'
+				? new URL( redirectPath, window.location.origin ).href
+				: redirectPath;
+
 		addEmailForwarder(
 			{
 				domain,
 				mailbox: `${ localPart }@${ domain }`,
 				destinations: forwardingAddresses,
+				redirectUrl,
 			},
 			{
 				onSuccess: () => {

--- a/packages/api-core/src/domain-email/mutators.ts
+++ b/packages/api-core/src/domain-email/mutators.ts
@@ -3,10 +3,12 @@ import { wpcom } from '../wpcom-fetcher';
 export async function addEmailForwarder(
 	domain: string,
 	mailbox: string,
-	destinations: string[]
+	destinations: string[],
+	redirectUrl?: string
 ): Promise< void > {
 	return wpcom.req.post( `/domains/${ encodeURIComponent( domain ) }/email/new`, {
 		mailbox,
 		destinations,
+		redirect_url: redirectUrl,
 	} );
 }

--- a/packages/api-queries/src/domain-email.ts
+++ b/packages/api-queries/src/domain-email.ts
@@ -26,6 +26,7 @@ type Variables = {
 	domain: string;
 	mailbox: string;
 	destinations: string[];
+	redirectUrl?: string;
 };
 
 export const addEmailForwarderMutation = () =>
@@ -34,11 +35,13 @@ export const addEmailForwarderMutation = () =>
 			domain,
 			mailbox,
 			destinations,
+			redirectUrl,
 		}: {
 			domain: string;
 			mailbox: string;
 			destinations: string[];
-		} ) => addEmailForwarder( domain, mailbox, destinations ),
+			redirectUrl?: string;
+		} ) => addEmailForwarder( domain, mailbox, destinations, redirectUrl ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: [ 'mailboxes' ] } );
 			queryClient.invalidateQueries( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-627/hosting-dashboard-emails-verification-email

## Proposed Changes

* Added an argument so that we can redirect to `v2/emails` when we create the forward from the Hosting Dashboard.
* Fixed an error where we were not handling the pending state correctly.
* Improved the delete forwarder action by adding a success notice.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buckle up
* First apply the wpcom patch to your sandbox (parent linear issue)
* Now, sandbox your API and sanbox WordPress.com
* On the Calypso live link
* Go to `/v2/emails`
* Add a new forwarder
* You can inspect the network request by filtering by `new`, the request should include the redirect_url argument in the payload.
* You should receive an email. When clicking on the link, you should end up on the hosting dashboard emails screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
