### PR TITLE
Form submission tests: consider formatted number when querying for folders

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -180,7 +180,7 @@ export class FeedbackInboxPage {
 			.getByRole( 'tab', { name: new RegExp( folderName, 'i' ) } )
 			.or(
 				this.page.getByRole( 'radio', {
-					name: new RegExp( `^${ folderName }\\s*\\(\\d+,\\)$`, 'i' ),
+					name: new RegExp( `^${ folderName }\\s*\\(\\d{1,3}(?:,\\d{3})*\\)$`, 'i' ),
 				} )
 			)
 			.click();

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -180,7 +180,7 @@ export class FeedbackInboxPage {
 			.getByRole( 'tab', { name: new RegExp( folderName, 'i' ) } )
 			.or(
 				this.page.getByRole( 'radio', {
-					name: new RegExp( `^${ folderName }\\s*\\(\\d{1,3}(?:,\\d{3})*\\)$`, 'i' ),
+					name: folderName,
 				} )
 			)
 			.click();


### PR DESCRIPTION


## Proposed Changes

This PR addresses an failing test while querying the dom for a folder with formatted numbers in it.

## Why are these changes being made?
Because the test was failing even when things worked as expected

## Testing Instructions

Run: `yarn workspace wp-e2e-tests build `, then:

```
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"

VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"

ATOMIC_VARIATION="php-new" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
