### PR TITLE
Declare wpcom.js types

### DIFF
--- a/packages/wpcom.js/types/index.d.ts
+++ b/packages/wpcom.js/types/index.d.ts
@@ -1,5 +1,126 @@
-export type WPCOM = {
-	// Temporary workaround so we can use the still untyped WPCOM object in typed contexts.
+// TypeScript definitions for the "wpcom" package API surface used by consumers
+
+export type RequestHeaders = Record< string, string >;
+
+export type RequestCallback< TResponse > = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	[ key: string ]: any;
+	error: Error | null,
+	data: TResponse,
+	headers: RequestHeaders
+) => void;
+
+export class Request {
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	get< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
+	get< TResponse = unknown >(
+		params: object | string,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+	get< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+
+	post< TResponse = unknown >(
+		params: object | string,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+	post< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		body?: object
+	): Promise< TResponse >;
+	post< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		body?: object,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+
+	// post and put are aliased in the runtime
+	put< TResponse = unknown >(
+		params: object | string,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+	put< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		body?: object
+	): Promise< TResponse >;
+	put< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		body?: object,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+
+	del< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
+	del< TResponse = unknown >(
+		params: object | string,
+		query?: object,
+		callback?: RequestCallback< TResponse >
+	): unknown;
+	/* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+export interface WpcomInstance {
+	/** Optional OAuth token currently loaded on the instance */
+	token?: string;
+	/** Default API version (defaults to '1.1') */
+	apiVersion: string;
+	/** Low-level request executor injected by the host environment */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	request: ( params: object, callback: any ) => any;
+	/** Convenience request wrapper with helpers and Promise support */
+	req: Request;
+	/** Pinghub instance for real-time updates */
+	pinghub: any;
+
+	/** Load or update the OAuth token at runtime */
+	loadToken( token?: string ): void;
+	/** Whether a token has been set on this instance */
+	isTokenLoaded(): boolean;
+
+	// Factory methods
+	domains(): any;
+	domain( domainId: string ): any;
+	site( id?: string ): any;
+	users(): any;
+	plans(): any;
+	batch(): any;
+	freshlyPressed( query?: object, fn?: RequestCallback< unknown > ): any;
+}
+
+// Static class references attached to the factory function
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type WpcomFactoryStatic = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Batch: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Domain: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Domains: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Pinghub: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Plans: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Request: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Site: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Users: any;
 };
+
+/** Factory function. Can be invoked with or without `new` at runtime. */
+declare const wpcomFactory: ( (
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	tokenOrHandler?: string | ( ( params: object, callback: any ) => any ),
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	reqHandler?: ( params: object, callback: any ) => any
+) => WpcomInstance ) &
+	WpcomFactoryStatic;
+
+export default wpcomFactory;
+export type WPCOM = WpcomInstance;

--- a/packages/wpcom.js/types/index.d.ts
+++ b/packages/wpcom.js/types/index.d.ts
@@ -14,18 +14,18 @@ export class Request {
 	get< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
 	get< TResponse = unknown >(
 		params: object | string,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		callback: RequestCallback< TResponse >
+	): void;
 	get< TResponse = unknown >(
 		params: object | string,
-		query?: object,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		query: object,
+		callback: RequestCallback< TResponse >
+	): void;
 
 	post< TResponse = unknown >(
 		params: object | string,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		callback: RequestCallback< TResponse >
+	): void;
 	post< TResponse = unknown >(
 		params: object | string,
 		query?: object,
@@ -33,16 +33,15 @@ export class Request {
 	): Promise< TResponse >;
 	post< TResponse = unknown >(
 		params: object | string,
-		query?: object,
-		body?: object,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		query: object,
+		body: object,
+		callback: RequestCallback< TResponse >
+	): void;
 
-	// post and put are aliased in the runtime
 	put< TResponse = unknown >(
 		params: object | string,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		callback: RequestCallback< TResponse >
+	): void;
 	put< TResponse = unknown >(
 		params: object | string,
 		query?: object,
@@ -50,17 +49,17 @@ export class Request {
 	): Promise< TResponse >;
 	put< TResponse = unknown >(
 		params: object | string,
-		query?: object,
-		body?: object,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		query: object,
+		body: object,
+		callback: RequestCallback< TResponse >
+	): void;
 
 	del< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
 	del< TResponse = unknown >(
 		params: object | string,
-		query?: object,
-		callback?: RequestCallback< TResponse >
-	): unknown;
+		query: object,
+		callback: RequestCallback< TResponse >
+	): void;
 	/* eslint-enable @typescript-eslint/no-explicit-any */
 }
 

--- a/packages/wpcom.js/types/index.d.ts
+++ b/packages/wpcom.js/types/index.d.ts
@@ -65,17 +65,8 @@ export class Request {
 }
 
 export interface WpcomInstance {
-	/** Optional OAuth token currently loaded on the instance */
-	token?: string;
-	/** Default API version (defaults to '1.1') */
-	apiVersion: string;
-	/** Low-level request executor injected by the host environment */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	request: ( params: object, callback: any ) => any;
 	/** Convenience request wrapper with helpers and Promise support */
 	req: Request;
-	/** Pinghub instance for real-time updates */
-	pinghub: any;
 
 	/** Load or update the OAuth token at runtime */
 	loadToken( token?: string ): void;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

I propose to add wpcom.js types declaration.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To simplify using the package in other projects e.g. Studio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test if build goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
