### PR TITLE
TeamCity: Remove list of changes from the BuildBaseImages failure notification

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -239,6 +239,7 @@ object BuildBaseImages : BuildType({
 				connection = "PROJECT_EXT_11"
 				sendTo = "#calypso"
 				messageFormat = verboseMessageFormat {
+					addChanges = false
 					addStatusText = true
 					addBranch = true
 				}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -239,7 +239,6 @@ object BuildBaseImages : BuildType({
 				connection = "PROJECT_EXT_11"
 				sendTo = "#calypso"
 				messageFormat = verboseMessageFormat {
-					addChanges = true
 					addStatusText = true
 					addBranch = true
 				}


### PR DESCRIPTION


## Proposed Changes

Remove the list of recent changes from the BuildBaseImages failure notification sent to Slack.

## Why are these changes being made?

The notification is too verbose while the list of changes is not adding value.

