### PR TITLE
Hosting Dashboard: Improve glue records error handling

### DIFF
--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -2,7 +2,9 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordCreateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
@@ -18,10 +20,10 @@ export default function AddDomainGlueRecords() {
 		meta: {
 			snackbar: {
 				success: __( 'Glue record saved.' ),
-				error: __( 'Failed to save glue record.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	const handleSubmit = ( glueRecord: DomainGlueRecord ) => {
@@ -38,12 +40,16 @@ export default function AddDomainGlueRecords() {
 					params: { domainName },
 				} );
 			},
-			onError: ( error ) => {
+			onError: ( error: Error ) => {
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_add_record_failure', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,
 					address: glueRecord.ip_addresses[ 0 ],
 					error_message: error.message,
+				} );
+
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 			},
 		} );

--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -5,7 +5,9 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainGlueRecord } from '@automattic/api-core';
@@ -26,10 +28,10 @@ const DomainGlueRecordDeleteModal = ( {
 		meta: {
 			snackbar: {
 				success: __( 'Glue record deleted.' ),
-				error: __( 'Failed to delete glue record.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	const onConfirm = () => {
@@ -43,12 +45,16 @@ const DomainGlueRecordDeleteModal = ( {
 
 				onClose?.();
 			},
-			onError: ( error ) => {
+			onError: ( error: Error ) => {
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_delete_record_failure', {
 					domain: domainName,
 					nameserver: glueRecord.nameserver,
 					address: glueRecord.ip_addresses[ 0 ],
 					error_message: error.message,
+				} );
+
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 
 				onClose?.();

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -2,7 +2,9 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordsQuery, domainGlueRecordUpdateMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
@@ -19,10 +21,10 @@ export default function EditDomainGlueRecords() {
 		meta: {
 			snackbar: {
 				success: __( 'Glue record saved.' ),
-				error: __( 'Failed to save glue record.' ),
 			},
 		},
 	} );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 	const glueRecord = glueRecordsData.find(
 		( glueRecord: DomainGlueRecord ) => glueRecord.nameserver === nameServer
@@ -42,12 +44,16 @@ export default function EditDomainGlueRecords() {
 					params: { domainName },
 				} );
 			},
-			onError: ( error ) => {
+			onError: ( error: Error ) => {
 				recordTracksEvent( 'calypso_dashboard_domain_glue_records_update_record_failure', {
 					domain: domainName,
 					nameserver: updatedGlueRecord.nameserver,
 					address: updatedGlueRecord.ip_addresses[ 0 ],
 					error_message: error.message,
+				} );
+
+				createErrorNotice( error.message, {
+					type: 'snackbar',
 				} );
 			},
 		} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-273

## Proposed Changes

* Improve the error handling on the domain glue records by displaying the error message from the backend response.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are certain cases where we can't do the validation on the frontend, and in those cases, we should show a more detailed error. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a few domain glue records to a domain.
* Edit the `createDomainGlueRecord`, `updateDomainGlueRecord`, and `deleteDomainGlueRecord` mutations to throw an error.
* Go to `/v2/domains/[domain]/glue-records/add` and fill the form.
* When submitting, you should see the thrown error.
* Try editing one of the existing glue records. You should see the thrown error when the form is submitted.
* Try deleting one of the existing glue records. You should see the thrown error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
