### PR TITLE
Allow siteless purchases to load in hosting dashboard

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1058,7 +1058,7 @@ export default function PurchaseSettings() {
 	} );
 	const formattedExpiry = useFormattedTime( purchase?.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase?.renew_date ?? '' );
-	if ( ! purchase || ! site ) {
+	if ( ! purchase ) {
 		return null;
 	}
 	const upgradeUrl = getUpgradeUrl( purchase );
@@ -1141,13 +1141,15 @@ export default function PurchaseSettings() {
 					<PurchasePriceCard purchase={ purchase } />
 				</HStack>
 				<HStack spacing={ 6 } justify="flex-start" alignment="center">
-					<PurchaseSettingsCard
-						icon={ siteLogo }
-						title={ __( 'Site' ) }
-						heading={ site.name }
-						description={ purchase.site_slug }
-						link={ `/v2/sites/${ purchase.site_slug }` }
-					/>
+					{ site && (
+						<PurchaseSettingsCard
+							icon={ siteLogo }
+							title={ __( 'Site' ) }
+							heading={ site.name }
+							description={ purchase.site_slug }
+							link={ `/v2/sites/${ purchase.site_slug }` }
+						/>
+					) }
 					<PurchaseSettingsCard
 						icon={ commentAuthorAvatar }
 						title={ __( 'Owner' ) }


### PR DESCRIPTION
Resolves #SHILL-1215

## Proposed Changes

* allow purchase to load even if there is no site associated with it.

## Why are these changes being made?
Purchases without a site do not load in the hosting dashboard:
http://calypso.localhost:3000/v2/me/billing/purchases/1170154
<img width="1183" height="1123" alt="Screenshot 2025-10-17 at 10 34 03 AM" src="https://github.com/user-attachments/assets/4f17b249-42dd-46f8-b8cc-380502817635" />



## Testing Instructions

1. Purchase a siteless jetpack add-on from here: https://jetpack.com/upgrade/anti-spam
2. Navigate to http://calypso.localhost:3000/v2/me/billing/purchases and click 
Jetpack Akismet Anti-spam to manage the purchase.
3. Verify that the Purchase details load

<img width="1597" height="1092" alt="image" src="https://github.com/user-attachments/assets/bfc3274f-bd25-4b09-8675-7d0324275051" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
