### PR TITLE
Use `ciab-workflow-support_chat` botSlug when in Commerce Garden

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -13,6 +13,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { useCanvasMode } from './hooks/use-canvas-mode';
+import { useSetupHelpCenterStore } from './use-setup-help-center-store';
 import { getEditorType } from './utils';
 import './help-center.scss';
 
@@ -22,6 +23,8 @@ function HelpCenterContent() {
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
 	const [ showHelpIcon, setShowHelpIcon ] = useState( false );
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
+
+	useSetupHelpCenterStore();
 
 	const show = useSelect( ( s ) => s( 'automattic/help-center' ).isHelpCenterShown() );
 

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -6,8 +6,10 @@ import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useCallback } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
-const queryClient = new QueryClient();
+import { useSetupHelpCenterStore } from './use-setup-help-center-store';
 import './help-center.scss';
+
+const queryClient = new QueryClient();
 
 function AdminHelpCenterContent() {
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( 'automattic/help-center' );
@@ -15,6 +17,7 @@ function AdminHelpCenterContent() {
 		show: select( 'automattic/help-center' ).isHelpCenterShown(),
 		unreadCount: select( 'automattic/help-center' ).getUnreadCount(),
 	} ) );
+	useSetupHelpCenterStore();
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
 	const masterbarNotificationsButton = document.getElementById( 'wp-admin-bar-notes' );
 	const supportLinks = document.querySelectorAll( '[data-target="wpcom-help-center"]' );

--- a/apps/help-center/use-setup-help-center-store.js
+++ b/apps/help-center/use-setup-help-center-store.js
@@ -1,0 +1,16 @@
+/* global helpCenterData */
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+
+/**
+ * Populate the help center store with the appropriate information on page load.
+ */
+export const useSetupHelpCenterStore = () => {
+	const { setOdieBotNameSlug } = useDispatch( 'automattic/help-center' );
+
+	useEffect( () => {
+		if ( helpCenterData.isCommerceGarden ) {
+			setOdieBotNameSlug( 'ciab-workflow-support_chat' );
+		}
+	}, [ setOdieBotNameSlug ] );
+};

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -32,8 +32,9 @@ export function HelpCenterChat( {
 	const siteUrl = params.get( 'siteUrl' );
 	const siteId = params.get( 'siteId' );
 
-	const commerceGardenFlowName = isCommerceGarden ? 'messaging_flow_commerce_in_a_box' : null;
-	const userFieldFlowName = commerceGardenFlowName || data?.eligibility?.user_field_flow_name;
+	const userFieldFlowName = isCommerceGarden
+		? 'messaging_flow_commerce_in_a_box'
+		: data?.eligibility?.user_field_flow_name;
 
 	const { forceEmailSupport, isChatRestricted } = useChatStatus();
 

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -163,4 +163,8 @@ export const getOdieInitialMessage = (
 
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;
-export const ODIE_ALLOWED_BOTS = [ 'wpcom-support-chat', 'wpcom-plan-support' ];
+export const ODIE_ALLOWED_BOTS = [
+	'wpcom-support-chat',
+	'wpcom-plan-support',
+	'ciab-workflow-support_chat',
+];

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -32,7 +32,7 @@ export const emptyChat: Chat = {
 export const OdieAssistantContext = createContext< OdieAssistantContextInterface >( {
 	addMessage: noop,
 	botName: 'Wapuu',
-	botNameSlug: 'wpcom-support-chat' as OdieAllowedBots,
+	botNameSlug: 'ciab-workflow-support_chat' as OdieAllowedBots,
 	chat: emptyChat,
 	canConnectToZendesk: false,
 	isLoadingCanConnectToZendesk: false,
@@ -82,7 +82,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 
 		const odieBotNameSlug = isOdieAllowedBot( store.getOdieBotNameSlug() )
 			? store.getOdieBotNameSlug()
-			: 'wpcom-support-chat';
+			: 'ciab-workflow-support_chat';
 
 		return {
 			botNameSlug: odieBotNameSlug as OdieAllowedBots,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
