### PR TITLE
SSH Migration: Verify and start the transfer to atomic

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -207,6 +207,7 @@ export const sshShareAccessPath = buildPathHelper<
 		queryParams: {
 			siteId?: number | string;
 			siteSlug: string;
+			transferId?: number | string;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -192,6 +192,16 @@ export const supportInstructionsPath = buildPathHelper<
 	typeof STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug
 >( STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug );
 
+export const sshVerificationPath = buildPathHelper<
+	{
+		queryParams: {
+			siteId?: number | string;
+			siteSlug: string;
+		};
+	},
+	typeof STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug
+>( STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug );
+
 export const sshShareAccessPath = buildPathHelper<
 	{
 		queryParams: {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -457,7 +457,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 				}
 
 				case STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug: {
-					const { allowSiteMigration } = providedDependencies as {
+					const { allowSiteMigration, transferId } = providedDependencies as {
 						verified: boolean;
 						transferId?: number;
 						allowSiteMigration?: boolean;
@@ -469,7 +469,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					// Otherwise proceed to SSH share access
-					return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+					return navigate( paths.sshShareAccessPath( { siteId, siteSlug, transferId } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
@@ -590,8 +590,13 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 				case STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug: {
 					const { destination } = providedDependencies as {
-						destination?: 'migration-started' | 'no-ssh-access';
+						destination?: 'migration-started' | 'no-ssh-access' | 'back-to-verification';
 					};
+
+					// Missing transferId, redirect back to verification
+					if ( destination === 'back-to-verification' ) {
+						return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+					}
 
 					// User doesn't have SSH access, redirect to credentials flow
 					if ( destination === 'no-ssh-access' ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -49,6 +49,7 @@ const BASE_STEPS = [
 	STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
 	STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
 	STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
+	STEPS.SITE_MIGRATION_SSH_VERIFICATION,
 	STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS,
 	STEPS.SITE_MIGRATION_SSH_IN_PROGRESS,
 	STEPS.PICK_SITE,
@@ -153,7 +154,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 					if ( isSSHMigrationAvailable ) {
 						if ( hasDestinationSite && canInstallPlugins ) {
-							return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+							return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
 						}
 
 						if ( hasDestinationSite ) {
@@ -225,7 +226,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 							// Check if this is an SSH migration flow
 							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
 								if ( selectedSiteCanInstallPlugins ) {
-									return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+									return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
 								}
 								return navigate(
 									paths.upgradePlanPath( { siteId, siteSlug, from: fromQueryParam, ssh: 'true' } )
@@ -445,7 +446,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
-						return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
+						return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
 					}
 
 					if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
@@ -453,6 +454,22 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					return navigate( paths.instructionsPath( { siteId, siteSlug, from: fromQueryParam } ) );
+				}
+
+				case STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug: {
+					const { allowSiteMigration } = providedDependencies as {
+						verified: boolean;
+						transferId?: number;
+						allowSiteMigration?: boolean;
+					};
+
+					// If site migration is not allowed, redirect to fallback credentials flow
+					if ( allowSiteMigration === false ) {
+						return navigate( paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } ) );
+					}
+
+					// Otherwise proceed to SSH share access
+					return navigate( paths.sshShareAccessPath( { siteId, siteSlug } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export interface SSHMigrationAtomicTransferStatusResponse {
+	blog_id: number;
+	transfer_id: number;
+	transfer_status: string;
+}
+
+const pollSSHMigrationAtomicTransfer = (
+	siteId: number,
+	transferId: number
+): Promise< SSHMigrationAtomicTransferStatusResponse > =>
+	wpcom.req.get( {
+		path: `/sites/${ siteId }/atomic/transfer-ssh-migration/${ transferId }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+export function usePollSSHMigrationAtomicTransferQueryKey( siteId: number, transferId: number ) {
+	return [ 'sites', siteId, 'atomic', 'transfer-ssh-migration', transferId ];
+}
+
+// Transfer statuses that indicate completion (no need to continue polling)
+const endStates = [ 'completed', 'failed', 'error', 'reverted' ];
+
+interface UsePollSSHMigrationAtomicTransferOptions {
+	enabled?: boolean;
+	refetchInterval?: number;
+}
+
+export const usePollSSHMigrationAtomicTransfer = (
+	siteId: number,
+	transferId: number | null,
+	{
+		enabled = true,
+		refetchInterval = 3000, // Default 3 seconds
+	}: UsePollSSHMigrationAtomicTransferOptions = {}
+) => {
+	const query = useQuery( {
+		queryKey: usePollSSHMigrationAtomicTransferQueryKey( siteId, transferId ?? 0 ),
+		queryFn: () => pollSSHMigrationAtomicTransfer( siteId, transferId ?? 0 ),
+		enabled: enabled && !! siteId && !! transferId,
+		refetchInterval: ( data ) => {
+			// Stop polling if we reach an end state
+			if ( data && endStates.includes( data.transfer_status ) ) {
+				return false;
+			}
+			return refetchInterval;
+		},
+		retry: false,
+	} );
+
+	const isTransferring =
+		query.data && ! endStates.includes( query.data.transfer_status ) ? true : false;
+
+	return {
+		...query,
+		isTransferring,
+		transferStatus: query.data?.transfer_status,
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
@@ -40,9 +40,9 @@ export const usePollSSHMigrationAtomicTransfer = (
 		queryKey: usePollSSHMigrationAtomicTransferQueryKey( siteId, transferId ?? 0 ),
 		queryFn: () => pollSSHMigrationAtomicTransfer( siteId, transferId ?? 0 ),
 		enabled: enabled && !! siteId && !! transferId,
-		refetchInterval: ( data ) => {
+		refetchInterval: ( query ) => {
 			// Stop polling if we reach an end state
-			if ( data && endStates.includes( data.transfer_status ) ) {
+			if ( query.state.data && endStates.includes( query.state.data.transfer_status ) ) {
 				return false;
 			}
 			return refetchInterval;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export interface VerifySSHMigrationAtomicTransferResponse {
+	blog_id: number;
+	transfer_id: number;
+	transfer_status: string;
+	allow_site_migration: boolean;
+}
+
+const verifySSHMigrationAtomicTransfer = (
+	siteId: number
+): Promise< VerifySSHMigrationAtomicTransferResponse > =>
+	wpcom.req.post( {
+		path: `/sites/${ siteId }/atomic/transfer-ssh-migration`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+export function useVerifySSHMigrationAtomicTransferQueryKey( siteId: number ) {
+	return [ 'sites', siteId, 'atomic', 'transfer-ssh-migration' ];
+}
+
+interface UseVerifySSHMigrationAtomicTransferOptions {
+	enabled?: boolean;
+}
+
+export const useVerifySSHMigrationAtomicTransfer = (
+	siteId: number,
+	{ enabled = true }: UseVerifySSHMigrationAtomicTransferOptions = {}
+) => {
+	return useQuery( {
+		queryKey: useVerifySSHMigrationAtomicTransferQueryKey( siteId ),
+		queryFn: () => verifySSHMigrationAtomicTransfer( siteId ),
+		enabled: enabled && !! siteId,
+		retry: false,
+		staleTime: Infinity, // Only fetch once
+	} );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -4,12 +4,14 @@ import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
+import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { urlToDomain } from 'calypso/lib/url';
 import { SupportNudge } from '../site-migration-instructions/support-nudge';
 import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
+import { usePollSSHMigrationAtomicTransfer } from './hooks/use-poll-ssh-migration-atomic-transfer';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
 import type { Step as StepType } from '../../types';
@@ -27,6 +29,16 @@ const SiteMigrationSshShareAccess: StepType< {
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? '';
 	const host = queryParams.get( 'host' ) ?? undefined;
+	const { get } = useFlowState();
+
+	// Get transfer_id from the verification step
+	const transferId = get( 'sshMigration' )?.transferId ?? null;
+
+	// Poll transfer status while user goes through the steps
+	// This keeps the atomic transfer progressing in the background
+	usePollSSHMigrationAtomicTransfer( siteId, transferId, {
+		enabled: !! transferId,
+	} );
 
 	const handleNoSSHAccess = useCallback( () => {
 		navigation.submit?.( { destination: 'no-ssh-access' } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -1,10 +1,9 @@
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
-import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { urlToDomain } from 'calypso/lib/url';
@@ -20,7 +19,7 @@ import './styles.scss';
 
 const SiteMigrationSshShareAccess: StepType< {
 	submits: {
-		destination?: 'migration-started' | 'no-ssh-access';
+		destination?: 'migration-started' | 'no-ssh-access' | 'back-to-verification';
 		how?: ( typeof HOW_TO_MIGRATE_OPTIONS )[ 'DO_IT_FOR_ME' ];
 	};
 } > = function ( { navigation } ) {
@@ -29,10 +28,15 @@ const SiteMigrationSshShareAccess: StepType< {
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? '';
 	const host = queryParams.get( 'host' ) ?? undefined;
-	const { get } = useFlowState();
+	const transferIdParam = queryParams.get( 'transferId' );
+	const transferId = transferIdParam ? parseInt( transferIdParam, 10 ) : null;
 
-	// Get transfer_id from the verification step
-	const transferId = get( 'sshMigration' )?.transferId ?? null;
+	// Redirect back to verification step if transferId is missing
+	useEffect( () => {
+		if ( ! transferId ) {
+			navigation.submit?.( { destination: 'back-to-verification' } );
+		}
+	}, [ transferId, navigation ] );
 
 	// Poll transfer status while user goes through the steps
 	// This keeps the atomic transfer progressing in the background

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -10,7 +10,6 @@ import { urlToDomain } from 'calypso/lib/url';
 import { SupportNudge } from '../site-migration-instructions/support-nudge';
 import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
-import { usePollSSHMigrationAtomicTransfer } from './hooks/use-poll-ssh-migration-atomic-transfer';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
 import type { Step as StepType } from '../../types';
@@ -37,12 +36,6 @@ const SiteMigrationSshShareAccess: StepType< {
 			navigation.submit?.( { destination: 'back-to-verification' } );
 		}
 	}, [ transferId, navigation ] );
-
-	// Poll transfer status while user goes through the steps
-	// This keeps the atomic transfer progressing in the background
-	usePollSSHMigrationAtomicTransfer( siteId, transferId, {
-		enabled: !! transferId,
-	} );
 
 	const handleNoSSHAccess = useCallback( () => {
 		navigation.submit?.( { destination: 'no-ssh-access' } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
@@ -1,0 +1,61 @@
+import { Step } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useVerifySSHMigrationAtomicTransfer } from '../site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer';
+import type { Step as StepType } from '../../types';
+
+const SiteMigrationSshVerification: StepType< {
+	submits: {
+		verified: boolean;
+		transferId?: number;
+		allowSiteMigration?: boolean;
+	};
+} > = function ( { navigation } ) {
+	const site = useSite();
+	const siteId = site?.ID ?? 0;
+	const title = translate( 'Verifying site migration capability' );
+	const { set } = useFlowState();
+
+	// Verify SSH migration atomic transfer capability
+	const {
+		data: verificationData,
+		isError: verificationError,
+		isSuccess,
+	} = useVerifySSHMigrationAtomicTransfer( siteId );
+
+	// Auto-submit when verification completes
+	useEffect( () => {
+		if ( isSuccess && verificationData ) {
+			// Store transfer_id in flow state for polling in SSH share access step
+			set( 'sshMigration', {
+				transferId: verificationData.transfer_id,
+				blogId: verificationData.blog_id,
+				transferStatus: verificationData.transfer_status,
+			} );
+
+			navigation.submit?.( {
+				verified: true,
+				transferId: verificationData.transfer_id,
+				allowSiteMigration: verificationData.allow_site_migration,
+			} );
+		} else if ( verificationError ) {
+			// If verification fails, treat it as not allowed
+			navigation.submit?.( {
+				verified: false,
+				allowSiteMigration: false,
+			} );
+		}
+	}, [ isSuccess, verificationData, verificationError, navigation, set ] );
+
+	return (
+		<>
+			<DocumentHead title={ title } />
+			<Step.Loading title={ title } delay={ 500 } />
+		</>
+	);
+};
+
+export default SiteMigrationSshVerification;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
@@ -1,8 +1,6 @@
 import { Step } from '@automattic/onboarding';
-import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useVerifySSHMigrationAtomicTransfer } from '../site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer';
 import type { Step as StepType } from '../../types';
@@ -16,8 +14,6 @@ const SiteMigrationSshVerification: StepType< {
 } > = function ( { navigation } ) {
 	const site = useSite();
 	const siteId = site?.ID ?? 0;
-	const title = translate( 'Verifying site migration capability' );
-	const { set } = useFlowState();
 
 	// Verify SSH migration atomic transfer capability
 	const {
@@ -29,13 +25,6 @@ const SiteMigrationSshVerification: StepType< {
 	// Auto-submit when verification completes
 	useEffect( () => {
 		if ( isSuccess && verificationData ) {
-			// Store transfer_id in flow state for polling in SSH share access step
-			set( 'sshMigration', {
-				transferId: verificationData.transfer_id,
-				blogId: verificationData.blog_id,
-				transferStatus: verificationData.transfer_status,
-			} );
-
 			navigation.submit?.( {
 				verified: true,
 				transferId: verificationData.transfer_id,
@@ -48,12 +37,12 @@ const SiteMigrationSshVerification: StepType< {
 				allowSiteMigration: false,
 			} );
 		}
-	}, [ isSuccess, verificationData, verificationError, navigation, set ] );
+	}, [ isSuccess, verificationData, verificationError, navigation ] );
 
 	return (
 		<>
-			<DocumentHead title={ title } />
-			<Step.Loading title={ title } delay={ 500 } />
+			<DocumentHead title="" />
+			<Step.Loading delay={ 500 } />
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-verification/index.tsx
@@ -1,6 +1,5 @@
 import { Step } from '@automattic/onboarding';
 import { useEffect } from 'react';
-import DocumentHead from 'calypso/components/data/document-head';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useVerifySSHMigrationAtomicTransfer } from '../site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer';
 import type { Step as StepType } from '../../types';
@@ -41,7 +40,6 @@ const SiteMigrationSshVerification: StepType< {
 
 	return (
 		<>
-			<DocumentHead title="" />
 			<Step.Loading delay={ 500 } />
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -308,6 +308,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-support-instructions' ),
 	},
 
+	SITE_MIGRATION_SSH_VERIFICATION: {
+		slug: 'site-migration-ssh-verification',
+		asyncComponent: () => import( './steps-repository/site-migration-ssh-verification' ),
+	},
+
 	SITE_MIGRATION_SSH_SHARE_ACCESS: {
 		slug: 'site-migration-ssh-share-access',
 		asyncComponent: () => import( './steps-repository/site-migration-ssh-share-access' ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15015

## Proposed Changes

* Add a new Verification step, to ensure the site can be migrated. 
* In combination with 194502-ghe-Automattic/wpcom, we only take the user to the SSH Migration flow if the site has the `allow_site_migration` meta, or if the site is simple. 
* In case the site is simple, we start the transfer to Atomic.
* Added the polling hook, but it's not being used yet.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I decided to abstract the logic for verifying the state of the site on a separate step, so it can have a clear porpouse and leave the "Securely share your access" as clean as possible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Apply 194502-ghe-Automattic/wpcom to your sandbox
* Go through the migration flow, with:
  * A new simple site, that should start to be transferred to Atomic once you reach the `Securely share your access`
  * A existing Atomic site provisioned in some other flow that is not the SSH Migration(so it don't have the allow_site_migration meta). You should be redirected to the credentials step. 
  * A existing Atomic site provisioned on the SSH Migration, which has the `allow_site_migratino` meta. You should reach the `Securely share your access` step.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?