### PR TITLE
Fix the Hosting Dashboard Domains list expiry field rendering, sorting and filtering

### DIFF
--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -1,70 +1,48 @@
-import { DomainSubtype } from '@automattic/api-core';
-import { Icon, __experimentalHStack as HStack } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import { caution, reusableBlock } from '@wordpress/icons';
+import { DomainSubtype, DomainStatus } from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Text } from '../../components/text';
+import { getPurchaseUrlForId } from '../../me/billing-purchases/urls';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainExpiryField = ( {
+	inOverview,
 	domain,
 	value,
-	isCompact = false,
 }: {
+	inOverview: boolean;
 	domain: DomainSummary;
 	value: string;
-	isCompact?: boolean;
 } ) => {
-	if ( ! domain.expiry ) {
+	// Site Overview does not show the Status column, so we use this column for error messages.
+	if (
+		inOverview &&
+		domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
+		domain.domain_status.id === DomainStatus.CONNECTION_ERROR
+	) {
+		return <Text intent={ domain.domain_status.type }>{ domain.domain_status.label }</Text>;
+	}
+
+	if ( domain.expiry === null ) {
 		if ( domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) {
 			return __( 'Free forever' );
 		}
 		return '-';
 	}
 
-	const isAutoRenewing = Boolean( domain.auto_renewing );
-	const isExpired = new Date( domain.expiry ) < new Date();
-	const isHundredYearDomain = Boolean( domain.tags.includes( 'hundred_year_domain' ) );
-	const renderExpiry = () => {
-		if ( isHundredYearDomain ) {
-			return sprintf(
-				/* translators: %s - The date until which a domain was paid for */
-				__( 'Paid until %s' ),
-				value
-			);
-		}
-
-		if ( isExpired ) {
-			return sprintf(
-				/* translators: %s - The date on which a domain has expired */
-				__( 'Expired on %s' ),
-				value
-			);
-		}
-
-		if ( ! isAutoRenewing ) {
-			return sprintf(
-				/* translators: %s - The date on which a domain expires */
-				__( 'Expires on %s' ),
-				value
-			);
-		}
-
-		return sprintf(
-			/* translators: %s - The future date on which a domain renews */
-			__( 'Renews on %s' ),
-			value
-		);
-	};
-
 	return (
-		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
-			{ ! isCompact && (
-				<Icon
-					icon={ isExpired || isHundredYearDomain ? caution : reusableBlock }
-					size={ 16 }
-					style={ { fill: 'currentColor' } }
-				/>
-			) }
-			<span>{ renderExpiry() }</span>
-		</HStack>
+		<VStack justify="flex-start" alignment="left" spacing={ 1 }>
+			<Text intent={ domain.expired ? 'error' : undefined }>{ value }</Text>
+			<Text variant="muted">
+				{ domain.auto_renewing ? (
+					__( 'Auto-renew is on' )
+				) : (
+					<Link to={ getPurchaseUrlForId( domain.subscription_id ?? 0 ) }>
+						{ __( 'Turn on auto-renew' ) }
+					</Link>
+				) }
+			</Text>
+		</VStack>
 	);
 };

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -153,19 +153,15 @@ export const useFields = ( {
 					return a.expiry.localeCompare( b.expiry ) * factor;
 				},
 				elements: [
-					{ value: '2-next-07-days', label: __( 'Next 7 days' ) },
-					{ value: '2-next-30-days', label: __( 'Next 30 days' ) },
-					{ value: '2-next-90-days', label: __( 'Next 90 days' ) },
-					{ value: '3-more-than-90-days', label: __( 'More than 90 days' ) },
+					{ value: '2-next-90-days', label: __( '90 days' ) },
 					{ value: '1-expired', label: __( 'Expired' ) },
-					{ value: '0-no-expiry', label: __( 'No expiry date' ) },
 				],
 				filterBy: {
 					operators: [ 'isAny' as Operator ],
 				},
 				getValue: ( { item }: { item: DomainSummary } ) => {
 					if ( ! item.expiry ) {
-						return '0-no-expiry';
+						return null;
 					}
 
 					const expiryDate = new Date( item.expiry );
@@ -177,10 +173,6 @@ export const useFields = ( {
 						return '1-expired';
 					} else if ( diffInDays <= 90 ) {
 						return '2-next-90-days';
-					} else if ( diffInDays <= 30 ) {
-						return '2-next-30-days';
-					} else if ( diffInDays <= 7 ) {
-						return '2-next-07-days';
 					}
 					return '3-more-than-90-days';
 				},

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -134,57 +134,62 @@ export const useFields = ( {
 			},
 			{
 				id: 'expiry',
-				label: __( 'Expires/Renews on' ),
+				label: __( 'Paid until' ),
 				enableHiding: false,
 				enableSorting: true,
+				sort: ( a, b, direction ) => {
+					if ( a.expiry === null && b.expiry === null ) {
+						return 0;
+					}
+					if ( a.expiry === null ) {
+						return 1;
+					}
+
+					if ( b.expiry === null ) {
+						return -1;
+					}
+
+					const factor = direction === 'asc' ? 1 : -1;
+					return a.expiry.localeCompare( b.expiry ) * factor;
+				},
 				elements: [
-					{ value: 'next-7-days', label: __( 'Next 7 days' ) },
-					{ value: 'next-30-days', label: __( 'Next 30 days' ) },
-					{ value: 'next-90-days', label: __( 'Next 90 days' ) },
-					{ value: 'expired', label: __( 'Expired' ) },
+					{ value: '2-next-07-days', label: __( 'Next 7 days' ) },
+					{ value: '2-next-30-days', label: __( 'Next 30 days' ) },
+					{ value: '2-next-90-days', label: __( 'Next 90 days' ) },
+					{ value: '3-more-than-90-days', label: __( 'More than 90 days' ) },
+					{ value: '1-expired', label: __( 'Expired' ) },
+					{ value: '0-no-expiry', label: __( 'No expiry date' ) },
 				],
 				filterBy: {
 					operators: [ 'isAny' as Operator ],
 				},
 				getValue: ( { item }: { item: DomainSummary } ) => {
 					if ( ! item.expiry ) {
-						return '';
+						return '0-no-expiry';
 					}
 
 					const expiryDate = new Date( item.expiry );
 					const now = new Date();
-					const diffInDays = Math.ceil(
-						( expiryDate.getTime() - now.getTime() ) / ( 1000 * 60 * 60 * 24 )
-					);
+					const diffInMs = expiryDate.getTime() - now.getTime();
+					const diffInDays = Math.ceil( diffInMs / ( 1000 * 60 * 60 * 24 ) );
 
-					if ( diffInDays < 0 ) {
-						return 'expired';
-					} else if ( diffInDays <= 7 ) {
-						return 'next-7-days';
-					} else if ( diffInDays <= 30 ) {
-						return 'next-30-days';
+					if ( item.expired ) {
+						return '1-expired';
 					} else if ( diffInDays <= 90 ) {
-						return 'next-90-days';
+						return '2-next-90-days';
+					} else if ( diffInDays <= 30 ) {
+						return '2-next-30-days';
+					} else if ( diffInDays <= 7 ) {
+						return '2-next-07-days';
 					}
-
-					return 'later';
+					return '3-more-than-90-days';
 				},
 				render: ( { item } ) => {
-					// Site Overview does not show the Status column, so we use this column for error messages.
-					// TODO: move this inside the DomainExpiryField component?
-					if (
-						inOverview &&
-						item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
-						item.domain_status.id === 'connection_error'
-					) {
-						return <Text intent={ item.domain_status.type }>{ item.domain_status.label }</Text>;
-					}
-
 					return (
 						<DomainExpiryField
+							inOverview={ inOverview ?? false }
 							domain={ item }
 							value={ item.expiry ? dateI18n( 'F j, Y', item.expiry ) : '' }
-							isCompact={ !! site }
 						/>
 					);
 				},

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -23,7 +23,7 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 		current_user_is_owner: true,
 		domain_status: { status: 'active' },
 		expired: false,
-		expiry: false,
+		expiry: null,
 		is_dnssec_enabled: false,
 		is_dnssec_supported: true,
 		is_eligible_for_inbound_transfer: false,

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -60,7 +60,7 @@ export function isDomainUpdatable( domain: DomainSummary ) {
 }
 
 export function isDomainInGracePeriod( domain: DomainSummary ) {
-	if ( ! domain.expiry ) {
+	if ( domain.expiry === null ) {
 		return true;
 	}
 

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -67,7 +67,7 @@ export interface DomainSummary {
 	auto_renewing: boolean;
 	current_user_is_owner: boolean | null;
 	is_domain_only_site: boolean;
-	expiry: string | false;
+	expiry: string | null;
 	expired: boolean;
 	primary_domain: boolean;
 	can_set_as_primary: boolean;


### PR DESCRIPTION
According to the design the field should be called "Paid until" and it should show the date and the auto-renew status

Part of [DOMAINS-1724: Fix the filters for the domains datagrid](https://linear.app/a8c/issue/DOMAINS-1724/fix-the-filters-for-the-domains-datagrid)

The Paid until column now looks like this (the date will be red if it's in the past):

<img width="215" height="382" alt="Screenshot 2025-10-18 at 11 56 40" src="https://github.com/user-attachments/assets/fc4a8845-2e7f-4de4-9c70-965f4b3f5fdf" />

## Proposed Changes

* Change the filed title to Paid until
* Added sort function so that empty expiry is always at the bottom
* Fixed the type of `expiry` domain property to `string | null`
* Changed how the column is rendered to show the date and the auto-renew status

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to sort by the paid until date
* Try to filter by the paid until date
* Verify that "Turn on auto-renew" sends you to the payment screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
