### PR TITLE
SSH Migration: Add the Verify Server step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/components/accordion.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/components/accordion.tsx
@@ -1,4 +1,5 @@
-import { Icon, check, chevronDown, chevronUp, swatch } from '@wordpress/icons';
+import { Gridicon } from '@automattic/components';
+import { Icon, chevronDown, chevronUp, swatch } from '@wordpress/icons';
 import clsx from 'clsx';
 import React, { FC } from 'react';
 import type { Steps as StepsType } from '../steps/use-steps';
@@ -12,11 +13,17 @@ interface AccordionStepProps {
 	index: number;
 }
 
-const AccordionStatusIcon = ( { completed }: { completed: boolean } ) => {
+const AccordionStatusIcon: FC< { completed: boolean } > = ( { completed } ) => {
 	return (
 		<div className="migration-site-ssh__accordion-status-icon">
 			{ completed ? (
-				<Icon icon={ check } className="migration-site-ssh__accordion-icon-completed" size={ 20 } />
+				<div className="migration-site-ssh__accordion-icon-container-completed">
+					<Gridicon
+						icon="checkmark"
+						className="migration-site-ssh__accordion-icon-completed"
+						size={ 12 }
+					/>
+				</div>
 			) : (
 				<Icon icon={ swatch } className="migration-site-ssh__accordion-icon-pending" size={ 20 } />
 			) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { urlToDomain } from 'calypso/lib/url';
 import { SupportNudge } from '../site-migration-instructions/support-nudge';
 import { Accordion } from './components/accordion';
@@ -21,6 +22,8 @@ const SiteMigrationSshShareAccess: StepType< {
 		how?: ( typeof HOW_TO_MIGRATE_OPTIONS )[ 'DO_IT_FOR_ME' ];
 	};
 } > = function ( { navigation } ) {
+	const site = useSite();
+	const siteId = site?.ID ?? 0;
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? '';
 	const host = queryParams.get( 'host' ) ?? undefined;
@@ -29,7 +32,19 @@ const SiteMigrationSshShareAccess: StepType< {
 		navigation.submit?.( { destination: 'no-ssh-access' } );
 	}, [ navigation ] );
 
-	const { steps } = useSteps( { host, onNoSSHAccess: handleNoSSHAccess } );
+	// Steps orchestration
+	const onCompleteSteps = () => {
+		navigation.submit?.( { destination: 'migration-started' } );
+	};
+
+	const { steps } = useSteps( {
+		fromUrl,
+		siteId,
+		siteName: site?.name ?? '',
+		onComplete: onCompleteSteps,
+		host,
+		onNoSSHAccess: handleNoSSHAccess,
+	} );
 
 	const handleContinue = () => {
 		navigation.submit?.( { destination: 'migration-started' } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 
@@ -11,9 +12,9 @@ export const HelpLink: FC< HelpLinkProps > = ( { href } ) => {
 	return (
 		<p className="migration-site-ssh__help-link">
 			{ translate( 'Need help?' ) }{ ' ' }
-			<a href={ href } target="_blank" rel="noopener noreferrer">
+			<ExternalLink href={ href } icon iconSize={ 14 }>
 				{ translate( 'Follow our guide' ) }
-			</a>
+			</ExternalLink>
 		</p>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -1,6 +1,6 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
-import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { AccordionNotice } from '../components/accordion-notice';
 import { useVerifySSHConnection } from '../hooks/use-verify-ssh-connection';
@@ -112,9 +112,14 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 				{ translate( 'This may be different than your website address.' ) }
 			</p>
 
-			<FormButton onClick={ handleVerify } disabled={ ! canVerify } busy={ isPending } primary>
+			<Button
+				variant="secondary"
+				onClick={ handleVerify }
+				disabled={ ! canVerify }
+				isBusy={ isPending }
+			>
 				{ translate( 'Verify server address' ) }
-			</FormButton>
+			</Button>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -4,6 +4,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { AccordionNotice } from '../components/accordion-notice';
 import { useVerifySSHConnection } from '../hooks/use-verify-ssh-connection';
+import { validatePort } from '../utils/validation';
 
 interface StepAddServerAddressProps {
 	siteId: number;
@@ -45,7 +46,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 		);
 	};
 
-	const canVerify = serverAddress.length > 0 && port > 0 && port <= 65535 && ! isPending;
+	const canVerify = serverAddress.length > 0 && validatePort( port ) && ! isPending;
 
 	const instructionText = hostDisplayName
 		? translate(
@@ -98,9 +99,11 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 						id="ssh-port"
 						type="number"
 						value={ String( port ) }
-						onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
-							onPortChange( parseInt( e.target.value, 10 ) || 22 )
-						}
+						onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) => {
+							const parsedPort = parseInt( e.target.value, 10 );
+							const newPort = Number.isNaN( parsedPort ) ? 22 : parsedPort;
+							onPortChange( newPort );
+						} }
 					/>
 				</div>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -1,0 +1,117 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC, ReactNode } from 'react';
+import FormButton from 'calypso/components/forms/form-button';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { AccordionNotice } from '../components/accordion-notice';
+import { useVerifySSHConnection } from '../hooks/use-verify-ssh-connection';
+
+interface StepAddServerAddressProps {
+	siteId: number;
+	serverAddress: string;
+	port: number;
+	hostDisplayName?: string;
+	helpLink: ReactNode;
+	onServerAddressChange: ( address: string ) => void;
+	onPortChange: ( port: number ) => void;
+	onVerify: () => void;
+}
+
+export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
+	siteId,
+	serverAddress,
+	port,
+	hostDisplayName,
+	helpLink,
+	onServerAddressChange,
+	onPortChange,
+	onVerify,
+} ) => {
+	const translate = useTranslate();
+
+	const { mutate: verifyConnection, isPending, error } = useVerifySSHConnection();
+
+	const handleVerify = () => {
+		verifyConnection(
+			{
+				siteId,
+				serverAddress,
+				port,
+			},
+			{
+				onSuccess: () => {
+					onVerify();
+				},
+			}
+		);
+	};
+
+	const canVerify = serverAddress.length > 0 && port > 0 && port <= 65535 && ! isPending;
+
+	const instructionText = hostDisplayName
+		? translate(
+				"We'll use your server address to securely connect and copy your site. You can find it in your %(currentHost)s SSH settings.",
+				{
+					args: { currentHost: hostDisplayName },
+				}
+		  )
+		: translate(
+				"We'll use your server address to securely connect and copy your site. You can find it in your hosting provider's SSH settings."
+		  );
+
+	return (
+		<div>
+			<p>{ instructionText }</p>
+
+			{ helpLink }
+
+			{ error && (
+				<AccordionNotice variant="error">
+					{ translate(
+						'We ran into a problem connecting to your server. Please check your details and try again.'
+					) }
+				</AccordionNotice>
+			) }
+
+			<div className="migration-site-ssh__step-add-server-address-form">
+				<div className="migration-site-ssh__step-add-server-address-server-address-field">
+					<label
+						htmlFor="ssh-server-address"
+						className="migration-site-ssh__step-add-server-address-label"
+					>
+						{ translate( 'Server address' ) }
+					</label>
+					<FormTextInput
+						id="ssh-server-address"
+						value={ serverAddress }
+						onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+							onServerAddressChange( e.target.value )
+						}
+						placeholder="ssh.wp.example-host.net"
+					/>
+				</div>
+
+				<div className="migration-site-ssh__step-add-server-address-port-field">
+					<label htmlFor="ssh-port" className="migration-site-ssh__step-add-server-address-label">
+						{ translate( 'Port' ) }
+					</label>
+					<FormTextInput
+						id="ssh-port"
+						type="number"
+						value={ String( port ) }
+						onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+							onPortChange( parseInt( e.target.value, 10 ) || 22 )
+						}
+					/>
+				</div>
+			</div>
+
+			<p className="migration-site-ssh__step-add-server-address-note">
+				{ translate( 'This may be different than your website address.' ) }
+			</p>
+
+			<FormButton onClick={ handleVerify } disabled={ ! canVerify } busy={ isPending } primary>
+				{ translate( 'Verify server address' ) }
+			</FormButton>
+		</div>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -1,22 +1,21 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
-import { HelpLink } from './help-link';
-import { getSSHSupportUrl, getSSHHostDisplayName } from './ssh-host-support-urls';
+import { FC, ReactNode } from 'react';
 
 interface StepFindSSHDetailsProps {
 	onSuccess: () => void;
 	onNoSSHAccess?: () => void;
-	host?: string;
+	hostDisplayName?: string;
+	helpLink: ReactNode;
 }
 
 export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 	onSuccess,
 	onNoSSHAccess,
-	host,
+	hostDisplayName,
+	helpLink,
 } ) => {
 	const translate = useTranslate();
-	const hostDisplayName = getSSHHostDisplayName( host );
 
 	const instructionText = hostDisplayName
 		? translate(
@@ -32,7 +31,7 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 	return (
 		<div>
 			<p>{ instructionText }</p>
-			<HelpLink href={ getSSHSupportUrl( host ) } />
+			{ helpLink }
 			<div className="migration-site-ssh__find-ssh-details-buttons">
 				<Button variant="primary" onClick={ onSuccess }>
 					{ translate( 'I found my SSH details' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -1,11 +1,36 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { HelpLink } from './help-link';
+import { getSSHHostDisplayName, getSSHSupportUrl } from './ssh-host-support-urls';
+import { StepAddServerAddress } from './step-add-server-address';
 import { StepFindSSHDetails } from './step-find-ssh-details';
 import type { Task, Expandable } from '@automattic/launchpad';
 
 const FIND_SSH_DETAILS = 'find-ssh-details';
 const ADD_SERVER_ADDRESS = 'add-server-address';
 const SHARE_SSH_ACCESS = 'share-ssh-access';
+
+interface SSHFormState {
+	foundSSHDetails: boolean;
+	serverAddress: string;
+	port: number;
+	isServerVerified: boolean;
+}
+
+interface StepsDataOptions {
+	fromUrl: string;
+	siteId: number;
+	siteName: string;
+	serverAddress: string;
+	port: number;
+	isServerVerified: boolean;
+	onServerAddressChange: ( address: string ) => void;
+	onPortChange: ( port: number ) => void;
+	onServerVerify: () => void;
+	onFindSSHDetailsSuccess: () => void;
+	host?: string;
+	onNoSSHAccess?: () => void;
+}
 
 interface StepData {
 	key: string;
@@ -25,25 +50,25 @@ export type Steps = Step[];
 
 interface StepsObject {
 	steps: Steps;
+	completedSteps: number;
+	formState: SSHFormState;
+	allStepsCompleted: boolean;
 }
 
 interface UseStepsOptions {
+	fromUrl: string;
+	siteId: number;
+	siteName: string;
+	onComplete: () => void;
 	host?: string;
-	onNoSSHAccess?: () => void;
+	onNoSSHAccess: () => void;
 }
 
-export const useSteps = ( options?: UseStepsOptions ): StepsObject => {
+const useStepsData = ( options: StepsDataOptions ): StepsData => {
 	const translate = useTranslate();
-	const [ completedSteps, setCompletedSteps ] = useState< Set< string > >( new Set() );
-	const { host, onNoSSHAccess } = options || {};
-
-	const isComplete = ( stepKey: string ): boolean => {
-		return completedSteps.has( stepKey );
-	};
-
-	const handleStepComplete = ( stepKey: string ) => {
-		setCompletedSteps( ( prev ) => new Set( prev ).add( stepKey ) );
-	};
+	const hostDisplayName = getSSHHostDisplayName( options.host );
+	const supportUrl = getSSHSupportUrl( options.host );
+	const helpLink = <HelpLink href={ supportUrl } />;
 
 	const stepsData: StepsData = [
 		{
@@ -51,16 +76,28 @@ export const useSteps = ( options?: UseStepsOptions ): StepsObject => {
 			title: translate( 'Find your SSH details' ),
 			content: (
 				<StepFindSSHDetails
-					onSuccess={ () => handleStepComplete( FIND_SSH_DETAILS ) }
-					onNoSSHAccess={ onNoSSHAccess }
-					host={ host }
+					onSuccess={ options.onFindSSHDetailsSuccess }
+					onNoSSHAccess={ options.onNoSSHAccess }
+					hostDisplayName={ hostDisplayName }
+					helpLink={ helpLink }
 				/>
 			),
 		},
 		{
 			key: ADD_SERVER_ADDRESS,
 			title: translate( 'Add SSH server address' ),
-			content: <div>Add SSH server address</div>,
+			content: (
+				<StepAddServerAddress
+					siteId={ options.siteId }
+					serverAddress={ options.serverAddress }
+					port={ options.port }
+					hostDisplayName={ hostDisplayName }
+					helpLink={ helpLink }
+					onServerAddressChange={ options.onServerAddressChange }
+					onPortChange={ options.onPortChange }
+					onVerify={ options.onServerVerify }
+				/>
+			),
 		},
 		{
 			key: SHARE_SSH_ACCESS,
@@ -69,9 +106,90 @@ export const useSteps = ( options?: UseStepsOptions ): StepsObject => {
 		},
 	];
 
+	return stepsData;
+};
+
+export const useSteps = ( {
+	fromUrl,
+	siteId,
+	siteName,
+	onNoSSHAccess,
+}: UseStepsOptions ): StepsObject => {
+	const [ currentStep, setCurrentStep ] = useState( 0 );
+	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
+
+	// SSH Form State
+	const [ formState, setFormState ] = useState< SSHFormState >( {
+		foundSSHDetails: false,
+		serverAddress: '',
+		port: 22,
+		isServerVerified: false,
+	} );
+
+	// State update handlers
+	const handleServerAddressChange = ( address: string ) => {
+		setFormState( ( prev ) => ( { ...prev, serverAddress: address, isServerVerified: false } ) );
+	};
+
+	const handlePortChange = ( port: number ) => {
+		setFormState( ( prev ) => ( { ...prev, port, isServerVerified: false } ) );
+	};
+
+	const handleServerVerify = () => {
+		setFormState( ( prev ) => ( { ...prev, isServerVerified: true } ) );
+		setCurrentStep( 2 );
+		if ( lastCompleteStep < 1 ) {
+			setLastCompleteStep( 1 );
+		}
+	};
+
+	const handleFindSSHDetailsSuccess = () => {
+		setFormState( ( prev ) => ( { ...prev, foundSSHDetails: true } ) );
+		setCurrentStep( 1 );
+		if ( lastCompleteStep < 0 ) {
+			setLastCompleteStep( 0 );
+		}
+	};
+
+	const stepsData = useStepsData( {
+		fromUrl,
+		siteId,
+		siteName,
+		serverAddress: formState.serverAddress,
+		port: formState.port,
+		isServerVerified: formState.isServerVerified,
+		onServerAddressChange: handleServerAddressChange,
+		onPortChange: handlePortChange,
+		onServerVerify: handleServerVerify,
+		onFindSSHDetailsSuccess: handleFindSSHDetailsSuccess,
+		onNoSSHAccess,
+	} );
+
+	const isComplete = ( stepKey: string ) => {
+		switch ( stepKey ) {
+			case FIND_SSH_DETAILS:
+				return formState.foundSSHDetails;
+			case ADD_SERVER_ADDRESS:
+				return formState.isServerVerified;
+			case SHARE_SSH_ACCESS:
+				return false;
+			default:
+				return false;
+		}
+	};
+
 	const steps: Steps = stepsData.map( ( step, index ) => {
+		// Allow clicking on visited steps only, so users can see the previous steps again.
+		const onItemClick =
+			lastCompleteStep < index
+				? undefined
+				: () => {
+						setCurrentStep( index );
+				  };
+
 		// Render the content with the step-specific elements
 		const contentNode = <>{ step.content }</>;
+
 		return {
 			task: {
 				id: step.key,
@@ -81,12 +199,18 @@ export const useSteps = ( options?: UseStepsOptions ): StepsObject => {
 			},
 			expandable: {
 				content: contentNode,
-				isOpen: index === 0,
+				isOpen: currentStep === index,
 			},
+			onClick: onItemClick,
 		};
 	} );
 
+	const allStepsCompleted = steps.every( ( step ) => step.task.completed );
+
 	return {
 		steps,
+		completedSteps: lastCompleteStep + 1,
+		formState,
+		allStepsCompleted,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -29,7 +29,7 @@ interface StepsDataOptions {
 	onServerVerify: () => void;
 	onFindSSHDetailsSuccess: () => void;
 	host?: string;
-	onNoSSHAccess?: () => void;
+	onNoSSHAccess: () => void;
 }
 
 interface StepData {
@@ -114,6 +114,7 @@ export const useSteps = ( {
 	siteId,
 	siteName,
 	onNoSSHAccess,
+	host,
 }: UseStepsOptions ): StepsObject => {
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
@@ -163,6 +164,7 @@ export const useSteps = ( {
 		onServerVerify: handleServerVerify,
 		onFindSSHDetailsSuccess: handleFindSSHDetailsSuccess,
 		onNoSSHAccess,
+		host,
 	} );
 
 	const isComplete = ( stepKey: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -112,6 +112,30 @@
 	font-size: 0.875rem;
 }
 
+.migration-site-ssh__step-add-server-address-form {
+	display: flex;
+	flex-direction: row;
+	gap: 1rem;
+}
+
+.migration-site-ssh__step-add-server-address-port-field {
+	flex: 2;
+}
+
+.migration-site-ssh__step-add-server-address-server-address-field {
+	flex: 4;
+}
+
+.migration-site-ssh__step-add-server-address-label {
+	font-weight: 600;
+	line-height: 1.25;
+}
+
+.migration-site-ssh__step-add-server-address-note {
+	margin: 0.5rem 0 1rem 0;
+	color: var(--color-neutral-70);
+}
+
 .migration-site-ssh__continue-button {
 	margin-left: 2.5rem;
 	button {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -54,6 +54,16 @@
 	height: 24px;
 }
 
+.migration-site-ssh__accordion-icon-container-completed {
+	border: 0.1rem solid var(--color-success, #00a32a);
+	border-radius: 50%;
+	width: 15px;
+	height: 15px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 .migration-site-ssh__accordion-icon-pending {
 	display: flex;
 	align-items: center;
@@ -133,7 +143,8 @@
 
 .migration-site-ssh__step-add-server-address-note {
 	margin: 0.5rem 0 1rem 0;
-	color: var(--color-neutral-70);
+	color: var(--studio-gray-40);
+	font-size: 0.875rem;
 }
 
 .migration-site-ssh__continue-button {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/validation.ts
@@ -1,0 +1,28 @@
+/**
+ * Validates a server address format
+ * @param address - The server address to validate
+ * @returns true if valid, false otherwise
+ */
+export const validateServerAddress = ( address: string ): boolean => {
+	if ( ! address || address.trim().length === 0 ) {
+		return false;
+	}
+
+	// Basic domain/IP validation
+	// Accepts: domain.com, subdomain.domain.com, IP addresses
+	const domainRegex =
+		/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/i;
+	const ipRegex =
+		/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+	return domainRegex.test( address ) || ipRegex.test( address );
+};
+
+/**
+ * Validates a port number
+ * @param port - The port number to validate
+ * @returns true if valid (1-65535), false otherwise
+ */
+export const validatePort = ( port: number ): boolean => {
+	return port >= 1 && port <= 65535 && Number.isInteger( port );
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

- Add the "Add Server Address" step to the SSH migration flow
- Add validation utilities for server address and port inputs
- Add the `useVerifySSHConnection` hook to verify SSH connectivity
- Add dynamic host display names and support URLs based on hosting provider
- Refactor step components to receive pre-rendered `HelpLink` component as prop

<img width="843" height="712" alt="Captura de Tela 2025-10-22 às 14 09 40" src="https://github.com/user-attachments/assets/810b27a7-3ac2-4d64-84f2-1e19918694fc" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  This PR splits out the "Add Server Address" step from the larger SSH migration flow PR (#106585) to make the changes more reviewable and easier to test independently. This step allows users to input and verify their SSH server address and port before proceeding to share their credentials.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow until you reach the `Securely share your access`
* Add the `host=godaddy` parameter in your URL, this should change the text and the link to the support.
* Click on `I found my SSH details`
* Now fill the Server Address and Port input with valid information and verify it checks successfully
* Then, use a wrong information so you can see it fail.
* Ensure the support link also works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
