### PR TITLE
Hide Site Redirect from dashboard v1

### DIFF
--- a/client/dashboard/sites/settings-redirect/summary.tsx
+++ b/client/dashboard/sites/settings-redirect/summary.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -12,6 +13,9 @@ export default function SiteRedirectSettingsSummary( {
 	site: Site;
 	density?: Density;
 } ) {
+	if ( isDashboardBackport() ) {
+		return null;
+	}
 	let badges = [];
 	if ( site.options?.is_redirect ) {
 		badges = [ { text: __( 'Enabled' ), intent: 'success' as const } ];


### PR DESCRIPTION
## Proposed Changes

Hide "Site redirect" from site settings in dashboard v1.

## Why are these changes being made?
This feature is enabled only in dashboard/v2.

## Testing Instructions
<img width="1388" height="384" alt="hide redirect" src="https://github.com/user-attachments/assets/0d12cf3f-5358-4bcd-b09c-2a87dc453e66" />

Apply this patch and check that the Site Redirect is not visible in dashboard v1.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
