### PR TITLE
Help Center: Handle unsupported canParse

### DIFF
--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -8,6 +8,14 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { HELP_CENTER_STORE } from '../stores';
 
+function canParse( url: string, baseUrl?: string ): URL | false {
+	try {
+		return new URL( url, baseUrl );
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Temporary: the Odie backend returns links with no protocol.
  * This function ensures that the link has a protocol.
@@ -17,12 +25,7 @@ import { HELP_CENTER_STORE } from '../stores';
  * @todo Remove this function when the Odie backend is updated.
  */
 function ensureProtocolAndParse( url: string, baseUrl?: string ) {
-	if ( URL.canParse( url, baseUrl ) ) {
-		return new URL( url, baseUrl );
-	} else if ( URL.canParse( 'https://' + url, baseUrl ) ) {
-		return new URL( 'https://' + url, baseUrl );
-	}
-	return null;
+	return canParse( url, baseUrl ) || canParse( 'https://' + url, baseUrl );
 }
 
 export const useContentFilter = ( node: HTMLDivElement | null ) => {


### PR DESCRIPTION
## Proposed Changes
Not all browsers support canParse. This works around that.

## Why are these changes being made?
Errors on Sentry.

## Testing Instructions
1. Open the Help Center.
2. Open an article.
3. Click a link inside the article pointing to another article.
4. It should work.
