### PR TITLE
Purchase extra storage from a modal

### DIFF
--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,22 +1,25 @@
 import { siteMediaStorageQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
-	ExternalLink,
+	Button,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import filesize from 'filesize';
+import { useState } from 'react';
 import { Stat } from '../../components/stat';
 import { hasStagingSite } from '../../utils/site-staging-site';
 import { getStorageAlertLevel } from '../../utils/site-storage';
 import { isStagingSite } from '../../utils/site-types';
+import { AddStorageModal } from '../storage/add-storage-modal';
 import type { Site } from '@automattic/api-core';
 
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 
 export default function SiteStorageStat( { site }: { site: Site } ) {
 	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const storageUsagePercent = Math.round(
 		( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
@@ -60,7 +63,16 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 				</Text>
 			) }
 			{ alertLevel !== 'none' && (
-				<ExternalLink href={ `/add-ons/${ site.slug }` }>{ __( 'Add more storage' ) }</ExternalLink>
+				<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
+					{ __( 'Add more storage' ) }
+				</Button>
+			) }
+			{ isModalOpen && (
+				<AddStorageModal
+					site={ site }
+					isOpen={ isModalOpen }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
 			) }
 		</VStack>
 	);

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -63,15 +63,17 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 				</Text>
 			) }
 			{ alertLevel !== 'none' && (
-				<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
-					{ __( 'Add more storage' ) }
-				</Button>
+				<>
+					<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
+						{ __( 'Add more storage' ) }
+					</Button>
+					<AddStorageModal
+						site={ site }
+						isOpen={ isModalOpen }
+						onClose={ () => setIsModalOpen( false ) }
+					/>
+				</>
 			) }
-			<AddStorageModal
-				site={ site }
-				isOpen={ isModalOpen }
-				onClose={ () => setIsModalOpen( false ) }
-			/>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -67,13 +67,11 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 					{ __( 'Add more storage' ) }
 				</Button>
 			) }
-			{ isModalOpen && (
-				<AddStorageModal
-					site={ site }
-					isOpen={ isModalOpen }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
+			<AddStorageModal
+				site={ site }
+				isOpen={ isModalOpen }
+				onClose={ () => setIsModalOpen( false ) }
+			/>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -77,13 +77,11 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 					}
 				) }
 			</Notice>
