### PR TITLE
Check DIFM chat for premium support

### DIFF
--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -59,7 +59,6 @@ export default function DIFMSitePickerStep( props: Props ) {
 	};
 
 	const { data: geoData } = useGeoLocationQuery();
-
 	const isPremiumHelpCenterLinkEnabled = geoData?.country_short === 'US';
 
 	const subHeaderText = translate(

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -4,7 +4,6 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import SiteSelector from 'calypso/components/site-selector';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch, useStore } from 'calypso/state';
@@ -58,18 +57,12 @@ export default function DIFMSitePickerStep( props: Props ) {
 		goToNextStep();
 	};
 
-	const { data: geoData } = useGeoLocationQuery();
-	const isPremiumHelpCenterLinkEnabled = geoData?.country_short === 'US';
-
 	const subHeaderText = translate(
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
 		{
 			components: {
 				SupportLink: (
-					<HelpCenterInlineButton
-						className="subtitle-link"
-						flowName={ isPremiumHelpCenterLinkEnabled ? props.flowName : undefined }
-					/>
+					<HelpCenterInlineButton className="subtitle-link" flowName={ props.flowName } />
 				),
 				NewSiteLink: (
 					<Button variant="link" className="subtitle-link" onClick={ onNewSiteClicked } />

--- a/packages/help-center/src/hooks/use-flow-custom-options.ts
+++ b/packages/help-center/src/hooks/use-flow-custom-options.ts
@@ -1,7 +1,10 @@
 import { DIFM_FLOW, DIFM_FLOW_STORE, WEBSITE_DESIGN_SERVICES } from '@automattic/onboarding';
+import { useSupportStatus } from '../data/use-support-status';
 
 // We want to give the Help Center custom options based on the flow in which the user is in
 export function useFlowCustomOptions( flowName: string ) {
+	const { data: supportStatus } = useSupportStatus();
+
 	if (
 		flowName === DIFM_FLOW ||
 		flowName === DIFM_FLOW_STORE ||
@@ -9,7 +12,7 @@ export function useFlowCustomOptions( flowName: string ) {
 	) {
 		return {
 			hideBackButton: true,
-			hasPremiumSupport: true,
+			hasPremiumSupport: Boolean( supportStatus?.availability.is_difm_chat_open ),
 		};
 	}
 

--- a/packages/help-center/src/hooks/use-flow-custom-options.ts
+++ b/packages/help-center/src/hooks/use-flow-custom-options.ts
@@ -1,9 +1,12 @@
 import { DIFM_FLOW, DIFM_FLOW_STORE, WEBSITE_DESIGN_SERVICES } from '@automattic/onboarding';
+/* eslint-disable no-restricted-imports */
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { useSupportStatus } from '../data/use-support-status';
 
 // We want to give the Help Center custom options based on the flow in which the user is in
 export function useFlowCustomOptions( flowName: string ) {
 	const { data: supportStatus } = useSupportStatus();
+	const { data: geoData } = useGeoLocationQuery();
 
 	if (
 		flowName === DIFM_FLOW ||
@@ -12,7 +15,9 @@ export function useFlowCustomOptions( flowName: string ) {
 	) {
 		return {
 			hideBackButton: true,
-			hasPremiumSupport: Boolean( supportStatus?.availability.is_difm_chat_open ),
+			hasPremiumSupport: Boolean(
+				supportStatus?.availability.is_difm_chat_open && geoData?.country_short === 'US'
+			),
 		};
 	}
 

--- a/packages/help-center/src/hooks/use-flow-custom-options.ts
+++ b/packages/help-center/src/hooks/use-flow-custom-options.ts
@@ -15,9 +15,8 @@ export function useFlowCustomOptions( flowName: string ) {
 	) {
 		return {
 			hideBackButton: true,
-			hasPremiumSupport: Boolean(
-				supportStatus?.availability.is_difm_chat_open && geoData?.country_short === 'US'
-			),
+			hasPremiumSupport:
+				supportStatus?.availability.is_difm_chat_open && geoData?.country_short === 'US',
 		};
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-317/difm-user-in-site-picker-get-support-even-if-closed

## What

A free new user who goes through start/do-it-for-me can get the premium support even if the DIFM queue is set to closed.
This is because in the site-picker we only check that the user is in the US (one of the conditions to have the DIFM premium support) and not that the chat is open.

## Testing

0. Check that `DIFM: Help Center support` in https://wordpress.com/wp-admin/network/admin.php?page=livechat_options is set to false
1. Have a free user with at least a website
2. Go to /start/do-it-for-me and reach the site-picker
3. 
<img width="1109" height="299" alt="image" src="https://github.com/user-attachments/assets/e0b0d0fc-4fe3-40ae-80d8-8261e2759543" />

4. Click on contact support, you should not be sent to a live chat but talk with AI


You need to be from the US to test this, fake it with a VPN or simply set the [geoData](https://github.com/Automattic/wp-calypso/blob/DOTSUP-317/difm-user-in-site-picker-get-support-even-if-closed/packages/help-center/src/hooks/use-flow-custom-options.ts#L19) check to true
