### PR TITLE
Checkout: allow renewing product with incorrect domain

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -384,25 +384,6 @@ function useAddRenewalItems( {
 		const productSlugs = productAlias?.split( ',' ) ?? [];
 		const purchaseIds = originalPurchaseId ? String( originalPurchaseId ).split( ',' ) : [];
 
-		// Renewals cannot be purchased without a site.
-		const isThereASite = cartKey && typeof cartKey === 'number';
-		if ( ! isThereASite && ! isGiftPurchase && ! sitelessCheckoutType ) {
-			debug(
-				'creating renewal products failed because there is no site. products:',
-				productAlias,
-				'cartKey:',
-				cartKey
-			);
-			dispatch( {
-				type: 'RENEWALS_ADD_ERROR',
-				message: translate(
-					'This renewal is invalid. Please verify that you are logged into the correct account for the product you want to renew.',
-					{ textOnly: true }
-				),
-			} );
-			return;
-		}
-
 		const productsForCart = purchaseIds
 			.map( ( subscriptionId, currentIndex ) => {
 				const productSlug = productSlugs[ currentIndex ];
@@ -426,7 +407,7 @@ function useAddRenewalItems( {
 					translate(
 						"I tried and failed to create products matching the identifier '%(productAlias)s'",
 						{
-							args: { productAlias: productAlias ?? '' },
+							args: { productAlias: `${ productAlias ?? '' } (${ originalPurchaseId })` },
 						}
 					)
 				),

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -20,7 +20,6 @@ import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
 	domainProduct,
 	planWithoutDomain,
-	planWithoutDomainMonthly,
 	mockSetCartEndpointWith,
 	getActivePersonalPlanDataForType,
 	countryList,
@@ -731,47 +730,6 @@ describe( 'CheckoutMain', () => {
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
 			expect( screen.getAllByText( 'bar.com' ) ).toHaveLength( 4 );
 		} );
-	} );
-
-	it( 'displays an error and empties the cart when the url has a renewal but no site', async () => {
-		const cartChanges = { products: [ planWithoutDomainMonthly ] };
-		const additionalProps = {
-			productAliasFromUrl: 'personal-bundle',
-			purchaseId: '12345',
-			siteId: 0,
-		};
-
-		( useCartKey as jest.Mock ).mockImplementation( () => 'no-site' );
-		render(
-			<MockCheckout
-				cartChanges={ cartChanges }
-				additionalProps={ additionalProps }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
-		await waitFor( async () => {
-			expect( navigate ).not.toHaveBeenCalled();
-		} );
-		await waitFor( async () => {
-			expect( await screen.findByText( /You have no items in your cart/ ) ).toBeInTheDocument();
-		} );
-
-		// Noticing the error message is a little difficult because we are not
-		// mounting the error display components. Instead, we spy on the
-		// `errorNotice` action creator. However, `CheckoutMain` does not pass the
-		// raw error message string to the action creator; it passes an array of
-		// React components, one of which contains the string. The following code
-		// lets us verify that.
-		expect( errorNotice ).toHaveBeenCalledWith(
-			expect.arrayContaining( [
-				expect.objectContaining( {
-					props: expect.objectContaining( {
-						children: expect.stringMatching( /This renewal is invalid/ ),
-					} ),
-				} ),
-			] )
-		);
 	} );
 
 	it( 'adds the product to the cart for a gift renewal', async () => {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -35,6 +35,11 @@ export function getProductSlugFromContext( context: Context ): string | undefine
 	const selectedSite = getSelectedSite( state );
 	const isGiftPurchase = pathname.includes( '/gift/' );
 
+	// Note that you can also end up with a renewal automatically if you try to
+	// purchase a product you already own, so this flag only identifies an
+	// intentional renewal request.
+	const isRenewalRequest = pathname.includes( '/renew/' );
+
 	// Jetpack siteless checkout routes always use `:productSlug` in the path.
 	if ( isContextJetpackSitelessCheckout( context ) ) {
 		return productSlug;
@@ -58,9 +63,13 @@ export function getProductSlugFromContext( context: Context ): string | undefine
 		return domainOrProduct || '';
 	}
 
-	// If there is no selected site, there will never be a `product`, and the
-	// `domainOrProduct` must be a product slug because a domain would have
-	// selected a site.
+	// If there is no selected site, there will probably never be a `product`,
+	// and the `domainOrProduct` must be a product slug because a domain would
+	// have selected a site. The only exception is if the domain in the URL is
+	// invalid for a renewal URL and we instead need to ignore it.
+	if ( ! selectedSite?.slug && isRenewalRequest && ! domainOrProduct && product ) {
+		return product;
+	}
 	if ( ! selectedSite?.slug ) {
 		return domainOrProduct || '';
 	}


### PR DESCRIPTION
Fixes [SHILL-1213](https://linear.app/a8c/issue/SHILL-1213)

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1187

## Proposed Changes

In this PR we modify checkout in two ways:

- We change the code that finds the product slug from a checkout URL to accept the renewal slug even if the site context is not set.
- We allow adding a renewal product to the shopping cart even if we don't know the current site and we don't recognize the siteless flow.

This should allow users to renew a product using wpcom siteless checkout even if the domain name at the end of their URL is not valid.

(The user still has to own the subscription. If they try to renew a subscription they do not own they will get the error `Sorry, you cannot renew this subscription that you do not own` or `Sorry, this user account does not own the product you are trying to renew`, depending on if the site exists).

Before             |  After
:-------------------------:|:-------------------------:
<img width="1057" height="399" alt="Screenshot 2025-10-16 at 2 34 00 PM" src="https://github.com/user-attachments/assets/ee497f75-e404-4a89-9264-0248ab8eaf57" /> | <img width="1504" height="490" alt="Screenshot 2025-10-16 at 5 23 26 PM" src="https://github.com/user-attachments/assets/5b6b9f50-96fb-4827-8d24-a41183106cbc" />

> [!NOTE]
> Siteless checkout is temporary; you cannot reload the checkout page or its contents will disappear. You'll have to visit the URL again to get its contents back.

> [!NOTE]
> This removes the error message that was added in https://github.com/Automattic/wp-calypso/pull/75309 as a way to solve an existing bug: https://github.com/Automattic/wp-calypso/issues/75240. We should make sure that bug is still fixed. I believe it's ok because we no longer redirect you away from checkout if there's an error.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When you go to renew a subscription, the renewal URL typically looks something like this: `http://wordpress.com/checkout/dotorg_domain:example.com/renew/9999999/example.com`. The pattern is: `/checkout` followed by the store product slug (followed by any metadata required like the domain name in this case), followed by `/renew`, followed by the purchase (store subscription) ID, followed by the domain name of the site on which the subscription is owned.

Subscriptions are already explicitly tied to a site, so there are only two reasons why we need the site at the end of the renewal URL:

1. To set the site context of calypso, which has a per-site interface.
2. To determine the shopping cart key to use to save the shopping cart for future reference.

However, both of these are optional, because we support siteless checkout in many cases.

If for some reason the domain name at the end of the URL is incorrect, either because there was a typo or because the domain being renewed has expired or been changed, the renewal will not correctly be added to the shopping cart. There are two reasons for this:

A. The code that finds the product slug from the URL fails if the site context of calypso has not been set (see point 1 above).
B. When preparing to add the product to the cart, we disallow adding a renewal without a site when we don't recognize the siteless checkout flow.

Point A is effectively just a bug and can be easily fixed. Point B is a little more difficult to fix because in the situation described, we are in an unique siteless checkout flow.o

As a result, the user gets the cryptic error message: "This renewal is invalid. Please verify that you are logged into the correct account for the product you want to renew."

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First apply 194221-ghe-Automattic/wpcom to your sandbox and point public-api.wordpress.com to your sandbox.

- Find or construct a valid subscription renewal URL (see the format described above).
- Modify the domain name at the end of the URL to be something fake, or something owned by another user, or something on a site other than the subscription being renewed.
- Visit the modified renewal URL.
- Verify that you see checkout load with the subscription you intended.
- Complete checkout.
- Verify that the product was renewed successfully.
- Verify that everything about the subscription and ownership worked correctly during the purchase process since there was no site selected at the time (there's a lot of code in the shopping cart that assumes we know what the current site is set to).