### PR TITLE
Initial Claude setup for calypso

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+	"permissions": {
+		"deny": [
+			"node_modules/**",
+			"vendor/**",
+			"build/**",
+			"public/**",
+			"**/dist/**",
+			"coverage/**",
+			".webpack-cache/**",
+			".cache/**",
+			".tsc-cache/**",
+			"**/*.tsbuildinfo",
+			"yarn.lock",
+			"composer.lock",
+			"config/secrets.json",
+			"config/*.local.json",
+			"**/*.log",
+			"playwright-report/**",
+			"test-results*.xml",
+			"*xunit_*.xml",
+			"desktop/e2e/logs/**",
+			"desktop/e2e/screenshots/**",
+			"*.rdb",
+			"*.db"
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ packages/plans-grid-next/static/mockServiceWorker.js
 playwright-report/
 /cookies
 output/
+
+# Claude settings and rules
+# Allow user-contributed files, but keep Claude.md and main settings under version control
+**/.claude.md
+**/.claude/settings.local.json

--- a/.rules/a4a-custom-rules.mdc
+++ b/.rules/a4a-custom-rules.mdc
@@ -1,0 +1,21 @@
+---
+description: Rules that applies for Automattic for Agencies related development
+globs: client/a8c-for-agencies/**/*.*
+---
+Use this rules on top of [calypso-client-rules.mdc](mdc:.cursor/rules/calypso-client-rules.mdc)
+
+## Code Style and Structure
+
+### Code Standards
+
+- When creating forms, use `calypso/a8c-for-agencies/components/form` and `calypso/components/forms/` components where possible.
+
+### Style Conventions
+
+- Use [style.scss](mdc:client/a8c-for-agencies/style.scss) as an example.
+- Don't use `&--` & `&__` selectors and write full name when defining styles.
+- Avoid using `--studio*` colors and instead use `--color*`. Example, instead of `var(--studio-gray-50)` use `var(--color-neutral-50)`.
+
+### Color and Typography Conventions
+
+#### Typography

--- a/.rules/calypso-client-rules.mdc
+++ b/.rules/calypso-client-rules.mdc
@@ -1,0 +1,92 @@
+---
+description: Rules that applies for all Clients within repository
+globs: client/**
+alwaysApply: false
+---
+You are an expert AI programming assistant that primarily focuses on producing clear, readable React and TypeScript code.
+You carefully provide accurate, factual, thoughtful answers, and are a genius at reasoning AI to chat, to generate code.
+You create a smooth UI that is scalable and performant.
+
+## Key Principles
+
+- Write concise, technical responses with accurate TypeScript examples.
+- Use functional, declarative programming. Avoid classes.
+- Prefer iteration and modularization over duplication.
+- Try to use `@wordpress/components` where possible as per this document [wordpress-imports.mdc](mdc:.cursor/rules/wordpress-imports.mdc)
+- Always check your work for errors before completing.
+- Read through related README files to have wider context.
+
+## Short codes
+
+Check the start of any user message for the following short codes and act appropriately:
+- ddc - short for `discuss don't code` so do not make any code changes only discuss the options until given the go ahead to make changes 
+- jdi - short for `just do it` so this is giving approval to go ahead and make the changes that have been discussed
+- cpd - short for `create PR description` for a given branch - you should find changes presented in current branch and create a description following this template [PULL_REQUEST_TEMPLATE.md](mdc:.github/PULL_REQUEST_TEMPLATE.md). The main branch name is `trunk`.
+
+## Analysis Process
+
+Before responding to any request, follow these steps:
+
+- Carefully read the instructions and research relative examples. 
+- If a screenshot is provided, carefully build a layout to match the provided designs.
+- Plan for internationalization using hook `{ useTranslate } from 'i18n-calypso';`
+- Verify accessibility requirements
+
+## Code Style and Structure
+
+### Code Standards
+
+- Implement WordPress hooks system.
+- Use WordPress `@wordpress/element` instead of direct React import.
+- Use `import clsx from 'clsx';` instead of `classnames`.
+- There should be 1 empty line between `import './style.scss';` and other imports.
+- Follow WordPress component lifecycle patterns.
+- Follow WordPress accessibility guidelines.
+- Use WordPress data store for state management.
+- Follow WordPress component patterns.
+- Implement proper WordPress hooks system.
+- Structure components using WordPress conventions.
+- Carrefully follow [.eslintrc.js](mdc:.eslintrc.js) coding standarts.
+
+### Naming Conventions
+
+- Use descriptive variable names with auxiliary verbs (e.g., isLoading).
+- Use lowercase with dashes for directories (e.g., components/auth-wizard).
+- Favor named exports for components.
+
+### Style Conventions
+
+- Don't use `&--` & `&__` selectors and write full name when defining styles.
+- Try to always use RTL specific styles. For example, instead of margin-left, use margin-inline-start.
+- WordPress code conventions include more generous whitespace, including spaces inside function call parentheses and property accessor brackets.
+
+## Dependencies
+
+- Use imports from [wordpress-imports.mdc](mdc:.cursor/rules/wordpress-imports.mdc)
+- Use named imports to bring in only the necessary functions or components, rather than importing the entire module. 
+
+## Documentation
+
+### Code Documentation
+
+- Follow WordPress documentation standards
+- Follow JSDoc conventions
+- Code comments should explain why the code exists or behaves a certain way, not just what it does. It should be concise, relevant, and avoid restating the obvious. Focus on intent, assumptions, and non-obvious decisions.
+- Wrap code comments to new lines at 100 columns
+
+### User Documentation
+
+- Follow WordPress documentation style
+- Provide clear usage instructions
+- Include troubleshooting guides
+
+Remember: Always prioritize WordPress coding standards and best practices while delivering the most appealing UI.
+
+## Testing
+
+- Run tests for individual files using the command `yarn test-client filename`, substituting `filename` with the relative path to the file you want to test.
+- When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
+- Prefer `userEvent` over `fireEvent` in tests to better simulate real user interactions.
+- Use `toBeVisible` instead of `toBeInTheDocument` when asserting that an element should be visible to the user. This ensures the test checks both presence in the DOM and actual visibility, aligning with user-perceived behavior.
+
+

--- a/.rules/wordpress-imports.mdc
+++ b/.rules/wordpress-imports.mdc
@@ -1,0 +1,295 @@
+---
+description: WordPress imports
+globs: client
+---
+## WordPress imports
+
+- `@wordpress/components` exports these React components:
+  - `AlignmentMatrixControl`
+  - `Animate`
+  - `AnglePickerControl`
+  - `ArrowCircle`
+  - `Autocomplete`
+  - `BaseControl`
+  - `BorderBoxControl`
+  - `BorderControl`
+  - `BoxControl`
+  - `Button`
+  - `ButtonGroup`
+  - `Card`
+  - `CardBody`
+  - `CardDivider`
+  - `CardFooter`
+  - `CardHeader`
+  - `CardMedia`
+  - `CheckboxControl`
+  - `ClipboardButton`
+  - `ColorIndicator`
+  - `ColorPalette`
+  - `ColorPicker`
+  - `ComboboxControl`
+  - `CustomGradientPicker`
+  - `CustomSelectControl`
+  - `Dashicon`
+  - `DatePicker`
+  - `DateTimePicker`
+  - `Disabled`
+  - `Draggable`
+  - `DropZone`
+  - `DropdownMenu`
+  - `Dropdown`
+  - `Droppable`
+  - `DuotonePicker`
+  - `DuotoneSwatch`
+  - `Flex`
+  - `FlexBlock`
+  - `FlexItem`
+  - `FocalPointPicker`
+  - `FocusableIframe`
+  - `FontSizePicker`
+  - `FormFileUpload`
+  - `FormTokenField`
+  - `FormToggle`
+  - `GradientPicker`
+  - `Grid`
+  - `Guide`
+  - `HStack`
+  - `Icon`
+  - `IconButton`
+  - `InputControl`
+  - `IsolatedEventContainer`
+  - `ItemGroup`
+  - `MenuGroup`
+  - `MenuItem`
+  - `Modal`
+  - `NavigableContainer`
+  - `NavigableMenu`
+  - `Notice`
+  - `NoticeList`
+  - `NumberControl`
+  - `Panel`
+  - `PanelBody`
+  - `PanelHeader`
+  - `PanelRow`
+  - `Placeholder`
+  - `Popover`
+  - `QueryControls`
+  - `RadioControl`
+  - `RangeControl`
+  - `ResizableBox`
+  - `ResponsiveWrapper`
+  - `RotateLeft`
+  - `RotateRight`
+  - `SandBox`
+  - `ScrollLock`
+  - `SearchControl`
+  - `SelectControl`
+  - `Shortcut`
+  - `Slot`
+  - `SlotFill`
+  - `SlotFillProvider`
+  - `Snackbar`
+  - `SnackbarList`
+  - `Spacer`
+  - `Spinner`
+  - `Surface`
+  - `TabPanel`
+  - `TabbableContainer`
+  - `TextControl`
+  - `TextareaControl`
+  - `TimePicker`
+  - `ToggleControl`
+  - `ToggleGroupControl`
+  - `Toolbar`
+  - `ToolbarButton`
+  - `ToolbarGroup`
+  - `ToolbarItem`
+  - `Tooltip`
+  - `TreeGrid`
+  - `TreeSelect`
+  - `Truncate`
+  - `UnitControl`
+  - `VStack`
+  - `VisuallyHidden`
+  - `ZStack`
+  - `__experimentalAlignmentMatrixControl`
+  - `__experimentalAnimatePresence`
+  - `__experimentalBorderControl`
+  - `__experimentalConfirmDialog`
+  - `__experimentalContainer`
+  - `__experimentalDimensionControl`
+  - `__experimentalDivider`
+  - `__experimentalDropdownContentWrapper`
+  - `__experimentalHStack`
+  - `__experimentalHeading`
+  - `__experimentalHoverCard`
+  - `__experimentalIframe`
+  - `__experimentalInputControl`
+  - `__experimentalInputControlWrapper`
+  - `__experimentalItemGroup`
+  - `__experimentalMotion`
+  - `__experimentalNavigationBackButton`
+  - `__experimentalNavigationGroup`
+  - `__experimentalNavigationItem`
+  - `__experimentalNavigationMenu`
+  - `__experimentalNumberControl`
+  - `__experimentalPaletteEdit`
+  - `__experimentalParseQuantityAndUnitFromRawValue`
+  - `__experimentalSpacer`
+  - `__experimentalText`
+  - `__experimentalToggleGroupControl`
+  - `__experimentalToggleGroupControlOption`
+  - `__experimentalToolsPanel`
+  - `__experimentalToolsPanelHeader`
+  - `__experimentalToolsPanelItem`
+  - `__experimentalTruncate`
+  - `__experimentalUnitControl`
+  - `__experimentalUseCustomUnits`
+  - `__experimentalVStack`
+  - `__experimentalView`
+  - `__experimentalWarning`
+  - `__experimentalZStack`
+- `@wordpress/block-editor` exports these React components:
+  - `AlignmentControl`
+  - `BlockAlignmentControl` 
+  - `BlockAlignmentMatrixControl`
+  - `BlockBreadcrumb`
+  - `BlockControls`
+  - `BlockEdit`
+  - `BlockEditorKeyboardShortcuts`
+  - `BlockFormatControls`
+  - `BlockIcon`
+  - `BlockInspector`
+  - `BlockList`
+  - `BlockMover`
+  - `BlockNavigationDropdown`
+  - `BlockPreview`
+  - `BlockSelectionClearer`
+  - `BlockSettingsMenu`
+  - `BlockTitle`
+  - `BlockToolbar`
+  - `ColorPaletteControl`
+  - `ContrastChecker`
+  - `CopyHandler`
+  - `DefaultBlockAppender`
+  - `FontSizePicker`
+  - `InnerBlocks`
+  - `InspectorAdvancedControls`
+  - `InspectorControls`
+  - `LineHeightControl`
+  - `MediaPlaceholder`
+  - `MediaUpload`
+  - `MediaUploadCheck`
+  - `NavigableToolbar`
+  - `ObserveTyping`
+  - `PanelColorSettings`
+  - `PlainText`
+  - `RichText`
+  - `RichTextShortcut`
+  - `RichTextToolbarButton`
+  - `SkipToSelectedBlock`
+  - `TableOfContents`
+  - `URLInput`
+  - `URLInputButton`
+  - `URLPopover`
+  - `Warning`
+  - `WritingFlow`
+  - `__experimentalBlockAlignmentMatrixToolbar`
+  - `__experimentalBlockFullHeightAligmentControl`
+  - `__experimentalBlockPatternSetup`
+  - `__experimentalBlockVariationPicker`
+  - `__experimentalBorderRadiusControl`
+  - `__experimentalImageSizeControl`
+  - `__experimentalLinkControl`
+  - `__experimentalPanelColorGradientSettings`
+  - `__experimentalUnitControl`
+  - `__experimentalUseGradient`
+  - `__experimentalUseMultipleOriginColorsAndGradients`
+  - `store` - The block editor data store
+  - `transformStyles` - Transform styles for blocks
+  - `getColorClassName` - Get color class names
+  - `getColorObjectByAttributeValues` - Get color object by values
+  - `getColorObjectByColorValue` - Get color object by value
+  - `getFontSize` - Get font size object
+  - `getFontSizeClass` - Get font size class name
+  - `withColors` - HOC to inject color functionality
+  - `withFontSizes` - HOC to inject font size functionality
+  - `useBlockProps` - Hook to get block props
+  - `useInnerBlocksProps` - Hook for inner blocks props
+  - `__experimentalUseEditorFeature` - Hook for editor features
+  - `__experimentalGetGradientClass` - Get gradient class name
+  - `__experimentalGetGradientValueBySlug` - Get gradient value by slug
+  - `__experimentalUseGradient` - Hook for gradient functionality
+- `@wordpress/data` exports following store management utilities, methods and hooks. They are working roughly as an internal Redux store.
+  - `batch` - Batches multiple dispatch calls to optimize rendering
+  - `combineReducers` - Helper to combine multiple reducers
+  - `controls` - (Deprecated) Control handler system
+  - `createReduxStore` - Creates a data store descriptor
+  - `createRegistry` - Creates a new store registry
+  - `createRegistryControl` - Creates a control with registry access
+  - `createRegistrySelector` - Creates a selector with registry access
+  - `createSelector` - Creates a memoized selector
+  - `dispatch` - Returns store's action creators
+  - `plugins` - Available registry plugins
+  - `register` - Registers a store descriptor
+  - `registerGenericStore` - (Deprecated) Registers generic store
+  - `registerStore` - (Deprecated) Registers standard store
+  - `RegistryConsumer` - React Context consumer for registry
+  - `RegistryProvider` - React Context provider for registry
+  - `resolveSelect` - Returns promise-wrapped selectors
+  - `select` - Returns store's selectors
+  - `subscribe` - Subscribes to store updates
+  - `suspendSelect` - Returns suspense-wrapped selectors
+  - `use` - Extends registry with plugin
+  - `useDispatch` - Hook for dispatch actions
+  - `useRegistry` - Hook for registry access
+  - `useSelect` - Hook for state selection
+  - `useSuspenseSelect` - Suspense-enabled selection hook
+  - `withDispatch` - HOC for dispatch actions
+  - `withRegistry` - HOC for registry access
+  - `withSelect` - HOC for state selection
+- `@wordpress/core-data` exports following higher order data management utilities related to WordPress entity store. Entity store provides an abstraction that automatically retrieves entities like Custom Post Types, general WordPress settings and other API elements:
+  - Entity Record Management:
+    - `getEntityRecord` - Get a single entity record
+    - `getEntityRecords` - Get multiple entity records
+    - `getEditedEntityRecord` - Get entity record with edits
+    - `hasEntityRecords` - Check if records exist
+    - `saveEntityRecord` - Save an entity record
+    - `deleteEntityRecord` - Delete an entity record
+    - `editEntityRecord` - Edit an entity record
+  - Entity Configuration:
+    - `getEntityConfig` - Get entity configuration
+    - `getEntitiesConfig` - Get multiple entities configuration
+  - Revisions & Autosaves:
+    - `getRevisions` - Get entity revisions
+    - `getRevision` - Get a specific revision
+    - `getAutosave` - Get autosave for post/author
+    - `getAutosaves` - Get all autosaves for post
+  - User & Permissions:
+    - `canUser` - Check user permissions
+    - `canUserEditEntityRecord` - Check edit permissions
+    - `getCurrentUser` - Get current user data
+  - State Management:
+    - `hasEditsForEntityRecord` - Check for pending edits
+    - `hasUndo` - Check for available undo
+    - `hasRedo` - Check for available redo
+    - `undo` - Undo last edit
+    - `redo` - Redo last undone edit
+  - React Hooks:
+    - `useEntityRecord` - Hook for single record management
+    - `useEntityRecords` - Hook for multiple records management
+    - `useEntityProp` - Hook for entity property management
+    - `useEntityBlockEditor` - Hook for entity block editor
+    - `useEntityId` - Hook for entity ID access
+    - `useResourcePermissions` - Hook for checking resource permissions
+  - Status & Error Handling:
+    - `isSavingEntityRecord` - Check save status
+    - `isDeletingEntityRecord` - Check delete status
+    - `isAutosavingEntityRecord` - Check autosave status
+    - `getLastEntitySaveError` - Get last save error
+    - `getLastEntityDeleteError` - Get last delete error
+  - Additional Utilities:
+    - `getEntityRecordsTotalItems` - Get total available records
+    - `getEntityRecordsTotalPages` - Get total available pages
+    - `getRawEntityRecord` - Get raw record data
+    - `getEntityRecordNonTransientEdits` - Get non-transient edits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+This file provides guidance to Codex (openai.com/codex) and compatible agents when working with code in this repository.
+
+Before you start, please read the following files:
+
+- @.rules/calypso-client-rules.mdc – Rules that applies for all Clients within repository
+- @.rules/wordpress-imports.mdc – WordPress imports
+- @.rules/a4a-custom-rules.mdc – Rules that applies for Automattic for Agencies related development
+
+If you are not sure about something, ask the user to clarify.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Before you start, please read the following files:
+
+- @.rules/calypso-client-rules.mdc – Rules that applies for all Clients within repository
+- @.rules/wordpress-imports.mdc – WordPress imports
+- @.rules/a4a-custom-rules.mdc – Rules that applies for Automattic for Agencies related development
+
+If you are not sure about something, ask the user to clarify.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

We already have a good setup for Cursor. This adds something similar for Claude.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual inspection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
