### PR TITLE
Domains: Trigger `calypso_domain_search_show_more_results` Tracks event when clicking on the "Show more results" button

### DIFF
--- a/client/components/domains/wpcom-domain-search/analytics.ts
+++ b/client/components/domains/wpcom-domain-search/analytics.ts
@@ -202,3 +202,20 @@ export function recordDomainClickMissing(
 		} )
 	);
 }
+
+export function recordShowMoreResults(
+	searchQuery: string,
+	pageNumber: number,
+	section: string,
+	flowName: string
+) {
+	return composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Show More Results' ),
+		recordTracksEvent( 'calypso_domain_search_show_more_results', {
+			search_query: searchQuery,
+			page_number: pageNumber,
+			section,
+			flow_name: flowName,
+		} )
+	);
+}

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -21,6 +21,7 @@ import {
 	recordDomainClickMissing,
 	recordFiltersReset,
 	recordFiltersSubmit,
+	recordShowMoreResults,
 } from './analytics';
 
 export const useWPCOMDomainSearchEvents = ( {
@@ -155,12 +156,7 @@ export const useWPCOMDomainSearchEvents = ( {
 				dispatch( recordFiltersReset( filter, keysToReset, analyticsSection, flowName ) );
 			},
 			onShowMoreResults: ( pageNumber ) => {
-				recordTracksEvent( 'calypso_domain_search_show_more_results', {
-					search_query: query ?? '',
-					flow_name: flowName,
-					page_number: pageNumber,
-					section: analyticsSection,
-				} );
+				dispatch( recordShowMoreResults( query ?? '', pageNumber, analyticsSection, flowName ) );
 			},
 			onSuggestionsReceive: ( query, suggestions, responseTime ) => {
 				dispatch(

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -154,6 +154,14 @@ export const useWPCOMDomainSearchEvents = ( {
 				debouncedDomainSearchEvent( query ?? '' );
 				dispatch( recordFiltersReset( filter, keysToReset, analyticsSection, flowName ) );
 			},
+			onShowMoreResults: ( pageNumber ) => {
+				recordTracksEvent( 'calypso_domain_search_show_more_results', {
+					search_query: query ?? '',
+					flow_name: flowName,
+					page_number: pageNumber,
+					section: analyticsSection,
+				} );
+			},
 			onSuggestionsReceive: ( query, suggestions, responseTime ) => {
 				dispatch(
 					recordSearchResultsReceive( query, suggestions, responseTime, analyticsSection, flowName )

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -25,7 +25,7 @@ const SearchResults = ( {
 		events.onShowMoreResults( pageNumber + 1 );
 		setPageNumber( pageNumber + 1 );
 		setnumberOfVisibleSuggestions( numberOfVisibleSuggestions + 10 );
-	}, [ events, pageNumber ] );
+	}, [ events, pageNumber, numberOfVisibleSuggestions ] );
 
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 

--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDomainSearch } from '../../page/context';
 import {
 	DomainSuggestionsList,
@@ -15,10 +15,18 @@ const SearchResults = ( {
 	suggestions: string[];
 	numberOfInitialVisibleSuggestions?: number;
 } ) => {
-	const { filter, resetFilter } = useDomainSearch();
+	const { filter, resetFilter, events } = useDomainSearch();
 	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
 		numberOfInitialVisibleSuggestions ?? 10
 	);
+	const [ pageNumber, setPageNumber ] = useState( 1 );
+
+	const showMoreResults = useCallback( () => {
+		events.onShowMoreResults( pageNumber + 1 );
+		setPageNumber( pageNumber + 1 );
+		setnumberOfVisibleSuggestions( numberOfVisibleSuggestions + 10 );
+	}, [ events, pageNumber ] );
+
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 
 	if ( suggestions.length === 0 ) {
@@ -39,11 +47,7 @@ const SearchResults = ( {
 					<SearchResultsItem key={ suggestion } domainName={ suggestion } />
 				) ) }
 			</DomainSuggestionsList>
-			{ shouldShowMoreResultsButton && (
-				<DomainSuggestionLoadMore
-					onClick={ () => setnumberOfVisibleSuggestions( numberOfVisibleSuggestions + 10 ) }
-				/>
-			) }
+			{ shouldShowMoreResultsButton && <DomainSuggestionLoadMore onClick={ showMoreResults } /> }
 		</>
 	);
 };

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -27,6 +27,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onDomainAddAvailabilityPreCheck: noop,
 		onFilterApplied: noop,
 		onFilterReset: noop,
+		onShowMoreResults: noop,
 		onSuggestionsReceive: noop,
 		onSuggestionRender: noop,
 		onSuggestionInteract: noop,

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1,5 +1,6 @@
 import { DomainAvailabilityStatus } from '@automattic/api-core';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { buildAvailability } from '../../test-helpers/factories/availability';
 import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
 import { buildFreeSuggestion, buildSuggestion } from '../../test-helpers/factories/suggestions';
@@ -643,6 +644,40 @@ describe( 'ResultsPage', () => {
 					[ 'test.com', 'test.net', 'test.org' ],
 					expect.any( Number )
 				);
+			} );
+		} );
+
+		it( 'fires the onShowMoreResults event when the show more results button is clicked', async () => {
+			const user = userEvent.setup();
+			const onShowMoreResults = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test query' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test1.com' } ),
+					buildSuggestion( { domain_name: 'test2.com' } ),
+					buildSuggestion( { domain_name: 'test3.com' } ),
+					buildSuggestion( { domain_name: 'test4.com' } ),
+					buildSuggestion( { domain_name: 'test5.com' } ),
+					buildSuggestion( { domain_name: 'test6.com' } ),
+					buildSuggestion( { domain_name: 'test7.com' } ),
+					buildSuggestion( { domain_name: 'test8.com' } ),
+					buildSuggestion( { domain_name: 'test9.com' } ),
+					buildSuggestion( { domain_name: 'test10.com' } ),
+					buildSuggestion( { domain_name: 'test11.com' } ),
+				],
+			} );
+
+			render(
+				<TestDomainSearch events={ { onShowMoreResults } } query="test query">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByText( 'Show more results' ) );
+
+			await waitFor( () => {
+				expect( onShowMoreResults ).toHaveBeenCalledWith( 2 ); // show second page of results
 			} );
 		} );
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -101,6 +101,61 @@ describe( 'ResultsPage', () => {
 			expect( testOrg ).not.toHaveTextContent( 'Recommended' );
 			expect( testOrg ).not.toHaveTextContent( 'Best alternative' );
 		} );
