### PR TITLE
Site monitoring: unify card header styles

### DIFF
--- a/client/dashboard/sites/monitoring-card/index.tsx
+++ b/client/dashboard/sites/monitoring-card/index.tsx
@@ -1,13 +1,7 @@
-import {
-	Card,
-	CardBody,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	Spinner,
-} from '@wordpress/components';
+import { Card, CardBody, __experimentalVStack as VStack, Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import { Text } from '../../components/text';
+import { SectionHeader } from '../../components/section-header';
 import type { ReactNode } from 'react';
 import './style.scss';
 
@@ -30,13 +24,6 @@ export default function MonitoringCard( {
 	cardLabel,
 	className,
 }: MonitoringCardProps ) {
-	const renderDescription = () => {
-		if ( description ) {
-			return description;
-		}
-		return <>&nbsp;</>;
-	};
-
 	const renderContent = () => {
 		if ( isLoading ) {
 			return <Spinner />;
@@ -44,19 +31,6 @@ export default function MonitoringCard( {
 
 		return children;
 	};
-
-	const topContent = (
-		<HStack justify="space-between" alignment="flex-start">
-			<VStack spacing={ 4 } className="dashboard-monitoring-card__header">
-				<Text weight="bold" size="15px">
-					{ title }
-				</Text>
-				<HStack justify="flex-start" alignment="baseline">
-					<Text variant="muted">{ renderDescription() }</Text>
-				</HStack>
-			</VStack>
-		</HStack>
-	);
 
 	const contentClassNames = clsx(
 		'dashboard-monitoring-card__content',
@@ -74,7 +48,7 @@ export default function MonitoringCard( {
 							properties={ { feature: tracksId } }
 						/>
 					) }
-					{ topContent }
+					<SectionHeader level={ 3 } title={ title } description={ description } />
 					{ children && (
 						<VStack className={ contentClassNames } spacing={ 2 } justify="space-between">
 							{ renderContent() }


### PR DESCRIPTION

## Proposed Changes

Use `<SectionHeader>` in Site monitoring cards, so that the design matches with the rest of the dashboard.

|Before|After|
|-|-|
|<img width="415" height="209" alt="image" src="https://github.com/user-attachments/assets/5edc24a6-aae5-42e0-bf30-079e93820eca" />|<img width="453" height="207" alt="image" src="https://github.com/user-attachments/assets/aa7b4ce7-a278-4e62-b96f-053e1b09638b" />


## Why are these changes being made?

Fit 'n finish.

## Testing Instructions

Go to /v2/sites/:siteSlug/monitoring of an Atomic site; verify you see the above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
