### PR TITLE
A4A: Update the Purchase section for the Billing Dragon context

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
@@ -8,6 +8,8 @@ import {
 	A4A_LICENSES_LINK,
 	A4A_PAYMENT_METHODS_LINK,
 	A4A_PURCHASES_LINK,
+	EXTERNAL_WPCOM_PAYMENT_METHODS_URL,
+	EXTERNAL_WPCOM_BILLING_HISTORY_URL,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -53,7 +55,7 @@ const usePurchasesMenuItems = ( path: string ) => {
 					icon: payment,
 					path: A4A_PURCHASES_LINK,
 					link: isBillingDragonCheckoutEnabled
-						? 'https://wordpress.com/me/purchases/payment-methods'
+						? EXTERNAL_WPCOM_PAYMENT_METHODS_URL
 						: A4A_PAYMENT_METHODS_LINK,
 					title: translate( 'Payment methods' ),
 					isExternalLink: isBillingDragonCheckoutEnabled,
@@ -71,7 +73,7 @@ const usePurchasesMenuItems = ( path: string ) => {
 					icon: receipt,
 					path: A4A_PURCHASES_LINK,
 					link: isBillingDragonCheckoutEnabled
-						? 'https://wordpress.com/me/purchases/billing'
+						? EXTERNAL_WPCOM_BILLING_HISTORY_URL
 						: A4A_INVOICES_LINK,
 					title: isBillingDragonCheckoutEnabled
 						? translate( 'Billing History' )

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-purchases-menu-items.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { store, key, payment, receipt } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -12,8 +13,9 @@ import { createItem } from '../lib/utils';
 
 const usePurchasesMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+	const isBillingDragonCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
 	const menuItems = useMemo( () => {
-		return [
+		const items = [
 			createItem(
 				{
 					icon: key,
@@ -26,44 +28,67 @@ const usePurchasesMenuItems = ( path: string ) => {
 				},
 				path
 			),
-			createItem(
-				{
-					icon: store,
-					path: A4A_PURCHASES_LINK,
-					link: A4A_BILLING_LINK,
-					title: translate( 'Billing' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Billing',
+		];
+
+		if ( ! isBillingDragonCheckoutEnabled ) {
+			items.push(
+				createItem(
+					{
+						icon: store,
+						path: A4A_PURCHASES_LINK,
+						link: A4A_BILLING_LINK,
+						title: translate( 'Billing' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Purchases / Billing',
+						},
 					},
-				},
-				path
-			),
+					path
+				)
+			);
+		}
+
+		items.push(
 			createItem(
 				{
 					icon: payment,
 					path: A4A_PURCHASES_LINK,
-					link: A4A_PAYMENT_METHODS_LINK,
+					link: isBillingDragonCheckoutEnabled
+						? 'https://wordpress.com/me/purchases/payment-methods'
+						: A4A_PAYMENT_METHODS_LINK,
 					title: translate( 'Payment methods' ),
+					isExternalLink: isBillingDragonCheckoutEnabled,
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Purchases / Payment methods',
 					},
 				},
 				path
-			),
+			)
+		);
+
+		items.push(
 			createItem(
 				{
 					icon: receipt,
 					path: A4A_PURCHASES_LINK,
-					link: A4A_INVOICES_LINK,
-					title: translate( 'Invoices' ),
+					link: isBillingDragonCheckoutEnabled
+						? 'https://wordpress.com/me/purchases/billing'
+						: A4A_INVOICES_LINK,
+					title: isBillingDragonCheckoutEnabled
+						? translate( 'Billing History' )
+						: translate( 'Invoices' ),
+					isExternalLink: isBillingDragonCheckoutEnabled,
 					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Purchases / Invoices',
+						menu_item: isBillingDragonCheckoutEnabled
+							? 'Automattic for Agencies / Purchases / Billing History'
+							: 'Automattic for Agencies / Purchases / Invoices',
 					},
 				},
 				path
-			),
-		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+			)
+		);
+
+		return items;
+	}, [ isBillingDragonCheckoutEnabled, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -65,4 +65,8 @@ export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHOD
 export const A4A_CLIENT_CHECKOUT = '/client/checkout';
 export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =
 	'https://agencieshelp.automattic.com/knowledge-base/client-billing/';
-export const EXTERNAL_WPCOM_ACCOUNT_URL = 'https://wordpress.com/me/';
+
+// WPCOM External Links
+export const EXTERNAL_WPCOM_ACCOUNT_URL = 'https://wordpress.com/me';
+export const EXTERNAL_WPCOM_PAYMENT_METHODS_URL = `${ EXTERNAL_WPCOM_ACCOUNT_URL }/purchases/payment-methods`;
+export const EXTERNAL_WPCOM_BILLING_HISTORY_URL = `${ EXTERNAL_WPCOM_ACCOUNT_URL }/purchases/billing`;

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,5 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import {
+	EXTERNAL_WPCOM_PAYMENT_METHODS_URL,
+	EXTERNAL_WPCOM_BILLING_HISTORY_URL,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
@@ -30,10 +34,8 @@ export default function () {
 	page( '/purchases/licenses/*', '/purchases/licenses' ); // Redirect invalid license list filters back to the main portal page.
 
 	if ( isBillingDragonCheckoutEnabled ) {
-		const redirectToWpcomPaymentMethods = () =>
-			page.redirect( 'https://wordpress.com/me/purchases/payment-methods' );
-		const redirectToWpcomInvoices = () =>
-			page.redirect( 'https://wordpress.com/me/purchases/billing' );
+		const redirectToWpcomPaymentMethods = () => page.redirect( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
+		const redirectToWpcomInvoices = () => page.redirect( EXTERNAL_WPCOM_BILLING_HISTORY_URL );
 
 		// Payment methods (redirect to WPCOM)
 		page( '/purchases/payment-methods', requireAccessContext, redirectToWpcomPaymentMethods );

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -12,6 +13,8 @@ import {
 } from './controller';
 
 export default function () {
+	const isBillingDragonCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
+
 	// Purchases
 	page( '/purchases', requireAccessContext, purchasesContext, makeLayout, clientRender );
 
@@ -26,27 +29,41 @@ export default function () {
 
 	page( '/purchases/licenses/*', '/purchases/licenses' ); // Redirect invalid license list filters back to the main portal page.
 
-	// Billing
-	page( '/purchases/billing', requireAccessContext, billingContext, makeLayout, clientRender );
+	if ( isBillingDragonCheckoutEnabled ) {
+		const redirectToWpcomPaymentMethods = () =>
+			page.redirect( 'https://wordpress.com/me/purchases/payment-methods' );
+		const redirectToWpcomInvoices = () =>
+			page.redirect( 'https://wordpress.com/me/purchases/billing' );
 
-	// Payment methods
-	page(
-		'/purchases/payment-methods',
-		requireAccessContext,
-		paymentMethodsContext,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/purchases/payment-methods/add',
-		requireAccessContext,
-		paymentMethodsAddContext,
-		makeLayout,
-		clientRender
-	);
+		// Payment methods (redirect to WPCOM)
+		page( '/purchases/payment-methods', requireAccessContext, redirectToWpcomPaymentMethods );
+		page( '/purchases/payment-methods/add', requireAccessContext, redirectToWpcomPaymentMethods );
 
-	// Invoices
-	page( '/purchases/invoices', requireAccessContext, invoicesContext, makeLayout, clientRender );
+		// Invoices (redirect to WPCOM)
+		page( '/purchases/invoices', requireAccessContext, redirectToWpcomInvoices );
+	} else {
+		// Billing
+		page( '/purchases/billing', requireAccessContext, billingContext, makeLayout, clientRender );
+
+		// Payment methods
+		page(
+			'/purchases/payment-methods',
+			requireAccessContext,
+			paymentMethodsContext,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/purchases/payment-methods/add',
+			requireAccessContext,
+			paymentMethodsAddContext,
+			makeLayout,
+			clientRender
+		);
+
+		// Invoices
+		page( '/purchases/invoices', requireAccessContext, invoicesContext, makeLayout, clientRender );
+	}
 
 	// CRM Downloads
 	page(


### PR DESCRIPTION
Part of https://github.com/Automattic/automattic-for-agencies-dev/issues/2904 

Linear: `A4A-1631/ui-remove-sections-and-add-links-to-wpcom-profile-page`

## Proposed Changes

This PR hides and updates some subsections from the `Purchase` section when the Billing Dragon context is active:

- **Billing**: Hides the `Billing` section. It's not needed when the Billing Dragon context is active.
- **Payment methods**: Update it, making it an external link to `https://wordpress.com/me/purchases/payment-methods`.
- **Invoices**: Renaming it as `Billing History` and making it an external link to `https://wordpress.com/me/purchases/billing`. 

**Before:**

<img width="251" height="362" alt="image" src="https://github.com/user-attachments/assets/7c8a8bed-9d33-450d-a034-76d14d462a69" />

**After:**

<img width="259" height="334" alt="image" src="https://github.com/user-attachments/assets/7a70f282-8ae5-46b2-b221-d55dc46a63a9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- You will have to set the billing type of your testing agency as `Billing Dragon` => `update_blog_option( $your_agency_id, 'agency_billing_system', 'billingdragon')`
- Visit the `Purchase` section and check that you see the new Submenus.
- Click on the `Payment methods` and `Billing History` links. They should open the links described above in a new tab.

When you finish testing, you can restore the billing type of your testing agency to the `legacy` billing system: `update_blog_option( $your_agency_id, ‘agency_billing_system’, ‘legacy’)`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
