### PR TITLE
Dashboard v2: make primary and secondary navs truly responsive

### DIFF
--- a/client/dashboard/app/header/index.tsx
+++ b/client/dashboard/app/header/index.tsx
@@ -1,4 +1,4 @@
-import { useViewportMatch } from '@wordpress/compose';
+import { useState } from 'react';
 import HeaderBar from '../../components/header-bar';
 import RouterLinkButton from '../../components/router-link-button';
 import { useAppContext } from '../context';
@@ -7,20 +7,32 @@ import SecondaryMenu from '../secondary-menu';
 
 function Header() {
 	const { Logo } = useAppContext();
-	const isDesktop = useViewportMatch( 'medium' );
+	const [ isPrimaryMenuCollapsed, setPrimaryMenuCollapsed ] = useState( false );
 
 	return (
 		<HeaderBar as="header">
-			{ ! isDesktop && <PrimaryMenu /> }
+			{ isPrimaryMenuCollapsed && (
+				<div style={ { flexShrink: 0 } }>
+					<PrimaryMenu forceCollapsed />
+				</div>
+			) }
 
 			{ Logo && (
-				<div style={ { display: 'flex', alignItems: 'center' } }>
+				<div style={ { flexShrink: 0 } }>
 					<RouterLinkButton icon={ <Logo /> } to="/" />
 				</div>
 			) }
 
-			<div style={ { flexGrow: 1 } }>{ isDesktop && <PrimaryMenu /> }</div>
-			<div>
+			<div
+				style={ {
+					flexGrow: 1,
+					visibility: isPrimaryMenuCollapsed ? 'hidden' : 'visible',
+				} }
+			>
+				<PrimaryMenu onCollapseChange={ setPrimaryMenuCollapsed } />
+			</div>
+
+			<div style={ { flexShrink: 0 } }>
 				<SecondaryMenu />
 			</div>
 		</HeaderBar>

--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -2,11 +2,14 @@ import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { useAppContext } from '../context';
 
-function PrimaryMenu() {
+function PrimaryMenu( props: {
+	forceCollapsed?: boolean;
+	onCollapseChange?: ( collapsed: boolean ) => void;
+} ) {
 	const { supports } = useAppContext();
 
 	return (
-		<ResponsiveMenu>
+		<ResponsiveMenu { ...props }>
 			{ supports.overview && (
 				<ResponsiveMenu.Item to="/overview">{ __( 'Overview' ) }</ResponsiveMenu.Item>
 			) }

--- a/client/dashboard/components/menu-divider/index.tsx
+++ b/client/dashboard/components/menu-divider/index.tsx
@@ -1,7 +1,7 @@
 import './style.scss';
 
-function MenuDivider() {
-	return <div className="dashboard-menu-divider" />;
+function MenuDivider( { style }: { style?: React.CSSProperties } ) {
+	return <div className="dashboard-menu-divider" style={ style } />;
 }
 
 export default MenuDivider;

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -1,28 +1,61 @@
 import { __experimentalHStack as HStack, Button, DropdownMenu } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
-import React, { type ComponentProps } from 'react';
+import React, { useEffect, useRef, useState, type ComponentProps } from 'react';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
 
 type ResponsiveMenuProps = {
+	prefix?: React.ReactNode;
 	children: React.ReactNode;
 	icon?: React.ReactElement;
 	label?: string;
 	dropdownPlacement?: 'bottom-end' | 'bottom-start' | 'bottom';
+	forceCollapsed?: boolean;
+	onCollapseChange?: ( collapsed: boolean ) => void;
 };
 
 function ResponsiveMenu( {
+	prefix,
 	children,
 	icon = menu,
 	label = 'Menu',
 	dropdownPlacement = 'bottom-end',
+	forceCollapsed,
+	onCollapseChange,
 }: ResponsiveMenuProps ) {
-	const isDesktop = useViewportMatch( 'medium' );
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
+	const measureRef = useRef< HTMLDivElement | null >( null );
+	const [ isCollapsed, setIsCollapsed ] = useState( false );
 
-	if ( isDesktop ) {
-		return (
+	const checkOverflow = () => {
+		const measure = measureRef.current;
+		const wrapper = wrapperRef.current;
+		if ( ! measure || ! wrapper ) {
+			return;
+		}
+
+		const containerWidth = wrapper.clientWidth;
+		const contentWidth = measure.scrollWidth;
+		const collapsed = contentWidth > containerWidth;
+
+		if ( collapsed !== isCollapsed ) {
+			setIsCollapsed( collapsed );
+			onCollapseChange?.( collapsed );
+		}
+	};
+
+	useEffect( () => {
+		const observer = new ResizeObserver( checkOverflow );
+		if ( wrapperRef.current ) {
+			observer.observe( wrapperRef.current );
+		}
+		return () => observer.disconnect();
+	}, [ isCollapsed, onCollapseChange ] );
+
+	const inlineMenu = (
+		<HStack spacing={ 3 }>
+			{ prefix }
 			<Menu>
 				{ React.Children.map( children, ( child ) => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
@@ -43,10 +76,10 @@ function ResponsiveMenu( {
 					return child;
 				} ) }
 			</Menu>
-		);
-	}
+		</HStack>
+	);
 
-	return (
+	const dropdownMenu = (
 		<DropdownMenu
 			icon={ icon }
 			label={ label }
@@ -77,6 +110,37 @@ function ResponsiveMenu( {
 				</>
 			) }
 		</DropdownMenu>
+	);
+
+	if ( forceCollapsed ) {
+		return dropdownMenu;
+	}
+
+	return (
+		<div
+			ref={ wrapperRef }
+			style={ {
+				position: 'relative',
+				width: '100%',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: isCollapsed ? 'flex-end' : 'flex-start',
+			} }
+		>
+			{ isCollapsed ? dropdownMenu : inlineMenu }
+
+			<div
+				ref={ measureRef }
+				style={ {
+					position: 'absolute',
+					visibility: 'hidden',
+					pointerEvents: 'none',
+					whiteSpace: 'nowrap',
+				} }
+			>
+				{ inlineMenu }
+			</div>
+		</div>
 	);
 }
 

--- a/client/dashboard/domains/domain-menu/index.tsx
+++ b/client/dashboard/domains/domain-menu/index.tsx
@@ -1,13 +1,14 @@
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 
 const DomainMenu = ( { domainName }: { domainName: string } ) => {
 	const { supports } = useAppContext();
 
 	return (
-		<ResponsiveMenu label={ __( 'Domain Menu' ) }>
+		<ResponsiveMenu label={ __( 'Domain Menu' ) } prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to={ `/domains/${ domainName }` }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -2,19 +2,16 @@ import { domainQuery, domainsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { globe } from '@wordpress/icons';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
-import MenuDivider from '../../components/menu-divider';
 import Switcher from '../../components/switcher';
 import DomainMenu from '../domain-menu';
 
 import './style.scss';
 
 function Domain() {
-	const isDesktop = useViewportMatch( 'medium' );
 	const { domainName } = domainRoute.useParams();
 	const domains = useQuery( domainsQuery() ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
@@ -23,7 +20,7 @@ function Domain() {
 	return (
 		<>
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<Switcher
 							items={ domains }
@@ -39,7 +36,6 @@ function Domain() {
 							}
 						/>
 					</HeaderBar.Title>
-					{ isDesktop && <MenuDivider /> }
 					<DomainMenu domainName={ domain.domain } />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -1,22 +1,17 @@
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import HeaderBar from '../components/header-bar';
-import MenuDivider from '../components/menu-divider';
 import MeMenu from './me-menu';
 
 function Me() {
-	const isDesktop = useViewportMatch( 'medium' );
-
 	return (
 		<>
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 4 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<span>{ __( 'Account' ) }</span>
 					</HeaderBar.Title>
-					{ isDesktop && <MenuDivider /> }
 					<MeMenu />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import type { AppConfig, MeSupports } from '../../app/context';
 
@@ -11,7 +12,7 @@ const MeMenu = () => {
 	const { supports } = useAppContext();
 
 	return (
-		<ResponsiveMenu>
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/preferences">{ __( 'Preferences' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>

--- a/client/dashboard/plugins/index.tsx
+++ b/client/dashboard/plugins/index.tsx
@@ -2,18 +2,16 @@ import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import HeaderBar from '../components/header-bar';
-import MenuDivider from '../components/menu-divider';
 import PluginsMenu from './plugins-menu';
 
 export default function Plugins() {
 	return (
 		<>
 			<HeaderBar>
-				<HStack spacing={ 4 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<span>{ __( 'Plugins' ) }</span>
 					</HeaderBar.Title>
-					<MenuDivider />
 					<PluginsMenu />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,9 +1,10 @@
 import { __ } from '@wordpress/i18n';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 
 const PluginsMenu = () => {
 	return (
-		<ResponsiveMenu>
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
 				{ __( 'Scheduled updates' ) }

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,6 +1,7 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -17,7 +18,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
 				</ResponsiveMenu.Item>
@@ -27,7 +28,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( hasSiteTrialEnded( site ) ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
 					{ __( 'Trial ended' ) }
 				</ResponsiveMenu.Item>
@@ -37,7 +38,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>
 					{ __( 'Site building' ) }
 				</ResponsiveMenu.Item>
@@ -56,7 +57,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 	}
 
 	return (
-		<ResponsiveMenu label={ __( 'Site Menu' ) }>
+		<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -8,7 +8,6 @@ import {
 	Icon,
 	Modal,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
@@ -30,7 +29,6 @@ import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
 	const { onboardingLinkSourceQueryArg } = useAppContext();
-	const isDesktop = useViewportMatch( 'medium' );
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
 	const { data: sites } = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } );
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
@@ -46,7 +44,7 @@ function Site() {
 		<>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<Switcher
 							items={ sites }
@@ -90,12 +88,7 @@ function Site() {
 							<AddNewSite context={ onboardingLinkSourceQueryArg } />
 						</Modal>
 					) }
-					{ ! isSiteMigrationInProgress( site ) && (
-						<>
-							{ isDesktop && <MenuDivider /> }
-							<SiteMenu site={ site } />
-						</>
-					) }
+					{ ! isSiteMigrationInProgress( site ) && <SiteMenu site={ site } /> }
 				</HStack>
 			</HeaderBar>
 			<Outlet />


### PR DESCRIPTION
Fixes DOTCOM-14632

## Proposed Changes

This PR avoids overlapping primary and secondary nav menu items, by using `ResizeObserver` to replace the list with a dropdown when there's no enough space.

For example in site-level nav:

Before


https://github.com/user-attachments/assets/b814d7f4-3fe0-44b1-9858-ffc07efb0931



After


https://github.com/user-attachments/assets/9af2dd54-70b5-4f9c-8bb8-55fa882f2e31




## Testing Instructions

Test resizing the browser width in v2's Sites, Domains, Plugins screens and verify the primary and secondary navs are collapsed when the width is not sufficient as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?