### PR TITLE
Refactor UserMessage and related types: remove canned response handling

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import {
 	getOdieForwardToForumsMessage,
 	getOdieForwardToZendeskMessage,
@@ -24,17 +23,11 @@ import type { Message } from '../../types';
 const getDisplayMessage = (
 	isUserEligibleForPaidSupport: boolean,
 	canConnectToZendesk: boolean,
-	messageContent: ReactNode,
-	hasCannedResponse?: boolean,
 	forceEmailSupport?: boolean,
 	isErrorMessage?: boolean
 ) => {
 	if ( isUserEligibleForPaidSupport && ! canConnectToZendesk ) {
 		return getOdieThirdPartyMessageContent();
-	}
-
-	if ( isUserEligibleForPaidSupport && hasCannedResponse ) {
-		return messageContent;
 	}
 
 	if ( isUserEligibleForPaidSupport && forceEmailSupport ) {
@@ -63,8 +56,6 @@ export const UserMessage = ( {
 		useOdieAssistantContext();
 
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
-
-	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = getIsRequestingHumanSupport( message );
 	const isLastBotMessage = getIsLastBotMessage( chat, message );
 
@@ -75,8 +66,6 @@ export const UserMessage = ( {
 		? getDisplayMessage(
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
-				message.content,
-				hasCannedResponse,
 				forceEmailSupport,
 				message?.context?.flags?.is_error_message
 		  )

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -29,7 +29,6 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 			site_id: selectedSiteId ?? null,
 			flags: {
 				forward_to_human_support: true,
-				canned_response: false,
 				hide_disclaimer_content: false,
 				show_contact_support_msg: true,
 				show_ai_avatar: true,

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -125,7 +125,6 @@ export type Context = {
 	};
 	flags?: {
 		forward_to_human_support?: boolean;
-		canned_response?: boolean;
 		hide_disclaimer_content?: boolean;
 		show_contact_support_msg?: boolean;
 		show_ai_avatar?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/HAL-385/remove-support-for-canned-response-flags-in-help-center

## Proposed Changes

Remove the canned_response flag handling and related code paths from the ODIE client

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `canned_response` path introduced a special-case where, for eligible paid-support users, the bot would display canned message content rather than running the standard escalation/forwarding logic. That special-case added complexity and inconsistency in how “request-for-human-support” messages are treated.

This was used in the past, and therefore we are dropping support as no new assistant is using it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open help center, talk with the assistant and try to escalate, the flow should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
