### PR TITLE
Multi-site Dashboard: Add purchaseless add payment method page

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -270,10 +270,33 @@ export const paymentMethodsRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => billingRoute,
-	path: '/payment-methods',
+	path: 'payment-methods',
+} );
+
+export const paymentMethodsIndexRoute = createRoute( {
+	getParentRoute: () => paymentMethodsRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../me/billing-payment-methods' ).then( ( d ) =>
 		createLazyRoute( 'payment-methods' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const addPaymentMethodRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add payment method' ),
+			},
+		],
+	} ),
+	getParentRoute: () => paymentMethodsRoute,
+	path: 'add',
+} ).lazy( () =>
+	import( '../../me/billing-purchases/add-payment-method' ).then( ( d ) =>
+		createLazyRoute( 'purchases-purchase-settings-add-payment-method' )( {
 			component: d.default,
 		} )
 	)
@@ -745,7 +768,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 					changePaymentMethodRoute,
 				] ),
 			] ),
-			paymentMethodsRoute,
+			paymentMethodsRoute.addChildren( [ paymentMethodsIndexRoute, addPaymentMethodRoute ] ),
 			taxDetailsRoute,
 		] )
 	);

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -247,7 +247,7 @@ export const changePaymentMethodRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'Change payment method' ),
+				title: __( 'Update payment method' ),
 			},
 		],
 	} ),

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	Icon,
 	ToggleControl,
@@ -21,6 +22,7 @@ import { info, warning } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { addPaymentMethodRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -64,6 +66,7 @@ function getItemId( item: StoredPaymentMethod ): string {
 }
 
 export default function PaymentMethods() {
+	const navigate = useNavigate();
 	const [ removeDialogPaymentMethod, setRemoveDialogPaymentMethod ] = useState<
 		StoredPaymentMethod | undefined
 	>();
@@ -164,9 +167,6 @@ export default function PaymentMethods() {
 		},
 	];
 
-	// FIXME: allow adding a payment method
-	const addPaymentMethodUrl = '/me/purchases/add-payment-method';
-
 	return (
 		<PageLayout
 			size="large"
@@ -175,7 +175,13 @@ export default function PaymentMethods() {
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Payment methods' ) }
 					actions={
-						<Button __next40pxDefaultSize variant="primary" href={ addPaymentMethodUrl }>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ () => {
+								navigate( { to: addPaymentMethodRoute.to } );
+							} }
+						>
 							{ __( 'Add payment method' ) }
 						</Button>
 					}

--- a/client/dashboard/me/billing-purchases/add-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/add-payment-method.tsx
@@ -51,7 +51,7 @@ function AddPaymentMethod() {
 		);
 	}
 
-	if ( isStripeLoading ) {
+	if ( isStripeLoading || ! creditCardMethod ) {
 		return (
 			<PageLayout
 				size="small"

--- a/client/dashboard/me/billing-purchases/add-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/add-payment-method.tsx
@@ -1,0 +1,113 @@
+import {
+	userSettingsQuery,
+	stripeConfigurationQuery,
+	razorpayConfigurationQuery,
+	queryClient,
+} from '@automattic/api-queries';
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { paymentMethodsRoute } from '../../app/router/me';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { PaymentMethodSelector } from './payment-method-selector';
+import { useCreateCreditCard } from './payment-methods';
+
+import './style.scss';
+
+function AddPaymentMethod() {
+	const navigate = useNavigate();
+
+	const { isStripeLoading, stripeLoadingError } = useStripe();
+
+	const creditCardMethod = useCreateCreditCard( {
+		isStripeLoading,
+		stripeLoadingError,
+		allowUseForAllSubscriptions: true,
+	} );
+
+	if ( stripeLoadingError || ( ! isStripeLoading && ! creditCardMethod ) ) {
+		return (
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						prefix={ <Breadcrumbs length={ 4 } /> }
+						title={ __( 'Add payment method' ) }
+					/>
+				}
+			>
+				<VStack spacing={ 6 }>
+					{ __(
+						'Sorry, an error occurred while loading the payment method form. Please refresh the page and try again.'
+					) }
+				</VStack>
+			</PageLayout>
+		);
+	}
+
+	if ( isStripeLoading ) {
+		return (
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						prefix={ <Breadcrumbs length={ 4 } /> }
+						title={ __( 'Add payment method' ) }
+					/>
+				}
+			>
+				<VStack spacing={ 6 }>{ __( 'Loading…' ) }</VStack>
+			</PageLayout>
+		);
+	}
+
+	const successCallback = () => {
+		navigate( { to: paymentMethodsRoute.to } );
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader prefix={ <Breadcrumbs length={ 4 } /> } title={ __( 'Add payment method' ) } />
+			}
+		>
+			<VStack spacing={ 6 }>
+				<PaymentMethodSelector
+					paymentMethods={ [ creditCardMethod ] }
+					successCallback={ successCallback }
+				/>
+			</VStack>
+		</PageLayout>
+	);
+}
+
+export default function AddPaymentMethodWrapper() {
+	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const locale = userSettings?.language || 'en';
+
+	const fetchStripeConfiguration = useCallback(
+		( requestArgs?: { country?: string; payment_partner?: string } ) => {
+			return queryClient.fetchQuery( stripeConfigurationQuery( requestArgs ) );
+		},
+		[]
+	);
+
+	const fetchRazorpayConfiguration = useCallback( ( requestArgs?: { sandbox: boolean } ) => {
+		return queryClient.fetchQuery( razorpayConfigurationQuery( requestArgs ) );
+	}, [] );
+
+	return (
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ fetchStripeConfiguration }>
+			<RazorpayHookProvider fetchRazorpayConfiguration={ fetchRazorpayConfiguration }>
+				<AddPaymentMethod />
+			</RazorpayHookProvider>
+		</StripeHookProvider>
+	);
+}

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -32,7 +32,7 @@ export function createCreditCardMethod( {
 	hasExistingCardMethods,
 	allowUseForAllSubscriptions,
 }: {
-	currency: string | null | undefined;
+	currency?: string | null | undefined;
 	hasExistingCardMethods?: boolean;
 	allowUseForAllSubscriptions?: boolean;
 } ): PaymentMethod {

--- a/client/dashboard/me/billing-purchases/payment-methods/use-create-credit-card.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/use-create-credit-card.tsx
@@ -9,7 +9,7 @@ export function useCreateCreditCard( {
 	hasExistingCardMethods,
 	allowUseForAllSubscriptions,
 }: {
-	currency: string | null | undefined;
+	currency?: string | null | undefined;
 	isStripeLoading: boolean;
 	stripeLoadingError: Error | null | undefined;
 	hasExistingCardMethods?: boolean;


### PR DESCRIPTION
Fixes SHILL-1231

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-236/hosting-dashboard-migrate-existing-addchange-payment-screens-to

## Proposed Changes

This PR adds a page and route to the Multi-site Dashboard (neé Hosting Dashboard) for adding a payment method without assigning it to a purchase.

<img width="572" height="693" alt="Screenshot 2025-10-23 at 11 59 21 AM" src="https://github.com/user-attachments/assets/b2674526-1ac4-4297-9f26-4d2c6215746f" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/v2/me/billing/payment-methods and click the "Add payment method" button.

Verify that you can successfully add a payment method.
