### PR TITLE
v2 HD - Scheduled Updates: Implement Active status toggle

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/hooks/use-toggle-schedule-active.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-toggle-schedule-active.ts
@@ -1,4 +1,8 @@
-import { setSiteUpdateScheduleActive, type UpdateSchedule } from '@automattic/api-core';
+import {
+	setSiteUpdateScheduleActive,
+	type HostingUpdateSchedulesResponse,
+	type UpdateSchedule,
+} from '@automattic/api-core';
 import {
 	hostingUpdateSchedulesQuery,
 	queryClient,
@@ -19,7 +23,9 @@ export function useToggleScheduleActive() {
 			const siteQuery = siteUpdateSchedulesQuery( siteId );
 			const prevSite = queryClient.getQueryData< UpdateSchedule[] >( siteQuery.queryKey );
 			const hostingQuery = hostingUpdateSchedulesQuery();
-			const prevHosting = queryClient.getQueryData( hostingQuery.queryKey );
+			const prevHosting = queryClient.getQueryData< HostingUpdateSchedulesResponse >(
+				hostingQuery.queryKey
+			);
 
 			// Optimistically update site list
 			if ( prevSite ) {
@@ -30,9 +36,9 @@ export function useToggleScheduleActive() {
 			}
 
 			// Optimistically update hosting list
-			if ( prevHosting && typeof prevHosting === 'object' && 'sites' in prevHosting ) {
+			if ( prevHosting?.sites ) {
 				const key = String( siteId );
-				if ( prevHosting.sites?.[ key ]?.[ scheduleId ] ) {
+				if ( prevHosting.sites[ key ]?.[ scheduleId ] ) {
 					const cloned = JSON.parse( JSON.stringify( prevHosting ) );
 					cloned.sites[ key ][ scheduleId ].active = active;
 					queryClient.setQueryData( hostingQuery.queryKey, cloned );

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-toggle-schedule-active.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-toggle-schedule-active.ts
@@ -1,0 +1,63 @@
+import { setSiteUpdateScheduleActive, type UpdateSchedule } from '@automattic/api-core';
+import {
+	hostingUpdateSchedulesQuery,
+	queryClient,
+	siteUpdateSchedulesQuery,
+} from '@automattic/api-queries';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Toggle schedule active state with optimistic updates, mirroring legacy behavior.
+ * Keeps parity with v1 while matching v2 hook style.
+ */
+export function useToggleScheduleActive() {
+	const mutateAsync = useCallback(
+		async ( variables: { siteId: number; scheduleId: string; active: boolean } ) => {
+			const { siteId, scheduleId, active } = variables;
+
+			// Snapshot previous caches
+			const siteQuery = siteUpdateSchedulesQuery( siteId );
+			const prevSite = queryClient.getQueryData< UpdateSchedule[] >( siteQuery.queryKey );
+			const hostingQuery = hostingUpdateSchedulesQuery();
+			const prevHosting = queryClient.getQueryData( hostingQuery.queryKey );
+
+			// Optimistically update site list
+			if ( prevSite ) {
+				const nextSite = prevSite.map( ( item ) =>
+					item.id === scheduleId ? { ...item, active } : item
+				);
+				queryClient.setQueryData( siteQuery.queryKey, nextSite );
+			}
+
+			// Optimistically update hosting list
+			if ( prevHosting && typeof prevHosting === 'object' && 'sites' in prevHosting ) {
+				const key = String( siteId );
+				if ( prevHosting.sites?.[ key ]?.[ scheduleId ] ) {
+					const cloned = JSON.parse( JSON.stringify( prevHosting ) );
+					cloned.sites[ key ][ scheduleId ].active = active;
+					queryClient.setQueryData( hostingQuery.queryKey, cloned );
+				}
+			}
+
+			try {
+				await setSiteUpdateScheduleActive( siteId, scheduleId, active );
+			} catch ( e ) {
+				// Rollback on error
+				if ( prevSite ) {
+					queryClient.setQueryData( siteQuery.queryKey, prevSite );
+				}
+				if ( prevHosting ) {
+					queryClient.setQueryData( hostingQuery.queryKey, prevHosting );
+				}
+				throw e;
+			}
+
+			// Invalidate to refetch fresh data
+			await queryClient.invalidateQueries( siteQuery );
+			await queryClient.invalidateQueries( hostingQuery );
+		},
+		[]
+	);
+
+	return { mutateAsync } as const;
+}

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,7 +1,4 @@
-// no imports from api-queries needed here
-// Toggle uses v2 hook with optimistic updates
 import { useLocale } from '@automattic/i18n-utils';
-//
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -1,5 +1,7 @@
 // no imports from api-queries needed here
+// Toggle uses v2 hook with optimistic updates
 import { useLocale } from '@automattic/i18n-utils';
+//
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -7,7 +9,7 @@ import { DataViews, type Field, filterSortAndPaginate, View } from '@wordpress/d
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import {
 	pluginsScheduledUpdatesEditRoute,
 	pluginsScheduledUpdatesNewRoute,
@@ -23,6 +25,7 @@ import { formatDate } from '../../utils/datetime';
 import { prepareScheduleName } from './helpers';
 import { useDeleteSchedules } from './hooks/use-delete-schedules';
 import { useScheduledUpdates } from './hooks/use-scheduled-updates';
+import { useToggleScheduleActive } from './hooks/use-toggle-schedule-active';
 import { ScheduledUpdateRow } from './types';
 
 // Create stable mapping for unique schedule names with invisible suffixes
@@ -40,7 +43,10 @@ const getUniqueScheduleName = ( () => {
 	};
 } )();
 
-const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
+const getFields = (
+	locale: string,
+	onToggleActive: ( item: ScheduledUpdateRow, active: boolean ) => void
+): Field< ScheduledUpdateRow >[] => {
 	return [
 		{
 			id: 'site',
@@ -105,7 +111,14 @@ const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
 			id: 'active',
 			type: 'text',
 			label: __( 'Active' ),
-			render: ( { item } ) => <FormToggle checked={ item.active } onChange={ () => {} } />,
+			render: ( { item } ) => (
+				<FormToggle
+					checked={ item.active }
+					onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+						onToggleActive( item, e.target.checked )
+					}
+				/>
+			),
 		},
 		{
 			id: 'actions',
@@ -148,7 +161,18 @@ export default function PluginsScheduledUpdates() {
 	const [ isDeletingSchedule, setIsDeletingSchedule ] = useState( false );
 	const locale = useLocale();
 	const navigate = useNavigate();
-	const fields = useMemo( () => getFields( locale ), [ locale ] );
+	const { mutateAsync: toggleActive } = useToggleScheduleActive();
+	const handleToggleActive = useCallback(
+		( item: ScheduledUpdateRow, active: boolean ) => {
+			void toggleActive( { siteId: item.site.ID, scheduleId: item.scheduleId, active } );
+		},
+		[ toggleActive ]
+	);
+
+	const fields = useMemo(
+		() => getFields( locale, handleToggleActive ),
+		[ locale, handleToggleActive ]
+	);
 
 	const { isLoading, scheduledUpdates } = useScheduledUpdates();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );

--- a/packages/api-core/src/site-update-schedules/mutators.ts
+++ b/packages/api-core/src/site-update-schedules/mutators.ts
@@ -37,3 +37,16 @@ export async function deleteSiteUpdateSchedule(
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+// Single-site active toggle
+export async function setSiteUpdateScheduleActive(
+	siteId: number,
+	scheduleId: string,
+	active: boolean
+): Promise< unknown > {
+	return await wpcom.req.post( {
+		path: `/sites/${ siteId }/update-schedules/${ scheduleId }/active`,
+		apiNamespace: 'wpcom/v2',
+		body: { active },
+	} );
+}

--- a/packages/api-queries/src/site-update-schedules.ts
+++ b/packages/api-queries/src/site-update-schedules.ts
@@ -5,9 +5,11 @@ import {
 	createSiteUpdateSchedule,
 	editSiteUpdateSchedule,
 	deleteSiteUpdateSchedule,
+	setSiteUpdateScheduleActive,
 	fetchSiteUpdateSchedules,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { hostingUpdateSchedulesQuery } from './hosting-update-schedules';
 import { queryClient } from './query-client';
 
 // Query: single-site schedules
@@ -56,6 +58,17 @@ export const siteUpdateScheduleDeleteMutation = ( siteId: number ) =>
 		mutationFn: ( scheduleId: string ) => deleteSiteUpdateSchedule( siteId, scheduleId ),
 		onSuccess: () => {
 			invalidateSiteUpdateSchedules( siteId );
+		},
+	} );
+
+// Mutation: toggle active for any site (siteId provided in variables)
+export const siteUpdateScheduleSetActiveMutation = () =>
+	mutationOptions( {
+		mutationFn: ( variables: { siteId: number; scheduleId: string; active: boolean } ) =>
+			setSiteUpdateScheduleActive( variables.siteId, variables.scheduleId, variables.active ),
+		onSuccess: ( _data, variables ) => {
+			invalidateSiteUpdateSchedules( variables.siteId );
+			queryClient.invalidateQueries( hostingUpdateSchedulesQuery() );
 		},
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/DSGCOM-213/schedule-updates-overview

## Proposed Changes

* The PR implements the Active status toggle in the main scheduled updates list
* The operation is an optimistic update, which allows for a more seamless UX in this case (the user sees the change immediately, not having to wait for the network call)
* We follow a similar approach to other queries/hooks. We keep the data layer lean, and handle the optimistic part or more complex logic through a custom hook on the consuming side. This has been a design decision from the start.

<img width="700" alt="Screenshot 2025-10-17 at 1 36 17 PM" src="https://github.com/user-attachments/assets/8335d986-a6b7-4034-859e-bf5fffaeb156" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/DSGCOM-213/schedule-updates-overview

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/plugins/scheduled-updates` and create a schedule
* In the main list view, change the "Active" status through the toggle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
