### PR TITLE
Dotcom 14977 add storage card to billing screen

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -20,7 +20,7 @@ import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { userNotificationsDevicesQuery } from '../../../../packages/api-queries/src/me-notifications-devices';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/urls';
-import { getTitleForDisplay, isWpcomPlan } from '../../utils/purchase';
+import { getTitleForDisplay, isDotcomPlan } from '../../utils/purchase';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { Purchase } from '@automattic/api-core';
@@ -226,11 +226,13 @@ export const purchaseSettingsIndexRoute = createRoute( {
 		const purchase = await queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
 
 		// Preload site and storage data for wpcom plans
-		if ( purchase.site_slug ) {
-			const site = await queryClient.ensureQueryData( siteBySlugQuery( purchase.site_slug ) );
-			if ( isWpcomPlan( purchase ) ) {
-				await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
-			}
+		if ( purchase.site_slug && purchase.blog_id ) {
+			await Promise.all( [
+				queryClient.ensureQueryData( siteBySlugQuery( purchase.site_slug ) ),
+				isDotcomPlan( purchase )
+					? queryClient.ensureQueryData( siteMediaStorageQuery( purchase.blog_id ) )
+					: undefined,
+			] );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -13,12 +13,14 @@ import {
 	userNotificationsSettingsQuery,
 	rawUserPreferencesQuery,
 	connectedApplicationsQuery,
+	siteBySlugQuery,
+	siteMediaStorageQuery,
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { userNotificationsDevicesQuery } from '../../../../packages/api-queries/src/me-notifications-devices';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/urls';
-import { getTitleForDisplay } from '../../utils/purchase';
+import { getTitleForDisplay, isWpcomPlan } from '../../utils/purchase';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { Purchase } from '@automattic/api-core';
@@ -220,6 +222,17 @@ export const purchaseSettingsRoute = createRoute( {
 export const purchaseSettingsIndexRoute = createRoute( {
 	getParentRoute: () => purchaseSettingsRoute,
 	path: '/',
+	loader: async ( { params: { purchaseId } } ) => {
+		const purchase = await queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
+
+		// Preload site and storage data for wpcom plans
+		if ( purchase.site_slug ) {
+			const site = await queryClient.ensureQueryData( siteBySlugQuery( purchase.site_slug ) );
+			if ( isWpcomPlan( purchase ) ) {
+				await queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) );
+			}
+		}
+	},
 } ).lazy( () =>
 	import( '../../me/billing-purchases/purchase-settings' ).then( ( d ) =>
 		createLazyRoute( 'purchases-purchase-settings' )( {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -73,7 +73,7 @@ import {
 	isJetpackCrmProduct,
 	isTitanMail,
 	isGoogleWorkspace,
-	isWpcomPlan,
+	isDotcomPlan,
 	getRenewalUrlFromPurchase,
 	isJetpackT1SecurityPlan,
 } from '../../../utils/purchase';
@@ -479,7 +479,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 }
 
 function WPComResourceMeters( { purchase, site }: { purchase: Purchase; site: Site } ) {
-	if ( ! isWpcomPlan( purchase ) ) {
+	if ( ! isDotcomPlan( purchase ) ) {
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -54,6 +54,8 @@ import OverviewCard from '../../../components/overview-card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import SiteIcon from '../../../components/site-icon';
+import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
+import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
 import {
 	getBillPeriodLabel,
@@ -71,13 +73,14 @@ import {
 	isJetpackCrmProduct,
 	isTitanMail,
 	isGoogleWorkspace,
+	isWpcomPlan,
 	getRenewalUrlFromPurchase,
 	isJetpackT1SecurityPlan,
 } from '../../../utils/purchase';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import { getPurchaseUrlForId } from '../urls';
 import { PurchaseNotice } from './purchase-notice';
-import type { User, Purchase } from '@automattic/api-core';
+import type { User, Purchase, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 import './style.scss';
@@ -472,6 +475,23 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>
 		</VStack>
+	);
+}
+
+function WPComResourceMeters( { purchase, site }: { purchase: Purchase; site: Site } ) {
+	if ( ! isWpcomPlan( purchase ) ) {
+		return null;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SiteStorageStat site={ site } />
+					<SiteBandwidthStat site={ site } />
+				</VStack>
+			</CardBody>
+		</Card>
 	);
 }
 
@@ -1103,6 +1123,7 @@ export default function PurchaseSettings() {
 						}
 					/>
 				</Grid>
+				{ site && <WPComResourceMeters purchase={ purchase } site={ site } /> }
 				<ManageSubscriptionCard purchase={ purchase } />
 				<PurchaseSettingsActions purchase={ purchase } />
 			</VStack>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -20,7 +20,7 @@ import {
 import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
@@ -1010,19 +1010,13 @@ export default function PurchaseSettings() {
 	const { user } = useAuth();
 	const params = purchaseSettingsRoute.useParams();
 	const purchaseId = params.purchaseId;
-	const { data: purchase } = useQuery( {
-		...purchaseQuery( parseInt( purchaseId ) ),
-		enabled: Boolean( purchaseId ),
-	} );
+	const { data: purchase } = useSuspenseQuery( purchaseQuery( parseInt( purchaseId ) ) );
 	const { data: site } = useQuery( {
-		...siteBySlugQuery( purchase?.site_slug ?? '' ),
-		enabled: Boolean( purchase?.site_slug ),
+		...siteBySlugQuery( purchase.site_slug ?? '' ),
+		enabled: Boolean( purchase.site_slug ),
 	} );
-	const formattedExpiry = useFormattedTime( purchase?.expiry_date ?? '' );
-	const formattedRenewal = useFormattedTime( purchase?.renew_date ?? '' );
-	if ( ! purchase ) {
-		return null;
-	}
+	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
+	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const willRenew = Boolean( purchase.renew_date && ! isExpiring( purchase ) );
 	const expiryDateTitle = ( () => {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -393,7 +393,7 @@ export function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
 	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
-export function isWpcomPlan( purchase: Purchase ): boolean {
+export function isDotcomPlan( purchase: Purchase ): boolean {
 	return purchase.is_plan && ! purchase.is_jetpack_plan_or_product;
 }
 

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -393,6 +393,10 @@ export function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
 	return securityT1Slugs.includes( purchase.product_slug as ( typeof securityT1Slugs )[ number ] );
 }
 
+export function isWpcomPlan( purchase: Purchase ): boolean {
+	return purchase.is_plan && ! purchase.is_jetpack_plan_or_product;
+}
+
 function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
 	if ( isAkismetProduct( purchase ) ) {
 		return 'akismet/';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14977

## Proposed Changes

Bring the site bandwidth/storage meters to the billing screen.

This PR is branched from #106621 as that changes the behaviour of the storage meter, and should be deployed real soon now. It can equally be cherry-picked/rebased on trunk.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To help people visualise the amount of storage their site is using. As they approach or exceed the limits they will also be able to increase the amount of storage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the calypso.live link to navigate to /v2/me/billing/purchases
2. Look at a variety of purchases
3. You should find that purchases of a wpcom plan (personal, premium, etc) show bandwidth/storage meters, while other purchases do not.


Before | After
-------|------
<img width="1061" height="1212" alt="Screenshot 2025-10-22 at 21 56 30" src="https://github.com/user-attachments/assets/5e8fe2a4-9103-4845-91fd-443a24591b6a" /> | <img width="1061" height="1212" alt="Screenshot 2025-10-22 at 21 55 45" src="https://github.com/user-attachments/assets/6959bb7e-7ba6-499c-b8f6-6100a87298b9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