+
+		it( 'renders the "show more results" button if there are more than 10 suggestions', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test1.com' } ),
+					buildSuggestion( { domain_name: 'test2.com' } ),
+					buildSuggestion( { domain_name: 'test3.com' } ),
+					buildSuggestion( { domain_name: 'test4.com' } ),
+					buildSuggestion( { domain_name: 'test5.com' } ),
+					buildSuggestion( { domain_name: 'test6.com' } ),
+					buildSuggestion( { domain_name: 'test7.com' } ),
+					buildSuggestion( { domain_name: 'test8.com' } ),
+					buildSuggestion( { domain_name: 'test9.com' } ),
+					buildSuggestion( { domain_name: 'test10.com' } ),
+					buildSuggestion( { domain_name: 'test11.com' } ),
+				],
+			} );
+
+			render(
+				<TestDomainSearch query="test">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'Show more results' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render the "show more results" button if there are 10 or less suggestions', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'test1.com' } ),
+					buildSuggestion( { domain_name: 'test2.com' } ),
+					buildSuggestion( { domain_name: 'test3.com' } ),
+					buildSuggestion( { domain_name: 'test4.com' } ),
+					buildSuggestion( { domain_name: 'test5.com' } ),
+					buildSuggestion( { domain_name: 'test6.com' } ),
+					buildSuggestion( { domain_name: 'test7.com' } ),
+					buildSuggestion( { domain_name: 'test8.com' } ),
+					buildSuggestion( { domain_name: 'test9.com' } ),
+					buildSuggestion( { domain_name: 'test10.com' } ),
+				],
+			} );
+
+			render(
+				<TestDomainSearch query="test">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			// This is just to wait for the suggestions to be loaded
+			await screen.findByTitle( 'test1.com' );
+			expect( screen.queryByText( 'Show more results' ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'TLD deemphasis', () => {

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -61,6 +61,7 @@ export interface DomainSearchEvents {
 	) => void;
 	onFilterApplied: ( filter: FilterState ) => void;
 	onFilterReset: ( filter: FilterState, keysToReset: string[] ) => void;
+	onShowMoreResults: ( pageNumber: number ) => void;
 	onSuggestionsReceive: ( query: string, suggestions: string[], responseTime: number ) => void;
 	onSuggestionRender: (
 		suggestion: ReturnType< typeof useSuggestion >,


### PR DESCRIPTION
Part of [DOMENG-193](https://linear.app/a8c/issue/DOMENG-193/)

## Proposed Changes

This PR adds tracking for the `calypso_domain_search_show_more_results` Tracks events when the "Show more results" button  (reintroduced in #106624) is clicked.

## Why are these changes being made?

We want to track when users click on that button.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to a domain search page (e.g. `/setup`)
- Open your browser's network tab and filter for `calypso_domain_search_show_more_results`
- Do a domain search
- Click on the "Show more results" button
- Ensure the Tracks event was fired with correct properties

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
