### PR TITLE
MSD: Make Switcher support searchable fields to search URL

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,6 +1,7 @@
 import { Dropdown, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import SwitcherContent, { type RenderItemIcon } from './switcher-content';
+import type { Field } from '@wordpress/dataviews';
 import type { ComponentProps } from 'react';
 
 interface RenderCallbackProps {
@@ -10,6 +11,7 @@ interface RenderCallbackProps {
 type SwitcherProps< T > = {
 	items?: T[];
 	value: T;
+	searchableFields?: Field< T >[];
 	children?: ( props: RenderCallbackProps ) => React.ReactNode;
 	getItemName: ( item: T ) => string;
 	getItemUrl: ( item: T ) => string;
@@ -19,6 +21,7 @@ type SwitcherProps< T > = {
 export default function Switcher< T >( {
 	items,
 	value,
+	searchableFields,
 	children,
 	getItemName,
 	getItemUrl,
@@ -56,6 +59,7 @@ export default function Switcher< T >( {
 			renderContent={ ( { onClose } ) => (
 				<SwitcherContent
 					items={ items }
+					searchableFields={ searchableFields }
 					getItemName={ getItemName }
 					getItemUrl={ getItemUrl }
 					renderItemIcon={ renderItemIcon }

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -46,7 +46,6 @@ export default function SwitcherContent< T >( {
 			...searchableFields.map( ( searchableField ) => ( {
 				...searchableField,
 				enableGlobalSearch: true,
-				isVisible: () => false,
 			} ) ),
 		];
 	}, [ searchableFields, getItemName ] );

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -3,7 +3,7 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { type PropsWithChildren, type ReactNode, useMemo, useState } from 'react';
 import RouterLinkMenuItem from '../router-link-menu-item';
-import type { View } from '@wordpress/dataviews';
+import type { View, Field } from '@wordpress/dataviews';
 
 const DEFAULT_VIEW: View = {
 	type: 'list',
@@ -20,6 +20,7 @@ export type RenderItemIcon< T > = ( props: {
 
 export default function SwitcherContent< T >( {
 	items,
+	searchableFields = [],
 	getItemName,
 	getItemUrl,
 	renderItemIcon,
@@ -27,6 +28,7 @@ export default function SwitcherContent< T >( {
 	onClose,
 }: PropsWithChildren< {
 	items?: T[];
+	searchableFields?: Field< T >[];
 	getItemName: ( item: T ) => string;
 	getItemUrl: ( item: T ) => string;
 	renderItemIcon: RenderItemIcon< T >;
@@ -41,8 +43,13 @@ export default function SwitcherContent< T >( {
 				getValue: ( { item }: { item: T } ) => getItemName( item ),
 				enableGlobalSearch: true,
 			},
+			...searchableFields.map( ( searchableField ) => ( {
+				...searchableField,
+				enableGlobalSearch: true,
+				isVisible: () => false,
+			} ) ),
 		];
-	}, [ getItemName ] );
+	}, [ searchableFields, getItemName ] );
 
 	if ( ! items ) {
 		return __( 'Loading…' );

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -11,6 +11,15 @@ import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import Switcher from '../../components/switcher';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import type { Site } from '@automattic/api-core';
+
+const searchableFields = [
+	{
+		id: 'URL',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
+	},
+];
 
 const CIABSiteSwitcher = () => {
 	const { recordTracksEvent } = useAnalytics();
@@ -44,6 +53,7 @@ const CIABSiteSwitcher = () => {
 		<Switcher
 			items={ sites }
 			value={ site }
+			searchableFields={ searchableFields }
 			getItemName={ getSiteDisplayName }
 			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
 			renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -15,7 +15,16 @@ import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import Switcher from '../../components/switcher';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import AddNewSite from '../add-new-site';
+import type { Site } from '@automattic/api-core';
+
+const searchableFields = [
+	{
+		id: 'URL',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
+	},
+];
 
 const SiteSwitcher = () => {
 	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
@@ -30,6 +39,7 @@ const SiteSwitcher = () => {
 			<Switcher
 				items={ sites }
 				value={ site }
+				searchableFields={ searchableFields }
 				getItemName={ getSiteDisplayName }
 				getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
 				renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-712

## Proposed Changes

* Enhance `Switcher` to support `searchableFields`, allowing consumers to specify which fields are searchable

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Select any site
* Open the site switcher on the menu
* Search for the site URL
* Ensure you can see the result

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
