### PR TITLE
Update more v2 plan links to use the plans-grid flow

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -40,6 +40,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreVertical, calendar, currencyDollar, commentAuthorAvatar } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -105,7 +106,12 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 		return `/plans/storage/${ purchase.site_slug }`;
 	}
 
-	return `/plans/${ purchase.site_slug }`;
+	const backUrl = window.location.href.replace( window.location.origin, '' );
+	return addQueryArgs( '/setup/plan-upgrade', {
+		siteSlug: purchase.site_slug,
+		redirect_to: backUrl,
+		cancel_to: backUrl,
+	} );
 }
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -7,7 +7,6 @@ import {
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 	DomainTransferStatus,
-	JetpackPlans,
 } from '@automattic/api-core';
 import {
 	domainQuery,
@@ -73,6 +72,7 @@ import {
 	isTitanMail,
 	isGoogleWorkspace,
 	getRenewalUrlFromPurchase,
+	isJetpackT1SecurityPlan,
 } from '../../../utils/purchase';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import { getPurchaseUrlForId } from '../urls';
@@ -128,15 +128,6 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	}
 
 	return `/plans/${ purchase.site_slug }`;
-}
-
-function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
-	const securityT1Slugs = [
-		JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
-		JetpackPlans.PLAN_JETPACK_SECURITY_T1_MONTHLY,
-		JetpackPlans.PLAN_JETPACK_SECURITY_T1_BI_YEARLY,
-	] as const;
-	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -7,6 +7,7 @@ import {
 	WPCOM_DIFM_LITE,
 	OFFSITE_REDIRECT,
 	DomainTransferStatus,
+	JetpackPlans,
 } from '@automattic/api-core';
 import {
 	domainQuery,
@@ -102,7 +103,7 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 		return `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }`;
 	}
 
-	if ( purchase.is_jetpack_backup_t1 ) {
+	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
 		return `/plans/storage/${ purchase.site_slug }`;
 	}
 
@@ -114,7 +115,7 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 }
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {
-	if ( purchase.is_jetpack_backup_t1 ) {
+	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
 		return `/plans/storage/${ purchase.site_slug }`;
 	}
 
@@ -127,6 +128,15 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	}
 
 	return `/plans/${ purchase.site_slug }`;
+}
+
+function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
+	const securityT1Slugs = [
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_MONTHLY,
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_BI_YEARLY,
+	] as const;
+	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -106,19 +106,36 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 		return `/plans/storage/${ purchase.site_slug }`;
 	}
 
-	const backUrl = window.location.href.replace( window.location.origin, '' );
-	return addQueryArgs( '/setup/plan-upgrade', {
-		siteSlug: purchase.site_slug,
-		redirect_to: backUrl,
-		cancel_to: backUrl,
-	} );
+	if ( purchase.is_jetpack_plan_or_product ) {
+		return `/plans/${ purchase.site_slug }`;
+	}
+
+	return getWpcomPlanGridUrl( purchase.site_slug );
 }
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	if ( purchase.is_jetpack_backup_t1 ) {
 		return `/plans/storage/${ purchase.site_slug }`;
 	}
+
+	if ( purchase.is_jetpack_plan_or_product ) {
+		return `/plans/${ purchase.site_slug }`;
+	}
+
+	if ( purchase.is_plan ) {
+		return getWpcomPlanGridUrl( purchase.site_slug );
+	}
+
 	return `/plans/${ purchase.site_slug }`;
+}
+
+function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
+	const backUrl = window.location.href.replace( window.location.origin, '' );
+	return addQueryArgs( '/setup/plan-upgrade', {
+		...( siteSlug && { siteSlug } ),
+		redirect_to: backUrl,
+		cancel_to: backUrl,
+	} );
 }
 
 function canPurchaseBeUpgraded( purchase: Purchase ): boolean {

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -111,7 +111,7 @@ function WpcomPlanCard( {
 
 	const getBillingLinkProps = () => {
 		if ( isFreePlan ) {
-			return { externalLink: `/plans/${ site.slug }` };
+			return { externalLink: `/setup/plan-upgrade?siteSlug=${ site.slug }` };
 		}
 
 		if ( ! isDashboardBackport() ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -6,6 +6,7 @@ import {
 	WPCOM_DIFM_LITE,
 	PRODUCT_1GB_SPACE,
 	JETPACK_SEARCH_PRODUCTS,
+	JetpackPlans,
 } from '@automattic/api-core';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
@@ -381,6 +382,15 @@ export function isTieredVolumeSpaceAddon( product: ObjectWithProductSlug ): bool
  */
 export function isJetpackSearch( product: ObjectWithProductSlug ): boolean {
 	return product.product_slug ? JETPACK_SEARCH_PRODUCTS.includes( product.product_slug ) : false;
+}
+
+export function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
+	const securityT1Slugs = [
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_MONTHLY,
+		JetpackPlans.PLAN_JETPACK_SECURITY_T1_BI_YEARLY,
+	] as const;
+	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
 function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14978

## Proposed Changes

This change updates the new billing dashboard as well as the overview plan card for free sites to point to /setup/plan-upgrade 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So that the user can choose the plan on the distraction-less plans-grid rather than the old grid presented in the site context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Billing Dashboard

1. Use the calypso live link in the comment below
2. Go to /v2/sites/
3. Choose a site on a paid plan
4. Click on the Plan card at the right of the site overview
5. You should find yourself on the billing dashboard for that purchase
6. Click on the two upgrade links, you should find yourself at the distraction-less plans-grid.


https://github.com/user-attachments/assets/d8cb3346-19a7-4654-9250-5a0928110da5



### Site overview

1. Use the calypso live link in the comment below
2. Go to /v2/sites/
3. Choose a site on the free plan
8. Click on the Plan card at the right of the site overview
9. You should find yourself at the distraction-less plans-grid

https://github.com/user-attachments/assets/5f9b43dd-bac1-4f9a-b234-580e9e6dfb37


To be thorough, test also with other sites/purchases e.g. a Jetpack plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
