### PR TITLE
MSD: Fix the site icon of dataviews is not clickable

### DIFF
--- a/client/dashboard/me/notifications-sites/site-preview/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-preview/index.tsx
@@ -1,7 +1,7 @@
 import { Site } from '@automattic/api-core';
 import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wordpress/components';
 import SiteIcon from '../../../components/site-icon';
-import { Name, URL } from '../../../sites/site-fields';
+import { NameLink, URL } from '../../../sites/site-fields';
 import { getSiteDisplayName } from '../../../utils/site-name';
 
 import './index.scss';
@@ -16,7 +16,7 @@ export const SitePreview = ( { site }: Props ) => {
 			<SiteIcon site={ site } size={ 44 } />
 			<Grid columns={ 1 } templateRows="24px 1fr" gap={ 0 } style={ { width: '100%' } }>
 				<div className="site-preview__name">
-					<Name site={ site } value={ getSiteDisplayName( site ) } />
+					<NameLink site={ site } value={ getSiteDisplayName( site ) } />
 				</div>
 				<div className="site-preview__url">
 					<URL site={ site } value={ site.URL } />

--- a/client/dashboard/me/notifications-sites/site-preview/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-preview/index.tsx
@@ -1,7 +1,7 @@
 import { Site } from '@automattic/api-core';
 import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wordpress/components';
 import SiteIcon from '../../../components/site-icon';
-import { NameLink, URL } from '../../../sites/site-fields';
+import { SiteLink, Name, URL } from '../../../sites/site-fields';
 import { getSiteDisplayName } from '../../../utils/site-name';
 
 import './index.scss';
@@ -16,7 +16,9 @@ export const SitePreview = ( { site }: Props ) => {
 			<SiteIcon site={ site } size={ 44 } />
 			<Grid columns={ 1 } templateRows="24px 1fr" gap={ 0 } style={ { width: '100%' } }>
 				<div className="site-preview__name">
-					<NameLink site={ site } value={ getSiteDisplayName( site ) } />
+					<SiteLink site={ site }>
+						<Name site={ site } value={ getSiteDisplayName( site ) } />
+					</SiteLink>
 				</div>
 				<div className="site-preview__url">
 					<URL site={ site } value={ site.URL } />

--- a/client/dashboard/me/notifications-sites/site-preview/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-preview/index.tsx
@@ -1,7 +1,6 @@
 import { Site } from '@automattic/api-core';
 import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wordpress/components';
-import SiteIcon from '../../../components/site-icon';
-import { SiteLink, Name, URL } from '../../../sites/site-fields';
+import { SiteLink, SiteIconLink, Name, URL } from '../../../sites/site-fields';
 import { getSiteDisplayName } from '../../../utils/site-name';
 
 import './index.scss';
@@ -13,7 +12,7 @@ interface Props {
 export const SitePreview = ( { site }: Props ) => {
 	return (
 		<HStack className="site-preview" spacing={ 3 }>
-			<SiteIcon site={ site } size={ 44 } />
+			<SiteIconLink site={ site } size={ 44 } />
 			<Grid columns={ 1 } templateRows="24px 1fr" gap={ 0 } style={ { width: '100%' } }>
 				<div className="site-preview__name">
 					<SiteLink site={ site }>

--- a/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/sites-selection.tsx
@@ -2,7 +2,8 @@ import { DataViews, Field, View, filterSortAndPaginate, type Action } from '@wor
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../../../components/dataviews-card';
-import { Name, URL, SiteIconLink } from '../../../sites/site-fields';
+import SiteIcon from '../../../components/site-icon';
+import { Name, URL, SiteLink } from '../../../sites/site-fields';
 import { getSiteDisplayName } from '../../../utils/site-name';
 import { getSiteDisplayUrl } from '../../../utils/site-url';
 import { useEligibleSites } from '../hooks/use-eligible-sites';
@@ -26,7 +27,7 @@ const siteFields: Field< Site >[] = [
 	{
 		id: 'icon.ico',
 		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIconLink site={ item } />,
+		render: ( { item } ) => <SiteIcon site={ item } />,
 		enableSorting: false,
 		enableGlobalSearch: false,
 	},
@@ -90,6 +91,7 @@ function ScheduledUpdatesSitesSelection( { selection, onChangeSelection }: Props
 					},
 				} }
 				paginationInfo={ paginationInfo }
+				renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
 			/>
 		</DataViewsCard>
 	);

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -17,7 +17,8 @@ import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
-import { SiteIconLink } from '../../sites/site-fields';
+import SiteIcon from '../../components/site-icon';
+import { SiteLink } from '../../sites/site-fields';
 import { formatDate } from '../../utils/datetime';
 import { prepareScheduleName } from './helpers';
 import { useDeleteSchedules } from './hooks/use-delete-schedules';
@@ -120,7 +121,7 @@ const getFields = ( locale: string ): Field< ScheduledUpdateRow >[] => {
 		{
 			id: 'icon.ico',
 			label: __( 'Site icon' ),
-			render: ( { item } ) => <SiteIconLink site={ item.site } />,
+			render: ( { item } ) => <SiteIcon site={ item.site } />,
 			enableSorting: false,
 			enableGlobalSearch: false,
 		},
@@ -247,6 +248,9 @@ export default function PluginsScheduledUpdates() {
 								},
 							},
 						] }
+						renderItemLink={ ( { item, ...props } ) => (
+							<SiteLink { ...props } site={ item.site } />
+						) }
 					/>
 				</DataViewsCard>
 			</PageLayout>

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import SiteIcon from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
@@ -17,7 +18,6 @@ import {
 	Status,
 	URL,
 	Uptime,
-	SiteIconLink,
 } from '../site-fields';
 import type { Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
@@ -41,7 +41,7 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'icon.ico',
 		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIconLink site={ item } />,
+		render: ( { item } ) => <SiteIcon site={ item } />,
 		enableSorting: false,
 	},
 	{

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,9 +1,8 @@
-import { Link } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
-import { getSiteManagementUrl } from '../site-fields';
+import { SiteLink } from '../site-fields';
 import { DEFAULT_LAYOUTS, DEFAULT_PER_PAGE_SIZES } from './views';
 import type { Site, SitesView } from '@automattic/api-core';
 import type { Action, Field, View } from '@wordpress/dataviews';
@@ -43,14 +42,7 @@ export const SitesDataViews = ( {
 					paginationInfo={ paginationInfo }
 					config={ { perPageSizes: DEFAULT_PER_PAGE_SIZES } }
 					empty={ empty }
-					renderItemLink={ ( { item, ...props } ) => (
-						<Link
-							{ ...props }
-							to={ getSiteManagementUrl( item ) }
-							disabled={ item.is_deleted }
-							style={ { textDecoration: 'none' } }
-						/>
-					) }
+					renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
 				/>
 			</DataViewsCard>
 			<GuidedTourContextProvider

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,7 +1,9 @@
+import { Link } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
+import { getSiteManagementUrl } from '../site-fields';
 import { DEFAULT_LAYOUTS, DEFAULT_PER_PAGE_SIZES } from './views';
 import type { Site, SitesView } from '@automattic/api-core';
 import type { Action, Field, View } from '@wordpress/dataviews';
@@ -41,6 +43,14 @@ export const SitesDataViews = ( {
 					paginationInfo={ paginationInfo }
 					config={ { perPageSizes: DEFAULT_PER_PAGE_SIZES } }
 					empty={ empty }
+					renderItemLink={ ( { item, ...props } ) => (
+						<Link
+							{ ...props }
+							to={ getSiteManagementUrl( item ) }
+							disabled={ item.is_deleted }
+							style={ { textDecoration: 'none' } }
+						/>
+					) }
 				/>
 			</DataViewsCard>
 			<GuidedTourContextProvider

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -76,15 +76,21 @@ export function Name( { site, value }: { site: Site; value: string } ) {
 	};
 
 	return (
+		<HStack alignment="center" spacing={ 1 }>
+			{ site.is_deleted ? (
+				<Text variant="muted">{ value }</Text>
+			) : (
+				<span style={ titleFieldTextOverflowStyles }>{ value }</span>
+			) }
+			<span style={ { flexShrink: 0 } }>{ renderBadge() }</span>
+		</HStack>
+	);
+}
+
+export function NameLink( { site, value }: { site: Site; value: string } ) {
+	return (
 		<Link to={ getSiteManagementUrl( site ) } disabled={ site.is_deleted }>
-			<HStack alignment="center" spacing={ 1 }>
-				{ site.is_deleted ? (
-					<Text variant="muted">{ value }</Text>
-				) : (
-					<span style={ titleFieldTextOverflowStyles }>{ value }</span>
-				) }
-				<span style={ { flexShrink: 0 } }>{ renderBadge() }</span>
-			</HStack>
+			<Name site={ site } value={ value } />
 		</Link>
 	);
 }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -36,6 +36,7 @@ import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { AtomicTransferStatus, Site } from '@automattic/api-core';
+import type { ComponentProps } from 'react';
 
 function IneligibleIndicator() {
 	return <Text color="#CCCCCC">-</Text>;
@@ -57,6 +58,17 @@ export const titleFieldTextOverflowStyles = {
 	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',
 } as const;
+
+export function SiteLink( { site, ...props }: ComponentProps< typeof Link > & { site: Site } ) {
+	return (
+		<Link
+			{ ...props }
+			to={ getSiteManagementUrl( site ) }
+			disabled={ site.is_deleted }
+			style={ { textDecoration: 'none' } }
+		/>
+	);
+}
 
 export function Name( { site, value }: { site: Site; value: string } ) {
 	const renderBadge = () => {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -65,7 +65,7 @@ export function SiteLink( { site, ...props }: ComponentProps< typeof Link > & { 
 			{ ...props }
 			to={ getSiteManagementUrl( site ) }
 			disabled={ site.is_deleted }
-			style={ { textDecoration: 'none' } }
+			style={ { width: 'auto', minWidth: 'unset', textDecoration: 'none', ...props.style } }
 		/>
 	);
 }
@@ -87,14 +87,16 @@ export function Name( { site, value }: { site: Site; value: string } ) {
 		return null;
 	};
 
+	const badge = renderBadge();
+
 	return (
-		<HStack alignment="center" spacing={ 1 }>
+		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
 			{ site.is_deleted ? (
 				<Text variant="muted">{ value }</Text>
 			) : (
 				<span style={ titleFieldTextOverflowStyles }>{ value }</span>
 			) }
-			<span style={ { flexShrink: 0 } }>{ renderBadge() }</span>
+			{ badge && <span style={ { flexShrink: 0 } }>{ badge }</span> }
 		</HStack>
 	);
 }
@@ -113,15 +115,11 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 	);
 }
 
-export function SiteIconLink( { site }: { site: Site } ) {
+export function SiteIconLink( props: ComponentProps< typeof SiteIcon > ) {
 	return (
-		<Link
-			to={ getSiteManagementUrl( site ) }
-			disabled={ site.is_deleted }
-			style={ { textDecoration: 'none' } }
-		>
-			<SiteIcon site={ site } />
-		</Link>
+		<SiteLink site={ props.site } style={ { flexShrink: 0 } }>
+			<SiteIcon { ...props } />
+		</SiteLink>
 	);
 }
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -99,14 +99,6 @@ export function Name( { site, value }: { site: Site; value: string } ) {
 	);
 }
 
-export function NameLink( { site, value }: { site: Site; value: string } ) {
-	return (
-		<Link to={ getSiteManagementUrl( site ) } disabled={ site.is_deleted }>
-			<Name site={ site } value={ value } />
-		</Link>
-	);
-}
-
 export function URL( { site, value }: { site: Site; value: string } ) {
 	return site.is_deleted ? (
 		<Text variant="muted">{ value }</Text>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-646

## Proposed Changes

* Fix the issue where the site icon in DataViews is not clickable by using renderItemLink. The problem is caused by the `::after` pseudo-element introduced in [[this Gutenberg pull request]()](https://github.com/WordPress/gutenberg/pull/70671)
* Instead of applying pointer-events: none to the ::after element, it is preferable to use renderItemLink to ensure that click events are handled by the ItemClickWrapper element.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Click the icon of any site
* Ensure it opens the overview page
* Go to /v2/plugins/scheduled-updates
* Click the icon of any site
* Ensure it opens the overview page
* Go to /v2/plugins/scheduled-updates/new
* Click the icon of any site
* Ensure it opens the overview page
* Go to /v2/me/notifications/sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
