### PR TITLE
Theme Showcase: Update the Sensei theme "included with plan" label

### DIFF
--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -5,6 +5,7 @@ import {
 	FEATURE_INSTALL_THEMES,
 	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 	WPCOM_FEATURES_COMMUNITY_THEMES,
+	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
 import {
 	FREE_THEME,
@@ -55,6 +56,13 @@ export function canUseTheme( state, siteId, themeId ) {
 	if ( type === BUNDLED_THEME ) {
 		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
 		const themeSoftware = themeSoftwareSet[ 0 ];
+
+		// Add a special case for Sensei themes to ensure they are limited to the Business plan.
+		// @todo refactor this whole file using theme tiers.
+		if ( themeSoftware === 'sensei' ) {
+			const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
+			return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
+		}
 
 		const featureChecks = [
 			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-110

## Proposed Changes

* Add a special case for Sensei themes in the `canUseTheme` function to ensure they are limited to the Business plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Sensei themes (currently only Course) is incorrectly being displayed as included in the Premium plan, while it should be included in Business only.

This happens because the `canUseTheme` check relies on the obsolete `themeType` property instead of `themeTier`. Using `themeType`, Sensei themes are grouped together with WooCommerce themes which are indeed part of Premium themes and Atomic, but have an extra `woop` feature that successfully limits them to Business.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a Premium Atomic site.
  * Navigate to the Calypso Theme Showcase and search for the Course theme. (`/themes/all/SITE?s=course`).
  * ➡️ Check that the label says "Available on Business".
  * Try activating it. It should require an upgrade to the Business plan.
* Select a Business Atomic site.
  * Navigate to the Calypso Theme Showcase and search for the Course theme. (`/themes/all/SITE?s=course`).
  * ➡️ Check that the label says "Included with plan".
  * Try activating it. It should activate straight away.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
