### PR TITLE
Add redirect param for post checkout destination

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -74,6 +74,7 @@ const allowedExternalSites = [
 	'jetpack.cloud.localhost',
 	'jetpack.com',
 	'akismet.com',
+	'difmrequest.com',
 ];
 
 export interface PostCheckoutUrlArguments {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -597,6 +597,13 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( redirectTo );
 	} );
 
+	it( 'redirects to external redirectTo url if the hostame is difmrequest.com', () => {
+		const adminUrl = 'https://my.site/wp-admin/';
+		const redirectTo = 'https://difmrequest.com/request-a-build-black-friday/';
+		const url = getThankYouPageUrl( { ...defaultArgs, adminUrl, redirectTo } );
+		expect( url ).toBe( redirectTo );
+	} );
+
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
 			...getMockCart(),

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -271,6 +271,7 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'cloud.jetpack.com',
 		'jetpack.com',
 		'akismet.com',
+		'difmrequest.com',
 		'agencies.automattic.com',
 		'agencies.localhost',
 		siteSlug,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -73,8 +73,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'coupon', 'storage' ],
-			optionalDependenciesInQuery: [ 'coupon', 'storage' ],
+			providesDependenciesInQuery: [ 'coupon', 'storage', 'redirect_to' ],
+			optionalDependenciesInQuery: [ 'coupon', 'storage', 'redirect_to' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -84,8 +84,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'coupon' ],
-			optionalDependenciesInQuery: [ 'coupon' ],
+			providesDependenciesInQuery: [ 'coupon', 'redirect_to' ],
+			optionalDependenciesInQuery: [ 'coupon', 'redirect_to' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -95,8 +95,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'coupon' ],
-			optionalDependenciesInQuery: [ 'coupon' ],
+			providesDependenciesInQuery: [ 'coupon', 'redirect_to' ],
+			optionalDependenciesInQuery: [ 'coupon', 'redirect_to' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -106,6 +106,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'redirect_to' ],
+			optionalDependenciesInQuery: [ 'redirect_to' ],
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -48,6 +48,8 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 			...( isDomainOnly && { isDomainOnly: 1 } ),
 			...( isGravatarDomain && { isGravatarDomain: 1 } ),
 			checkoutBackUrl: finalCheckoutBackUrl,
+			// Pass the final destination as redirect_to so checkout knows where to go after completion
+			...( destination && { redirect_to: destination } ),
 		},
 		checkoutURL
 	);
@@ -76,7 +78,12 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-function getSignupDestination( { domainItem, siteId, siteSlug, refParameter } ) {
+function getSignupDestination( { domainItem, siteId, siteSlug, refParameter, redirect_to } ) {
+	// If a redirect_to parameter is provided, use it as the destination
+	if ( redirect_to ) {
+		return redirect_to;
+	}
+
 	if ( 'no-site' === siteSlug ) {
 		return '/home';
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1760456723587539/1760390220.791069-slack-CFFF01Q4V

## Proposed Changes

* ensures that the `redirect_to` param is passed through the plan flows and used as post-checkout destination

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed for the Black Friday redirect

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/business/user-social?redirect_to=https://difmrequest.com/request-a-build-black-friday/`
* After checkout, you should land on the specified redirect URL


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?