### PR TITLE
Dashboard v2: Activity Logs: Ensure the Datepicker is visible for simple sites on a paid account

### DIFF
--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -128,7 +128,9 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 		hasHostingFeature( site, HostingFeatures.ACTIVITY_LOG ) ||
 		hasPlanFeature( site, HostingFeatures.ACTIVITY_LOG );
 	// hide the datepicker if the user doesn't have access to activity logs or doesn't have logging feature at all
-	const shouldShowDateRangePicker = hasHostingFeature( site, HostingFeatures.LOGS );
+	const shouldShowDateRangePicker =
+		hasHostingFeature( site, HostingFeatures.LOGS ) ||
+		( hasActivityLogAccess && logType === LogType.ACTIVITY ); // simple sites might have access to activity logs only
 	return (
 		<PageLayout
 			header={


### PR DESCRIPTION
Part of #DOTMSD-711

## Proposed Changes

* We now display the DatePicker in the Activity Logs page for Simple Sites on a paid account by checking if the site has access to `ACTIVITY_LOG`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simple sites that are on a paid account couldn't access the activity log filters because the date picker was missing, since we are only checking for the `LOGS` permission, that is not available for Simple Sites. 

## Testing Instructions
<img width="3372" height="2324" alt="CleanShot 2025-10-23 at 16 11 00@2x" src="https
<img width="3364" height="1900" alt="CleanShot 2025-10-23 at 15 54 10@2x" src="https://github.com/user-attachments/assets/976e6138-b885-40b1-bc1e-4b0068ffd76e" />
://github.com/user-attachments/assets/8447216d-2d60-454b-827b-5d5bf183cf80" />

* Check that the DatePicker is available and working for Simple Sites on a paid plan, and not available for free sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
