### PR TITLE
Enable V1 deployments for Flex sites

### DIFF
--- a/client/sites/deployments/components/page-shell/index.tsx
+++ b/client/sites/deployments/components/page-shell/index.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { transferInProgress } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isWpcomFlexSite from 'calypso/state/sites/selectors/is-wpcom-flex-site';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -25,6 +26,7 @@ interface GitHubDeploymentsProps {
 export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploymentsProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const isFlexSite = useSelector( ( state ) => isWpcomFlexSite( state, siteId as number ) );
 	const dispatch = useDispatch();
 	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const [ hasTransfer, setHasTransferring ] = useState(
@@ -33,7 +35,8 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 			transferInProgress.includes( transferState as ( typeof transferInProgress )[ number ] )
 		)
 	);
-	const showHostingActivationBanner = ! isSiteAtomic && ! hasTransfer;
+	const hasHostingFeatures = isSiteAtomic || isFlexSite;
+	const showHostingActivationBanner = ! hasHostingFeatures && ! hasTransfer;
 
 	const clickActivate = () => {
 		dispatch( initiateThemeTransfer( siteId ?? 0, null, '', '', 'hosting' ) );
@@ -60,11 +63,11 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 		}
 	};
 
-	if ( ! isSiteAtomic ) {
+	if ( ! hasHostingFeatures ) {
 		return null;
 	}
 
-	const WrapperComponent = ! isSiteAtomic ? FeatureExample : Fragment;
+	const WrapperComponent = ! hasHostingFeatures ? FeatureExample : Fragment;
 	return (
 		<Panel wide className="github-deployments tools-deployments">
 			<DocumentHead title={ pageTitle } />
@@ -89,7 +92,7 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 				<HostingActivateStatus
 					context="hosting"
 					onTick={ onTick }
-					keepAlive={ ! isSiteAtomic && hasTransfer }
+					keepAlive={ ! hasHostingFeatures && hasTransfer }
 				/>
 			) }
 			<WrapperComponent>{ children }</WrapperComponent>


### PR DESCRIPTION
This will allow us to update the backend to support deployments

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* V1 Deployments need a few additional ifs to be enabled for Flex sites
* This change doesn't quite work without a backend diff but it allows us to actually test the backend diff

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Create a Flex site
* Go to /sites, select the site, go to Github Deployments

<img width="1410" height="760" alt="Screenshot 2025-10-23 at 15 07 58" src="https://github.com/user-attachments/assets/fbd16d37-5feb-4aed-a3f7-0d95ea5e9242" />

Without a backend change to enable the endpoint, this blinks and is not functional.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
