### PR TITLE
SSH Migration: Add the error screen on the Dashboard

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1134,6 +1134,24 @@ export const siteMigrationOverviewRoute = createRoute( {
 	)
 );
 
+export const siteSSHMigrationFailedRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'We hit a snag, but we’re on it' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteRoute,
+	path: 'ssh-migration-failed',
+} ).lazy( () =>
+	import( '../../sites/ssh-migration-failed' ).then( ( d ) =>
+		createLazyRoute( 'ssh-migration-failed' )( {
+			component: () => <d.default />,
+		} )
+	)
+);
+
 export const siteSSHMigrationCompleteRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1187,6 +1205,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 		siteDifmLiteInProgressRoute,
 		siteMigrationOverviewRoute,
 		siteSSHMigrationCompleteRoute,
+		siteSSHMigrationFailedRoute,
 	];
 
 	if ( config.supports.sites.deployments ) {

--- a/client/dashboard/sites/ssh-migration-failed/index.tsx
+++ b/client/dashboard/sites/ssh-migration-failed/index.tsx
@@ -47,7 +47,11 @@ export default function SSHMigrationFailed() {
 								<HStack justify="flex-start" key={ index } spacing={ 3 }>
 									<Card size="extraSmall" style={ { minWidth: '40px' } }>
 										<CardBody style={ { lineHeight: '0' } }>
-											<Icon icon={ item.icon } size={ 24 } style={ { fill: '#646970' } } />
+											<Icon
+												icon={ item.icon }
+												size={ 24 }
+												style={ { fill: 'var(--wp-admin-theme-color-muted, #646970)' } }
+											/>
 										</CardBody>
 									</Card>
 									<Text variant="muted">{ item.text }</Text>

--- a/client/dashboard/sites/ssh-migration-failed/index.tsx
+++ b/client/dashboard/sites/ssh-migration-failed/index.tsx
@@ -1,0 +1,62 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	Icon,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { copy, globe, scheduled } from '@wordpress/icons';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import { Text } from '../../components/text';
+
+const GUIDE_LIST = [
+	{
+		icon: scheduled,
+		text: __(
+			'We’ll investigate what happened and get back to you within a business day with next steps.'
+		),
+	},
+	{
+		icon: copy,
+		text: __( 'We’ll bring over a copy of your site without affecting your current live version.' ),
+	},
+	{
+		icon: globe,
+		text: __( 'We’ll help you switch your domain after we have completed the migration.' ),
+	},
+];
+
+export default function SSHMigrationFailed() {
+	return (
+		<PageLayout size="small">
+			<VStack spacing={ 8 } expanded={ false }>
+				<PageHeader
+					title={ __( 'We hit a snag, but we’re on it' ) }
+					description={ __(
+						'Your migration ran into an issue but don’t worry — our migration team will take over from here and get your site moved safely.'
+					) }
+				/>
+				<Card size="medium">
+					<CardBody>
+						<VStack spacing={ 3 }>
+							<SectionHeader title={ __( 'What to expect' ) } level={ 3 } />
+							{ GUIDE_LIST.map( ( item, index ) => (
+								<HStack justify="flex-start" key={ index } spacing={ 3 }>
+									<Card size="extraSmall" style={ { minWidth: '40px' } }>
+										<CardBody style={ { lineHeight: '0' } }>
+											<Icon icon={ item.icon } size={ 24 } style={ { fill: '#646970' } } />
+										</CardBody>
+									</Card>
+									<Text variant="muted">{ item.text }</Text>
+								</HStack>
+							) ) }
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -8,6 +8,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ActiveDomainsCard from './active-domains-card';
 import MigrationOverview from './migration-overview';
 import { MigrationSSHComplete } from './migration-overview/components/migration-ssh-complete';
+import { MigrationSSHFailed } from './migration-overview/components/migration-ssh-failed';
 import PlanCard from './plan-card';
 import PlanCreditNotice from './plan-credit-notice';
 import QuickActionsCard from './quick-actions-card';
@@ -22,8 +23,12 @@ const HostingOverview: FC = () => {
 
 	if ( site ) {
 		const queryParams = new URLSearchParams( window.location.search );
-		if ( queryParams.get( 'ssh-migration' ) === 'complete' ) {
+		const sshMigration = queryParams.get( 'ssh-migration' );
+		if ( sshMigration === 'complete' ) {
 			return <MigrationSSHComplete site={ site } />;
+		}
+		if ( sshMigration === 'failed' ) {
+			return <MigrationSSHFailed />;
 		}
 
 		if ( isMigrationInProgress( site ) ) {

--- a/client/sites/overview/components/migration-overview/components/migration-ssh-failed.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-ssh-failed.tsx
@@ -1,0 +1,66 @@
+import { copy, globe, Icon, scheduled } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
+import { HostingCard } from 'calypso/components/hosting-card';
+import { Container, Header } from './layout';
+
+type MigrationFailedListProps = {
+	children: ReactElement< MigrationFailedItemProps > | ReactElement< MigrationFailedItemProps >[];
+};
+
+type MigrationFailedItemProps = {
+	icon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
+	text: string;
+};
+
+const MigrationFailedList = ( { children }: MigrationFailedListProps ) => (
+	<ul className="migration-ssh-failed__list">{ children }</ul>
+);
+
+const MigrationFailedItem = ( { icon, text }: MigrationFailedItemProps ) => (
+	<li className="migration-ssh-failed__item">
+		<div className="migration-ssh-failed__icon-wrapper">
+			<Icon icon={ icon } className="migration-ssh-failed__icon" size={ 30 } />
+		</div>
+		<span>{ text }</span>
+	</li>
+);
+
+export const MigrationSSHFailed = () => {
+	const translate = useTranslate();
+
+	const title = translate( 'We hit a snag, but we’re on it' );
+	const subTitle = translate(
+		'Your migration ran into an issue but don’t worry — our migration team will take over from here and get your site moved safely.'
+	);
+
+	return (
+		<Container>
+			<Header title={ title } subTitle={ subTitle } />
+			<div className="migration-ssh-failed">
+				<HostingCard title={ translate( 'What to expect' ) }>
+					<MigrationFailedList>
+						<MigrationFailedItem
+							icon={ scheduled }
+							text={ translate(
+								'We’ll investigate what happened and get back to you within a business day with next steps.'
+							) }
+						/>
+						<MigrationFailedItem
+							icon={ copy }
+							text={ translate(
+								'We’ll bring over a copy of your site without affecting your current live version.'
+							) }
+						/>
+						<MigrationFailedItem
+							icon={ globe }
+							text={ translate(
+								'We’ll help you switch your domain after we have completed the migration.'
+							) }
+						/>
+					</MigrationFailedList>
+				</HostingCard>
+			</div>
+		</Container>
+	);
+};

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -80,6 +80,41 @@
 			}
 		}
 	}
+
+	.migration-ssh-failed {
+		display: flex;
+		flex-direction: column;
+		margin: 0 auto;
+		max-width: 500px;
+
+		.migration-ssh-failed__list {
+			display: flex;
+			flex-direction: column;
+			gap: .75rem;
+			margin: 0;
+		}
+
+		.migration-ssh-failed__item {
+			display: flex;
+			gap: .75rem;
+			font-size: 1rem;
+			align-items: center;
+		}
+
+		.migration-ssh-failed__icon {
+			fill: #3858E9;
+		}
+
+		.migration-ssh-failed__icon-wrapper {
+			width: 52px;
+			height: 52px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			background-color: #F7F8FE;
+			flex-shrink: 0;
+		}
+	}
 }
 
 .migration-started-difm__cancel-dialog {

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -25,7 +25,11 @@ export async function dashboardBackportSiteOverview( context: PageJSContext, nex
 	const { site: siteSlug } = context.params;
 	const site = getSelectedSite( context.store.getState() ) as SiteExcerptData;
 
-	if ( isMigrationInProgress( site ) || context.query?.[ 'ssh-migration' ] === 'complete' ) {
+	const queryParams = new URLSearchParams( window.location.search );
+	const sshMigration = [ 'complete', 'failed' ].includes(
+		queryParams.get( 'ssh-migration' ) ?? ''
+	);
+	if ( isMigrationInProgress( site ) || sshMigration ) {
 		// Temporarily show the v1 site migration overview page.
 		// @todo implement the page in v2.
 		return overview( context, next );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15001

## Proposed Changes

* Add the error screen to the dashboard.

### V2

<img width="836" height="485" alt="Captura de Tela 2025-10-22 às 10 09 48" src="https://github.com/user-attachments/assets/5aff5993-741a-4943-87e8-1ec4e2328d35" />

### V1

<img width="950" height="487" alt="Captura de Tela 2025-10-22 às 10 10 19" src="https://github.com/user-attachments/assets/11ac303d-8c60-42eb-b8b1-1e45442f5975" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We'll redirect the user to this page when the SSH Migration fails.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment.
* Navigate to `/sites/SITE_SLUG?ssh-migration=failed` so you can the see the Overview version.
* Navigate to `/v2/sites/SITE_SLUG/ssh-migration-failed` so you can see the new Hosting Dashboard version.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
