### PR TITLE
Hosting Dashboard: User not logged out when attempting to access page they do not have access to

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -127,9 +127,8 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 				event.type === 'updated' &&
 				event.action.type === 'error' &&
 				isWpError( event.action.error ) &&
-				[ 401, 403 ].includes( event.action.error.statusCode ) &&
-				event.action.error.error === 'authorization_required' &&
-				! authErrorHandled.current // Prevents repeated calls to redirect
+				event.action.error.statusCode === 401 &&
+				[ 'rest_forbidden', 'authorization_required' ].includes( event.action.error.error ?? '' )
 			) {
 				handleAuthError();
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR weakens the `<AuthProvider>` code which redirects the user to the log in screen if they appear to be logged out. Which was added in #106494.

* Only redirects on `401`, not `403` - we see that WP users `401` for logged out users https://github.com/WordPress/WordPress/blob/e9bd8510b6aa506ff0a5d83de418b25c7f907701/wp-includes/rest-api.php#L1410
* Also checks for the `rest_forbidden` status - WP uses this status too when a rest endpoint is not allowed https://github.com/WordPress/WordPress/blob/e9bd8510b6aa506ff0a5d83de418b25c7f907701/wp-includes/rest-api/class-wp-rest-server.php#L1265
* Cleans up the unnecessary `authErrorHandled.current` check - it is already checked in the `handleAuthError()` callback

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

@mmtr discovered that the check is too aggressive https://github.com/Automattic/wp-calypso/pull/106494#issuecomment-3425956394. For example, if you are logged in and paste the URL of a hosting dashboard page you don't have access to (e.g. a site or email you can't access) then you correctly get a `403` response. You shouldn't be treated as if you are logged out, otherwise you might end up in some login loop.

https://github.com/user-attachments/assets/2d3bdae8-a499-403f-823b-eff540fa7304

Unfortunately these changes make the `<AuthProvider>` redirect basically useless. It is true that `401` should be sued to detect the logged out state, but there are important `public-api` endpoints that return `403` e.g. fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qzr%2Qfvgrf%2Qraqcbvag.cuc%3Se%3Q330qq338%2324-og

I would say this is a bug, but is it too entrenched to change and endpoint like this at this point in the game? CC @taipeicoder 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?