### PR TITLE
Hosting Dashboard: Default to `img` instead of `ico` for quality.

### DIFF
--- a/client/dashboard/me/preferences-login/site-dropdown.tsx
+++ b/client/dashboard/me/preferences-login/site-dropdown.tsx
@@ -30,7 +30,7 @@ interface PreferencesLoginSiteDropdownProps {
 // Simple site icon component following dashboard pattern
 function SiteIcon( { site, size = 24 }: { site: Site; size?: number } ) {
 	const dims = { width: size, height: size };
-	const ico = site.icon?.ico;
+	const ico = site.icon?.img || site.icon?.ico;
 	const src = useMemo( () => {
 		if ( ! ico ) {
 			return;

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -87,7 +87,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 	describe( 'Site icon rendering logic', () => {
 		test( 'renders image when site has valid icon', () => {
 			const siteWithIcon = createMockSite( {
-				icon: { ico: 'https://example.com/icon.png' },
+				icon: { ico: 'https://example.com/icon.png', img: 'https://example.com/icon.png' },
 			} );
 
 			const { container } = render(
@@ -112,7 +112,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 
 		test( 'renders fallback globe icon when site icon ico is missing', () => {
 			const siteWithEmptyIcon = createMockSite( {
-				icon: { ico: '' },
+				icon: { ico: '', img: 'https://example.com/icon.png' },
 			} );
 
 			const { getByTestId } = render(

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -95,7 +95,8 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 			);
 
 			const img = container.querySelector( 'img' );
-			expect( img?.src ).toContain( 'https://example.com/image.png' );
+			expect( img ).not.toBeNull();
+			expect( img.src ).toContain( 'https://example.com/image.png' );
 		} );
 
 		test( 'renders fallback icon when site has no image', () => {
@@ -108,7 +109,8 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 			);
 
 			const img = container.querySelector( 'img' );
-			expect( img?.src ).toContain( 'https://example.com/icon.png' );
+			expect( img ).not.toBeNull();
+			expect( img.src ).toContain( 'https://example.com/icon.png' );
 		} );
 
 		test( 'renders fallback globe icon when site icon img/ico is missing', () => {

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -87,7 +87,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 	describe( 'Site icon rendering logic', () => {
 		test( 'renders image when site has valid icon', () => {
 			const siteWithIcon = createMockSite( {
-				icon: { ico: 'https://example.com/icon.png', img: 'https://example.com/icon.png' },
+				icon: { ico: 'https://example.com/icon.png' },
 			} );
 
 			const { container } = render(
@@ -112,7 +112,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 
 		test( 'renders fallback globe icon when site icon ico is missing', () => {
 			const siteWithEmptyIcon = createMockSite( {
-				icon: { ico: '', img: 'https://example.com/icon.png' },
+				icon: { ico: '' },
 			} );
 
 			const { getByTestId } = render(

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -122,5 +122,17 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 
 			expect( getByTestId( 'icon-globe' ) ).toBeInTheDocument();
 		} );
+
+		test( 'renders fallback globe icon when site has no icon', () => {
+			const siteWithoutIcon = createMockSite( {
+				icon: undefined,
+			} );
+
+			const { getByTestId } = render(
+				<PreferencesLoginSiteDropdown sites={ [ siteWithoutIcon ] } onChange={ jest.fn() } />
+			);
+
+			expect( getByTestId( 'icon-globe' ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -96,7 +96,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 
 			const img = container.querySelector( 'img' );
 			expect( img ).not.toBeNull();
-			expect( img.src ).toContain( 'https://example.com/image.png' );
+			expect( img?.src ).toContain( 'https://example.com/image.png' );
 		} );
 
 		test( 'renders fallback icon when site has no image', () => {
@@ -110,7 +110,7 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 
 			const img = container.querySelector( 'img' );
 			expect( img ).not.toBeNull();
-			expect( img.src ).toContain( 'https://example.com/icon.png' );
+			expect( img?.src ).toContain( 'https://example.com/icon.png' );
 		} );
 
 		test( 'renders fallback globe icon when site icon img/ico is missing', () => {

--- a/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-login/test/site-dropdown.test.tsx
@@ -85,9 +85,9 @@ function createMockSite( overrides: Partial< Site > = {} ): Site {
 
 describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 	describe( 'Site icon rendering logic', () => {
-		test( 'renders image when site has valid icon', () => {
+		test( 'renders image when site has valid image', () => {
 			const siteWithIcon = createMockSite( {
-				icon: { ico: 'https://example.com/icon.png' },
+				icon: { ico: 'https://example.com/icon.png', img: 'https://example.com/image.png' },
 			} );
 
 			const { container } = render(
@@ -95,24 +95,25 @@ describe( 'PreferencesLoginSiteDropdown - Business Logic', () => {
 			);
 
 			const img = container.querySelector( 'img' );
-			expect( img ).toBeInTheDocument();
+			expect( img?.src ).toContain( 'https://example.com/image.png' );
 		} );
 
-		test( 'renders fallback globe icon when site has no icon', () => {
-			const siteWithoutIcon = createMockSite( {
-				icon: undefined,
+		test( 'renders fallback icon when site has no image', () => {
+			const siteWithoutImg = createMockSite( {
+				icon: { ico: 'https://example.com/icon.png', img: '' },
 			} );
 
-			const { getByTestId } = render(
-				<PreferencesLoginSiteDropdown sites={ [ siteWithoutIcon ] } onChange={ jest.fn() } />
+			const { container } = render(
+				<PreferencesLoginSiteDropdown sites={ [ siteWithoutImg ] } onChange={ jest.fn() } />
 			);
 
-			expect( getByTestId( 'icon-globe' ) ).toBeInTheDocument();
+			const img = container.querySelector( 'img' );
+			expect( img?.src ).toContain( 'https://example.com/icon.png' );
 		} );
 
-		test( 'renders fallback globe icon when site icon ico is missing', () => {
+		test( 'renders fallback globe icon when site icon img/ico is missing', () => {
 			const siteWithEmptyIcon = createMockSite( {
-				icon: { ico: '' },
+				icon: { ico: '', img: '' },
 			} );
 
 			const { getByTestId } = render(

--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 
 export default function SiteIcon( { site, size = 48 }: { site: Site; size?: number } ) {
 	const dims = { width: size, height: size };
-	const ico = site.icon?.ico;
+	const ico = site.icon?.img ?? site.icon?.ico;
 	const src = useMemo( () => {
 		if ( ! ico ) {
 			return;

--- a/client/dashboard/sites/site-icon/index.tsx
+++ b/client/dashboard/sites/site-icon/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 
 export default function SiteIcon( { site, size = 48 }: { site: Site; size?: number } ) {
 	const dims = { width: size, height: size };
-	const ico = site.icon?.img ?? site.icon?.ico;
+	const ico = site.icon?.img || site.icon?.ico;
 	const src = useMemo( () => {
 		if ( ! ico ) {
 			return;

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -44,6 +44,7 @@ export interface Site {
 	name: string;
 	URL: string;
 	icon?: {
+		img: string;
 		ico: string;
 	};
 	plan?: SitePlan;


### PR DESCRIPTION
Fixes: DOTCOM-14664

## Proposed Changes

Default the site icon to use the `img` which is larger and renders more clearly than the `ico`.

| Before | After |
|--------|--------|
| <img width="363" height="193" alt="Screenshot 2025-10-21 at 10 05 18 AM" src="https://github.com/user-attachments/assets/3b53cc6c-3bb7-42d3-ac76-6b70ef4dee28" /> | <img width="354" height="178" alt="Screenshot 2025-10-21 at 10 05 00 AM" src="https://github.com/user-attachments/assets/543bc5ad-2568-4463-b399-73760b35de12" /> |
| <img width="354" height="200" alt="Screenshot 2025-10-21 at 10 10 30 AM" src="https://github.com/user-attachments/assets/9cbdac41-85ad-4ca9-9a92-240ce7dcaa05" /> | <img width="346" height="200" alt="Screenshot 2025-10-21 at 10 10 48 AM" src="https://github.com/user-attachments/assets/b83fb36e-cc0b-4bfd-bc7c-7724e4b9ff44" /> | 
| <img width="564" height="294" alt="Screenshot 2025-10-21 at 10 04 31 AM" src="https://github.com/user-attachments/assets/7504f656-8000-4338-a0a4-428b24850a87" /> | <img width="579" height="282" alt="Screenshot 2025-10-21 at 10 04 52 AM" src="https://github.com/user-attachments/assets/9a9d60f2-5196-4b8b-adb7-cadee01d4be2" /> |
| <img width="336" height="212" alt="Screenshot 2025-10-21 at 10 03 49 AM" src="https://github.com/user-attachments/assets/b44044ce-48f8-44a9-af6d-fc74bf012088" /> | <img width="322" height="176" alt="Screenshot 2025-10-21 at 10 03 31 AM" src="https://github.com/user-attachments/assets/af4ec49c-8386-4421-a27b-76bef8626c9d" /> |
| <img width="314" height="216" alt="Screenshot 2025-10-21 at 10 03 56 AM" src="https://github.com/user-attachments/assets/f17e85fb-2dc6-4ef7-8763-74837882694f" /> | <img width="332" height="217" alt="Screenshot 2025-10-21 at 10 03 25 AM" src="https://github.com/user-attachments/assets/9f206b5d-5312-4aed-9f0a-e4d43deabc7c" /> | 


## Considerations

- This will load a larger assets. The `img` is about `2x` the size of the `ico`. 
  - I think its worth it. 


## Testing Instructions
- Visit your site overview, expect to see a sharp icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
