### PR TITLE
Domains: Add e2e tests for `/start/domain` (domain-only) flow

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -125,6 +125,28 @@ export class DomainSearchComponent {
 	}
 
 	/**
+	 * Click on the "Just buy a domain" option in the "Choose how to use your domain" page
+	 */
+	async selectJustBuyADomain(): Promise< void > {
+		const button = await this.getContainer().getByRole( 'button', {
+			name: /Just buy a domain.*/,
+		} );
+		await button.waitFor();
+		await button.click();
+	}
+
+	/**
+	 * Click on the "New site" option in the "Choose how to use your domain" page
+	 */
+	async selectNewSite(): Promise< void > {
+		const button = await this.getContainer().getByRole( 'button', {
+			name: /New site.*/,
+		} );
+		await button.waitFor();
+		await button.click();
+	}
+
+	/**
 	 * Select a domain matching the keyword.
 	 *
 	 * The keyword can be anything that uniquely identifies the desired domain name

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -6,7 +6,7 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
  * The plans page URL regex.
  */
 export const plansPageUrl =
-	/.*setup\/onboarding\/plans|setup\/domain\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
+	/.*setup\/onboarding\/plans|setup\/domain\/plans|start\/plans|start\/with-theme\/plans-theme-preselected|start\/domain\/plans-site-selected.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.
@@ -31,6 +31,7 @@ export class SignupPickPlanPage {
 	 * Selects a WordPress.com plan matching the name, triggering site creation.
 	 *
 	 * @param {Plans} name Name of the plan.
+	 * @param {RegExp} redirectUrl Optional redirect URL to wait for.
 	 * @returns {Promise<SiteDetails>} Details of the newly created site.
 	 */
 	async selectPlan( name: Plans, redirectUrl?: RegExp ): Promise< NewSiteResponse > {
@@ -69,18 +70,24 @@ export class SignupPickPlanPage {
 	}
 
 	/**
-	 * Selects a WordPress.com plan matching the name in the `plans-site-selected` signup step
+	 * Selects a WordPress.com plan matching the name but does not wait for site creation
 	 *
-	 * The domain-only flow is different from the other flows since, after plan selection, the user
-	 * is redirected to the user login step if they are logged out. Site creation happens after user login.
+	 * The `selectPlan` method assumes that, after plan selection, a site will be created.
+	 * That's not true for the domain-only flow, where a logged out user is redirected to
+	 * the login step after plan selection.
 	 *
 	 * @param name Name of the plan.
 	 * @returns {Promise<void>}
 	 */
-	async selectPlanInDomainOnlyFlow( name: Plans ): Promise< void > {
-		await this.page.waitForURL( /.*start\/domain\/plans-site-selected.*/ );
+	async selectPlanWithoutSiteCreation( name: Plans, redirectUrl?: RegExp ): Promise< void > {
+		await this.page.waitForURL( plansPageUrl );
 
-		const redirectUrl = new RegExp( '.*start/domain/user-social.*' );
+		if ( name !== 'Free' ) {
+			// Non-free plans should redirect to the Checkout cart.
+			redirectUrl ??= new RegExp( '.*checkout.*' );
+		} else {
+			redirectUrl ??= new RegExp( '.*setup/site-setup.*' );
+		}
 
 		const actions = [
 			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -67,4 +67,26 @@ export class SignupPickPlanPage {
 		body.blog_details.blogid = Number( body.blog_details.blogid );
 		return body;
 	}
+
+	/**
+	 * Selects a WordPress.com plan matching the name in the `plans-site-selected` signup step
+	 *
+	 * The domain-only flow is different from the other flows since, after plan selection, the user
+	 * is redirected to the user login step if they are logged out. Site creation happens after user login.
+	 *
+	 * @param name Name of the plan.
+	 * @returns {Promise<void>}
+	 */
+	async selectPlanInDomainOnlyFlow( name: Plans ): Promise< void > {
+		await this.page.waitForURL( /.*start\/domain\/plans-site-selected.*/ );
+
+		const redirectUrl = new RegExp( '.*start/domain/user-social.*' );
+
+		const actions = [
+			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
+			this.plansPage.selectPlan( name ),
+		];
+
+		await Promise.all( actions );
+	}
 }

--- a/test/e2e/specs/flows/start-domain__purchase-domain-and-plan.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-domain-and-plan.ts
@@ -1,0 +1,106 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	BrowserManager,
+	DataHelper,
+	DomainSearchComponent,
+	CartCheckoutPage,
+	UserSignupPage,
+	NewUserResponse,
+	RestAPIClient,
+	SignupPickPlanPage,
+	NewSiteResponse,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
+import { apiDeleteSite } from '../shared/api-delete-site';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Domain-only flow: Purchase domain and plan' ), function () {
+	const testUser = DataHelper.getNewTestUser();
+	const planName = 'Personal';
+	let page: Page;
+	let selectedDomain: string;
+	let newUserDetails: NewUserResponse;
+	let newSiteDetails: NewSiteResponse;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+	} );
+
+	it( 'Enter the flow', async function () {
+		const flowUrl = DataHelper.getCalypsoURL( '/start/domain' );
+		await page.goto( flowUrl );
+	} );
+
+	it( 'Search for a domain', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( DataHelper.getBlogName() );
+	} );
+
+	it( 'Add the first suggestion to the cart', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+	} );
+
+	it( 'Continue to next step', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.continue();
+	} );
+
+	it( 'Select "New site" option', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.selectNewSite();
+	} );
+
+	it( `Select ${ planName } plan`, async function () {
+		const signupPickPlanPage = new SignupPickPlanPage( page );
+		await signupPickPlanPage.selectPlanWithoutSiteCreation(
+			planName,
+			new RegExp( '.*start/domain/user-social.*' )
+		);
+	} );
+
+	it( 'Sign up as a new user and wait for site creation', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		[ newUserDetails, newSiteDetails ] = await userSignupPage.signupWithEmailAndWaitForSiteCreation(
+			testUser.email
+		);
+	} );
+
+	it( 'See domain and plan at checkout', async function () {
+		const cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiDeleteSite( restAPIClient, {
+			url: newSiteDetails.blog_details.url,
+			id: newSiteDetails.blog_details.blogid,
+			name: newSiteDetails.blog_details.blogname,
+		} );
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );

--- a/test/e2e/specs/flows/start-domain__purchase-domain.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-domain.ts
@@ -1,0 +1,84 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	BrowserManager,
+	DataHelper,
+	DomainSearchComponent,
+	CartCheckoutPage,
+	UserSignupPage,
+	NewUserResponse,
+	RestAPIClient,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared/api-close-account';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Domain-only flow: Purchase domain' ), function () {
+	const testUser = DataHelper.getNewTestUser();
+	let page: Page;
+	let selectedDomain: string;
+	let newUserDetails: NewUserResponse;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+	} );
+
+	it( 'Enter the flow', async function () {
+		const flowUrl = DataHelper.getCalypsoURL( '/start/domain' );
+		await page.goto( flowUrl );
+	} );
+
+	it( 'Search for a domain', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( DataHelper.getBlogName() );
+	} );
+
+	it( 'Add the first suggestion to the cart', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		selectedDomain = await domainSearchComponent.selectFirstSuggestion();
+	} );
+
+	it( 'Continue to next step', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.continue();
+	} );
+
+	it( 'Select "Just buy a domain" option', async function () {
+		const domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.selectJustBuyADomain();
+	} );
+
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupWithEmail( testUser.email );
+	} );
+
+	it( 'See domain at checkout', async function () {
+		const cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of [DOMAINS-1636](https://linear.app/a8c/issue/DOMAINS-1636/)

## Proposed Changes

This PR adds two test cases for the `/start/domain` flow. The tests are:
- Purchase a domain - only buy a domain
- Purchase a domain - create a new site, purchase a plan

This PR also adds two more helper methods, `SignupPickPlanPage.selectPlanWithoutSiteCreation` and  `UserSignupPage.signupWithEmailAndWaitForSiteCreation`, to account for the different order of steps in the domain-only flow (login happens after plan selection, and site creation happens after login). I'm not too happy with them, but I couldn't think of a more elegant solution right now 😕 

## Why are these changes being made?

We want to be confident that the domain-only flow won't easily break or have regressions.

## Testing Instructions

- Code inspection
- Ensure pre-release e2e tests are passing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
