### PR TITLE
Help Center: Update messaging source to current URL

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -22,7 +22,6 @@ export function HelpCenterChat( {
 } ): JSX.Element {
 	const navigate = useNavigate();
 	const shouldUseWapuu = useShouldUseWapuu();
-	const { sectionName } = useHelpCenterContext();
 	// Before issuing a redirect, make sure the status is loaded.
 	const preventOdieAccess = ! shouldUseWapuu && ! isUserEligibleForPaidSupport && ! isLoadingStatus;
 	const { currentUser, site } = useHelpCenterContext();
@@ -56,7 +55,6 @@ export function HelpCenterChat( {
 			userFieldFlowName={ userFieldFlowName ?? params.get( 'userFieldFlowName' ) }
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			forceEmailSupport={ Boolean( forceEmailSupport ) }
-			sectionName={ sectionName }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -50,7 +50,6 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	setMessageLikedStatus: noop,
 	trackEvent: noop,
 	forceEmailSupport: false,
-	sectionName: '',
 } );
 
 // Custom hook to access the OdieAssistantContext
@@ -75,7 +74,6 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	currentUser,
 	forceEmailSupport = false,
 	children,
-	sectionName,
 } ) => {
 	const { botNameSlug, isMinimized, isChatLoaded } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
@@ -182,7 +180,6 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 		<OdieAssistantContext.Provider
 			value={ {
 				addMessage,
-				sectionName,
 				botName,
 				botNameSlug,
 				chat: mainChatState,

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -24,7 +24,6 @@ export const useCreateZendeskConversation = (): ( ( {
 		setChat,
 		chat,
 		trackEvent,
-		sectionName,
 	} = useOdieAssistantContext();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
@@ -83,7 +82,7 @@ export const useCreateZendeskConversation = (): ( ( {
 				messaging_ai_chat_id: chatId || undefined,
 				messaging_url: selectedSiteURL || window.location.href,
 				messaging_flow: userFieldFlowName || null,
-				messaging_source: sectionName,
+				messaging_source: window.location.href,
 			} );
 
 			await submitUserFields( {
@@ -92,7 +91,7 @@ export const useCreateZendeskConversation = (): ( ( {
 				messaging_ai_chat_id: chatId || undefined,
 				messaging_url: selectedSiteURL || window.location.href,
 				messaging_flow: userFieldFlowName || null,
-				messaging_source: sectionName,
+				messaging_source: window.location.href,
 			} );
 
 			trackEvent( 'submitted_zendesk_user_fields' );

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -27,7 +27,6 @@ export type OdieAssistantContextInterface = {
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	version?: string | null;
-	sectionName: string;
 };
 
 export type OdieAssistantProviderProps = {
@@ -46,7 +45,6 @@ export type OdieAssistantProviderProps = {
 	forceEmailSupport?: boolean;
 	children?: ReactNode;
 	setChatStatus?: ( status: ChatStatus ) => void;
-	sectionName: string;
 } & PropsWithChildren;
 
 export type CurrentUser = {


### PR DESCRIPTION
Fixes DOTSUP-321

## Testing instructions

1. Open DevTools > Network. Filter by `update-user-fields`
2. Start a chat, ask for a human.
3. The sent `message_source` should be the current URL.