### PR TITLE
GitHub Deployments: update "create a repository" help text

### DIFF
--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -110,14 +110,9 @@ const RepositorySelector = ( {
 
 	return (
 		<VStack spacing={ 2 }>
-			<HStack justify="space-between" alignment="center">
-				<Text weight={ 500 } size="11" style={ { textTransform: 'uppercase' } }>
-					{ __( 'Repository' ) }
-				</Text>
-				<ExternalLink href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-repo-existing-source/">
-					{ __( 'Create a new repository' ) }
-				</ExternalLink>
-			</HStack>
+			<Text weight={ 500 } size="11" style={ { textTransform: 'uppercase' } }>
+				{ __( 'Repository' ) }
+			</Text>
 			<div ref={ comboboxRef }>
 				<ComboboxControl
 					__next40pxDefaultSize
@@ -507,11 +502,19 @@ export const ConnectRepositoryForm = ( {
 		}
 
 		return createInterpolateElement(
-			__( 'Missing GitHub repositories? <a>Adjust permissions on GitHub</a>' ),
+			__(
+				'Missing GitHub repositories? <adjustPermissions>Adjust permissions on GitHub</adjustPermissions> or <createRepo>learn how to create a repository</createRepo>.'
+			),
 			{
-				a: (
+				adjustPermissions: (
 					<ExternalLink
 						href={ `https://github.com/settings/installations/${ selectedInstallation.external_id }` }
+						children={ null }
+					/>
+				),
+				createRepo: (
+					<ExternalLink
+						href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-repo-existing-source/"
 						children={ null }
 					/>
 				),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDASH-678

## Proposed Changes

* Remove the "Create a new repository" link from the top of the Repository selector
* Add the link to the help text of the Repository selector

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This link was easy to misunderstand, and we'd like to show it in a more contextual place

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and start Calypso locally or use Calypso live link below
* Go to `/v2/sites/:siteSlug/settings/repositories/connect`
* Check that the "Create new repositories" link is added to the help text of the repository selector
* Go back to the repositories list, and select a repository to configure the connection
* Check the same field on the connection configuration page

| Before | After |
|--------|--------|
| <img width="1380" height="1872" alt="CleanShot 2025-10-21 at 17 25 44@2x" src="https://github.com/user-attachments/assets/c1ba6587-c083-46bc-b314-18f11781456f" /> | <img width="1380" height="1872" alt="CleanShot 2025-10-21 at 17 26 35@2x" src="https://github.com/user-attachments/assets/3006404f-fcfe-42d8-ac8f-1f62d3c90502" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
