### PR TITLE
Notifications Settings: Add missing period when there is no site

### DIFF
--- a/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
@@ -55,7 +55,7 @@ export const SiteListSettings = () => {
 							{ createInterpolateElement(
 								sprintf(
 									// translators: %s is the search query
-									__( 'No sites found with the search query <strong>%(search)s</strong>' ),
+									__( 'No sites found with the search query <strong>%(search)s</strong>.' ),
 									{
 										search: search,
 									}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTMSD-699



## Proposed Changes
* Add a missing period 


<img width="1678" height="1144" alt="CleanShot 2025-10-23 at 09 18 54@2x" src="https://github.com/user-attachments/assets/cd32a105-799d-46ab-9208-51cce9308f89" />



## Testing Instructions
* Go to `/v2/me/notifications/sites`
* Search for any crazy value. E.g `ddddddd`
* Check there is a period as the screenshot above demonstrates. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
