### PR TITLE
CIAB HD: Display only commerce-garden sites on /sites

### DIFF
--- a/client/dashboard/ciab-sites/index.tsx
+++ b/client/dashboard/ciab-sites/index.tsx
@@ -47,6 +47,7 @@ const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchS
 	}
 
 	return {
+		site_filters: [ 'commerce-garden' ],
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || isRestoringAccount ? 'all' : 'visible',

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -5,11 +5,13 @@ import type { Site } from '../site';
 export interface FetchSitesOptions {
 	include_a8c_owned: boolean;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
+	site_filters?: ( 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden' )[];
 }
 
 export async function fetchSites( {
 	include_a8c_owned,
 	site_visibility,
+	site_filters,
 }: FetchSitesOptions ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -23,6 +25,7 @@ export async function fetchSites( {
 			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
+			filters: site_filters ? site_filters.join( ',' ) : undefined,
 		}
 	);
 	return sites;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* We should display only commerce-garden sites on /sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /ciab
* Create a new one from "Build with AI" if needed
* Ensure you can see only commerce-garden sites in the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
