### PR TITLE
Hosting dashboard: Add site redirect entry in site settings summary

### DIFF
--- a/client/dashboard/sites/settings-redirect/summary.tsx
+++ b/client/dashboard/sites/settings-redirect/summary.tsx
@@ -1,0 +1,31 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Site } from '@automattic/api-core';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function SiteRedirectSettingsSummary( {
+	site,
+	density,
+}: {
+	site: Site;
+	density?: Density;
+} ) {
+	let badges = [];
+	if ( site.options?.is_redirect ) {
+		badges = [ { text: __( 'Enabled' ), intent: 'success' as const } ];
+	} else {
+		badges = [ { text: __( 'Disabled' ) } ];
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/site-redirect` }
+			title={ __( 'Site redirect' ) }
+			density={ density }
+			decoration={ <Icon icon={ globe } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -13,6 +13,7 @@ import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
 import HundredYearPlanSettingsSummary from '../settings-hundred-year-plan/summary';
 import PHPSettingsSummary from '../settings-php/summary';
 import PrimaryDataCenterSettingsSummary from '../settings-primary-data-center/summary';
+import SiteRedirectSettingsSummary from '../settings-redirect/summary';
 import RepositoriesSettingsSummary from '../settings-repositories/summary';
 import SftpSshSettingsSummary from '../settings-sftp-ssh/summary';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
@@ -34,6 +35,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<SectionHeader title={ __( 'General' ) } level={ 3 } />
 				<SummaryButtonList>
 					<SiteVisibilitySettingsSummary site={ site } />
+					<SiteRedirectSettingsSummary site={ site } />
 					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
 					<AgencySettingsSummary site={ site } />
 					<HundredYearPlanSettingsSummary site={ site } settings={ settings } />


### PR DESCRIPTION
Closes [DOTDASH-662](https://linear.app/a8c/issue/DOTDASH-662)

## Proposed Changes
Add a site redirect settings summary component to the main settings dashboard that displays redirect status and provides quick access to redirect configuration.

## Why are these changes being made?
We need to a link to access site redirect configuration page.

<img width="1598" height="678" alt="site-redirect-off" src="https://github.com/user-attachments/assets/cd81c8d0-962e-4d7e-8ba3-a5d2ad8dab09" />
<img width="1444" height="570" alt="site-redirect-on" src="https://github.com/user-attachments/assets/15e4354d-c817-49ef-a327-2f6971ac3823" />

## Testing Instructions
- For sites with redirect enabled: Verify "Enabled" badge appears
- For sites with redirect disabled: Verify "Disabled" badge appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
