### PR TITLE
Hosting Dashboard: Replace performance score chart with modal.

### DIFF
--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -151,44 +151,36 @@ export default function CoreMetricsChart( {
 	metric: Metrics;
 	metricsThresholds: Record< Metrics, { good: number; needsImprovement: number; bad: number } >;
 } ) {
-	const { good, needsImprovement, bad } = metricsThresholds[ metric ];
+	const { good, needsImprovement } = metricsThresholds[ metric ];
 	const isDesktop = useViewportMatch( 'medium' );
 	const lineChartData = useLineChartData( metric, report.history );
 
-	const formatThresholdValue = ( isOverall: boolean, valuation: Valuation ) => {
+	const formatThresholdValue = ( valuation: Valuation ) => {
 		const unit = getDisplayUnit( metric );
 		if ( valuation === 'good' ) {
-			return isOverall
-				? sprintf( '(90–%(to)s)', { to: getFormattedValue( metric, good ) } )
-				: sprintf( '(0–%(to)s%(unit)s)', {
-						to: getFormattedValue( metric, good ),
-						unit,
-				  } );
+			return sprintf( '(0–%(to)s%(unit)s)', {
+				to: getFormattedValue( metric, good ),
+				unit,
+			} );
 		}
 
 		if ( valuation === 'needsImprovement' ) {
-			return isOverall
-				? sprintf( '(50–%(to)s)', { to: getFormattedValue( metric, needsImprovement ) } )
-				: sprintf( '(%(from)s–%(to)s%(unit)s)', {
-						from: getFormattedValue( metric, good ),
-						to: getFormattedValue( metric, needsImprovement ),
-						unit,
-				  } );
+			return sprintf( '(%(from)s–%(to)s%(unit)s)', {
+				from: getFormattedValue( metric, good ),
+				to: getFormattedValue( metric, needsImprovement ),
+				unit,
+			} );
 		}
 
 		if ( valuation === 'bad' ) {
-			return isOverall
-				? sprintf( '(0-%(to)s)', { to: getFormattedValue( metric, bad ) } )
-				: sprintf( '(Over %(from)s%(unit)s)', {
-						from: getFormattedValue( metric, needsImprovement ),
-						unit,
-				  } );
+			return sprintf( '(Over %(from)s%(unit)s)', {
+				from: getFormattedValue( metric, needsImprovement ),
+				unit,
+			} );
 		}
 
 		return '';
 	};
-
-	const isOverall = metric === 'overall_score';
 
 	return (
 		<>
@@ -196,17 +188,17 @@ export default function CoreMetricsChart( {
 				<MetricLabel
 					indicator="good"
 					label={ __( 'Excellent' ) }
-					value={ formatThresholdValue( isOverall, 'good' ) }
+					value={ formatThresholdValue( 'good' ) }
 				/>
 				<MetricLabel
 					indicator="needsImprovement"
 					label={ __( 'Needs Improvement' ) }
-					value={ formatThresholdValue( isOverall, 'needsImprovement' ) }
+					value={ formatThresholdValue( 'needsImprovement' ) }
 				/>
 				<MetricLabel
 					indicator="bad"
 					label={ __( 'Poor' ) }
-					value={ formatThresholdValue( isOverall, 'bad' ) }
+					value={ formatThresholdValue( 'bad' ) }
 				/>
 			</HStack>
 			{ lineChartData ? (

--- a/client/dashboard/sites/performance/core-metrics-content.tsx
+++ b/client/dashboard/sites/performance/core-metrics-content.tsx
@@ -12,7 +12,7 @@ import {
 import CoreMetricsChart from './core-metrics-chart';
 import CoreMetricsExplanation from './core-metrics-explanation';
 import { CoreMetricsRecommendLink } from './core-metrics-recommend-link';
-import { OverallScore, MetricScore } from './core-metrics-score';
+import { MetricScore } from './core-metrics-score';
 import { CoreMetricsStatusBadge } from './core-metrics-status-badge';
 import { filterRecommendations } from './performance-insights';
 import type { SitePerformanceReport } from '@automattic/api-core';
@@ -36,7 +36,6 @@ export default function CoreMetricsContent( {
 	const value = report[ activeTab ];
 	const status = mapThresholdsToStatus( activeTab as Metrics, value );
 
-	const isOverall = activeTab === 'overall_score';
 	return (
 		<VStack spacing={ 4 }>
 			<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
@@ -48,16 +47,13 @@ export default function CoreMetricsContent( {
 						<CoreMetricsStatusBadge value={ status } />
 					</HStack>
 
-					{ isOverall ? (
-						<OverallScore size={ 32 } status={ status } value={ value } />
-					) : (
-						<MetricScore
-							size={ 32 }
-							metric={ activeTab as Metrics }
-							status={ status }
-							value={ value }
-						/>
-					) }
+					<MetricScore
+						size={ 32 }
+						metric={ activeTab as Metrics }
+						status={ status }
+						value={ value }
+					/>
+
 					<CoreMetricsExplanation activeTab={ activeTab } />
 				</VStack>
 				{ numberOfAuditsForMetric > 0 && (

--- a/client/dashboard/sites/performance/core-metrics-performance.tsx
+++ b/client/dashboard/sites/performance/core-metrics-performance.tsx
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
 import { getPerformanceStatus } from '../../utils/site-performance';
 
-export default function CoreMetricsExplanation( {
+export default function CoreMetricsPerformance( {
 	value,
 	onRecommendationsFilterChange,
 }: {

--- a/client/dashboard/sites/performance/core-metrics-performance.tsx
+++ b/client/dashboard/sites/performance/core-metrics-performance.tsx
@@ -17,11 +17,7 @@ export default function CoreMetricsPerformance( {
 	const formattedScore = `${ score }/100`;
 
 	const RecommendationLink = (
-		<Button
-			variant="link"
-			size="compact"
-			onClick={ () => onRecommendationsFilterChange( 'overall_score' ) }
-		/>
+		<Button variant="link" onClick={ () => onRecommendationsFilterChange( 'overall_score' ) } />
 	);
 
 	if ( status === 'bad' ) {

--- a/client/dashboard/sites/performance/core-metrics-performance.tsx
+++ b/client/dashboard/sites/performance/core-metrics-performance.tsx
@@ -1,0 +1,52 @@
+import {
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+	ProgressBar,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Valuation } from '../../utils/site-performance';
+import { CoreMetricsStatusBadge } from './core-metrics-status-badge';
+
+export default function CoreMetricsExplanation( {
+	screenshot,
+	value,
+	status,
+}: {
+	screenshot: string;
+	value: number;
+	status: Valuation;
+} ) {
+	return (
+		<Card>
+			<CardBody>
+				<HStack expanded>
+					<VStack expanded>
+						<Text size="title" weight={ 500 } as="h2">
+							{ __( 'Performance Score' ) }
+						</Text>
+						<Text size="title" weight={ 500 } as="h2">
+							{ Math.floor( value * 100 ) } / 100
+						</Text>
+						<ProgressBar value={ value * 100 } />
+						<CoreMetricsStatusBadge value={ status } />
+					</VStack>
+					{ screenshot && (
+						<img
+							style={ {
+								border: '1px solid #e0e0e0',
+								borderRadius: '4px',
+								height: '280px',
+								width: 'auto',
+							} }
+							src={ screenshot }
+							alt={ __( 'Performance Score' ) }
+						/>
+					) }
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/core-metrics-performance.tsx
+++ b/client/dashboard/sites/performance/core-metrics-performance.tsx
@@ -1,52 +1,87 @@
-import {
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	Card,
-	CardBody,
-	ProgressBar,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Valuation } from '../../utils/site-performance';
-import { CoreMetricsStatusBadge } from './core-metrics-status-badge';
+import { Metrics } from '@automattic/api-core';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+import { getPerformanceStatus } from '../../utils/site-performance';
 
 export default function CoreMetricsExplanation( {
-	screenshot,
 	value,
-	status,
+	onRecommendationsFilterChange,
 }: {
-	screenshot: string;
 	value: number;
-	status: Valuation;
+	onRecommendationsFilterChange: ( filter: Metrics ) => void;
 } ) {
+	const status = getPerformanceStatus( value );
+	const score = Math.floor( value * 100 );
+	const formattedScore = `${ score }/100`;
+
+	const RecommendationLink = (
+		<Button
+			variant="link"
+			size="compact"
+			onClick={ () => onRecommendationsFilterChange( 'overall_score' ) }
+		/>
+	);
+
+	if ( status === 'bad' ) {
+		return (
+			<Notice
+				title={ sprintf(
+					/* translators: %s is the performance score */
+					__( 'Performance issues detected — %s' ),
+					formattedScore
+				) }
+				variant="error"
+			>
+				{ createInterpolateElement(
+					__(
+						'Your site may feel slow or unresponsive. Start with the <recommendationsLink>top recommendations</recommendationsLink> to make the biggest impact.'
+					),
+					{
+						recommendationsLink: RecommendationLink,
+					}
+				) }
+			</Notice>
+		);
+	} else if ( status === 'needsImprovement' ) {
+		return (
+			<Notice
+				title={ sprintf(
+					/* translators: %s is the performance score */
+					__( 'Needs improvement — %s' ),
+					formattedScore
+				) }
+				variant="warning"
+			>
+				{ createInterpolateElement(
+					__(
+						'This page could be faster and more efficient. <recommendationsLink>Review the recommendations</recommendationsLink> to boost your score.'
+					),
+					{
+						recommendationsLink: RecommendationLink,
+					}
+				) }
+			</Notice>
+		);
+	}
+
 	return (
-		<Card>
-			<CardBody>
-				<HStack expanded>
-					<VStack expanded>
-						<Text size="title" weight={ 500 } as="h2">
-							{ __( 'Performance Score' ) }
-						</Text>
-						<Text size="title" weight={ 500 } as="h2">
-							{ Math.floor( value * 100 ) } / 100
-						</Text>
-						<ProgressBar value={ value * 100 } />
-						<CoreMetricsStatusBadge value={ status } />
-					</VStack>
-					{ screenshot && (
-						<img
-							style={ {
-								border: '1px solid #e0e0e0',
-								borderRadius: '4px',
-								height: '280px',
-								width: 'auto',
-							} }
-							src={ screenshot }
-							alt={ __( 'Performance Score' ) }
-						/>
-					) }
-				</HStack>
-			</CardBody>
-		</Card>
+		<Notice
+			title={ sprintf(
+				/* translators: %s is the performance score */ __( 'Great performance — %s' ),
+				formattedScore
+			) }
+			variant="success"
+		>
+			{ createInterpolateElement(
+				__(
+					'This page is running smoothly. Keep it up! <recommendationsLink>Review recommendations</recommendationsLink> to stay ahead of best practices.'
+				),
+				{
+					recommendationsLink: RecommendationLink,
+				}
+			) }
+		</Notice>
 	);
 }

--- a/client/dashboard/sites/performance/core-metrics-score.tsx
+++ b/client/dashboard/sites/performance/core-metrics-score.tsx
@@ -1,5 +1,4 @@
 import { Metrics } from '@automattic/api-core';
-import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Text } from '../../components/text';
 import { getColorForStatus, getDisplayValue, Valuation } from '../../utils/site-performance';
 
@@ -26,35 +25,6 @@ const getValueText = ( {
 		{ getDisplayValue( metric, value ) }
 	</Text>
 );
-
-export function OverallScore( {
-	lineHeight = 'inherit',
-	status,
-	size = 20,
-	value,
-}: {
-	lineHeight?: string;
-	status: Valuation;
-	size?: number;
-	value: number;
-} ) {
-	const formattedValue = value * 100;
-
-	return (
-		<HStack spacing={ 1 } justify="flex-start">
-			{ getValueText( {
-				metric: 'overall_score',
-				status,
-				value: formattedValue,
-				size,
-				lineHeight,
-			} ) }
-			<Text size={ 12 } variant="muted">
-				/ 100
-			</Text>
-		</HStack>
-	);
-}
 
 export function MetricScore( {
 	lineHeight = 'inherit',

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -40,6 +40,10 @@ const CoreMetricsTabs = ( {
 
 	const availableMetrics = getAvailableMetrics( report );
 
+	if ( availableMetrics.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<Tabs.TabList style={ { maxWidth: '100%' } }>
 			{ availableMetrics.map( ( metricKey ) => {

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -1,9 +1,12 @@
-import { Metrics } from '@automattic/api-core';
 import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Text } from '../../components/text';
-import { metricsNames, mapThresholdsToStatus } from '../../utils/site-performance';
+import {
+	metricsNames,
+	mapThresholdsToStatus,
+	getAvailableMetrics,
+} from '../../utils/site-performance';
 import { MetricScore } from './core-metrics-score';
 import type { SitePerformanceReport } from '@automattic/api-core';
 
@@ -35,46 +38,29 @@ const CoreMetricsTabs = ( {
 } ) => {
 	const isSmall = useViewportMatch( 'small' );
 
+	const availableMetrics = getAvailableMetrics( report );
+
 	return (
 		<Tabs.TabList style={ { maxWidth: '100%' } }>
-			{ Object.entries( metricsNames ).map(
-				( [ key, { name: displayName, shortName: shortDisplayName } ] ) => {
-					// We don't want to display the overall score in the tabs.
-					if ( key === 'overall_score' ) {
-						return null;
-					}
+			{ availableMetrics.map( ( metricKey ) => {
+				const { name: displayName, shortName: shortDisplayName } = metricsNames[ metricKey ];
+				const status = mapThresholdsToStatus( metricKey, report[ metricKey ] );
 
-					if (
-						report[ key as keyof SitePerformanceReport ] === undefined ||
-						report[ key as keyof SitePerformanceReport ] === null
-					) {
-						return null;
-					}
-
-					// Only display TBT if INP is not available
-					if ( key === 'tbt' && report[ 'inp' ] !== undefined && report[ 'inp' ] !== null ) {
-						return null;
-					}
-
-					const status = mapThresholdsToStatus( key as Metrics, report[ key as Metrics ] );
-					const metricKey = key as Metrics;
-
-					return (
-						<Tab key={ key } tabId={ metricKey }>
-							<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
-								{ compact ? shortDisplayName : displayName }
-							</Text>
-							<MetricScore
-								lineHeight="32px"
-								metric={ metricKey }
-								status={ status }
-								size={ isSmall ? 20 : 16 }
-								value={ report[ metricKey ] }
-							/>
-						</Tab>
-					);
-				}
-			) }
+				return (
+					<Tab key={ metricKey } tabId={ metricKey }>
+						<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
+							{ compact ? shortDisplayName : displayName }
+						</Text>
+						<MetricScore
+							lineHeight="32px"
+							metric={ metricKey }
+							status={ status }
+							size={ isSmall ? 20 : 16 }
+							value={ report[ metricKey ] }
+						/>
+					</Tab>
+				);
+			} ) }
 		</Tabs.TabList>
 	);
 };

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -39,7 +39,7 @@ const CoreMetricsTabs = ( {
 		<Tabs.TabList style={ { maxWidth: '100%' } }>
 			{ Object.entries( metricsNames ).map(
 				( [ key, { name: displayName, shortName: shortDisplayName } ] ) => {
-					// Overall score is displayed in the first card
+					// We don't want to display the overall score in the tabs.
 					if ( key === 'overall_score' ) {
 						return null;
 					}

--- a/client/dashboard/sites/performance/core-metrics-tabs.tsx
+++ b/client/dashboard/sites/performance/core-metrics-tabs.tsx
@@ -4,7 +4,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Text } from '../../components/text';
 import { metricsNames, mapThresholdsToStatus } from '../../utils/site-performance';
-import { OverallScore, MetricScore } from './core-metrics-score';
+import { MetricScore } from './core-metrics-score';
 import type { SitePerformanceReport } from '@automattic/api-core';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -37,17 +37,6 @@ const CoreMetricsTabs = ( {
 
 	return (
 		<Tabs.TabList style={ { maxWidth: '100%' } }>
-			<Tab tabId="overall_score">
-				<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
-					{ compact ? metricsNames.overall_score.shortName : metricsNames.overall_score.name }
-				</Text>
-				<OverallScore
-					lineHeight="32px"
-					status={ mapThresholdsToStatus( 'overall_score', report.overall_score ) }
-					size={ isSmall ? 20 : 16 }
-					value={ report.overall_score }
-				/>
-			</Tab>
 			{ Object.entries( metricsNames ).map(
 				( [ key, { name: displayName, shortName: shortDisplayName } ] ) => {
 					// Overall score is displayed in the first card

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -21,7 +21,7 @@ export default function CoreMetrics( {
 	report: SitePerformanceReport;
 	onRecommendationsFilterChange: ( filter: Metrics ) => void;
 } ) {
-	const [ activeTab, setActiveTab ] = useState< Metrics >( 'overall_score' );
+	const [ activeTab, setActiveTab ] = useState< Metrics >( 'fcp' );
 	const isDesktop = useViewportMatch( 'medium' );
 
 	return (

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -2,7 +2,8 @@ import { Metrics } from '@automattic/api-core';
 import { __experimentalHStack as HStack, privateApis, Card, CardBody } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { getAvailableMetrics } from '../../utils/site-performance';
 import CoreMetricsContent from './core-metrics-content';
 import CoreMetricsTabs from './core-metrics-tabs';
 import type { SitePerformanceReport } from '@automattic/api-core';
@@ -14,6 +15,15 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { Tabs } = unlock( privateApis );
 
+/**
+ * Gets the first available tab based on the report data.
+ * This uses the shared utility function for consistency.
+ */
+const getFirstAvailableTab = ( report: SitePerformanceReport ): Metrics | null => {
+	const availableMetrics = getAvailableMetrics( report );
+	return availableMetrics.length > 0 ? availableMetrics[ 0 ] : null;
+};
+
 export default function CoreMetrics( {
 	report,
 	onRecommendationsFilterChange,
@@ -21,8 +31,14 @@ export default function CoreMetrics( {
 	report: SitePerformanceReport;
 	onRecommendationsFilterChange: ( filter: Metrics ) => void;
 } ) {
-	const [ activeTab, setActiveTab ] = useState< Metrics >( 'fcp' );
+	const firstAvailableTab = useMemo( () => getFirstAvailableTab( report ), [ report ] );
+	const [ activeTab, setActiveTab ] = useState< Metrics | null >( firstAvailableTab );
 	const isDesktop = useViewportMatch( 'medium' );
+
+	// If no tabs are available, don't render the component
+	if ( ! firstAvailableTab ) {
+		return null;
+	}
 
 	return (
 		<Tabs
@@ -39,7 +55,7 @@ export default function CoreMetrics( {
 						<Tabs.TabPanel tabId={ activeTab }>
 							<CoreMetricsContent
 								report={ report }
-								activeTab={ activeTab }
+								activeTab={ activeTab! }
 								onRecommendationsFilterChange={ onRecommendationsFilterChange }
 							/>
 						</Tabs.TabPanel>

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -35,8 +35,7 @@ export default function CoreMetrics( {
 	const [ activeTab, setActiveTab ] = useState< Metrics | null >( firstAvailableTab );
 	const isDesktop = useViewportMatch( 'medium' );
 
-	// If no tabs are available, don't render the component
-	if ( ! firstAvailableTab || ! activeTab ) {
+	if ( ! activeTab ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -36,7 +36,7 @@ export default function CoreMetrics( {
 	const isDesktop = useViewportMatch( 'medium' );
 
 	// If no tabs are available, don't render the component
-	if ( ! firstAvailableTab ) {
+	if ( ! firstAvailableTab || ! activeTab ) {
 		return null;
 	}
 
@@ -55,7 +55,7 @@ export default function CoreMetrics( {
 						<Tabs.TabPanel tabId={ activeTab }>
 							<CoreMetricsContent
 								report={ report }
-								activeTab={ activeTab! }
+								activeTab={ activeTab }
 								onRecommendationsFilterChange={ onRecommendationsFilterChange }
 							/>
 						</Tabs.TabPanel>

--- a/client/dashboard/sites/performance/core-metrics.tsx
+++ b/client/dashboard/sites/performance/core-metrics.tsx
@@ -2,7 +2,7 @@ import { Metrics } from '@automattic/api-core';
 import { __experimentalHStack as HStack, privateApis, Card, CardBody } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { getAvailableMetrics } from '../../utils/site-performance';
 import CoreMetricsContent from './core-metrics-content';
 import CoreMetricsTabs from './core-metrics-tabs';
@@ -31,7 +31,7 @@ export default function CoreMetrics( {
 	report: SitePerformanceReport;
 	onRecommendationsFilterChange: ( filter: Metrics ) => void;
 } ) {
-	const firstAvailableTab = useMemo( () => getFirstAvailableTab( report ), [ report ] );
+	const firstAvailableTab = getFirstAvailableTab( report );
 	const [ activeTab, setActiveTab ] = useState< Metrics | null >( firstAvailableTab );
 	const isDesktop = useViewportMatch( 'medium' );
 

--- a/client/dashboard/sites/performance/report.tsx
+++ b/client/dashboard/sites/performance/report.tsx
@@ -1,7 +1,9 @@
 import { Metrics } from '@automattic/api-core';
 import { __experimentalVStack as VStack, Card, CardBody } from '@wordpress/components';
 import { useState, useRef } from 'react';
+import { getPerformanceStatus } from '../../utils/site-performance';
 import CoreMetrics from './core-metrics';
+import CoreMetricsPerformance from './core-metrics-performance';
 import PerformanceInsights from './performance-insights';
 import ReportFooter from './report-footer';
 import ScreenshotTimeline from './screenshot-timeline';
@@ -32,6 +34,13 @@ export default function Report( {
 
 	return (
 		<VStack spacing={ 8 }>
+			<CoreMetricsPerformance
+				value={ report.crux_score ? report.crux_score : report.performance }
+				screenshot={ screenshots?.[ screenshots.length - 1 ]?.data ?? '' }
+				status={ getPerformanceStatus(
+					report.crux_score ? report.crux_score : report.performance
+				) }
+			/>
 			<CoreMetrics report={ report } onRecommendationsFilterChange={ handleFilterChange } />
 			<ScreenshotTimeline screenshots={ screenshots ?? [] } />
 			{ audits && (

--- a/client/dashboard/sites/performance/report.tsx
+++ b/client/dashboard/sites/performance/report.tsx
@@ -34,7 +34,7 @@ export default function Report( {
 	return (
 		<VStack spacing={ 8 }>
 			<CoreMetricsPerformance
-				value={ report.crux_score ? report.crux_score : report.overall_score }
+				value={ report.crux_score ?? report.overall_score }
 				onRecommendationsFilterChange={ handleFilterChange }
 			/>
 			<CoreMetrics report={ report } onRecommendationsFilterChange={ handleFilterChange } />

--- a/client/dashboard/sites/performance/report.tsx
+++ b/client/dashboard/sites/performance/report.tsx
@@ -1,7 +1,6 @@
 import { Metrics } from '@automattic/api-core';
 import { __experimentalVStack as VStack, Card, CardBody } from '@wordpress/components';
 import { useState, useRef } from 'react';
-import { getPerformanceStatus } from '../../utils/site-performance';
 import CoreMetrics from './core-metrics';
 import CoreMetricsPerformance from './core-metrics-performance';
 import PerformanceInsights from './performance-insights';
@@ -35,11 +34,8 @@ export default function Report( {
 	return (
 		<VStack spacing={ 8 }>
 			<CoreMetricsPerformance
-				value={ report.crux_score ? report.crux_score : report.performance }
-				screenshot={ screenshots?.[ screenshots.length - 1 ]?.data ?? '' }
-				status={ getPerformanceStatus(
-					report.crux_score ? report.crux_score : report.performance
-				) }
+				value={ report.crux_score ? report.crux_score : report.overall_score }
+				onRecommendationsFilterChange={ handleFilterChange }
 			/>
 			<CoreMetrics report={ report } onRecommendationsFilterChange={ handleFilterChange } />
 			<ScreenshotTimeline screenshots={ screenshots ?? [] } />

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -182,7 +182,7 @@ export const shouldDisplayMetric = ( key: string, report: SitePerformanceReport 
 };
 
 export const getAvailableMetrics = ( report: SitePerformanceReport ): Metrics[] => {
-	return Object.keys( metricsNames )
-		.filter( ( key ) => shouldDisplayMetric( key, report ) )
-		.map( ( key ) => key as Metrics );
+	return ( Object.keys( metricsNames ) as Metrics[] ).filter( ( key ) =>
+		shouldDisplayMetric( key, report )
+	);
 };

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -160,10 +160,6 @@ export function getFormattedSize( size: number ) {
 	);
 }
 
-/**
- * Checks if a metric should be displayed in tabs based on the report data.
- * This follows the same filtering logic used in CoreMetricsTabs.
- */
 export const shouldDisplayMetric = ( key: string, report: SitePerformanceReport ): boolean => {
 	// We don't want to display the overall score in the tabs.
 	if ( key === 'overall_score' ) {
@@ -185,10 +181,6 @@ export const shouldDisplayMetric = ( key: string, report: SitePerformanceReport 
 	return true;
 };
 
-/**
- * Gets all available metrics that should be displayed in tabs.
- * Returns an array of metric keys in the order they should appear.
- */
 export const getAvailableMetrics = ( report: SitePerformanceReport ): Metrics[] => {
 	return Object.keys( metricsNames )
 		.filter( ( key ) => shouldDisplayMetric( key, report ) )

--- a/client/dashboard/utils/site-performance.ts
+++ b/client/dashboard/utils/site-performance.ts
@@ -1,5 +1,6 @@
 import { Metrics } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import type { SitePerformanceReport } from '@automattic/api-core';
 
 export type Valuation = 'good' | 'needsImprovement' | 'bad';
 
@@ -158,3 +159,38 @@ export function getFormattedSize( size: number ) {
 		[ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
 	);
 }
+
+/**
+ * Checks if a metric should be displayed in tabs based on the report data.
+ * This follows the same filtering logic used in CoreMetricsTabs.
+ */
+export const shouldDisplayMetric = ( key: string, report: SitePerformanceReport ): boolean => {
+	// We don't want to display the overall score in the tabs.
+	if ( key === 'overall_score' ) {
+		return false;
+	}
+
+	if (
+		report[ key as keyof SitePerformanceReport ] === undefined ||
+		report[ key as keyof SitePerformanceReport ] === null
+	) {
+		return false;
+	}
+
+	// Only display TBT if INP is not available
+	if ( key === 'tbt' && report[ 'inp' ] !== undefined && report[ 'inp' ] !== null ) {
+		return false;
+	}
+
+	return true;
+};
+
+/**
+ * Gets all available metrics that should be displayed in tabs.
+ * Returns an array of metric keys in the order they should appear.
+ */
+export const getAvailableMetrics = ( report: SitePerformanceReport ): Metrics[] => {
+	return Object.keys( metricsNames )
+		.filter( ( key ) => shouldDisplayMetric( key, report ) )
+		.map( ( key ) => key as Metrics );
+};


### PR DESCRIPTION
Fixes: DOTMSD-656.

## Proposed Changes

As mentioned in DOTMSD-656, we don't return any data for the Performance score, and therefore, users will never have a LineChart with data.

This PR removes the Performance Score from the chart area and communicates the score in a modal that provides users a click that then scrolls them down to the recommendations.

## Screenshots
| Before | After |
|-----|-----|
| <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=133 (4)" src="https://github.com/user-attachments/assets/7c4e493f-ec10-4bb6-a81d-f73363711240" /> | <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=131" src="https://github.com/user-attachments/assets/9a37f7a5-c0f1-4149-bc28-25a68a6435fe" /> | 
| <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=0" src="https://github.com/user-attachments/assets/1287fb76-3fd9-4214-bc13-4e91689591a3" /> | <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=133 (2)" src="https://github.com/user-attachments/assets/508efae2-ef14-4b0b-bcae-78632acb258d" /> | 
| <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=133 (3)" src="https://github.com/user-attachments/assets/5d69004a-2bc4-43a8-8dcf-2506eb6bbde0" /> | <img width="2106" height="1936" alt="calypso localhost_3000_v2_sites_abstracting blog_performance_page_id=131 (1)" src="https://github.com/user-attachments/assets/528020cb-32fd-40af-93c6-125cb2db3a5e" /> | 



## GIF

![Screen Recording on 2025-10-24 at 12-17-40](https://github.com/user-attachments/assets/5a6b298e-9134-4560-b56e-a8584cb98a40)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
