### PR TITLE
Dashboard v2: remove redundant description from Settings -> Database upsell

### DIFF
--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -21,6 +21,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { hasPlanFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import ResetPasswordModal from './reset-password-modal';
 import upsellIllustrationUrl from './upsell-illustration.svg';
@@ -71,6 +72,17 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 		);
 	};
 
+	const description = hasPlanFeature( site, HostingFeatures.DATABASE )
+		? createInterpolateElement(
+				__(
+					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL. <link>Learn more</link>'
+				),
+				{
+					link: <InlineSupportLink supportContext="hosting-mysql" />,
+				}
+		  )
+		: undefined;
+
 	return (
 		<PageLayout
 			size="small"
@@ -78,14 +90,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Database' ) }
-					description={ createInterpolateElement(
-						__(
-							'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL. <link>Learn more</link>'
-						),
-						{
-							link: <InlineSupportLink supportContext="hosting-mysql" />,
-						}
-					) }
+					description={ description }
 				/>
 			}
 		>


### PR DESCRIPTION
Fixes DES-290

## Proposed Changes

This PR removes the description from Settings -> Database, when the site is Simple. It's because the description is redundant as the upsell callout also has it.

|Free Simple (Before)|Free Simple (After)|
|-|-|
|<img width="674" height="449" alt="image" src="https://github.com/user-attachments/assets/afdd3ff5-777c-4a70-9a91-08e823682f12" />|<img width="678" height="407" alt="image" src="https://github.com/user-attachments/assets/e80c373f-2187-400a-9a5d-3ebc12c379e2" />

|Business Simple|Business Atomic|
|-|-|
<img width="680" height="450" alt="image" src="https://github.com/user-attachments/assets/577abc9d-6c0b-40c2-b65c-03e598691e13" />|<img width="672" height="428" alt="image" src="https://github.com/user-attachments/assets/e780e7f8-1f71-410c-a407-cba24a301d4c" />|


## Why are these changes being made?

Fit 'n finish.

## Testing Instructions

1. Prepare 3 sites:
   - Free Simple
   - Business Simple
   - Business Atomic
2. Verify the callout in Settings -> Database as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
