### PR TITLE
E2E tests: Do not assume that all form patterns have a name field

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -55,13 +55,8 @@ export class FormPatternsFlow implements BlockFlow {
 			.getAttribute( 'id' );
 		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
 
-		// Name and Email are common fields shared amongst all Form patterns.
-		// So let's make them unique here!
-		await labelFormFieldBlock( newParentBlockLocator, {
-			blockName: 'Name field',
-			accessibleLabelName: 'Add label…',
-			labelText: this.addLabelPrefix( 'Name field' ),
-		} );
+		// Email is a common field shared amongst all Form patterns.
+		// So let's make it unique here!
 		await labelFormFieldBlock( newParentBlockLocator, {
 			blockName: 'Email field',
 			accessibleLabelName: 'Add label…',
@@ -111,7 +106,6 @@ export class FormPatternsFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		await validatePublishedFormFields( context.page, [
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email field' ) },
 			...this.validationData.otherExpectedFields,
 		] );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

The Form block patterns received a new first pattern that did not have a Name field. The test assumed there would always be a Name field and tried to modify it, resulting in a failure.

This PR removes that assumption.

Reference: p1761136799406499-slack-C01U2KGS2PQ

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Build the tests (`yarn workspace wp-e2e-tests build`) then run the following:
```
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__jetpack-forms.ts"
```
```
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__jetpack-forms.ts"
```
```
ATOMIC_VARIATION="php-old" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__jetpack-forms.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?