### PR TITLE
Billing History: Remove hiding internal A4A domains in favor of server-side code

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -380,8 +380,6 @@ function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Recei
 		stripZeros: true,
 	} );
 
-	const shouldShowDomain = item.domain && ! item.domain.includes( 'a8cagency.blog' );
-
 	return (
 		<VStack className="receipt-line-item">
 			<HStack justify="space-between" alignment="flex-start">
@@ -392,7 +390,7 @@ function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Recei
 						</Text>
 						<VStack spacing={ 0 }>
 							{ termLabel && <Text>{ termLabel }</Text> }
-							{ shouldShowDomain && <Text variant="muted">{ item.domain }</Text> }
+							{ item.domain && <Text variant="muted">{ item.domain }</Text> }
 							{ item.licensed_quantity && (
 								<Text>{ renderTransactionQuantitySummary( item ) }</Text>
 							) }

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,7 +1,6 @@
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
-import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
@@ -23,11 +22,10 @@ function renderServiceNameDescription(
 	const plan = capitalPDangit( transaction.variation );
 	const termLabel = getTransactionTermLabel( transaction, translate );
 
-	const shouldShowDomain = transaction.domain && ! isInternalA4AAgencyDomain( transaction.domain );
 	return (
 		<div>
 			<strong>{ plan }</strong>
-			{ shouldShowDomain && <small>{ transaction.domain }</small> }
+			{ transaction.domain && <small>{ transaction.domain }</small> }
 			{ termLabel && <small>{ termLabel }</small> }
 			{ transaction.licensed_quantity && (
 				<small>{ renderTransactionQuantitySummary( transaction, translate ) }</small>

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -24,7 +24,6 @@ import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
-import { isInternalA4AAgencyDomain } from 'calypso/me/purchases/utils';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { useDispatch } from 'calypso/state';
@@ -566,8 +565,6 @@ function ReceiptLineItem( {
 		stripZeros: true,
 	} );
 
-	const shouldShowDomain = item.domain && ! isInternalA4AAgencyDomain( item.domain );
-
 	return (
 		<>
 			<tr>
@@ -575,7 +572,7 @@ function ReceiptLineItem( {
 					<span>{ item.variation }</span>
 					<small>({ item.type_localized })</small>
 					{ termLabel && <em>{ termLabel }</em> }
-					{ shouldShowDomain && <em>{ item.domain }</em> }
+					{ item.domain && <em>{ item.domain }</em> }
 					{ item.licensed_quantity && (
 						<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
 					) }

--- a/client/me/purchases/utils.ts
+++ b/client/me/purchases/utils.ts
@@ -78,12 +78,3 @@ export function getCancelPurchaseSurveyCompletedPreferenceKey(
 ): string {
 	return `cancel-purchase-survey-completed-${ purchaseId }`;
 }
-
-/**
- * Checks if a domain is for an internal A4A agency site.
- * @param domain The domain to check
- * @returns True if the domain is an internal A4A agency domain
- */
-export function isInternalA4AAgencyDomain( domain: string ): boolean {
-	return domain?.endsWith( '.agencies.automattic.com' );
-}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/CHE-268/billing-history-move-hiding-internal-a4a-domains-to-the-server

## Proposed Changes

There is currently client-side Calypso code that prevents showing A4A domains in the billing history list.  To avoid migrating that code to the Hosting Dashboard, we can just hide the internal domains in the API endpoint instead, and remove it here.

This will also fix a bug on the Hosting Dashboard receipt page, which was recently migrated over.

## Testing Instructions

This can be tested along with 194442-ghe-Automattic/wpcom.