### PR TITLE
A4A-Billing Dragon: Activate automatically the a4a-bd-checkout feature flag based on the agency billing system.

### DIFF
--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -56,6 +56,14 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 		if ( newAgency ) {
 			dispatch( setActiveAgency( newAgency ) );
 
+			// Enable the a4a-bd-checkout feature flag if the billing system is 'billingdragon'
+			if (
+				! config.isEnabled( 'a4a-bd-checkout' ) &&
+				newAgency.billing_system === 'billingdragon'
+			) {
+				config.enable( 'a4a-bd-checkout' );
+			}
+
 			// Enable the Partner Directory section
 			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory.allowed ) {
 				config.enable( 'a4a-partner-directory' );

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -113,6 +113,7 @@ export interface Agency {
 	};
 	approval_status: ApprovalStatus | '';
 	created_at: string;
+	billing_system?: 'billingdragon' | 'legacy';
 }
 
 export type UserBillingType = 'legacy' | 'billingdragon';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of Linear: A4A-1617

## Proposed Changes

This PR uses the new field `billing_system` field from the agency endpoint to determine if it has to activate the feature flag `a4a-bd-checkout`. This checks the `billing_system` value; if it is `billingdragon`, the feature flag will be activated.

This PR depends on 194125-ghe-Automattic/wpcom

**Billing Dragon Checkout page:**

<img width="1179" height="442" alt="image" src="https://github.com/user-attachments/assets/c1139860-ba6b-4d7a-9e5e-7c514ec5626f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Billing Dragon Phase 2 project
- Linear issue: A4A-1617

## Testing Instructions

- You will need this PR in your sandbox if it's not already merged: 194125-ghe-Automattic/wpcom
- Point WPCOM host to your sandbox IP.
- Launch an A4A live site with the link below.
- Go to the marketplace and add any product to the cart.
- Click on Checkout (you don't have to finish the checkout)
- You will see the normal checkout page (by default, all agencies use the current billing system).
- Now, you have to "trick" the `Agency_Resource` and set  `billing_system` = `billingdragon`.
- Refresh the page to get the new value from the `agency` endpoint.
- Go again to the marketplace, add any product to the cart, and click on Checkout.
- Now, it will load the Billing Dragon checkout page instead of the current checkout page. (you don't have to finish the checkout)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?