### PR TITLE
Hosting Dashboard: Performance Add bypass for loading url.

### DIFF
--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -3,6 +3,7 @@ import {
 	sitePerformancePagesQuery,
 	siteSettingsQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -67,6 +68,9 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		return pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
 
+	const performanceUrl =
+		config( 'env_id' ) === 'production' ? url ?? currentPage?.link : currentPage?.link;
+
 	const {
 		hasError,
 		createNewReport,
@@ -75,7 +79,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		getReport,
 		hasCompleted,
 	} = useSitePerformanceData(
-		url ?? currentPage?.link,
+		performanceUrl,
 		currentPage?.wpcom_performance_report_hash,
 		runNewReport
 	);

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -68,8 +68,9 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		return pagesData?.[ 0 ];
 	}, [ page_id, pagesData ] );
 
-	const performanceUrl =
-		config( 'env_id' ) === 'production' ? url ?? currentPage?.link : currentPage?.link;
+	const performanceUrl = [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) )
+		? url ?? currentPage?.link
+		: currentPage?.link;
 
 	const {
 		hasError,

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -54,7 +54,10 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 	const { data: pagesData, refetch: refetchPages } = useQuery( {
 		...sitePerformancePagesQuery( site.ID ),
 	} );
-	const { page_id } = useSearch( { from: sitePerformanceRoute.fullPath } ) as { page_id?: string };
+	const { page_id, url } = useSearch( { from: sitePerformanceRoute.fullPath } ) as {
+		page_id?: string;
+		url?: string;
+	};
 
 	const currentPage = useMemo( () => {
 		if ( page_id ) {
@@ -72,7 +75,7 @@ function SitePerformanceContent( { site }: { site: Site } ) {
 		getReport,
 		hasCompleted,
 	} = useSitePerformanceData(
-		currentPage?.link,
+		url ?? currentPage?.link,
 		currentPage?.wpcom_performance_report_hash,
 		runNewReport
 	);


### PR DESCRIPTION
## Proposed Changes

Allow setting `?url={site}` to the URL to temporarily allow users to test external sites. 

## Why are these changes being made?

We're going to open this up for testing but most users don't have enough data on their site to see charts. By adding this bypass, users can test sites that do have data.

## Considerations

When users first load the page with the URL, they'll get the "Error" banner. This is expected because the site doesn't match the test token. Clicking re-run test should fix that by queing a new job with the correct token.

![Screen Recording on 2025-10-17 at 11-07-52](https://github.com/user-attachments/assets/49fc9b5f-0be8-45e2-bd11-1dd3c797d809)


## Testing Instructions

1. Load `/v2/sites/{site}/performance?url=https://google.com`
2. Expect to see the error message
3. Click "re run test"
4. Expect the test to run and return results.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
