### PR TITLE
Dashboard: consolidate upsell Tracks events pt 2: refine props

### DIFF
--- a/client/dashboard/components/upsell-cta-button/index.tsx
+++ b/client/dashboard/components/upsell-cta-button/index.tsx
@@ -8,19 +8,17 @@ import './style.scss';
 
 type UpsellCTAButtonProps = ComponentProps< typeof Button > & {
 	upsellId: string;
-	upsellType: string;
 	upsellFeatureId?: string;
 	onClick?: ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => void;
 };
 
 export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
-	const { upsellId, upsellType, upsellFeatureId, onClick, ...buttonProps } = props;
+	const { upsellId, upsellFeatureId, onClick, ...buttonProps } = props;
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleClick = ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => {
 		recordTracksEvent( 'calypso_dashboard_upsell_click', {
 			upsell_id: upsellId,
-			upsell_type: upsellType,
 			upsell_feature_id: upsellFeatureId,
 		} );
 		onClick?.( event );
@@ -32,7 +30,6 @@ export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
 				eventName="calypso_dashboard_upsell_impression"
 				properties={ {
 					upsell_id: upsellId,
-					upsell_type: upsellType,
 					upsell_feature_id: upsellFeatureId,
 				} }
 			/>

--- a/client/dashboard/components/upsell-cta-button/index.tsx
+++ b/client/dashboard/components/upsell-cta-button/index.tsx
@@ -7,8 +7,18 @@ import type { ComponentProps } from 'react';
 import './style.scss';
 
 type UpsellCTAButtonProps = ComponentProps< typeof Button > & {
+	/**
+	 * A unique ID for the upsell. Should also indicate the location where the upsell is being shown.
+	 * Example: `site-overview-claim-this-domain`
+	 */
 	upsellId: string;
+
+	/**
+	 * The feature that is being upsold. Multiple upsells which upsell the same feature should have the same `upsellFeatureId`.
+	 * Example: `domain`
+	 */
 	upsellFeatureId?: string;
+
 	onClick?: ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => void;
 };
 

--- a/client/dashboard/components/upsell-cta-button/index.tsx
+++ b/client/dashboard/components/upsell-cta-button/index.tsx
@@ -7,18 +7,21 @@ import type { ComponentProps } from 'react';
 import './style.scss';
 
 type UpsellCTAButtonProps = ComponentProps< typeof Button > & {
-	tracksId: string;
+	upsellId: string;
+	upsellType: string;
+	upsellFeatureId?: string;
 	onClick?: ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => void;
 };
 
 export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
-	const { tracksId, onClick, ...buttonProps } = props;
+	const { upsellId, upsellType, upsellFeatureId, onClick, ...buttonProps } = props;
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleClick = ( event: React.MouseEvent< HTMLButtonElement | HTMLAnchorElement > ) => {
 		recordTracksEvent( 'calypso_dashboard_upsell_click', {
-			feature: tracksId,
-			type: 'cta-button',
+			upsell_id: upsellId,
+			upsell_type: upsellType,
+			upsell_feature_id: upsellFeatureId,
 		} );
 		onClick?.( event );
 	};
@@ -27,13 +30,16 @@ export default function UpsellCTAButton( props: UpsellCTAButtonProps ) {
 		<>
 			<ComponentViewTracker
 				eventName="calypso_dashboard_upsell_impression"
-				properties={ { feature: tracksId, type: 'cta-button' } }
+				properties={ {
+					upsell_id: upsellId,
+					upsell_type: upsellType,
+					upsell_feature_id: upsellFeatureId,
+				} }
 			/>
 			<Button
 				className="dashboard-upsell-cta-button"
-				icon={ upsell }
 				onClick={ handleClick }
-				size="compact"
+				{ ...( buttonProps.variant !== 'link' && { icon: upsell, size: 'compact' } ) }
 				{ ...buttonProps }
 			/>
 		</>

--- a/client/dashboard/domains/name-servers/upsell-nudge.tsx
+++ b/client/dashboard/domains/name-servers/upsell-nudge.tsx
@@ -40,7 +40,7 @@ export default function UpsellNudge( { domainName, domainSiteSlug }: Props ) {
 				<UpsellCTAButton
 					text={ __( 'Upgrade plan' ) }
 					upsellId="domain-nameservers-primary-domain"
-					upsellType="plan-upgrade"
+					upsellFeatureId="domain"
 					variant="primary"
 					href={ `/checkout/${ domainSiteSlug }/business` }
 				/>

--- a/client/dashboard/domains/name-servers/upsell-nudge.tsx
+++ b/client/dashboard/domains/name-servers/upsell-nudge.tsx
@@ -39,7 +39,8 @@ export default function UpsellNudge( { domainName, domainSiteSlug }: Props ) {
 			actions={
 				<UpsellCTAButton
 					text={ __( 'Upgrade plan' ) }
-					tracksId="nameservers"
+					upsellId="domain-nameservers-primary-domain"
+					upsellType="plan-upgrade"
 					variant="primary"
 					href={ `/checkout/${ domainSiteSlug }/business` }
 				/>

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -253,8 +253,8 @@ function SiteBackups() {
 		<HostingFeatureGatedWithCallout
 			site={ site }
 			feature={ HostingFeatures.BACKUPS }
-			tracksFeatureId="backups"
 			overlay={ <PageLayout header={ <PageHeader title={ __( 'Backups' ) } /> } /> }
+			upsellId="site-backups"
 			upsellIcon={ backup }
 			upsellTitle={ __( 'Secure your content with Jetpack Backups' ) }
 			upsellImage={ illustrationUrl }

--- a/client/dashboard/sites/deployments/deployments-callout.tsx
+++ b/client/dashboard/sites/deployments/deployments-callout.tsx
@@ -7,8 +7,8 @@ import type { Site } from '@automattic/api-core';
 
 export function getDeploymentsCalloutProps() {
 	return {
-		tracksFeatureId: 'deployments',
 		feature: HostingFeatures.DEPLOYMENT,
+		upsellId: 'site-deployments',
 		upsellIcon: <GithubIcon aria-label={ __( 'GitHub logo' ) } />,
 		upsellTitle: __( 'Deploy from GitHub' ),
 		upsellImage: illustrationUrl,

--- a/client/dashboard/sites/hosting-feature-gate/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/index.tsx
@@ -6,7 +6,8 @@ import type { HostingFeatureSlug, Site } from '@automattic/api-core';
 export interface HostingFeatureGateProps {
 	site: Site;
 	feature: HostingFeatureSlug;
-	tracksFeatureId: string;
+	upsellId: string;
+	upsellFeatureId?: string;
 	children: ReactNode;
 	renderUpsellComponent: () => ReactNode;
 	renderActivationComponent: ( { onClick }: { onClick: () => void } ) => ReactNode;
@@ -15,7 +16,8 @@ export interface HostingFeatureGateProps {
 export default function HostingFeatureGate( {
 	site,
 	feature,
-	tracksFeatureId,
+	upsellId,
+	upsellFeatureId,
 	children,
 	renderUpsellComponent,
 	renderActivationComponent,
@@ -29,7 +31,7 @@ export default function HostingFeatureGate( {
 			<HostingFeatureActivation
 				site={ site }
 				feature={ feature }
-				tracksFeatureId={ tracksFeatureId }
+				tracksFeatureId={ upsellFeatureId ?? upsellId }
 				renderActivationComponent={ renderActivationComponent }
 			/>
 		);

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -26,7 +26,7 @@ export default function HostingFeatureGatedWithCallout( {
 	upsellDescription,
 	...props
 }: HostingFeatureGatedWithCalloutProps ) {
-	const { site, tracksFeatureId, feature } = props;
+	const { site, upsellId, upsellFeatureId, feature } = props;
 
 	return (
 		<HostingFeatureGate
@@ -35,7 +35,8 @@ export default function HostingFeatureGatedWithCallout( {
 				const callout = (
 					<UpsellCallout
 						site={ site }
-						tracksFeatureId={ tracksFeatureId }
+						upsellId={ upsellId }
+						upsellFeatureId={ upsellFeatureId }
 						upsellIcon={ upsellIcon }
 						upsellImage={ upsellImage }
 						upsellTitle={ upsellTitle }

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -11,6 +11,9 @@ import type { CalloutProps } from '../../components/callout/types';
 import type { HostingFeatureSlug, Site } from '@automattic/api-core';
 
 export interface UpsellCalloutProps {
+	site: Site;
+	upsellId: string;
+	upsellFeatureId?: string;
 	upsellIcon?: CalloutProps[ 'icon' ];
 	upsellImage?: CalloutProps[ 'image' ];
 	upsellTitle?: CalloutProps[ 'title' ];
@@ -21,17 +24,15 @@ export interface UpsellCalloutProps {
 
 export default function UpsellCallout( {
 	site,
-	tracksFeatureId,
+	upsellId,
+	upsellFeatureId,
 	upsellIcon,
 	upsellImage,
 	upsellTitle,
 	upsellTitleAs,
 	upsellDescription,
 	feature,
-}: {
-	site: Site;
-	tracksFeatureId: string;
-} & UpsellCalloutProps ) {
+}: UpsellCalloutProps ) {
 	const handleUpsellClick = () => {
 		const backUrl = window.location.href.replace( window.location.origin, '' );
 
@@ -82,9 +83,11 @@ export default function UpsellCallout( {
 			actions={
 				<UpsellCTAButton
 					text={ __( 'Upgrade plan' ) }
-					tracksId={ tracksFeatureId }
 					variant="primary"
 					onClick={ handleUpsellClick }
+					upsellId={ upsellId }
+					upsellType="plan-upgrade"
+					upsellFeatureId={ upsellFeatureId ?? upsellId }
 				/>
 			}
 		/>

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -86,7 +86,6 @@ export default function UpsellCallout( {
 					variant="primary"
 					onClick={ handleUpsellClick }
 					upsellId={ upsellId }
-					upsellType="plan-upgrade"
 					upsellFeatureId={ upsellFeatureId ?? upsellId }
 				/>
 			}

--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -20,7 +20,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 	upsellLink = '',
 	...props
 }: HostingFeatureGatedWithOverviewCardProps ) {
-	const { tracksFeatureId } = props;
+	const { upsellId, upsellFeatureId } = props;
 
 	const cardProps: Partial< OverviewCardProps > = {
 		heading: upsellHeading,
@@ -37,7 +37,9 @@ export default function HostingFeatureGatedWithOverviewCard( {
 				<OverviewCard
 					{ ...cardProps }
 					title={ __( 'Upgrade to unlock' ) }
-					tracksId={ tracksFeatureId }
+					tracksId={ upsellId }
+					upsellType="plan-upgrade"
+					upsellFeatureId={ upsellFeatureId ?? upsellId }
 				/>
 			) }
 			renderActivationComponent={ ( { onClick } ) => (

--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -38,7 +38,6 @@ export default function HostingFeatureGatedWithOverviewCard( {
 					{ ...cardProps }
 					title={ __( 'Upgrade to unlock' ) }
 					tracksId={ upsellId }
-					upsellType="plan-upgrade"
 					upsellFeatureId={ upsellFeatureId ?? upsellId }
 				/>
 			) }

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -8,8 +8,8 @@ import type { Site } from '@automattic/api-core';
 
 export function getActivityLogsCalloutProps() {
 	return {
-		tracksFeatureId: 'logs-activity',
 		feature: HostingFeatures.ACTIVITY_LOG,
+		upsellId: 'site-logs-activity',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Track every action with Jetpack Activity' ),
 		upsellImage: illustrationUrl,

--- a/client/dashboard/sites/logs/logs-callout.tsx
+++ b/client/dashboard/sites/logs/logs-callout.tsx
@@ -7,8 +7,8 @@ import type { Site } from '@automattic/api-core';
 
 export function getLogsCalloutProps() {
 	return {
-		tracksFeatureId: 'logs',
 		feature: HostingFeatures.LOGS,
+		upsellId: 'site-logs',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Access detailed logs' ),
 		upsellImage: illustrationUrl,

--- a/client/dashboard/sites/monitoring/monitoring-callout.tsx
+++ b/client/dashboard/sites/monitoring/monitoring-callout.tsx
@@ -7,8 +7,8 @@ import type { Site } from '@automattic/api-core';
 
 export function getMonitoringCalloutProps() {
 	return {
-		tracksFeatureId: 'monitoring',
 		feature: HostingFeatures.MONITOR,
+		upsellId: 'site-monitoring',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Monitor server stats' ),
 		upsellImage: illustrationUrl,

--- a/client/dashboard/sites/overview-agency-site-share-card/index.tsx
+++ b/client/dashboard/sites/overview-agency-site-share-card/index.tsx
@@ -16,7 +16,7 @@ export default function AgencySiteShareCard( { site }: { site: Site } ) {
 			description={ __( 'Collaborators with the link can view your site.' ) }
 			link={ `/sites/${ site.slug }/settings/site-visibility` }
 			title={ __( 'Share' ) }
-			tracksId="agency-site-share"
+			tracksId="site-overview-agency-site-share"
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -13,7 +13,7 @@ import type { Site, SiteActivityLog } from '@automattic/api-core';
 const CARD_PROPS = {
 	icon: backup,
 	title: __( 'Last backup' ),
-	tracksId: 'backup',
+	tracksId: 'site-overview-backups',
 };
 
 const SUCCESSFUL_BACKUP_ACTIVITIES = [
@@ -106,7 +106,8 @@ export default function BackupCard( { site }: { site: Site } ) {
 			site={ site }
 			feature={ HostingFeatures.BACKUPS }
 			featureIcon={ CARD_PROPS.icon }
-			tracksFeatureId={ CARD_PROPS.tracksId }
+			upsellId={ CARD_PROPS.tracksId }
+			upsellFeatureId="site-backups"
 			upsellHeading={ __( 'Back up your site' ) }
 			upsellDescription={ __( 'Get back online quickly with one-click restores.' ) }
 			upsellLink={ getBackupUrl( site ) }

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -48,7 +48,6 @@ export interface OverviewCardProps {
 
 	tracksId?: string;
 
-	upsellType?: string;
 	upsellFeatureId?: string;
 
 	bottom?: ReactNode;
@@ -67,7 +66,6 @@ export default function OverviewCard( {
 	link,
 	externalLink: externalLinkProp,
 	tracksId,
-	upsellType,
 	upsellFeatureId,
 	bottom,
 	onClick,
@@ -189,7 +187,6 @@ export default function OverviewCard( {
 			if ( intent === 'upsell' ) {
 				recordTracksEvent( 'calypso_dashboard_upsell_click', {
 					upsell_id: tracksId,
-					upsell_type: upsellType,
 					upsell_feature_id: upsellFeatureId,
 				} );
 			} else {
@@ -253,7 +250,6 @@ export default function OverviewCard( {
 							eventName="calypso_dashboard_upsell_impression"
 							properties={ {
 								upsell_id: tracksId,
-								upsell_type: upsellType,
 								upsell_feature_id: upsellFeatureId,
 							} }
 						/>

--- a/client/dashboard/sites/overview-card/index.tsx
+++ b/client/dashboard/sites/overview-card/index.tsx
@@ -47,6 +47,10 @@ export interface OverviewCardProps {
 	externalLink?: string;
 
 	tracksId?: string;
+
+	upsellType?: string;
+	upsellFeatureId?: string;
+
 	bottom?: ReactNode;
 	onClick?: () => void;
 }
@@ -63,6 +67,8 @@ export default function OverviewCard( {
 	link,
 	externalLink: externalLinkProp,
 	tracksId,
+	upsellType,
+	upsellFeatureId,
 	bottom,
 	onClick,
 }: OverviewCardProps ) {
@@ -182,12 +188,13 @@ export default function OverviewCard( {
 		if ( tracksId ) {
 			if ( intent === 'upsell' ) {
 				recordTracksEvent( 'calypso_dashboard_upsell_click', {
-					feature: tracksId,
-					type: 'card',
+					upsell_id: tracksId,
+					upsell_type: upsellType,
+					upsell_feature_id: upsellFeatureId,
 				} );
 			} else {
 				recordTracksEvent( 'calypso_dashboard_overview_card_click', {
-					type: tracksId,
+					card_id: tracksId,
 					intent,
 				} );
 			}
@@ -244,12 +251,16 @@ export default function OverviewCard( {
 					( intent === 'upsell' ? (
 						<ComponentViewTracker
 							eventName="calypso_dashboard_upsell_impression"
-							properties={ { feature: tracksId, type: 'card' } }
+							properties={ {
+								upsell_id: tracksId,
+								upsell_type: upsellType,
+								upsell_feature_id: upsellFeatureId,
+							} }
 						/>
 					) : (
 						<ComponentViewTracker
 							eventName="calypso_dashboard_overview_card_impression"
-							properties={ { feature: tracksId, intent } }
+							properties={ { card_id: tracksId, intent } }
 						/>
 					) ) }
 				{ renderContent() }

--- a/client/dashboard/sites/overview-difm-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-difm-upsell-card/index.tsx
@@ -41,7 +41,8 @@ export default function DIFMUpsellCard( { site }: { site: Site } ) {
 					target="_blank"
 					text={ __( 'Build it for me' ) }
 					variant="secondary"
-					tracksId="difm"
+					upsellId="site-overview-difm"
+					upsellType="site-difm"
 				/>
 			}
 		/>

--- a/client/dashboard/sites/overview-difm-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-difm-upsell-card/index.tsx
@@ -42,7 +42,7 @@ export default function DIFMUpsellCard( { site }: { site: Site } ) {
 					text={ __( 'Build it for me' ) }
 					variant="secondary"
 					upsellId="site-overview-difm"
-					upsellType="site-difm"
+					upsellFeatureId="site-difm"
 				/>
 			}
 		/>

--- a/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
@@ -24,7 +24,7 @@ export default function DomainTransferUpsellCard() {
 					text={ __( 'Transfer domain' ) }
 					size="compact"
 					upsellId="site-overview-transfer-domain"
-					upsellType="domain-transfer"
+					upsellFeatureId="domain"
 					variant="secondary"
 				/>
 			}

--- a/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
@@ -23,7 +23,8 @@ export default function DomainTransferUpsellCard() {
 					href="/setup/domain-transfer"
 					text={ __( 'Transfer domain' ) }
 					size="compact"
-					tracksId="transfer-domain"
+					upsellId="site-overview-transfer-domain"
+					upsellType="domain-transfer"
 					variant="secondary"
 				/>
 			}

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
-import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
@@ -34,26 +33,20 @@ const DomainUpsellCardContent = ( {
 	title,
 	description,
 	upsellCTAButtonText,
-	tracksId,
+	upsellId,
+	upsellType,
 }: {
 	site: Site;
 	title: string;
 	description: string;
 	upsellCTAButtonText: string;
-	tracksId: string;
+	upsellId: string;
+	upsellType: string;
 } ) => {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
-	const { recordTracksEvent } = useAnalytics();
 
 	const backUrl = window.location.href.replace( window.location.origin, '' );
-
-	const handleChooseYourOwn = () => {
-		recordTracksEvent( 'calypso_dashboard_upsell_click', {
-			feature: tracksId,
-			type: 'link',
-		} );
-	};
 
 	const handleUpsell = async () => {
 		if ( suggestedDomain ) {
@@ -101,7 +94,14 @@ const DomainUpsellCardContent = ( {
 						) : (
 							<TextBlur>{ search }</TextBlur>
 						),
-						link: <a href={ chooseYourOwnUrl } onClick={ handleChooseYourOwn } />,
+						link: (
+							<UpsellCTAButton
+								variant="link"
+								href={ chooseYourOwnUrl }
+								upsellId="site-overview-choose-your-own-domain"
+								upsellType={ upsellType }
+							/>
+						),
 					} ) }
 				</Text>
 			}
@@ -119,7 +119,8 @@ const DomainUpsellCardContent = ( {
 					text={ upsellCTAButtonText }
 					variant="primary"
 					size="compact"
-					tracksId={ tracksId }
+					upsellId={ upsellId }
+					upsellType={ upsellType }
 					isBusy={ isSubmitting }
 					onClick={ handleUpsell }
 				/>
@@ -142,8 +143,9 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 				description={ __(
 					'<domain /> is included free for one year with your paid plan. Claim this domain or <link>choose your own</link>.'
 				) }
+				upsellId="site-overview-claim-this-domain"
+				upsellType="domain-purchase"
 				upsellCTAButtonText={ __( 'Claim this domain' ) }
-				tracksId="claim-this-domain"
 			/>
 		);
 	}
@@ -155,8 +157,9 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 			description={ __(
 				'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
 			) }
+			upsellId="site-overview-get-this-domain"
+			upsellType="plan-and-domain-purchase"
 			upsellCTAButtonText={ __( 'Get this domain' ) }
-			tracksId="get-this-domain"
 		/>
 	);
 };

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -34,14 +34,12 @@ const DomainUpsellCardContent = ( {
 	description,
 	upsellCTAButtonText,
 	upsellId,
-	upsellType,
 }: {
 	site: Site;
 	title: string;
 	description: string;
 	upsellCTAButtonText: string;
 	upsellId: string;
-	upsellType: string;
 } ) => {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
@@ -99,7 +97,7 @@ const DomainUpsellCardContent = ( {
 								variant="link"
 								href={ chooseYourOwnUrl }
 								upsellId="site-overview-choose-your-own-domain"
-								upsellType={ upsellType }
+								upsellFeatureId="domain"
 							/>
 						),
 					} ) }
@@ -120,7 +118,7 @@ const DomainUpsellCardContent = ( {
 					variant="primary"
 					size="compact"
 					upsellId={ upsellId }
-					upsellType={ upsellType }
+					upsellFeatureId="domain"
 					isBusy={ isSubmitting }
 					onClick={ handleUpsell }
 				/>
@@ -144,7 +142,6 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 					'<domain /> is included free for one year with your paid plan. Claim this domain or <link>choose your own</link>.'
 				) }
 				upsellId="site-overview-claim-this-domain"
-				upsellType="domain-purchase"
 				upsellCTAButtonText={ __( 'Claim this domain' ) }
 			/>
 		);
@@ -158,7 +155,6 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 				'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
 			) }
 			upsellId="site-overview-get-this-domain"
-			upsellType="plan-and-domain-purchase"
 			upsellCTAButtonText={ __( 'Get this domain' ) }
 		/>
 	);

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -13,7 +13,8 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 			description={ __( 'Bring your site to WordPress.com.' ) }
 			externalLink={ addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ) }
 			intent="upsell"
-			tracksId="migrate-site"
+			tracksId="site-overview-migrate-site"
+			upsellType="site-migration"
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -14,7 +14,7 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 			externalLink={ addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ) }
 			intent="upsell"
 			tracksId="site-overview-migrate-site"
-			upsellType="site-migration"
+			upsellFeatureId="site-migration"
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -15,7 +15,7 @@ import type { SitePerformanceReport, Site } from '@automattic/api-core';
 const CARD_PROPS = {
 	icon: chartBar,
 	title: __( 'Performance' ),
-	tracksId: 'performance',
+	tracksId: 'site-overview-performance',
 };
 
 function getPerformanceUrl( site: Site, device?: string ) {
@@ -163,7 +163,8 @@ export default function PerformanceCard( { site }: { site: Site } ) {
 			site={ site }
 			feature={ HostingFeatures.PERFORMANCE }
 			featureIcon={ CARD_PROPS.icon }
-			tracksFeatureId={ CARD_PROPS.tracksId }
+			upsellId={ CARD_PROPS.tracksId }
+			upsellFeatureId="site-performance"
 			upsellHeading={ __( 'Test site performance' ) }
 			upsellDescription={ __( 'Get detailed metrics and recommendations.' ) }
 			upsellLink={ getPerformanceUrl( site ) }

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -71,7 +71,7 @@ function JetpackPlanCard( {
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
 			externalLink={ `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }` }
-			tracksId="plan"
+			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={
 				<VStack spacing={ 3 }>
@@ -128,7 +128,7 @@ function WpcomPlanCard( {
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
 			{ ...getBillingLinkProps() }
-			tracksId="plan"
+			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
 		/>
@@ -152,7 +152,7 @@ function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ description }
-			tracksId="plan"
+			tracksId="site-overview-plan"
 			isLoading={ isLoadingProductionSite }
 			bottom={ <SitePlanStats site={ site } /> }
 		/>
@@ -167,7 +167,7 @@ function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ __( 'Managed by Automattic for Agencies.' ) }
 			externalLink={ `https://agencies.automattic.com/sites/overview/${ site.slug }` }
-			tracksId="plan"
+			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
 		/>

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -13,7 +13,7 @@ import type { SiteScan, Site } from '@automattic/api-core';
 const CARD_PROPS = {
 	icon: shield,
 	title: __( 'Last scan' ),
-	tracksId: 'scan',
+	tracksId: 'site-overview-scan',
 };
 
 function getScanURL( site: Site ) {
@@ -92,7 +92,8 @@ export default function ScanCard( { site }: { site: Site } ) {
 			site={ site }
 			feature={ HostingFeatures.SCAN }
 			featureIcon={ CARD_PROPS.icon }
-			tracksFeatureId={ CARD_PROPS.tracksId }
+			upsellId={ CARD_PROPS.tracksId }
+			upsellFeatureId="site-scan"
 			upsellHeading={ __( 'Scan for security threats' ) }
 			upsellDescription={ __( 'We guard your site. You run your business.' ) }
 			upsellLink={ getScanURL( site ) }

--- a/client/dashboard/sites/overview-subscribers-card/index.tsx
+++ b/client/dashboard/sites/overview-subscribers-card/index.tsx
@@ -12,7 +12,7 @@ export default function SubscribersCard( { site }: { site: Site } ) {
 			description={ __( 'Total subscribers.' ) }
 			externalLink={ `https://cloud.jetpack.com/subscribers/${ site.slug }` }
 			intent="success"
-			tracksId="subscribers"
+			tracksId="site-overview-subscribers"
 		/>
 	);
 }

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -9,7 +9,7 @@ import type { Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
 	title: __( 'Visibility' ),
-	trackId: 'visibility',
+	trackId: 'site-overview-visibility',
 };
 
 function getVisibilityURL( site: Site ) {

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -55,7 +55,7 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 				<UpsellCTAButton
 					variant="primary"
 					upsellId={ upsellId }
-					upsellType="add-on-storage-purchase"
+					upsellFeatureId="site-storage"
 					href={ `/add-ons/${ site.slug }` }
 				>
 					{ __( 'Add more storage' ) }

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -43,13 +43,21 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 					title: __( 'Your site is out of storage' ),
 			  };
 
-	const tracksId = alertLevel === 'warning' ? 'storage-warning-low' : 'storage-warning-exceeded';
+	const upsellId =
+		alertLevel === 'warning'
+			? 'site-overview-storage-warning-low'
+			: 'site-overview-storage-warning-exceeded';
 
 	return (
 		<Notice
 			{ ...noticeProps }
 			actions={
-				<UpsellCTAButton variant="primary" tracksId={ tracksId } href={ `/add-ons/${ site.slug }` }>
+				<UpsellCTAButton
+					variant="primary"
+					upsellId={ upsellId }
+					upsellType="add-on-storage-purchase"
+					href={ `/add-ons/${ site.slug }` }
+				>
 					{ __( 'Add more storage' ) }
 				</UpsellCTAButton>
 			}

--- a/client/dashboard/sites/performance/performance-callout.tsx
+++ b/client/dashboard/sites/performance/performance-callout.tsx
@@ -7,8 +7,8 @@ import type { Site } from '@automattic/api-core';
 
 export function getPerformanceCalloutProps() {
 	return {
-		tracksFeatureId: 'performance',
 		feature: HostingFeatures.PERFORMANCE,
+		upsellId: 'site-performance',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Optimize your site’s performance' ),
 		upsellImage: illustrationUrl,

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -92,7 +92,7 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 		<HostingFeatureGatedWithCallout
 			site={ site }
 			feature={ HostingFeatures.SCAN }
-			tracksFeatureId="scan"
+			upsellId="site-scan"
 			overlay={ <PageLayout header={ <PageHeader title={ __( 'Scan' ) } /> } /> }
 			upsellIcon={ shield }
 			upsellTitle={ __( 'Scan for security threats' ) }

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -328,7 +328,7 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.CACHING }
-				tracksFeatureId="settings-caching"
+				upsellId="site-settings-caching"
 			>
 				{ renderForm() }
 				{ renderActions() }

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -92,7 +92,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.DATABASE }
-				tracksFeatureId="settings-database"
+				upsellId="site-settings-database"
 				upsellIcon={ blockTable }
 				upsellImage={ upsellIllustrationUrl }
 				upsellTitle={ __( 'Fast, familiar database access' ) }

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -232,7 +232,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.DEFENSIVE_MODE }
-				tracksFeatureId="settings-defensive-mode"
+				upsellId="site-settings-defensive-mode"
 			>
 				{ data?.enabled ? renderEnabled() : renderDisabled() }
 			</HostingFeatureGatedWithCallout>

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -92,7 +92,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.PHP }
-				tracksFeatureId="settings-php"
+				upsellId="site-settings-php"
 			>
 				<Card>
 					<CardBody>

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -178,7 +178,8 @@ function SiteRepositories() {
 				<HostingFeatureGatedWithCallout
 					site={ site }
 					feature={ HostingFeatures.DEPLOYMENT }
-					tracksFeatureId="settings-repositories"
+					upsellId="site-settings-repositories"
+					upsellFeatureId="site-deployments"
 					upsellIcon={ <GithubIcon aria-label={ __( 'GitHub logo' ) } /> }
 					upsellImage={ illustrationUrl }
 					upsellTitle={ __( 'Deploy from GitHub' ) }

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -43,7 +43,7 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.SFTP }
-				tracksFeatureId="settings-sftp-ssh"
+				upsellId="site-settings-sftp-ssh"
 				upsellIcon={ file }
 				upsellImage={ upsellIllustrationUrl }
 				upsellTitle={ __( 'Direct access to your site’s files' ) }

--- a/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
+++ b/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
@@ -32,7 +32,7 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 				variant="link"
 				href={ `/plans/${ site.slug }` }
 				upsellId={ `site-settings-visibility-trial-notice:${ getTrialType() }` }
-				upsellType="plan-upgrade"
+				upsellFeatureId="site-trial"
 			/>
 		);
 

--- a/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
+++ b/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
@@ -1,15 +1,12 @@
 import { DotcomPlans } from '@automattic/api-core';
-import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useAnalytics } from '../../app/analytics';
-import ComponentViewTracker from '../../components/component-view-tracker';
 import Notice from '../../components/notice';
+import UpsellCTAButton from '../../components/upsell-cta-button';
 import { isSitePlanLaunchable } from '../plans';
 import type { Site } from '@automattic/api-core';
 
 export default function TrialUpsellNotice( { site }: { site: Site } ) {
-	const { recordTracksEvent } = useAnalytics();
 	const isSiteOnECommerceTrial = site.plan?.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY;
 	const isSiteOnMigrationTrial = site.plan?.product_slug === DotcomPlans.MIGRATION_TRIAL_MONTHLY;
 
@@ -29,24 +26,21 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 		return site.plan?.product_slug ?? 'free';
 	};
 
-	const handleClick = () => {
-		recordTracksEvent( 'calypso_dashboard_upsell_click', {
-			feature: 'plans',
-			type: `trial-notice:${ getTrialType() }`,
-		} );
-	};
-
 	const renderContent = () => {
-		const buttonProps = {
-			variant: 'link' as const,
-			href: `/plans/${ site.slug }`,
-		};
+		const upsellCTALink = (
+			<UpsellCTAButton
+				variant="link"
+				href={ `/plans/${ site.slug }` }
+				upsellId={ `site-settings-visibility-trial-notice:${ getTrialType() }` }
+				upsellType="plan-upgrade"
+			/>
+		);
 
 		if ( isSiteOnECommerceTrial ) {
 			return createInterpolateElement(
 				__( 'Before you can share your store with the world, you need to <a>pick a plan</a>.' ),
 				{
-					a: <Button { ...buttonProps } onClick={ handleClick } />,
+					a: upsellCTALink,
 				}
 			);
 		}
@@ -55,7 +49,7 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 			return createInterpolateElement(
 				__( 'Ready to launch your site? <a>Upgrade to a paid plan</a>.' ),
 				{
-					a: <Button { ...buttonProps } onClick={ handleClick } />,
+					a: upsellCTALink,
 				}
 			);
 		}
@@ -63,18 +57,10 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 		return createInterpolateElement(
 			__( 'Ready to launch your site? <a>Upgrade to a paid plan</a>.' ),
 			{
-				a: <Button { ...buttonProps } onClick={ handleClick } />,
+				a: upsellCTALink,
 			}
 		);
 	};
 
-	return (
-		<>
-			<ComponentViewTracker
-				eventName="calypso_dashboard_upsell_impression"
-				properties={ { feature: 'plans', type: `trial-notice:${ getTrialType() }` } }
-			/>
-			<Notice variant="warning">{ renderContent() }</Notice>
-		</>
-	);
+	return <Notice variant="warning">{ renderContent() }</Notice>;
 }

--- a/client/dashboard/sites/settings-static-file-404/index.tsx
+++ b/client/dashboard/sites/settings-static-file-404/index.tsx
@@ -93,7 +93,7 @@ export default function SiteStaticFile404Settings( { siteSlug }: { siteSlug: str
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.STATIC_FILE_404 }
-				tracksFeatureId="settings-static-file-404"
+				upsellId="site-settings-static-file-404"
 			>
 				<Card>
 					<CardBody>

--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -57,7 +57,7 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.SECURITY_SETTINGS }
-				tracksFeatureId="settings-security"
+				upsellId="site-settings-waf"
 			>
 				{ ! modulesAvailable && (
 					<Notice>

--- a/client/dashboard/sites/settings-wpcom-login/index.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/index.tsx
@@ -56,7 +56,7 @@ export default function WpcomLoginSettings( { siteSlug }: { siteSlug: string } )
 			<HostingFeatureGatedWithCallout
 				site={ site }
 				feature={ HostingFeatures.SECURITY_SETTINGS }
-				tracksFeatureId="settings-security"
+				upsellId="site-settings-wpcom-login"
 			>
 				{ ! ssoAvailable && (
 					<Notice>

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -103,7 +103,8 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 							<ButtonStack>
 								<UpsellCTAButton
 									text={ __( 'Purchase plan' ) }
-									tracksId="trial"
+									upsellId="site-trial-ended"
+									upsellType="plan-upgrade"
 									variant="primary"
 									href={ addQueryArgs( `/checkout/${ site.slug }/${ product.pathSlug }`, {
 										cancel_to: backUrl,

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -104,7 +104,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 								<UpsellCTAButton
 									text={ __( 'Purchase plan' ) }
 									upsellId="site-trial-ended"
-									upsellType="plan-upgrade"
+									upsellFeatureId="site-trial"
 									variant="primary"
 									href={ addQueryArgs( `/checkout/${ site.slug }/${ product.pathSlug }`, {
 										cancel_to: backUrl,


### PR DESCRIPTION
Context: pgz0xU-i5-p2

## Proposed Changes

This PR consolidates the upsell events in the Hosting Dashboard to have uniform events and props as follows:

- On show: `calypso_dashboard_upsell_impression`
- On click: `calypso_dashboard_upsell_click`
- Both have the following props:
   - `upsell_id`: The ID of the upsell; also indicates the location where the upsell is being shown.
   - ~~`upsell_type`: What this upsell is leading to (e.g. `plan-upgrade`)~~
   - `upsell_feature_id`: ~~What feature this upsell unlocks when the purchase is made (`e.g. site-monitoring`)~~ What PRIMARY feature is being upsold.

The upsells are as follows:

### Hosting feature callouts

E.g.:

|<img width="1376" height="844" alt="image" src="https://github.com/user-attachments/assets/32a98ddf-99bd-4404-b37e-f3b0b78fee49" />|<img width="1410" height="964" alt="image" src="https://github.com/user-attachments/assets/6d23af67-7366-450a-af79-9b261749132c" />|
|-|-|

|`upsell_id`|`upsell_feature_id`|
|-|-|
|`site-deployments`|`site-deployments`|
|`site-monitoring`|`site-monitoring`|
|`site-performance`|`site-performance`|
|`site-logs`|`site-logs`|
|`site-logs-activity`|`site-logs-activity`|
|`site-backups`|`site-backups`|
|`site-scan`|`site-scan`|
|`site-settings-caching`|`site-settings-caching`|
|`site-settings-database`|`site-settings-database`|
|`site-settings-defensive-mode`|`site-settings-defensive-mode`|
|`site-settings-php`|`site-settings-php`|
|`site-settings-repositories`|`site-deployments`|
|`site-settings-sftp-ssh`|`site-settings-sftp-ssh`|
|`site-settings-static-file-404`|`site-settings-static-file-404`|
|`site-settings-waf`|`site-settings-waf`|
|`site-settings-wpcom-login`|`site-settings-wpcom-login`|

### Hosting feature cards

E.g.:

<img width="899" height="153" alt="image" src="https://github.com/user-attachments/assets/803c5750-b44d-4719-8440-27d26649f303" />

|`upsell_id`|`upsell_feature_id`|
|-|-|-|
|`site-overview-backups`|`site-backups`|
|`site-overview-scan`|`site-scan`|
|`site-overview-performance`|`site-performance`|

### Various upsell cards

|Card|`upsell_id`|`upsell_feature_id`|
|-|-|-|
|<img width="300" height="364" alt="image" src="https://github.com/user-attachments/assets/6977ee7b-94aa-41e8-abc4-a30432974be1" />|`site-overview-difm`|`site-difm`|
|<img width="300" height="410" alt="image" src="https://github.com/user-attachments/assets/3afc881b-6828-4fe4-8cbc-08a4aaa0fdf0" />|`site-overview-transfer-domain`|`domain`|
|<img width="300" height="404" alt="image" src="https://github.com/user-attachments/assets/54354714-2d74-4a1c-887b-52f6b41e326a" />|`site-overview-claim-this-domain`|`domain`|
|<img width="300" height="410" alt="image" src="https://github.com/user-attachments/assets/69a59bdd-ab7f-4e05-a658-840229401697" />|`site-overview-get-this-domain`|`domain`|
|<img width="345" height="154" alt="image" src="https://github.com/user-attachments/assets/e47eb4f5-0d4d-4abb-9cc1-3844e2b764c6" />|`site-overview-migrate-site`|`site-migration`|
|<img width="300" height="524" alt="image" src="https://github.com/user-attachments/assets/7d30d310-43f4-45d2-af7e-e52c02ae8e73" />|`domain-nameservers-primary-domain`|`domain`|
|<img width="300" height="516" alt="image" src="https://github.com/user-attachments/assets/f81cadd5-08a4-41de-b561-d0fef35c1e6e" />|`site-trial-ended`|`site-trial`|

### Various upsell links

|Link|`upsell_id`|`upsell_feature_id`|
|-|-|-|
|<img width="300" height="182" alt="image" src="https://github.com/user-attachments/assets/8d25679c-277c-49a6-8603-2e01dcb41227" />|`site-settings-visibility-trial-notice:ecommerce`|`site-trial`|
|<img width="300" height="404" alt="image" src="https://github.com/user-attachments/assets/54354714-2d74-4a1c-887b-52f6b41e326a" />|`site-overview-choose-your-own-domain`|`domain`|
|<img width="300" height="410" alt="image" src="https://github.com/user-attachments/assets/69a59bdd-ab7f-4e05-a658-840229401697" />|`site-overview-choose-your-own-domain`|`domain`|

### Non-upsell <OverviewCard>

I also took an opportunity to refactor OverviewCard's Track event id which are not upsells:

- replace `type` prop with `card_id` props which indicates the location as well.

## Testing Instructions

1. Visually check the code changes.
2. Random test some of the above upsells.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?