### PR TITLE
Update payment method modification endpoints to use 1.2

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -59,7 +59,7 @@ const wpcomAssignPaymentMethod = (
 	wp.req.post( {
 		path: '/upgrades/' + subscriptionId + '/assign-payment-method',
 		body: { stored_details_id },
-		apiVersion: '1',
+		apiVersion: '1.2',
 	} );
 
 const wpcomCreatePayPalAgreement = (

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -122,7 +122,7 @@ export async function updateCreditCard( {
 	const response = await wp.req.post(
 		{
 			path: '/upgrades/' + purchaseId + '/update-credit-card',
-			apiVersion: '1.1',
+			apiVersion: '1.2',
 		},
 		{
 			payment_partner,

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -43,7 +43,7 @@ export async function updateCreditCard(
 ): Promise< StoredPaymentMethod > {
 	return await wpcom.req.post( {
 		path: `/upgrades/${ params.purchaseId }/update-credit-card`,
-		apiVersion: '1.1',
+		apiVersion: '1.2',
 		body: {
 			payment_partner: params.paymentPartner,
 			paygate_token: params.paygateToken,
@@ -63,7 +63,7 @@ export async function updateCreditCard(
 export async function assignPaymentMethod( params: AssignPaymentMethodParams ): Promise< unknown > {
 	return await wpcom.req.post( {
 		path: `/upgrades/${ params.subscriptionId }/assign-payment-method`,
-		apiVersion: '1',
+		apiVersion: '1.2',
 		body: {
 			stored_details_id: params.storedDetailsId,
 		},

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -1,6 +1,5 @@
 import { normalizePurchase } from '../purchase';
 import { wpcom } from '../wpcom-fetcher';
-import type { StoredPaymentMethod } from '../me-payment-methods';
 import type { Purchase } from '../purchase';
 
 export interface UpdateCreditCardParams {
@@ -33,15 +32,15 @@ export async function setPurchaseAutoRenew(
 		apiVersion: '1.1',
 	} );
 	return {
-		...data,
+		success: data.success,
 		upgrade: normalizePurchase( data.upgrade ),
 	};
 }
 
 export async function updateCreditCard(
 	params: UpdateCreditCardParams
-): Promise< StoredPaymentMethod > {
-	return await wpcom.req.post( {
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const data = await wpcom.req.post( {
 		path: `/upgrades/${ params.purchaseId }/update-credit-card`,
 		apiVersion: '1.2',
 		body: {
@@ -58,14 +57,24 @@ export async function updateCreditCard(
 			setup_key: params.setupKey,
 		},
 	} );
+	return {
+		success: data.success,
+		upgrade: normalizePurchase( data.upgrade ),
+	};
 }
 
-export async function assignPaymentMethod( params: AssignPaymentMethodParams ): Promise< unknown > {
-	return await wpcom.req.post( {
+export async function assignPaymentMethod(
+	params: AssignPaymentMethodParams
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const data = await wpcom.req.post( {
 		path: `/upgrades/${ params.subscriptionId }/assign-payment-method`,
 		apiVersion: '1.2',
 		body: {
 			stored_details_id: params.storedDetailsId,
 		},
 	} );
+	return {
+		success: data.payment_method_changed,
+		upgrade: normalizePurchase( data.upgrade ),
+	};
 }


### PR DESCRIPTION
Fixes SHILL-1226
Part of https://linear.app/a8c/issue/SHILL-1228/remove-set-properties-for-purchases-rest-api

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR modifies the code that calls the `update-credit-card` and `assign-payment-method` endpoints to use the 1.2 version of those endpoints added in https://linear.app/a8c/issue/SHILL-1206

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The 1.2 versions of these endpoints use a newer, more standardized way to return purchase objects.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These return values are not really used anywhere currently, so there's no much to test.

Make sure that adding or changing the payment method attached to a subscription still works.
