### PR TITLE
Disable set primary site address for sites with an active redirect

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -35,7 +35,6 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
-
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
 	const sitesByBlogId: Record< number, Site > = useMemo( () => {
 		if ( ! sites ) {

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -35,6 +35,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const router = useRouter();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
+
 	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
 	const sitesByBlogId: Record< number, Site > = useMemo( () => {
 		if ( ! sites ) {
@@ -192,7 +193,8 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				},
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
-					return !! site && canSetAsPrimary( { domain: item, site, user } );
+					const hasRedirect = site?.options?.is_redirect ?? false;
+					return !! site && canSetAsPrimary( { domain: item, site, user } ) && ! hasRedirect;
 				},
 				disabled: setPrimaryDomainMutation.isPending,
 			},

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -31,7 +31,7 @@ function SiteDomains() {
 			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},
 	} );
-	const { data: redirect } = useQuery( siteRedirectQuery( site.ID ) );
+	const { data: redirect, isLoading: isRedirectLoading } = useQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;
 
 	const fields = useFields( {
@@ -60,7 +60,7 @@ function SiteDomains() {
 				/>
 			}
 		>
-			{ ! isLoading && siteDomains && (
+			{ ! isLoading && ! isRedirectLoading && siteDomains && ! hasRedirect && (
 				<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />
 			) }
 			{ hasRedirect && (


### PR DESCRIPTION
Closes [DOTDASH-681](https://linear.app/a8c/issue/DOTDASH-681/hide-set-primary-actions-for-sites-with-a-redirect-upgrade)

## Proposed Changes
- Disable set primary site address selector for sites with an active redirect
- Disable set primary site address action for sites with an active redirect in the site domains list

## Why are these changes being made?
The primary site address should always be the free subdomain for sites with an active redirect.

## Testing Instructions
Open site domains list (`v2/sites/[SITE]/domains`) for a site with a custom domain and a site redirect (and a paid plan) and verify that the primary selector and the set as primary action (in the custom domain actions) are disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
