### PR TITLE
Hosting Dashboard Emails: Professional email - Add footer

### DIFF
--- a/client/dashboard/emails/add-professional-email/components/cart.scss
+++ b/client/dashboard/emails/add-professional-email/components/cart.scss
@@ -1,0 +1,31 @@
+.cart__cushion {
+	margin-top: 36px;
+	height: 80px;
+}
+
+.cart__container {
+	position: fixed !important;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 80px;
+}
+
+.cart {
+	justify-content: center;
+	align-items: center;
+	padding-inline: 24px;
+	display: flex;
+	box-sizing: border-box;
+	height: 100%;
+}
+
+.cart__content {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: var( --page-layout-max-width );
+}
+
+.cart-summary__total {
+	font-size: 1.125rem !important; /* stylelint-disable-line scales/font-sizes */
+}

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -22,11 +22,6 @@ const animation = {
 		display: 'flex',
 		opacity: 1,
 	},
-	animateOut: {
-		y: '100%',
-		display: 'none',
-		opacity: 0,
-	},
 };
 
 export const Cart = ( {

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -1,0 +1,87 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__unstableMotion as motion,
+	Card,
+} from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { Text } from '../../../components/text';
+
+import './style.scss';
+
+const animation = {
+	initial: {
+		y: '100%',
+		display: 'none',
+		opacity: 0,
+	},
+	animateIn: {
+		y: 0,
+		display: 'flex',
+		opacity: 1,
+	},
+	animateOut: {
+		y: '100%',
+		display: 'none',
+		opacity: 0,
+	},
+};
+
+export const Cart = ( {
+	className,
+	totalItems,
+	totalPrice,
+	isCartBusy,
+}: {
+	className?: string;
+	totalItems: number;
+	totalPrice: string;
+	isCartBusy: boolean;
+} ) => {
+	const mailboxCount = sprintf(
+		// translators: %(mailboxes)s is the number of mailboxes selected.
+		_n( '%(mailboxes)s mailbox', '%(mailboxes)s mailboxes', totalItems ),
+		{
+			mailboxes: totalItems,
+		}
+	);
+
+	return (
+		<>
+			<div className="cart__cushion" />
+			<motion.div
+				className={ clsx( 'cart__container', className ) }
+				initial={ animation.initial }
+				animate={ animation.animateIn }
+				transition={ { type: 'tween', duration: 0.25 } }
+			>
+				<Card isRounded={ false } elevation={ 2 } style={ { width: '100%' } }>
+					<div className="cart">
+						<div className="cart__content">
+							<HStack spacing={ 2 }>
+								<VStack spacing={ 2 } alignment="left">
+									<Text size="footnote">{ mailboxCount }</Text>
+									<Text className="cart-summary__total">{ totalPrice }</Text>
+								</VStack>
+
+								<HStack spacing={ 4 } style={ { width: 'auto' } }>
+									<Button
+										variant="primary"
+										__next40pxDefaultSize
+										disabled={ isCartBusy }
+										type="submit"
+									>
+										{ __( 'Continue' ) }
+									</Button>
+								</HStack>
+							</HStack>
+						</div>
+					</div>
+				</Card>
+			</motion.div>
+		</>
+	);
+};

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -52,25 +52,23 @@ export const Cart = ( {
 			>
 				<Card isRounded={ false } elevation={ 2 } style={ { width: '100%' } }>
 					<div className="cart">
-						<div className="cart__content">
-							<HStack spacing={ 2 }>
-								<VStack spacing={ 2 } alignment="left">
-									<Text size="footnote">{ mailboxCount }</Text>
-									<Text className="cart-summary__total">{ totalPrice }</Text>
-								</VStack>
+						<HStack className="cart__content" spacing={ 2 }>
+							<VStack spacing={ 2 } alignment="left">
+								<Text size="footnote">{ mailboxCount }</Text>
+								<Text className="cart-summary__total">{ totalPrice }</Text>
+							</VStack>
 
-								<HStack spacing={ 4 } style={ { width: 'auto' } }>
-									<Button
-										variant="primary"
-										__next40pxDefaultSize
-										disabled={ isCartBusy }
-										type="submit"
-									>
-										{ __( 'Continue' ) }
-									</Button>
-								</HStack>
+							<HStack spacing={ 4 } style={ { width: 'auto' } }>
+								<Button
+									variant="primary"
+									__next40pxDefaultSize
+									disabled={ isCartBusy }
+									type="submit"
+								>
+									{ __( 'Continue' ) }
+								</Button>
 							</HStack>
-						</div>
+						</HStack>
 					</div>
 				</Card>
 			</motion.div>

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -58,16 +58,9 @@ export const Cart = ( {
 								<Text className="cart-summary__total">{ totalPrice }</Text>
 							</VStack>
 
-							<HStack spacing={ 4 } style={ { width: 'auto' } }>
-								<Button
-									variant="primary"
-									__next40pxDefaultSize
-									disabled={ isCartBusy }
-									type="submit"
-								>
-									{ __( 'Continue' ) }
-								</Button>
-							</HStack>
+							<Button variant="primary" __next40pxDefaultSize disabled={ isCartBusy } type="submit">
+								{ __( 'Continue' ) }
+							</Button>
 						</HStack>
 					</div>
 				</Card>

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -9,7 +9,7 @@ import {
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Text } from '../../../components/text';
 
-import './style.scss';
+import './cart.scss';
 
 const animation = {
 	initial: {

--- a/client/dashboard/emails/add-professional-email/components/cart.tsx
+++ b/client/dashboard/emails/add-professional-email/components/cart.tsx
@@ -7,7 +7,6 @@ import {
 	Card,
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import clsx from 'clsx';
 import { Text } from '../../../components/text';
 
 import './style.scss';
@@ -31,12 +30,10 @@ const animation = {
 };
 
 export const Cart = ( {
-	className,
 	totalItems,
 	totalPrice,
 	isCartBusy,
 }: {
-	className?: string;
 	totalItems: number;
 	totalPrice: string;
 	isCartBusy: boolean;
@@ -53,7 +50,7 @@ export const Cart = ( {
 		<>
 			<div className="cart__cushion" />
 			<motion.div
-				className={ clsx( 'cart__container', className ) }
+				className="cart__container"
 				initial={ animation.initial }
 				animate={ animation.animateIn }
 				transition={ { type: 'tween', duration: 0.25 } }

--- a/client/dashboard/emails/add-professional-email/components/mailbox-form.tsx
+++ b/client/dashboard/emails/add-professional-email/components/mailbox-form.tsx
@@ -27,10 +27,12 @@ import './style.scss';
 export const MailboxForm = ( {
 	mailboxEntity,
 	disabled = false,
+	onChange,
 	removeForm = undefined,
 }: {
 	mailboxEntity: MailboxFormEntity< SupportedEmailProvider >;
 	disabled: boolean;
+	onChange: () => void;
 	removeForm?: () => void;
 } ) => {
 	const { domainName } = useDomainFromUrlParam();
@@ -62,7 +64,7 @@ export const MailboxForm = ( {
 		field.dispatchState();
 	};
 
-	const onChange = ( {
+	const changeHandler = ( {
 		value,
 		field,
 		lowerCaseChangeValue = false,
@@ -84,6 +86,8 @@ export const MailboxForm = ( {
 		field.dispatchState();
 
 		onFieldValueChanged( field );
+
+		onChange();
 	};
 
 	return (
@@ -100,7 +104,7 @@ export const MailboxForm = ( {
 					</InputControlSuffixWrapper>
 				}
 				onBlur={ onBlur }
-				onChange={ onChange }
+				onChange={ changeHandler }
 			/>
 
 			<VStack>
@@ -123,7 +127,7 @@ export const MailboxForm = ( {
 					// Hint to LastPass not to attempt autofill
 					data-lpignore="true"
 					onBlur={ onBlur }
-					onChange={ onChange }
+					onChange={ changeHandler }
 				/>
 
 				{ ! isPasswordResetEmailVisible && (
@@ -161,7 +165,7 @@ export const MailboxForm = ( {
 					label={ __( 'Password reset email address' ) }
 					disabled={ disabled }
 					onBlur={ onBlur }
-					onChange={ onChange }
+					onChange={ changeHandler }
 				/>
 			) }
 

--- a/client/dashboard/emails/add-professional-email/components/pricing-notice.tsx
+++ b/client/dashboard/emails/add-professional-email/components/pricing-notice.tsx
@@ -7,19 +7,11 @@ import { add } from 'date-fns';
 import { useLocale } from '../../../app/locale';
 import { Text } from '../../../components/text';
 import { formatDate } from '../../../utils/datetime';
+import { doesAdditionalPriceMatchStandardPrice } from '../../utils/does-additional-price-match-standard-price';
 import { getTitanExpiryDate } from '../../utils/get-titan-expiry-date';
 import { isDomainEligibleForTitanIntroductoryOffer } from '../../utils/is-domain-eligible-for-titan-introductory-offer';
 import { isMonthlyEmailProduct } from '../../utils/is-monthly-email-product';
 import { isUserOnTitanFreeTrial } from '../../utils/is-user-on-titan-free-trial';
-
-const doesAdditionalPriceMatchStandardPrice = (
-	mailProduct: Product,
-	purchaseCost: EmailCost
-): boolean => {
-	return (
-		purchaseCost.amount === mailProduct.cost && purchaseCost.currency === mailProduct.currency_code
-	);
-};
 
 function getPriceMessage( domain?: Domain ) {
 	if ( ! domain?.titan_mail_subscription?.purchase_cost_per_mailbox ) {

--- a/client/dashboard/emails/add-professional-email/components/style.scss
+++ b/client/dashboard/emails/add-professional-email/components/style.scss
@@ -5,3 +5,35 @@
 		fill: currentcolor;
 	}
 }
+
+.cart__cushion {
+	margin-top: 36px;
+	height: 80px;
+}
+
+.cart__container {
+	position: fixed !important;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 80px;
+}
+
+.cart {
+	justify-content: center;
+	align-items: center;
+	padding-inline: 24px;
+	display: flex;
+	box-sizing: border-box;
+	height: 100%;
+}
+
+.cart__content {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: var( --page-layout-max-width );
+}
+
+.cart-summary__total {
+	font-size: 1.125rem !important; /* stylelint-disable-line scales/font-sizes */
+}

--- a/client/dashboard/emails/add-professional-email/components/style.scss
+++ b/client/dashboard/emails/add-professional-email/components/style.scss
@@ -5,35 +5,3 @@
 		fill: currentcolor;
 	}
 }
-
-.cart__cushion {
-	margin-top: 36px;
-	height: 80px;
-}
-
-.cart__container {
-	position: fixed !important;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	height: 80px;
-}
-
-.cart {
-	justify-content: center;
-	align-items: center;
-	padding-inline: 24px;
-	display: flex;
-	box-sizing: border-box;
-	height: 100%;
-}
-
-.cart__content {
-	box-sizing: border-box;
-	width: 100%;
-	max-width: var( --page-layout-max-width );
-}
-
-.cart-summary__total {
-	font-size: 1.125rem !important; /* stylelint-disable-line scales/font-sizes */
-}

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -225,6 +225,7 @@ const AddProfessionalEmail = () => {
 								<MailboxForm
 									mailboxEntity={ mailboxEntity }
 									disabled={ disabled }
+									onChange={ persistMailboxesToState }
 									removeForm={ index > 0 ? () => removeForm( index ) : undefined }
 								/>
 							</CardBody>

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -1,4 +1,5 @@
 import { mailboxAccountsQuery } from '@automattic/api-queries';
+import { formatCurrency } from '@automattic/number-formatters';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, Card, CardBody } from '@wordpress/components';
@@ -31,6 +32,7 @@ import { useEmailProduct } from '../hooks/use-email-product';
 import { IntervalLength } from '../types';
 import { getCartItems } from '../utils/get-cart-items';
 import { getEmailProductProperties } from '../utils/get-email-product-properties';
+import { Cart } from './components/cart';
 import { MailboxForm } from './components/mailbox-form';
 import { PricingNotice } from './components/pricing-notice';
 
@@ -181,6 +183,15 @@ const AddProfessionalEmail = () => {
 	const showEmailPurchaseDisabledMessage = ! userCanAddEmail && ! isDomainInCart;
 	const disabled = isSubmitting || showEmailPurchaseDisabledMessage;
 
+	const filledMailboxes = mailboxEntities.filter(
+		( mailbox ) => !! mailbox.getFieldValue( FIELD_MAILBOX )
+	);
+	const totalItems = filledMailboxes.length;
+	const totalCost = totalItems * product.cost;
+	const totalPrice = formatCurrency( totalCost, product.currency_code, {
+		stripZeros: true,
+	} );
+
 	return (
 		<PageLayout
 			header={ <PageHeader prefix={ <BackToEmailsPrefix /> } /> }
@@ -231,11 +242,7 @@ const AddProfessionalEmail = () => {
 						</Button>
 					</ButtonStack>
 
-					<ButtonStack justify="flex-start">
-						<Button __next40pxDefaultSize variant="primary" disabled={ disabled } type="submit">
-							{ __( 'Continue' ) }
-						</Button>
-					</ButtonStack>
+					<Cart totalItems={ totalItems } totalPrice={ totalPrice } isCartBusy={ isSubmitting } />
 				</VStack>
 			</form>
 		</PageLayout>

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -32,6 +32,7 @@ import { useEmailProduct } from '../hooks/use-email-product';
 import { IntervalLength } from '../types';
 import { getCartItems } from '../utils/get-cart-items';
 import { getEmailProductProperties } from '../utils/get-email-product-properties';
+import { getTotalCost } from '../utils/get-total-cost';
 import { Cart } from './components/cart';
 import { MailboxForm } from './components/mailbox-form';
 import { PricingNotice } from './components/pricing-notice';
@@ -187,7 +188,11 @@ const AddProfessionalEmail = () => {
 		( mailbox ) => !! mailbox.getFieldValue( FIELD_MAILBOX )
 	);
 	const totalItems = filledMailboxes.length;
-	const totalCost = totalItems * product.cost;
+	const totalCost = getTotalCost( {
+		amount: totalItems,
+		domain: domain,
+		product: product,
+	} );
 	const totalPrice = formatCurrency( totalCost, product.currency_code, {
 		stripZeros: true,
 	} );

--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -184,9 +184,7 @@ const AddProfessionalEmail = () => {
 	const showEmailPurchaseDisabledMessage = ! userCanAddEmail && ! isDomainInCart;
 	const disabled = isSubmitting || showEmailPurchaseDisabledMessage;
 
-	const filledMailboxes = mailboxEntities.filter(
-		( mailbox ) => !! mailbox.getFieldValue( FIELD_MAILBOX )
-	);
+	const filledMailboxes = mailboxEntities.filter( ( mailbox ) => mailbox.isValid() );
 	const totalItems = filledMailboxes.length;
 	const totalCost = getTotalCost( {
 		amount: totalItems,

--- a/client/dashboard/emails/utils/does-additional-price-match-standard-price.ts
+++ b/client/dashboard/emails/utils/does-additional-price-match-standard-price.ts
@@ -1,0 +1,10 @@
+import { EmailCost, Product } from '@automattic/api-core';
+
+export const doesAdditionalPriceMatchStandardPrice = (
+	mailProduct: Product,
+	purchaseCost: EmailCost
+): boolean => {
+	return (
+		purchaseCost.amount === mailProduct.cost && purchaseCost.currency === mailProduct.currency_code
+	);
+};

--- a/client/dashboard/emails/utils/get-total-cost.ts
+++ b/client/dashboard/emails/utils/get-total-cost.ts
@@ -1,0 +1,29 @@
+import { Domain, Product } from '@automattic/api-core';
+import { doesAdditionalPriceMatchStandardPrice } from './does-additional-price-match-standard-price';
+import { isDomainEligibleForTitanIntroductoryOffer } from './is-domain-eligible-for-titan-introductory-offer';
+import { isUserOnTitanFreeTrial } from './is-user-on-titan-free-trial';
+
+export const getTotalCost = ( {
+	amount,
+	domain,
+	product,
+}: {
+	amount: number;
+	domain: Domain;
+	product: Product;
+} ) => {
+	const purchaseCost = domain.titan_mail_subscription?.purchase_cost_per_mailbox;
+
+	if ( purchaseCost && doesAdditionalPriceMatchStandardPrice( product, purchaseCost ) ) {
+		return amount * purchaseCost.amount;
+	}
+
+	if (
+		isUserOnTitanFreeTrial( domain ) ||
+		isDomainEligibleForTitanIntroductoryOffer( { domain, product } )
+	) {
+		return 0;
+	}
+
+	return amount * product.cost;
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-480

## Proposed Changes

* Add a footer that shows the cost of the mailboxes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of or effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/v2/emails/add-professional-email/{domainName}`
* Add mailboxes, check that the pricing on the footer gets updated:

<img width="1356" height="1883" alt="image" src="https://github.com/user-attachments/assets/747a5b67-81ec-40d4-9713-823350c12a16" />

<img width="1356" height="1883" alt="image" src="https://github.com/user-attachments/assets/648ab0e5-979e-4012-8d17-1a12689ef4bc" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
