### PR TITLE
Dashboard v2 backport: prevent calypso_page_view race condition

### DIFF
--- a/client/dashboard/components/page-view-tracker/index.tsx
+++ b/client/dashboard/components/page-view-tracker/index.tsx
@@ -1,15 +1,15 @@
-import { useRouter } from '@tanstack/react-router';
+import { useRouterState } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 
 export function PageViewTracker() {
-	const router = useRouter();
+	const routerState = useRouterState();
 	const { recordPageView } = useAnalytics();
 	const lastPath = useRef();
 
 	useEffect( () => {
-		return router.subscribe( 'onResolved', () => {
-			const leafMatch = router.state.matches.at( -1 );
+		if ( routerState.status !== 'pending' ) {
+			const leafMatch = routerState.matches.at( -1 );
 			const basePath = leafMatch?.context?.config?.basePath;
 			const path = ( basePath !== '/' ? basePath : '' ) + leafMatch?.routeId;
 
@@ -17,8 +17,8 @@ export function PageViewTracker() {
 				recordPageView( path, document.title );
 				lastPath.current = path;
 			}
-		} );
-	}, [ router, recordPageView ] );
+		}
+	}, [ routerState.status, routerState.location.href, recordPageView ] );
 
 	return null;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/106566#issuecomment-3421753679

## Proposed Changes

Currently, `calypso_page_view` is fired inside a `router.subscribe( 'onResolved' )` when `<PageViewTracker>` mounts (via `useEffect()`).

It turns out in backported screens, due to delay in mounting components (we're waiting for the cache to fill), the route finishes resolving before the component mounts. In such case, the event will never be fired (it's too late).

This PR fixes that by observing the route changes via`useRouterState()` instead, so that it's in sync with React `useEffect` lifecycle.


## Testing Instructions

1. Verify you can't repro the bug from https://github.com/Automattic/wp-calypso/pull/106566#issuecomment-3421753679.
2. Go to `/v2`, click around, verify the event is still fired with the correct props. when any page is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
