### PR TITLE
Dashboard Navigation: Add font color and weight tweaks to "active" menu item in HD

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -32,7 +32,7 @@
 	--dashboard-header__divider-color: #064057;
 
 	// Menu
-	--dashboard-menu-item__color: #949494;
+	--dashboard-menu-item__color: #{$gray-600};
 	--dashboard-menu-item-active__color: #FFF;
 
 	// Secondary menu

--- a/client/dashboard/app-ciab/style.scss
+++ b/client/dashboard/app-ciab/style.scss
@@ -33,7 +33,7 @@
 
 	// Menu
 	--dashboard-menu-item__color: #{$gray-700};
-	--dashboard-menu-item-active__color: #{$black};
+	--dashboard-menu-item-active__color: #{$gray-900};
 
 	// Secondary menu
 	--dashboard-secondary-menu-item__color: #{$gray-900};

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -33,7 +33,7 @@
 
 	// Menu
 	--dashboard-menu-item__color: #{$gray-700};
-	--dashboard-menu-item-active__color: #{$black};
+	--dashboard-menu-item-active__color: #{$gray-900};
 
 	// Secondary menu
 	--dashboard-secondary-menu-item__color: #{$gray-900};

--- a/client/dashboard/components/menu/style.scss
+++ b/client/dashboard/components/menu/style.scss
@@ -1,7 +1,10 @@
+@import '@wordpress/base-styles/colors';
+
 .dashboard-menu__item.dashboard-menu__item {
 	color: var( --dashboard-menu-item__color );
 
 	&.active {
 		color: var( --dashboard-menu-item-active__color );
+		font-weight: $font-weight-medium;
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

Adds semi-bold weight to the active menu, and slightly tweaks the active item color.

| Before | After |
| --- | --- |
| <img width="2064" height="298" alt="CleanShot 2025-10-21 at 20 22 59@2x" src="https://github.com/user-attachments/assets/5af98407-5037-43b1-9003-b6e641cb9789" /> | <img width="2070" height="290" alt="CleanShot 2025-10-21 at 20 23 44@2x" src="https://github.com/user-attachments/assets/4ebfc071-30fd-48fc-bfac-6b46d0a7bf40" /> |
| <img width="2066" height="284" alt="CleanShot 2025-10-21 at 20 22 36@2x" src="https://github.com/user-attachments/assets/21b3c721-e2b6-40f2-b398-8f55fde6e417" /> | <img width="2064" height="280" alt="CleanShot 2025-10-21 at 20 22 06@2x" src="https://github.com/user-attachments/assets/86d2d0e3-8c37-4e00-bf5d-2eaf7dadda6b" /> |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I felt like the active menu item didn't wasn't obvious enough, and when I looked at the Figma discovered that we hadn't quite implemented the design correctly.
QOBjujZah0UlGDDdLKZhzi-fi-4204_216343

Git history shows the menu has always been this way, so it looks like we just never implemented it and not that it was a requested deviation from the design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Try out the menus in `/v2`, `/v2-a4a`, and `/ciab`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?