### PR TITLE
Hosting Dashboard: Reduce h1 on mobile devices.

### DIFF
--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -41,7 +41,7 @@
 	// Headings
 	--dashboard-h1__font-size: clamp(32px, 3vw, 40px);
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: clamp(32px, 3vw, 40px);
+	--dashboard-h1__line-height: clamp(42px, 4vw, 54px);
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -39,9 +39,9 @@
 	--dashboard-secondary-menu-item__color: #{$gray-900};
 
 	// Headings
-	--dashboard-h1__font-size: 40px;
+	--dashboard-h1__font-size: clamp(32px, 3vw, 40px);
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: 54px;
+	--dashboard-h1__line-height: clamp(32px, 3vw, 40px);
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview


### PR DESCRIPTION
Related to: #106567
Fixes: DOTCOM-14983

## Proposed Changes

Use `clamp` to reduce the size of the `h1` on mobile. Used a rough `1.3` multiple for the line-height.


## Screenshot
| Header | Header |
|--------|--------|
| <img width="860" height="1762" alt="calypso localhost_3000_v2_sites_abstracting blog_settings_static-file-404 (1)" src="https://github.com/user-attachments/assets/f7a80108-be6a-4b46-a1c9-00793c83952e" /> | <img width="860" height="1762" alt="calypso localhost_3000_v2_sites_abstracting blog" src="https://github.com/user-attachments/assets/8d11826f-102f-4fc6-8642-d25ae67eca8f" /> |  
| <img width="860" height="1762" alt="calypso localhost_3000_v2_sites_abstracting blog_settings_static-file-404" src="https://github.com/user-attachments/assets/a0baf658-1027-4359-9887-9f27e5a747d3" /> | <img width="860" height="1762" alt="calypso localhost_3000_v2_sites_abstracting blog_settings_static-file-404 (2)" src="https://github.com/user-attachments/assets/8e66a26b-c5b3-40d7-9626-6a351722eccc" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
