### PR TITLE
CIAB MSD: Don't display non-CIAB sites under domains and subscriptions

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -113,6 +113,11 @@ module.exports = {
 						],
 						message: 'Use local components exported from client/dashboard/components/card instead.',
 					},
+					{
+						name: '@automattic/api-queries',
+						importNames: [ 'sitesQuery' ],
+						message: 'Use local queries exported from either context or useAppContext instead.',
+					},
 				],
 			},
 		],

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -1,3 +1,4 @@
+import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import { Logo, LoadingLogo } from './logo';
 import './style.scss';
@@ -44,5 +45,8 @@ boot( {
 	components: {
 		sites: () => import( '../sites' ),
 		siteSwitcher: () => import( '../sites/site-switcher' ),
+	},
+	queries: {
+		sitesQuery,
 	},
 } );

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -1,4 +1,4 @@
-import { sitesQuery } from '@automattic/api-queries';
+import { sitesQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
 import boot from '../app/boot';
 import { Logo, LoadingLogo } from './logo';
 import type { FetchSitesOptions } from '@automattic/api-core';

--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -1,6 +1,7 @@
 import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import { Logo, LoadingLogo } from './logo';
+import type { FetchSitesOptions } from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -47,6 +48,6 @@ boot( {
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		sitesQuery,
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -2,6 +2,7 @@ import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import Logo from './logo';
 import './translations';
+import type { FetchSitesOptions } from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -47,7 +48,7 @@ boot( {
 		siteSwitcher: () => import( '../sites-ciab/site-switcher' ),
 	},
 	queries: {
-		sitesQuery: ( fetchSitesOptions ) =>
-			sitesQuery( Object.assign( {}, fetchSitesOptions, { site_filters: [ 'commerce-garden' ] } ) ),
+		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>
+			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -1,3 +1,4 @@
+import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import Logo from './logo';
 import './translations';
@@ -44,5 +45,9 @@ boot( {
 	components: {
 		sites: () => import( '../sites-ciab' ),
 		siteSwitcher: () => import( '../sites-ciab/site-switcher' ),
+	},
+	queries: {
+		sitesQuery: ( fetchSitesOptions ) =>
+			sitesQuery( Object.assign( {}, fetchSitesOptions, { site_filters: [ 'commerce-garden' ] } ) ),
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -1,4 +1,4 @@
-import { sitesQuery } from '@automattic/api-queries';
+import { sitesQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
 import boot from '../app/boot';
 import Logo from './logo';
 import './translations';

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,4 +1,4 @@
-import { sitesQuery } from '@automattic/api-queries';
+import { sitesQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
 import boot from '../app/boot';
 import Logo from './logo';
 import type { FetchSitesOptions } from '@automattic/api-core';

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,6 +1,7 @@
 import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import Logo from './logo';
+import type { FetchSitesOptions } from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -46,6 +47,6 @@ boot( {
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		sitesQuery,
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,3 +1,4 @@
+import { sitesQuery } from '@automattic/api-queries';
 import boot from '../app/boot';
 import Logo from './logo';
 import './style.scss';
@@ -43,5 +44,8 @@ boot( {
 	components: {
 		sites: () => import( '../sites' ),
 		siteSwitcher: () => import( '../sites/site-switcher' ),
+	},
+	queries: {
+		sitesQuery,
 	},
 } );

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,43 +1,56 @@
-import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
+import type { AppConfig } from '../context';
 import type { User, Site } from '@automattic/api-core';
 import type { QueryClient } from '@tanstack/react-query';
 import type { AnyRouter } from '@tanstack/react-router';
 
-export const getSuperProps = ( user: User, router: AnyRouter, queryClient: QueryClient ) => () => {
-	const superProps = {
-		environment: process.env.NODE_ENV,
-		environment_id: config( 'env_id' ),
-		site_count: user.site_count,
-		site_id_label: 'wpcom',
-		client: config( 'client_slug' ),
+export const getSuperProps =
+	( {
+		user,
+		router,
+		queryClient,
+		queries,
+	}: {
+		user: User;
+		router: AnyRouter;
+		queryClient: QueryClient;
+		queries: AppConfig[ 'queries' ];
+	} ) =>
+	() => {
+		const superProps = {
+			environment: process.env.NODE_ENV,
+			environment_id: config( 'env_id' ),
+			site_count: user.site_count,
+			site_id_label: 'wpcom',
+			client: config( 'client_slug' ),
+		};
+
+		if ( typeof window !== 'undefined' ) {
+			Object.assign( superProps, {
+				vph: window.innerHeight,
+				vpw: window.innerWidth,
+			} );
+		}
+
+		const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
+		if ( ! siteSlug ) {
+			return superProps;
+		}
+
+		const site = getSiteFromCache( { queryClient, queries, siteSlug } );
+		if ( ! site ) {
+			return superProps;
+		}
+
+		return {
+			...superProps,
+			blog_id: site.ID,
+			blog_lang: site.lang,
+			site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
+			site_plan_id: site.plan?.product_id ?? null,
+		};
 	};
-
-	if ( typeof window !== 'undefined' ) {
-		Object.assign( superProps, {
-			vph: window.innerHeight,
-			vpw: window.innerWidth,
-		} );
-	}
-
-	const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
-	if ( ! siteSlug ) {
-		return superProps;
-	}
-
-	const site = getSiteFromCache( queryClient, siteSlug );
-	if ( ! site ) {
-		return superProps;
-	}
-
-	return {
-		...superProps,
-		blog_id: site.ID,
-		blog_lang: site.lang,
-		site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
-		site_plan_id: site.plan?.product_id ?? null,
-	};
-};
 
 /**
  * Attempts to retrieve the site information from the tanstack cache.
@@ -47,13 +60,20 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
  * hoping to attach site info if it happens to be available. So I think checking
  * both caches represents a "best effort" attempt.
  */
-function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
+function getSiteFromCache( {
+	queryClient,
+	queries,
+	siteSlug,
+}: {
+	queryClient: QueryClient;
+	queries: AppConfig[ 'queries' ];
+	siteSlug: string;
+} ): Site | undefined {
 	const site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
 	if ( site ) {
 		return site;
 	}
 
-	// TODO: We need to get different sites across apps
-	const sites = queryClient.getQueryData< Site[] >( sitesQuery().queryKey );
+	const sites = queryClient.getQueryData< Site[] >( queries.sitesQuery().queryKey );
 	return sites?.find( ( s ) => s.slug === siteSlug );
 }

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -1,56 +1,43 @@
-import { siteBySlugQuery } from '@automattic/api-queries';
+import { siteBySlugQuery, sitesQueryKey } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import type { AppConfig } from '../context';
 import type { User, Site } from '@automattic/api-core';
 import type { QueryClient } from '@tanstack/react-query';
 import type { AnyRouter } from '@tanstack/react-router';
 
-export const getSuperProps =
-	( {
-		user,
-		router,
-		queryClient,
-		queries,
-	}: {
-		user: User;
-		router: AnyRouter;
-		queryClient: QueryClient;
-		queries: AppConfig[ 'queries' ];
-	} ) =>
-	() => {
-		const superProps = {
-			environment: process.env.NODE_ENV,
-			environment_id: config( 'env_id' ),
-			site_count: user.site_count,
-			site_id_label: 'wpcom',
-			client: config( 'client_slug' ),
-		};
-
-		if ( typeof window !== 'undefined' ) {
-			Object.assign( superProps, {
-				vph: window.innerHeight,
-				vpw: window.innerWidth,
-			} );
-		}
-
-		const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
-		if ( ! siteSlug ) {
-			return superProps;
-		}
-
-		const site = getSiteFromCache( { queryClient, queries, siteSlug } );
-		if ( ! site ) {
-			return superProps;
-		}
-
-		return {
-			...superProps,
-			blog_id: site.ID,
-			blog_lang: site.lang,
-			site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
-			site_plan_id: site.plan?.product_id ?? null,
-		};
+export const getSuperProps = ( user: User, router: AnyRouter, queryClient: QueryClient ) => () => {
+	const superProps = {
+		environment: process.env.NODE_ENV,
+		environment_id: config( 'env_id' ),
+		site_count: user.site_count,
+		site_id_label: 'wpcom',
+		client: config( 'client_slug' ),
 	};
+
+	if ( typeof window !== 'undefined' ) {
+		Object.assign( superProps, {
+			vph: window.innerHeight,
+			vpw: window.innerWidth,
+		} );
+	}
+
+	const siteSlug = router.state.matches.at( -1 )?.params?.siteSlug;
+	if ( ! siteSlug ) {
+		return superProps;
+	}
+
+	const site = getSiteFromCache( queryClient, siteSlug );
+	if ( ! site ) {
+		return superProps;
+	}
+
+	return {
+		...superProps,
+		blog_id: site.ID,
+		blog_lang: site.lang,
+		site_id_label: site.jetpack ? 'jetpack' : 'wpcom',
+		site_plan_id: site.plan?.product_id ?? null,
+	};
+};
 
 /**
  * Attempts to retrieve the site information from the tanstack cache.
@@ -60,20 +47,18 @@ export const getSuperProps =
  * hoping to attach site info if it happens to be available. So I think checking
  * both caches represents a "best effort" attempt.
  */
-function getSiteFromCache( {
-	queryClient,
-	queries,
-	siteSlug,
-}: {
-	queryClient: QueryClient;
-	queries: AppConfig[ 'queries' ];
-	siteSlug: string;
-} ): Site | undefined {
+function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
 	const site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
 	if ( site ) {
 		return site;
 	}
 
-	const sites = queryClient.getQueryData< Site[] >( queries.sitesQuery().queryKey );
-	return sites?.find( ( s ) => s.slug === siteSlug );
+	const sitesQueries = queryClient.getQueriesData< Site[] >( { queryKey: sitesQueryKey } );
+	const sitesBySlug = new Map(
+		sitesQueries
+			.map( ( [ , sites ] ) => ( sites || [] ).map( ( site ) => [ site.slug, site ] ) )
+			.flat() as [ string, Site ][]
+	);
+
+	return sitesBySlug.get( siteSlug );
 }

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -53,6 +53,7 @@ function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | 
 		return site;
 	}
 
+	// TODO: We need to get different sites across apps
 	const sites = queryClient.getQueryData< Site[] >( sitesQuery().queryKey );
 	return sites?.find( ( s ) => s.slug === siteSlug );
 }

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -18,7 +18,6 @@ interface AuthContextType {
 	user: User;
 	logout: () => Promise< void >;
 }
-
 export const AuthContext = createContext< AuthContextType | undefined >( undefined );
 
 async function initializeCurrentUser(): Promise< User > {

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -14,10 +14,11 @@ import type { User } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
 
-interface AuthContextType {
+export interface AuthContextType {
 	user: User;
 	logout: () => Promise< void >;
 }
+
 export const AuthContext = createContext< AuthContextType | undefined >( undefined );
 
 async function initializeCurrentUser(): Promise< User > {

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -14,7 +14,7 @@ import type { User } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
 
-export interface AuthContextType {
+interface AuthContextType {
 	user: User;
 	logout: () => Promise< void >;
 }

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,4 +1,4 @@
-import { sitesQuery } from '@automattic/api-queries';
+import { sitesQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
 import { createContext, useContext } from 'react';
 import type { FetchSitesOptions } from '@automattic/api-core';
 

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -62,7 +62,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	LoadingLogo: undefined,
 	supports: {
 		overview: false,
-		sites: false,
+		sites: false as const,
 		plugins: false,
 		domains: false,
 		emails: false,
@@ -70,7 +70,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		reader: false,
 		help: false,
 		notifications: false,
-		me: false,
+		me: false as const,
 		commandPalette: false,
 	},
 	optIn: false,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,3 +1,4 @@
+import { sitesQuery } from '@automattic/api-queries';
 import { createContext, useContext } from 'react';
 
 export type SiteSettingsGeneralSupports = {
@@ -48,6 +49,9 @@ export type AppConfig = {
 	};
 	optIn: boolean;
 	components: Record< string, () => Promise< { default: React.FC } > >;
+	queries: {
+		sitesQuery: typeof sitesQuery;
+	};
 };
 
 export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
@@ -71,6 +75,9 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	},
 	optIn: false,
 	components: {},
+	queries: {
+		sitesQuery,
+	},
 };
 
 const AppContext = createContext< AppConfig >( APP_CONTEXT_DEFAULT_CONFIG );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -63,7 +63,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	LoadingLogo: undefined,
 	supports: {
 		overview: false,
-		sites: false as const,
+		sites: false,
 		plugins: false,
 		domains: false,
 		emails: false,
@@ -71,7 +71,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		reader: false,
 		help: false,
 		notifications: false,
-		me: false as const,
+		me: false,
 		commandPalette: false,
 	},
 	optIn: false,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,5 +1,6 @@
 import { sitesQuery } from '@automattic/api-queries';
 import { createContext, useContext } from 'react';
+import type { FetchSitesOptions } from '@automattic/api-core';
 
 export type SiteSettingsGeneralSupports = {
 	redirect: boolean;
@@ -50,7 +51,7 @@ export type AppConfig = {
 	optIn: boolean;
 	components: Record< string, () => Promise< { default: React.FC } > >;
 	queries: {
-		sitesQuery: typeof sitesQuery;
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => ReturnType< typeof sitesQuery >;
 	};
 };
 
@@ -76,7 +77,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	optIn: false,
 	components: {},
 	queries: {
-		sitesQuery,
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 	},
 };
 

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -12,9 +12,10 @@ import { useMemo, useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from './analytics';
 import { getSuperProps } from './analytics/super-props';
 import { AuthProvider, useAuth } from './auth';
-import { AppProvider, type AppConfig } from './context';
+import { AppProvider, useAppContext } from './context';
 import { I18nProvider } from './i18n';
 import { getRouter } from './router';
+import type { AppConfig } from './context';
 
 function RouterProviderWithAuth( { config, router }: { config: AppConfig; router: AnyRouter } ) {
 	const auth = useAuth();
@@ -29,12 +30,13 @@ function AnalyticsProviderWithClient( {
 	router: AnyRouter;
 } ) {
 	const { user } = useAuth();
+	const { queries } = useAppContext();
 
 	useEffect( () => {
 		if ( user ) {
-			initializeAnalytics( user, getSuperProps( user, router, queryClient ) );
+			initializeAnalytics( user, getSuperProps( { user, router, queryClient, queries } ) );
 		}
-	}, [ user, router ] );
+	}, [ user, router, queries ] );
 
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -17,11 +17,6 @@ import { I18nProvider } from './i18n';
 import { getRouter } from './router';
 import type { AppConfig } from './context';
 
-function RouterProviderWithAuth( { config, router }: { config: AppConfig; router: AnyRouter } ) {
-	const auth = useAuth();
-	return <RouterProvider router={ router } context={ { auth, config } } />;
-}
-
 function AnalyticsProviderWithClient( {
 	children,
 	router,
@@ -72,7 +67,7 @@ function Layout( { config }: { config: AppConfig } ) {
 				<AuthProvider>
 					<I18nProvider>
 						<AnalyticsProviderWithClient router={ router }>
-							<RouterProviderWithAuth router={ router } config={ config } />
+							<RouterProvider router={ router } context={ { config } } />
 						</AnalyticsProviderWithClient>
 					</I18nProvider>
 				</AuthProvider>

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -12,7 +12,7 @@ import { useMemo, useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from './analytics';
 import { getSuperProps } from './analytics/super-props';
 import { AuthProvider, useAuth } from './auth';
-import { AppProvider, useAppContext } from './context';
+import { AppProvider } from './context';
 import { I18nProvider } from './i18n';
 import { getRouter } from './router';
 import type { AppConfig } from './context';
@@ -25,13 +25,12 @@ function AnalyticsProviderWithClient( {
 	router: AnyRouter;
 } ) {
 	const { user } = useAuth();
-	const { queries } = useAppContext();
 
 	useEffect( () => {
 		if ( user ) {
-			initializeAnalytics( user, getSuperProps( { user, router, queryClient, queries } ) );
+			initializeAnalytics( user, getSuperProps( user, router, queryClient ) );
 		}
-	}, [ user, router, queries ] );
+	}, [ user, router ] );
 
 	const analyticsClient: AnalyticsClient = useMemo(
 		() => ( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -8,7 +8,6 @@ import {
 	domainsQuery,
 	mailboxesQuery,
 	siteByIdQuery,
-	sitesQuery,
 	queryClient,
 	domainTransferRequestQuery,
 	domainWhoisQuery,
@@ -46,9 +45,9 @@ export const domainsRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'domains',
-	loader: async () => {
+	loader: async ( { context } ) => {
 		queryClient.ensureQueryData( domainsQuery() );
-		queryClient.ensureQueryData( sitesQuery() );
+		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -7,7 +7,6 @@ import {
 	rawUserPreferencesQuery,
 	siteByIdQuery,
 	siteDomainsQuery,
-	sitesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, redirect } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
@@ -26,12 +25,12 @@ export const emailsRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'emails',
-	loader: async () => {
+	loader: async ( { context } ) => {
 		// Preload user prefs used broadly
 		const prefsPromise = queryClient.ensureQueryData( rawUserPreferencesQuery() );
 
 		// 1) Preload sites
-		const sites = await queryClient.ensureQueryData( sitesQuery() );
+		const sites = await queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 		const managedSites = ( sites ?? [] ).filter( ( site ) => site.capabilities?.manage_options );
 
 		// 2) Preload domains for each managed site
@@ -99,9 +98,9 @@ export const chooseDomainRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'emails/choose-domain',
-	loader: async () => {
+	loader: async ( { context } ) => {
 		// 1) Preload sites
-		const sites = await queryClient.ensureQueryData( sitesQuery() );
+		const sites = await queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 		const managedSites = ( sites ?? [] ).filter( ( site ) => site.capabilities?.manage_options );
 
 		// 2) Preload domains for each managed site

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -61,6 +61,10 @@ export const getRouter = ( config: AppConfig ) => {
 	return new Router( {
 		routeTree,
 		basepath: config.basePath,
+		context: {
+			auth: undefined,
+			config,
+		},
 		defaultErrorComponent: UnknownError,
 		defaultNotFoundComponent: NotFound,
 		defaultPreload: 'intent',

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -62,7 +62,6 @@ export const getRouter = ( config: AppConfig ) => {
 		routeTree,
 		basepath: config.basePath,
 		context: {
-			auth: undefined,
 			config,
 		},
 		defaultErrorComponent: UnknownError,

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -5,7 +5,6 @@ import {
 	userReceiptsQuery,
 	purchaseQuery,
 	receiptQuery,
-	sitesQuery,
 	queryClient,
 	accountRecoveryQuery,
 	smsCountryCodesQuery,
@@ -180,10 +179,10 @@ export const purchasesRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => billingRoute,
-	loader: async () => {
+	loader: async ( { context } ) => {
 		await Promise.all( [
 			queryClient.ensureQueryData( userPurchasesQuery() ),
-			queryClient.ensureQueryData( sitesQuery() ),
+			queryClient.ensureQueryData( context.config.queries.sitesQuery() ),
 		] );
 	},
 	validateSearch: ( search ): { site: string | undefined } => {

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -1,6 +1,5 @@
 import {
 	pluginsQuery,
-	sitesQuery,
 	queryClient,
 	rawUserPreferencesQuery,
 	marketplacePluginsQuery,
@@ -126,8 +125,8 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsScheduledUpdatesRoute,
 	path: '/new',
-	loader: () => {
-		queryClient.ensureQueryData( sitesQuery() );
+	loader: async ( { context } ) => {
+		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/new' ).then( ( d ) =>
@@ -147,8 +146,8 @@ export const pluginsScheduledUpdatesEditRoute = createRoute( {
 	} ),
 	getParentRoute: () => pluginsScheduledUpdatesRoute,
 	path: '/edit/$scheduleId',
-	loader: () => {
-		queryClient.ensureQueryData( sitesQuery() );
+	loader: async ( { context } ) => {
+		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/edit' ).then( ( d ) =>

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -3,8 +3,8 @@ import Root from '../root';
 import type { AuthContextType } from '../auth';
 import type { AppConfig } from '../context';
 
-type RootRouterContext = {
-	auth: AuthContextType;
+export type RootRouterContext = {
+	auth: AuthContextType | undefined;
 	config: AppConfig;
 };
 

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -1,4 +1,11 @@
-import { createRootRoute } from '@tanstack/react-router';
+import { createRootRouteWithContext } from '@tanstack/react-router';
 import Root from '../root';
+import type { AuthContextType } from '../auth';
+import type { AppConfig } from '../context';
 
-export const rootRoute = createRootRoute( { component: Root } );
+type RootRouterContext = {
+	auth: AuthContextType;
+	config: AppConfig;
+};
+
+export const rootRoute = createRootRouteWithContext< RootRouterContext >()( { component: Root } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -1,10 +1,8 @@
 import { createRootRouteWithContext } from '@tanstack/react-router';
 import Root from '../root';
-import type { AuthContextType } from '../auth';
 import type { AppConfig } from '../context';
 
 export type RootRouterContext = {
-	auth: AuthContextType | undefined;
 	config: AppConfig;
 };
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -29,7 +29,6 @@ import {
 	siteScanQuery,
 	siteSettingsQuery,
 	siteSftpUsersQuery,
-	sitesQuery,
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
@@ -59,9 +58,9 @@ export const sitesRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: async () => {
+	loader: async ( { context } ) => {
 		// Preload the default sites list response without blocking.
-		queryClient.ensureQueryData( sitesQuery() );
+		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
 
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),

--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -1,4 +1,3 @@
-import { sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import {
 	SearchControl,
@@ -8,6 +7,7 @@ import {
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, useCallback, useRef } from 'react';
+import { useAppContext } from '../../app/context';
 import SiteIcon from '../../components/site-icon';
 import { canManageSite } from '../../sites/features';
 import { getSiteDisplayUrl } from '../../utils/site-url';
@@ -21,7 +21,8 @@ interface Props {
 }
 
 export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
-	const { data: allSites = [], isLoading } = useQuery( sitesQuery() );
+	const { queries } = useAppContext();
+	const { data: allSites = [], isLoading } = useQuery( queries.sitesQuery() );
 	const sites = useMemo(
 		() => allSites.filter( ( site ) => canManageSite( site ) && site.ID !== attachedSiteId ),
 		[ allSites, attachedSiteId ]

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -3,7 +3,7 @@ import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { DataViewsCard } from '../components/dataviews-card';
@@ -13,7 +13,7 @@ import PageLayout from '../components/page-layout';
 import { AddDomainButton } from './add-domain-button';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
 import type { DomainsView } from './dataviews';
-import type { DomainSummary } from '@automattic/api-core';
+import type { DomainSummary, Site } from '@automattic/api-core';
 
 export function getDomainId( domain: DomainSummary ): string {
 	return `${ domain.domain }-${ domain.blog_id }`;
@@ -37,10 +37,23 @@ function Domains() {
 		],
 	} ) );
 
+	const sitesById = useMemo( () => {
+		if ( ! sites ) {
+			return {};
+		}
+		return sites.reduce( ( acc: Record< number, Site >, site ) => {
+			acc[ site.ID ] = site;
+			return acc;
+		}, {} );
+	}, [ sites ] );
+
 	const { data: domains, isLoading } = useQuery( {
 		...domainsQuery(),
 		select: ( data ) => {
-			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
+			return data.filter(
+				( domain ) =>
+					domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS && !! sitesById[ domain.blog_id ]
+			);
 		},
 	} );
 

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,10 +1,11 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainsQuery, sitesQuery } from '@automattic/api-queries';
+import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAuth } from '../app/auth';
+import { useAppContext } from '../app/context';
 import { DataViewsCard } from '../components/dataviews-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
@@ -20,8 +21,9 @@ export function getDomainId( domain: DomainSummary ): string {
 
 function Domains() {
 	const { user } = useAuth();
+	const { queries } = useAppContext();
 	const fields = useFields();
-	const { data: sites } = useQuery( sitesQuery() );
+	const { data: sites } = useQuery( queries.sitesQuery() );
 	const actions = useActions( { user, sites } );
 	const [ view, setView ] = useState< DomainsView >( () => ( {
 		...DEFAULT_VIEW,

--- a/client/dashboard/emails/hooks/use-domains.ts
+++ b/client/dashboard/emails/hooks/use-domains.ts
@@ -1,10 +1,12 @@
 import { Domain } from '@automattic/api-core';
-import { siteDomainsQuery, sitesQuery } from '@automattic/api-queries';
+import { siteDomainsQuery } from '@automattic/api-queries';
 import { useQueries, useQuery } from '@tanstack/react-query';
+import { useAppContext } from '../../app/context';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 
 export const useDomains = (): { domains: Domain[]; isLoading: boolean } => {
-	const { data: allSites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const { queries } = useAppContext();
+	const { data: allSites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 	const sites = ( allSites ?? [] )
 		.filter( ( site ) => {
 			const product = site?.plan?.product_slug ?? null;

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -82,9 +82,23 @@ export default function PurchasesList() {
 			} );
 		},
 	} );
+
+	const sitesById = useMemo( () => {
+		if ( ! sites ) {
+			return {};
+		}
+		return sites.reduce( ( acc: Record< number, Site >, site ) => {
+			acc[ site.ID ] = site;
+			return acc;
+		}, {} );
+	}, [ sites ] );
+
 	const allSubscriptions = useMemo( () => {
-		return [ ...( purchases ?? [] ), ...( transferredPurchases ?? [] ) ];
-	}, [ purchases, transferredPurchases ] );
+		return [ ...( purchases ?? [] ), ...( transferredPurchases ?? [] ) ].filter(
+			( subscription ) => !! sitesById[ subscription.blog_id ]
+		);
+	}, [ purchases, transferredPurchases, sitesById ] );
+
 	const { data: filteredSubscriptions, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( allSubscriptions, currentView, purchasesDataFields );
 	}, [ allSubscriptions, currentView, purchasesDataFields ] );

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -2,7 +2,6 @@ import {
 	userPaymentMethodsQuery,
 	userPurchasesQuery,
 	userTransferredPurchasesQuery,
-	sitesQuery,
 } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
@@ -10,6 +9,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { useAppContext } from '../../app/context';
 import { purchasesRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
@@ -41,12 +41,13 @@ function persistPurchasesViewToUrl( view: View, sites: Site[] ): void {
 }
 
 export default function PurchasesList() {
+	const { queries } = useAppContext();
 	const { site: siteSlug }: { site?: string } = purchasesRoute.useSearch();
 	const { data: purchases, isLoading: isLoadingPurchases } = useQuery( userPurchasesQuery() );
 	const { data: transferredPurchases, isLoading: isLoadingTransferredPurchases } = useQuery(
 		userTransferredPurchasesQuery()
 	);
-	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 
 	const [ currentView, setView ] = useState( purchasesDataView );
 	const idFromSiteSlug = siteSlug ? sites?.find( ( site ) => site.slug === siteSlug )?.ID : '';

--- a/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
@@ -1,11 +1,11 @@
 import { Site } from '@automattic/api-core';
-import { sitesQuery } from '@automattic/api-queries';
 import { useFuzzySearch } from '@automattic/search';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, SearchControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDeferredValue, useState } from 'react';
+import { useAppContext } from '../../../app/context';
 import { Card, CardBody } from '../../../components/card';
 import { CollapsibleCard } from '../../../components/collapsible-card';
 import { SitePreview } from '../site-preview';
@@ -14,9 +14,10 @@ import { SiteSettings } from '../site-settings';
 import './index.scss';
 
 export const SiteListSettings = () => {
+	const { queries } = useAppContext();
 	const [ search, setSearch ] = useState< string | undefined >();
 	const { data: sites } = useSuspenseQuery( {
-		...sitesQuery( { include_a8c_owned: true, site_visibility: 'visible' } ),
+		...queries.sitesQuery( { include_a8c_owned: true, site_visibility: 'visible' } ),
 	} );
 
 	const deferredSearch = useDeferredValue( search );

--- a/client/dashboard/me/preferences-login/index.tsx
+++ b/client/dashboard/me/preferences-login/index.tsx
@@ -3,7 +3,6 @@ import {
 	userPreferencesMutation,
 	userSettingsQuery,
 	rawUserPreferencesQuery,
-	sitesQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
@@ -17,6 +16,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAuth } from '../../app/auth';
+import { useAppContext } from '../../app/context';
 import { ButtonStack } from '../../components/button-stack/';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -33,6 +33,7 @@ export default function PreferencesLogin() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const { user } = useAuth();
+	const { queries } = useAppContext();
 	const { data: primarySiteId } = useSuspenseQuery( {
 		...userSettingsQuery(),
 		select: ( data ) => data.primary_site_ID,
@@ -51,7 +52,7 @@ export default function PreferencesLogin() {
 	} );
 
 	const { data: sites, isLoading: isSiteListLoading } = useQuery(
-		sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
+		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
 	);
 
 	const { mutateAsync: saveUserSettings, isPending: isSavingUserSettings } = useMutation(

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -3,12 +3,12 @@ import {
 	marketplacePluginsQuery,
 	marketplaceSearchQuery,
 	pluginsQuery,
-	sitesQuery,
 } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
+import { useAppContext } from '../../app/context';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { OptInWelcome } from '../../components/opt-in-welcome';
 import { PageHeader } from '../../components/page-header';
@@ -22,8 +22,9 @@ import type { PluginListRow } from './types';
 import './style.scss';
 
 export default function PluginsList() {
+	const { queries } = useAppContext();
 	const { data: sitesPlugins, isLoading: isLoadingPlugins } = useQuery( pluginsQuery() );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 	const actions = getActions();
 	const [ view, setView ] = useState( defaultView );
 	const data = useMemo(

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -1,13 +1,13 @@
 import { PluginItem, Site, SitePlugin } from '@automattic/api-core';
 import {
 	pluginsQuery,
-	sitesQuery,
 	wpOrgPluginQuery,
 	sitePluginQuery,
 	marketplacePluginsQuery,
 } from '@automattic/api-queries';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { useAppContext } from '../../app/context';
 import { useLocale } from '../../app/locale';
 
 export interface SiteWithPluginData extends Site {
@@ -17,13 +17,14 @@ export interface SiteWithPluginData extends Site {
 
 export const usePlugin = ( pluginSlug: string ) => {
 	const queryClient = useQueryClient();
+	const { queries } = useAppContext();
 	const locale = useLocale();
 	const {
 		data: sitesPlugins,
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( pluginsQuery() );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()
 	);

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-eligible-sites.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-eligible-sites.ts
@@ -1,10 +1,12 @@
-import { sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { useAppContext } from '../../../app/context';
 import type { Site } from '@automattic/api-core';
 
 export function useEligibleSites() {
+	const { queries } = useAppContext();
+
 	return useQuery( {
-		...sitesQuery(),
+		...queries.sitesQuery(),
 		select: ( sites: Site[] ) =>
 			sites.filter( ( site ) => {
 				const canUpdatePlugins = Boolean( site.capabilities?.update_plugins );

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-scheduled-updates.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-scheduled-updates.ts
@@ -1,17 +1,15 @@
-import {
-	hostingUpdateSchedulesQuery,
-	siteCorePluginsQuery,
-	sitesQuery,
-} from '@automattic/api-queries';
+import { hostingUpdateSchedulesQuery, siteCorePluginsQuery } from '@automattic/api-queries';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { ScheduledUpdateRow } from '../types';
+import { useAppContext } from '../../../app/context';
+import type { ScheduledUpdateRow } from '../types';
 
 export function useScheduledUpdates() {
+	const { queries } = useAppContext();
 	const { data: scheduledUpdates, isLoading: isLoadingSchedules } = useQuery(
 		hostingUpdateSchedulesQuery()
 	);
-	const { data: sites, isLoading: isLoadingSites } = useQuery( sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 	const siteIds = Object.keys( scheduledUpdates?.sites ?? [] );
 	const pluginQueries = useQueries( {
 		queries: siteIds.map( ( id ) => siteCorePluginsQuery( Number( id ) ) ),

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -2,7 +2,6 @@ import {
 	isAutomatticianQuery,
 	userPreferenceQuery,
 	userPreferenceMutation,
-	sitesQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
 } from '@automattic/api-queries';
@@ -21,6 +20,7 @@ import deepmerge from 'deepmerge';
 import { useEffect } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
+import { useAppContext } from '../app/context';
 import { useHelpCenter } from '../app/help-center';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
@@ -48,7 +48,6 @@ const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchS
 	}
 
 	return {
-		site_filters: [ 'commerce-garden' ],
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || isRestoringAccount ? 'all' : 'visible',
@@ -65,6 +64,7 @@ export default function CIABSites() {
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
+	const { queries } = useAppContext();
 	const { setShowHelpCenter } = useHelpCenter();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 	const { data: viewPreferences } = useSuspenseQuery( userPreferenceQuery( 'ciab-sites-view' ) );
@@ -85,7 +85,7 @@ export default function CIABSites() {
 		isLoading: isLoadingSites,
 		isPlaceholderData,
 	} = useQuery( {
-		...sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
+		...queries.sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
 		placeholderData: keepPreviousData,
 	} );
 

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -28,7 +28,6 @@ const CIABSiteSwitcher = () => {
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
 	const { data: sites } = useQuery( {
 		...queries.sitesQuery( {
-			site_filters: [ 'commerce-garden' ],
 			site_visibility: 'visible',
 			include_a8c_owned: false,
 		} ),

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -1,4 +1,4 @@
-import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack, MenuGroup, MenuItem, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -6,6 +6,7 @@ import { plus } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
@@ -23,9 +24,10 @@ const searchableFields = [
 
 const CIABSiteSwitcher = () => {
 	const { recordTracksEvent } = useAnalytics();
+	const { queries } = useAppContext();
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
 	const { data: sites } = useQuery( {
-		...sitesQuery( {
+		...queries.sitesQuery( {
 			site_filters: [ 'commerce-garden' ],
 			site_visibility: 'visible',
 			include_a8c_owned: false,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -2,7 +2,6 @@ import {
 	isAutomatticianQuery,
 	userPreferenceQuery,
 	userPreferenceMutation,
-	sitesQuery,
 	siteBySlugQuery,
 	siteByIdQuery,
 } from '@automattic/api-queries';
@@ -22,6 +21,7 @@ import { useState, useEffect } from 'react';
 import { Experiment } from 'calypso/lib/explat';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
+import { useAppContext } from '../app/context';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { PageHeader } from '../components/page-header';
@@ -65,6 +65,7 @@ export default function Sites() {
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const queryClient = useQueryClient();
+	const { queries } = useAppContext();
 	const currentSearchParams = sitesRoute.useSearch();
 	const viewSearchParams: ViewSearchParams = currentSearchParams.view ?? {};
 	const isRestoringAccount = !! currentSearchParams.restored;
@@ -87,7 +88,7 @@ export default function Sites() {
 		isLoading: isLoadingSites,
 		isPlaceholderData,
 	} = useQuery( {
-		...sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
+		...queries.sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
 		placeholderData: keepPreviousData,
 	} );
 

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -1,4 +1,4 @@
-import { siteBySlugQuery, sitesQuery } from '@automattic/api-queries';
+import { siteBySlugQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -10,6 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
+import { useAppContext } from '../../app/context';
 import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
@@ -27,8 +28,9 @@ const searchableFields = [
 ];
 
 const SiteSwitcher = () => {
+	const { queries } = useAppContext();
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
-	const { data: sites } = useQuery( { ...sitesQuery(), enabled: isSwitcherOpen } );
+	const { data: sites } = useQuery( { ...queries.sitesQuery(), enabled: isSwitcherOpen } );
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -1,16 +1,17 @@
 import { siteBySlugQuery, queryClient } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Outlet, createRootRoute, createRoute } from '@tanstack/react-router';
+import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { canManageSite } from 'calypso/dashboard/sites/features';
 import { getSiteDisplayName } from 'calypso/dashboard/utils/site-name';
 import { hasSiteTrialEnded } from 'calypso/dashboard/utils/site-trial';
 import Root from './components/root';
 import type { Site } from '@automattic/api-core';
+import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
 
 /**
  * Define general routes
  */
-export const rootRoute = createRootRoute( { component: Root } );
+export const rootRoute = createRootRouteWithContext< RootRouterContext >()( { component: Root } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {
 	getParentRoute: () => rootRoute,

--- a/client/sites/v2/site-overview/layout.tsx
+++ b/client/sites/v2/site-overview/layout.tsx
@@ -3,16 +3,14 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
-import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import { AuthProvider } from 'calypso/dashboard/app/auth';
 import router, {
 	routerConfig,
 	syncBrowserHistoryToRouter,
 	syncMemoryRouterToBrowserHistory,
 } from './router';
 
-function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
-	const auth = useAuth();
-
+function RouterProviderWithConfig( { siteSlug }: { siteSlug?: string } ) {
 	useEffect( () => {
 		syncBrowserHistoryToRouter( router );
 	}, [ siteSlug ] );
@@ -31,7 +29,7 @@ function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
+	return <RouterProvider router={ router } context={ { config: routerConfig } } />;
 }
 
 function Layout( {
@@ -45,7 +43,7 @@ function Layout( {
 		<QueryClientProvider client={ queryClient }>
 			<AuthProvider>
 				<AnalyticsProvider client={ analyticsClient }>
-					<RouterProviderWithAuth siteSlug={ siteSlug } />
+					<RouterProviderWithConfig siteSlug={ siteSlug } />
 				</AnalyticsProvider>
 			</AuthProvider>
 		</QueryClientProvider>

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -1,7 +1,7 @@
 import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
-import { defaultAppConfig } from 'calypso/dashboard/app/context';
+import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import siteSettingsRouter from '../site-settings/router';
@@ -62,7 +62,7 @@ export const getRouter = ( config: AppConfig ) => {
 };
 
 export const routerConfig = {
-	...defaultAppConfig,
+	...APP_CONTEXT_DEFAULT_CONFIG,
 	basePath: '/',
 };
 

--- a/client/sites/v2/site-overview/router.tsx
+++ b/client/sites/v2/site-overview/router.tsx
@@ -1,11 +1,13 @@
 import { WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { defaultAppConfig } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
 import type { WPBreakpoint } from '@wordpress/compose/build-types/hooks/use-viewport-match';
+import type { AppConfig } from 'calypso/dashboard/app/context';
 
 const siteOverviewRoute = createRoute( {
 	...appRouterSites.siteOverviewRoute.options,
@@ -49,18 +51,18 @@ const createRouteTree = () =>
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync();
 
-export const getRouter = ( { basePath }: { basePath: string } ) => {
+export const getRouter = ( config: AppConfig ) => {
 	const routeTree = createRouteTree();
 	const router = createRouter( {
-		...getRouterOptions(),
+		...getRouterOptions( config ),
 		routeTree,
-		basepath: basePath,
 	} );
 
 	return router;
 };
 
 export const routerConfig = {
+	...defaultAppConfig,
 	basePath: '/',
 };
 

--- a/client/sites/v2/site-settings/layout.tsx
+++ b/client/sites/v2/site-settings/layout.tsx
@@ -4,7 +4,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
-import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import { AuthProvider } from 'calypso/dashboard/app/auth';
 import {
 	AppProvider,
 	APP_CONTEXT_DEFAULT_CONFIG,
@@ -17,9 +17,13 @@ import router, {
 } from './router';
 import type { Store } from 'redux';
 
-function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; feature?: string } ) {
-	const auth = useAuth();
-
+function RouterProviderWithConfig( {
+	siteSlug,
+	feature,
+}: {
+	siteSlug?: string;
+	feature?: string;
+} ) {
 	useEffect( () => {
 		syncBrowserHistoryToRouter( router );
 	}, [ siteSlug, feature ] );
@@ -38,7 +42,7 @@ function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; fea
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
+	return <RouterProvider router={ router } context={ { config: routerConfig } } />;
 }
 
 function Layout( {
@@ -73,7 +77,7 @@ function Layout( {
 				<AuthProvider>
 					<AnalyticsProvider client={ analyticsClient }>
 						<ReduxProvider store={ store }>
-							<RouterProviderWithAuth siteSlug={ siteSlug } feature={ feature } />
+							<RouterProviderWithConfig siteSlug={ siteSlug } feature={ feature } />
 						</ReduxProvider>
 					</AnalyticsProvider>
 				</AuthProvider>

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -1,5 +1,5 @@
 import { Router, createLazyRoute, createRoute } from '@tanstack/react-router';
-import { defaultAppConfig } from 'calypso/dashboard/app/context';
+import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
@@ -225,7 +225,7 @@ export const getRouter = ( config: AppConfig ) => {
 };
 
 export const routerConfig = {
-	...defaultAppConfig,
+	...APP_CONTEXT_DEFAULT_CONFIG,
 	basePath: '/',
 };
 

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -1,7 +1,9 @@
 import { Router, createLazyRoute, createRoute } from '@tanstack/react-router';
+import { defaultAppConfig } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute, dashboardSitesCompatibilityRoute, siteRoute } from '../router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
+import type { AppConfig } from 'calypso/dashboard/app/context';
 
 const settingsRoute = createRoute( {
 	...appRouterSites.siteSettingsRoute.options,
@@ -212,18 +214,18 @@ const createRouteTree = () =>
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync();
 
-export const getRouter = ( { basePath }: { basePath: string } ) => {
+export const getRouter = ( config: AppConfig ) => {
 	const routeTree = createRouteTree();
 	const router = new Router( {
-		...getRouterOptions(),
+		...getRouterOptions( config ),
 		routeTree,
-		basepath: basePath,
 	} );
 
 	return router;
 };
 
 export const routerConfig = {
+	...defaultAppConfig,
 	basePath: '/',
 };
 

--- a/client/sites/v2/sites-list/layout.tsx
+++ b/client/sites/v2/sites-list/layout.tsx
@@ -3,16 +3,14 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
-import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import { AuthProvider } from 'calypso/dashboard/app/auth';
 import router, {
 	routerConfig,
 	syncBrowserHistoryToRouter,
 	syncMemoryRouterToBrowserHistory,
 } from './router';
 
-function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
-	const auth = useAuth();
-
+function RouterProviderWithConfig( { siteSlug }: { siteSlug?: string } ) {
 	useEffect( () => {
 		syncBrowserHistoryToRouter( router );
 	}, [ siteSlug ] );
@@ -31,7 +29,7 @@ function RouterProviderWithAuth( { siteSlug }: { siteSlug?: string } ) {
 		};
 	}, [] );
 
-	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
+	return <RouterProvider router={ router } context={ { config: routerConfig } } />;
 }
 
 function Layout( {
@@ -45,7 +43,7 @@ function Layout( {
 		<QueryClientProvider client={ queryClient }>
 			<AuthProvider>
 				<AnalyticsProvider client={ analyticsClient }>
-					<RouterProviderWithAuth siteSlug={ siteSlug } />
+					<RouterProviderWithConfig siteSlug={ siteSlug } />
 				</AnalyticsProvider>
 			</AuthProvider>
 		</QueryClientProvider>

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -1,5 +1,5 @@
 import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
-import { defaultAppConfig } from 'calypso/dashboard/app/context';
+import { APP_CONTEXT_DEFAULT_CONFIG } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute } from '../router';
 import siteOverviewRouter from '../site-overview/router';
@@ -85,7 +85,7 @@ export const getRouter = ( config: AppConfig ) => {
 };
 
 export const routerConfig = {
-	...defaultAppConfig,
+	...APP_CONTEXT_DEFAULT_CONFIG,
 	basePath: '/',
 };
 

--- a/client/sites/v2/sites-list/router.tsx
+++ b/client/sites/v2/sites-list/router.tsx
@@ -1,9 +1,11 @@
 import { createLazyRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { defaultAppConfig } from 'calypso/dashboard/app/context';
 import * as appRouterSites from 'calypso/dashboard/app/router/sites';
 import { rootRoute } from '../router';
 import siteOverviewRouter from '../site-overview/router';
 import siteSettingsRouter from '../site-settings/router';
 import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
+import type { AppConfig } from 'calypso/dashboard/app/context';
 
 // Keep the loading state active to prevent displaying a white screen during the redirection.
 const infiniteLoader = () => new Promise( () => {} );
@@ -72,18 +74,18 @@ const createRouteTree = () =>
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
 	createBrowserHistoryAndMemoryRouterSync();
 
-export const getRouter = ( { basePath }: { basePath: string } ) => {
+export const getRouter = ( config: AppConfig ) => {
 	const routeTree = createRouteTree();
 	const router = createRouter( {
-		...getRouterOptions(),
+		...getRouterOptions( config ),
 		routeTree,
-		basepath: basePath,
 	} );
 
 	return router;
 };
 
 export const routerConfig = {
+	...defaultAppConfig,
 	basePath: '/',
 };
 

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -8,7 +8,6 @@ export function getRouterOptions( config: AppConfig ) {
 	return {
 		basepath: config.basePath,
 		context: {
-			auth: undefined,
 			config,
 		},
 		defaultPreload: 'intent' as const,

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -2,9 +2,15 @@ import pagejs from '@automattic/calypso-router';
 import { createMemoryHistory } from '@tanstack/react-router';
 import { getQueryArgs } from '@wordpress/url';
 import type { AnyRoute, AnyRouter } from '@tanstack/react-router';
+import type { AppConfig } from 'calypso/dashboard/app/context';
 
-export function getRouterOptions() {
+export function getRouterOptions( config: AppConfig ) {
 	return {
+		basepath: config.basePath,
+		context: {
+			auth: undefined,
+			config,
+		},
 		defaultPreload: 'intent' as const,
 		defaultPreloadStaleTime: 0,
 		defaultNotFoundComponent: () => null,

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -2,17 +2,23 @@ import { JOINED_SITE_FIELDS, JOINED_SITE_OPTIONS } from '../site';
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from '../site';
 
+type FetchSitesFilter = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden';
+
+/**
+ * This option is required to ensure consumers explicitly specify which types of sites they want.
+ * The `all` option means fetching all types of sites.
+ */
+export type FetchSitesFilters = 'all' | FetchSitesFilter[];
+
 export interface FetchSitesOptions {
 	include_a8c_owned: boolean;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
-	site_filters?: ( 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden' )[];
 }
 
-export async function fetchSites( {
-	include_a8c_owned,
-	site_visibility,
-	site_filters,
-}: FetchSitesOptions ): Promise< Site[] > {
+export async function fetchSites(
+	site_filters: FetchSitesFilters,
+	{ include_a8c_owned, site_visibility }: FetchSitesOptions
+): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
 			path: '/me/sites',
@@ -25,7 +31,7 @@ export async function fetchSites( {
 			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
-			filters: site_filters ? site_filters.join( ',' ) : undefined,
+			filters: site_filters !== 'all' ? site_filters.join( ',' ) : undefined,
 		}
 	);
 	return sites;

--- a/packages/api-queries/src/site-jetpack-modules.ts
+++ b/packages/api-queries/src/site-jetpack-modules.ts
@@ -6,7 +6,7 @@ import {
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import { sitesQuery } from './sites';
+import { sitesQueryFilter } from './sites';
 
 export const siteJetpackModulesQuery = ( siteId: number ) =>
 	queryOptions( {
@@ -34,6 +34,6 @@ export const siteJetpackModulesMutation = ( siteId: number ) =>
 			} );
 			queryClient.invalidateQueries( { queryKey: siteJetpackModulesQuery( siteId ).queryKey } );
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( { queryKey: sitesQuery().queryKey } );
+			queryClient.invalidateQueries( sitesQueryFilter() );
 		},
 	} );

--- a/packages/api-queries/src/site-jetpack-modules.ts
+++ b/packages/api-queries/src/site-jetpack-modules.ts
@@ -6,7 +6,7 @@ import {
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import { sitesQueryFilter } from './sites';
+import { sitesQueryKey } from './sites';
 
 export const siteJetpackModulesQuery = ( siteId: number ) =>
 	queryOptions( {
@@ -34,6 +34,6 @@ export const siteJetpackModulesMutation = ( siteId: number ) =>
 			} );
 			queryClient.invalidateQueries( { queryKey: siteJetpackModulesQuery( siteId ).queryKey } );
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( sitesQueryFilter() );
+			queryClient.invalidateQueries( { queryKey: sitesQueryKey } );
 		},
 	} );

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -1,21 +1,14 @@
 import { fetchSites, SITE_FIELDS, SITE_OPTIONS } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 import type { FetchSitesFilters, FetchSitesOptions } from '@automattic/api-core';
-import type { Query } from '@tanstack/react-query';
 
-const DEFAULT_QUERY_KEYS = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
+export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
 	siteFilters: FetchSitesFilters,
 	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) =>
 	queryOptions( {
-		queryKey: [ ...DEFAULT_QUERY_KEYS, siteFilters, fetchSitesOptions ],
+		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptions ],
 		queryFn: () => fetchSites( siteFilters, fetchSitesOptions ),
 	} );
-
-export const sitesQueryFilter = () => ( {
-	predicate: ( { queryKey }: Query ) => {
-		return DEFAULT_QUERY_KEYS.every( ( value, i ) => value === queryKey[ i ] );
-	},
-} );

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -1,11 +1,21 @@
 import { fetchSites, SITE_FIELDS, SITE_OPTIONS } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
-import type { FetchSitesOptions } from '@automattic/api-core';
+import type { FetchSitesFilters, FetchSitesOptions } from '@automattic/api-core';
+import type { Query } from '@tanstack/react-query';
+
+const DEFAULT_QUERY_KEYS = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
+	siteFilters: FetchSitesFilters,
 	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) =>
 	queryOptions( {
-		queryKey: [ 'sites', SITE_FIELDS, SITE_OPTIONS, fetchSitesOptions ],
-		queryFn: () => fetchSites( fetchSitesOptions ),
+		queryKey: [ ...DEFAULT_QUERY_KEYS, siteFilters, fetchSitesOptions ],
+		queryFn: () => fetchSites( siteFilters, fetchSitesOptions ),
 	} );
+
+export const sitesQueryFilter = () => ( {
+	predicate: ( { queryKey }: Query ) => {
+		return DEFAULT_QUERY_KEYS.every( ( value, i ) => value === queryKey[ i ] );
+	},
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Introduce `queries` to the app config
* Use `config.queries.sitesQuery` to control the sitesQuery across apps
* Show domains belonging to the available sites (either all sites or CIAB sites)
* Show subscriptions belonging to the available sites (either all sites or CIAB sites)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /ciab/domains
* Ensure it displays domains associated with the CIAB sites
* Go to /ciab/me/billing/purchases
* Ensure it displays subscriptions associated with the CIAB sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
