### PR TITLE
SSH Migration: Add SSH steps skeleton and navigation

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -45,6 +45,7 @@ export const siteCreationPath = buildPathHelper<
 		queryParams: {
 			from?: string | null;
 			platform: ImporterPlatform;
+			ssh?: string;
 		};
 	},
 	typeof STEPS.SITE_CREATION_STEP.slug
@@ -52,7 +53,7 @@ export const siteCreationPath = buildPathHelper<
 
 export const sitePickerPath = buildPathHelper<
 	{
-		queryParams: { from: string | null; platform: ImporterPlatform };
+		queryParams: { from: string | null; platform: ImporterPlatform; ssh?: string };
 	},
 	typeof STEPS.PICK_SITE.slug
 >( STEPS.PICK_SITE.slug );
@@ -111,6 +112,7 @@ export const upgradePlanPath = buildPathHelper<
 			from?: string | null;
 			destination?: string;
 			how?: string;
+			ssh?: string;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -190,6 +190,26 @@ export const supportInstructionsPath = buildPathHelper<
 	typeof STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug
 >( STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug );
 
+export const sshShareAccessPath = buildPathHelper<
+	{
+		queryParams: {
+			siteId?: number | string;
+			siteSlug: string;
+		};
+	},
+	typeof STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug
+>( STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug );
+
+export const sshInProgressPath = buildPathHelper<
+	{
+		queryParams: {
+			siteId?: number | string;
+			siteSlug: string;
+		};
+	},
+	typeof STEPS.SITE_MIGRATION_SSH_IN_PROGRESS.slug
+>( STEPS.SITE_MIGRATION_SSH_IN_PROGRESS.slug );
+
 export const identifyPath = buildPathHelper<
 	{
 		queryParams: { from: string | null };

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -117,11 +117,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const { get, sessionId } = useFlowState();
 		const userHasOtherWPComSites = siteCount && siteCount > 1;
 		const entryPoint = get( 'flow' )?.entryPoint;
-		const canInstallPlugins = site?.plan?.features?.active.find(
-			( feature: string ) => feature === 'install-plugins'
-		)
-			? true
-			: false;
+		const canInstallPlugins = site?.plan?.features?.active.includes( 'install-plugins' ) ?? false;
 		const exitFlow = ( to: string, replace = false ) => {
 			if ( replace ) {
 				return window.location.replace(

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard } from '@automattic/data-stores';
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
@@ -48,6 +49,8 @@ const BASE_STEPS = [
 	STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
 	STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
 	STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
+	STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS,
+	STEPS.SITE_MIGRATION_SSH_IN_PROGRESS,
 	STEPS.PICK_SITE,
 	STEPS.SITE_CREATION_STEP,
 	STEPS.PROCESSING,
@@ -144,6 +147,21 @@ const siteMigration: FlowV2< typeof initialize > = {
 						action: SiteMigrationIdentifyAction;
 					};
 					const hasDestinationSite = hasSite( siteId, siteSlug );
+					// TODO: Remove the call and use a actual check for the hosting
+					const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
+
+					if ( isSSHMigrationAvailable ) {
+						if ( hasDestinationSite ) {
+							return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+						}
+
+						if ( userHasOtherWPComSites ) {
+							return navigate( paths.sitePickerPath( { from, platform } ) );
+						}
+
+						return navigate( paths.siteCreationPath( { from, platform } ) );
+					}
+
 					if ( hasDestinationSite ) {
 						if ( platform !== 'wordpress' || action === 'skip_platform_identification' ) {
 							if ( isPlatformImportable( platform ) && from ) {
@@ -507,6 +525,14 @@ const siteMigration: FlowV2< typeof initialize > = {
 						);
 					}
 
+					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
+				}
+
+				case STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug: {
+					return navigate( paths.sshInProgressPath( { siteId, siteSlug } ) );
+				}
+
+				case STEPS.SITE_MIGRATION_SSH_IN_PROGRESS.slug: {
 					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 				}
 			}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -218,16 +218,10 @@ const siteMigration: FlowV2< typeof initialize > = {
 						}
 						case 'select-site': {
 							const { ID: siteId, slug: siteSlug } = providedDependencies.site as SiteExcerptData;
-							const selectedSite = providedDependencies.site as SiteExcerptData;
-							const selectedSiteCanInstallPlugins = selectedSite?.plan?.features?.active.find(
-								( feature: string ) => feature === 'install-plugins'
-							)
-								? true
-								: false;
 
 							// Check if this is an SSH migration flow
 							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
-								if ( selectedSiteCanInstallPlugins ) {
+								if ( canInstallPlugins ) {
 									return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
 								}
 								return navigate(

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -219,11 +219,8 @@ const siteMigration: FlowV2< typeof initialize > = {
 						case 'select-site': {
 							const { ID: siteId, slug: siteSlug } = providedDependencies.site as SiteExcerptData;
 							const selectedSite = providedDependencies.site as SiteExcerptData;
-							const selectedSiteCanInstallPlugins = selectedSite?.plan?.features?.active.find(
-								( feature: string ) => feature === 'install-plugins'
-							)
-								? true
-								: false;
+							const selectedSiteCanInstallPlugins =
+								selectedSite?.plan?.features?.active.includes( 'install-plugins' ) ?? false;
 
 							// Check if this is an SSH migration flow
 							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -188,10 +188,10 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					if ( userHasOtherWPComSites ) {
-						return navigate( paths.sitePickerPath( { from, platform, ssh: 'true' } ) );
+						return navigate( paths.sitePickerPath( { from, platform } ) );
 					}
 
-					return navigate( paths.siteCreationPath( { from, platform, ssh: 'true' } ) );
+					return navigate( paths.siteCreationPath( { from, platform } ) );
 				}
 
 				case STEPS.PICK_SITE.slug: {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -105,7 +105,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 	useStepNavigation( currentStep, navigate: NavigateV2< typeof BASE_STEPS > ) {
 		const flowName = this.name;
-		const { siteId, siteSlug } = useSiteData();
+		const { siteId, siteSlug, site } = useSiteData();
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
 		const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
@@ -117,6 +117,11 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const { get, sessionId } = useFlowState();
 		const userHasOtherWPComSites = siteCount && siteCount > 1;
 		const entryPoint = get( 'flow' )?.entryPoint;
+		const canInstallPlugins = site?.plan?.features?.active.find(
+			( feature: string ) => feature === 'install-plugins'
+		)
+			? true
+			: false;
 		const exitFlow = ( to: string, replace = false ) => {
 			if ( replace ) {
 				return window.location.replace(
@@ -152,14 +157,17 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 					if ( isSSHMigrationAvailable ) {
 						if ( hasDestinationSite ) {
-							return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+							if ( canInstallPlugins ) {
+								return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+							}
+							return navigate( paths.upgradePlanPath( { siteId, siteSlug, from, ssh: 'true' } ) );
 						}
 
 						if ( userHasOtherWPComSites ) {
-							return navigate( paths.sitePickerPath( { from, platform } ) );
+							return navigate( paths.sitePickerPath( { from, platform, ssh: 'true' } ) );
 						}
 
-						return navigate( paths.siteCreationPath( { from, platform } ) );
+						return navigate( paths.siteCreationPath( { from, platform, ssh: 'true' } ) );
 					}
 
 					if ( hasDestinationSite ) {
@@ -183,10 +191,10 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					if ( userHasOtherWPComSites ) {
-						return navigate( paths.sitePickerPath( { from, platform } ) );
+						return navigate( paths.sitePickerPath( { from, platform, ssh: 'true' } ) );
 					}
 
-					return navigate( paths.siteCreationPath( { from, platform } ) );
+					return navigate( paths.siteCreationPath( { from, platform, ssh: 'true' } ) );
 				}
 
 				case STEPS.PICK_SITE.slug: {
@@ -213,6 +221,22 @@ const siteMigration: FlowV2< typeof initialize > = {
 						}
 						case 'select-site': {
 							const { ID: siteId, slug: siteSlug } = providedDependencies.site as SiteExcerptData;
+							const selectedSite = providedDependencies.site as SiteExcerptData;
+							const selectedSiteCanInstallPlugins = selectedSite?.plan?.features?.active.find(
+								( feature: string ) => feature === 'install-plugins'
+							)
+								? true
+								: false;
+
+							// Check if this is an SSH migration flow
+							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+								if ( selectedSiteCanInstallPlugins ) {
+									return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+								}
+								return navigate(
+									paths.upgradePlanPath( { siteId, siteSlug, from: fromQueryParam, ssh: 'true' } )
+								);
+							}
 
 							if ( 'migrate' === actionQueryParam ) {
 								return navigate(
@@ -244,13 +268,20 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 							return navigate( paths.importOrMigratePath( { siteSlug, siteId } ) );
 						}
-						case 'create-site':
-							return navigate(
-								paths.siteCreationPath( {
-									from: fromQueryParam,
-									platform: platformQueryParam,
-								} )
-							);
+						case 'create-site': {
+							const queryParams: {
+								from: string | null;
+								platform: ImporterPlatform;
+								ssh?: string;
+							} = {
+								from: fromQueryParam,
+								platform: platformQueryParam,
+							};
+							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+								queryParams.ssh = 'true';
+							}
+							return navigate( paths.siteCreationPath( queryParams ) );
+						}
 					}
 				}
 
@@ -278,6 +309,18 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					recordSignupComplete( { siteId } );
+
+					// Check if this is an SSH migration flow
+					if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+						return replace(
+							paths.upgradePlanPath( {
+								siteId,
+								from: fromQueryParam,
+								siteSlug,
+								ssh: 'true',
+							} )
+						);
+					}
 
 					//NOTE: There are links pointing to this step with the action=migrate query param, so we need to ignore the platform
 					if ( actionQueryParam === 'migrate' ) {
@@ -377,7 +420,9 @@ const siteMigration: FlowV2< typeof initialize > = {
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
 					if ( providedDependencies?.goToCheckout ) {
 						let redirectAfterCheckout: string = STEPS.SITE_MIGRATION_INSTRUCTIONS.slug;
-						if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
+						if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+							redirectAfterCheckout = STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug;
+						} else if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
 							redirectAfterCheckout = STEPS.SITE_MIGRATION_CREDENTIALS.slug;
 						}
 						const destination = addQueryArgs(
@@ -403,6 +448,10 @@ const siteMigration: FlowV2< typeof initialize > = {
 									: {},
 						} );
 						return;
+					}
+
+					if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+						return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
 					}
 
 					if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -218,10 +218,16 @@ const siteMigration: FlowV2< typeof initialize > = {
 						}
 						case 'select-site': {
 							const { ID: siteId, slug: siteSlug } = providedDependencies.site as SiteExcerptData;
+							const selectedSite = providedDependencies.site as SiteExcerptData;
+							const selectedSiteCanInstallPlugins = selectedSite?.plan?.features?.active.find(
+								( feature: string ) => feature === 'install-plugins'
+							)
+								? true
+								: false;
 
 							// Check if this is an SSH migration flow
 							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
-								if ( canInstallPlugins ) {
+								if ( selectedSiteCanInstallPlugins ) {
 									return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
 								}
 								return navigate(

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -152,10 +152,11 @@ const siteMigration: FlowV2< typeof initialize > = {
 					const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 
 					if ( isSSHMigrationAvailable ) {
+						if ( hasDestinationSite && canInstallPlugins ) {
+							return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+						}
+
 						if ( hasDestinationSite ) {
-							if ( canInstallPlugins ) {
-								return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
-							}
 							return navigate( paths.upgradePlanPath( { siteId, siteSlug, from, ssh: 'true' } ) );
 						}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
@@ -1,0 +1,44 @@
+import { NextButton, StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationSshInProgress: Step< {
+	submits: {
+		action: 'continue';
+	};
+} > = function ( { navigation } ) {
+	const translate = useTranslate();
+
+	const handleContinue = () => {
+		navigation.submit?.( { action: 'continue' } );
+	};
+
+	const stepContent = (
+		<div>
+			<p>{ translate( 'SSH Migration In Progress - Coming Soon' ) }</p>
+			<NextButton onClick={ handleContinue }>{ translate( 'Go to Dashboard' ) }</NextButton>
+		</div>
+	);
+
+	return (
+		<StepContainer
+			stepName="site-migration-ssh-in-progress"
+			isFullLayout
+			formattedHeader={
+				<FormattedHeader
+					headerText={ translate( 'Migration In Progress' ) }
+					subHeaderText={ translate( 'This step is under development.' ) }
+					align="center"
+				/>
+			}
+			hideSkip
+			hideBack
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default SiteMigrationSshInProgress;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -1,0 +1,44 @@
+import { NextButton, StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationSshShareAccess: Step< {
+	submits: {
+		action: 'continue';
+	};
+} > = function ( { navigation } ) {
+	const translate = useTranslate();
+
+	const handleContinue = () => {
+		navigation.submit?.( { action: 'continue' } );
+	};
+
+	const stepContent = (
+		<div>
+			<p>{ translate( 'SSH Share Access - Coming Soon' ) }</p>
+			<NextButton onClick={ handleContinue }>{ translate( 'Continue' ) }</NextButton>
+		</div>
+	);
+
+	return (
+		<StepContainer
+			stepName="site-migration-ssh-share-access"
+			isFullLayout
+			formattedHeader={
+				<FormattedHeader
+					headerText={ translate( 'Share SSH Access' ) }
+					subHeaderText={ translate( 'This step is under development.' ) }
+					align="center"
+				/>
+			}
+			hideSkip
+			hideBack
+			stepContent={ stepContent }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default SiteMigrationSshShareAccess;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -308,6 +308,16 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-support-instructions' ),
 	},
 
+	SITE_MIGRATION_SSH_SHARE_ACCESS: {
+		slug: 'site-migration-ssh-share-access',
+		asyncComponent: () => import( './steps-repository/site-migration-ssh-share-access' ),
+	},
+
+	SITE_MIGRATION_SSH_IN_PROGRESS: {
+		slug: 'site-migration-ssh-in-progress',
+		asyncComponent: () => import( './steps-repository/site-migration-ssh-in-progress' ),
+	},
+
 	PICK_SITE: {
 		slug: 'sitePicker',
 		asyncComponent: () => import( './steps-repository/site-picker' ),

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Turns off the SSH Migration feature flag on development to not interfere in other developers work.
* Use the feature flag to identify that the site can go through the SSH Migration flow.
* Adds the navigation to the SSH Migration step. This PR should handle all redirects to the new SSH Migration step.
* Adds the base skeleton for the "Securely share your access" and "Your migration is underway" steps.  

**Note**: I will perform the check for the capability of performing the SSH migration(having the allow_site_migration meta), on the SSH Migration step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the SSH Migration, we need to redirect the users to the SSH Migration steps when we identify the Site can be migrated through SSH. This check will happen on the Analyze URL step, but for now I'm using the feature flag to pretend the site is capable of migrating through SSH.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your sandbox:
* Use the Console to enable the flag:
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* You may need to do the migration multiple times, but once you get to the "Let's find your site" step(Analyze step) you need to test the following scenarios:
    * Create a new site -> Checkout -> Should land on the SSH Migration placeholder step
    * Select an existing free site -> Checkout -> Should land on the SSH Migration placeholder step
    * Select an existing site with the Business plan -> Should land on the SSH Migration placeholder step
* On an existing free site, go to Import -> Wordpress. After the Analyze step you should be redirected to the Upgrade step, and then the SSH Migration skeleton.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
