### PR TITLE
SSH Migration: Add the real status check for the in-progress step

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -254,3 +254,12 @@ export const siteSetupGoalsPath = buildPathHelper< {
 		siteSlug: string;
 	};
 } >( '/setup/site-setup/goals' );
+
+export const dashboardSiteSSHMigration = buildPathHelper< {
+	queryParams: {
+		'ssh-migration': 'completed' | 'failed';
+	};
+	params: {
+		siteSlug: string;
+	};
+} >( '/sites/:siteSlug' );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -585,7 +585,22 @@ const siteMigration: FlowV2< typeof initialize > = {
 				}
 
 				case STEPS.SITE_MIGRATION_SSH_IN_PROGRESS.slug: {
-					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
+					const { action } = providedDependencies as {
+						action: 'migration-completed' | 'migration-failed' | 'preflight' | 'unexpected-status';
+					};
+
+					switch ( action ) {
+						case 'migration-completed':
+							return exitFlow(
+								paths.dashboardSiteSSHMigration( { 'ssh-migration': 'completed' }, { siteSlug } )
+							);
+						case 'migration-failed':
+							return exitFlow(
+								paths.dashboardSiteSSHMigration( { 'ssh-migration': 'failed' }, { siteSlug } )
+							);
+						default:
+							return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+					}
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface SSHMigrationStatusParams {
+	siteId: number;
+	enabled?: boolean;
+}
+
+interface SSHMigrationStatusResponse {
+	success: boolean;
+	status: 'not_started' | 'in_progress' | 'completed' | 'failed';
+	step: string;
+}
+
+/**
+ * Fetches the SSH migration status for a site
+ * @param siteId - The site ID to check migration status for
+ * @returns Promise with migration status response
+ */
+const fetchSSHMigrationStatus = async ( siteId: number ): Promise< SSHMigrationStatusResponse > => {
+	try {
+		const response = await wpcom.req.get( {
+			path: `/sites/${ siteId }/ssh-migration/status`,
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		return response;
+	} catch ( error ) {
+		throw new Error(
+			error instanceof Error ? error.message : 'Failed to fetch SSH migration status'
+		);
+	}
+};
+
+/**
+ * Hook to fetch and poll SSH migration status
+ * @param params - Site ID and optional enabled flag
+ * @param pollingInterval - Optional polling interval in milliseconds (default: 5000ms)
+ * @returns Query object with migration status data and status
+ */
+export const useSSHMigrationStatus = (
+	params: SSHMigrationStatusParams,
+	pollingInterval = 5000
+) => {
+	const { siteId, enabled = true } = params;
+
+	return useQuery< SSHMigrationStatusResponse, Error >( {
+		queryKey: [ 'ssh-migration-status', siteId ],
+		queryFn: () => fetchSSHMigrationStatus( siteId ),
+		enabled: enabled && siteId > 0,
+		refetchInterval: ( query ) => {
+			// Stop polling if migration is completed or failed
+			const status = query.state.data?.status;
+			if ( status === 'completed' || status === 'failed' ) {
+				return false;
+			}
+			return pollingInterval;
+		},
+		refetchIntervalInBackground: true,
+		// Retry failed requests
+		retry: 3,
+		retryDelay: ( attemptIndex ) => Math.min( 1000 * 2 ** attemptIndex, 30000 ),
+	} );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
@@ -6,6 +6,12 @@ interface SSHMigrationStatusParams {
 	enabled?: boolean;
 }
 
+/**
+ * Response from the SSH migration status endpoint
+ * @property success - Indicates if the status request was successful
+ * @property status - High-level migration status (in-progress, migrating, completed, or failed)
+ * @property step - Detailed migration step indicating current progress through the migration process
+ */
 interface SSHMigrationStatusResponse {
 	success: boolean;
 	status: 'in-progress' | 'migrating' | 'completed' | 'failed';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
@@ -8,8 +8,21 @@ interface SSHMigrationStatusParams {
 
 interface SSHMigrationStatusResponse {
 	success: boolean;
-	status: 'not_started' | 'in_progress' | 'completed' | 'failed';
-	step: string;
+	status: 'in-progress' | 'migrating' | 'completed' | 'failed';
+	step:
+		| 'starting-migration'
+		| 'quickforget-read'
+		| 'quickforget-decode'
+		| 'migration-create'
+		| 'migration-created'
+		| 'migration-update'
+		| 'preflight'
+		| 'preflight-success'
+		| 'preflight-running'
+		| 'migration-success'
+		| 'migration-starting'
+		| 'migration-running'
+		| 'completed';
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
@@ -41,7 +41,7 @@ const SiteMigrationSshInProgressChecklist = ( {
 
 const SiteMigrationSshInProgress: StepType< {
 	submits: {
-		action: 'continue';
+		action: 'migration-completed' | 'migration-failed' | 'preflight' | 'unexpected-status';
 	};
 } > = function ( { navigation } ) {
 	const translate = useTranslate();
@@ -50,25 +50,33 @@ const SiteMigrationSshInProgress: StepType< {
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? null;
 
-	// Poll migration status
 	const { data: migrationStatus } = useSSHMigrationStatus( {
 		siteId,
 		enabled: siteId > 0,
 	} );
 
-	// Handle migration completion or failure
 	useEffect( () => {
 		if ( ! migrationStatus ) {
 			return;
 		}
 
-		if ( migrationStatus.status === 'completed' ) {
-			// Navigate to success/completion screen
-			navigation.submit?.( { action: 'continue' } );
-		} else if ( migrationStatus.status === 'failed' ) {
-			// Could navigate to an error screen or show an error message
-			// For now, we'll let it stay on this screen
-			// You might want to add error handling here
+		// Handle different migration statuses
+		switch ( migrationStatus.status ) {
+			case 'completed':
+				navigation.submit?.( { action: 'migration-completed' } );
+				break;
+			case 'failed':
+				if ( ! [ 'migration-starting', 'migration-running' ].includes( migrationStatus.step ) ) {
+					navigation.submit?.( { action: 'unexpected-status' } );
+					break;
+				}
+				navigation.submit?.( { action: 'migration-failed' } );
+				break;
+			case 'migrating':
+				break;
+			default:
+				navigation.submit?.( { action: 'unexpected-status' } );
+				break;
 		}
 	}, [ migrationStatus, navigation ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
@@ -1,6 +1,6 @@
-import { Gridicon, ProgressBar } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { Step } from '@automattic/onboarding';
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody, ProgressBar } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -83,7 +83,7 @@ const SiteMigrationSshInProgress: StepType< {
 	const stepContent = (
 		<div className="site-migration-ssh-in-progress">
 			<div className="site-migration-ssh-in-progress__progress">
-				<ProgressBar value={ 40 } total={ 100 } compact isPulsing />
+				<ProgressBar className="site-migration-ssh-in-progress__progress-container" />
 			</div>
 
 			<Card className="site-migration-ssh-in-progress__card">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
@@ -2,9 +2,12 @@ import { Gridicon, ProgressBar } from '@automattic/components';
 import { Step } from '@automattic/onboarding';
 import { Card, CardBody } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { urlToDomain } from 'calypso/lib/url';
+import { useSSHMigrationStatus } from './hooks/use-ssh-migration-status';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -40,15 +43,39 @@ const SiteMigrationSshInProgress: StepType< {
 	submits: {
 		action: 'continue';
 	};
-} > = function () {
+} > = function ( { navigation } ) {
 	const translate = useTranslate();
+	const site = useSite();
+	const siteId = site?.ID ?? 0;
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? null;
+
+	// Poll migration status
+	const { data: migrationStatus } = useSSHMigrationStatus( {
+		siteId,
+		enabled: siteId > 0,
+	} );
+
+	// Handle migration completion or failure
+	useEffect( () => {
+		if ( ! migrationStatus ) {
+			return;
+		}
+
+		if ( migrationStatus.status === 'completed' ) {
+			// Navigate to success/completion screen
+			navigation.submit?.( { action: 'continue' } );
+		} else if ( migrationStatus.status === 'failed' ) {
+			// Could navigate to an error screen or show an error message
+			// For now, we'll let it stay on this screen
+			// You might want to add error handling here
+		}
+	}, [ migrationStatus, navigation ] );
 
 	const stepContent = (
 		<div className="site-migration-ssh-in-progress">
 			<div className="site-migration-ssh-in-progress__progress">
-				<ProgressBar value={ 40 } total={ 100 } compact isPulsing={ false } />
+				<ProgressBar value={ 40 } total={ 100 } compact isPulsing />
 			</div>
 
 			<Card className="site-migration-ssh-in-progress__card">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/index.tsx
@@ -66,6 +66,10 @@ const SiteMigrationSshInProgress: StepType< {
 				navigation.submit?.( { action: 'migration-completed' } );
 				break;
 			case 'failed':
+				// We should only consider a migration failed when the step
+				// is related to the migration. This is because we can get the failed
+				// status when the preflight check fails. Which should not be
+				// responsibility of this step.
 				if ( ! [ 'migration-starting', 'migration-running' ].includes( migrationStatus.step ) ) {
 					navigation.submit?.( { action: 'unexpected-status' } );
 					break;
@@ -73,8 +77,10 @@ const SiteMigrationSshInProgress: StepType< {
 				navigation.submit?.( { action: 'migration-failed' } );
 				break;
 			case 'migrating':
+				// This means that the migration is still in progress.
 				break;
 			default:
+				// Any other statuses should be considered as unexpected.
 				navigation.submit?.( { action: 'unexpected-status' } );
 				break;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/style.scss
@@ -50,3 +50,12 @@
 	flex-shrink: 0;
 	margin-top: 2px;
 }
+
+.site-migration-ssh-in-progress__progress-container{
+	width: 100% !important;
+	background: var(--color-neutral-5);
+
+	> div {
+		background: var(--color-accent);
+	}
+}

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -24,7 +24,7 @@ const HostingOverview: FC = () => {
 	if ( site ) {
 		const queryParams = new URLSearchParams( window.location.search );
 		const sshMigration = queryParams.get( 'ssh-migration' );
-		if ( sshMigration === 'complete' ) {
+		if ( sshMigration === 'completed' ) {
 			return <MigrationSSHComplete site={ site } />;
 		}
 		if ( sshMigration === 'failed' ) {

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -26,7 +26,7 @@ export async function dashboardBackportSiteOverview( context: PageJSContext, nex
 	const site = getSelectedSite( context.store.getState() ) as SiteExcerptData;
 
 	const queryParams = new URLSearchParams( window.location.search );
-	const sshMigration = [ 'complete', 'failed' ].includes(
+	const sshMigration = [ 'completed', 'failed' ].includes(
 		queryParams.get( 'ssh-migration' ) ?? ''
 	);
 	if ( isMigrationInProgress( site ) || sshMigration ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14745

## Proposed Changes

- Created `useSSHMigrationStatus` hook to poll `/sites/:siteId/ssh-migration/status` endpoint every 5 seconds
- Updated `site-migration-ssh-in-progress` step to handle status changes and trigger navigation
- Added submit handler logic in `site-migration-flow.ts` to route users based on migration outcomes
- Polling automatically stops when migration reaches `completed` or `failed` status
- Updated the design of the Loading Bar


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Previously we only had the placeholder step, without any actions. This PR implements the polling and navigation logic for the SSH migration in-progress step. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing requires updating the migration status through wpsh on a sandbox environment:

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow until you reach the `Securely share your access`
* On `wpsh` require the following file:
```php
require_once 'wp-content/lib/migration/ssh-migration-functions.php';
```
* Then update the status of the migration to `migrating`
```php
return ssh_migration_update_status( YOUR_TEST_SITE_ID, 'migrating', 'migration-running' );
```
* Then update the URL to point to `site-migration-ssh-in-progress` step.
* You should be able to stay longer the 5 seconds in this step.
* Save the URL so you can navigate to this step for the tests.
* Now test the following scenarios, always first running the update and then accessing the saved endpoint
```php
# Should take you to the failure screen on the dashboard
return ssh_migration_update_status( YOUR_TEST_SITE_ID, 'failed', 'migration-running' );

# Should take you to the celebration screen on the dashboard
return ssh_migration_update_status( YOUR_TEST_SITE_ID, 'completed', 'migration-running' );

# Should take you to the Securely share your access step
return ssh_migration_update_status( YOUR_TEST_SITE_ID, 'in-progress', 'step' );
return ssh_migration_update_status( YOUR_TEST_SITE_ID, 'failed', 'step' );
``` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
