### PR TITLE
Streamlined pricing cleanup: Rename remaining experiment referrence

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -319,7 +319,7 @@ const ProductTitleAreaForCostOverridesList = styled.div`
 	}
 `;
 
-const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
+const SimplifiedSingleProductAndCostOverridesListWrapper = styled(
 	SingleProductAndCostOverridesListWrapper
 )`
 	padding-left: 24px;
@@ -331,7 +331,7 @@ const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
 	}
 `;
 
-const StreamlinedLineItemPriceWrapper = styled.span`
+const SimplifiedLineItemPriceWrapper = styled.span`
 	display: flex;
 	flex: 0 0 auto;
 	gap: 4px;
@@ -352,7 +352,7 @@ const StreamlinedLineItemPriceWrapper = styled.span`
 	}
 `;
 
-const StreamlinedLineItemPrice = function ( {
+const SimplifiedLineItemPrice = function ( {
 	actualAmount,
 	crossedOutAmount,
 }: {
@@ -360,10 +360,10 @@ const StreamlinedLineItemPrice = function ( {
 	crossedOutAmount?: string;
 } ) {
 	return (
-		<StreamlinedLineItemPriceWrapper>
+		<SimplifiedLineItemPriceWrapper>
 			{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
 			<span>{ actualAmount }</span>
-		</StreamlinedLineItemPriceWrapper>
+		</SimplifiedLineItemPriceWrapper>
 	);
 };
 
@@ -421,17 +421,17 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	}
 
 	return (
-		<StreamlinedSingleProductAndCostOverridesListWrapper>
+		<SimplifiedSingleProductAndCostOverridesListWrapper>
 			<WPCheckoutCheckIcon />
 			<ProductTitleAreaForCostOverridesList>
 				<span className="cost-overrides-list-product__title">{ label }</span>
-				<StreamlinedLineItemPrice
+				<SimplifiedLineItemPrice
 					actualAmount={ actualAmountDisplay }
 					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 				/>
 			</ProductTitleAreaForCostOverridesList>
 			<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
-		</StreamlinedSingleProductAndCostOverridesListWrapper>
+		</SimplifiedSingleProductAndCostOverridesListWrapper>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [M4R73CH-1029](https://linear.app/a8c/issue/M4R73CH-1029/cleanup-experiment-code)

## Proposed Changes

* renames a few components that are named after the streamlined experiment

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  removing experiment code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using EUR and IDR (intro offer) go through the `/setup/onboarding` flow
* Ensure the are no visible style differences on checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
