### PR TITLE
Add default filter in the all Domains view in the Hosting Dashboard that would show only domains that you own

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -91,12 +91,27 @@ export const useFields = ( {
 				},
 				getValue: ( { item }: { item: DomainSummary } ) => item.subtype.id,
 			},
-			// {
-			// 	id: 'owner',
-			// 	label: __( 'Owner' ),
-			// 	enableHiding: false,
-			// 	enableSorting: true,
-			// },
+			{
+				id: 'owner',
+				label: __( 'Owner' ),
+				enableHiding: true,
+				enableSorting: true,
+				elements: [
+					{ value: 'owned-by-me', label: __( 'Me' ) },
+					{ value: 'owned-by-someone-else', label: __( 'Someone else' ) },
+				],
+				filterBy: {
+					operators: [ 'isAny' as Operator ],
+				},
+				getValue: ( { item }: { item: DomainSummary } ) =>
+					item?.current_user_is_owner ? 'owned-by-me' : 'owned-by-someone-else',
+				render: ( { field, item } ) =>
+					field.getValue( { item } ) === 'owned-by-me' ? (
+						<Text intent="success">{ __( 'Owned by me' ) }</Text>
+					) : (
+						<IneligibleIndicator />
+					),
+			},
 			{
 				id: 'blog_name',
 				label: __( 'Site' ),

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -35,6 +35,11 @@ function Domains() {
 					DomainSubtype.DOMAIN_CONNECTION,
 				],
 			},
+			{
+				field: 'owner',
+				operator: 'isAny',
+				value: [ 'owned-by-me' ],
+			},
 		],
 	} ) );
 


### PR DESCRIPTION
This one adds a default filter by Owner in the All domains list. I think it's useful to have all domains listed in there in case you want to see domains that you're not the owner of so we can use the default filter of the datagrid

Part of [DOMAINS-1723: Add `Owned by me" column in the All domains list](https://linear.app/a8c/issue/DOMAINS-1723/add-owned-by-me-column-in-the-all-domains-list)

The filter looks like this:

<img width="406" height="292" alt="Screenshot 2025-10-17 at 16 06 18" src="https://github.com/user-attachments/assets/3421a705-f147-4afd-b0f0-094c23003e11" />

## Proposed Changes

* Add new Owner field and a default filter in the All domains list

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to show only domains that you're the owner of in the all domains list

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/domains` and verify that you see only domains that you're the owner of (that's a default filter applied to the view). Click on the filter and try the different options for filter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
