### PR TITLE
Domains: Remove unneeded product load in `site-or-domain` signup step

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -3,47 +3,31 @@ import { Gridicon } from '@automattic/components';
 import { SelectItems } from '@automattic/onboarding';
 import { globe, addCard, layout } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import QueryProductsList from 'calypso/components/data/query-products-list';
 import { getUserSiteCountForPlatform } from 'calypso/components/site-selector/utils';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getDomainProductSlug } from 'calypso/lib/domains';
 import { preventWidows } from 'calypso/lib/formatting';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 
 import './style.scss';
 
 class SiteOrDomain extends Component {
 	getDomainName() {
-		const { signupDependencies } = this.props;
-		let isValidDomain = false;
-		const domain = get( signupDependencies, 'domainItem.meta', false );
-
-		if ( domain ) {
-			if ( domain.split( '.' ).length > 1 ) {
-				const productSlug = getDomainProductSlug( domain );
-				isValidDomain = !! this.props.productsList[ productSlug ];
-			}
-			return isValidDomain && domain;
-		}
-
 		const domainCart = this.getDomainCart();
 		if ( domainCart.length ) {
-			const productSlug = domainCart[ 0 ].product_slug;
-			isValidDomain = !! this.props.productsList[ productSlug ];
-			return isValidDomain && domainCart[ 0 ].meta;
+			return domainCart[ 0 ].meta;
 		}
+
 		return false;
 	}
 
 	getDomainCart() {
 		const { signupDependencies } = this.props;
-		const domainCart = get( signupDependencies, 'domainCart', [] );
+		const domainCart = signupDependencies?.domainCart ?? [];
 
 		return domainCart;
 	}
@@ -160,12 +144,7 @@ class SiteOrDomain extends Component {
 	}
 
 	renderScreen() {
-		return (
-			<div>
-				{ ! this.props.productsLoaded && <QueryProductsList /> }
-				{ this.renderChoices() }
-			</div>
-		);
+		return <div>{ this.renderChoices() }</div>;
 	}
 
 	submitDomain( designType ) {
@@ -232,10 +211,10 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
-		const { translate, productsLoaded } = this.props;
+		const { translate } = this.props;
 		const domainName = this.getDomainName();
 
-		if ( productsLoaded && ! domainName ) {
+		if ( ! domainName ) {
 			const headerText = translate( 'Unsupported domain.' );
 			const subHeaderText = translate(
 				'Please visit {{a}}wordpress.com/domains{{/a}} to search for a domain.',
@@ -289,14 +268,10 @@ class SiteOrDomain extends Component {
 
 export default connect(
 	( state ) => {
-		const productsList = getAvailableProductsList( state );
-		const productsLoaded = ! isEmpty( productsList );
 		const user = getCurrentUser( state );
 
 		return {
 			isLoggedIn: isUserLoggedIn( state ),
-			productsList,
-			productsLoaded,
 			siteCount: getUserSiteCountForPlatform( user ),
 		};
 	},


### PR DESCRIPTION
Part of [DOMENG-195](https://linear.app/a8c/issue/DOMENG-195/)

## Proposed Changes

This PR removes an unnecessary product list load in the "site or domain" signup step. That step is currently only used in the `/start/domain` flow (it's also declared in the Gravatar `/start/domain-for-gravatar` flow, but is always skipped for that case).

This is the "Site or domain" step:

<img width="2296" height="1468" alt="Screenshot 2025-10-23 at 14 49 48" src="https://github.com/user-attachments/assets/4375e3e6-934d-4798-9f37-959969f50df3" />

## Why are these changes being made?

The product list was loaded and used to check if the selected domain had a valid TLD that we sell in WPCOM. However, now the domain is first added to the shopping cart in the domain search step, and the shopping cart already validates if the domain is valid or not, so we don't need to load the product list anymore.

This was [added 8 years ago](https://github.com/Automattic/wp-calypso/commit/ec72959b75d9e78f1501b1bdbd8f75ca269b73c9), back when I believe there was a lot less validation on the products in signup flows.

I noticed this when writing e2e tests for the `/start/domain` flow. A simple happy path test was failing because the test ran too quickly and the products list wasn't loaded yet.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Visit the `/start/domain` flow
- Search for a domain and select one or more domains
- Go to the "Site or domain" step
- Ensure the three options are still working normally ("Just buy a domain", "New site" and "Existing WPCOM site") and checkout shows the correct items

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
