### PR TITLE
Deployments: `Back to deployments` button overlapping with snackbar notifications

### DIFF
--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -10,6 +10,6 @@
 	margin: $grid-unit-20;
 }
 
-body:has( .repositories-back-button ) .dashboard-snackbars {
+body:has( .back-to-deployments-button ) .dashboard-snackbars {
 	margin-bottom: calc( $grid-unit-20 + 52px );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related discussion: https://github.com/Automattic/wp-calypso/pull/106611#issuecomment-3435706878

## Proposed Changes

* update class name in the snackbar notification selector from `repositories-back-button` to `back-to-deployments-button`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix small regressions of overlapping snackbar notifications with the `Back to Deployments` button.

Before:

https://github.com/user-attachments/assets/2ef3c495-960a-4c3c-ba9e-29f516ffffc2

After:

<img width="1208" height="564" alt="Markup on 2025-10-23 at 10:04:44" src="https://github.com/user-attachments/assets/63f0135b-f2d1-4148-b306-59f437b2454a" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual check should be enough: the new class should match the component class updated in https://github.com/Automattic/wp-calypso/pull/106611.

If you would like to test:

1. Check out PR branch and build the app with `yarn && yarn start` (or use the Calypso Live link below).
2. Head over to the V2 Hosting Dashboard and trigger any snackbar notification. For example, you can initiate a statging site sync and wait for it to finish.
3. With GitHub Deployments set up, navigate to one of the repositories from the Deployments tab:

<img width="1548" height="954" alt="Markup on 2025-10-23 at 10:20:46" src="https://github.com/user-attachments/assets/9f18202d-8a2e-4af8-9426-84810cfbea08" />

4. The back button should not overlap with the snackbar notification.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
