### PR TITLE
Domain Search Rewrite: Always show an available FQDN search at the top of the domain suggestions list

### DIFF
--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -137,7 +137,7 @@ export interface DomainAvailability {
 	vendor?: string;
 
 	/**
-	 * This is a domain suggestion property, but availability checks can return it when the domain is available for registration
+	 * This is a domain suggestion property, but availability checks return it when the domain is available for registration
 	 * @example [ "exact-match", "tld-exact" ]
 	 */
 	match_reasons?: string[];

--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -127,7 +127,7 @@ export interface DomainAvailability {
 	product_slug?: string;
 
 	/**
-	 * Raw price of the domain
+	 * Raw price of the domain, returned when the domain is available for registration
 	 */
 	raw_price?: number;
 

--- a/packages/api-core/src/domain-availability/types.ts
+++ b/packages/api-core/src/domain-availability/types.ts
@@ -115,6 +115,32 @@ export interface DomainAvailability {
 	 * Trademark claims notice info
 	 */
 	trademark_claims_notice_info?: TrademarkClaimsNoticeInfo;
+
+	/**
+	 * Domain product ID, returned when the domain is available for registration
+	 */
+	product_id?: number;
+
+	/**
+	 * Product slug, returned when the domain is available for registration
+	 */
+	product_slug?: string;
+
+	/**
+	 * Raw price of the domain
+	 */
+	raw_price?: number;
+
+	/**
+	 * Search provider vendor, it's value is `availability` when the domain is available for registration
+	 */
+	vendor?: string;
+
+	/**
+	 * This is a domain suggestion property, but availability checks can return it when the domain is available for registration
+	 * @example [ "exact-match", "tld-exact" ]
+	 */
+	match_reasons?: string[];
 }
 
 export enum DomainAvailabilityStatus {

--- a/packages/domain-search/src/components/suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/test/index.tsx
@@ -2,13 +2,11 @@ import { DomainAvailabilityStatus } from '@automattic/api-core';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DomainSuggestionCTA } from '..';
+import { convertAvailabilityToSuggestion } from '../../../helpers/convert-availability-to-suggestion';
 import { DomainPriceRule } from '../../../hooks/use-suggestion';
 import { buildAvailability } from '../../../test-helpers/factories/availability';
 import { buildCartItem } from '../../../test-helpers/factories/cart';
-import {
-	buildSuggestionFromAvailability,
-	buildSuggestion,
-} from '../../../test-helpers/factories/suggestions';
+import { buildSuggestion } from '../../../test-helpers/factories/suggestions';
 import { mockGetAvailabilityQuery } from '../../../test-helpers/queries/availability';
 import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
 import { TestDomainSearchWithSuggestions } from '../../../test-helpers/renderer';
@@ -84,14 +82,16 @@ describe( 'DomainSuggestionCTA', () => {
 			} );
 		} );
 
