### PR TITLE
MSD: Add app-level site settings configuration

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -19,6 +19,13 @@ boot( {
 			scan: true,
 			domains: false,
 			emails: false,
+			settings: {
+				general: {
+					redirect: false,
+				},
+				server: false,
+				security: false,
+			},
 		},
 		domains: false,
 		emails: false,

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -19,6 +19,13 @@ boot( {
 			scan: false,
 			domains: true,
 			emails: false,
+			settings: {
+				general: {
+					redirect: false,
+				},
+				server: false,
+				security: false,
+			},
 		},
 		domains: true,
 		emails: true,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -18,6 +18,13 @@ boot( {
 			scan: true,
 			domains: true,
 			emails: true,
+			settings: {
+				general: {
+					redirect: true,
+				},
+				server: true,
+				security: true,
+			},
 		},
 		domains: true,
 		emails: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,5 +1,15 @@
 import { createContext, useContext } from 'react';
 
+export type SiteSettingsGeneralSupports = {
+	redirect: boolean;
+};
+
+export type SiteSettingsSupports = {
+	general: SiteSettingsGeneralSupports;
+	server: boolean;
+	security: boolean;
+};
+
 export type SiteFeatureSupports = {
 	deployments: boolean;
 	performance: boolean;
@@ -9,6 +19,7 @@ export type SiteFeatureSupports = {
 	scan: boolean;
 	domains: boolean;
 	emails: boolean;
+	settings: SiteSettingsSupports | false;
 };
 
 export type MeSupports = {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1136,30 +1136,6 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 	const siteRoutes: AnyRoute[] = [
 		siteOverviewRoute,
-		siteSettingsRoute.addChildren( [
-			siteSettingsIndexRoute,
-			siteSettingsSiteVisibilityRoute,
-			siteSettingsSubscriptionGiftingRoute,
-			siteSettingsDatabaseRoute,
-			siteSettingsWordPressRoute,
-			siteSettingsPHPRoute,
-			siteSettingsAgencyRoute,
-			siteSettingsRepositoriesRoute.addChildren( [
-				siteSettingsRepositoriesIndexRoute,
-				siteSettingsRepositoriesConnectRoute,
-				siteSettingsRepositoriesManageRoute,
-			] ),
-			siteSettingsHundredYearPlanRoute,
-			siteSettingsPrimaryDataCenterRoute,
-			siteSettingsStaticFile404Route,
-			siteSettingsCachingRoute,
-			siteSettingsDefensiveModeRoute,
-			siteSettingsTransferSiteRoute,
-			siteSettingsSftpSshRoute,
-			siteSettingsWebApplicationFirewallRoute,
-			siteSettingsWpcomLoginRoute,
-			siteSettingsRedirectRoute,
-		] ),
 		siteTrialEndedRoute,
 		siteDifmLiteInProgressRoute,
 		siteMigrationOverviewRoute,
@@ -1213,6 +1189,56 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 
 	if ( config.supports.sites.domains ) {
 		siteRoutes.push( siteDomainsRoute );
+	}
+
+	if ( config.supports.sites.settings ) {
+		const settingsRoutes: AnyRoute[] = [ siteSettingsIndexRoute ];
+
+		if ( config.supports.sites.settings.general ) {
+			const settingsGeneralRoutes: AnyRoute[] = [
+				siteSettingsSiteVisibilityRoute,
+				siteSettingsSubscriptionGiftingRoute,
+				siteSettingsAgencyRoute,
+				siteSettingsHundredYearPlanRoute,
+			];
+
+			if ( config.supports.sites.settings.general.redirect ) {
+				settingsGeneralRoutes.push( siteSettingsRedirectRoute );
+			}
+
+			settingsRoutes.push( ...settingsGeneralRoutes );
+		}
+
+		if ( config.supports.sites.settings.server ) {
+			settingsRoutes.push(
+				...[
+					siteSettingsWordPressRoute,
+					siteSettingsPHPRoute,
+					siteSettingsSftpSshRoute,
+					siteSettingsRepositoriesRoute.addChildren( [
+						siteSettingsRepositoriesIndexRoute,
+						siteSettingsRepositoriesConnectRoute,
+						siteSettingsRepositoriesManageRoute,
+					] ),
+					siteSettingsDatabaseRoute,
+					siteSettingsPrimaryDataCenterRoute,
+					siteSettingsStaticFile404Route,
+					siteSettingsCachingRoute,
+				]
+			);
+		}
+
+		if ( config.supports.sites.settings.security ) {
+			settingsRoutes.push(
+				...[
+					siteSettingsWebApplicationFirewallRoute,
+					siteSettingsWpcomLoginRoute,
+					siteSettingsDefensiveModeRoute,
+				]
+			);
+		}
+
+		siteRoutes.push( siteSettingsRoute.addChildren( settingsRoutes ) );
 	}
 
 	return [

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -2,6 +2,7 @@ import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
@@ -24,44 +25,84 @@ import WordPressSettingsSummary from '../settings-wordpress/summary';
 import WpcomLoginSettingsSummary from '../settings-wpcom-login/summary';
 import DangerZone from './danger-zone';
 import SiteActions from './site-actions';
+import type { SiteSettingsGeneralSupports } from '../../app/context';
+import type { Site, SiteSettings } from '@automattic/api-core';
+
+const renderGeneralSettingsButtonList = (
+	supports: SiteSettingsGeneralSupports,
+	site: Site,
+	settings?: SiteSettings
+) => {
+	const buttonList = [ <SiteVisibilitySettingsSummary key="site-visibility" site={ site } /> ];
+
+	if ( supports.redirect ) {
+		buttonList.push( <SiteRedirectSettingsSummary key="site-redirect" site={ site } /> );
+	}
+
+	buttonList.push(
+		...[
+			<SubscriptionGiftingSettingsSummary
+				key="subscription-gifting"
+				site={ site }
+				settings={ settings }
+			/>,
+			<AgencySettingsSummary key="agency" site={ site } />,
+			<HundredYearPlanSettingsSummary
+				key="hundred-year-plan"
+				site={ site }
+				settings={ settings }
+			/>,
+		]
+	);
+
+	return buttonList;
+};
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { supports } = useAppContext();
+	const supportsSettings = supports.sites && supports.sites.settings;
+
+	if ( ! supportsSettings ) {
+		return null;
+	}
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
-			<VStack spacing={ 3 }>
-				<SectionHeader title={ __( 'General' ) } level={ 3 } />
-				<SummaryButtonList>
-					<SiteVisibilitySettingsSummary site={ site } />
-					<SiteRedirectSettingsSummary site={ site } />
-					<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
-					<AgencySettingsSummary site={ site } />
-					<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
-				</SummaryButtonList>
-			</VStack>
-			<VStack spacing={ 3 }>
-				<SectionHeader title={ __( 'Server' ) } level={ 3 } />
-				<SummaryButtonList>
-					<WordPressSettingsSummary site={ site } />
-					<PHPSettingsSummary site={ site } />
-					<SftpSshSettingsSummary site={ site } />
-					<RepositoriesSettingsSummary site={ site } />
-					<DatabaseSettingsSummary site={ site } />
-					<PrimaryDataCenterSettingsSummary site={ site } />
-					<StaticFile404SettingsSummary site={ site } />
-					<CachingSettingsSummary site={ site } />
-				</SummaryButtonList>
-			</VStack>
-			<VStack spacing={ 3 }>
-				<SectionHeader title={ __( 'Security' ) } level={ 3 } />
-				<SummaryButtonList>
-					<WebApplicationFirewallSettingsSummary site={ site } />
-					<WpcomLoginSettingsSummary site={ site } />
-					<DefensiveModeSettingsSummary site={ site } />
-				</SummaryButtonList>
-			</VStack>
+			{ supportsSettings.general && (
+				<VStack spacing={ 3 }>
+					<SectionHeader title={ __( 'General' ) } level={ 3 } />
+					<SummaryButtonList>
+						{ renderGeneralSettingsButtonList( supportsSettings.general, site, settings ) }
+					</SummaryButtonList>
+				</VStack>
+			) }
+			{ supportsSettings.server && (
+				<VStack spacing={ 3 }>
+					<SectionHeader title={ __( 'Server' ) } level={ 3 } />
+					<SummaryButtonList>
+						<WordPressSettingsSummary site={ site } />
+						<PHPSettingsSummary site={ site } />
+						<SftpSshSettingsSummary site={ site } />
+						<RepositoriesSettingsSummary site={ site } />
+						<DatabaseSettingsSummary site={ site } />
+						<PrimaryDataCenterSettingsSummary site={ site } />
+						<StaticFile404SettingsSummary site={ site } />
+						<CachingSettingsSummary site={ site } />
+					</SummaryButtonList>
+				</VStack>
+			) }
+			{ supportsSettings.security && (
+				<VStack spacing={ 3 }>
+					<SectionHeader title={ __( 'Security' ) } level={ 3 } />
+					<SummaryButtonList>
+						<WebApplicationFirewallSettingsSummary site={ site } />
+						<WpcomLoginSettingsSummary site={ site } />
+						<DefensiveModeSettingsSummary site={ site } />
+					</SummaryButtonList>
+				</VStack>
+			) }
 			<SiteActions site={ site } />
 			<DangerZone site={ site } />
 		</PageLayout>


### PR DESCRIPTION
## Proposed Changes

As discussed in p1761133256103549-slack-C09JEQLTH8R, we want to remove some site settings for CIAB. That is, to just keep Site Visibility setting, and the Danger Zone.

<img width="751" height="558" alt="SCR-20251023-jvsc" src="https://github.com/user-attachments/assets/206b4892-b0ac-42ef-8215-b6ddfe068b97" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

CIAB-MSD

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a site and click on the Settings tab
* Ensure that it works as before, and every button navigates to the expected screen
* Head to /ciab
* Select a site and click on the Settings tab
* Ensure that it only displays the expected settings, and every button navigates to the expected screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?