### PR TITLE
Remove enums and replace them with objects and custom types

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -114,8 +114,9 @@ export const useActions = ( { user, site }: { user: User; site?: Site } ) => {
 					} );
 				},
 				isEligible: ( item: DomainSummary ) => {
-					return [ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
-						item.subtype.id
+					return (
+						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
+						item.subtype.id === DomainSubtype.DOMAIN_REGISTRATION
 					);
 				},
 			},

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -28,11 +28,9 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 	}
 
 	if (
-		[
-			DomainSubtype.DOMAIN_REGISTRATION,
-			DomainSubtype.DOMAIN_CONNECTION,
-			DomainSubtype.DOMAIN_TRANSFER,
-		].includes( domain.subtype.id ) &&
+		( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
+			domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION ||
+			domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER ) &&
 		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC &&
 		domain.can_manage_dns_records
 	) {
@@ -60,11 +58,9 @@ export default function DomainOverviewSettings( { domain }: { domain: Domain } )
 	 * mapping. Right now I copied the code from the original code but it seems wrong
 	 */
 	if (
-		[
-			DomainSubtype.DOMAIN_REGISTRATION,
-			DomainSubtype.DOMAIN_CONNECTION,
-			DomainSubtype.DOMAIN_TRANSFER,
-		].includes( domain.subtype.id ) &&
+		( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
+			domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION ||
+			domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER ) &&
 		domain.transfer_status !== DomainTransferStatus.PENDING_ASYNC
 	) {
 		buttonListItems.push( <DomainSecuritySettingsSummary key="security" domain={ domain } /> );

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -46,12 +46,12 @@ export function isDomainRenewable( domain: DomainSummary ): boolean {
 	return (
 		!! domain.subscription_id &&
 		!! domain.current_user_is_owner &&
-		! [
-			DomainStatus.PENDING_RENEWAL,
-			DomainStatus.PENDING_TRANSFER,
-			DomainStatus.PENDING_REGISTRATION,
-			DomainStatus.EXPIRED_IN_AUCTION,
-		].includes( domain.domain_status.id )
+		! (
+			domain.domain_status.id === DomainStatus.PENDING_RENEWAL ||
+			domain.domain_status.id === DomainStatus.PENDING_TRANSFER ||
+			domain.domain_status.id === DomainStatus.PENDING_REGISTRATION ||
+			domain.domain_status.id === DomainStatus.EXPIRED_IN_AUCTION
+		)
 	);
 }
 
@@ -99,9 +99,8 @@ export function shouldUpgradeToMakeDomainPrimary( {
 	user: User;
 } ) {
 	return (
-		[ DomainSubtype.DOMAIN_CONNECTION, DomainSubtype.DOMAIN_REGISTRATION ].includes(
-			domain.subtype.id
-		) &&
+		( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
+			domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION ) &&
 		! domain.primary_domain &&
 		userHasFlag( user, 'calypso_allow_nonprimary_domains_without_plan' ) &&
 		!! site.plan?.is_free &&

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -1,9 +1,11 @@
-export enum DomainTypes {
-	MAPPED = 'mapping',
-	SITE_REDIRECT = 'redirect',
-	WPCOM = 'wpcom',
-	TRANSFER = 'transfer',
-}
+export const DomainTypes = {
+	MAPPED: 'mapping',
+	SITE_REDIRECT: 'redirect',
+	WPCOM: 'wpcom',
+	TRANSFER: 'transfer',
+} as const;
+
+export type DomainTypes = ( typeof DomainTypes )[ keyof typeof DomainTypes ];
 
 export const DomainTransferStatus = {
 	PENDING_OWNER: 'pending_owner',
@@ -17,28 +19,32 @@ export const DomainTransferStatus = {
 export type DomainTransferStatus =
 	( typeof DomainTransferStatus )[ keyof typeof DomainTransferStatus ];
 
-export enum DomainSubtype {
-	DEFAULT_ADDRESS = 'default_address',
-	DOMAIN_CONNECTION = 'domain_connection',
-	DOMAIN_REGISTRATION = 'domain_registration',
-	DOMAIN_TRANSFER = 'domain_transfer',
-	SITE_REDIRECT = 'site_redirect',
-}
+export const DomainSubtype = {
+	DEFAULT_ADDRESS: 'default_address',
+	DOMAIN_CONNECTION: 'domain_connection',
+	DOMAIN_REGISTRATION: 'domain_registration',
+	DOMAIN_TRANSFER: 'domain_transfer',
+	SITE_REDIRECT: 'site_redirect',
+} as const;
 
-export enum DomainStatus {
-	ACTIVE = 'active',
-	IN_PROGRESS = 'in_progress',
-	EXPIRED = 'expired',
-	EXPIRED_IN_AUCTION = 'expired_in_auction',
-	PENDING_RENEWAL = 'pending_renewal',
-	PENDING_TRANSFER = 'pending_transfer',
-	EXPIRING_SOON = 'expiring_soon',
-	TRANSFER_COMPLETED = 'transfer_completed',
-	CONNECTION_ERROR = 'connection_error',
-	TRANSFER_PENDING = 'transfer_pending',
-	TRANSFER_ERROR = 'transfer_error',
-	PENDING_REGISTRATION = 'pending_registration',
-}
+export type DomainSubtype = ( typeof DomainSubtype )[ keyof typeof DomainSubtype ];
+
+export const DomainStatus = {
+	ACTIVE: 'active',
+	IN_PROGRESS: 'in_progress',
+	EXPIRED: 'expired',
+	EXPIRED_IN_AUCTION: 'expired_in_auction',
+	PENDING_RENEWAL: 'pending_renewal',
+	PENDING_TRANSFER: 'pending_transfer',
+	EXPIRING_SOON: 'expiring_soon',
+	TRANSFER_COMPLETED: 'transfer_completed',
+	CONNECTION_ERROR: 'connection_error',
+	TRANSFER_PENDING: 'transfer_pending',
+	TRANSFER_ERROR: 'transfer_error',
+	PENDING_REGISTRATION: 'pending_registration',
+} as const;
+
+export type DomainStatus = ( typeof DomainStatus )[ keyof typeof DomainStatus ];
 
 export const DomainStatusCta = {
 	VIEW_DOMAIN: 'view_domain',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1721: Change enums for DomainSubtype and DomainStatus to objects](https://linear.app/a8c/issue/DOMAINS-1721/change-enums-for-domainsubtype-and-domainstatus-to-objects)

## Proposed Changes

* As discussed in Slack we should not use enums and we opt-in for objects of properties and a custom type

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the code consistent with the rest of the Hosting Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that there are no type errors
* Click around domains and verify nothing is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
