### PR TITLE
Add accessible label to WordPress.com link in the top-left of HD

### DIFF
--- a/client/dashboard/app/header/index.tsx
+++ b/client/dashboard/app/header/index.tsx
@@ -1,4 +1,5 @@
 import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
 import HeaderBar from '../../components/header-bar';
 import RouterLinkButton from '../../components/router-link-button';
 import { useAppContext } from '../context';
@@ -6,7 +7,7 @@ import PrimaryMenu from '../primary-menu';
 import SecondaryMenu from '../secondary-menu';
 
 function Header() {
-	const { Logo } = useAppContext();
+	const { Logo, name } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
 
 	return (
@@ -15,7 +16,12 @@ function Header() {
 
 			{ Logo && (
 				<div style={ { display: 'flex', alignItems: 'center' } }>
-					<RouterLinkButton icon={ <Logo /> } to="/" />
+					<RouterLinkButton
+						/* translators: Screen reader text for link to root of the hosting dashboard. "name" is the product of whose hosting dashboard this is: e.g. WordPress.com */
+						aria-label={ sprintf( __( '%(name)s home' ), { name } ) }
+						icon={ <Logo /> }
+						to="/"
+					/>
 				</div>
 			) }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This link is now called "WordPress.com home" according to screen readers

<img width="662" alt="CleanShot 2025-10-20 at 12 51 15@2x" src="https://github.com/user-attachments/assets/e923c87a-73f1-4f6d-bd8b-d2e20e345598" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Accessibility fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The change is visible in the browser's a11y tree

<img width="937" alt="CleanShot 2025-10-20 at 12 52 06@2x" src="https://github.com/user-attachments/assets/fe8dc85e-edec-4e28-aa6c-712960749453" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
