### PR TITLE
Hosting Dashboard: Add site redirect warning on site domains list

### DIFF
--- a/test.tx
+++ b/test.tx
@@ -1,0 +1,167 @@
+diff --git a/client/dashboard/domains/dataviews/fields.tsx b/client/dashboard/domains/dataviews/fields.tsx
+index c584dace261..d641abdcadf 100644
+--- a/client/dashboard/domains/dataviews/fields.tsx
++++ b/client/dashboard/domains/dataviews/fields.tsx
+@@ -137,19 +137,23 @@ export const useFields = ( {
+ 					return a.expiry.localeCompare( b.expiry ) * factor;
+ 				},
+ 				elements: [
+-					{ value: '2-next-07-days', label: __( 'Next 7 days' ) },
+-					{ value: '2-next-30-days', label: __( 'Next 30 days' ) },
+-					{ value: '2-next-90-days', label: __( 'Next 90 days' ) },
+-					{ value: '3-more-than-90-days', label: __( 'More than 90 days' ) },
+-					{ value: '1-expired', label: __( 'Expired' ) },
+-					{ value: '0-no-expiry', label: __( 'No expiry date' ) },
++					{ value: 'expired', label: __( 'Expired' ) },
++					{ value: 'next-7-days', label: __( 'Next 7 days' ) },
++					{ value: 'next-30-days', label: __( 'Next 30 days' ) },
++					{ value: 'next-90-days', label: __( 'Next 90 days' ) },
++					{ value: 'more-than-90-days', label: __( 'More than 90 days' ) },
++					{ value: 'no-expiry', label: __( 'No expiry date' ) },
+ 				],
+ 				filterBy: {
+ 					operators: [ 'isAny' as Operator ],
+ 				},
+ 				getValue: ( { item }: { item: DomainSummary } ) => {
+ 					if ( ! item.expiry ) {
+-						return '0-no-expiry';
++						return 'no-expiry';
++					}
++
++					if ( item.expired ) {
++						return 'expired';
+ 					}
+ 
+ 					const expiryDate = new Date( item.expiry );
+@@ -157,16 +161,15 @@ export const useFields = ( {
+ 					const diffInMs = expiryDate.getTime() - now.getTime();
+ 					const diffInDays = Math.ceil( diffInMs / ( 1000 * 60 * 60 * 24 ) );
+ 
+-					if ( item.expired ) {
+-						return '1-expired';
+-					} else if ( diffInDays <= 90 ) {
+-						return '2-next-90-days';
++					// Return the most specific category for display purposes
++					if ( diffInDays <= 7 ) {
++						return 'next-7-days';
+ 					} else if ( diffInDays <= 30 ) {
+-						return '2-next-30-days';
+-					} else if ( diffInDays <= 7 ) {
+-						return '2-next-07-days';
++						return 'next-30-days';
++					} else if ( diffInDays <= 90 ) {
++						return 'next-90-days';
+ 					}
+-					return '3-more-than-90-days';
++					return 'more-than-90-days';
+ 				},
+ 				render: ( { item } ) => {
+ 					return (
+@@ -197,7 +200,7 @@ export const useFields = ( {
+ 				},
+ 			},
+ 		],
+-		[ site, showPrimaryDomainBadge, siteElements ]
++		[ site, showPrimaryDomainBadge, siteElements, inOverview ]
+ 	);
+ 
+ 	return fields;
+diff --git a/client/dashboard/domains/index.tsx b/client/dashboard/domains/index.tsx
+index ef07236f449..691391f3823 100644
+--- a/client/dashboard/domains/index.tsx
++++ b/client/dashboard/domains/index.tsx
+@@ -3,7 +3,7 @@ import { domainsQuery } from '@automattic/api-queries';
+ import { useQuery } from '@tanstack/react-query';
+ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+ import { __ } from '@wordpress/i18n';
+-import { useState } from 'react';
++import { useState, useMemo } from 'react';
+ import { useAuth } from '../app/auth';
+ import { DataViewsCard } from '../components/dataviews-card';
+ import { OptInWelcome } from '../components/opt-in-welcome';
+@@ -13,11 +13,55 @@ import { AddDomainButton } from './add-domain-button';
+ import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
+ import type { DomainsView } from './dataviews';
+ import type { DomainSummary } from '@automattic/api-core';
++import type { Filter } from '@wordpress/dataviews';
+ 
+ export function getDomainId( domain: DomainSummary ): string {
+ 	return `${ domain.domain }-${ domain.blog_id }`;
+ }
+ 
++// Custom filtering function to handle overlapping expiry ranges
++function customFilterDomains( domains: DomainSummary[], filters: Filter[] ): DomainSummary[] {
++	const expiryFilter = filters.find( ( filter ) => filter.field === 'expiry' );
++
++	if ( ! expiryFilter || ! expiryFilter.value ) {
++		return domains;
++	}
++
++	const filterValues = Array.isArray( expiryFilter.value )
++		? expiryFilter.value
++		: [ expiryFilter.value ];
++
++	return domains.filter( ( domain ) => {
++		if ( ! domain.expiry ) {
++			return filterValues.includes( 'no-expiry' );
++		}
++
++		if ( domain.expired ) {
++			return filterValues.includes( 'expired' );
++		}
++
++		const expiryDate = new Date( domain.expiry );
++		const now = new Date();
++		const diffInMs = expiryDate.getTime() - now.getTime();
++		const diffInDays = Math.ceil( diffInMs / ( 1000 * 60 * 60 * 24 ) );
++
++		return filterValues.some( ( value ) => {
++			switch ( value ) {
++				case 'next-7-days':
++					return diffInDays <= 7;
++				case 'next-30-days':
++					return diffInDays <= 30;
++				case 'next-90-days':
++					return diffInDays <= 90;
++				case 'more-than-90-days':
++					return diffInDays > 90;
++				default:
++					return false;
++			}
++		} );
++	} );
++}
++
+ function Domains() {
+ 	const { user } = useAuth();
+ 	const fields = useFields();
+@@ -39,9 +83,27 @@ function Domains() {
+ 	} ) );
+ 
+ 	const { data: domains, isLoading } = useQuery( domainsQuery() );
++
++	// Apply custom expiry filtering first
++	const customFilteredDomains = useMemo( () => {
++		if ( ! domains ) {
++			return [];
++		}
++		return customFilterDomains( domains, view.filters ?? [] );
++	}, [ domains, view.filters ] );
++
++	// Create a view without expiry filters for standard filtering
++	const viewWithoutExpiryFilters = useMemo(
++		() => ( {
++			...view,
++			filters: ( view.filters ?? [] ).filter( ( filter ) => filter.field !== 'expiry' ),
++		} ),
++		[ view ]
++	);
++
+ 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+-		domains ?? [],
+-		view,
++		customFilteredDomains,
++		viewWithoutExpiryFilters,
+ 		fields
+ 	);
+ 


### PR DESCRIPTION
Closes [DOTDASH-657](https://linear.app/a8c/issue/DOTDASH-657/site-redirect-changes-for-the-site-domains-list)

## Proposed Changes
Add a warning notice to the domains page that alerts users when their site has an active redirect configuration and provides a direct link to manage redirect settings.

![Screenshot 2025-10-17 alle 11 58 55](https://github.com/user-attachments/assets/614786b6-2b91-475f-b85c-e3d4d77424e3)

## Why are these changes being made?
When users manage their domains, they need to be aware if their site has an active redirect configuration that affects all domains. Currently, there's no indication on the domains page that a redirect is active, which can lead to confusion when users see their domains but don't understand why they're redirecting to another location. This change provides clear visibility into redirect status and easy access to manage redirect settings directly from the domains page.

## Testing Instructions
1. **Test with no redirect:**
   - Navigate to `/sites/{site-slug}/domains` for a site without redirect
   - Verify no warning notice appears

2. **Test with active redirect:**
   - Set up a site redirect via `/sites/{site-slug}/settings/redirect`
   - Navigate to `/sites/{site-slug}/domains`
   - Verify warning notice appears with:
     - Site name in bold
     - Redirect destination in bold
     - Clickable "click here" link
   - Click the link and verify it navigates to redirect settings page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
