### PR TITLE
Reish20251023/command palette test

### DIFF
--- a/apps/command-palette-wp-admin/src/index.js
+++ b/apps/command-palette-wp-admin/src/index.js
@@ -1,53 +1,32 @@
-import CommandPalette from '@automattic/command-palette';
 import domReady from '@wordpress/dom-ready';
-import { createRoot } from 'react-dom/client';
-import setLocale from './set-locale';
-import { useCommandsWpAdmin } from './use-commands';
-import { useSites } from './use-sites';
 
-function CommandPaletteApp() {
-	if ( ! window.commandPaletteConfig ) {
-		// Can't load the command palette without a config.
-		return null;
-	}
-
-	const {
-		siteId,
-		isAtomic = false,
-		isSimple = false,
-		capabilities,
-	} = window?.commandPaletteConfig || {};
-
-	if ( ! isSimple && ! isAtomic ) {
-		return;
-	}
-
-	const currentRoute = window.location.pathname + window.location.search;
-
-	const navigate = ( url, openInNewTab ) => window.open( url, openInNewTab ? '_blank' : '_self' );
-
-	setLocale();
-
-	const userCapabilities = { [ siteId ]: capabilities };
-
-	return (
-		<CommandPalette
-			navigate={ navigate }
-			currentRoute={ currentRoute }
-			useCommands={ useCommandsWpAdmin }
-			currentSiteId={ siteId }
-			useSites={ useSites }
-			userCapabilities={ userCapabilities }
-		/>
+// Set webpack publicPath to the CDN folder of this script
+// so dynamic imports resolve correctly.
+try {
+	// eslint-disable-next-line no-undef
+	__webpack_public_path__ = new URL( document.currentScript.src ).href.replace(
+		/build\.min\.js$/,
+		''
 	);
-}
+} catch {}
 
-function wpcomInitCommandPalette() {
-	const commandPaletteContainer = document.createElement( 'div' );
-	document.body.appendChild( commandPaletteContainer );
+let appPromise;
+const loadApp = () => {
+	if ( ! appPromise ) {
+		appPromise = import( /* webpackChunkName: "command-palette-app" */ './mount' );
+	}
+	return appPromise;
+};
 
-	const root = createRoot( commandPaletteContainer );
-	root.render( <CommandPaletteApp /> );
-}
+// Lazy init on first Cmd/Ctrl+K
+const onKeyDown = ( e ) => {
+	if ( ( e.metaKey || e.ctrlKey ) && e.key.toLowerCase() === 'k' ) {
+		e.preventDefault();
+		document.removeEventListener( 'keydown', onKeyDown );
+		loadApp().then( ( { mount } ) => mount( { openImmediately: true } ) );
+	}
+};
 
-domReady( wpcomInitCommandPalette );
+domReady( () => {
+	document.addEventListener( 'keydown', onKeyDown );
+} );

--- a/apps/command-palette-wp-admin/src/index.js
+++ b/apps/command-palette-wp-admin/src/index.js
@@ -1,15 +1,5 @@
 import domReady from '@wordpress/dom-ready';
 
-// Set webpack publicPath to the CDN folder of this script
-// so dynamic imports resolve correctly.
-try {
-	// eslint-disable-next-line no-undef
-	__webpack_public_path__ = new URL( document.currentScript.src ).href.replace(
-		/build\.min\.js$/,
-		''
-	);
-} catch {}
-
 let appPromise;
 const loadApp = () => {
 	if ( ! appPromise ) {

--- a/apps/command-palette-wp-admin/src/mount.tsx
+++ b/apps/command-palette-wp-admin/src/mount.tsx
@@ -41,7 +41,22 @@ export function mount( { openImmediately = false } = {} ) {
 			currentSiteId={ siteId }
 			useSites={ useSites }
 			userCapabilities={ userCapabilities }
-			isOpenGlobal={ openImmediately }
 		/>
 	);
+	// If openImmediately is true, trigger the open after initial render
+	// This allows the palette to open once but still be closeable
+	if ( openImmediately ) {
+		// Use setTimeout to ensure the component is fully mounted before opening
+		setTimeout( () => {
+			// Simulate the keyboard shortcut that opens the palette (Cmd+K)
+			const event = new KeyboardEvent( 'keydown', {
+				key: 'k',
+				code: 'KeyK',
+				metaKey: true,
+				ctrlKey: false,
+				bubbles: true,
+			} );
+			document.dispatchEvent( event );
+		}, 0 );
+	}
 }

--- a/apps/command-palette-wp-admin/src/mount.tsx
+++ b/apps/command-palette-wp-admin/src/mount.tsx
@@ -1,0 +1,47 @@
+import CommandPalette from '@automattic/command-palette';
+import { createRoot } from 'react-dom/client';
+import setLocale from './set-locale';
+import { useCommandsWpAdmin } from './use-commands';
+import { useSites } from './use-sites';
+
+export function mount( { openImmediately = false } = {} ) {
+	if ( ! window.commandPaletteConfig ) {
+		// Can't load the command palette without a config.
+		return null;
+	}
+
+	const {
+		siteId,
+		isAtomic = false,
+		isSimple = false,
+		capabilities,
+	} = window?.commandPaletteConfig || {};
+
+	if ( ! isSimple && ! isAtomic ) {
+		return;
+	}
+
+	const currentRoute = window.location.pathname + window.location.search;
+
+	const navigate = ( url, openInNewTab ) => window.open( url, openInNewTab ? '_blank' : '_self' );
+
+	setLocale();
+
+	const userCapabilities = { [ siteId ]: capabilities };
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+
+	const root = createRoot( container );
+	root.render(
+		<CommandPalette
+			navigate={ navigate }
+			currentRoute={ currentRoute }
+			useCommands={ useCommandsWpAdmin }
+			currentSiteId={ siteId }
+			useSites={ useSites }
+			userCapabilities={ userCapabilities }
+			isOpenGlobal={ openImmediately }
+		/>
+	);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
