### PR TITLE
Show the "Renew now" action only for domains that you're the owner of

### DIFF
--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -37,7 +37,7 @@ export function isRecentlyRegistered( registrationDate: string, numberOfMinutes 
 	);
 }
 
-export function isDomainRenewable( domain: DomainSummary ) {
+export function isDomainRenewable( domain: DomainSummary ): boolean {
 	// Only registered domains can be manually renewed
 	if ( ! isRegisteredDomain( domain ) ) {
 		return false;
@@ -45,6 +45,7 @@ export function isDomainRenewable( domain: DomainSummary ) {
 
 	return (
 		!! domain.subscription_id &&
+		!! domain.current_user_is_owner &&
 		! [
 			DomainStatus.PENDING_RENEWAL,
 			DomainStatus.PENDING_TRANSFER,


### PR DESCRIPTION
We need to show the "Renew now" action only for domains that you own

Part of [DOMAINS-1728: Show the "Renew now" action only for domains that you're the owner of](https://linear.app/a8c/issue/DOMAINS-1728/show-the-renew-now-action-only-for-domains-that-youre-the-owner-of)

## Proposed Changes

* Fix the isDomainRenewable to check the current_user_is_owner too

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because if you don't own a domain you can't really renew it

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go the the domains list and verify that you don't see the "Renew now" action for domains that you don't own

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
