### PR TITLE
Help Center History: Fix double border

### DIFF
--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -15,5 +15,7 @@
 		margin: 16px;
 		width: calc(100% - 32px);
 		border-radius: 8px;
+		border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		box-shadow: none;
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-320/remove-double-border-from-new-chat-button

## Before

<img width="658" height="118" alt="image" src="https://github.com/user-attachments/assets/97ff7fcb-0c12-4e63-b8b5-e1a127e00d43" />

## After

<img width="506" height="98" alt="image" src="https://github.com/user-attachments/assets/e2e3aa55-2461-4fb3-803b-80c61b8789cf" />

## Testing steps

- You need a user without chats 
- Check the border at the bottom
