### PR TITLE
Hosting Dashboard: Prevent layout shift on atomic site settings menu

### DIFF
--- a/client/dashboard/sites/settings-primary-data-center/index.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/index.tsx
@@ -1,8 +1,7 @@
-import { getDataCenterOptions, HostingFeatures } from '@automattic/api-core';
+import { getDataCenterOptions } from '@automattic/api-core';
 import { siteBySlugQuery, sitePrimaryDataCenterQuery } from '@automattic/api-queries';
 import SummaryButton from '@automattic/components/src/summary-button';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Card, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cloud } from '@wordpress/icons';
@@ -10,26 +9,16 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { hasHostingFeature } from '../../utils/site-features';
 import type { DataCenterOption } from '@automattic/api-core';
 
 export default function PrimaryDataCenterSettings( { siteSlug }: { siteSlug: string } ) {
-	const router = useRouter();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: primaryDataCenter } = useQuery( {
-		...sitePrimaryDataCenterQuery( site.ID ),
-		enabled: hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ),
-	} );
+	const { data: primaryDataCenter } = useSuspenseQuery( sitePrimaryDataCenterQuery( site.ID ) );
 
 	const dataCenterOptions = getDataCenterOptions();
-	const primaryDataCenterName = primaryDataCenter
-		? dataCenterOptions[ primaryDataCenter as DataCenterOption ]
-		: null;
-
-	if ( ! primaryDataCenterName ) {
-		router.navigate( { to: `/sites/${ siteSlug }/settings` } );
-		return null;
-	}
+	const badges = primaryDataCenter
+		? [ { text: dataCenterOptions[ primaryDataCenter as DataCenterOption ] } ]
+		: undefined;
 
 	return (
 		<PageLayout
@@ -58,7 +47,7 @@ export default function PrimaryDataCenterSettings( { siteSlug }: { siteSlug: str
 							decoration={ <Icon icon={ cloud } /> }
 							showArrow={ false }
 							disabled
-							badges={ [ { text: primaryDataCenterName } ] }
+							badges={ badges }
 						/>
 					</VStack>
 				</Card>

--- a/client/dashboard/sites/settings-primary-data-center/summary.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/summary.tsx
@@ -21,14 +21,14 @@ export default function SettingsPrimaryDataCenterSummary( {
 		enabled: hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ),
 	} );
 
-	if ( ! hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) ) {
-		return;
-	}
-
 	const dataCenterOptions = getDataCenterOptions();
 	const primaryDataCenterName = primaryDataCenter
 		? dataCenterOptions[ primaryDataCenter as DataCenterOption ]
 		: null;
+
+	if ( ! primaryDataCenterName ) {
+		return null;
+	}
 
 	return (
 		<RouterLinkSummaryButton
@@ -36,7 +36,7 @@ export default function SettingsPrimaryDataCenterSummary( {
 			title={ __( 'Primary data center' ) }
 			density={ density }
 			decoration={ <Icon icon={ cloud } /> }
-			badges={ primaryDataCenterName ? [ { text: primaryDataCenterName } ] : undefined }
+			badges={ [ { text: primaryDataCenterName } ] }
 		/>
 	);
 }

--- a/client/dashboard/sites/settings-primary-data-center/summary.tsx
+++ b/client/dashboard/sites/settings-primary-data-center/summary.tsx
@@ -21,14 +21,14 @@ export default function SettingsPrimaryDataCenterSummary( {
 		enabled: hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ),
 	} );
 
+	if ( ! hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) ) {
+		return;
+	}
+
 	const dataCenterOptions = getDataCenterOptions();
 	const primaryDataCenterName = primaryDataCenter
 		? dataCenterOptions[ primaryDataCenter as DataCenterOption ]
 		: null;
-
-	if ( ! primaryDataCenterName ) {
-		return null;
-	}
 
 	return (
 		<RouterLinkSummaryButton
@@ -36,7 +36,7 @@ export default function SettingsPrimaryDataCenterSummary( {
 			title={ __( 'Primary data center' ) }
 			density={ density }
 			decoration={ <Icon icon={ cloud } /> }
-			badges={ [ { text: primaryDataCenterName } ] }
+			badges={ primaryDataCenterName ? [ { text: primaryDataCenterName } ] : undefined }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

**Before**

Layout shift 🤮🤮🤮 
The primary data center button hides till

https://github.com/user-attachments/assets/0e063fbd-475d-4ac1-bdf6-37dd619e3092

**After**

No layout shift and no change in load time! 🦄🦄🦄
We can just load the badge async, like the other summary buttons.

https://github.com/user-attachments/assets/4a077a4e-8938-423e-9fd6-3c142dfc8386



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Pump those CLS metrics!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test at `/v2/sites/{{ site slug }}/settings` with an atomic site.

You will need to clear the `REACT_QUERY_OFFLINE_CACHE` local storage between loads

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
