### PR TITLE
CIAB MSD: Add CIAB SiteSwitcher

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -33,17 +33,9 @@ boot( {
 		plugins: true,
 		commandPalette: false,
 	},
-	onboardingLinkSourceQueryArg: 'sites-dashboard',
-	onboardingLinks: {
-		default: {
-			href: '/start',
-		},
-		withAI: {
-			href: '/setup/ai-site-builder',
-		},
-	},
 	optIn: false,
 	components: {
 		sites: () => import( '../sites' ),
+		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -33,17 +33,9 @@ boot( {
 		plugins: false,
 		commandPalette: false,
 	},
-	onboardingLinkSourceQueryArg: 'ciab-sites-dashboard',
-	onboardingLinks: {
-		default: {
-			href: '/start',
-		},
-		withAI: {
-			href: '/setup/ai-site-builder-spec',
-		},
-	},
 	optIn: false,
 	components: {
 		sites: () => import( '../sites-ciab' ),
+		siteSwitcher: () => import( '../sites-ciab/site-switcher' ),
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -32,17 +32,9 @@ boot( {
 		plugins: true,
 		commandPalette: false,
 	},
-	onboardingLinkSourceQueryArg: 'sites-dashboard',
-	onboardingLinks: {
-		default: {
-			href: '/start',
-		},
-		withAI: {
-			href: '/setup/ai-site-builder',
-		},
-	},
 	optIn: true,
 	components: {
 		sites: () => import( '../sites' ),
+		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -16,10 +16,6 @@ export type MeSupports = {
 	apps: boolean;
 };
 
-export type OnboardingLink = {
-	href: string;
-};
-
 export type AppConfig = {
 	name: string;
 	basePath: string;
@@ -38,11 +34,6 @@ export type AppConfig = {
 		notifications: boolean;
 		me: MeSupports | false;
 		commandPalette: boolean;
-	};
-	onboardingLinkSourceQueryArg?: 'sites-dashboard' | 'ciab-sites-dashboard';
-	onboardingLinks?: {
-		default: OnboardingLink;
-		withAI: OnboardingLink;
 	};
 	optIn: boolean;
 	components: Record< string, () => Promise< { default: React.FC } > >;
@@ -67,8 +58,6 @@ const AppContext = createContext< AppConfig >( {
 		me: false,
 		commandPalette: false,
 	},
-	onboardingLinkSourceQueryArg: undefined,
-	onboardingLinks: undefined,
 	optIn: false,
 	components: {},
 } );

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -21,7 +21,6 @@ import deepmerge from 'deepmerge';
 import { useEffect } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
-import { useAppContext } from '../app/context';
 import { useHelpCenter } from '../app/help-center';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
@@ -66,7 +65,6 @@ export default function CIABSites() {
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
-	const { onboardingLinks } = useAppContext();
 	const { setShowHelpCenter } = useHelpCenter();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 	const { data: viewPreferences } = useSuspenseQuery( userPreferenceQuery( 'ciab-sites-view' ) );
@@ -96,7 +94,7 @@ export default function CIABSites() {
 
 	const handleAddNewStore = () => {
 		setShowHelpCenter( false );
-		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		recordTracksEvent( 'calypso_dashboard_sites_add_new_site_click', {
 			action: 'big-sky',
 		} );
 	};
@@ -152,7 +150,7 @@ export default function CIABSites() {
 		}
 	}, [ sites, queryClient ] );
 
-	const addNewStoreUrl = addQueryArgs( onboardingLinks?.withAI.href || '/setup/ai-site-builder', {
+	const addNewStoreUrl = addQueryArgs( '/setup/ai-site-builder-spec', {
 		source: 'ciab-sites-dashboard',
 		ref: 'new-site-popover',
 	} );

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { MenuGroup, MenuItem, Icon } from '@wordpress/components';
+import { __experimentalHStack as HStack, MenuGroup, MenuItem, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -53,10 +53,10 @@ const CIABSiteSwitcher = () => {
 			{ () => (
 				<MenuGroup>
 					<MenuItem onClick={ handleAddNewStore }>
-						<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+						<HStack justify="flex-start" alignment="center">
 							<Icon icon={ plus } />
-							{ __( 'Add new store', 'Commerce in a box' ) }
-						</div>
+							<span>{ __( 'Add new store', 'Commerce in a box' ) }</span>
+						</HStack>
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -27,7 +27,7 @@ const CIABSiteSwitcher = () => {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 	const handleAddNewStore = () => {
-		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		recordTracksEvent( 'calypso_dashboard_site_switcher_new_site_button_click', {
 			action: 'big-sky',
 			context: 'ciab-sites-dashboard',
 		} );

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -1,0 +1,67 @@
+import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { MenuGroup, MenuItem, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { siteRoute } from '../../app/router/sites';
+import SiteIcon from '../../components/site-icon';
+import Switcher from '../../components/switcher';
+import { getSiteDisplayName } from '../../utils/site-name';
+
+const CIABSiteSwitcher = () => {
+	const { recordTracksEvent } = useAnalytics();
+	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
+	const { data: sites } = useQuery( {
+		...sitesQuery( {
+			site_filters: [ 'commerce-garden' ],
+			site_visibility: 'visible',
+			include_a8c_owned: false,
+		} ),
+		enabled: isSwitcherOpen,
+	} );
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+	const handleAddNewStore = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+			action: 'big-sky',
+			context: 'ciab-sites-dashboard',
+		} );
+
+		const addNewStoreUrl = addQueryArgs( '/setup/ai-site-builder-spec', {
+			source: 'ciab-sites-dashboard',
+			ref: 'new-site-popover',
+		} );
+
+		window.location.href = addNewStoreUrl;
+	};
+
+	return (
+		<Switcher
+			items={ sites }
+			value={ site }
+			getItemName={ getSiteDisplayName }
+			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
+			renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+			open={ isSwitcherOpen }
+			onToggle={ setIsSwitcherOpen }
+		>
+			{ () => (
+				<MenuGroup>
+					<MenuItem onClick={ handleAddNewStore }>
+						<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+							<Icon icon={ plus } />
+							{ __( 'Add new store', 'Commerce in a box' ) }
+						</div>
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</Switcher>
+	);
+};
+
+export default CIABSiteSwitcher;

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -14,7 +14,6 @@ import { download, reusableBlock, Icon } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import { useAnalytics } from '../../app/analytics';
-import { useAppContext } from '../../app/context';
 import { useHelpCenter } from '../../app/help-center';
 import Column from './column';
 import MenuItem from './menu-item';
@@ -23,7 +22,6 @@ import './style.scss';
 
 function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 	const { recordTracksEvent } = useAnalytics();
-	const { onboardingLinks } = useAppContext();
 
 	const wordpressClick = () => {
 		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
@@ -74,7 +72,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title="WordPress.com"
 					description={ __( 'Build and grow your site, all in one powerful platform.' ) }
 					onClick={ wordpressClick }
-					href={ addQueryArgs( onboardingLinks?.default.href || '/start', {
+					href={ addQueryArgs( '/start', {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -92,7 +90,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 							action: 'big-sky',
 						} );
 					} }
-					href={ addQueryArgs( onboardingLinks?.withAI.href || '/setup/ai-site-builder', {
+					href={ addQueryArgs( '/setup/ai-site-builder', {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -1,0 +1,61 @@
+import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { MenuGroup, MenuItem, Icon, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { useState } from 'react';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { siteRoute } from '../../app/router/sites';
+import SiteIcon from '../../components/site-icon';
+import Switcher from '../../components/switcher';
+import { getSiteDisplayName } from '../../utils/site-name';
+import AddNewSite from '../add-new-site';
+
+const SiteSwitcher = () => {
+	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
+	const { data: sites } = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } );
+	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<>
+			<Switcher
+				items={ sites }
+				value={ site }
+				getItemName={ getSiteDisplayName }
+				getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
+				renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+				open={ isSwitcherOpen }
+				onToggle={ setIsSwitcherOpen }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								onClose();
+								setIsAddSiteModalOpen( true );
+							} }
+						>
+							<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+								<Icon icon={ plus } />
+								{ __( 'Add new site' ) }
+							</div>
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</Switcher>
+			{ isAddSiteModalOpen && (
+				<Modal
+					title={ __( 'Add new site' ) }
+					onRequestClose={ () => setIsAddSiteModalOpen( false ) }
+				>
+					<AddNewSite context="sites-dashboard" />
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default SiteSwitcher;

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -1,6 +1,12 @@
 import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { MenuGroup, MenuItem, Icon, Modal } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	MenuGroup,
+	MenuItem,
+	Icon,
+	Modal,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
@@ -38,10 +44,10 @@ const SiteSwitcher = () => {
 								setIsAddSiteModalOpen( true );
 							} }
 						>
-							<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+							<HStack justify="flex-start" alignment="center">
 								<Icon icon={ plus } />
-								{ __( 'Add new site' ) }
-							</div>
+								<span>{ __( 'Add new site' ) }</span>
+							</HStack>
 						</MenuItem>
 					</MenuGroup>
 				) }

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,80 +1,38 @@
-import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, notFound } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	MenuGroup,
-	MenuItem,
-	Icon,
-	Modal,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
-import { useState } from 'react';
+import { Suspense, useMemo, lazy } from 'react';
 import { useAppContext } from '../../app/context';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
-import SiteIcon from '../../components/site-icon';
-import Switcher from '../../components/switcher';
-import { getSiteDisplayName } from '../../utils/site-name';
 import { hasStagingSite } from '../../utils/site-staging-site';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
-import AddNewSite from '../add-new-site';
 import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteMenu from '../site-menu';
 import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
-	const { onboardingLinkSourceQueryArg } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
-	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
-	const { data: sites } = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } );
-	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+	const { components } = useAppContext();
+	const SiteSwitcher = useMemo( () => lazy( components.siteSwitcher ), [ components ] );
 
 	if ( ! canManageSite( site ) ) {
 		throw notFound();
 	}
 
 	return (
-		<>
+		<Suspense fallback={ null }>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
 			<HeaderBar>
 				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
 					<HeaderBar.Title>
-						<Switcher
-							items={ sites }
-							value={ site }
-							getItemName={ getSiteDisplayName }
-							getItemUrl={ ( site ) =>
-								buildCurrentRouteLink( { params: { siteSlug: site.slug } } )
-							}
-							renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
-							open={ isSwitcherOpen }
-							onToggle={ setIsSwitcherOpen }
-						>
-							{ ( { onClose } ) => (
-								<MenuGroup>
-									<MenuItem
-										onClick={ () => {
-											onClose();
-											setIsAddSiteModalOpen( true );
-										} }
-									>
-										<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-											<Icon icon={ plus } />
-											{ __( 'Add new site' ) }
-										</div>
-									</MenuItem>
-								</MenuGroup>
-							) }
-						</Switcher>
+						<SiteSwitcher />
 						{ canSwitchEnvironment( site ) && (
 							<>
 								<MenuDivider />
@@ -82,14 +40,6 @@ function Site() {
 							</>
 						) }
 					</HeaderBar.Title>
-					{ isAddSiteModalOpen && (
-						<Modal
-							title={ __( 'Add new site' ) }
-							onRequestClose={ () => setIsAddSiteModalOpen( false ) }
-						>
-							<AddNewSite context={ onboardingLinkSourceQueryArg } />
-						</Modal>
-					) }
 					{ ! isSiteMigrationInProgress( site ) && (
 						<>
 							{ isDesktop && <MenuDivider /> }
@@ -99,7 +49,7 @@ function Site() {
 				</HStack>
 			</HeaderBar>
 			<Outlet />
-		</>
+		</Suspense>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106558

## Proposed Changes

* Add CIAB SiteSwitcher to
  * Display ciab sites
  * Open the create new store flow by clicking the button
* Get rid of `onboardingLinkSourceQueryArg` and `onboardingLinks` as it's not required

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /ciab
* Select any site
* Open the site switcher
* It should list only ciab sites
* Click `Add new store`
* It should navigate to the create new store flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
