### PR TITLE
Multi-site dashboard Emails: Align header of Provider Selector step to the left

### DIFF
--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -157,26 +157,24 @@ export default function ChooseEmailSolution() {
 			}
 		>
 			{ /* Billing interval selector */ }
-			<div className="billing-interval-selector">
-				<ToggleGroupControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					isBlock
-					label={ __( 'Billing interval' ) }
-					hideLabelFromVision
-					value={ billingInterval }
-					onChange={ ( newBillingInterval ) =>
-						setBillingInterval( newBillingInterval as IntervalLength )
-					}
-				>
-					<ToggleGroupControlOption label={ __( 'Monthly' ) } value="monthly" />
-					<ToggleGroupControlOption
-						/* translators: %d is the annual savings percentage. */
-						label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
-						value="annually"
-					/>
-				</ToggleGroupControl>
-			</div>
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				isBlock
+				label={ __( 'Billing interval' ) }
+				hideLabelFromVision
+				value={ billingInterval }
+				onChange={ ( newBillingInterval ) =>
+					setBillingInterval( newBillingInterval as IntervalLength )
+				}
+			>
+				<ToggleGroupControlOption label={ __( 'Monthly' ) } value="monthly" />
+				<ToggleGroupControlOption
+					/* translators: %d is the annual savings percentage. */
+					label={ sprintf( __( 'Annually (save up to %d%%)' ), bestAnnualSavings ) }
+					value="annually"
+				/>
+			</ToggleGroupControl>
 
 			{ /* Split card for providers */ }
 			<div className="email-providers">

--- a/client/dashboard/emails/choose-email-solution/style.scss
+++ b/client/dashboard/emails/choose-email-solution/style.scss
@@ -1,19 +1,6 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
 
-.dashboard-page-header {
-	align-self: center;
-}
-
-.billing-interval-selector {
-	align-self: center;
-	width: 100%;
-
-	@include break-small {
-		width: 450px;
-	}
-}
-
 .email-providers {
 	border: 1px solid $gray-200;
 	border-radius: 8px;


### PR DESCRIPTION
Fixes DOTMSD-700
## Proposed Changes

Changes the header alignment of the "Choose an email solution" step:

Before | After
--- | ---
<img width="685" height="784" alt="Screenshot 2025-10-22 at 11 54 10" src="https://github.com/user-attachments/assets/4100d50a-9326-407e-899e-176ab6db8317" /> | <img width="711" height="788" alt="Screenshot 2025-10-22 at 12 05 26" src="https://github.com/user-attachments/assets/6e17d232-7774-4180-8d75-a0696fbe31bc" />


## Why are these changes being made?

Because the alignment was inconsistent with the rest of the Multi-site dashboard.

## Testing Instructions

- Use the Calypso live link below
- Go to `/v2/emails/choose-email-solution/:domain`
- Make sure the header is aligned to the left
- Make sure the billing interval toggle takes the full width

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
