### PR TITLE
Domains: Show "Show more results" button in domain search

### DIFF
--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -8,9 +8,17 @@ import {
 import { SearchResultsItem } from './item';
 import { SearchResultsPlaceholder } from './placeholder';
 
-const SearchResults = ( { suggestions }: { suggestions: string[] } ) => {
+const SearchResults = ( {
+	suggestions,
+	numberOfInitialVisibleSuggestions,
+}: {
+	suggestions: string[];
+	numberOfInitialVisibleSuggestions: number;
+} ) => {
 	const { filter, resetFilter } = useDomainSearch();
-	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState( 10 );
+	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
+		numberOfInitialVisibleSuggestions
+	);
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 
 	if ( suggestions.length === 0 ) {

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -13,11 +13,11 @@ const SearchResults = ( {
 	numberOfInitialVisibleSuggestions,
 }: {
 	suggestions: string[];
-	numberOfInitialVisibleSuggestions: number;
+	numberOfInitialVisibleSuggestions?: number;
 } ) => {
 	const { filter, resetFilter } = useDomainSearch();
 	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
-		numberOfInitialVisibleSuggestions
+		numberOfInitialVisibleSuggestions ?? 10
 	);
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,10 +1,16 @@
+import { useState } from 'react';
 import { useDomainSearch } from '../../page/context';
-import { DomainSuggestionsList, DomainSuggestionFilterReset } from '../../ui';
+import {
+	DomainSuggestionsList,
+	DomainSuggestionFilterReset,
+	DomainSuggestionLoadMore,
+} from '../../ui';
 import { SearchResultsItem } from './item';
 import { SearchResultsPlaceholder } from './placeholder';
 
 const SearchResults = ( { suggestions }: { suggestions: string[] } ) => {
 	const { filter, resetFilter } = useDomainSearch();
+	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState( 10 );
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 
 	if ( suggestions.length === 0 ) {
@@ -15,12 +21,22 @@ const SearchResults = ( { suggestions }: { suggestions: string[] } ) => {
 		return null;
 	}
 
+	const shouldShowMoreResultsButton = numberOfVisibleSuggestions < suggestions.length;
+	const suggestionsToShow = suggestions.slice( 0, numberOfVisibleSuggestions );
+
 	return (
-		<DomainSuggestionsList>
-			{ suggestions.map( ( suggestion ) => (
-				<SearchResultsItem key={ suggestion } domainName={ suggestion } />
-			) ) }
-		</DomainSuggestionsList>
+		<>
+			<DomainSuggestionsList>
+				{ suggestionsToShow.map( ( suggestion ) => (
+					<SearchResultsItem key={ suggestion } domainName={ suggestion } />
+				) ) }
+			</DomainSuggestionsList>
+			{ shouldShowMoreResultsButton && (
+				<DomainSuggestionLoadMore
+					onClick={ () => setnumberOfVisibleSuggestions( numberOfVisibleSuggestions + 10 ) }
+				/>
+			) }
+		</>
 	);
 };
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -14,6 +14,7 @@ export const ResultsPage = () => {
 	const { slots, config } = useDomainSearch();
 
 	const { isLoading, featuredSuggestions, regularSuggestions } = useSuggestionsList();
+	const numberOfInitialVisibleSuggestions = 10 - featuredSuggestions.length;
 
 	useRequestTracking();
 
@@ -37,7 +38,10 @@ export const ResultsPage = () => {
 				{ isLoading ? (
 					<SearchResults.Placeholder />
 				) : (
-					<SearchResults suggestions={ regularSuggestions } />
+					<SearchResults
+						suggestions={ regularSuggestions }
+						numberOfInitialVisibleSuggestions={ numberOfInitialVisibleSuggestions }
+					/>
 				) }
 			</VStack>
 			<Cart />


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOMENG-192/show-the-show-more-suggestions-button-in-domain-search

## Proposed Changes

This PR reintroduces the "Show more results" button in the domain search pages. During the [Domain Search Rewrite project](https://linear.app/a8c/project/rewrite-the-domain-search-functionality-ce0c3fb1a270/overview) that behavior was inadvertently removed in favor of showing all the 30 suggestion results we got from the backend.

## Recordings

- Before 

https://github.com/user-attachments/assets/096478e2-8910-48f9-aff1-e2c1b81d7373

- After

https://github.com/user-attachments/assets/08bca73a-b1c1-4c2b-900e-56079a58527e

## Why are these changes being made?

The behavior of showing a smaller initial set of suggestions and having the user click on "Show more results" to see more is important for contractual and partnership reasons.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Check domain search in the onboarding flow (`/setup`)
- Do a domain search and ensure only 10 suggestions are shown initially (counting the featured and regular suggestions, and not counting the free subdomain option)
- Click on the "Show more results" button and ensure 10 more suggestions are shown
- Go to the domain-only flow (`/start/domain`)
- Do a domain search and ensure only 10 suggestions are shown initially (counting the featured and regular suggestions)
- Click on the "Show more results" button and ensure 10 more suggestions are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
