### PR TITLE
Add CTAs to some of the domain statuses

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-status.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-status.tsx
@@ -1,0 +1,61 @@
+import { DomainStatusCta } from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	domainOverviewRoute,
+	domainConnectionSetupRoute,
+	domainTransferSetupRoute,
+} from '../../app/router/domains';
+import { Text } from '../../components/text';
+import { getPurchaseUrlForId } from '../../me/billing-purchases/urls';
+import type { DomainSummary } from '@automattic/api-core';
+
+const getCtaLink = ( domain: DomainSummary ) => {
+	switch ( domain.domain_status?.cta ) {
+		case DomainStatusCta.VIEW_DOMAIN:
+			return (
+				<Link to={ domainOverviewRoute.fullPath } params={ { domainName: domain.domain } }>
+					{ __( 'Needs attention' ) }
+				</Link>
+			);
+		case DomainStatusCta.VIEW_PURCHASE:
+			if ( domain.subscription_id === null ) {
+				return null;
+			}
+			return (
+				<Link to={ getPurchaseUrlForId( domain.subscription_id ) }>
+					{ __( 'Needs attention' ) }
+				</Link>
+			);
+		case DomainStatusCta.VIEW_DOMAIN_SETUP:
+			return (
+				<Link to={ domainConnectionSetupRoute.fullPath } params={ { domainName: domain.domain } }>
+					{ __( 'Setup connection' ) }
+				</Link>
+			);
+		case DomainStatusCta.VIEW_TRANSFER_SETUP:
+			return (
+				<Link to={ domainTransferSetupRoute.fullPath } params={ { domainName: domain.domain } }>
+					{ __( 'Setup transfer' ) }
+				</Link>
+			);
+		default:
+			return null;
+	}
+};
+
+export const DomainStatusField = ( {
+	domain,
+	value,
+}: {
+	domain: DomainSummary;
+	value: string;
+} ) => {
+	return (
+		<VStack spacing={ 1 }>
+			<Text intent={ domain.domain_status.type }>{ value }</Text>
+			{ domain.domain_status?.cta && getCtaLink( domain ) }
+		</VStack>
+	);
+};

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { Text } from '../../components/text';
 import { DomainNameField } from './field-domain-name';
 import { DomainSiteField } from './field-domain-site';
+import { DomainStatusField } from './field-domain-status';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
@@ -188,7 +189,7 @@ export const useFields = ( {
 				},
 				getValue: ( { item } ) => item.domain_status.label,
 				render: ( { item } ) => {
-					return <Text intent={ item.domain_status.type }>{ item.domain_status.label }</Text>;
+					return <DomainStatusField domain={ item } value={ item.domain_status.label } />;
 				},
 			},
 		],

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -40,6 +40,15 @@ export enum DomainStatus {
 	PENDING_REGISTRATION = 'pending_registration',
 }
 
+export const DomainStatusCta = {
+	VIEW_DOMAIN: 'view_domain',
+	VIEW_PURCHASE: 'view_purchase',
+	VIEW_DOMAIN_SETUP: 'view_domain_setup',
+	VIEW_TRANSFER_SETUP: 'view_transfer_setup',
+} as const;
+
+export type DomainStatusCta = ( typeof DomainStatusCta )[ keyof typeof DomainStatusCta ];
+
 export interface DomainSummary {
 	domain: string;
 	subtype: {
@@ -60,7 +69,7 @@ export interface DomainSummary {
 		id: DomainStatus;
 		label: string;
 		type: 'success' | 'warning' | 'error';
-		cta: string;
+		cta?: DomainStatusCta;
 	};
 	subscription_id: string | null;
 	tags: string[];


### PR DESCRIPTION
We do have a new property for the domain_status called cta. We want to use it tho show the proper CTA in the domain status column in the domain list.

This is how it looks:
<img width="219" height="267" alt="Screenshot 2025-10-17 at 20 05 18" src="https://github.com/user-attachments/assets/f6bdd1a4-c813-4fae-8800-8add51934c2b" />

The difference with the design is that in the design we show the external link icon. @ollierozdarz - do we actually want to do that? Should those links open in new tabs?

Part of [DOMAINS-1726: Show CTAs for the domain statuses](https://linear.app/a8c/issue/DOMAINS-1726/show-ctas-for-the-domain-statuses)

## Proposed Changes

* Add the CTA link below the domain status

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the design of the Hosting Dashboard domains datagrid

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /v2/domains and find a domain where the Status column is not "Active" and click on the "Needs attention" link and make sure it sends you to the correct place

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
