### PR TITLE
Buld plugin dataview: Fix toggling a plugin selects row

### DIFF
--- a/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/field-action-toggle.tsx
@@ -16,8 +16,6 @@ export type FieldActionToggleProps = {
 	errorOn: string;
 	successOff: string;
 	errorOff: string;
-	// Prevent default click (to avoid row selection etc.). Defaults to true.
-	preventDefaultClick?: boolean;
 	// Action identifier used for analytics: e.g. "activate" or "autoupdate".
 	actionId: 'activate' | 'autoupdate';
 };
@@ -31,36 +29,37 @@ export default function FieldActionToggle( {
 	errorOn,
 	successOff,
 	errorOff,
-	preventDefaultClick = true,
 	actionId,
 }: FieldActionToggleProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	return (
-		<ToggleControl
-			__nextHasNoMarginBottom
-			label={ label }
-			checked={ checked }
-			onClick={ ( e ) => {
-				if ( preventDefaultClick ) {
-					e.preventDefault();
-				}
-			} }
-			onChange={ ( next ) => {
-				recordTracksEvent( 'calypso_dashboard_plugins_toggle_click', {
-					action_id: actionId,
-					next_state: next ? 'enable' : 'disable',
-				} );
-				onToggle( next )
-					.then( () => {
-						createSuccessNotice( next ? successOn : successOff, { type: 'snackbar' } );
-					} )
-					.catch( () => {
-						createErrorNotice( next ? errorOn : errorOff, { type: 'snackbar' } );
+		<div
+			role="presentation"
+			onClick={ ( e ) => e.stopPropagation() }
+			onMouseDown={ ( e ) => e.stopPropagation() }
+			onKeyDown={ ( e ) => e.stopPropagation() }
+		>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ label }
+				checked={ checked }
+				onChange={ ( next ) => {
+					recordTracksEvent( 'calypso_dashboard_plugins_toggle_click', {
+						action_id: actionId,
+						next_state: next ? 'enable' : 'disable',
 					} );
-			} }
-			disabled={ disabled }
-		/>
+					onToggle( next )
+						.then( () => {
+							createSuccessNotice( next ? successOn : successOff, { type: 'snackbar' } );
+						} )
+						.catch( () => {
+							createErrorNotice( next ? errorOn : errorOff, { type: 'snackbar' } );
+						} );
+				} }
+				disabled={ disabled }
+			/>
+		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-730/bulk-plugin-dataview-toggling-a-plugin-onoff-also-selects-the-dataview

## Proposed Changes

* When we click on the toggle control the row doesn't become selected anymore.


https://github.com/user-attachments/assets/9fdb5a79-cf57-444f-8168-d2bc8e77d430



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/plugins/manage/akismet` (or other plugin)
* Click on the toggles, and the rows should not become selected for bulk actions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
