### PR TITLE
Dashboard v2: make ResponsiveMenu horizontally scrollable

### DIFF
--- a/client/dashboard/components/menu/style.scss
+++ b/client/dashboard/components/menu/style.scss
@@ -1,6 +1,7 @@
 @import '@wordpress/base-styles/colors';
 
 .dashboard-menu__item.dashboard-menu__item {
+	flex-shrink: 0;
 	color: var( --dashboard-menu-item__color );
 
 	&.active {

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -1,19 +1,64 @@
-import { __experimentalHStack as HStack, Button, DropdownMenu } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
-import { menu } from '@wordpress/icons';
-import React, { type ComponentProps } from 'react';
+import { __experimentalHStack as HStack, Button, DropdownMenu, Icon } from '@wordpress/components';
+import { throttle, useViewportMatch } from '@wordpress/compose';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight, menu } from '@wordpress/icons';
+import React, { useEffect, useRef, useState, ComponentProps, CSSProperties } from 'react';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
 
 type ResponsiveMenuProps = {
+	prefix?: React.ReactNode;
 	children: React.ReactNode;
 	icon?: React.ReactElement;
 	label?: string;
 	dropdownPlacement?: 'bottom-end' | 'bottom-start' | 'bottom';
 };
 
+function ScrollButton( {
+	style,
+	onClick,
+	children,
+}: {
+	style: CSSProperties;
+	onClick: () => void;
+	children: React.ReactNode;
+} ) {
+	return (
+		<div
+			style={ {
+				position: 'absolute',
+				zIndex: 1,
+				pointerEvents: 'none',
+				height: '100%',
+				display: 'flex',
+				alignItems: 'center',
+				transition: 'opacity 0.2s ease-in-out',
+				...style,
+			} }
+			aria-hidden
+		>
+			<Button
+				style={ {
+					padding: '6px',
+					pointerEvents: 'auto',
+					width: '32px',
+					height: '32px',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					background: 'var(--dashboard__background-color)',
+				} }
+				tabIndex={ -1 }
+				onClick={ onClick }
+			>
+				{ children }
+			</Button>
+		</div>
+	);
+}
+
 function ResponsiveMenu( {
+	prefix,
 	children,
 	icon = menu,
 	label = 'Menu',
@@ -21,8 +66,78 @@ function ResponsiveMenu( {
 }: ResponsiveMenuProps ) {
 	const isDesktop = useViewportMatch( 'medium' );
 
+	const containerRef = useRef< HTMLDivElement | null >( null );
+
+	const [ showLeftButton, setShowLeftButton ] = useState( false );
+	const [ showRightButton, setShowRightButton ] = useState( false );
+
+	const updateScrollButtonVisibility = () => {
+		const container = containerRef.current;
+		if ( ! container ) {
+			return;
+		}
+
+		const { scrollWidth, clientWidth, scrollLeft } = container;
+		const scrollThreshold = 10;
+		const canScroll = scrollWidth > clientWidth;
+
+		if ( isRTL() ) {
+			const isAtStart = Math.abs( scrollLeft ) < scrollThreshold;
+			const isAtEnd = Math.abs( scrollLeft ) >= scrollWidth - clientWidth - scrollThreshold;
+
+			setShowLeftButton( canScroll && ! isAtEnd );
+			setShowRightButton( canScroll && ! isAtStart );
+		} else {
+			const isAtStart = scrollLeft < scrollThreshold;
+			const isAtEnd = scrollLeft >= scrollWidth - clientWidth - scrollThreshold;
+
+			setShowLeftButton( canScroll && ! isAtStart );
+			setShowRightButton( canScroll && ! isAtEnd );
+		}
+	};
+
+	// Scroll the active tab into view on initial render.
+	useEffect( () => {
+		const activeItemElement = containerRef.current?.querySelector( '.active' );
+		activeItemElement?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'center',
+		} );
+	}, [] );
+
+	// Show/hide scroll buttons when the menu width resizes.
+	useEffect( () => {
+		if ( ! containerRef.current ) {
+			return;
+		}
+
+		const observer = new ResizeObserver( updateScrollButtonVisibility );
+		observer.observe( containerRef.current );
+
+		updateScrollButtonVisibility();
+
+		return () => observer.disconnect();
+	}, [ isDesktop ] );
+
+	const handleScroll = throttle( updateScrollButtonVisibility, 50 );
+
+	// Scroll the menu slightly horizontally when the scroll buttons are clicked.
+	const bumpScrollX = ( shouldScrollLeft = false ) => {
+		if ( containerRef.current ) {
+			const directionMultiplier = shouldScrollLeft ? -1 : 1;
+
+			// 2/3 reflects the fraction of visible width that will scroll.
+			const scrollAmount = containerRef.current.clientWidth * ( 2 / 3 );
+
+			const finalPositionX = containerRef.current.scrollLeft + directionMultiplier * scrollAmount;
+
+			containerRef.current.scrollTo( { top: 0, left: finalPositionX, behavior: 'smooth' } );
+		}
+	};
+
 	if ( isDesktop ) {
-		return (
+		const inlineMenu = (
 			<Menu>
 				{ React.Children.map( children, ( child ) => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
@@ -44,6 +159,62 @@ function ResponsiveMenu( {
 				} ) }
 			</Menu>
 		);
+
+		return (
+			<HStack spacing={ 3 }>
+				{ prefix }
+				<div
+					style={ {
+						position: 'relative',
+						width: '100%',
+						display: 'flex',
+						overflow: 'visible',
+					} }
+				>
+					<ScrollButton
+						style={ {
+							left: '-2px',
+							paddingRight: '30px',
+							background:
+								'linear-gradient(90deg, var(--dashboard__background-color) 30%, transparent 100%)',
+							opacity: showLeftButton ? 1 : 0,
+							pointerEvents: showLeftButton ? 'auto' : 'none',
+						} }
+						onClick={ () => bumpScrollX( true ) }
+					>
+						<Icon icon={ chevronLeft } />
+					</ScrollButton>
+
+					<div
+						ref={ containerRef }
+						style={ {
+							overflowX: 'scroll',
+							scrollbarWidth: 'none',
+							msOverflowStyle: 'none',
+							padding: '2px',
+							margin: '-2px',
+						} }
+						onScroll={ handleScroll }
+					>
+						{ inlineMenu }
+					</div>
+
+					<ScrollButton
+						style={ {
+							right: '-2px',
+							paddingLeft: '30px',
+							background:
+								'linear-gradient(270deg, var(--dashboard__background-color) 30%, transparent 100%)',
+							opacity: showRightButton ? 1 : 0,
+							pointerEvents: showRightButton ? 'auto' : 'none',
+						} }
+						onClick={ () => bumpScrollX() }
+					>
+						<Icon icon={ chevronRight } />
+					</ScrollButton>
+				</div>
+			</HStack>
+		);
 	}
 
 	return (
@@ -53,6 +224,7 @@ function ResponsiveMenu( {
 			popoverProps={ {
 				placement: dropdownPlacement,
 			} }
+			style={ { justifyContent: 'flex-end' } }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -6,6 +6,8 @@ import React, { useEffect, useRef, useState, ComponentProps, CSSProperties } fro
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
 
+import './style.scss';
+
 type ResponsiveMenuProps = {
 	prefix?: React.ReactNode;
 	children: React.ReactNode;
@@ -184,13 +186,7 @@ function ResponsiveMenu( {
 
 					<div
 						ref={ containerRef }
-						style={ {
-							overflowX: 'scroll',
-							scrollbarWidth: 'none',
-							msOverflowStyle: 'none',
-							padding: '2px',
-							margin: '-2px',
-						} }
+						className="dashboard-responsive-menu__scrollable-container"
 						onScroll={ handleScroll }
 					>
 						{ inlineMenu }

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -1,4 +1,9 @@
-import { __experimentalHStack as HStack, Button, DropdownMenu, Icon } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	DropdownMenu,
+	IconType,
+} from '@wordpress/components';
 import { throttle, useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, menu } from '@wordpress/icons';
@@ -17,13 +22,13 @@ type ResponsiveMenuProps = {
 };
 
 function ScrollButton( {
+	icon,
 	style,
 	onClick,
-	children,
 }: {
+	icon: IconType;
 	style: CSSProperties;
 	onClick: () => void;
-	children: React.ReactNode;
 } ) {
 	return (
 		<div
@@ -38,6 +43,7 @@ function ScrollButton( {
 			aria-hidden
 		>
 			<Button
+				icon={ icon }
 				style={ {
 					padding: '6px',
 					pointerEvents: 'auto',
@@ -50,9 +56,7 @@ function ScrollButton( {
 				} }
 				tabIndex={ -1 }
 				onClick={ onClick }
-			>
-				{ children }
-			</Button>
+			/>
 		</div>
 	);
 }
@@ -172,6 +176,7 @@ function ResponsiveMenu( {
 					} }
 				>
 					<ScrollButton
+						icon={ chevronLeft }
 						style={ {
 							left: '-2px',
 							paddingRight: '30px',
@@ -180,9 +185,7 @@ function ResponsiveMenu( {
 							display: showLeftButton ? 'flex' : 'none',
 						} }
 						onClick={ () => bumpScrollX( true ) }
-					>
-						<Icon icon={ chevronLeft } />
-					</ScrollButton>
+					/>
 
 					<div
 						ref={ containerRef }
@@ -193,6 +196,7 @@ function ResponsiveMenu( {
 					</div>
 
 					<ScrollButton
+						icon={ chevronRight }
 						style={ {
 							right: '-2px',
 							paddingLeft: '30px',
@@ -201,9 +205,7 @@ function ResponsiveMenu( {
 							display: showRightButton ? 'flex' : 'none',
 						} }
 						onClick={ () => bumpScrollX() }
-					>
-						<Icon icon={ chevronRight } />
-					</ScrollButton>
+					/>
 				</div>
 			</HStack>
 		);

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -30,7 +30,6 @@ function ScrollButton( {
 				zIndex: 1,
 				pointerEvents: 'none',
 				height: '100%',
-				display: 'flex',
 				alignItems: 'center',
 				transition: 'opacity 0.2s ease-in-out',
 				...style,
@@ -177,7 +176,7 @@ function ResponsiveMenu( {
 							paddingRight: '30px',
 							background:
 								'linear-gradient(90deg, var(--dashboard__background-color) 30%, transparent 100%)',
-							opacity: showLeftButton ? 1 : 0,
+							display: showLeftButton ? 'flex' : 'none',
 							pointerEvents: showLeftButton ? 'auto' : 'none',
 						} }
 						onClick={ () => bumpScrollX( true ) }
@@ -205,7 +204,7 @@ function ResponsiveMenu( {
 							paddingLeft: '30px',
 							background:
 								'linear-gradient(270deg, var(--dashboard__background-color) 30%, transparent 100%)',
-							opacity: showRightButton ? 1 : 0,
+							display: showRightButton ? 'flex' : 'none',
 							pointerEvents: showRightButton ? 'auto' : 'none',
 						} }
 						onClick={ () => bumpScrollX() }

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -41,7 +41,6 @@ function ScrollButton( {
 				pointerEvents: 'none',
 				...style,
 			} }
-			aria-hidden
 		>
 			<Button
 				icon={ icon }
@@ -55,7 +54,6 @@ function ScrollButton( {
 					justifyContent: 'center',
 					background: 'var(--dashboard__background-color)',
 				} }
-				tabIndex={ -1 }
 				onClick={ onClick }
 			/>
 		</div>

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -38,6 +38,7 @@ function ScrollButton( {
 				height: '100%',
 				alignItems: 'center',
 				transition: 'opacity 0.2s ease-in-out',
+				pointerEvents: 'none',
 				...style,
 			} }
 			aria-hidden

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -28,7 +28,6 @@ function ScrollButton( {
 			style={ {
 				position: 'absolute',
 				zIndex: 1,
-				pointerEvents: 'none',
 				height: '100%',
 				alignItems: 'center',
 				transition: 'opacity 0.2s ease-in-out',
@@ -177,7 +176,6 @@ function ResponsiveMenu( {
 							background:
 								'linear-gradient(90deg, var(--dashboard__background-color) 30%, transparent 100%)',
 							display: showLeftButton ? 'flex' : 'none',
-							pointerEvents: showLeftButton ? 'auto' : 'none',
 						} }
 						onClick={ () => bumpScrollX( true ) }
 					>
@@ -205,7 +203,6 @@ function ResponsiveMenu( {
 							background:
 								'linear-gradient(270deg, var(--dashboard__background-color) 30%, transparent 100%)',
 							display: showRightButton ? 'flex' : 'none',
-							pointerEvents: showRightButton ? 'auto' : 'none',
 						} }
 						onClick={ () => bumpScrollX() }
 					>

--- a/client/dashboard/components/responsive-menu/style.scss
+++ b/client/dashboard/components/responsive-menu/style.scss
@@ -1,0 +1,13 @@
+.dashboard-responsive-menu__scrollable-container {
+	overflow-x: scroll;
+	-ms-overflow-style: none;  /* Internet Explorer 10+ */
+	scrollbar-width: none;  /* Firefox */
+
+	&::-webkit-scrollbar {
+		display: none;  /* Safari and Chrome */
+	}
+
+	// Restores focus ring appearances
+	padding: 2px;
+	margin: -2px;
+}

--- a/client/dashboard/domains/domain-menu/index.tsx
+++ b/client/dashboard/domains/domain-menu/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import { emailsRoute } from '../../app/router/emails';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 
 const DomainMenu = ( { domainName }: { domainName: string } ) => {
@@ -9,7 +10,7 @@ const DomainMenu = ( { domainName }: { domainName: string } ) => {
 	const router = useRouter();
 
 	return (
-		<ResponsiveMenu label={ __( 'Domain Menu' ) }>
+		<ResponsiveMenu label={ __( 'Domain Menu' ) } prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to={ `/domains/${ domainName }` }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -2,19 +2,16 @@ import { domainQuery, domainsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { globe } from '@wordpress/icons';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
-import MenuDivider from '../../components/menu-divider';
 import Switcher from '../../components/switcher';
 import DomainMenu from '../domain-menu';
 
 import './style.scss';
 
 function Domain() {
-	const isDesktop = useViewportMatch( 'medium' );
 	const { domainName } = domainRoute.useParams();
 	const domains = useQuery( domainsQuery() ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
@@ -23,7 +20,7 @@ function Domain() {
 	return (
 		<>
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<Switcher
 							items={ domains }
@@ -39,7 +36,6 @@ function Domain() {
 							}
 						/>
 					</HeaderBar.Title>
-					{ isDesktop && <MenuDivider /> }
 					<DomainMenu domainName={ domain.domain } />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -1,22 +1,17 @@
 import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import HeaderBar from '../components/header-bar';
-import MenuDivider from '../components/menu-divider';
 import MeMenu from './me-menu';
 
 function Me() {
-	const isDesktop = useViewportMatch( 'medium' );
-
 	return (
 		<>
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 4 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<span>{ __( 'Account' ) }</span>
 					</HeaderBar.Title>
-					{ isDesktop && <MenuDivider /> }
 					<MeMenu />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import type { AppConfig, MeSupports } from '../../app/context';
 
@@ -11,7 +12,7 @@ const MeMenu = () => {
 	const { supports } = useAppContext();
 
 	return (
-		<ResponsiveMenu>
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to="/me/profile">{ __( 'Profile' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/preferences">{ __( 'Preferences' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/me/billing">{ __( 'Billing' ) }</ResponsiveMenu.Item>

--- a/client/dashboard/plugins/index.tsx
+++ b/client/dashboard/plugins/index.tsx
@@ -2,18 +2,16 @@ import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import HeaderBar from '../components/header-bar';
-import MenuDivider from '../components/menu-divider';
 import PluginsMenu from './plugins-menu';
 
 export default function Plugins() {
 	return (
 		<>
 			<HeaderBar>
-				<HStack spacing={ 4 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<span>{ __( 'Plugins' ) }</span>
 					</HeaderBar.Title>
-					<MenuDivider />
 					<PluginsMenu />
 				</HStack>
 			</HeaderBar>

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,9 +1,10 @@
 import { __ } from '@wordpress/i18n';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 
 const PluginsMenu = () => {
 	return (
-		<ResponsiveMenu>
+		<ResponsiveMenu prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
 				{ __( 'Scheduled updates' ) }

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,6 +1,7 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
+import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
@@ -17,7 +18,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
 				</ResponsiveMenu.Item>
@@ -27,7 +28,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( hasSiteTrialEnded( site ) ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/trial-ended` }>
 					{ __( 'Trial ended' ) }
 				</ResponsiveMenu.Item>
@@ -37,7 +38,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 
 	if ( site.options?.is_difm_lite_in_progress && ! isSupportSession() ) {
 		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) }>
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/site-building-in-progress` }>
 					{ __( 'Site building' ) }
 				</ResponsiveMenu.Item>
@@ -56,7 +57,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 	}
 
 	return (
-		<ResponsiveMenu label={ __( 'Site Menu' ) }>
+		<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -2,7 +2,6 @@ import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet, notFound } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { Suspense, useMemo, lazy } from 'react';
 import { useAppContext } from '../../app/context';
 import { siteRoute } from '../../app/router/sites';
@@ -16,7 +15,6 @@ import SiteMenu from '../site-menu';
 import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
-	const isDesktop = useViewportMatch( 'medium' );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { components } = useAppContext();
@@ -30,7 +28,7 @@ function Site() {
 		<Suspense fallback={ null }>
 			{ hasStagingSite( site ) && <StagingSiteSyncMonitor site={ site } /> }
 			<HeaderBar>
-				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 3 }>
+				<HStack spacing={ 3 }>
 					<HeaderBar.Title>
 						<SiteSwitcher />
 						{ canSwitchEnvironment( site ) && (
@@ -40,12 +38,7 @@ function Site() {
 							</>
 						) }
 					</HeaderBar.Title>
-					{ ! isSiteMigrationInProgress( site ) && (
-						<>
-							{ isDesktop && <MenuDivider /> }
-							<SiteMenu site={ site } />
-						</>
-					) }
+					{ ! isSiteMigrationInProgress( site ) && <SiteMenu site={ site } /> }
 				</HStack>
 			</HeaderBar>
 			<Outlet />


### PR DESCRIPTION
Fixes DOTCOM-14632

Based on https://github.com/Automattic/wp-calypso/pull/106542#issuecomment-3426364229

## Proposed Changes

This PR avoids overlapping primary and secondary nav menu items, by making the menu horizontally scrollable when the items start to overlap.

On < 782px (`useViewportMatch('medium ')`), we completely hide the items inside a hamburger menu.

For example in site-level nav:

Before


https://github.com/user-attachments/assets/b814d7f4-3fe0-44b1-9858-ffc07efb0931



After



https://github.com/user-attachments/assets/00d77361-90c5-4159-8677-de4c46225a99





## Testing Instructions

Test resizing the browser width in v2's Sites, Domains, Plugins screens and verify the primary and secondary navs are scrollable and then collapsed when the width is not sufficient as shown above.

Test also with RTL language such as Arabic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?