### PR TITLE
Manage Plugins: Fixed crash when sorting

### DIFF
--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -9,7 +9,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate, View, type Field } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { link, linkOff, trash } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
@@ -55,12 +55,12 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 		setSiteToUpdate( null );
 	};
 
-	const fields = useMemo(
+	const fields: Field< SiteWithPluginData >[] = useMemo(
 		() => [
 			{
 				id: 'domain',
 				label: __( 'Site' ),
-				type: 'string',
+				type: 'text',
 				getValue: ( { item }: { item: SiteWithPluginData } ) => item.URL,
 				render: ( { item }: { item: SiteWithPluginData } ) => item.URL,
 				enableHiding: false,

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -60,6 +60,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			{
 				id: 'domain',
 				label: __( 'Site' ),
+				type: 'string',
 				getValue: ( { item }: { item: SiteWithPluginData } ) => item.URL,
 				render: ( { item }: { item: SiteWithPluginData } ) => item.URL,
 				enableHiding: false,
@@ -69,6 +70,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			{
 				id: 'active',
 				label: __( 'Active' ),
+				type: 'boolean',
 				getValue: ( { item }: { item: SiteWithPluginData } ) =>
 					pluginBySiteId.get( item.ID )?.active ?? false,
 				render: ( { item }: { item: SiteWithPluginData } ) => {
@@ -116,6 +118,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			{
 				id: 'autoupdate',
 				label: __( 'Autoupdate' ),
+				type: 'boolean',
 				getValue: ( { item }: { item: SiteWithPluginData } ) =>
 					pluginBySiteId.get( item.ID )?.autoupdate ?? false,
 				render: ( { item }: { item: SiteWithPluginData } ) => {
@@ -192,9 +195,9 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 							__next40pxDefaultSize
 						>
 							{ sprintf(
-								// translators: %(version) is the new version of the plugin.
-								__( 'Update to version %(version)s', update.new_version ),
-								{ version: update.new_version }
+								// translators: %s is the new version of the plugin.
+								__( 'Update to version %s' ),
+								update.new_version
 							) }
 						</Button>
 					);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTDASH-682/manage-plugins-crash-when-sorting-by-active-or-autoupdate

## Proposed Changes

* Fixed an issue that was causing the dataview to crash when sorting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/plugins/manage/akismet`
* Filter by the active and autoupdate fields through the dataview and grid icons
* It should work as expected without crashes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
