### PR TITLE
Domains: Make the number of domain results per page a configurable parameter

### DIFF
--- a/packages/domain-search/src/components/search-results/index.tsx
+++ b/packages/domain-search/src/components/search-results/index.tsx
@@ -15,17 +15,19 @@ const SearchResults = ( {
 	suggestions: string[];
 	numberOfInitialVisibleSuggestions?: number;
 } ) => {
-	const { filter, resetFilter, events } = useDomainSearch();
+	const { filter, resetFilter, events, config } = useDomainSearch();
 	const [ numberOfVisibleSuggestions, setnumberOfVisibleSuggestions ] = useState(
-		numberOfInitialVisibleSuggestions ?? 10
+		numberOfInitialVisibleSuggestions ?? config.numberOfDomainsResultsPerPage
 	);
 	const [ pageNumber, setPageNumber ] = useState( 1 );
 
 	const showMoreResults = useCallback( () => {
 		events.onShowMoreResults( pageNumber + 1 );
 		setPageNumber( pageNumber + 1 );
-		setnumberOfVisibleSuggestions( numberOfVisibleSuggestions + 10 );
-	}, [ events, pageNumber, numberOfVisibleSuggestions ] );
+		setnumberOfVisibleSuggestions(
+			numberOfVisibleSuggestions + config.numberOfDomainsResultsPerPage
+		);
+	}, [ events, pageNumber, numberOfVisibleSuggestions, config.numberOfDomainsResultsPerPage ] );
 
 	const hasActiveFilters = filter.exactSldMatchesOnly || filter.tlds.length > 0;
 

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -64,6 +64,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		allowsUsingOwnDomain: false,
 		includeOwnedDomainInSuggestions: false,
 		allowedTlds: [],
+		numberOfDomainsResultsPerPage: 10,
 		priceRules: {
 			hidePrice: false,
 			oneTimePrice: false,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -14,7 +14,8 @@ export const ResultsPage = () => {
 	const { slots, config } = useDomainSearch();
 
 	const { isLoading, featuredSuggestions, regularSuggestions } = useSuggestionsList();
-	const numberOfInitialVisibleSuggestions = 10 - featuredSuggestions.length;
+	const numberOfInitialVisibleSuggestions =
+		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
 
 	useRequestTracking();
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -103,26 +103,18 @@ describe( 'ResultsPage', () => {
 			expect( testOrg ).not.toHaveTextContent( 'Best alternative' );
 		} );
 
-		it( 'renders the "show more results" button if there are more than 10 suggestions', async () => {
+		it( 'renders the "show more results" button if there are more than config.numberOfDomainsResultsPerPage suggestions', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test' },
 				suggestions: [
 					buildSuggestion( { domain_name: 'test1.com' } ),
 					buildSuggestion( { domain_name: 'test2.com' } ),
 					buildSuggestion( { domain_name: 'test3.com' } ),
-					buildSuggestion( { domain_name: 'test4.com' } ),
-					buildSuggestion( { domain_name: 'test5.com' } ),
-					buildSuggestion( { domain_name: 'test6.com' } ),
-					buildSuggestion( { domain_name: 'test7.com' } ),
-					buildSuggestion( { domain_name: 'test8.com' } ),
-					buildSuggestion( { domain_name: 'test9.com' } ),
-					buildSuggestion( { domain_name: 'test10.com' } ),
-					buildSuggestion( { domain_name: 'test11.com' } ),
 				],
 			} );
 
 			render(
-				<TestDomainSearch query="test">
+				<TestDomainSearch config={ { numberOfDomainsResultsPerPage: 2 } } query="test">
 					<ResultsPage />
 				</TestDomainSearch>
 			);
@@ -130,25 +122,17 @@ describe( 'ResultsPage', () => {
 			expect( await screen.findByText( 'Show more results' ) ).toBeInTheDocument();
 		} );
 
-		it( 'does not render the "show more results" button if there are 10 or less suggestions', async () => {
+		it( 'does not render the "show more results" button if there are config.numberOfDomainsResultsPerPage or less suggestions', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test' },
 				suggestions: [
 					buildSuggestion( { domain_name: 'test1.com' } ),
 					buildSuggestion( { domain_name: 'test2.com' } ),
-					buildSuggestion( { domain_name: 'test3.com' } ),
-					buildSuggestion( { domain_name: 'test4.com' } ),
-					buildSuggestion( { domain_name: 'test5.com' } ),
-					buildSuggestion( { domain_name: 'test6.com' } ),
-					buildSuggestion( { domain_name: 'test7.com' } ),
-					buildSuggestion( { domain_name: 'test8.com' } ),
-					buildSuggestion( { domain_name: 'test9.com' } ),
-					buildSuggestion( { domain_name: 'test10.com' } ),
 				],
 			} );
 
 			render(
-				<TestDomainSearch query="test">
+				<TestDomainSearch config={ { numberOfDomainsResultsPerPage: 2 } } query="test">
 					<ResultsPage />
 				</TestDomainSearch>
 			);

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -84,6 +84,7 @@ export interface DomainSearchConfig {
 	allowsUsingOwnDomain: boolean;
 	allowedTlds: string[];
 	includeOwnedDomainInSuggestions: boolean;
+	numberOfDomainsResultsPerPage: number;
 }
 
 export interface DomainSearchProps {


### PR DESCRIPTION
Part of [DOMENG-192](https://linear.app/a8c/issue/DOMENG-192/)

## Proposed Changes

This is a follow up to #106624.

This PR makes the number of domain results per page a configurable parameter.

## Why are these changes being made?

This should make future changes and experiments in domain search simpler.

## Testing Instructions

- Unit tests should be passing
- Open the live Calypso link or build this branch locally
- Go to a domain search page (e.g. `/setup`)
- Do a domain search
- Ensure the "Show more results" button is working normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