-		it( 'allows adding a domain to the cart if the user searched for a FQDN', async () => {
+		/**
+		 * The scenario in this test case can happen when the user searches for a FQDN with a
+		 * TLD that's not present in the TLDs filter
+		 */
+		it( 'allows adding a domain to the cart if the user searched for a FQDN that is not in the suggestion list', async () => {
 			const user = userEvent.setup();
 
-			// test-add-to-cart.com is not in the suggestions list possibly due to TLD filtering
 			const suggestion = buildSuggestion( {
 				domain_name: 'test-add-to-cart.blog',
 				vendor: 'donuts',
-				is_premium: true,
 			} );
 
 			mockGetSuggestionsQuery( {
@@ -133,7 +133,7 @@ describe( 'DomainSuggestionCTA', () => {
 
 			await user.click( addToCartCta );
 
-			const availabilitySuggestion = buildSuggestionFromAvailability( availability );
+			const availabilitySuggestion = convertAvailabilityToSuggestion( availability );
 
 			await waitFor( () => {
 				expect( onSuggestionInteract ).toHaveBeenCalledWith( {

--- a/packages/domain-search/src/components/suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/test/index.tsx
@@ -5,7 +5,10 @@ import { DomainSuggestionCTA } from '..';
 import { DomainPriceRule } from '../../../hooks/use-suggestion';
 import { buildAvailability } from '../../../test-helpers/factories/availability';
 import { buildCartItem } from '../../../test-helpers/factories/cart';
-import { buildSuggestion } from '../../../test-helpers/factories/suggestions';
+import {
+	buildSuggestionFromAvailability,
+	buildSuggestion,
+} from '../../../test-helpers/factories/suggestions';
 import { mockGetAvailabilityQuery } from '../../../test-helpers/queries/availability';
 import { mockGetSuggestionsQuery } from '../../../test-helpers/queries/suggestions';
 import { TestDomainSearchWithSuggestions } from '../../../test-helpers/renderer';
@@ -77,6 +80,79 @@ describe( 'DomainSuggestionCTA', () => {
 					availability,
 					'test-add-to-cart.com',
 					'donuts'
+				);
+			} );
+		} );
+
+		it( 'allows adding a domain to the cart if the user searched for a FQDN', async () => {
+			const user = userEvent.setup();
+
+			// test-add-to-cart.com is not in the suggestions list possibly due to TLD filtering
+			const suggestion = buildSuggestion( {
+				domain_name: 'test-add-to-cart.blog',
+				vendor: 'donuts',
+				is_premium: true,
+			} );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-add-to-cart.com' },
+				suggestions: [ suggestion ],
+			} );
+
+			const availability = buildAvailability( {
+				domain_name: 'test-add-to-cart.com',
+				status: DomainAvailabilityStatus.AVAILABLE,
+				product_id: 123,
+				product_slug: 'dotcom_domain',
+				raw_price: 40,
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-add-to-cart.com' },
+				availability,
+			} );
+
+			const onAddDomainToCart = jest.fn();
+			const onDomainAddAvailabilityPreCheck = jest.fn();
+			const onSuggestionInteract = jest.fn();
+
+			render(
+				<TestDomainSearchWithSuggestions
+					query="test-add-to-cart.com"
+					events={ { onAddDomainToCart, onDomainAddAvailabilityPreCheck, onSuggestionInteract } }
+				>
+					<DomainSuggestionsList>
+						<DomainSuggestionCTA domainName="test-add-to-cart.com" />
+					</DomainSuggestionsList>
+				</TestDomainSearchWithSuggestions>
+			);
+
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+
+			expect( addToCartCta ).toBeInTheDocument();
+
+			await user.click( addToCartCta );
+
+			const availabilitySuggestion = buildSuggestionFromAvailability( availability );
+
+			await waitFor( () => {
+				expect( onSuggestionInteract ).toHaveBeenCalledWith( {
+					...availabilitySuggestion,
+					position: 0,
+					price_rule: DomainPriceRule.PRICE,
+				} );
+
+				expect( onAddDomainToCart ).toHaveBeenCalledWith(
+					'test-add-to-cart.com',
+					0, // position
+					false, // is_premium
+					'availability' // vendor
+				);
+
+				expect( onDomainAddAvailabilityPreCheck ).toHaveBeenCalledWith(
+					availability,
+					'test-add-to-cart.com',
+					'availability' // root_vendor
 				);
 			} );
 		} );

--- a/packages/domain-search/src/helpers/add-availability-as-suggestion.ts
+++ b/packages/domain-search/src/helpers/add-availability-as-suggestion.ts
@@ -1,0 +1,17 @@
+import { type DomainAvailability, type DomainSuggestion } from '@automattic/api-core';
+import { convertAvailabilityToSuggestion } from './convert-availability-to-suggestion';
+
+export const addAvailabilityAsSuggestion = (
+	suggestions: DomainSuggestion[],
+	fqdnAvailability: DomainAvailability
+): DomainSuggestion[] => {
+	const isFQDNAlreadyInSuggestions = suggestions.some(
+		( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
+	);
+	if ( ! isFQDNAlreadyInSuggestions ) {
+		// An FQDN search should always be the first suggestion, so we add it to the
+		// beginning of the suggestions list
+		suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
+	}
+	return suggestions;
+};

--- a/packages/domain-search/src/helpers/convert-availability-to-suggestion.ts
+++ b/packages/domain-search/src/helpers/convert-availability-to-suggestion.ts
@@ -8,23 +8,15 @@ export const convertAvailabilityToSuggestion = (
 	availability: DomainAvailability
 ): DomainSuggestion => {
 	return {
-		domain_name: availability.domain_name,
-		cost: availability.cost,
-		currency_code: availability.currency_code,
 		product_id: availability.product_id ?? 0,
 		product_slug: availability.product_slug ?? 'domain_registration',
 		raw_price: availability.raw_price ?? 0,
 		relevance: 1, // It's an exact match
 		max_reg_years: 10,
 		multi_year_reg_allowed: true,
-		supports_privacy: availability.supports_privacy,
 		vendor: availability.vendor ?? 'availability',
 		is_premium:
 			availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM ? true : undefined,
-		renew_cost: availability.renew_cost,
-		sale_cost: availability.sale_cost,
-		hsts_required: availability.hsts_required,
-		dot_gay_notice_required: availability.dot_gay_notice_required,
-		match_reasons: availability.match_reasons,
+		...availability,
 	};
 };

--- a/packages/domain-search/src/helpers/convert-availability-to-suggestion.ts
+++ b/packages/domain-search/src/helpers/convert-availability-to-suggestion.ts
@@ -1,0 +1,30 @@
+import {
+	type DomainAvailability,
+	type DomainSuggestion,
+	DomainAvailabilityStatus,
+} from '@automattic/api-core';
+
+export const convertAvailabilityToSuggestion = (
+	availability: DomainAvailability
+): DomainSuggestion => {
+	return {
+		domain_name: availability.domain_name,
+		cost: availability.cost,
+		currency_code: availability.currency_code,
+		product_id: availability.product_id ?? 0,
+		product_slug: availability.product_slug ?? 'domain_registration',
+		raw_price: availability.raw_price ?? 0,
+		relevance: 1, // It's an exact match
+		max_reg_years: 10,
+		multi_year_reg_allowed: true,
+		supports_privacy: availability.supports_privacy,
+		vendor: availability.vendor ?? 'availability',
+		is_premium:
+			availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM ? true : undefined,
+		renew_cost: availability.renew_cost,
+		sale_cost: availability.sale_cost,
+		hsts_required: availability.hsts_required,
+		dot_gay_notice_required: availability.dot_gay_notice_required,
+		match_reasons: availability.match_reasons,
+	};
+};

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -1,4 +1,3 @@
-import { DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { getTld } from './get-tld';
 
 export type FeaturedSuggestionReason = 'exact-match' | 'recommended' | 'best-alternative';
@@ -17,32 +16,17 @@ interface PartitionSuggestionsParams {
 	suggestions: string[];
 	query: string;
 	deemphasizedTlds: string[];
-	fqdnAvailability: DomainAvailability | undefined;
 }
 
 export const partitionSuggestions = ( {
 	suggestions,
 	query,
 	deemphasizedTlds,
-	fqdnAvailability,
 }: PartitionSuggestionsParams ): PartitionedSuggestions => {
 	const exactMatch = suggestions.find( ( suggestion ) => suggestion === query );
 
-	// If a user searches for a FQDN and it's available, even if it's not in the suggestions list,
-	// we should always show it first
-	if ( fqdnAvailability && fqdnAvailability.status === DomainAvailabilityStatus.AVAILABLE ) {
-		return {
-			featuredSuggestions: [
-				{
-					suggestion: fqdnAvailability.domain_name,
-					reason: 'exact-match',
-				},
-			],
-			regularSuggestions: suggestions.filter( ( suggestion ) => suggestion !== query ),
-		};
-	}
-
-	if ( exactMatch && ! deemphasizedTlds.some( ( tld ) => getTld( exactMatch ) === tld ) ) {
+	// If we have an exact match, we always want to show it at the top, even if the TLD is deemphasized
+	if ( exactMatch ) {
 		return {
 			featuredSuggestions: [
 				{

--- a/packages/domain-search/src/helpers/partition-suggestions.ts
+++ b/packages/domain-search/src/helpers/partition-suggestions.ts
@@ -1,3 +1,4 @@
+import { DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { getTld } from './get-tld';
 
 export type FeaturedSuggestionReason = 'exact-match' | 'recommended' | 'best-alternative';
@@ -16,14 +17,30 @@ interface PartitionSuggestionsParams {
 	suggestions: string[];
 	query: string;
 	deemphasizedTlds: string[];
+	fqdnAvailability: DomainAvailability | undefined;
 }
 
 export const partitionSuggestions = ( {
 	suggestions,
 	query,
 	deemphasizedTlds,
+	fqdnAvailability,
 }: PartitionSuggestionsParams ): PartitionedSuggestions => {
 	const exactMatch = suggestions.find( ( suggestion ) => suggestion === query );
+
+	// If a user searches for a FQDN and it's available, even if it's not in the suggestions list,
+	// we should always show it first
+	if ( fqdnAvailability && fqdnAvailability.status === DomainAvailabilityStatus.AVAILABLE ) {
+		return {
+			featuredSuggestions: [
+				{
+					suggestion: fqdnAvailability.domain_name,
+					reason: 'exact-match',
+				},
+			],
+			regularSuggestions: suggestions.filter( ( suggestion ) => suggestion !== query ),
+		};
+	}
 
 	if ( exactMatch && ! deemphasizedTlds.some( ( tld ) => getTld( exactMatch ) === tld ) ) {
 		return {

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -55,45 +55,33 @@ export const useSuggestion = ( domainName: string ) => {
 		...queries.domainAvailability( domainName ),
 	} );
 
-	const { data: suggestion } = useQuery( {
+	const { data: suggestions } = useQuery( {
 		...queries.domainSuggestions( query ),
-		select: ( data ) => {
-			const suggestionPosition = data.findIndex(
-				( suggestion ) => suggestion.domain_name === domainName
-			);
-
-			if ( suggestionPosition === -1 ) {
-				// If there's no suggestion matching the domain name, the user might have
-				// provided a FQDN and the filters do not match the FQDN's TLD
-				if ( fqdnAvailability && query === fqdnAvailability.domain_name ) {
-					const suggestionObject = convertAvailabilityToSuggestion( fqdnAvailability );
-					return {
-						...suggestionObject,
-						position: 0,
-						price_rule: getPriceRuleForSuggestion( {
-							suggestion: suggestionObject,
-							priceRules: config.priceRules,
-						} ),
-					};
-				}
-
-				events.onSuggestionNotFound( domainName );
-				throw new Error( `Suggestion not found for domain: ${ domainName }` );
-			}
-
-			const suggestion = data[ suggestionPosition ];
-
-			return {
-				...suggestion,
-				position: suggestionPosition,
-				price_rule: getPriceRuleForSuggestion( { suggestion, priceRules: config.priceRules } ),
-			};
-		},
 	} );
 
-	if ( ! suggestion ) {
-		throw new Error( `Suggestion not found for domain: ${ domainName }` );
+	// Add FQDN availability to the suggestions list if it's an exact match
+	if ( suggestions && fqdnAvailability && query === fqdnAvailability.domain_name ) {
+		suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
 	}
 
-	return suggestion;
+	if ( suggestions ) {
+		const suggestionPosition = suggestions.findIndex(
+			( suggestion ) => suggestion.domain_name === domainName
+		);
+
+		if ( suggestionPosition === -1 ) {
+			events.onSuggestionNotFound( domainName );
+			throw new Error( `Suggestion not found for domain: ${ domainName }` );
+		}
+
+		const suggestion = suggestions[ suggestionPosition ];
+
+		return {
+			...suggestion,
+			position: suggestionPosition,
+			price_rule: getPriceRuleForSuggestion( { suggestion, priceRules: config.priceRules } ),
+		};
+	}
+
+	throw new Error( `Suggestion not found for domain: ${ domainName }` );
 };

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -61,7 +61,12 @@ export const useSuggestion = ( domainName: string ) => {
 
 	// Add FQDN availability to the suggestions list
 	if ( suggestions && fqdnAvailability ) {
-		suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
+		const isFQDNAlreadyInSuggestions = suggestions.some(
+			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
+		);
+		if ( ! isFQDNAlreadyInSuggestions ) {
+			suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
+		}
 	}
 
 	if ( suggestions ) {

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -1,7 +1,7 @@
-import { type DomainSuggestion, DomainAvailabilityStatus } from '@automattic/api-core';
 import { isDomainMoveInternal } from '@automattic/calypso-products';
 import { useQuery } from '@tanstack/react-query';
 import { useDomainSearch } from '../page/context';
+import type { DomainSuggestion } from '@automattic/api-core';
 
 export enum DomainPriceRule {
 	ONE_TIME_PRICE = 'ONE_TIME_PRICE',
@@ -64,7 +64,7 @@ export const useSuggestion = ( domainName: string ) => {
 			if ( suggestionPosition === -1 ) {
 				// If there's no suggestion matching the domain name, the user might have
 				// provided a FQDN and the filters do not match the FQDN's TLD
-				if ( fqdnAvailability && fqdnAvailability.status === DomainAvailabilityStatus.AVAILABLE ) {
+				if ( fqdnAvailability && query === fqdnAvailability.domain_name ) {
 					return fqdnAvailability;
 				}
 

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -1,6 +1,6 @@
 import { isDomainMoveInternal } from '@automattic/calypso-products';
 import { useQuery } from '@tanstack/react-query';
-import { convertAvailabilityToSuggestion } from '../helpers/convert-availability-to-suggestion';
+import { addAvailabilityAsSuggestion } from '../helpers/add-availability-as-suggestion';
 import { useDomainSearch } from '../page/context';
 import type { DomainSuggestion } from '@automattic/api-core';
 
@@ -59,14 +59,8 @@ export const useSuggestion = ( domainName: string ) => {
 		...queries.domainSuggestions( query ),
 	} );
 
-	// Add FQDN availability to the suggestions list
 	if ( suggestions && fqdnAvailability ) {
-		const isFQDNAlreadyInSuggestions = suggestions.some(
-			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
-		);
-		if ( ! isFQDNAlreadyInSuggestions ) {
-			suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
-		}
+		addAvailabilityAsSuggestion( suggestions, fqdnAvailability );
 	}
 
 	if ( suggestions ) {

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -59,8 +59,8 @@ export const useSuggestion = ( domainName: string ) => {
 		...queries.domainSuggestions( query ),
 	} );
 
-	// Add FQDN availability to the suggestions list if it's an exact match
-	if ( suggestions && fqdnAvailability && query === fqdnAvailability.domain_name ) {
+	// Add FQDN availability to the suggestions list
+	if ( suggestions && fqdnAvailability ) {
 		suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
 	}
 

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -1,7 +1,7 @@
+import { type DomainSuggestion, DomainAvailabilityStatus } from '@automattic/api-core';
 import { isDomainMoveInternal } from '@automattic/calypso-products';
 import { useQuery } from '@tanstack/react-query';
 import { useDomainSearch } from '../page/context';
-import type { DomainSuggestion } from '@automattic/api-core';
 
 export enum DomainPriceRule {
 	ONE_TIME_PRICE = 'ONE_TIME_PRICE',
@@ -50,6 +50,10 @@ const getPriceRuleForSuggestion = ( {
 export const useSuggestion = ( domainName: string ) => {
 	const { query, queries, config, events } = useDomainSearch();
 
+	const { data: fqdnAvailability } = useQuery( {
+		...queries.domainAvailability( domainName ),
+	} );
+
 	const { data: suggestion } = useQuery( {
 		...queries.domainSuggestions( query ),
 		select: ( data ) => {
@@ -58,6 +62,12 @@ export const useSuggestion = ( domainName: string ) => {
 			);
 
 			if ( suggestionPosition === -1 ) {
+				// If there's no suggestion matching the domain name, the user might have
+				// provided a FQDN and the filters do not match the FQDN's TLD
+				if ( fqdnAvailability && fqdnAvailability.status === DomainAvailabilityStatus.AVAILABLE ) {
+					return fqdnAvailability;
+				}
+
 				events.onSuggestionNotFound( domainName );
 				throw new Error( `Suggestion not found for domain: ${ domainName }` );
 			}

--- a/packages/domain-search/src/hooks/use-suggestion.ts
+++ b/packages/domain-search/src/hooks/use-suggestion.ts
@@ -1,5 +1,6 @@
 import { isDomainMoveInternal } from '@automattic/calypso-products';
 import { useQuery } from '@tanstack/react-query';
+import { convertAvailabilityToSuggestion } from '../helpers/convert-availability-to-suggestion';
 import { useDomainSearch } from '../page/context';
 import type { DomainSuggestion } from '@automattic/api-core';
 
@@ -65,7 +66,15 @@ export const useSuggestion = ( domainName: string ) => {
 				// If there's no suggestion matching the domain name, the user might have
 				// provided a FQDN and the filters do not match the FQDN's TLD
 				if ( fqdnAvailability && query === fqdnAvailability.domain_name ) {
-					return fqdnAvailability;
+					const suggestionObject = convertAvailabilityToSuggestion( fqdnAvailability );
+					return {
+						...suggestionObject,
+						position: 0,
+						price_rule: getPriceRuleForSuggestion( {
+							suggestion: suggestionObject,
+							priceRules: config.priceRules,
+						} ),
+					};
 				}
 
 				events.onSuggestionNotFound( domainName );

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -68,6 +68,7 @@ export const useSuggestionsList = () => {
 		isLoadingQueryAvailability ||
 		isLoadingAvailablePremiumDomains;
 
+	// Add FQDN availability to the suggestions list if it isn't already there
 	if ( fqdnAvailability ) {
 		const isFQDNAlreadyInSuggestions = suggestions.some(
 			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -1,11 +1,8 @@
-import {
-	type DomainAvailability,
-	DomainAvailabilityStatus,
-	DomainSuggestion,
-} from '@automattic/api-core';
+import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
 import { DefinedUseQueryResult, useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getTld } from '../helpers';
+import { convertAvailabilityToSuggestion } from '../helpers/convert-availability-to-suggestion';
 import { isSupportedPremiumDomain } from '../helpers/is-supported-premium-domain';
 import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from '../page/context';
@@ -24,29 +21,6 @@ const availablePremiumDomainsCombinator = (
 		availablePremiumDomains: results
 			.filter( hasDataAndIsSupportedPremiumDomain )
 			.map( ( { data: availabilityQuery } ) => availabilityQuery.domain_name ),
-	};
-};
-
-const convertAvailabilityToSuggestion = ( availability: DomainAvailability ): DomainSuggestion => {
-	return {
-		domain_name: availability.domain_name,
-		cost: availability.cost,
-		currency_code: availability.currency_code,
-		product_id: availability.product_id ?? 0,
-		product_slug: availability.product_slug ?? 'domain_registration',
-		raw_price: availability.raw_price ?? 0,
-		relevance: 1, // It's an exact match
-		max_reg_years: 10,
-		multi_year_reg_allowed: true,
-		supports_privacy: availability.supports_privacy,
-		vendor: availability.vendor ?? 'availability',
-		is_premium:
-			availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM ? true : undefined,
-		renew_cost: availability.renew_cost,
-		sale_cost: availability.sale_cost,
-		hsts_required: availability.hsts_required,
-		dot_gay_notice_required: availability.dot_gay_notice_required,
-		match_reasons: availability.match_reasons,
 	};
 };
 
@@ -95,10 +69,10 @@ export const useSuggestionsList = () => {
 		isLoadingAvailablePremiumDomains;
 
 	if ( fqdnAvailability ) {
-		const isAvailabilityAlreadyInSuggestions = suggestions.some(
+		const isFQDNAlreadyInSuggestions = suggestions.some(
 			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
 		);
-		if ( ! isAvailabilityAlreadyInSuggestions ) {
+		if ( ! isFQDNAlreadyInSuggestions ) {
 			suggestions.push( convertAvailabilityToSuggestion( fqdnAvailability ) );
 		}
 	}

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -68,17 +68,17 @@ export const useSuggestionsList = () => {
 		isLoadingQueryAvailability ||
 		isLoadingAvailablePremiumDomains;
 
-	// Add FQDN availability to the suggestions list if it isn't already there
-	if ( fqdnAvailability ) {
-		const isFQDNAlreadyInSuggestions = suggestions.some(
-			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
-		);
-		if ( ! isFQDNAlreadyInSuggestions ) {
-			suggestions.push( convertAvailabilityToSuggestion( fqdnAvailability ) );
-		}
-	}
-
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
+		// Add FQDN availability to the suggestions list if it isn't already there
+		if ( fqdnAvailability ) {
+			const isFQDNAlreadyInSuggestions = suggestions.some(
+				( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
+			);
+			if ( ! isFQDNAlreadyInSuggestions ) {
+				suggestions.push( convertAvailabilityToSuggestion( fqdnAvailability ) );
+			}
+		}
+
 		return partitionSuggestions( {
 			suggestions: suggestions
 				.filter( ( { domain_name: suggestion, is_premium } ) => {

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -92,6 +92,7 @@ export const useSuggestionsList = () => {
 				.map( ( suggestion ) => suggestion.domain_name ),
 			query,
 			deemphasizedTlds: config.deemphasizedTlds,
+			fqdnAvailability,
 		} );
 	}, [
 		suggestions,

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -2,7 +2,7 @@ import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/a
 import { DefinedUseQueryResult, useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getTld } from '../helpers';
-import { convertAvailabilityToSuggestion } from '../helpers/convert-availability-to-suggestion';
+import { addAvailabilityAsSuggestion } from '../helpers/add-availability-as-suggestion';
 import { isSupportedPremiumDomain } from '../helpers/is-supported-premium-domain';
 import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from '../page/context';
@@ -69,14 +69,8 @@ export const useSuggestionsList = () => {
 		isLoadingAvailablePremiumDomains;
 
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
-		// Add FQDN availability to the suggestions list if it isn't already there
 		if ( suggestions && fqdnAvailability && query === fqdnAvailability.domain_name ) {
-			const isFQDNAlreadyInSuggestions = suggestions.some(
-				( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
-			);
-			if ( ! isFQDNAlreadyInSuggestions ) {
-				suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
-			}
+			addAvailabilityAsSuggestion( suggestions, fqdnAvailability );
 		}
 
 		return partitionSuggestions( {

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -1,4 +1,8 @@
-import { type DomainAvailability, DomainAvailabilityStatus } from '@automattic/api-core';
+import {
+	type DomainAvailability,
+	DomainAvailabilityStatus,
+	DomainSuggestion,
+} from '@automattic/api-core';
 import { DefinedUseQueryResult, useQueries, useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { getTld } from '../helpers';
@@ -20,6 +24,29 @@ const availablePremiumDomainsCombinator = (
 		availablePremiumDomains: results
 			.filter( hasDataAndIsSupportedPremiumDomain )
 			.map( ( { data: availabilityQuery } ) => availabilityQuery.domain_name ),
+	};
+};
+
+const convertAvailabilityToSuggestion = ( availability: DomainAvailability ): DomainSuggestion => {
+	return {
+		domain_name: availability.domain_name,
+		cost: availability.cost,
+		currency_code: availability.currency_code,
+		product_id: availability.product_id ?? 0,
+		product_slug: availability.product_slug ?? 'domain_registration',
+		raw_price: availability.raw_price ?? 0,
+		relevance: 1, // It's an exact match
+		max_reg_years: 10,
+		multi_year_reg_allowed: true,
+		supports_privacy: availability.supports_privacy,
+		vendor: availability.vendor ?? 'availability',
+		is_premium:
+			availability.status === DomainAvailabilityStatus.AVAILABLE_PREMIUM ? true : undefined,
+		renew_cost: availability.renew_cost,
+		sale_cost: availability.sale_cost,
+		hsts_required: availability.hsts_required,
+		dot_gay_notice_required: availability.dot_gay_notice_required,
+		match_reasons: availability.match_reasons,
 	};
 };
 
@@ -67,6 +94,15 @@ export const useSuggestionsList = () => {
 		isLoadingQueryAvailability ||
 		isLoadingAvailablePremiumDomains;
 
+	if ( fqdnAvailability ) {
+		const isAvailabilityAlreadyInSuggestions = suggestions.some(
+			( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
+		);
+		if ( ! isAvailabilityAlreadyInSuggestions ) {
+			suggestions.push( convertAvailabilityToSuggestion( fqdnAvailability ) );
+		}
+	}
+
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
 		return partitionSuggestions( {
 			suggestions: suggestions
@@ -92,7 +128,6 @@ export const useSuggestionsList = () => {
 				.map( ( suggestion ) => suggestion.domain_name ),
 			query,
 			deemphasizedTlds: config.deemphasizedTlds,
-			fqdnAvailability,
 		} );
 	}, [
 		suggestions,

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -70,12 +70,12 @@ export const useSuggestionsList = () => {
 
 	const { featuredSuggestions, regularSuggestions } = useMemo( () => {
 		// Add FQDN availability to the suggestions list if it isn't already there
-		if ( fqdnAvailability ) {
+		if ( suggestions && fqdnAvailability && query === fqdnAvailability.domain_name ) {
 			const isFQDNAlreadyInSuggestions = suggestions.some(
 				( suggestion ) => suggestion.domain_name === fqdnAvailability.domain_name
 			);
 			if ( ! isFQDNAlreadyInSuggestions ) {
-				suggestions.push( convertAvailabilityToSuggestion( fqdnAvailability ) );
+				suggestions.unshift( convertAvailabilityToSuggestion( fqdnAvailability ) );
 			}
 		}
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -176,7 +176,7 @@ describe( 'ResultsPage', () => {
 	} );
 
 	describe( 'FQDN suggestion', () => {
-		it( 'shows FQDN suggestion if it is available, even if it is not in the suggestions list', async () => {
+		it( 'adds FQDN suggestion to the suggestions list if the availability query is successful and it is available, even if it is not in the suggestions list', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-available.com' },
 				suggestions: [
@@ -202,6 +202,59 @@ describe( 'ResultsPage', () => {
 			expect( await screen.findByTitle( 'test-available.com' ) ).toBeInTheDocument();
 			expect( screen.queryByTitle( 'test-available.blog' ) ).toBeInTheDocument();
 			expect( screen.queryByTitle( 'test-available.org' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not add FQDN suggestion to the suggestions list if the availability query is successful but it is not available', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-unavailable.com' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test-available.blog' } ),
+					buildSuggestion( { domain_name: 'test-available.org' } ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-unavailable.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-unavailable.com',
+					status: DomainAvailabilityStatus.NOT_AVAILABLE,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearch query="test-unavailable.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'test-available.blog' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-available.org' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-unavailable.com' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not add FQDN suggestion to the suggestions list if the availability query fails', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-unavailable.com' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test-available.blog' } ),
+					buildSuggestion( { domain_name: 'test-available.org' } ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-unavailable.com' },
+				availability: new Error( 'Test error' ),
+			} );
+
+			render(
+				<TestDomainSearch query="test-unavailable.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'test-available.blog' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-available.org' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-unavailable.com' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'removes FQDN suggestion from the list if availability query is not successful', async () => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -176,7 +176,7 @@ describe( 'ResultsPage', () => {
 	} );
 
 	describe( 'FQDN suggestion', () => {
-		it( 'adds FQDN suggestion to the suggestions list if the availability query is successful and it is available, even if it is not in the suggestions list', async () => {
+		it( 'adds FQDN suggestion to the suggestions list if the availability query is successful and it is available', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-available.com' },
 				suggestions: [

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -104,7 +104,7 @@ describe( 'ResultsPage', () => {
 	} );
 
 	describe( 'TLD deemphasis', () => {
-		it( 'removes deemphasized TLDs from featured suggestions if searching for a FQDN', async () => {
+		it( 'does not remove deemphasized TLDs from featured suggestions if searching for a FQDN', async () => {
 			mockGetAvailabilityQuery( {
 				params: { domainName: 'test.com' },
 				availability: buildAvailability( {
@@ -127,7 +127,7 @@ describe( 'ResultsPage', () => {
 			const testCom = await screen.findByTitle( 'test.com' );
 
 			expect( testCom ).toBeInTheDocument();
-			expect( testCom ).not.toHaveTextContent( "It's available!" );
+			expect( testCom ).toHaveTextContent( "It's available!" );
 			expect( testCom ).not.toHaveTextContent( 'Recommended' );
 			expect( testCom ).not.toHaveTextContent( 'Best alternative' );
 		} );
@@ -176,6 +176,34 @@ describe( 'ResultsPage', () => {
 	} );
 
 	describe( 'FQDN suggestion', () => {
+		it( 'shows FQDN suggestion if it is available, even if it is not in the suggestions list', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-available.com' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test-available.blog' } ),
+					buildSuggestion( { domain_name: 'test-available.org' } ),
+				],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-available.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-available.com',
+					status: DomainAvailabilityStatus.AVAILABLE,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearch query="test-available.com" config={ { deemphasizedTlds: [ 'com' ] } }>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'test-available.com' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-available.blog' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'test-available.org' ) ).toBeInTheDocument();
+		} );
+
 		it( 'removes FQDN suggestion from the list if availability query is not successful', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-unavailable.com' },

--- a/packages/domain-search/src/test-helpers/factories/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/factories/suggestions.ts
@@ -1,4 +1,8 @@
-import type { DomainSuggestion, FreeDomainSuggestion } from '@automattic/api-core';
+import type {
+	DomainSuggestion,
+	FreeDomainSuggestion,
+	DomainAvailability,
+} from '@automattic/api-core';
 
 export const buildFreeSuggestion = (
 	suggestion: Partial< FreeDomainSuggestion > = {}
@@ -26,5 +30,24 @@ export const buildSuggestion = (
 		vendor: 'donuts',
 		cost: suggestion.cost ?? '$5',
 		...suggestion,
+	};
+};
+
+export const buildSuggestionFromAvailability = (
+	availability: Partial< DomainAvailability > = {}
+): DomainSuggestion => {
+	return {
+		domain_name: availability.domain_name ?? 'example.com',
+		currency_code: 'USD',
+		max_reg_years: 10,
+		multi_year_reg_allowed: true,
+		product_id: 123,
+		product_slug: 'dotcom_domain',
+		raw_price: 40,
+		relevance: 1,
+		supports_privacy: true,
+		vendor: 'availability',
+		cost: availability.cost ?? '$5',
+		...availability,
 	};
 };

--- a/packages/domain-search/src/test-helpers/factories/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/factories/suggestions.ts
@@ -1,8 +1,4 @@
-import type {
-	DomainSuggestion,
-	FreeDomainSuggestion,
-	DomainAvailability,
-} from '@automattic/api-core';
+import type { DomainSuggestion, FreeDomainSuggestion } from '@automattic/api-core';
 
 export const buildFreeSuggestion = (
 	suggestion: Partial< FreeDomainSuggestion > = {}
@@ -30,24 +26,5 @@ export const buildSuggestion = (
 		vendor: 'donuts',
 		cost: suggestion.cost ?? '$5',
 		...suggestion,
-	};
-};
-
-export const buildSuggestionFromAvailability = (
-	availability: Partial< DomainAvailability > = {}
-): DomainSuggestion => {
-	return {
-		domain_name: availability.domain_name ?? 'example.com',
-		currency_code: 'USD',
-		max_reg_years: 10,
-		multi_year_reg_allowed: true,
-		product_id: 123,
-		product_slug: 'dotcom_domain',
-		raw_price: 40,
-		relevance: 1,
-		supports_privacy: true,
-		vendor: 'availability',
-		cost: availability.cost ?? '$5',
-		...availability,
 	};
 };


### PR DESCRIPTION
Part of [DOMAINS-1713](https://linear.app/a8c/issue/DOMAINS-1713)

## Proposed Changes

This PR updates the domain search code to always show an available FQDN search at the top of the domain suggestions list.

### Screenshots

| Description | Before | After |
| --- | --- | --- |
| Search for an available FQDN with TLD selected in the filter | <img width="2302" height="2072" alt="Screenshot 2025-10-16 at 20 07 31" src="https://github.com/user-attachments/assets/81e5eaa8-818f-4cc4-a301-a14eef6a5981" /> | <img width="2300" height="2062" alt="Screenshot 2025-10-16 at 20 07 45" src="https://github.com/user-attachments/assets/465379cb-c770-4d3c-9b8c-8f9a710d8709" /> |
| Search for an available FQDN with TLD not selected in the filter | <img width="2286" height="2060" alt="Screenshot 2025-10-16 at 20 05 51" src="https://github.com/user-attachments/assets/b5b4e5b9-8ef5-4565-b8f1-dfda4f37faaa" /> | <img width="2298" height="2052" alt="Screenshot 2025-10-16 at 20 05 05" src="https://github.com/user-attachments/assets/ceba2317-ae25-44f0-b462-62074e1e57c4" /> |

Demo:

https://github.com/user-attachments/assets/fa9fb3ed-19d6-4122-9b8d-35f7c0a83809

## Why are these changes being made?

In the rewritten domain search (p7DVsv-o8Q-p2), when a user searches for an available FQDN, we want to always show it at the top of the results list, even if the selected filters do not contain the FQDN's TLD (see this comment pdtkmj-40Z-p2#comment-7790 in the CFT).

In that case, the suggestions list will not contain the searched FQDN, so we transform the result of the availability check into a suggestion and insert it at the beginning of the suggestions list.

## Testing Instructions

This depends on 194148-ghe-Automattic/wpcom

- Open the live Calypso link or build this branch locally
- Go to a domain search flow, e.g. `/setup/domain`
- Make a regular domain search and ensure it works correctly
- Make a FQDN domain search and ensure it works correctly, both for available and unavailable FQDNs
- Now open the search filter and limit the search to one TLD only, e.g. `.com`
- Make a FQDN domain search with a TLD that's not `.com`, e.g. `example-domain-search.blog`
  - If `example-domain-search.blog` is available, it should appear at the top of the suggestions list, even if `.blog` is not among the filtered TLDs
  - If `example-domain-search.blog` is not available, the usual `domain is already registered` notice should be shown, and the rest of the suggestions should adhere to the selected filter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?