### PR TITLE
Hosting Dashboard: Add optIn app-level config

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -43,4 +43,5 @@ boot( {
 			href: '/setup/ai-site-builder',
 		},
 	},
+	optIn: false,
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -33,4 +33,5 @@ boot( {
 			href: '/setup/ai-site-builder-spec',
 		},
 	},
+	optIn: false,
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -42,4 +42,5 @@ boot( {
 			href: '/setup/ai-site-builder',
 		},
 	},
+	optIn: true,
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -45,6 +45,7 @@ export type AppConfig = {
 		default: OnboardingLink;
 		withAI: OnboardingLink;
 	};
+	optIn?: boolean;
 };
 
 const AppContext = createContext< AppConfig >( {
@@ -69,6 +70,7 @@ const AppContext = createContext< AppConfig >( {
 	},
 	onboardingLinkSourceQueryArg: undefined,
 	onboardingLinks: undefined,
+	optIn: undefined,
 } );
 
 interface AppProviderProps {

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -45,7 +45,7 @@ export type AppConfig = {
 		default: OnboardingLink;
 		withAI: OnboardingLink;
 	};
-	optIn?: boolean;
+	optIn: boolean;
 };
 
 const AppContext = createContext< AppConfig >( {
@@ -70,7 +70,7 @@ const AppContext = createContext< AppConfig >( {
 	},
 	onboardingLinkSourceQueryArg: undefined,
 	onboardingLinks: undefined,
-	optIn: undefined,
+	optIn: false,
 } );
 
 interface AppProviderProps {

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -6,10 +6,12 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import Notice from '../../components/notice';
 import ComponentViewTracker from '../component-view-tracker';
 
 export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
+	const { optIn } = useAppContext();
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
 	);
@@ -24,6 +26,10 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 			context: tracksContext,
 		} );
 	};
+
+	if ( ! optIn ) {
+		return null;
+	}
 
 	// Optimistically hide the banner assuming the preference will get saved.
 	if ( isDismissing || isDismissedPersisted ) {

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -14,7 +14,6 @@ import { useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
-import { useAppContext } from '../../app/context';
 import FlashMessage from '../../components/flash-message';
 import { Notice } from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
@@ -51,8 +50,7 @@ const fields: Field< OptInFormData >[] = [
 	},
 ];
 
-export default function PreferencesLanguageForm() {
-	const { optIn: supportsOptIn } = useAppContext();
+export default function PreferencesOptInForm() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
@@ -63,10 +61,6 @@ export default function PreferencesLanguageForm() {
 		enabled: optIn.value === 'opt-in',
 	} );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
-
-	if ( ! supportsOptIn ) {
-		return null;
-	}
 
 	const isDirty = formData.enabled !== ( optIn.value === 'opt-in' );
 

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -14,6 +14,7 @@ import { useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import FlashMessage from '../../components/flash-message';
 import { Notice } from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
@@ -51,6 +52,7 @@ const fields: Field< OptInFormData >[] = [
 ];
 
 export default function PreferencesLanguageForm() {
+	const { optIn: supportsOptIn } = useAppContext();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
@@ -61,6 +63,10 @@ export default function PreferencesLanguageForm() {
 		enabled: optIn.value === 'opt-in',
 	} );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
+	if ( ! supportsOptIn ) {
+		return null;
+	}
 
 	const isDirty = formData.enabled !== ( optIn.value === 'opt-in' );
 

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import PreferencesLanguageForm from '../preferences-language';
@@ -6,9 +7,11 @@ import PreferencesLogin from '../preferences-login';
 import PreferencesNewHostingDashboard from '../preferences-new-hosting-dashboard';
 
 export default function Preferences() {
+	const { optIn } = useAppContext();
+
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Preferences' ) } /> }>
-			<PreferencesNewHostingDashboard />
+			{ optIn && <PreferencesNewHostingDashboard /> }
 			<PreferencesLanguageForm />
 			<PreferencesLogin />
 		</PageLayout>


### PR DESCRIPTION
## Proposed Changes

Add optIn so that only app-dotcom has opt-in enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure you see the opt-in welcome banner on top-level pages
* Ensure you see the opt-in setting in /v2/me/preferences
* Head to /ciab
* Ensure you DO NOT see the opt-in welcome banner on top-level pages
* Ensure you DO NOT see the opt-in setting in /ciab/me/preferences

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
