### PR TITLE
Streamlined pricing cleanup: Remove experiment code from the plans grid and main checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -29,11 +29,6 @@ import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import IntentToggle from 'calypso/my-sites/plans-features-main/components/intent-toggle';
-import { useFCCARestrictions } from 'calypso/my-sites/plans-features-main/hooks/use-fcca-restrictions';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPricePlansTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getStepUrl } from 'calypso/signup/utils';
 import { getDomainFromUrl } from 'calypso/site-profiler/utils/get-valid-url';
 import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
@@ -247,8 +242,6 @@ function UnifiedPlansStep( {
 	const initializedSitesBackUrl = useSelector( ( state ) =>
 		getCurrentUserSiteCount( state ) ? '/sites/' : null
 	);
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
 
 	useSiteGlobalStylesOnPersonal();
 
@@ -502,18 +495,7 @@ function UnifiedPlansStep( {
 		}
 	}
 
-	const { shouldRestrict3YearPlans } = useFCCARestrictions();
-	let defaultIntervalType = 'yearly';
-	const experimentValue = streamlinedPriceExperimentAssignment as string;
-	if (
-		! isStreamlinedPriceExperimentLoading &&
-		isStreamlinedPricePlansTreatment( experimentValue ) &&
-		experimentValue.startsWith( 'plans_3y' )
-	) {
-		defaultIntervalType = shouldRestrict3YearPlans() ? '2yearly' : '3yearly';
-	}
-
-	const intervalTypeValue = intervalType || getIntervalType( path, defaultIntervalType );
+	const intervalTypeValue = intervalType || getIntervalType( path );
 
 	let freeWPComSubdomain: string | undefined;
 	if ( typeof siteUrl === 'string' && siteUrl.includes( '.wordpress.com' ) ) {

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -17,7 +17,6 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import {
-	LineItemPrice,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 	doesIntroductoryOfferHavePriceIncrease,
 	filterCostOverridesForLineItem,
@@ -27,10 +26,6 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useEquivalentMonthlyTotals from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useSelector } from 'calypso/state';
 import {
 	getIsOnboardingAffiliateFlow,
@@ -249,7 +244,6 @@ function LineItemCostOverride( {
 	product: ResponseCartProduct;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( isPriceIncrease ) {
 		return (
 			<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -258,9 +252,7 @@ function LineItemCostOverride( {
 		);
 	}
 
-	const shouldShowDiscount =
-		! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ||
-		isWpComPlan( product.product_slug );
+	const shouldShowDiscount = isWpComPlan( product.product_slug );
 
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -392,12 +384,7 @@ const WPCheckoutCheckIcon = styled( CheckIcon )`
 
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-	const costOverridesList = filterCostOverridesForLineItem(
-		product,
-		translate,
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
-	);
+	const costOverridesList = filterCostOverridesForLineItem( product, translate );
 	const label = getLabel( product );
 	const actualAmountDisplay = formatCurrency(
 		product.item_original_subtotal_integer,
@@ -409,53 +396,42 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	);
 
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
-	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
-		let streamlinedActualAmountDisplay;
+	let streamlinedActualAmountDisplay;
 
-		const originalAmountInteger =
-			monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
-		const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
-		const itemSubtotalInteger =
-			product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
-		streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
-		const isDiscounted = Boolean(
-			itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
-		);
+	const originalAmountInteger =
+		monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
+	const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const itemSubtotalInteger =
+		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
+	streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const isDiscounted = Boolean(
+		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
+	);
 
-		// For WPCOM plans always show the renewal amount for legal reasons.
-		// Introductory offer discount would be shown in LineItemCostOverrides.
-		if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
-			streamlinedActualAmountDisplay = actualAmountDisplay;
-		}
-
-		return (
-			<StreamlinedSingleProductAndCostOverridesListWrapper>
-				<WPCheckoutCheckIcon />
-				<ProductTitleAreaForCostOverridesList>
-					<span className="cost-overrides-list-product__title">{ label }</span>
-					<StreamlinedLineItemPrice
-						actualAmount={ streamlinedActualAmountDisplay }
-						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
-					/>
-				</ProductTitleAreaForCostOverridesList>
-				<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
-			</StreamlinedSingleProductAndCostOverridesListWrapper>
-		);
+	// For WPCOM plans always show the renewal amount for legal reasons.
+	// Introductory offer discount would be shown in LineItemCostOverrides.
+	if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
+		streamlinedActualAmountDisplay = actualAmountDisplay;
 	}
+
 	return (
-		<SingleProductAndCostOverridesListWrapper>
+		<StreamlinedSingleProductAndCostOverridesListWrapper>
+			<WPCheckoutCheckIcon />
 			<ProductTitleAreaForCostOverridesList>
 				<span className="cost-overrides-list-product__title">{ label }</span>
-				<LineItemPrice actualAmount={ actualAmountDisplay } />
+				<StreamlinedLineItemPrice
+					actualAmount={ streamlinedActualAmountDisplay }
+					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
+				/>
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
-		</SingleProductAndCostOverridesListWrapper>
+		</StreamlinedSingleProductAndCostOverridesListWrapper>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -386,17 +386,8 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
 	const label = getLabel( product );
-	const actualAmountDisplay = formatCurrency(
-		product.item_original_subtotal_integer,
-		product.currency,
-		{
-			isSmallestUnit: true,
-			stripZeros: true,
-		}
-	);
 
 	const monthlyPrices = useEquivalentMonthlyTotals( [ product ] );
-	let streamlinedActualAmountDisplay;
 
 	const originalAmountInteger =
 		monthlyPrices[ product.product_slug as PlanSlug ] || product.item_original_subtotal_integer;
@@ -406,18 +397,27 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	} );
 	const itemSubtotalInteger =
 		product.item_subtotal_integer + ( product.coupon_savings_integer ?? 0 );
-	streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
-		isSmallestUnit: true,
-		stripZeros: true,
-	} );
 	const isDiscounted = Boolean(
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
 
 	// For WPCOM plans always show the renewal amount for legal reasons.
 	// Introductory offer discount would be shown in LineItemCostOverrides.
+	let actualAmountDisplay;
 	if ( ! isDiscounted || isWpComPlan( product.product_slug ) ) {
-		streamlinedActualAmountDisplay = actualAmountDisplay;
+		actualAmountDisplay = formatCurrency(
+			product.item_original_subtotal_integer,
+			product.currency,
+			{
+				isSmallestUnit: true,
+				stripZeros: true,
+			}
+		);
+	} else {
+		actualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 	}
 
 	return (
@@ -426,7 +426,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			<ProductTitleAreaForCostOverridesList>
 				<span className="cost-overrides-list-product__title">{ label }</span>
 				<StreamlinedLineItemPrice
-					actualAmount={ streamlinedActualAmountDisplay }
+					actualAmount={ actualAmountDisplay }
 					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 				/>
 			</ProductTitleAreaForCostOverridesList>

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -1,24 +1,8 @@
-import { formatCurrency } from '@automattic/number-formatters';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import {
-	getTotalLineItemFromCart,
-	getTaxBreakdownLineItemsFromCart,
-	getCreditsLineItemFromCart,
-	NonProductLineItem,
-	LineItemType,
-	getSubtotalWithoutDiscounts,
-	getTotalDiscountsWithoutCredits,
-	isBillingInfoEmpty,
-} from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import CheckoutTerms from '../components/checkout-terms';
-import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
 	& > * {
@@ -63,17 +47,6 @@ const CheckoutTermsWrapper = styled.div`
 	}
 `;
 
-const NonTotalPrices = styled.div`
-	font-size: 12px;
-	border-top: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
-	border-bottom: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
-	padding: 16px 0;
-`;
-const TotalPrice = styled.div`
-	font-size: 14px;
-	padding: 16px 0 6px;
-`;
-
 const TaxNotCalculatedLineItemWrapper = styled.div`
 	font-size: 14px;
 	text-wrap: pretty;
@@ -96,62 +69,10 @@ export function TaxNotCalculatedLineItem() {
 export default function BeforeSubmitCheckoutHeader() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
-	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
-	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
-	const translate = useTranslate();
-
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
-
-	const totalAdjustments = getTotalDiscountsWithoutCredits( responseCart );
-	const adjustmentLineItem: LineItemType = {
-		id: 'total-adjustments',
-		type: 'subtotal',
-		label: totalAdjustments < 0 ? translate( 'Discounts' ) : translate( 'Additional charges' ),
-		formattedAmount: formatCurrency( totalAdjustments, responseCart.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} ),
-	};
-
-	const subtotalBeforeAdjustments = getSubtotalWithoutDiscounts( responseCart );
-	const subTotalLineItemWithoutCoupon: LineItemType = {
-		id: 'subtotal-without-coupon',
-		type: 'subtotal',
-		label:
-			totalAdjustments < 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
-		formattedAmount: formatCurrency( subtotalBeforeAdjustments, responseCart.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} ),
-	};
 
 	return (
-		<>
-			<CheckoutTermsWrapper>
-				<CheckoutTerms cart={ responseCart } />
-			</CheckoutTermsWrapper>
-			{ ! isStreamlinedPriceExperimentLoading &&
-				! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
-					<WPOrderReviewSection>
-						<NonTotalPrices>
-							<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-							{ totalAdjustments !== 0 && (
-								<NonProductLineItem subtotal lineItem={ adjustmentLineItem } />
-							) }
-							{ taxLineItems.map( ( taxLineItem ) => (
-								<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
-							) ) }
-							{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-								<NonProductLineItem subtotal lineItem={ creditsLineItem } />
-							) }
-						</NonTotalPrices>
-						<TotalPrice>
-							<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
-						</TotalPrice>
-						{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
-					</WPOrderReviewSection>
-				) }
-		</>
+		<CheckoutTermsWrapper>
+			<CheckoutTerms cart={ responseCart } />
+		</CheckoutTermsWrapper>
 	);
 }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -340,8 +340,7 @@ export function doesIntroductoryOfferHavePriceIncrease( product: ResponseCartPro
 
 export function filterCostOverridesForLineItem(
 	product: ResponseCartProduct,
-	translate: ReturnType< typeof useTranslate >,
-	shouldShowComparison?: boolean
+	translate: ReturnType< typeof useTranslate >
 ): LineItemCostOverrideForDisplay[] {
 	const costOverrides = product?.cost_overrides ?? [];
 
@@ -352,13 +351,7 @@ export function filterCostOverridesForLineItem(
 			.filter( ( costOverride ) => costOverride.override_code !== 'coupon-discount' )
 			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
 			.map( ( costOverride ) =>
-				makeIntroductoryOfferCostOverrideUnique(
-					costOverride,
-					product,
-					translate,
-					true,
-					shouldShowComparison
-				)
+				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, true, true )
 			)
 			.map( ( costOverride ) => {
 				// Introductory offers which are renewals may have a prorated


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1029](https://linear.app/a8c/issue/M4R73CH-1029/cleanup-experiment-code)

## Proposed Changes

* removes the experiment code for plans interval on the plans step
* removes the experiment code from the cost overrides of the side checkout summary
* removes the bottom checkout cost summary 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* removing experiment code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using EUR and IDR (intro offer) go through the `/setup/onboarding` flow
* Select a domain to purchase
* Ensure the are no visible style differences on the plans step and checkout compared to staging

| Before | After |
|--------|--------|
| <img width="1500" height="2575" alt="screencapture-wordpress-checkout-claudiuthefilip-ioehb-wordpress-com-2025-10-17-09_15_15" src="https://github.com/user-attachments/assets/f926a3bf-ee3c-4f0a-81e5-6b95a3c01990" /> | <img width="1500" height="2575" alt="screencapture-calypso-localhost-3000-checkout-claudiuthefilip-ebhnt-wordpress-com-2025-10-17-09_13_37" src="https://github.com/user-attachments/assets/3c18a400-f772-4522-9357-8db73c1cdd78" />| 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
