### PR TITLE
CIAB: update Checkout for Woo Hosted sites

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -37,6 +37,13 @@ const CheckoutMasterbar = ( {
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteSlug ?? '' } );
 
 	const getCheckoutType = () => {
+		// Woo Hosted sites are supposed to default to WPcom colors, but without
+		// a logo. We should update this once we have a better way to identify
+		// Garden sites outside of the Hosting Dashboard.
+		if ( isJetpackNotAtomic && siteSlug?.endsWith( '.commerce-garden.com' ) ) {
+			return 'woo-hosted';
+		}
+
 		if ( window.location.pathname.startsWith( '/checkout/jetpack' ) || isJetpackNotAtomic ) {
 			return 'jetpack';
 		}
@@ -54,7 +61,8 @@ const CheckoutMasterbar = ( {
 	const checkoutType = getCheckoutType();
 
 	const showCloseButton =
-		isLeavingAllowed && ( checkoutType === 'wpcom' || checkoutType === 'gravatar' );
+		isLeavingAllowed &&
+		( checkoutType === 'wpcom' || checkoutType === 'gravatar' || checkoutType === 'woo-hosted' );
 
 	return (
 		<Masterbar

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -548,9 +548,9 @@ export default function CheckoutMain( {
 		[ dataForProcessor, translate ]
 	);
 
+	// Gravatar Theme
 	let gravatarColors = {};
 	let gravatarFontWeights = {};
-
 	if ( isGravatarDomain ) {
 		gravatarColors = {
 			primary: '#1d4fc4',
@@ -565,18 +565,25 @@ export default function CheckoutMain( {
 		};
 	}
 
-	const jetpackColors = isJetpackNotAtomic
-		? {
-				primary: colors[ 'Jetpack Green' ],
-				primaryBorder: colors[ 'Jetpack Green 80' ],
-				primaryOver: colors[ 'Jetpack Green 60' ],
-				success: colors[ 'Jetpack Green' ],
-				discount: colors[ 'Jetpack Green' ],
-				highlight: colors[ 'WordPress Blue 50' ],
-				highlightBorder: colors[ 'WordPress Blue 80' ],
-				highlightOver: colors[ 'WordPress Blue 60' ],
-		  }
-		: {};
+	// Jetpack Theme
+	// Woo Hosted sites are technically Jetpack, but are supposed to default to
+	// WPcom colors. We should update this once we have a better way to identify
+	// Garden sites outside of the Hosting Dashboard.
+	const jetpackColors =
+		isJetpackNotAtomic && ! updatedSiteSlug?.endsWith( '.commerce-garden.com' )
+			? {
+					primary: colors[ 'Jetpack Green' ],
+					primaryBorder: colors[ 'Jetpack Green 80' ],
+					primaryOver: colors[ 'Jetpack Green 60' ],
+					success: colors[ 'Jetpack Green' ],
+					discount: colors[ 'Jetpack Green' ],
+					highlight: colors[ 'WordPress Blue 50' ],
+					highlightBorder: colors[ 'WordPress Blue 80' ],
+					highlightOver: colors[ 'WordPress Blue 60' ],
+			  }
+			: {};
+
+	// A4A Theme
 	const a4aColors =
 		sitelessCheckoutType === 'a4a'
 			? {
@@ -588,6 +595,7 @@ export default function CheckoutMain( {
 					highlightOver: colors[ 'Automattic Blue 60' ],
 			  }
 			: {};
+
 	const theme = {
 		...checkoutTheme,
 		colors: { ...checkoutTheme.colors, ...gravatarColors, ...jetpackColors, ...a4aColors },


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/SHILL-929/ciab-create-checkout-flow-for-ciab

## Proposed Changes

This hides the top bar logo and uses the default color scheme in Checkout for Woo Hosted sites.

<img width="1621" height="1056" alt="Screenshot 2025-10-20 at 12 16 08" src="https://github.com/user-attachments/assets/76e048d6-d4c9-41cc-8a5d-3ed3ceedbaa5" />

## Why are these changes being made?

Woo Hosted sites are technically Jetpack sites, but are supposed to use the default color scheme without a logo in Checkout. This uses the siteSlug `.commerce-garden.com` pattern to identify to identify Woo Hosted checkout (until we have a better method outside of the dashboard), and overrides the Jetpack styling in Checkout. 

**Note:** The line item introductory offer pricing and sidebar upsell discount should be fix by a different issue: https://linear.app/a8c/issue/CHE-266/checkout-introductory-offer-pricing-can-be-confusingincorrect-in

## Testing Instructions

**Test Woo Hosted color scheme:**
- Create a garden dev site in MC > `/tools/garden/`
- Visit Checkout with a Woo Hosted plan: http://calypso.localhost:3000/checkout/{your_commerce_garden_site}/woo_hosted_basic_plan_yearly/
- Verify that the Checkout logo is hidden and the default color scheme is used

**Test Jetpack color scheme:**
- Create a Jurassic Ninja site
- From your admin, pick a product to visit checkout
- Switch the checkout url to http://calypso.localhost:3000/
- Verify that the Jetpack logo is shown and Jetpack's color scheme is used

**Test Jetpack siteless color scheme:** 
- Incognito, visit jetpack.com/pricing and pick a product
- Switch the checkout url to http://calypso.localhost:3000/
- Verify that the Jetpack logo is shown and Jetpack's color scheme is used
