### PR TITLE
Forms: verify actions menu exists

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -299,4 +299,30 @@ export class FeedbackInboxPage {
 			.last()
 			.waitFor();
 	}
+
+	/**
+	 * Opens the actions menu (three dot menu) and verifies the specified action exists.
+	 *
+	 * @param {string} text The text to match in the row. Using the name field is a good choice.
+	 * @param {string} actionName The name of the action to verify in the dropdown menu.
+	 */
+	async verifyActionExistsInMenu( text: string, actionName: string ): Promise< void > {
+		const responseRowLocator = this.page
+			.locator( '.jp-forms__inbox__dataviews .dataviews-view-table__row' )
+			.filter( { hasText: text } )
+			.first();
+
+		// Click the Actions button (three dot menu)
+		await responseRowLocator.getByRole( 'button', { name: 'Actions' } ).click();
+
+		// Wait for the dropdown menu to appear and assign it to a variable
+		const menu = this.page.getByRole( 'menu' ).last();
+		await menu.waitFor();
+
+		// Verify the specified action exists in the dropdown menu
+		await this.page.getByRole( 'menuitem', { name: actionName } ).waitFor();
+
+		// Close the menu by pressing Escape key (trying to click the "Dismiss popup" button didn't work)
+		await this.page.keyboard.press( 'Escape' );
+	}
 }

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -375,8 +375,12 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 	describe( 'Test response actions', function () {
 		let feedbackInboxPage: FeedbackInboxPage;
 
-		it( 'Ensure first response is selected', async function () {
+		it( 'Verify Trash action exists in actions menu', async function () {
 			feedbackInboxPage = new FeedbackInboxPage( page );
+			await feedbackInboxPage.verifyActionExistsInMenu( formData1.name, 'Trash' );
+		} );
+
+		it( 'Ensure first response is selected', async function () {
 			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 		} );
 


### PR DESCRIPTION


## Proposed Changes

This PR adds a test for an initial check for actions menu with Trash item inside

## Why are these changes being made?
Because we want to make sure the menu is there

## Testing Instructions

Run these tests, see that they pass:

```bash
yarn workspace wp-e2e-tests build &&
ATOMIC_VARIATION="wp-previous" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"


yarn workspace wp-e2e-tests build &&
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"


yarn workspace wp-e2e-tests build &&
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
