### PR TITLE
Validate form on blur

### DIFF
--- a/client/dashboard/emails/add-professional-email/components/mailbox-form.tsx
+++ b/client/dashboard/emails/add-professional-email/components/mailbox-form.tsx
@@ -56,6 +56,16 @@ export const MailboxForm = ( {
 		mailboxEntity.validateField( FIELD_MAILBOX );
 	};
 
+	const onBlur = ( { field }: { field: MailboxFormFieldBase< string > } ) => {
+		if ( ! field.isTouched ) {
+			field.isTouched = field.value?.length > 0;
+		}
+		if ( field.isTouched ) {
+			onRequestFieldValidation( field );
+		}
+		field.dispatchState();
+	};
+
 	const onChange = ( {
 		value,
 		field,
@@ -93,6 +103,7 @@ export const MailboxForm = ( {
 						<Text variant="muted">{ `@${ domain }` }</Text>
 					</InputControlSuffixWrapper>
 				}
+				onBlur={ onBlur }
 				onChange={ onChange }
 			/>
 
@@ -115,6 +126,7 @@ export const MailboxForm = ( {
 					}
 					// Hint to LastPass not to attempt autofill
 					data-lpignore="true"
+					onBlur={ onBlur }
 					onChange={ onChange }
 				/>
 
@@ -152,6 +164,7 @@ export const MailboxForm = ( {
 					mailboxEntity={ mailboxEntity }
 					label={ __( 'Password reset email address' ) }
 					disabled={ disabled }
+					onBlur={ onBlur }
 					onChange={ onChange }
 				/>
 			) }

--- a/client/dashboard/emails/add-professional-email/components/mailbox-input.tsx
+++ b/client/dashboard/emails/add-professional-email/components/mailbox-input.tsx
@@ -17,6 +17,7 @@ import type { InputControlProps } from '@wordpress/components/build-types/input-
 export const MailboxInput = ( {
 	fieldName,
 	mailboxEntity,
+	onBlur,
 	onChange,
 	lowerCaseChangeValue = false,
 	...inputControlProps
@@ -24,12 +25,13 @@ export const MailboxInput = ( {
 	fieldName: 'mailbox' | 'password' | 'passwordResetEmail';
 	mailboxEntity: MailboxFormEntity< SupportedEmailProvider >;
 	lowerCaseChangeValue?: boolean;
+	onBlur: ( args: { field: MailboxFormFieldBase< string > } ) => void;
 	onChange: ( args: {
 		value: string | undefined;
 		field: MailboxFormFieldBase< string >;
 		lowerCaseChangeValue?: boolean;
 	} ) => void;
-} & Omit< InputControlProps, 'onChange' > ) => {
+} & Omit< InputControlProps, 'onBlur' | 'onChange' > ) => {
 	const originalField = ( mailboxEntity.formFields as TitanMailboxFormFields )[
 		fieldName
 	] as TextMailboxFormField;
@@ -48,6 +50,9 @@ export const MailboxInput = ( {
 			<InputControl
 				__next40pxDefaultSize
 				value={ mailboxEntity.getFieldValue( fieldName ) }
+				onBlur={ () => {
+					onBlur( { field: originalField } );
+				} }
 				onChange={ ( value ) => {
 					onChange( {
 						value,
@@ -61,7 +66,7 @@ export const MailboxInput = ( {
 			{ mailboxEntity.getFieldError( fieldName ) && (
 				<Text className="error-message" as="p" intent="error">
 					<Icon size={ 20 } icon={ info } />
-					{ mailboxEntity.getFieldError( fieldName ) }
+					<div>{ mailboxEntity.getFieldError( fieldName ) }</div>
 				</Text>
 			) }
 		</VStack>

--- a/client/dashboard/emails/add-professional-email/components/style.scss
+++ b/client/dashboard/emails/add-professional-email/components/style.scss
@@ -1,6 +1,5 @@
 .error-message {
 	display: flex;
-	align-items: center;
 
 	svg {
 		fill: currentcolor;

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -114,6 +114,10 @@ const AddProfessionalEmail = () => {
 		return mailbox;
 	}, [ domainName, existingMailboxes, user.email ] );
 
+	const persistMailboxesToState = useCallback( () => {
+		setMailboxEntities( [ ...mailboxEntities ] );
+	}, [ mailboxEntities ] );
+
 	useEffect( () => {
 		isFetched && setMailboxEntities( [ createNewMailbox() ] );
 	}, [ createNewMailbox, isFetched ] );
@@ -126,7 +130,8 @@ const AddProfessionalEmail = () => {
 		);
 
 		mailboxEntities.forEach( ( mailbox ) => mailbox.validate( true ) );
-		const mailboxOperations = new MailboxOperations( mailboxEntities, () => {} );
+		persistMailboxesToState();
+		const mailboxOperations = new MailboxOperations( mailboxEntities, persistMailboxesToState );
 
 		setIsSubmitting( true );
 

--- a/client/dashboard/emails/entities/validators.ts
+++ b/client/dashboard/emails/entities/validators.ts
@@ -315,7 +315,7 @@ class PreviouslySpecifiedMailboxNamesValidator extends ExistingMailboxNamesValid
 			sprintf(
 				// Translators: %(emailAddress)s is the email address that has already been specified in this form.
 				__(
-					'Please use unique email addresses. {{strong}}%(emailAddress)s{{/strong}} has already been specified before.'
+					'Please use unique email addresses. <strong>%(emailAddress)s</strong> has already been specified before.'
 				),
 				{ emailAddress: `${ existingMailboxName }@${ domainName }` }
 			),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDASH-480

## Proposed Changes

* Trigger react state updates so that validation errors are rendered when needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of or effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview.
* Go to `/v2/emails/add-professional-email/{domainName}`.
* Add a mailbox with the `test` address, then on the password field type just two characters and `tab` out of it, check that you see the appropriate error:

<img width="1443" height="536" alt="image" src="https://github.com/user-attachments/assets/c3596451-63a5-4b72-ac88-baa5777c69a5" />

* Fill the password to the required length.
* Add another mailbox with the `test` address.
* Submit the form, check that you see the appropriate error:

<img width="1719" height="1628" alt="image" src="https://github.com/user-attachments/assets/8f74ab70-dffa-43c5-aafb-fc81ca77b373" />

* Attempt to submit a mailbox using the same domain as the mailbox on the password reset email address, check that you see an error:

<img width="1717" height="857" alt="image" src="https://github.com/user-attachments/assets/01bfb6bf-1eee-4eda-9a15-35ab564fa3e2" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
