### PR TITLE
Staging Sites: Add subheading to Sync modal and adjust styling

### DIFF
--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -456,7 +456,7 @@ function StagingSiteSyncModalInner( {
 								spacing={ 2 }
 								justify="space-between"
 								alignment="center"
-								style={ { paddingBottom: '4px', marginTop: '-4px' } }
+								style={ { padding: '4px 0', marginTop: '-8px' } }
 							>
 								<CheckboxControl
 									__nextHasNoMarginBottom
@@ -518,8 +518,8 @@ function StagingSiteSyncModalInner( {
 								alignment="left"
 								spacing={ 2 }
 								style={ {
-									padding: '15px 0',
-									marginTop: isFileBrowserVisible ? '16px' : '0',
+									padding: '16px 0',
+									marginTop: isFileBrowserVisible ? '12px' : '0',
 								} }
 							>
 								<CheckboxControl

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -452,7 +452,7 @@ function StagingSiteSyncModalInner( {
 								spacing={ 2 }
 								justify="space-between"
 								alignment="center"
-								style={ { padding: '4px 0' } }
+								style={ { padding: '0 0 4px 0' } }
 							>
 								<CheckboxControl
 									__nextHasNoMarginBottom

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -485,7 +485,7 @@ function StagingSiteSyncModalInner( {
 
 							<div
 								hidden={ ! isFileBrowserVisible }
-								style={ { border: '1px solid #dcdcde', borderRadius: '2px', padding: '12px 32px' } }
+								style={ { border: '1px solid #dcdcde', borderRadius: '2px', padding: '12px 24px' } }
 							>
 								<VStack spacing={ 4 }>
 									<HStack>

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -13,6 +13,7 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
 	CheckboxControl,
 	SelectControl,
 } from '@wordpress/components';
@@ -97,6 +98,7 @@ const EnvironmentLabel = ( { environmentType, siteTitle }: EnvironmentLabelProps
 };
 interface EnvironmentConfig {
 	title: string;
+	subTitle: string;
 	description: string;
 	syncFrom: EnvironmentType;
 	syncTo: EnvironmentType;
@@ -114,6 +116,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 		return {
 			staging: {
 				title: __( 'Pull from Production' ),
+				subTitle: __( 'What would you like to pull?' ),
 				description: __(
 					'Pulling will replace the existing files and database of the staging site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 				),
@@ -122,6 +125,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 			},
 			production: {
 				title: __( 'Pull from Staging' ),
+				subTitle: __( 'What would you like to pull?' ),
 				description: __(
 					'Pulling will replace the existing files and database of the production site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 				),
@@ -136,6 +140,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 	return {
 		staging: {
 			title: __( 'Push to Production' ),
+			subTitle: __( 'What would you like to push?' ),
 			description: __(
 				'Pushing will replace the existing files and database of the production site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 			),
@@ -144,6 +149,7 @@ const getSyncConfig = ( type: 'pull' | 'push' ): SyncConfig => {
 		},
 		production: {
 			title: __( 'Push to Staging' ),
+			subTitle: __( 'What would you like to push?' ),
 			description: __(
 				'Pushing will replace the existing files and database of the staging site. An automatic backup will be created of your environment, so you can revert it if needed in <a>Activity log</a>.'
 			),
@@ -399,11 +405,15 @@ function StagingSiteSyncModalInner( {
 						a: <ExternalLink href={ `/activity-log/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
-				<HStack spacing={ 4 } alignment="left">
+				<HStack spacing={ 4 } alignment="left" style={ { height: '40px' } }>
 					<EnvironmentLabel environmentType={ sourceEnvironment } siteTitle={ sourceSiteTitle } />
 					<DirectionArrow />
 					<EnvironmentLabel environmentType={ targetEnvironment } siteTitle={ targetSiteTitle } />
 				</HStack>
+				<CardDivider />
+				<Heading lineHeight="28px" size={ 11 } weight={ 500 } upperCase>
+					{ syncConfig[ environment ].subTitle }
+				</Heading>
 				{ /* File selection and database controls */ }
 				<VStack spacing={ 5 }>
 					{ shouldDisableGranularSync ? (
@@ -469,11 +479,21 @@ function StagingSiteSyncModalInner( {
 								/>
 							</HStack>
 
-							<div hidden={ ! isFileBrowserVisible }>
+							<div
+								hidden={ ! isFileBrowserVisible }
+								style={ { border: '1px solid #dcdcde', borderRadius: '2px', padding: '12px 32px' } }
+							>
 								<VStack spacing={ 4 }>
-									<CardDivider />
+									<HStack>
+										<FileBrowser
+											rewindId={ rewindId }
+											siteId={ querySiteId }
+											siteSlug={ querySiteSlug as string }
+											fileBrowserConfig={ fileBrowserConfig }
+										/>
+									</HStack>
 									{ displayBackupDate && (
-										<HStack alignment="left" spacing={ 1 } style={ { marginInlineStart: '14px' } }>
+										<HStack alignment="left" spacing={ 1 }>
 											<Text variant="muted">
 												{ createInterpolateElement(
 													__( 'Content from the latest backup: <date />.' ),
@@ -488,24 +508,12 @@ function StagingSiteSyncModalInner( {
 											</Text>
 										</HStack>
 									) }
-									<HStack style={ { marginInlineStart: '14px' } }>
-										<FileBrowser
-											rewindId={ rewindId }
-											siteId={ querySiteId }
-											siteSlug={ querySiteSlug as string }
-											fileBrowserConfig={ fileBrowserConfig }
-										/>
-									</HStack>
 								</VStack>
 							</div>
 							<HStack
 								alignment="left"
 								spacing={ 2 }
 								style={ {
-									borderTop: '1px solid var(--wp-components-color-gray-300, #ddd)',
-									borderBottom: hasWarning
-										? 'none'
-										: '1px solid var(--wp-components-color-gray-300, #ddd)',
 									padding: '15px 0',
 									marginTop: isFileBrowserVisible ? '16px' : '0',
 								} }

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -456,7 +456,7 @@ function StagingSiteSyncModalInner( {
 								spacing={ 2 }
 								justify="space-between"
 								alignment="center"
-								style={ { padding: '0 0 4px 0' } }
+								style={ { paddingBottom: '4px' } }
 							>
 								<CheckboxControl
 									__nextHasNoMarginBottom

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -456,7 +456,7 @@ function StagingSiteSyncModalInner( {
 								spacing={ 2 }
 								justify="space-between"
 								alignment="center"
-								style={ { paddingBottom: '4px' } }
+								style={ { paddingBottom: '4px', marginTop: '-4px' } }
 							>
 								<CheckboxControl
 									__nextHasNoMarginBottom

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -410,10 +410,14 @@ function StagingSiteSyncModalInner( {
 					<DirectionArrow />
 					<EnvironmentLabel environmentType={ targetEnvironment } siteTitle={ targetSiteTitle } />
 				</HStack>
-				<CardDivider />
-				<Heading lineHeight="28px" size={ 11 } weight={ 500 } upperCase>
-					{ syncConfig[ environment ].subTitle }
-				</Heading>
+				{ ! shouldDisableGranularSync && (
+					<>
+						<CardDivider />
+						<Heading lineHeight="28px" size={ 11 } weight={ 500 } upperCase>
+							{ syncConfig[ environment ].subTitle }
+						</Heading>
+					</>
+				) }
 				{ /* File selection and database controls */ }
 				<VStack spacing={ 5 }>
 					{ shouldDisableGranularSync ? (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STU-798

## Proposed Changes

This PR is a part of STU-798 task where the goal is to align designs of Staging sites Sync modal in Calypso with Sync modal in the Studio app.

Here's the related Figma design: RToz6tIuQ7nlZrikBte4GU-fi-9870_110924

In this PR we are adjusting the Staging sites Sync modal in V2 Hosting Dashboard:

* add `What would you like to push/pull?` subtitle
* remove horizontal lines between elements
* enclose the `FileBrowser` inside a bordered box
* move the `Content from the latest backup: [...]` message below the files list 
* adjust spacing of some of the modal elements to match the design

| Before | After |
|--------|--------|
| <img width="1690" height="1000" alt="Markup on 2025-10-20 at 12:37:59" src="https://github.com/user-attachments/assets/3b9f584c-2871-4e72-b336-c840fefe0c84" /> | <img width="1706" height="1186" alt="Markup on 2025-10-20 at 12:36:57" src="https://github.com/user-attachments/assets/b5cb94f4-2d0c-45d8-a28d-3620132740b9" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To align designs of Staging sites Sync modal in Calypso with Sync modal in the Studio app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link in the comment below).
2. Navigate to the Overview tab in the V2 Hosting Deashboard of a WoA site that has a staging site created: `http://calypso.localhost:3000/v2/sites/{site-slug}`.
3. Open the Sync modal and review its content.
4. The modal should still work without any issues.

ℹ️ Please note that the elements spacing doesn't match the Figma design for 100% because we would have to override the default styling of WordPress core elements. For example, I did not adjust the checkboxes spacing in the `FileBrowser` component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?