### PR TITLE
Hosting Dashboard Emails: notify of unused mailboxes

### DIFF
--- a/client/dashboard/emails/components/unused-mailbox-notice.tsx
+++ b/client/dashboard/emails/components/unused-mailbox-notice.tsx
@@ -1,0 +1,55 @@
+import { Link } from '@tanstack/react-router';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { addTitanmailMailboxRoute } from '../../app/router/emails';
+import { Notice } from '../../components/notice';
+
+interface UnusedMailboxNoticeProps {
+	domains: string[];
+}
+
+const UnusedMailboxNotice = ( { domains }: UnusedMailboxNoticeProps ) => {
+	if ( ! domains?.length ) {
+		return null;
+	}
+
+	const count = domains.length;
+	const title = sprintf(
+		/* translators: %d is the number of free mailboxes */
+		_n(
+			'You have %d free mailbox waiting to be set up.',
+			'You have %d free mailboxes waiting to be set up.',
+			count
+		),
+		count
+	);
+
+	return (
+		<Notice variant="info" title={ title }>
+			<VStack spacing={ 4 }>
+				<Text as="p">
+					{ __( 'Create your mailbox now and start using your custom email address.' ) }
+				</Text>
+				<VStack spacing={ 2 }>
+					{ domains.map( ( domain ) => (
+						<HStack key={ domain }>
+							<Link to={ addTitanmailMailboxRoute.to }>
+								{ sprintf(
+									// translators: %s is a domain name
+									__( 'Set up mailbox for %s' ),
+									domain
+								) }
+							</Link>
+						</HStack>
+					) ) }
+				</VStack>
+			</VStack>
+		</Notice>
+	);
+};
+
+export default UnusedMailboxNotice;

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -9,6 +9,7 @@ import { domainHasEmail } from '../utils/domain';
 import { persistViewToUrl, useSetInitialViewFromUrl } from '../utils/persist-view-to-url';
 import NoDomainsAvailableEmptyState from './components/no-domains-available-empty-state';
 import NoEmailsAvailableEmptyState from './components/no-emails-available-empty-state';
+import UnusedMailboxNotice from './components/unused-mailbox-notice';
 import { DEFAULT_EMAILS_VIEW, getEmailFields, useEmailActions } from './dataviews';
 import { useDomains } from './hooks/use-domains';
 import { Layout } from './layout';
@@ -53,17 +54,36 @@ function Emails() {
 			return [];
 		}
 		return domainsWithEmails.flatMap( ( domain, index ) => {
-			const mailboxes = ( mailboxQueries[ index ]?.data as EmailAccount[] ) ?? [];
+			const emailAccounts = ( mailboxQueries[ index ]?.data as EmailAccount[] ) ?? [];
 
-			const skipFilterForwards = mailboxes.length === 1;
+			const skipFilterForwards = emailAccounts.length === 1;
 
-			return mailboxes
+			return emailAccounts
 				.filter( ( account ) => skipFilterForwards || account.account_type !== 'email_forwarding' )
 				.flatMap( ( account ) =>
 					account.emails.map( ( box: EmailBox ) => mapMailboxToEmail( box, account, domain ) )
 				)
 				.filter( ( email ) => email.canUserManage ) as Email[];
 		} );
+	}, [ domainsWithEmails, mailboxQueries ] );
+
+	// Gather domains with unused mailbox warnings
+	const domainsWithUnusedMailbox: string[] = useMemo( () => {
+		if ( ! domainsWithEmails.length ) {
+			return [];
+		}
+		return domainsWithEmails.reduce< string[] >( ( acc, domain, index ) => {
+			const emailAccounts = ( mailboxQueries[ index ]?.data as EmailAccount[] ) ?? [];
+			const hasUnusedWarning = emailAccounts.some( ( account ) =>
+				( account.warnings ?? [] ).some(
+					( w ) => w.warning_slug === 'unused_mailboxes' && w.warning_type === 'notice'
+				)
+			);
+			if ( hasUnusedWarning ) {
+				acc.push( domain.domain );
+			}
+			return acc;
+		}, [] );
 	}, [ domainsWithEmails, mailboxQueries ] );
 
 	const [ selection, setSelection ] = useState< Email[] >( [] );
@@ -98,6 +118,9 @@ function Emails() {
 
 	return (
 		<Layout>
+			{ ! isLoadingDomains && ! isLoadingMailboxes && domainsWithUnusedMailbox.length > 0 && (
+				<UnusedMailboxNotice domains={ domainsWithUnusedMailbox } />
+			) }
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -118,7 +118,7 @@ function Emails() {
 
 	return (
 		<Layout>
-			{ ! isLoadingDomains && ! isLoadingMailboxes && domainsWithUnusedMailbox.length > 0 && (
+			{ ! isLoadingDomains && ! isLoadingMailboxes && (
 				<UnusedMailboxNotice domains={ domainsWithUnusedMailbox } />
 			) }
 			<DataViewsCard>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-664/hosting-dashboard-emails-notify-of-unused-mailboxes

## Proposed Changes

* We now display a notice when the user has unused mailboxes so that they can configure the mailbox for free.

<img width="1528" height="1288" alt="Screenshot 2025-10-17 at 10 46 59" src="https://github.com/user-attachments/assets/d89ae336-748b-46c3-b015-7807af2dca3a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `/v2/emails`
* Make sure you have a Titan mail account with no email boxes.
* You should see the notice displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
