### PR TITLE
Hosting Dashboard: Remove the reader text until desktop.

### DIFF
--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -9,6 +9,7 @@ import {
 	MenuItem,
 	Spinner,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { help, commentAuthorAvatar } from '@wordpress/icons';
 import { Suspense, lazy, useCallback, useState } from 'react';
@@ -144,13 +145,14 @@ function UserProfile() {
 
 function SecondaryMenu() {
 	const { supports } = useAppContext();
+	const isDesktop = useViewportMatch( 'medium' );
 
 	return (
 		<HStack spacing={ 2 } justify="flex-end">
 			{ supports.reader && (
 				<Button
 					className="dashboard-secondary-menu__item"
-					icon={ <ReaderIcon /> }
+					icon={ isDesktop ? <ReaderIcon /> : null }
 					text={ __( 'Reader' ) }
 					href="/reader"
 				/>

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -152,8 +152,9 @@ function SecondaryMenu() {
 			{ supports.reader && (
 				<Button
 					className="dashboard-secondary-menu__item"
-					icon={ isDesktop ? <ReaderIcon /> : null }
-					text={ __( 'Reader' ) }
+					icon={ <ReaderIcon /> }
+					label={ __( 'Reader' ) }
+					text={ isDesktop ? __( 'Reader' ) : undefined }
 					href="/reader"
 				/>
 			) }


### PR DESCRIPTION
Related to: DOTCOM-14984

## Proposed Changes

Remove the "Reader" text until the desktop size preset. 

It currently grows:
![Screen Recording on 2025-10-20 at 01-30-30](https://github.com/user-attachments/assets/2ac6b7eb-c99a-477e-90a5-22b4f77d1bac)

## Screenshot
| Before | After |
|--------|--------|
| ![Screen Recording on 2025-10-20 at 01-27-56](https://github.com/user-attachments/assets/49cc1b6b-e73d-4cf2-84a3-dbc04fcd1e41) | ![Screen Recording on 2025-10-21 at 07-57-19](https://github.com/user-attachments/assets/fb9621e9-6f91-464a-9dff-9be639fa2008)
 | 

## Why not display it earlier?

I don't know, I just tied into the desktop size because that's when the rest of the menu appears. 

I feel having the same menu in portrait and landscape makes more sense than it appearing.


## Testing Instructions

- Load `v2` in mobile, and table
- Expect to not see the icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
