### PR TITLE
Dashboard v2: add path prop to Track events

### DIFF
--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -39,7 +39,11 @@ function AnalyticsProviderWithClient( {
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				recordTracksEvent( eventName, properties );
+				const path = router?.state.matches.at( -1 )?.fullPath;
+				recordTracksEvent( eventName, {
+					path,
+					...properties,
+				} );
 			},
 
 			// The title property is used by Google Analytics not Tracks. The hosting
@@ -51,7 +55,7 @@ function AnalyticsProviderWithClient( {
 				} );
 			},
 		} ),
-		[]
+		[ router ]
 	);
 
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -39,7 +39,7 @@ function AnalyticsProviderWithClient( {
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				const path = router?.state.matches.at( -1 )?.fullPath;
+				const path = router.basepath + router.state.matches.at( -1 )?.fullPath;
 				recordTracksEvent( eventName, {
 					path,
 					...properties,

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -59,8 +59,8 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 	next();
 }
 
-function HostingFeatureCallout( { children }: { children: React.ReactNode } ) {
-	const analyticsClient = useAnalyticsClient();
+function HostingFeatureCallout( { path, children }: { path: string; children: React.ReactNode } ) {
+	const analyticsClient = useAnalyticsClient( undefined, path );
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
 }
 
@@ -73,6 +73,7 @@ export function hostingFeaturesCallout(
 	return ( context: Context, next: () => void ) => {
 		const state = context.store.getState();
 		const site = getSelectedSite( state );
+		const path = getRouteFromContext( context );
 
 		if ( site && ! areHostingFeaturesSupported( site ) ) {
 			const callout =
@@ -81,7 +82,7 @@ export function hostingFeaturesCallout(
 				site.plan?.features.active.includes( FEATURE_SFTP ) ? (
 					<HostingActivationCallout siteId={ site.ID } />
 				) : (
-					<HostingFeatureCallout>
+					<HostingFeatureCallout path={ path }>
 						<CalloutComponent siteSlug={ site.slug } titleAs="h3" />
 					</HostingFeatureCallout>
 				);

--- a/client/sites/v2/hooks/use-analytics-client.ts
+++ b/client/sites/v2/hooks/use-analytics-client.ts
@@ -22,7 +22,7 @@ export const useAnalyticsClient = ( router?: AnyRouter, currentPath?: string ) =
 				dispatch( recordPageView( url, title ) );
 			},
 		} ),
-		[ router, dispatch ]
+		[ router, currentPath, dispatch ]
 	);
 
 	return analyticsClient;

--- a/client/sites/v2/hooks/use-analytics-client.ts
+++ b/client/sites/v2/hooks/use-analytics-client.ts
@@ -4,13 +4,13 @@ import { recordTracksEvent, recordPageView } from 'calypso/state/analytics/actio
 import type { AnyRouter } from '@tanstack/react-router';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 
-export const useAnalyticsClient = ( router?: AnyRouter ) => {
+export const useAnalyticsClient = ( router?: AnyRouter, currentPath?: string ) => {
 	const dispatch = useDispatch();
 
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
-				const path = router?.state.matches.at( -1 )?.fullPath;
+				const path = currentPath || router?.state.matches.at( -1 )?.fullPath;
 				dispatch(
 					recordTracksEvent( eventName, {
 						path,


### PR DESCRIPTION
Context: https://github.com/Automattic/wp-calypso/pull/106537#issuecomment-3417513509

## Proposed Changes

This PR adds a `path` property to Track events fired from the new Hosting Dashboard:

<img width="621" height="199" alt="image" src="https://github.com/user-attachments/assets/2815c987-d8be-4910-bf11-733d17d5b918" />

In v1 backport we also added this:

- https://github.com/Automattic/wp-calypso/issues/105685

## Why are these changes being made?

So that data / marketing teams can easily tell where a particular event is fired from.

## Testing Instructions

1. Go to /v2/sites
2. Click a site
3. Click anything in the site overview
4. Verify you see the new `path` prop in the Track events.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
