### PR TITLE
Hosting Dashboard: Improve domain forwarding error handling

### DIFF
--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -1,7 +1,9 @@
 import { domainQuery, domainForwardingSaveMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -20,10 +22,10 @@ export default function AddDomainForwarding() {
 		meta: {
 			snackbar: {
 				success: __( 'Domain forwarding rule saved.' ),
-				error: __( 'Failed to save domain forwarding rule.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 
@@ -35,6 +37,11 @@ export default function AddDomainForwarding() {
 				router.navigate( {
 					to: domainForwardingRoute.fullPath,
 					params: { domainName },
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 			},
 		} );

--- a/client/dashboard/domains/domain-forwarding/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwarding/delete-modal.tsx
@@ -5,7 +5,9 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainForwarding } from '@automattic/api-core';
@@ -26,10 +28,10 @@ const DomainForwardingDeleteModal = ( {
 		meta: {
 			snackbar: {
 				success: __( 'Domain forwarding rule deleted.' ),
-				error: __( 'Failed to delete domain forwarding rule.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {
@@ -43,12 +45,16 @@ const DomainForwardingDeleteModal = ( {
 
 				onClose?.();
 			},
-			onError: ( error ) => {
+			onError: ( error: Error ) => {
 				recordTracksEvent( 'calypso_dashboard_domain_forwarding_delete_record_failure', {
 					domain: domainName,
 					fqdn: domainForwarding.fqdn,
 					target_host: domainForwarding.target_host,
 					error_message: error.message,
+				} );
+
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 
 				onClose?.();

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -5,8 +5,10 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound, useRouter } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -26,10 +28,10 @@ export default function EditDomainForwarding() {
 		meta: {
 			snackbar: {
 				success: __( 'Domain forwarding rule saved.' ),
-				error: __( 'Failed to save domain forwarding rule.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const forceSubdomainsOnly = domainData?.primary_domain && ! domainData?.is_domain_only_site;
 
@@ -62,6 +64,11 @@ export default function EditDomainForwarding() {
 				router.navigate( {
 					to: domainForwardingRoute.fullPath,
 					params: { domainName },
+				} );
+			},
+			onError: ( error: Error ) => {
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 			},
 		} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-273

## Proposed Changes

* Improve the error handling on the domain forwarding screens by displaying the error message from the backend response.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are certain cases where we can't do the validation on the frontend, and in those cases, we should show a more detailed error. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a few domain forwardings to a domain.
* Edit the `deleteDomainForwarding` and `saveDomainForwarding` mutations to throw an error.
* Go to `/v2/domains/[domain]/forwarding/add` and fill the form.
* When submitting, you should see the thrown error.
* Try editing one of the existing forwardings. You should see the thrown error when the form is submitted.
* Try deleting one of the existing forwardings. You should see the thrown error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
