### PR TITLE
A4A: Add back Transactions column to WooPayments dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -12,6 +12,7 @@ import { getSiteData } from '../lib/site-data';
 import {
 	SiteColumn,
 	WooPaymentsStatusColumn,
+	TransactionsColumn,
 	CommissionsPaidColumn,
 	TimeframeCommissionsColumn,
 } from './site-columns';
@@ -36,6 +37,17 @@ export default function SitesWithWooPaymentsMobileView( {
 						<ListItemCardContent title={ translate( 'Site' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								<SiteColumn site={ item.siteUrl } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Transactions' ) }>
+							<div className="sites-with-woopayments-list-mobile-view__column">
+								{ isLoadingWooPaymentsData ? (
+									<TextPlaceholder />
+								) : (
+									<TransactionsColumn
+										transactions={ getSiteData( woopaymentsData, item.blogId ).transactions }
+									/>
+								) }
 							</div>
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Commissions Paid' ) }>

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -19,6 +19,11 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
 };
 
+export const TransactionsColumn = memo( ( { transactions }: { transactions: number | null } ) => {
+	return transactions ?? <Gridicon icon="minus" />;
+} );
+TransactionsColumn.displayName = 'TransactionsColumn';
+
 export const CommissionsPaidColumn = memo( ( { payout }: { payout: number | null } ) => {
 	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
 } );

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -16,6 +16,7 @@ import { getSiteData } from '../lib/site-data';
 import SitesWithWooPaymentsMobileView from './mobile-view';
 import {
 	SiteColumn,
+	TransactionsColumn,
 	CommissionsPaidColumn,
 	TimeframeCommissionsColumn,
 	WooPaymentsStatusColumn,
@@ -46,7 +47,13 @@ export default function SitesWithWooPayments() {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'site', 'commissionsPaid', 'timeframeCommissions', 'woopaymentsStatus' ],
+		fields: [
+			'site',
+			'transactions',
+			'commissionsPaid',
+			'timeframeCommissions',
+			'woopaymentsStatus',
+		],
 	} );
 
 	const fields = useMemo(
@@ -58,6 +65,20 @@ export default function SitesWithWooPayments() {
 				render: ( { item }: { item: SitesWithWooPaymentsState } ) => (
 					<SiteColumn site={ item.siteUrl } />
 				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'transactions',
+				label: translate( 'Transactions' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ) => {
+					if ( isLoadingWooPaymentsData ) {
+						return <TextPlaceholder />;
+					}
+					const { transactions } = getSiteData( woopaymentsData, item.blogId );
+					return <TransactionsColumn transactions={ transactions } />;
+				},
 				enableHiding: false,
 				enableSorting: false,
 			},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/A4A-1511/show-the-pending-woopayments-transactions

## Proposed Changes

* Reverts https://github.com/Automattic/wp-calypso/pull/105562

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
