### PR TITLE
HD perf: preload queries on deployment routes

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1,5 +1,8 @@
 import { HostingFeatures, DotcomFeatures, LogType } from '@automattic/api-core';
 import {
+	codeDeploymentQuery,
+	codeDeploymentsQuery,
+	githubInstallationsQuery,
 	isAutomatticianQuery,
 	productsQuery,
 	rawUserPreferencesQuery,
@@ -203,6 +206,10 @@ export const siteDeploymentsRoute = createRoute( {
 export const siteDeploymentsListRoute = createRoute( {
 	getParentRoute: () => siteDeploymentsRoute,
 	path: '/',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		queryClient.ensureQueryData( codeDeploymentsQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/deployments-list' ).then( ( d ) =>
 		createLazyRoute( 'site-deployments-list' )( {
@@ -953,6 +960,11 @@ export const siteSettingsRepositoriesRoute = createRoute( {
 export const siteSettingsRepositoriesIndexRoute = createRoute( {
 	getParentRoute: () => siteSettingsRepositoriesRoute,
 	path: '/',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		queryClient.ensureQueryData( codeDeploymentsQuery( site.ID ) );
+		queryClient.ensureQueryData( githubInstallationsQuery() );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-repositories' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-repositories' )( {
@@ -971,6 +983,9 @@ export const siteSettingsRepositoriesConnectRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRepositoriesRoute,
 	path: 'connect',
+	loader: () => {
+		queryClient.ensureQueryData( githubInstallationsQuery() );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-repositories/connect-repository' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-repositories-connect' )( {
@@ -985,6 +1000,10 @@ export const siteSettingsRepositoriesManageRoute = createRoute( {
 	parseParams: ( params ) => ( {
 		deploymentId: Number( params.deploymentId ),
 	} ),
+	loader: async ( { params: { siteSlug, deploymentId } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( codeDeploymentQuery( site.ID, deploymentId ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-repositories/configure-repository' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-repositories-manage' )( {


### PR DESCRIPTION
## Proposed Changes

This PR preloads the queries used in the following routes:

- `/v2/sites/:siteSlug/deployments`
- `/v2/sites/:siteSlug/settings/repositories`
- `/v2/sites/:siteSlug/settings/repositories/connect`
- `/v2/sites/:siteSlug/settings/repositories/manage/:deploymentId`

## Why are these changes being made?

Performance audit.

## Testing Instructions

1. Prepare a Business site.
2. Clear REACT_QUERY_OFFLINE_CACHE from your local storage.
3. Open Network tab in browser console and filter for Fetch requests.
4. Go to the site overview page (`/v2/sites/:siteSlug`).
5. Hover to Deployments.
    - Verify the fetch queries are kicked off.
7. Click Deployments.
    - Verify that it *feels* faster to load.
8. Repeat the same thing for the 3 Settings -> Repositories screens as above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
