### PR TITLE
SSH Migration: Add Host Lookup when analyzing the URL

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -199,8 +199,8 @@ export const sshVerificationPath = buildPathHelper<
 		queryParams: {
 			siteId?: number | string;
 			siteSlug: string;
-			from?: string;
-			host?: string;
+			from?: string | null;
+			host?: string | null;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug
@@ -212,8 +212,8 @@ export const sshShareAccessPath = buildPathHelper<
 			siteId?: number | string;
 			siteSlug: string;
 			transferId?: number | string;
-			from?: string;
-			host?: string;
+			from?: string | null;
+			host?: string | null;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -46,6 +46,7 @@ export const siteCreationPath = buildPathHelper<
 			from?: string | null;
 			platform: ImporterPlatform;
 			ssh?: string;
+			host?: string;
 		};
 	},
 	typeof STEPS.SITE_CREATION_STEP.slug
@@ -53,7 +54,7 @@ export const siteCreationPath = buildPathHelper<
 
 export const sitePickerPath = buildPathHelper<
 	{
-		queryParams: { from: string | null; platform: ImporterPlatform; ssh?: string };
+		queryParams: { from: string | null; platform: ImporterPlatform; ssh?: string; host?: string };
 	},
 	typeof STEPS.PICK_SITE.slug
 >( STEPS.PICK_SITE.slug );
@@ -113,6 +114,7 @@ export const upgradePlanPath = buildPathHelper<
 			destination?: string;
 			how?: string;
 			ssh?: string;
+			host?: string;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
@@ -197,6 +199,8 @@ export const sshVerificationPath = buildPathHelper<
 		queryParams: {
 			siteId?: number | string;
 			siteSlug: string;
+			from?: string;
+			host?: string;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_SSH_VERIFICATION.slug
@@ -208,6 +212,8 @@ export const sshShareAccessPath = buildPathHelper<
 			siteId?: number | string;
 			siteSlug: string;
 			transferId?: number | string;
+			from?: string;
+			host?: string;
 		};
 	},
 	typeof STEPS.SITE_MIGRATION_SSH_SHARE_ACCESS.slug

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -14,6 +14,7 @@ import {
 	getFullImporterUrl,
 } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { type SiteMigrationIdentifyAction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify';
+import { isHostingSupportedForSSHMigration } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation';
 import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { goToImporter } from 'calypso/landing/stepper/declarative-flow/migration/helpers';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
@@ -23,6 +24,7 @@ import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -143,29 +145,45 @@ const siteMigration: FlowV2< typeof initialize > = {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
-					const { from, platform, action } = providedDependencies as {
+					const { from, platform, action, host } = providedDependencies as {
 						from: string;
 						platform: ImporterPlatform;
 						action: SiteMigrationIdentifyAction;
+						host?: string;
 					};
 					const hasDestinationSite = hasSite( siteId, siteSlug );
-					// TODO: Remove the call and use a actual check for the hosting
 					const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 
-					if ( isSSHMigrationAvailable ) {
+					// Check if hosting provider is supported for SSH migration
+					const isHostingSupported = isHostingSupportedForSSHMigration( host );
+
+					// Track hosting provider detection
+					recordTracksEvent( 'calypso_site_migration_hosting_detected', {
+						hosting_provider: host || 'unknown',
+						is_ssh_supported: isHostingSupported,
+						ssh_feature_enabled: isSSHMigrationAvailable,
+						redirected_to_ssh: isSSHMigrationAvailable && isHostingSupported,
+					} );
+
+					// SSH migration is ONLY available if feature flag is enabled AND hosting is supported
+					const canUseSSHMigration = isSSHMigrationAvailable && isHostingSupported;
+
+					if ( canUseSSHMigration ) {
 						if ( hasDestinationSite && canInstallPlugins ) {
-							return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+							return navigate( paths.sshVerificationPath( { siteId, siteSlug, from, host } ) );
 						}
 
 						if ( hasDestinationSite ) {
-							return navigate( paths.upgradePlanPath( { siteId, siteSlug, from, ssh: 'true' } ) );
+							return navigate(
+								paths.upgradePlanPath( { siteId, siteSlug, from, ssh: 'true', host } )
+							);
 						}
 
 						if ( userHasOtherWPComSites ) {
-							return navigate( paths.sitePickerPath( { from, platform, ssh: 'true' } ) );
+							return navigate( paths.sitePickerPath( { from, platform, ssh: 'true', host } ) );
 						}
 
-						return navigate( paths.siteCreationPath( { from, platform, ssh: 'true' } ) );
+						return navigate( paths.siteCreationPath( { from, platform, ssh: 'true', host } ) );
 					}
 
 					if ( hasDestinationSite ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -117,6 +117,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const actionQueryParam = urlQueryParams.get( 'action' );
 		const platformQueryParam = ( urlQueryParams.get( 'platform' ) ||
 			'unknown' ) as ImporterPlatform;
+		const hostQueryParam = urlQueryParams.get( 'host' ) ?? undefined;
 		const { get, sessionId } = useFlowState();
 		const userHasOtherWPComSites = siteCount && siteCount > 1;
 		const entryPoint = get( 'flow' )?.entryPoint;
@@ -244,10 +245,23 @@ const siteMigration: FlowV2< typeof initialize > = {
 							// Check if this is an SSH migration flow
 							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
 								if ( selectedSiteCanInstallPlugins ) {
-									return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+									return navigate(
+										paths.sshVerificationPath( {
+											siteId,
+											siteSlug,
+											from: fromQueryParam,
+											host: hostQueryParam,
+										} )
+									);
 								}
 								return navigate(
-									paths.upgradePlanPath( { siteId, siteSlug, from: fromQueryParam, ssh: 'true' } )
+									paths.upgradePlanPath( {
+										siteId,
+										siteSlug,
+										from: fromQueryParam,
+										ssh: 'true',
+										host: hostQueryParam,
+									} )
 								);
 							}
 
@@ -444,6 +458,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 								siteSlug,
 								from: fromQueryParam,
 								siteId,
+								host: hostQueryParam,
 							},
 							`/setup/${ flowPath }/${ redirectAfterCheckout }`
 						);
@@ -465,7 +480,14 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
-						return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+						return navigate(
+							paths.sshVerificationPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam,
+								host: hostQueryParam,
+							} )
+						);
 					}
 
 					if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
