### PR TITLE
Calypso Domains: Restore E2E test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -11,14 +11,24 @@ import { reloadAndRetry, waitForElementEnabled } from '../../element-helper';
  */
 export class DomainSearchComponent {
 	private page: Page;
-
+	private container?: Locator;
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
 	 */
-	constructor( page: Page ) {
+	constructor( page: Page, container?: Locator ) {
 		this.page = page;
+		this.container = container;
+	}
+
+	/**
+	 * Gets the container locator.
+	 *
+	 * @returns {Locator} The container locator.
+	 */
+	private getContainer(): Page | Locator {
+		return this.container ?? this.page;
 	}
 
 	/**
@@ -80,7 +90,7 @@ export class DomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectDomain( keyword: string ): Promise< string > {
-		const targetRow = this.page.getByTitle( keyword );
+		const targetRow = this.getContainer().getByTitle( keyword );
 		const suggestion = await this.selectSuggestion( targetRow );
 
 		if ( ! suggestion ) {
@@ -96,7 +106,7 @@ export class DomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectFirstSuggestion(): Promise< string > {
-		const targetRow = this.page.getByRole( 'listitem' ).first();
+		const targetRow = this.getContainer().getByRole( 'listitem' ).first();
 		const suggestion = await this.selectSuggestion( targetRow );
 
 		if ( ! suggestion ) {

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -134,9 +134,11 @@ export class CartCheckoutPage {
 	 *
 	 * @param {string} cartItemName Name of the item to remove from the cart.
 	 */
-	async removeCartItem( cartItemName: string ): Promise< void > {
+	async removeCartItem( cartItemName: string, closeCheckout: boolean = true ): Promise< void > {
 		await this.page.click( selectors.removeCartItemButton( cartItemName ) );
-		await this.page.click( selectors.modalContinueButton );
+		if ( closeCheckout ) {
+			await this.page.click( selectors.modalContinueButton );
+		}
 	}
 
 	/**

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -1,5 +1,5 @@
 /**
- * @group quarantined
+ * @group calypso-release
  */
 
 import {

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -9,8 +9,6 @@ import {
 	SidebarComponent,
 	DomainSearchComponent,
 	CartCheckoutPage,
-	IndividualPurchasePage,
-	NavbarComponent,
 	NavbarCartComponent,
 	TestAccount,
 } from '@automattic/calypso-e2e';
@@ -18,7 +16,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
+describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
 	let page: Page;
 	let sidebarComponent: SidebarComponent;
 	let domainSearchComponent: DomainSearchComponent;
@@ -26,8 +24,6 @@ describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), fu
 	let navbarCartComponent: NavbarCartComponent;
 	let selectedDomain: string;
 	let domainsPage: DomainsPage;
-
-	const blogName = DataHelper.getBlogName();
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -39,76 +35,45 @@ describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), fu
 		await BrowserManager.setStoreCookie( page );
 	} );
 
-	describe( 'Purchase domain', function () {
-		it( 'Navigate to Upgrades > Domains', async function () {
-			sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
-		} );
-
-		it( 'If required, clear the cart', async function () {
-			domainsPage = new DomainsPage( page );
-			navbarCartComponent = new NavbarCartComponent( page );
-
-			// Only attempt to clear the cart if the cart has items
-			if ( await navbarCartComponent.isCartButtonVisible() ) {
-				await navbarCartComponent.openCart();
-				await navbarCartComponent.emptyCart();
-			}
-		} );
-
-		it( 'Add domain to site', async function () {
-			await domainsPage.addDomain();
-		} );
-
-		it( 'Search for a domain name', async function () {
-			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.live' );
-		} );
-
-		it( 'Choose the .live TLD', async function () {
-			selectedDomain = await domainSearchComponent.selectDomain( '.live' );
-		} );
-
-		it( 'Decline Titan Email upsell', async function () {
-			await page.getByRole( 'button', { name: 'Skip' } ).click();
-		} );
-
-		it( 'See secure payment', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( selectedDomain );
-		} );
-
-		it( 'Make purchase', async function () {
-			await Promise.all( [
-				page.waitForNavigation( {
-					url: '**/checkout/thank-you/**',
-					// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
-					timeout: 90 * 1000,
-				} ),
-				cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
-			] );
-		} );
+	it( 'Navigate to Upgrades > Domains', async function () {
+		sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Upgrades', 'Domains' );
 	} );
 
-	describe( 'Cancel domain', function () {
-		it( 'Return to Home dashboard', async function () {
-			const navbarComponent = new NavbarComponent( page );
-			await navbarComponent.clickMySites();
-		} );
+	it( 'If required, clear the cart', async function () {
+		domainsPage = new DomainsPage( page );
+		navbarCartComponent = new NavbarCartComponent( page );
 
-		it( 'Navigate to Upgrades > Domains', async function () {
-			sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
-		} );
+		// Only attempt to clear the cart if the cart has items
+		if ( await navbarCartComponent.isCartButtonVisible() ) {
+			await navbarCartComponent.openCart();
+			await navbarCartComponent.emptyCart();
+		}
+	} );
 
-		it( 'Click on purchased domain', async function () {
-			const domainsPage = new DomainsPage( page );
-			await domainsPage.click( selectedDomain );
-		} );
+	it( 'Add domain to site', async function () {
+		await domainsPage.addDomain();
+	} );
 
-		it( 'Cancel domain', async function () {
-			const individualPurchasePage = new IndividualPurchasePage( page );
-			await individualPurchasePage.deleteDomain();
-		} );
+	it( 'Choose the first suggestion', async function () {
+		domainSearchComponent = new DomainSearchComponent( page, page.getByRole( 'main' ) );
+		selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+	} );
+
+	it( 'Continue to next step', async function () {
+		await domainSearchComponent.continue();
+	} );
+
+	it( 'Decline Titan Email upsell', async function () {
+		await page.getByRole( 'main' ).getByRole( 'button', { name: 'Skip' } ).click();
+	} );
+
+	it( 'See domain at checkout', async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+
+	it( 'Remove domain from cart', async function () {
+		await cartCheckoutPage.removeCartItem( selectedDomain, false );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

The `domains__add` E2E test, which tested the `/domains/add/%s` Calypso page, were disabled for a couple of reasons:
- https://github.com/Automattic/wp-calypso/pull/58130
- https://github.com/Automattic/wp-calypso/pull/103010

Mainly, it was not possible to cancel it through the E2E test because the purchase page never loads. From the second bullet point PR:
>Currently, we are blocked to Cancel previously purchased domains because the [purchase](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx#L28) object is an empty one and the [domain object missing some data](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx#L29). It's probably something related to the testing environment.

But I don't think that's a reason to keep the test disabled. Instead of going through the whole flow, let's verify that at least the domain shows up at checkout, which is good enough for now.

This test has been disabled for four years and could have been used to prevent regressions this whole time, and will definitely be useful moving forward.

## Testing Instructions

Check that the Pre-release E2E tests are still passing.