### PR TITLE
GitHub Deployments: update deployment modal layout

### DIFF
--- a/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
+++ b/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
@@ -115,9 +115,8 @@ export function DeploymentLogsModalContent( {
 						<VStack spacing={ 2 }>
 							<div
 								style={ {
-									height: '216px',
-									maxHeight: '100%',
-									overflowY: 'auto',
+									maxHeight: '15lh',
+									overflowY: 'scroll',
 									backgroundColor: 'var(--dashboard__text-color)',
 									borderRadius: '4px',
 								} }

--- a/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
+++ b/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
@@ -55,23 +55,27 @@ export function DeploymentLogsModalContent( {
 					{ repositoryName }
 				</Heading>
 
-				<HStack spacing={ 1 } alignment="left">
-					<ExternalLink
-						href={ `https://github.com/${ deployment.repository_name }/commit/${ commit_sha }` }
-					>
-						<Text as="code" size={ 15 } weight={ 700 } style={ { flexShrink: 0 } }>
-							{ shortSha }
-						</Text>
-					</ExternalLink>
-					<Text size={ 15 } truncate numberOfLines={ 1 } weight={ 500 }>
-						{ commit_message }
-					</Text>
-				</HStack>
+				<Text size={ 15 } truncate numberOfLines={ 1 } weight={ 500 }>
+					{ commit_message }
+				</Text>
 
 				<HStack spacing={ 3 } alignment="left">
 					{ deployment.is_active_deployment && (
 						<Badge style={ { flexShrink: 0 } }>{ __( 'Active deployment' ) }</Badge>
 					) }
+
+					<ExternalLink
+						style={ { flexShrink: 0 } }
+						href={ `https://github.com/${ deployment.repository_name }/commit/${ commit_sha }` }
+					>
+						<Text
+							as="code"
+							size="small"
+							style={ { color: 'var(--wp-admin-theme-color-darker-20)' } }
+						>
+							{ shortSha }
+						</Text>
+					</ExternalLink>
 
 					<div style={ { width: 'auto', flexShrink: 0, maxWidth: '50%' } }>
 						<BranchDisplay branchName={ deployment.branch_name } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

- Resolves DOTDASH-675
- Resolves DOTDASH-673

## Proposed Changes

* Increase the max heigh of the logs to match v1
* Move the commit hash to the items row and update link styles

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX of the deployments modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run Calypso locally or open the Calypso Live link below
* Navigate to `/v2/sites/:siteSlug/deplolyments` and click the icon in the actions column to open the deployment details
* Check that the logs height and the commit hash display are updated

| Before | After |
|--------|--------|
| <img width="1748" height="980" alt="CleanShot 2025-10-21 at 12 38 23@2x" src="https://github.com/user-attachments/assets/d91e2cdf-54a9-4b69-a68c-9e7a933f974d" /> | <img width="1726" height="1114" alt="CleanShot 2025-10-21 at 12 38 32@2x" src="https://github.com/user-attachments/assets/2becfe41-1703-4335-bd41-6cab21cb1956" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