@@ -488,7 +510,15 @@ const siteMigration: FlowV2< typeof initialize > = {
 					}
 
 					// Otherwise proceed to SSH share access
-					return navigate( paths.sshShareAccessPath( { siteId, siteSlug, transferId } ) );
+					return navigate(
+						paths.sshShareAccessPath( {
+							siteId,
+							siteSlug,
+							transferId,
+							from: fromQueryParam,
+							host: hostQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
@@ -618,7 +648,14 @@ const siteMigration: FlowV2< typeof initialize > = {
 
 					// Missing transferId, redirect back to verification
 					if ( destination === 'back-to-verification' ) {
-						return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+						return navigate(
+							paths.sshVerificationPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam,
+								host: hostQueryParam,
+							} )
+						);
 					}
 
 					// User doesn't have SSH access, redirect to credentials flow

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -117,7 +117,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const actionQueryParam = urlQueryParams.get( 'action' );
 		const platformQueryParam = ( urlQueryParams.get( 'platform' ) ||
 			'unknown' ) as ImporterPlatform;
-		const hostQueryParam = urlQueryParams.get( 'host' ) ?? undefined;
+		const hostQueryParam = urlQueryParams.get( 'host' ) || undefined;
 		const { get, sessionId } = useFlowState();
 		const userHasOtherWPComSites = siteCount && siteCount > 1;
 		const entryPoint = get( 'flow' )?.entryPoint;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -1,0 +1,15 @@
+import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
+
+/**
+ * Checks if a hosting provider is supported for SSH migration
+ * @param hostingSlug - The hosting provider slug (e.g., 'digitalocean', 'bluehost')
+ * @returns true if the hosting provider is in the supported list
+ */
+export const isHostingSupportedForSSHMigration = ( hostingSlug?: string ): boolean => {
+	if ( ! hostingSlug ) {
+		return false;
+	}
+
+	const normalizedSlug = hostingSlug.toLowerCase().trim();
+	return normalizedSlug in SSH_HOST_DISPLAY_NAMES;
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15007

## Proposed Changes

* Updates the `Analyzer` step to also check for the host.
* Updates the navigation to take the host parameter to the `Securely share your access` step.
* Now the message and support documentation should be customized for the host.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to identify the site's host so we can know if we can redirect the user to the SSH Migration flow. Beyond that we also use the host to customize the messages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow with a fresh simple site until you reach the `Securely share your access`
* Once you reach the `Securely share your access` verify that subtitle mentions the correct host for your site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
