### PR TITLE
Multi-site Dashboard: pass purchase data to the commerce garden plan card

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -222,7 +222,7 @@ export default function PlanCard( { site }: { site: Site } ) {
 	}
 
 	if ( isCommerceGarden( site ) ) {
-		return <CommerceGardenPlanCard site={ site } isLoading={ isLoading } />;
+		return <CommerceGardenPlanCard site={ site } purchase={ purchase } isLoading={ isLoading } />;
 	}
 
 	if ( isSelfHostedJetpackConnected( site ) ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/SHILL-929/ciab-create-checkout-flow-for-ciab
Fixes https://linear.app/a8c/issue/SHILL-1227/ciab-fix-plan-card-in-dashboard

## Proposed Changes

This passes purchase information through to the Commerce Garden plan card.

| Before  | After |
| ----------- | ----------- |
| <img width="342" height="160" alt="Screenshot 2025-10-22 at 14 14 50" src="https://github.com/user-attachments/assets/61736d0e-cc98-4738-ba66-a9f1a3037298" /> | <img width="345" height="179" alt="Screenshot 2025-10-22 at 14 14 38" src="https://github.com/user-attachments/assets/d16b0216-9ec8-43ac-9126-1067bd39a263" /> |

## Testing Instructions

- Apply 194453-ghe-Automattic/wpcom and sandbox Store and `public-api.wordpress.com`
- Create a commerce site via the MC > Tools > Garden page
- Purchase a Woo Hosted plan from `wordpress.com/checkout/{yoursiteaddress}/woo_hosted_basic_plan_yearly/`
- Visit calypso:localhost:3000/ciab/sites/
- Click on your commerce site's site name
- Verify that the plan card shows additional info about the purchase
- Click the card
- Verify that you are taken to the purchase management page.