### PR TITLE
Hosting Dashboard Emails: Domain step always goes to provider selector

### DIFF
--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -11,11 +11,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { arrowLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
+import { emailsRoute, chooseEmailSolutionRoute } from '../../app/router/emails';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { Text } from '../../components/text';
-import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
 import AddNewDomain from '../components/add-new-domain';
 import { useDomains } from '../hooks/use-domains';
 
@@ -43,17 +43,9 @@ export default function ChooseDomain() {
 	}, [ eligibleDomains, search ] );
 
 	const handleDomainClick = ( d: SiteDomain ) => {
-		// Navigate based on existing email solution
-		if ( hasTitanMailWithUs( d ) ) {
-			router.navigate( { to: '/emails/add-titan-mailbox' } );
-			return;
-		}
-		if ( hasGSuiteWithUs( d ) ) {
-			router.navigate( { to: '/emails/add-google-mailbox' } );
-			return;
-		}
 		router.navigate( {
-			to: `/emails/choose-email-solution/${ encodeURIComponent( d.domain ) }`,
+			to: chooseEmailSolutionRoute.to,
+			params: { domain: d.domain },
 		} );
 	};
 
@@ -66,7 +58,7 @@ export default function ChooseDomain() {
 							className="add-forwarder__back-button"
 							icon={ arrowLeft }
 							iconSize={ 12 }
-							to="/emails"
+							to={ emailsRoute.to }
 						>
 							<Text variant="muted">{ __( 'Emails' ) }</Text>
 						</RouterLinkButton>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-665/hosting-dashboard-emails-domain-step-always-goes-to-provider-selector

## Proposed Changes

* We now always redirect to the choose provider screen instead of branching.


https://github.com/user-attachments/assets/4536789f-9cc3-4283-b2e5-65c8cad19e05



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to improve the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calyspo live link and go to `/v2/emails`
* Click on add new mailbox
* Clicking on any/all domains should land you on the choose provider flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