-			{ isModalOpen && (
-				<AddStorageModal
-					site={ site }
-					isOpen={ isModalOpen }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
+			<AddStorageModal
+				site={ site }
+				isOpen={ isModalOpen }
+				onClose={ () => setIsModalOpen( false ) }
+			/>
 		</>
 	);
 }

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -6,9 +6,11 @@ import {
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { sprintf, __ } from '@wordpress/i18n';
 import filesize from 'filesize';
+import { useState } from 'react';
 import Notice from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { getStorageAlertLevel } from '../../utils/site-storage';
+import { AddStorageModal } from '../storage/add-storage-modal';
 import type { Site } from '@automattic/api-core';
 
 export function StorageWarningBanner( { site }: { site: Site } ) {
@@ -19,6 +21,7 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 	const { mutate: updateDismissed, isPending: isDismissing } = useMutation(
 		userPreferenceMutation( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
 	);
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	// Optimistically hide the banner assuming the preference will get saved.
 	const isDismissed = isDismissedPersisted || isDismissing;
@@ -49,29 +52,38 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 			: 'site-overview-storage-warning-exceeded';
 
 	return (
-		<Notice
-			{ ...noticeProps }
-			actions={
-				<UpsellCTAButton
-					variant="primary"
-					upsellId={ upsellId }
-					upsellFeatureId="site-storage"
-					href={ `/add-ons/${ site.slug }` }
-				>
-					{ __( 'Add more storage' ) }
-				</UpsellCTAButton>
-			}
-		>
-			{ sprintf(
-				// translators: "used" and "available" amounts data including a unit, e.g. "2.03 MB" or "1.5 GB".
-				__(
-					'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
-				),
-				{
-					used: filesize( mediaStorage.storage_used_bytes, { round: 0 } ),
-					available: filesize( mediaStorage.max_storage_bytes, { round: 0 } ),
+		<>
+			<Notice
+				{ ...noticeProps }
+				actions={
+					<UpsellCTAButton
+						variant="primary"
+						upsellId={ upsellId }
+						upsellFeatureId="site-storage"
+						onClick={ () => setIsModalOpen( true ) }
+					>
+						{ __( 'Add more storage' ) }
+					</UpsellCTAButton>
 				}
+			>
+				{ sprintf(
+					// translators: "used" and "available" amounts data including a unit, e.g. "2.03 MB" or "1.5 GB".
+					__(
+						'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
+					),
+					{
+						used: filesize( mediaStorage.storage_used_bytes, { round: 0 } ),
+						available: filesize( mediaStorage.max_storage_bytes, { round: 0 } ),
+					}
+				) }
+			</Notice>
+			{ isModalOpen && (
+				<AddStorageModal
+					site={ site }
+					isOpen={ isModalOpen }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
 			) }
-		</Notice>
+		</>
 	);
 }

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -151,7 +151,7 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 				<VStack spacing={ 2 }>
 					<Text weight={ 600 }>{ __( 'New storage capacity' ) }</Text>
 					<StorageCapacityStat
-						description={ filesize( mediaStorage.storage_used_bytes, { round: 1 } ) + ' used' }
+						description={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) + ' used' }
 						currentCapacityBytes={ planStorageBytes }
 						addOnCapacityBytes={ selectedAddOnStorageBytes }
 					/>

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -1,0 +1,146 @@
+import { productsQuery, siteMediaStorageQuery, sitePurchasesQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	Modal,
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	CustomSelectControl,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import filesize from 'filesize';
+import { useState } from 'react';
+import { StorageCapacityStat } from './storage-capacity-stat';
+import {
+	getStorageAddOnProduct,
+	getPurchasedStorageAddOn,
+	getStorageTierOptions,
+	getPurchasedStorageQuantity,
+	type StorageTierOption,
+} from './storage-utils';
+import type { Site } from '@automattic/api-core';
+
+interface AddStorageModalProps {
+	site: Site;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+interface SelectOption {
+	key: string;
+	name: string;
+}
+
+export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps ) {
+	const { data: products } = useSuspenseQuery( productsQuery() );
+	const { data: purchases } = useSuspenseQuery( sitePurchasesQuery( site.ID ) );
+	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+
+	const storageProduct = getStorageAddOnProduct( products );
+	const purchasedStorageAddOn = getPurchasedStorageAddOn( purchases );
+	const tierOptions = getStorageTierOptions( storageProduct );
+	const currentPurchasedQuantity = getPurchasedStorageQuantity( purchasedStorageAddOn );
+
+	// Filter out tiers that are less than or equal to what's already purchased
+	const availableTiers = tierOptions.filter( ( tier ) => tier.quantity > currentPurchasedQuantity );
+
+	// Default to the first available tier
+	const [ selectedTier, setSelectedTier ] = useState< StorageTierOption | null >(
+		availableTiers[ 0 ] ?? null
+	);
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	// Calculate storage breakdown
+	const planStorageBytes =
+		mediaStorage.max_storage_bytes - mediaStorage.max_storage_bytes_from_add_ons;
+	const selectedAddOnStorageBytes = ( selectedTier?.quantity ?? 0 ) * 1024 * 1024 * 1024;
+
+	// Build select options
+	const selectOptions: SelectOption[] = availableTiers.map( ( tier ) => ( {
+		key: String( tier.quantity ),
+		name: sprintf(
+			// translators: %1$d: storage amount in GB, %2$s: formatted monthly price, e.g., "50 GB Storage (£40.71/month, billed yearly)"
+			__( '%1$d GB Storage (%2$s/month, billed yearly)' ),
+			tier.quantity,
+			tier.formattedMonthlyPrice
+		),
+	} ) );
+
+	const selectedOption = selectedTier
+		? {
+				key: String( selectedTier.quantity ),
+				name: sprintf(
+					// translators: %1$d: storage amount in GB, %2$s: formatted monthly price
+					__( '%1$d GB Storage (%2$s/month, billed yearly)' ),
+					selectedTier.quantity,
+					selectedTier.formattedMonthlyPrice
+				),
+		  }
+		: selectOptions[ 0 ];
+
+	const handleSelectChange = ( { selectedItem }: { selectedItem: SelectOption } ) => {
+		const tier = tierOptions.find( ( t ) => String( t.quantity ) === selectedItem.key );
+		if ( tier ) {
+			setSelectedTier( tier );
+		}
+	};
+
+	const handleBuyStorage = () => {
+		if ( ! selectedTier ) {
+			return;
+		}
+
+		const backUrl = window.location.href.replace( window.location.origin, '' );
+		const checkoutUrl = addQueryArgs(
+			`/checkout/${ site.slug }/${ storageProduct.product_slug }:-q-${ selectedTier.quantity }`,
+			{
+				cancel_to: backUrl,
+				return_to: backUrl,
+			}
+		);
+
+		window.location.href = checkoutUrl;
+	};
+
+	return (
+		<Modal title={ __( 'Add more storage' ) } onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				<Text>{ __( 'Make more space for high-quality photos, videos, and other media.' ) }</Text>
+
+				<VStack spacing={ 2 }>
+					<Text weight={ 600 }>{ __( 'Storage add-on' ) }</Text>
+					<CustomSelectControl
+						__next40pxDefaultSize
+						hideLabelFromVision
+						label={ __( 'Select storage amount' ) }
+						options={ selectOptions }
+						value={ selectedOption }
+						onChange={ handleSelectChange }
+					/>
+				</VStack>
+
+				<VStack spacing={ 2 }>
+					<Text weight={ 600 }>{ __( 'New storage capacity' ) }</Text>
+					<StorageCapacityStat
+						description={ filesize( mediaStorage.storage_used_bytes, { round: 1 } ) + ' used' }
+						currentCapacityBytes={ planStorageBytes }
+						addOnCapacityBytes={ selectedAddOnStorageBytes }
+					/>
+				</VStack>
+
+				<VStack spacing={ 2 } direction="row" justify="flex-end">
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button variant="primary" onClick={ handleBuyStorage } disabled={ ! selectedTier }>
+						{ __( 'Buy storage' ) }
+					</Button>
+				</VStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -1,4 +1,5 @@
 import { productsQuery, siteMediaStorageQuery, sitePurchasesQuery } from '@automattic/api-queries';
+import { formatCurrency } from '@automattic/number-formatters';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Modal,
@@ -17,6 +18,7 @@ import {
 	getPurchasedStorageAddOn,
 	getStorageTierOptions,
 	getPurchasedStorageQuantity,
+	getStorageTierYearlyPrice,
 	type StorageTierOption,
 } from './storage-utils';
 import type { Site } from '@automattic/api-core';
@@ -41,6 +43,10 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 	const purchasedStorageAddOn = getPurchasedStorageAddOn( purchases );
 	const tierOptions = getStorageTierOptions( storageProduct );
 	const currentPurchasedQuantity = getPurchasedStorageQuantity( purchasedStorageAddOn );
+	const currentPurchasedYearlyPrice = getStorageTierYearlyPrice(
+		tierOptions,
+		currentPurchasedQuantity
+	);
 
 	// Filter out tiers that are less than or equal to what's already purchased
 	const availableTiers = tierOptions.filter( ( tier ) => tier.quantity > currentPurchasedQuantity );
@@ -59,25 +65,40 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 		mediaStorage.max_storage_bytes - mediaStorage.max_storage_bytes_from_add_ons;
 	const selectedAddOnStorageBytes = ( selectedTier?.quantity ?? 0 ) * 1024 * 1024 * 1024;
 
-	// Build select options
-	const selectOptions: SelectOption[] = availableTiers.map( ( tier ) => ( {
-		key: String( tier.quantity ),
-		name: sprintf(
-			// translators: %1$d: storage amount in GB, %2$s: formatted monthly price, e.g., "50 GB Storage (£40.71/month, billed yearly)"
-			__( '%1$d GB Storage (%2$s/month, billed yearly)' ),
-			tier.quantity,
-			tier.formattedMonthlyPrice
-		),
-	} ) );
+	// Build select options - show additional storage and incremental price.
+	// That is, it is presented as the user choosing further additional amounts rather than choosing a new total storage.
+	// e.g. if they have 50gb the list shows +50gb, +100gb, +200gb, +250gb, +300gb rather than 100gb, 150gb, 250gb, 300gb, 350gb.
+	// Functionally, this is the same but it emphasises what extra they're getting and how much more it'll cost them today.
+	const selectOptions: SelectOption[] = availableTiers.map( ( tier ) => {
+		const additionalGB = tier.quantity - currentPurchasedQuantity;
+		const incrementalMonthlyPrice = ( tier.yearlyPrice - currentPurchasedYearlyPrice ) / 12;
+		const formattedIncrementalPrice = formatCurrency( incrementalMonthlyPrice, tier.currencyCode, {
+			isSmallestUnit: true,
+		} );
+
+		return {
+			key: String( tier.quantity ),
+			name: sprintf(
+				// translators: %1$d: additional storage amount in GB, %2$s: formatted cost of additional storage, e.g., "+ 50 GB Storage (£40.71/month, billed yearly)"
+				__( '+ %1$d GB Storage (%2$s/month, billed yearly)' ),
+				additionalGB,
+				formattedIncrementalPrice
+			),
+		};
+	} );
 
 	const selectedOption = selectedTier
 		? {
 				key: String( selectedTier.quantity ),
 				name: sprintf(
-					// translators: %1$d: storage amount in GB, %2$s: formatted monthly price
-					__( '%1$d GB Storage (%2$s/month, billed yearly)' ),
-					selectedTier.quantity,
-					selectedTier.formattedMonthlyPrice
+					// translators: %1$d: additional storage amount in GB, %2$s: formatted cost of additional storage.
+					__( '+ %1$d GB Storage (%2$s/month, billed yearly)' ),
+					selectedTier.quantity - currentPurchasedQuantity,
+					formatCurrency(
+						( selectedTier.yearlyPrice - currentPurchasedYearlyPrice ) / 12,
+						selectedTier.currencyCode,
+						{ isSmallestUnit: true }
+					)
 				),
 		  }
 		: selectOptions[ 0 ];

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -68,7 +68,7 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 	// Build select options - show additional storage and incremental price.
 	// That is, it is presented as the user choosing further additional amounts rather than choosing a new total storage.
 	// e.g. if they have 50gb the list shows +50gb, +100gb, +200gb, +250gb, +300gb rather than 100gb, 150gb, 250gb, 300gb, 350gb.
-	// Functionally, this is the same but it emphasises what extra they're getting and how much more it'll cost them today.
+	// Functionally, this is the same but it emphasises what extra they're getting and how much more it'll cost them today, pro-rating their previous upgrade.
 	const selectOptions: SelectOption[] = availableTiers.map( ( tier ) => {
 		const additionalGB = tier.quantity - currentPurchasedQuantity;
 		const incrementalMonthlyPrice = ( tier.yearlyPrice - currentPurchasedYearlyPrice ) / 12;

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -1,9 +1,10 @@
 import { productsQuery, siteMediaStorageQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
 	Modal,
 	Button,
+	Spinner,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	CustomSelectControl,
@@ -35,9 +36,31 @@ interface SelectOption {
 }
 
 export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps ) {
-	const { data: products } = useSuspenseQuery( productsQuery() );
-	const { data: purchases } = useSuspenseQuery( sitePurchasesQuery( site.ID ) );
-	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: products, isLoading: isLoadingProducts } = useQuery( productsQuery() );
+	const { data: purchases, isLoading: isLoadingPurchases } = useQuery(
+		sitePurchasesQuery( site.ID )
+	);
+	const { data: mediaStorage, isLoading: isLoadingStorage } = useQuery(
+		siteMediaStorageQuery( site.ID )
+	);
+
+	const [ userSelectedTier, setUserSelectedTier ] = useState< StorageTierOption | null >( null );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const isLoading = isLoadingProducts || isLoadingPurchases || isLoadingStorage;
+
+	if ( isLoading || ! products || ! purchases || ! mediaStorage ) {
+		return (
+			<Modal title={ __( 'Add more storage' ) } onRequestClose={ onClose }>
+				<VStack spacing={ 4 } alignment="center">
+					<Spinner />
+				</VStack>
+			</Modal>
+		);
+	}
 
 	const storageProduct = getStorageAddOnProduct( products );
 	const purchasedStorageAddOn = getPurchasedStorageAddOn( purchases );
@@ -51,14 +74,7 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 	// Filter out tiers that are less than or equal to what's already purchased
 	const availableTiers = tierOptions.filter( ( tier ) => tier.quantity > currentPurchasedQuantity );
 
-	// Default to the first available tier
-	const [ selectedTier, setSelectedTier ] = useState< StorageTierOption | null >(
-		availableTiers[ 0 ] ?? null
-	);
-
-	if ( ! isOpen ) {
-		return null;
-	}
+	const selectedTier = userSelectedTier ?? availableTiers[ 0 ] ?? null;
 
 	// Calculate storage breakdown
 	const planStorageBytes =
@@ -94,7 +110,7 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 	const handleSelectChange = ( { selectedItem }: { selectedItem: SelectOption } ) => {
 		const tier = tierOptions.find( ( t ) => String( t.quantity ) === selectedItem.key );
 		if ( tier ) {
-			setSelectedTier( tier );
+			setUserSelectedTier( tier );
 		}
 	};
 

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -87,21 +87,9 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 		};
 	} );
 
-	const selectedOption = selectedTier
-		? {
-				key: String( selectedTier.quantity ),
-				name: sprintf(
-					// translators: %1$d: additional storage amount in GB, %2$s: formatted cost of additional storage.
-					__( '+ %1$d GB Storage (%2$s/month, billed yearly)' ),
-					selectedTier.quantity - currentPurchasedQuantity,
-					formatCurrency(
-						( selectedTier.yearlyPrice - currentPurchasedYearlyPrice ) / 12,
-						selectedTier.currencyCode,
-						{ isSmallestUnit: true }
-					)
-				),
-		  }
-		: selectOptions[ 0 ];
+	const selectedOption =
+		selectOptions.find( ( option ) => option.key === String( selectedTier?.quantity ) ) ||
+		selectOptions[ 0 ];
 
 	const handleSelectChange = ( { selectedItem }: { selectedItem: SelectOption } ) => {
 		const tier = tierOptions.find( ( t ) => String( t.quantity ) === selectedItem.key );

--- a/client/dashboard/sites/storage/storage-capacity-stat.scss
+++ b/client/dashboard/sites/storage/storage-capacity-stat.scss
@@ -1,0 +1,61 @@
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
+.dashboard-storage-capacity-stat {
+	--dashboard-storage-capacity-stat-current-color: var(--wp-admin-theme-color);
+	--dashboard-storage-capacity-stat-addon-color: var(--dashboard__background-color-success);
+
+	&__metric {
+		font-size: $font-size-large;
+		font-weight: $font-weight-medium;
+		line-height: $font-line-height-small;
+		color: $gray-900;
+	}
+
+	&__description {
+		color: $gray-700;
+		font-size: $font-size-small;
+		line-height: $font-line-height-small;
+	}
+
+	&__progress-bar {
+		display: flex;
+		height: $grid-unit-05;
+		margin-block: 0.25 * $grid-unit;
+		background-color: $gray-100;
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	&__progress-segment {
+		height: 100%;
+		transition: width 0.2s ease-in-out;
+
+		&--current {
+			background-color: var(--dashboard-storage-capacity-stat-current-color);
+		}
+
+		&--addon {
+			background-color: var(--dashboard-storage-capacity-stat-addon-color);
+		}
+	}
+
+	&__legend-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+
+		&::before {
+			content: '●';
+			font-size: 1em;
+		}
+
+		&--current::before {
+			color: var(--dashboard-storage-capacity-stat-current-color);
+		}
+
+		&--addon::before {
+			color: var(--dashboard-storage-capacity-stat-addon-color);
+		}
+	}
+}

--- a/client/dashboard/sites/storage/storage-capacity-stat.tsx
+++ b/client/dashboard/sites/storage/storage-capacity-stat.tsx
@@ -1,0 +1,86 @@
+import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import filesize from 'filesize';
+import './storage-capacity-stat.scss';
+
+const MINIMUM_SEGMENT_WIDTH = 0.5; // Minimum width in % to ensure visibility
+
+interface StorageCapacityStatProps {
+	/**
+	 * Description displayed beside the total capacity (e.g., "6.6 GB used")
+	 */
+	description: string;
+
+	/**
+	 * Current plan storage capacity in bytes
+	 */
+	currentCapacityBytes: number;
+
+	/**
+	 * Add-on storage capacity in bytes
+	 */
+	addOnCapacityBytes: number;
+}
+
+export function StorageCapacityStat( {
+	description,
+	currentCapacityBytes,
+	addOnCapacityBytes,
+}: StorageCapacityStatProps ) {
+	// Calculate total and percentages
+	const totalBytes = currentCapacityBytes + addOnCapacityBytes;
+	const totalCapacity = filesize( totalBytes, { round: 0 } );
+	const currentCapacityPercent = ( currentCapacityBytes / totalBytes ) * 100;
+	const addOnCapacityPercent = ( addOnCapacityBytes / totalBytes ) * 100;
+
+	// Ensure segments are visible even if very small
+	const currentWidth = Math.max( currentCapacityPercent, MINIMUM_SEGMENT_WIDTH );
+	const addOnWidth = Math.max( addOnCapacityPercent, MINIMUM_SEGMENT_WIDTH );
+
+	return (
+		<div className="dashboard-storage-capacity-stat">
+			<HStack alignment="baseline" spacing={ 2 } justify="space-between">
+				<div className="dashboard-storage-capacity-stat__metric">{ totalCapacity }</div>
+				<div className="dashboard-storage-capacity-stat__description">{ description }</div>
+			</HStack>
+			<div
+				className="dashboard-storage-capacity-stat__progress-bar"
+				role="progressbar"
+				aria-label={ __( 'Storage capacity breakdown' ) }
+			>
+				<div
+					className="dashboard-storage-capacity-stat__progress-segment dashboard-storage-capacity-stat__progress-segment--current"
+					style={ { width: `${ currentWidth }%` } }
+				/>
+				<div
+					className="dashboard-storage-capacity-stat__progress-segment dashboard-storage-capacity-stat__progress-segment--addon"
+					style={ { width: `${ addOnWidth }%` } }
+				/>
+			</div>
+			<HStack spacing={ 2 } alignment="left">
+				<Text
+					variant="muted"
+					size={ 12 }
+					className="dashboard-storage-capacity-stat__legend-item dashboard-storage-capacity-stat__legend-item--current"
+				>
+					{ sprintf(
+						// translators: %s is the plan storage amount
+						__( '%s plan storage' ),
+						filesize( currentCapacityBytes, { round: 0 } )
+					) }
+				</Text>
+				<Text
+					variant="muted"
+					size={ 12 }
+					className="dashboard-storage-capacity-stat__legend-item dashboard-storage-capacity-stat__legend-item--addon"
+				>
+					{ sprintf(
+						// translators: %s is the storage add-on amount
+						__( '%s storage add-on' ),
+						filesize( addOnCapacityBytes, { round: 0 } )
+					) }
+				</Text>
+			</HStack>
+		</div>
+	);
+}

--- a/client/dashboard/sites/storage/storage-utils.ts
+++ b/client/dashboard/sites/storage/storage-utils.ts
@@ -1,0 +1,80 @@
+import { PRODUCT_1GB_SPACE, type Product, type Purchase } from '@automattic/api-core';
+
+/**
+ * Represents a storage tier option for the dropdown.
+ */
+export interface StorageTierOption {
+	quantity: number;
+	monthlyPrice: number;
+	yearlyPrice: number;
+	formattedMonthlyPrice: string;
+	currencyCode: string;
+}
+
+/**
+ * Gets the storage add-on product from the products list.
+ */
+export function getStorageAddOnProduct( products: Record< number, Product > ): Product {
+	const storageProduct = Object.values( products ).find(
+		( product ) => product.product_slug === PRODUCT_1GB_SPACE
+	);
+
+	if ( ! storageProduct ) {
+		throw new Error( 'Storage add-on product not found' );
+	}
+
+	return storageProduct;
+}
+
+/**
+ * Gets the currently purchased storage add-on from a list of purchases.
+ */
+export function getPurchasedStorageAddOn( purchases: Purchase[] ): Purchase | null {
+	const storagePurchase = purchases.find(
+		( purchase ) =>
+			purchase.product_slug === PRODUCT_1GB_SPACE && purchase.subscription_status === 'active'
+	);
+
+	return storagePurchase ?? null;
+}
+
+/**
+ * Calculates storage tier options from a storage product's price tier list.
+ * Derives available tiers from the product's price_tier_list.
+ */
+export function getStorageTierOptions( product: Product ): StorageTierOption[] {
+	const options: StorageTierOption[] = [];
+
+	// For tiered pricing, use the maximum_units from each tier as the purchasable quantity
+	// Filter out tiers without a maximum (usually the last open-ended tier)
+	for ( const priceTier of product.price_tier_list ) {
+		if ( priceTier.maximum_units && priceTier.maximum_price_monthly_display ) {
+			const quantity = priceTier.maximum_units;
+			const yearlyPrice = priceTier.maximum_price;
+			const monthlyPrice = priceTier.maximum_price / 12;
+
+			options.push( {
+				quantity,
+				monthlyPrice,
+				yearlyPrice,
+				formattedMonthlyPrice: priceTier.maximum_price_monthly_display,
+				currencyCode: product.currency_code,
+			} );
+		}
+	}
+
+	// Sort by quantity ascending
+	return options.sort( ( a, b ) => a.quantity - b.quantity );
+}
+
+/**
+ * Gets the quantity of storage from a purchase (if it's a tiered product).
+ */
+export function getPurchasedStorageQuantity( purchase: Purchase | null ): number {
+	if ( ! purchase ) {
+		return 0;
+	}
+
+	// For tiered products, the quantity is stored in renewal_price_tier_usage_quantity
+	return purchase.renewal_price_tier_usage_quantity ?? 0;
+}

--- a/client/dashboard/sites/storage/storage-utils.ts
+++ b/client/dashboard/sites/storage/storage-utils.ts
@@ -78,3 +78,15 @@ export function getPurchasedStorageQuantity( purchase: Purchase | null ): number
 	// For tiered products, the quantity is stored in renewal_price_tier_usage_quantity
 	return purchase.renewal_price_tier_usage_quantity ?? 0;
 }
+
+/**
+ * Gets the yearly price for a specific storage tier quantity.
+ * Returns 0 if the tier is not found.
+ */
+export function getStorageTierYearlyPrice(
+	tierOptions: StorageTierOption[],
+	quantity: number
+): number {
+	const tier = tierOptions.find( ( t ) => t.quantity === quantity );
+	return tier?.yearlyPrice ?? 0;
+}

--- a/packages/api-core/src/purchase/types.ts
+++ b/packages/api-core/src/purchase/types.ts
@@ -24,8 +24,10 @@ export interface PriceTierEntry {
 	maximum_units?: null | number;
 	minimum_price: number;
 	minimum_price_display: string;
+	minimum_price_monthly_display?: string;
 	maximum_price: number;
 	maximum_price_display?: string | null;
+	maximum_price_monthly_display?: string;
 
 	/**
 	 * If set, is used to transform the usage/quantity of units used to derive the number of units

--- a/packages/api-core/src/purchase/types.ts
+++ b/packages/api-core/src/purchase/types.ts
@@ -24,7 +24,6 @@ export interface PriceTierEntry {
 	maximum_units?: null | number;
 	minimum_price: number;
 	minimum_price_display: string;
-	minimum_price_monthly_display?: string;
 	maximum_price: number;
 	maximum_price_display?: string | null;
 	maximum_price_monthly_display?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-14998

## Proposed Changes

In the new Hosting Dashboard, use a modal to display the add-on storage options rather than linking to WordPress.com/add-ons/:siteSlug


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It keeps the user in the hosting dashboard, rather than pushing them out to wp-admin. This makes sense as it's a hosting concern rather than a wp-admin one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
/plans | New modal
-------|------
 <img width="562" height="302" alt="Screenshot 2025-10-21 at 16 28 11" src="https://github.com/user-attachments/assets/c58b602f-0373-4f02-8a91-ba79f25a244a" />  | <img width="562" height="428" alt="Screenshot 2025-10-21 at 20 01 46" src="https://github.com/user-attachments/assets/be8b3649-4554-426b-9098-aa55e86fb4c8" />

For the button that launches the modal to be displayed you need to be close or over the storage capacity limit. The easiest way to achieve this is to checkout the branch locally, update [storage-warning-banner.tsx](https://github.com/Automattic/wp-calypso/blob/79213813451e7ffbf68ea90b48858a199538d589/client/dashboard/sites/overview/storage-warning-banner.tsx#L26) and [site-storage-stat.tsx](https://github.com/Automattic/wp-calypso/blob/79213813451e7ffbf68ea90b48858a199538d589/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx#L31) to hardcode `alertLevel` to `warning` and then build as normal.

Another way of testing this is to update `Media_Storage::get_space_info` on your sandbox to hardcode the desired numbers for your test blog.

1. Go to /v2/sites/ and choose a site
2. Using the notice press 'Add more storage' to launch the modal
3. Try different amounts of storage, the labels / meter beneath should react
4. Press checkout, you should go to the checkout with the thing you've chosen


You should cross-reference with the functionality on https://wordpress.com/add-ons/:siteSlug - it's displayed very slightly differently, but ultimately it's another way of purchasing the same thing.

You should also see an 'Add more storage' link on the plan card which launches the same modal.

https://github.com/user-attachments/assets/09c27873-286a-4d31-ba3a-488043f73d17



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
