### PR TITLE
SSH Migration: Add the Find Your SSH Details step and documentation

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -572,6 +572,15 @@ const siteMigration: FlowV2< typeof initialize > = {
 				}
 
 				case STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug: {
+					const { destination } = providedDependencies as {
+						destination?: 'migration-started' | 'no-ssh-access';
+					};
+
+					// User doesn't have SSH access, redirect to credentials flow
+					if ( destination === 'no-ssh-access' ) {
+						return navigate( paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } ) );
+					}
+
 					return navigate( paths.sshInProgressPath( { siteId, siteSlug } ) );
 				}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
@@ -1,0 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+
+interface HelpLinkProps {
+	href: string;
+}
+
+export const HelpLink: FC< HelpLinkProps > = ( { href } ) => {
+	const translate = useTranslate();
+
+	return (
+		<p className="migration-site-ssh__help-link">
+			{ translate( 'Need help?' ) }{ ' ' }
+			<a href={ href } target="_blank" rel="noopener noreferrer">
+				{ translate( 'Follow our guide' ) }
+			</a>
+		</p>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
@@ -1,0 +1,86 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+
+/**
+ * Mapping of normalized host slugs to their display names
+ */
+export const SSH_HOST_DISPLAY_NAMES: Record< string, string > = {
+	godaddy: 'GoDaddy',
+	bluehost: 'Bluehost',
+	ionos: 'IONOS',
+	hostinger: 'Hostinger',
+	inmotion: 'InMotion Hosting',
+	aruba: 'Aruba',
+	hostgator: 'HostGator',
+	digitalocean: 'DigitalOcean',
+	hetzner: 'Hetzner',
+	namecheap: 'Namecheap',
+	ovh: 'OVHcloud',
+	dreamhost: 'DreamHost',
+};
+
+/**
+ * Mapping of hosting providers to their specific SSH migration support documentation URLs
+ */
+const SSH_HOST_SUPPORT_URLS: Record< string, string > = {
+	godaddy: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-godaddy-using-ssh/' ),
+	bluehost: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-bluehost-using-ssh/' ),
+	ionos: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ionos-using-ssh/' ),
+	hostinger: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-hostinger-using-ssh/'
+	),
+	inmotion: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-inmotion-hosting-using-ssh/'
+	),
+	aruba: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-aruba-hosting-using-ssh/'
+	),
+	hostgator: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-hostgator-using-ssh/'
+	),
+	digitalocean: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-digitalocean-using-ssh/'
+	),
+	hetzner: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hetzner-using-ssh/' ),
+	namecheap: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-namecheap-using-ssh/'
+	),
+	ovh: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ovhcloud-using-ssh/' ),
+	dreamhost: localizeUrl(
+		'https://wordpress.com/support/migrate-a-site-from-dreamhost-using-ssh/'
+	),
+};
+
+/**
+ * Generic fallback URL for hosts without specific documentation
+ */
+const GENERIC_SSH_MIGRATION_SUPPORT_URL = localizeUrl(
+	'https://wordpress.com/support/migrate-a-site-to-wordpress-com-using-ssh/'
+);
+
+/**
+ * Get the display name for a specific hosting provider
+ * @param host - The hosting provider slug (case-insensitive)
+ * @returns The display name for the host, or undefined if not found
+ */
+export const getSSHHostDisplayName = ( host?: string ): string | undefined => {
+	if ( ! host ) {
+		return undefined;
+	}
+
+	const normalizedHost = host.toLowerCase().trim();
+	return SSH_HOST_DISPLAY_NAMES[ normalizedHost ];
+};
+
+/**
+ * Get the support URL for a specific hosting provider
+ * @param host - The hosting provider name (case-insensitive)
+ * @returns The support URL for the host, or the generic fallback if not found
+ */
+export const getSSHSupportUrl = ( host?: string ): string => {
+	if ( ! host ) {
+		return GENERIC_SSH_MIGRATION_SUPPORT_URL;
+	}
+
+	const normalizedHost = host.toLowerCase().trim();
+	return SSH_HOST_SUPPORT_URLS[ normalizedHost ] ?? GENERIC_SSH_MIGRATION_SUPPORT_URL;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+import { HelpLink } from './help-link';
+import { getSSHSupportUrl, getSSHHostDisplayName } from './ssh-host-support-urls';
+
+interface StepFindSSHDetailsProps {
+	onSuccess: () => void;
+	onNoSSHAccess?: () => void;
+	host?: string;
+}
+
+export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
+	onSuccess,
+	onNoSSHAccess,
+	host,
+} ) => {
+	const translate = useTranslate();
+	const hostDisplayName = getSSHHostDisplayName( host );
+
+	const instructionText = hostDisplayName
+		? translate(
+				"Go to your %(currentHost)s WordPress site's settings, enable SSH, and take note of your details.",
+				{
+					args: { currentHost: hostDisplayName },
+				}
+		  )
+		: translate(
+				"Go to your hosting provider's control panel, enable SSH access for your WordPress site, and take note of your SSH details (hostname, port, username, and authentication method)."
+		  );
+
+	return (
+		<div>
+			<p>{ instructionText }</p>
+			<HelpLink href={ getSSHSupportUrl( host ) } />
+			<div className="migration-site-ssh__find-ssh-details-buttons">
+				<Button variant="primary" onClick={ onSuccess }>
+					{ translate( 'I found my SSH details' ) }
+				</Button>
+				<Button variant="link" onClick={ onNoSSHAccess }>
+					{ translate( "I don't have SSH access" ) }
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import { AccordionNotice } from '../components/accordion-notice';
+import { useState } from 'react';
+import { StepFindSSHDetails } from './step-find-ssh-details';
 import type { Task, Expandable } from '@automattic/launchpad';
 
 const FIND_SSH_DETAILS = 'find-ssh-details';
@@ -26,19 +27,34 @@ interface StepsObject {
 	steps: Steps;
 }
 
-const useStepsData = (): StepsData => {
-	const translate = useTranslate();
+interface UseStepsOptions {
+	host?: string;
+	onNoSSHAccess?: () => void;
+}
 
-	return [
+export const useSteps = ( options?: UseStepsOptions ): StepsObject => {
+	const translate = useTranslate();
+	const [ completedSteps, setCompletedSteps ] = useState< Set< string > >( new Set() );
+	const { host, onNoSSHAccess } = options || {};
+
+	const isComplete = ( stepKey: string ): boolean => {
+		return completedSteps.has( stepKey );
+	};
+
+	const handleStepComplete = ( stepKey: string ) => {
+		setCompletedSteps( ( prev ) => new Set( prev ).add( stepKey ) );
+	};
+
+	const stepsData: StepsData = [
 		{
 			key: FIND_SSH_DETAILS,
 			title: translate( 'Find your SSH details' ),
 			content: (
-				<div>
-					<AccordionNotice variant="error">
-						<p>Find your SSH details</p>
-					</AccordionNotice>
-				</div>
+				<StepFindSSHDetails
+					onSuccess={ () => handleStepComplete( FIND_SSH_DETAILS ) }
+					onNoSSHAccess={ onNoSSHAccess }
+					host={ host }
+				/>
 			),
 		},
 		{
@@ -52,17 +68,6 @@ const useStepsData = (): StepsData => {
 			content: <div>Share SSH access</div>,
 		},
 	];
-};
-
-export const useSteps = (): StepsObject => {
-	const stepsData = useStepsData();
-
-	const isComplete = ( stepKey: string ): boolean => {
-		switch ( stepKey ) {
-			default:
-				return false;
-		}
-	};
 
 	const steps: Steps = stepsData.map( ( step, index ) => {
 		// Render the content with the step-specific elements

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -90,7 +90,30 @@
 	font-size: 0.875rem;
 }
 
+@keyframes migration-site-ssh__slideDown {
+	from {
+		opacity: 0;
+		transform: translateY(-8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.migration-site-ssh__find-ssh-details-buttons {
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+}
+
+.migration-site-ssh__help-link {
+	margin: 1rem 0;
+	font-size: 0.875rem;
+}
+
 .migration-site-ssh__continue-button {
+	margin-left: 2.5rem;
 	button {
 		width: 100%;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Added the first step of the "Securely share your access", in which the user can exit the flow, navigate to the support page or continue with the SSH Migration.
* Add a Helper Link component, that will be used in all steps in the accordion.
* Added the mapping for the supported hosts, and the documentation.

<img width="785" height="649" alt="Captura de Tela 2025-10-21 às 17 50 50" src="https://github.com/user-attachments/assets/ef2a3519-3e37-4eeb-8e34-a1dbee657cc1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I'm splitting the main https://github.com/Automattic/wp-calypso/pull/106585 PR into smaller parts to make it easy the reviewing process. This is step is the first thing the user will see once they land on the SSH Migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment.
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow until you reach the `Securely share your access`
* Add the `host=godaddy` parameter in your URL, this should change the text and the link to the support.
* Verify that the support link works.
* Verify that the "I found my SSH details" button completes the page.
* Verify that the "I don't have SSH access" button takes you to the fallback step.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
