### PR TITLE
Multi Site Dashboard: Add email status pending_deletion

### DIFF
--- a/client/dashboard/emails/fields/status.tsx
+++ b/client/dashboard/emails/fields/status.tsx
@@ -32,6 +32,10 @@ export const statusField: Field< Email > = {
 			return <Text intent="error">{ __( 'No subscription' ) }</Text>;
 		}
 
+		if ( item.status === 'pending_deletion' ) {
+			return <Text intent="warning">{ __( 'Pending deletion' ) }</Text>;
+		}
+
 		return <Text>{ item.status }</Text>;
 	},
 	getValue: ( { item }: { item: Email } ) => item.status,

--- a/client/dashboard/emails/types.ts
+++ b/client/dashboard/emails/types.ts
@@ -22,6 +22,7 @@ export interface Email {
 		| 'unverified_forwards'
 		| 'no_subscription'
 		| 'unused_mailboxes'
+		| 'pending_deletion'
 		| 'other_provider';
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-731/multi-site-dashboard-email-status-pending-deletion-is-showing-a-not

## Proposed Changes

* Added a new status for when the deletion is pending.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It's complicated to test.
* Make sure you have some titan mailboxes
* Remove the subscription
* And delete it
* Go to `/v2/emails`
* You should see (probably) a row with status `Pending deletion`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
