### PR TITLE
Hosting Dashboard Emails: Professional email

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -99,6 +99,24 @@ export const chooseEmailSolutionRoute = createRoute( {
 	)
 );
 
+export const addProfessionalEmailRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add Professional Email' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'emails/add-professional-email/$domain',
+} ).lazy( () =>
+	import( '../../emails/add-professional-email' ).then( ( d ) =>
+		createLazyRoute( 'add-professional-email' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const addTitanmailMailboxRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -158,6 +176,7 @@ export const createEmailsRoutes = () => {
 		emailsRoute,
 		chooseDomainRoute,
 		chooseEmailSolutionRoute,
+		addProfessionalEmailRoute,
 		addTitanmailMailboxRoute,
 		addGoogleMailboxRoute,
 		addEmailForwarderRoute,

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -11,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { seen, unseen } from '@wordpress/icons';
 import { useState } from 'react';
+import { useAuth } from '../../app/auth';
 import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -32,6 +33,7 @@ const EmailForm = ( {
 	state: FormState;
 	setState: ( state: FormState ) => void;
 } ) => {
+	const { user } = useAuth();
 	const router = useRouter();
 	// Extract params from the current match for this route
 	const match = router.state.matches[ router.state.matches.length - 1 ];
@@ -79,7 +81,7 @@ const EmailForm = ( {
 							__(
 								'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
 							),
-							{ userEmail: 'user@example.com' }
+							{ userEmail: user?.email }
 						),
 						{
 							strong: <strong />,

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -1,0 +1,91 @@
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { seen, unseen } from '@wordpress/icons';
+import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
+
+const AddProfessionalEmail = () => {
+	const router = useRouter();
+	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
+	// Extract params from the current match for this route
+	const match = router.state.matches[ router.state.matches.length - 1 ];
+	const params = ( match?.params ?? {} ) as { domain?: string; type?: string };
+	const { domain = '' } = params;
+
+	return (
+		<PageLayout header={ <PageHeader /> } size="small">
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<InputControl
+							__next40pxDefaultSize
+							label={ __( 'Email address' ) }
+							suffix={ <InputControlSuffixWrapper>{ `@${ domain }` }</InputControlSuffixWrapper> }
+						/>
+
+						<VStack>
+							<InputControl
+								__next40pxDefaultSize
+								type={ isPasswordVisible ? 'text' : 'password' }
+								label={ __( 'Password' ) }
+								// value={ getValue( { item: data } ) }
+								// onChange={ ( value ) => {
+								// 	return onChange( { [ id ]: value ?? '' } );
+								// } }
+								// disabled={ isLoading }
+								suffix={
+									<InputControlSuffixWrapper>
+										<Button
+											icon={ isPasswordVisible ? unseen : seen }
+											onClick={ () => {
+												setIsPasswordVisible( ! isPasswordVisible );
+											} }
+										/>
+									</InputControlSuffixWrapper>
+								}
+								// Hint to LastPass not to attempt autofill
+								data-lpignore="true"
+							/>
+
+							<Text variant="muted">
+								{ createInterpolateElement(
+									sprintf(
+										// Translators: %(userEmail)s is the email address that the user has currently configured as their password reset email.
+										__(
+											'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
+										),
+										{ userEmail: 'user@example.com' }
+									),
+									{
+										strong: <strong />,
+										passwordChangeLink: <a href="#change-password" />,
+									}
+								) }
+							</Text>
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+
+			<ButtonStack justify="flex-start">
+				<Button __next40pxDefaultSize variant="secondary">
+					{ __( 'Add another mailbox' ) }
+				</Button>
+			</ButtonStack>
+		</PageLayout>
+	);
+};
+
+export default AddProfessionalEmail;

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -16,71 +16,133 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 
-const AddProfessionalEmail = () => {
+interface FormState {
+	localPart: string;
+	password: string;
+}
+
+const EmailForm = ( {
+	disabled = false,
+	removeForm = undefined,
+	state: { localPart, password },
+	setState,
+}: {
+	disabled: boolean;
+	removeForm?: () => void;
+	state: FormState;
+	setState: ( state: FormState ) => void;
+} ) => {
 	const router = useRouter();
-	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
 	// Extract params from the current match for this route
 	const match = router.state.matches[ router.state.matches.length - 1 ];
 	const params = ( match?.params ?? {} ) as { domain?: string; type?: string };
 	const { domain = '' } = params;
+	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
+
+	return (
+		<VStack spacing={ 4 }>
+			<InputControl
+				__next40pxDefaultSize
+				label={ __( 'Email address' ) }
+				value={ localPart }
+				onChange={ ( value ) => setState( { localPart: value || '', password } ) }
+				disabled={ disabled }
+				suffix={ <InputControlSuffixWrapper>{ `@${ domain }` }</InputControlSuffixWrapper> }
+			/>
+
+			<VStack>
+				<InputControl
+					__next40pxDefaultSize
+					type={ isPasswordVisible ? 'text' : 'password' }
+					label={ __( 'Password' ) }
+					value={ password }
+					onChange={ ( value ) => setState( { localPart, password: value || '' } ) }
+					disabled={ disabled }
+					suffix={
+						<InputControlSuffixWrapper>
+							<Button
+								icon={ isPasswordVisible ? unseen : seen }
+								onClick={ () => {
+									setIsPasswordVisible( ! isPasswordVisible );
+								} }
+							/>
+						</InputControlSuffixWrapper>
+					}
+					// Hint to LastPass not to attempt autofill
+					data-lpignore="true"
+				/>
+
+				<Text variant="muted">
+					{ createInterpolateElement(
+						sprintf(
+							// Translators: %(userEmail)s is the email address that the user has currently configured as their password reset email.
+							__(
+								'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
+							),
+							{ userEmail: 'user@example.com' }
+						),
+						{
+							strong: <strong />,
+							passwordChangeLink: <a href="#change-password" />,
+						}
+					) }
+				</Text>
+			</VStack>
+
+			{ removeForm && (
+				<ButtonStack justify="flex-start">
+					<Button
+						__next40pxDefaultSize
+						isDestructive
+						variant="secondary"
+						onClick={ removeForm }
+						disabled={ disabled }
+					>
+						{ __( 'Remove mailbox' ) }
+					</Button>
+				</ButtonStack>
+			) }
+		</VStack>
+	);
+};
+
+const AddProfessionalEmail = () => {
+	const [ emailForms, setEmailForms ] = useState< FormState[] >( [
+		{ localPart: '', password: '' },
+	] );
+
+	const removeForm = ( index: number ) => {
+		const newForms = emailForms.filter( ( _, i ) => i !== index );
+		setEmailForms( newForms );
+	};
 
 	return (
 		<PageLayout header={ <PageHeader /> } size="small">
-			<Card>
-				<CardBody>
-					<VStack spacing={ 4 }>
-						<InputControl
-							__next40pxDefaultSize
-							label={ __( 'Email address' ) }
-							suffix={ <InputControlSuffixWrapper>{ `@${ domain }` }</InputControlSuffixWrapper> }
+			{ emailForms.map( ( state, index ) => (
+				<Card key={ index }>
+					<CardBody>
+						<EmailForm
+							disabled={ false }
+							removeForm={ index > 0 ? () => removeForm( index ) : undefined }
+							state={ state }
+							setState={ ( newState ) => {
+								const newEmailForms = [ ...emailForms ];
+								newEmailForms[ index ] = newState;
+								setEmailForms( newEmailForms );
+							} }
 						/>
-
-						<VStack>
-							<InputControl
-								__next40pxDefaultSize
-								type={ isPasswordVisible ? 'text' : 'password' }
-								label={ __( 'Password' ) }
-								// value={ getValue( { item: data } ) }
-								// onChange={ ( value ) => {
-								// 	return onChange( { [ id ]: value ?? '' } );
-								// } }
-								// disabled={ isLoading }
-								suffix={
-									<InputControlSuffixWrapper>
-										<Button
-											icon={ isPasswordVisible ? unseen : seen }
-											onClick={ () => {
-												setIsPasswordVisible( ! isPasswordVisible );
-											} }
-										/>
-									</InputControlSuffixWrapper>
-								}
-								// Hint to LastPass not to attempt autofill
-								data-lpignore="true"
-							/>
-
-							<Text variant="muted">
-								{ createInterpolateElement(
-									sprintf(
-										// Translators: %(userEmail)s is the email address that the user has currently configured as their password reset email.
-										__(
-											'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
-										),
-										{ userEmail: 'user@example.com' }
-									),
-									{
-										strong: <strong />,
-										passwordChangeLink: <a href="#change-password" />,
-									}
-								) }
-							</Text>
-						</VStack>
-					</VStack>
-				</CardBody>
-			</Card>
+					</CardBody>
+				</Card>
+			) ) }
 
 			<ButtonStack justify="flex-start">
-				<Button __next40pxDefaultSize variant="secondary">
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ () => {
+						setEmailForms( ( prevForms ) => [ ...prevForms, { localPart: '', password: '' } ] );
+					} }
+				>
 					{ __( 'Add another mailbox' ) }
 				</Button>
 			</ButtonStack>

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -1,3 +1,5 @@
+import { domainQuery, productsQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
@@ -16,6 +18,11 @@ import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
+import { getEmailCheckoutPath } from '../../utils/email-paths';
+import { IntervalLength } from '../types';
+import { getCartItems } from '../utils/get-cart-items';
+import { getEmailProductProperties, ProductListItem } from '../utils/get-email-product-properties';
+import { getProductSlugForProviderAndInterval } from '../utils/get-product-slug-for-provider-and-interval';
 
 interface FormState {
 	localPart: string;
@@ -131,13 +138,58 @@ const EmailForm = ( {
 };
 
 const AddProfessionalEmail = () => {
+	const router = useRouter();
+	// Extract params from the current match for this route
+	const match = router.state.matches[ router.state.matches.length - 1 ];
+	const params = ( match?.params ?? {} ) as { domain?: string; type?: string };
+	const { domain = '' } = params;
+	let interval: IntervalLength = router.state.location.search.interval;
+	if ( interval !== 'monthly' && interval !== 'annually' ) {
+		interval = 'annually';
+	}
+	const { data: domainData } = useSuspenseQuery( domainQuery( domain ) );
+	const { data: site } = useQuery( siteBySlugQuery( domain ) );
+	const { data: products } = useQuery( productsQuery() );
 	const [ emailForms, setEmailForms ] = useState< FormState[] >( [
 		{ localPart: '', password: '' },
 	] );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
 	const removeForm = ( index: number ) => {
 		const newForms = emailForms.filter( ( _, i ) => i !== index );
 		setEmailForms( newForms );
+	};
+
+	const handleSubmit = async () => {
+		setIsSubmitting( true );
+
+		const { shoppingCartManagerClient } = await import(
+			/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
+		);
+
+		const productSlug = getProductSlugForProviderAndInterval( 'titan', interval );
+		const product = products[ productSlug ];
+		const numberOfMailboxes = emailForms.length;
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const emailProperties = getEmailProductProperties(
+			'titan',
+			domainData,
+			product as ProductListItem,
+			numberOfMailboxes
+		);
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const checkoutPath = getEmailCheckoutPath(
+			domain,
+			domainData.domain,
+			router.state.location.pathname,
+			`${ emailForms[ 0 ].localPart }@${ domain }`
+		);
+
+		await shoppingCartManagerClient
+			.forCartKey( site?.ID )
+			.actions.addProductsToCart( [ getCartItems( 'titan' ) ] );
 	};
 
 	return (
@@ -146,7 +198,7 @@ const AddProfessionalEmail = () => {
 				<Card key={ index }>
 					<CardBody>
 						<EmailForm
-							disabled={ false }
+							disabled={ isSubmitting }
 							removeForm={ index > 0 ? () => removeForm( index ) : undefined }
 							state={ state }
 							setState={ ( newState ) => {
@@ -168,6 +220,12 @@ const AddProfessionalEmail = () => {
 					} }
 				>
 					{ __( 'Add another mailbox' ) }
+				</Button>
+			</ButtonStack>
+
+			<ButtonStack justify="flex-start">
+				<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
+					{ __( 'Continue' ) }
 				</Button>
 			</ButtonStack>
 		</PageLayout>

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -40,6 +40,8 @@ const EmailForm = ( {
 	const params = ( match?.params ?? {} ) as { domain?: string; type?: string };
 	const { domain = '' } = params;
 	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
+	const [ passwordResetEmail, setPasswordResetEmail ] = useState( user.email );
+	const [ isPasswordResetEmailVisible, setIsPasswordResetEmailVisible ] = useState( false );
 
 	return (
 		<VStack spacing={ 4 }>
@@ -74,22 +76,42 @@ const EmailForm = ( {
 					data-lpignore="true"
 				/>
 
-				<Text variant="muted">
-					{ createInterpolateElement(
-						sprintf(
-							// Translators: %(userEmail)s is the email address that the user has currently configured as their password reset email.
-							__(
-								'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
+				{ ! isPasswordResetEmailVisible && (
+					<Text variant="muted">
+						{ createInterpolateElement(
+							sprintf(
+								// Translators: %(userEmail)s is the email address that the user has currently configured as their password reset email.
+								__(
+									'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
+								),
+								{ userEmail: user.email }
 							),
-							{ userEmail: user?.email }
-						),
-						{
-							strong: <strong />,
-							passwordChangeLink: <a href="#change-password" />,
-						}
-					) }
-				</Text>
+							{
+								strong: <strong />,
+								passwordChangeLink: (
+									<a
+										href="#change-password"
+										onClick={ ( e ) => {
+											e.preventDefault();
+											setIsPasswordResetEmailVisible( ( prev ) => ! prev );
+										} }
+									/>
+								),
+							}
+						) }
+					</Text>
+				) }
 			</VStack>
+
+			{ isPasswordResetEmailVisible && (
+				<InputControl
+					__next40pxDefaultSize
+					label={ __( 'Password reset email address' ) }
+					value={ passwordResetEmail }
+					onChange={ ( value ) => setPasswordResetEmail( value || '' ) }
+					disabled={ disabled }
+				/>
+			) }
 
 			{ removeForm && (
 				<ButtonStack justify="flex-start">

--- a/client/dashboard/emails/types.ts
+++ b/client/dashboard/emails/types.ts
@@ -23,3 +23,5 @@ export interface Email {
 		| 'no_subscription'
 		| 'unused_mailboxes';
 }
+
+export type IntervalLength = 'monthly' | 'annually';

--- a/client/dashboard/emails/utils/get-cart-items.ts
+++ b/client/dashboard/emails/utils/get-cart-items.ts
@@ -1,0 +1,65 @@
+// export interface TitanProductProps {
+// 	domain?: string;
+// 	meta?: string;
+// 	source?: string;
+// 	quantity?: number | null;
+// 	extra?: RequestCartProductExtra;
+// }
+
+import { EmailProvider } from '@automattic/api-core';
+
+// /**
+//  * Creates a new shopping cart item for Titan Mail.
+//  */
+// function titanMailProduct(
+// 	properties: TitanProductProps,
+// 	productSlug: string
+// ): MinimalRequestCartProduct {
+// 	const domainName = properties.meta ?? properties.domain;
+
+// 	if ( ! domainName ) {
+// 		throw new Error( 'Titan mail requires a domain' );
+// 	}
+
+// 	return {
+// 		...domainItem( productSlug, domainName, properties.source ),
+// 		quantity: properties.quantity,
+// 		extra: properties.extra,
+// 	};
+// }
+
+// /**
+//  * Creates a new shopping cart item for Titan Mail Yearly.
+//  */
+// export function titanMailYearly( properties: TitanProductProps ): MinimalRequestCartProduct {
+// 	return titanMailProduct( properties, TITAN_MAIL_YEARLY_SLUG );
+// }
+
+// /**
+//  * Creates a new shopping cart item for Titan Mail Monthly.
+//  */
+// export function titanMailMonthly( properties: TitanProductProps ): MinimalRequestCartProduct {
+// 	return titanMailProduct( properties, TITAN_MAIL_MONTHLY_SLUG );
+// }
+
+const getTitanCartItems = () => {
+	// const { emailProduct, newQuantity, quantity } = mailProperties;
+	// const email_users = mailboxes.map( ( mailbox ) => mailbox.getAsCartItem() );
+	// const cartItemFunction = isTitanMonthlyProduct( emailProduct )
+	// 	? titanMailMonthly
+	// 	: titanMailYearly;
+	// return cartItemFunction( {
+	// 	domain: mailboxes[ 0 ].formFields.domain.value,
+	// 	quantity,
+	// 	extra: {
+	// 		email_users,
+	// 		new_quantity: newQuantity,
+	// 	},
+	// } );
+};
+
+const getGSuiteCartItems = () => {};
+
+export const getCartItems = ( provider: EmailProvider ) => {
+	return provider === 'titan' ? getTitanCartItems() : getGSuiteCartItems();
+};

--- a/client/dashboard/emails/utils/get-email-product-properties.ts
+++ b/client/dashboard/emails/utils/get-email-product-properties.ts
@@ -1,0 +1,125 @@
+import { Domain, EmailProvider } from '@automattic/api-core';
+import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
+
+export type IntroductoryOfferTimeUnit = 'day' | 'week' | 'month' | 'year';
+
+export interface ProductIntroductoryOffer {
+	cost_per_interval: number;
+	interval_count: number;
+	interval_unit: IntroductoryOfferTimeUnit;
+	should_prorate_when_offer_ends: boolean;
+	transition_after_renewal_count: number;
+	usage_limit: number | null;
+}
+
+export interface PriceTierEntry {
+	minimum_units: number;
+	maximum_units?: undefined | null | number;
+	minimum_price: number;
+	minimum_price_display: string;
+	minimum_price_monthly_display?: string | null | undefined;
+	maximum_price: number;
+	maximum_price_display?: string | null | undefined;
+	maximum_price_monthly_display?: string | null | undefined;
+	/**
+	 * If set, is used to transform the usage/quantity of units used to derive the number of units
+	 * we want to bill the customer for, before multiplying by the per_unit_fee.
+	 *
+	 * To put simply, the purpose of this attribute is to bill the customer at a different granularity compared to their usage.
+	 */
+	transform_quantity_divide_by?: number | null | undefined;
+	/**
+	 * Used for rounding the number of units we want to bill the customer for (which is derived after dividing the
+	 * usage/quantity of units by the `transform_quantity_divide_by` number).
+	 *
+	 * Used only when `transform_quantity_divide_by` is set. Possible values are: `up`, `down`
+	 */
+	transform_quantity_round?: string | null | undefined;
+	/**
+	 * The amount in the currency's smallest unit that this tier costs per unit.
+	 */
+	per_unit_fee?: number | null | undefined;
+	/**
+	 * The amount in the currency's smallest unit that this tier costs as a flat fee (for the entire tier).
+	 */
+	flat_fee?: number | null | undefined;
+}
+
+export interface ProductListItem {
+	product_id: number;
+	product_name: string;
+	product_slug: string;
+	description: string;
+	product_type: string;
+	available: boolean;
+	is_domain_registration: boolean;
+	cost_display: string;
+	cost: number;
+	cost_smallest_unit: number;
+	currency_code: string;
+	introductory_offer?: ProductIntroductoryOffer;
+	price_tier_list: PriceTierEntry[];
+	price_tier_usage_quantity: null | number;
+	price_tier_slug: string;
+	sale_coupon?: {
+		discount?: number;
+		allowed_for_domain_transfers?: boolean;
+		start_date?: string;
+		expires?: string;
+	};
+	sale_cost?: number;
+	is_privacy_protection_product_purchase_allowed?: boolean;
+	product_term?: string;
+	billing_product_slug: string;
+}
+
+type EmailProperties = {
+	existingItemsCount: number;
+	isAdditionalMailboxesPurchase: boolean;
+	emailProduct: ProductListItem;
+	newQuantity: number | undefined;
+	quantity: number;
+};
+
+/**
+ * Returns the maximum number of mailboxes that can be provisioned for a domain. Because a Titan
+ * subscription must have at least one mailbox, `1` is the default return value even for domains
+ * without an active Titan subscription.
+ */
+export function getMaxTitanMailboxCount( domain: Domain ): number {
+	// @ts-ignore - TODO: check the difference between Domain and ResponseDomain
+	return domain.titan_mail_subscription?.maximum_mailbox_count ?? 1;
+}
+
+export function getGSuiteMailboxCount( domain: Domain ): number {
+	// @ts-ignore - TODO: check the difference between Domain and ResponseDomain
+	return domain?.google_apps_subscription?.total_user_count ?? 0;
+}
+
+export const getEmailProductProperties = (
+	provider: EmailProvider,
+	domain: Domain,
+	emailProduct: ProductListItem,
+	newMailboxesCount = 1
+): EmailProperties => {
+	const isTitanProvider = provider === 'titan';
+	const isAdditionalMailboxesPurchase = isTitanProvider
+		? hasTitanMailWithUs( domain )
+		: hasGSuiteWithUs( domain );
+
+	const existingItemsCount = isTitanProvider
+		? getMaxTitanMailboxCount( domain )
+		: getGSuiteMailboxCount( domain );
+
+	const quantity = isAdditionalMailboxesPurchase
+		? existingItemsCount + newMailboxesCount
+		: newMailboxesCount;
+
+	return {
+		existingItemsCount,
+		isAdditionalMailboxesPurchase,
+		emailProduct,
+		newQuantity: newMailboxesCount,
+		quantity,
+	};
+};

--- a/client/dashboard/emails/utils/get-product-slug-for-provider-and-interval.ts
+++ b/client/dashboard/emails/utils/get-product-slug-for-provider-and-interval.ts
@@ -1,0 +1,20 @@
+import { EmailProvider } from '@automattic/api-core';
+import { IntervalLength } from '../types';
+
+/**
+ * Returns the correct product slug for the specified provider and interval using a map.
+ */
+export const getProductSlugForProviderAndInterval = (
+	provider: EmailProvider,
+	intervalLength: IntervalLength
+) => {
+	switch ( provider ) {
+		case 'titan':
+			return intervalLength === 'monthly' ? 'wp_titan_mail_monthly' : 'wp_titan_mail_yearly';
+
+		case 'google_workspace':
+			return intervalLength === 'monthly'
+				? 'wp_google_workspace_business_starter_monthly'
+				: 'wp_google_workspace_business_starter_yearly';
+	}
+};

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -52,6 +52,7 @@ export * from './notification-devices';
 export * from './odie';
 export * from './p2';
 export * from './plugins';
+export * from './products';
 export * from './purchase';
 export * from './read-teams';
 export * from './site';

--- a/packages/api-core/src/products/fetchers.ts
+++ b/packages/api-core/src/products/fetchers.ts
@@ -1,0 +1,8 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export function fetchProducts() {
+	return wpcom.req.get( {
+		path: '/products',
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-core/src/products/index.ts
+++ b/packages/api-core/src/products/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchers';

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -43,8 +43,8 @@ export * from './meta-sms-country-codes';
 export * from './notification-devices';
 export * from './odie';
 export * from './p2';
-
 export * from './plugin';
+export * from './products';
 export * from './purchase';
 export * from './site-activity-log';
 export * from './site-activity-log-backup';

--- a/packages/api-queries/src/products.ts
+++ b/packages/api-queries/src/products.ts
@@ -1,0 +1,8 @@
+import { fetchProducts } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const productsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'products' ],
+		queryFn: () => fetchProducts(),
+	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
