### PR TITLE
SSH Migration: Add the mutations to verify the host and start the migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
@@ -27,27 +27,19 @@ const startSSHMigration = async (
 	params: StartSSHMigrationParams
 ): Promise< StartSSHMigrationResponse > => {
 	try {
-		const body: Record< string, string > = {
+		const optionalFields = {
+			...( params.remotePass && { remote_pass: params.remotePass } ),
+			...( params.remoteDocroot && { remote_docroot: params.remoteDocroot } ),
+			...( params.sshId && { ssh_id: params.sshId } ),
+			...( params.sshIdPass && { ssh_id_pass: params.sshIdPass } ),
+		};
+
+		const body = {
 			remote_host: params.remoteHost,
 			remote_user: params.remoteUser,
 			remote_domain: params.remoteDomain,
+			...optionalFields,
 		};
-
-		if ( params.remotePass ) {
-			body.remote_pass = params.remotePass;
-		}
-
-		if ( params.remoteDocroot ) {
-			body.remote_docroot = params.remoteDocroot;
-		}
-
-		if ( params.sshId ) {
-			body.ssh_id = params.sshId;
-		}
-
-		if ( params.sshIdPass ) {
-			body.ssh_id_pass = params.sshIdPass;
-		}
 
 		const response = await wpcom.req.post( {
 			path: `/sites/${ params.siteId }/ssh-migration/start`,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
@@ -1,0 +1,76 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface StartSSHMigrationParams {
+	siteId: number;
+	remoteHost: string;
+	remoteUser: string;
+	remoteDomain: string;
+	remotePass?: string;
+	remoteDocroot?: string;
+	sshId?: string;
+	sshIdPass?: string;
+}
+
+interface StartSSHMigrationResponse {
+	success: boolean;
+	message?: string;
+	error?: string;
+}
+
+/**
+ * Starts SSH migration for the specified site
+ * @param params - Migration parameters including host, credentials, etc.
+ * @returns Promise with migration start response
+ */
+const startSSHMigration = async (
+	params: StartSSHMigrationParams
+): Promise< StartSSHMigrationResponse > => {
+	try {
+		const body: Record< string, string > = {
+			remote_host: params.remoteHost,
+			remote_user: params.remoteUser,
+			remote_domain: params.remoteDomain,
+		};
+
+		if ( params.remotePass ) {
+			body.remote_pass = params.remotePass;
+		}
+
+		if ( params.remoteDocroot ) {
+			body.remote_docroot = params.remoteDocroot;
+		}
+
+		if ( params.sshId ) {
+			body.ssh_id = params.sshId;
+		}
+
+		if ( params.sshIdPass ) {
+			body.ssh_id_pass = params.sshIdPass;
+		}
+
+		const response = await wpcom.req.post( {
+			path: `/sites/${ params.siteId }/ssh-migration/start`,
+			apiNamespace: 'wpcom/v2',
+			body,
+		} );
+
+		if ( ! response.success ) {
+			throw new Error( response.message || 'Failed to start SSH migration' );
+		}
+
+		return response;
+	} catch ( error ) {
+		throw new Error( error instanceof Error ? error.message : 'Failed to start SSH migration' );
+	}
+};
+
+/**
+ * Hook to start SSH migration
+ * @returns Mutation object with start function and status
+ */
+export const useStartSSHMigration = () => {
+	return useMutation< StartSSHMigrationResponse, Error, StartSSHMigrationParams >( {
+		mutationFn: startSSHMigration,
+	} );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-connection.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-connection.ts
@@ -1,0 +1,52 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface VerifySSHConnectionParams {
+	serverAddress: string;
+	port: number;
+	siteId: number;
+}
+
+interface VerifySSHConnectionResponse {
+	success: boolean;
+	message?: string;
+	error?: string;
+}
+
+/**
+ * Verifies SSH connection to the specified server
+ * @param params - Server address, port, and site ID
+ * @returns Promise with verification response
+ */
+const verifySSHConnection = async (
+	params: VerifySSHConnectionParams
+): Promise< VerifySSHConnectionResponse > => {
+	try {
+		const response = await wpcom.req.post( {
+			path: `/sites/${ params.siteId }/ssh-migration/verify-host`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				host: params.serverAddress,
+				port: String( params.port ),
+			},
+		} );
+
+		if ( ! response.success ) {
+			throw new Error( response.message || 'Failed to verify SSH connection' );
+		}
+
+		return response;
+	} catch ( error ) {
+		throw new Error( error instanceof Error ? error.message : 'Failed to verify SSH connection' );
+	}
+};
+
+/**
+ * Hook to verify SSH connection
+ * @returns Mutation object with verify function and status
+ */
+export const useVerifySSHConnection = () => {
+	return useMutation< VerifySSHConnectionResponse, Error, VerifySSHConnectionParams >( {
+		mutationFn: verifySSHConnection,
+	} );
+};


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Add the Start Migration mutation, so we can start the migration once the user fill all the information.
* Add the Verify Host mutation, so we can verify the host. Related to: DOTCOM-15002

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need these mutations to verify the host provided by the user and to start the migration once we verify all the information. I'm splitting this from https://github.com/Automattic/wp-calypso/pull/106585.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
