### PR TITLE
v2 HD - Flex: Add Usage route and skeleton page

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -107,6 +107,24 @@ export const billingRoute = createRoute( {
 	path: 'billing',
 } );
 
+const usageRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Usage' ),
+			},
+		],
+	} ),
+	getParentRoute: () => meRoute,
+	path: 'usage',
+} ).lazy( () =>
+	import( '../../me/usage' ).then( ( d ) =>
+		createLazyRoute( 'usage' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const billingIndexRoute = createRoute( {
 	getParentRoute: () => billingRoute,
 	path: '/',
@@ -713,7 +731,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		return [];
 	}
 
-	const meRoutes: AnyRoute[] = [ profileRoute, preferencesRoute ];
+	const meRoutes: AnyRoute[] = [ profileRoute, preferencesRoute, usageRoute ];
 
 	meRoutes.push(
 		billingRoute.addChildren( [

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -28,6 +28,7 @@ const MeMenu = () => {
 			{ hasAppSupport( supports, 'apps' ) && (
 				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
 			) }
+			<ResponsiveMenu.Item to="/me/usage">{ __( 'Usage' ) }</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);
 };

--- a/client/dashboard/me/usage/components/flex-usage-card/index.tsx
+++ b/client/dashboard/me/usage/components/flex-usage-card/index.tsx
@@ -1,0 +1,47 @@
+import {
+	Card,
+	CardBody,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Spinner,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import type { ReactNode } from 'react';
+
+interface FlexUsageCardProps {
+	title: string;
+	description?: ReactNode;
+	isLoading?: boolean;
+	children?: ReactNode;
+}
+
+export default function FlexUsageCard( {
+	title,
+	description,
+	isLoading,
+	children,
+}: FlexUsageCardProps ) {
+	return (
+		<Card style={ { flexGrow: 1 } } className="flex-usage-card">
+			<CardBody>
+				<VStack spacing={ 4 } justify="flex-start">
+					<HStack justify="space-between" alignment="flex-start">
+						<VStack spacing={ 4 }>
+							<Text weight="bold" size="15px">
+								{ title }
+							</Text>
+							<HStack justify="flex-start" alignment="baseline">
+								<Text variant="muted">{ description || <>&nbsp;</> }</Text>
+							</HStack>
+						</VStack>
+					</HStack>
+					{ children && (
+						<VStack spacing={ 2 } justify="space-between">
+							{ isLoading ? <Spinner /> : children }
+						</VStack>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/me/usage/index.tsx
+++ b/client/dashboard/me/usage/index.tsx
@@ -1,13 +1,14 @@
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	Card,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
+import FlexUsageCard from './components/flex-usage-card';
 
 function getMonthToDateRange( locale: string ) {
 	const now = new Date();
@@ -19,9 +20,10 @@ function getMonthToDateRange( locale: string ) {
 	return `${ startText }\u200E–\u200E${ endText }`;
 }
 
-function Usage() {
+function FlexUsage() {
 	// Skeleton layout only; charts/cards to be implemented in later tasks
 	const locale = useLocale();
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	return (
 		<PageLayout
 			size="large"
@@ -29,19 +31,34 @@ function Usage() {
 				<PageHeader title={ __( 'Usage' ) } description={ getMonthToDateRange( locale ) } />
 			}
 		>
-			<VStack spacing={ 8 } alignment="stretch">
-				<HStack spacing={ 8 } wrap alignment="stretch">
-					<Card>{ __( 'Overall usage (pie) – coming soon' ) }</Card>
-					<Card>{ __( 'Sites usage list – coming soon' ) }</Card>
+			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
+				<HStack wrap alignment="stretch" spacing={ isSmallViewport ? 4 : 8 }>
+					<FlexUsageCard
+						title={ __( 'Plan usage' ) }
+						description={ __( 'This section provides an overview of your plan usage.' ) }
+						isLoading={ false }
+					></FlexUsageCard>
+					<FlexUsageCard
+						title={ __( 'Sites usage' ) }
+						description={ __( 'See how each site contributes to your total resource usage.' ) }
+						isLoading={ false }
+					></FlexUsageCard>
 				</HStack>
-
-				<VStack spacing={ 8 } alignment="stretch">
-					<Card>{ __( 'Bandwidth over time – coming soon' ) }</Card>
-					<Card>{ __( 'Storage over time – coming soon' ) }</Card>
-				</VStack>
+				<FlexUsageCard
+					title={ __( 'Bandwidth' ) }
+					description={ __(
+						'The bandwidth report shows the total data your site has transmitted. Chart reflects GMT/UTC time.'
+					) }
+					isLoading={ false }
+				></FlexUsageCard>
+				<FlexUsageCard
+					title={ __( 'Storage' ) }
+					description={ __( 'The disk space report shows usage compared to the account limit.' ) }
+					isLoading={ false }
+				></FlexUsageCard>
 			</VStack>
 		</PageLayout>
 	);
 }
 
-export default Usage;
+export default FlexUsage;

--- a/client/dashboard/me/usage/index.tsx
+++ b/client/dashboard/me/usage/index.tsx
@@ -1,0 +1,47 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Card,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useLocale } from '../../app/locale';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { formatDate } from '../../utils/datetime';
+
+function getMonthToDateRange( locale: string ) {
+	const now = new Date();
+	const start = new Date( now.getFullYear(), now.getMonth(), 1 );
+	const options: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'long', year: 'numeric' };
+	const startText = formatDate( start, locale, options );
+	const endText = formatDate( now, locale, options );
+	// Use LRM around en dash for RTL safety
+	return `${ startText }\u200E–\u200E${ endText }`;
+}
+
+function Usage() {
+	// Skeleton layout only; charts/cards to be implemented in later tasks
+	const locale = useLocale();
+	return (
+		<PageLayout
+			size="large"
+			header={
+				<PageHeader title={ __( 'Usage' ) } description={ getMonthToDateRange( locale ) } />
+			}
+		>
+			<VStack spacing={ 8 } alignment="stretch">
+				<HStack spacing={ 8 } wrap alignment="stretch">
+					<Card>{ __( 'Overall usage (pie) – coming soon' ) }</Card>
+					<Card>{ __( 'Sites usage list – coming soon' ) }</Card>
+				</HStack>
+
+				<VStack spacing={ 8 } alignment="stretch">
+					<Card>{ __( 'Bandwidth over time – coming soon' ) }</Card>
+					<Card>{ __( 'Storage over time – coming soon' ) }</Card>
+				</VStack>
+			</VStack>
+		</PageLayout>
+	);
+}
+
+export default Usage;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/DOTMART-43/add-route-and-skeleton-for-global-usage-page

## Proposed Changes

- This PR adds the route for the Usage section under Account and a skeleton page
- Adds a "flex-usage-card" for alignment 

| Desktop | Mobile |
|--------|--------|
| <img width="700" alt="Screenshot 2025-10-21 at 3 25 56 PM" src="https://github.com/user-attachments/assets/cc518c35-4a6a-42bc-b357-5a787d4e1b5d" /> | <img width="671" height="736" alt="Screenshot 2025-10-21 at 3 29 20 PM" src="https://github.com/user-attachments/assets/39e1962d-ee46-4c55-bf98-6c796bc0f9c2" /> |

### TODO

- [ ] Gate this so it only shows for users with either a subscription to a flex plan or a site with the `is_wpcom_flex` property

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/DOTMART-43/add-route-and-skeleton-for-global-usage-page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a flex site (Follow instructions in 192692-ghe-Automattic/wpcom to create one)
* Go to `/v2/me/usage` and confirm page renders

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?