### PR TITLE
Made auto-renew link toggle appear for akismet siteless purchases

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
@@ -230,11 +230,7 @@ class AutoRenewToggle extends Component<
 		const { planName, siteDomain, purchase, withTextStatus, shouldDisable, showLink, children } =
 			this.props;
 
-		if ( ! this.shouldRender( purchase ) ) {
-			return null;
-		}
-
-		if ( ! planName ) {
+		if ( ! showLink && ! this.shouldRender( purchase ) ) {
 			return null;
 		}
 
@@ -247,7 +243,7 @@ class AutoRenewToggle extends Component<
 					variant="link"
 					className="is-link"
 					onClick={ this.onToggleAutoRenew }
-					disabled={ shouldDisable }
+					disabled={ shouldDisable || ! this.shouldRender( purchase ) }
 				>
 					{ children }
 				</Button>
@@ -268,7 +264,7 @@ class AutoRenewToggle extends Component<
 				{ toggle }
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }
-					planName={ planName }
+					planName={ planName ? planName : '' }
 					purchase={ purchase }
 					siteDomain={ siteDomain }
 					onClose={ this.onCloseAutoRenewDisablingDialog }


### PR DESCRIPTION
Resolves CHE-260

  ## Proposed Changes
  * Fix auto-renew toggle display for Akismet siteless purchases by modifying the rendering logic in `AutoRenewToggle` component
      * Allow purchases without a planName 
      * Disable (but still show) the link variant of the component (`showLink` prop is true)  if `shouldRender()` returns false
          *  current shouldRender = `return ! isExpired( purchase ) && ! isOneTimePurchase( purchase );`

  ## Why are these changes being made?
  * The auto-renew toggle for Akismet purchases was not displaying properly, making the interface look broken
  * Users with Akismet subscriptions couldn't see the auto-renew status in their purchase management page

 ## Impact/Notes
 * There are three locations that use the AutoRenewToggle component 
     * purchase details: /me/purchases/siteless.akismet.com::0PtyQetUTvPtBKN3u8RwgTpo/1170154
     * email subscription details: /email/emailonly123.blog/manage/emailonly123.wordpress.com
     * domain details: /manage/domainonlycredit123.blog/edit/domainonlycredit123.blog
 * The AutoRenewToggle component can reneder two different variants:
     * a link: On or Off 
         * controlled by showLink prop
         * purchase details: /me/purchases/siteless.akismet.com::0PtyQetUTvPtBKN3u8RwgTpo/1170154
     * a On-Off slider/toggle control
         * email subscription details: /email/emailonly123.blog/manage/emailonly123.wordpress.com
         * domain details: /manage/domainonlycredit123.blog/edit/domainonlycredit123.blog
 * There is a lot of logic in the front end that ideally would be controlled by the backend instead, both within the AutoRenewToggle and outside of it where it is rendered.
     * the Purchase entity from Store_Subscription has properties like can_disable_auto_renew and can_reenable_auto_renewal that could replace some front end logic, but would require a larger fix and testing effort.

## Testing Instructions
  1. Purchase an Akismet plan via https://akismet.com/pricing/
  2. Navigate to https://wordpress.com/me/purchases and click through to manage the Akismet purchase
  3. Verify that the auto-renew toggle now appears (showing "On" status)
  6. Ensure that clicking On/Off toggle triggers popups

   Additional regression scenarios:
   - credit only domain - buy a domain with credits only
       - check /me/purchases and /domains/manage
   - siteless domain  - buy a domain but don't connect it to a site from here: https://wordpress.com/domains/
       - check /me/purchases and /domains/manage
   - email  - add email from here: https://wordpress.com/professional-email/
       - check /me/purchases and /email 
   - jetpack siteless - add antispam as a siteless jetpack add-on from here: https://jetpack.com/upgrade/anti-spam
       - check /me/purchases 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
