### PR TITLE
Site list links to MSD domain view intead of the external Calypso one

### DIFF
--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { backup, wordpress } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { siteDomainsRoute } from '../../app/router/sites';
 import { isP2, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canManageSite } from '../features';
 import type { Site } from '@automattic/api-core';
@@ -48,7 +49,7 @@ export function useActions(): Action< Site >[] {
 			label: __( 'Domains' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
-				router.navigate( { to: '/sites/$siteSlug/domains', params: { siteSlug: site.slug } } );
+				router.navigate( { to: siteDomainsRoute.fullPath, params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) => canManageSite( item ),
 		},

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -45,10 +45,10 @@ export function useActions(): Action< Site >[] {
 		},
 		{
 			id: 'domains',
-			label: __( 'Domains ↗' ),
+			label: __( 'Domains' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
-				window.open( `/domains/manage/${ site.slug }` );
+				router.navigate( { to: '/sites/$siteSlug/domains', params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) => canManageSite( item ),
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-722

## Proposed Changes

* Site list now links to site-specific domain view in MSD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This link came from a time when the MSD didn't have a domain view

<img width="736" height="962" alt="CleanShot 2025-10-24 at 21 06 59@2x" src="https://github.com/user-attachments/assets/9730bf4b-97fa-497f-90b2-a3c991ee268e" />

Now there's a domain view at `/sites/$siteSlug/domains`. So the menu points to that internal link now.

<img width="638" height="744" alt="CleanShot 2025-10-24 at 21 08 11@2x" src="https://github.com/user-attachments/assets/22744ebd-ba2f-4b86-809f-81dda89dedc7" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
