### PR TITLE
Hosting dashboard v1 callouts: add missing calypso_page_view event

### DIFF
--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -82,6 +82,10 @@ export function hostingFeaturesCallout(
 					<HostingActivationCallout siteId={ site.ID } />
 				) : (
 					<HostingFeatureCallout>
+						<PageViewTracker
+							title="Sites > Hosting Feature Callout"
+							path={ getRouteFromContext( context ) }
+						/>
 						<CalloutComponent siteSlug={ site.slug } titleAs="h3" />
 					</HostingFeatureCallout>
 				);

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -82,15 +82,19 @@ export function hostingFeaturesCallout(
 					<HostingActivationCallout siteId={ site.ID } />
 				) : (
 					<HostingFeatureCallout>
-						<PageViewTracker
-							title="Sites > Hosting Feature Callout"
-							path={ getRouteFromContext( context ) }
-						/>
 						<CalloutComponent siteSlug={ site.slug } titleAs="h3" />
 					</HostingFeatureCallout>
 				);
 
-			context.primary = <div className="hosting-features-callout">{ callout }</div>;
+			context.primary = (
+				<div className="hosting-features-callout">
+					<PageViewTracker
+						title="Sites > Hosting Feature Callout"
+						path={ getRouteFromContext( context ) }
+					/>
+					{ callout }
+				</div>
+			);
 		}
 
 		next();


### PR DESCRIPTION
Fixes p1760741389057129/1760518731.172859-slack-C08JZTRS6NA

## Proposed Changes

This PR adds the `calypso_page_view` Tracks event consistently when the user visits any site hosting feature tabs, even on lower plans.

Similar to:

- https://github.com/Automattic/wp-calypso/pull/102731

## Why are these changes being made?

Data consistency.

## Testing Instructions

1. Go to /sites/:site of site with Free plan.
2. Go to any hosting feature tab.
3. Verify that the `calypso_page_view` is fired with the correct properties (including `path`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?