### PR TITLE
v2 HD: Add Segmented Bar component (for use in plan/flex usage)

### DIFF
--- a/client/dashboard/components/segmented-bar/index.stories.tsx
+++ b/client/dashboard/components/segmented-bar/index.stories.tsx
@@ -1,0 +1,41 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import SegmentedBar, { SegmentedBarSegment } from './';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof SegmentedBar > = {
+	title: 'client/dashboard/SegmentedBar',
+	component: SegmentedBar,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+type Story = StoryObj< typeof SegmentedBar >;
+
+const baseSegments: SegmentedBarSegment[] = [
+	{ id: 'storage', value: 2, label: 'Storage' },
+	{ id: 'bandwidth', value: 1, label: 'Bandwidth' },
+	{ id: 'compute', value: 0.5, label: 'Compute' },
+];
+
+export const Default: Story = {
+	args: {
+		segments: baseSegments,
+		ariaLabel: 'Baseline usage',
+	},
+};
+
+export const Custom: Story = {
+	args: {
+		segments: [
+			{ id: 'storage', value: 2, color: 'var(--studio-blue-50)', label: 'Storage' },
+			{ id: 'bandwidth', value: 1, color: 'var(--studio-green-50)', label: 'Bandwidth' },
+			{ id: 'compute', value: 0.5, color: 'var(--studio-orange-40)', label: 'Compute' },
+		],
+		radius: 8,
+		ariaLabel: 'Custom usage',
+		gap: 0,
+		formatValue: ( value: number ) => {
+			return formatCurrency( value, 'USD' );
+		},
+	},
+};

--- a/client/dashboard/components/segmented-bar/index.tsx
+++ b/client/dashboard/components/segmented-bar/index.tsx
@@ -1,0 +1,160 @@
+import { useViewportMatch } from '@wordpress/compose';
+import type { CSSProperties } from 'react';
+import './style.scss';
+
+/**
+ * A single segment in the SegmentedBar visualisation.
+ */
+export type SegmentedBarSegment = {
+	/** Stable identifier for the segment */
+	id: string;
+	/** Numeric value that determines the segment size */
+	value: number;
+	/** Optional text label used for accessibility and analytics */
+	label?: string;
+	/** Optional custom color; falls back to palette in CSS */
+	color?: string;
+};
+
+export type SegmentedBarProps = {
+	/**
+	 * Array of segments to render. The relative size of each segment is
+	 * determined by its value relative to the sum (or `total` if provided).
+	 */
+	segments: SegmentedBarSegment[];
+	/**
+	 * When provided, percentages are computed against this number instead of
+	 * the sum of segment values. Useful if you need to normalize against a
+	 * known total that includes hidden buckets.
+	 */
+	total?: number;
+	/**
+	 * Minimum percentage shown for a non-zero segment to keep it visible.
+	 * Defaults to 2.5% to match small UI density.
+	 */
+	minPercent?: number;
+	/** Optional overall ARIA label for the segmented bar */
+	ariaLabel?: string;
+	/** Height in pixels, defaults to 16 */
+	height?: number;
+	/** Border radius in pixels, defaults to 0 (square ends) */
+	radius?: number;
+	/** Optional gap between segments in pixels. Defaults to 6 (some spacing). */
+	gap?: number;
+	/** Render labels row above the bar. Defaults to true. */
+	showLabels?: boolean;
+	/** Custom renderer for label values (e.g., currency). Defaults to raw value. */
+	formatValue?: ( value: number, segment: SegmentedBarSegment ) => React.ReactNode;
+};
+
+/**
+ * Converts raw numeric values into normalized percentages while ensuring a
+ * minimum visible size for non-zero buckets.
+ */
+function normalizePercents( values: number[], minPercent: number ): number[] {
+	const sum = values.reduce( ( acc, v ) => acc + v, 0 );
+	if ( sum <= 0 || values.length === 0 ) {
+		// Nothing to show; render empty bar
+		return values.map( () => 0 );
+	}
+
+	// Raw percentages based on provided values
+	const raw = values.map( ( v ) => ( v <= 0 ? 0 : ( v / sum ) * 100 ) );
+
+	// Ensure visibility for tiny, non-zero buckets
+	const adjusted = raw.map( ( p, idx ) => ( values[ idx ] > 0 ? Math.max( p, minPercent ) : 0 ) );
+	const adjustedTotal = adjusted.reduce( ( a, b ) => a + b, 0 ) || 1;
+
+	// Normalize back to exactly 100%
+	return adjusted.map( ( p ) => ( p / adjustedTotal ) * 100 );
+}
+
+/**
+ * SegmentedBar renders a single horizontal bar divided into proportional
+ * segments. It is intentionally minimal and CSS-driven so it can be moved
+ * to a shared chart package in the future.
+ */
+export default function SegmentedBar( {
+	segments,
+	total,
+	minPercent = 2.5,
+	ariaLabel,
+	height = 16,
+	radius = 0,
+	gap = 6,
+	showLabels = true,
+	formatValue,
+}: SegmentedBarProps ) {
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const values = segments.map( ( s ) => s.value );
+	const effectiveSum = typeof total === 'number' ? total : values.reduce( ( a, b ) => a + b, 0 );
+
+	const percents =
+		effectiveSum > 0 ? normalizePercents( values, minPercent ) : values.map( () => 0 );
+
+	const containerStyle: CSSProperties = {
+		height,
+		borderRadius: radius,
+		gap,
+	};
+
+	return (
+		<div className="dashboard-segmented-bar-wrapper">
+			{ showLabels && (
+				<div
+					className={ `dashboard-segmented-bar__labels${
+						isSmallViewport ? ' dashboard-segmented-bar__labels--vertical' : ''
+					}` }
+					aria-hidden
+				>
+					{ segments.map( ( segment, i ) => {
+						const dotStyle: CSSProperties | undefined = segment.color
+							? { backgroundColor: segment.color }
+							: undefined;
+						const value = formatValue ? formatValue( segment.value, segment ) : segment.value;
+						return (
+							<div
+								key={ segment.id }
+								className={ `dashboard-segmented-bar__label-item dashboard-segmented-bar__label-item--index-${
+									i + 1
+								}` }
+							>
+								<span className="dashboard-segmented-bar__label-dot" style={ dotStyle } />
+								<span className="dashboard-segmented-bar__label-text">
+									{ segment.label ? `${ segment.label }: ` : '' }
+									{ value }
+								</span>
+							</div>
+						);
+					} ) }
+				</div>
+			) }
+			<div
+				className="dashboard-segmented-bar"
+				role="group"
+				aria-label={ ariaLabel }
+				style={ containerStyle }
+			>
+				{ segments.map( ( segment, index ) => {
+					const weight = percents[ index ] || 0;
+					const style: CSSProperties = {
+						flexGrow: weight,
+						flexBasis: 0,
+						backgroundColor: segment.color,
+					};
+					const aria = segment.label
+						? `${ segment.label }: ${ Math.round( weight ) }%`
+						: `${ Math.round( weight ) }%`;
+					return (
+						<div
+							key={ segment.id }
+							className="dashboard-segmented-bar__segment"
+							style={ style }
+							aria-label={ aria }
+						/>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}

--- a/client/dashboard/components/segmented-bar/index.tsx
+++ b/client/dashboard/components/segmented-bar/index.tsx
@@ -23,12 +23,6 @@ export type SegmentedBarProps = {
 	 */
 	segments: SegmentedBarSegment[];
 	/**
-	 * When provided, percentages are computed against this number instead of
-	 * the sum of segment values. Useful if you need to normalize against a
-	 * known total that includes hidden buckets.
-	 */
-	total?: number;
-	/**
 	 * Minimum percentage shown for a non-zero segment to keep it visible.
 	 * Defaults to 2.5% to match small UI density.
 	 */
@@ -76,7 +70,6 @@ function normalizePercents( values: number[], minPercent: number ): number[] {
  */
 export default function SegmentedBar( {
 	segments,
-	total,
 	minPercent = 2.5,
 	ariaLabel,
 	height = 16,
@@ -87,10 +80,9 @@ export default function SegmentedBar( {
 }: SegmentedBarProps ) {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const values = segments.map( ( s ) => s.value );
-	const effectiveSum = typeof total === 'number' ? total : values.reduce( ( a, b ) => a + b, 0 );
+	const sum = values.reduce( ( a, b ) => a + b, 0 );
 
-	const percents =
-		effectiveSum > 0 ? normalizePercents( values, minPercent ) : values.map( () => 0 );
+	const percents = sum > 0 ? normalizePercents( values, minPercent ) : values.map( () => 0 );
 
 	const containerStyle: CSSProperties = {
 		height,

--- a/client/dashboard/components/segmented-bar/style.scss
+++ b/client/dashboard/components/segmented-bar/style.scss
@@ -1,0 +1,88 @@
+.dashboard-segmented-bar-wrapper {
+	// Define shared palette so both the labels and the bar can use the same colors
+	--segmented-bar-bg: var(--color-surface-backdrop, #f0f0f0);
+	--segmented-bar-color-1: var(--studio-blue-50);
+	--segmented-bar-color-2: var(--studio-green-50);
+	--segmented-bar-color-3: var(--studio-orange-40);
+	--segmented-bar-color-4: var(--studio-purple-50);
+	--segmented-bar-color-5: var(--studio-teal-50);
+
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.dashboard-segmented-bar__labels {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 32px;
+}
+
+.dashboard-segmented-bar__labels--vertical {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.dashboard-segmented-bar__label-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.dashboard-segmented-bar__label-dot {
+	display: inline-block;
+	inline-size: 8px;
+	block-size: 8px;
+	width: 8px; // fallback for environments without logical props
+	height: 8px; // fallback
+	border-radius: 8px;
+	background: var(--segmented-bar-color-1);
+}
+
+// Fallback colors for label dots when segment.color is not provided
+.dashboard-segmented-bar__label-item--index-1 .dashboard-segmented-bar__label-dot {
+	background: var(--segmented-bar-color-1);
+}
+.dashboard-segmented-bar__label-item--index-2 .dashboard-segmented-bar__label-dot {
+	background: var(--segmented-bar-color-2);
+}
+.dashboard-segmented-bar__label-item--index-3 .dashboard-segmented-bar__label-dot {
+	background: var(--segmented-bar-color-3);
+}
+.dashboard-segmented-bar__label-item--index-4 .dashboard-segmented-bar__label-dot {
+	background: var(--segmented-bar-color-4);
+}
+.dashboard-segmented-bar__label-item--index-5 .dashboard-segmented-bar__label-dot {
+	background: var(--segmented-bar-color-5);
+}
+
+.dashboard-segmented-bar {
+	display: flex;
+	width: 100%;
+	background: var(--segmented-bar-bg);
+	overflow: hidden;
+}
+
+
+.dashboard-segmented-bar__segment {
+	height: 100%;
+	background: var(--segmented-bar-color-1);
+	border-radius: 0; // segments have square ends per design
+
+	&:nth-child(2) {
+		background: var(--segmented-bar-color-2);
+	}
+
+	&:nth-child(3) {
+		background: var(--segmented-bar-color-3);
+	}
+
+	&:nth-child(4) {
+		background: var(--segmented-bar-color-4);
+	}
+
+	&:nth-child(5) {
+		background: var(--segmented-bar-color-5);
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTMART-37/purchases-implement-a-plan-usage-component

## Proposed Changes

- The PR adds a `SegmentedBar` that we will use for rendering the Plan Usage card for the flex sites/plans.
- This is a reusable/generic component with a Storybook entry for testing/viewing. Not wired anywhere else in the code right now
- I could not find an available segmented bar component in `components` or `charts` packages, so this could eventually migrate out of the dashboard down the line

<img width="700" alt="Screenshot 2025-10-22 at 4 01 17 PM" src="https://github.com/user-attachments/assets/a0424d79-3224-45eb-bda2-1444ae05436b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTMART-37/purchases-implement-a-plan-usage-component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn storybook:start`
* Go to `dashboard / SegmentedBar` to view and test

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
