### PR TITLE
Remove unused query params for the all-domains endpoint

### DIFF
--- a/packages/api-core/src/domains/fetchers.ts
+++ b/packages/api-core/src/domains/fetchers.ts
@@ -2,12 +2,6 @@ import { wpcom } from '../wpcom-fetcher';
 import type { DomainSummary } from './types';
 
 export async function fetchDomains(): Promise< DomainSummary[] > {
-	const { domains } = await wpcom.req.get(
-		{ path: '/all-domains', apiVersion: '1.2' },
-		{
-			no_wpcom: true,
-			resolve_status: true,
-		}
-	);
+	const { domains } = await wpcom.req.get( { path: '/all-domains', apiVersion: '1.2' } );
 	return domains;
 }


### PR DESCRIPTION
That's it - we don't use those params in the 1.2 endpoint so just cleaning up

Part of #

## Proposed Changes

* Remove the query params for the all-domains endpoint since v1.2 doesn't use them

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Cleaning up leftovers from the old version of the endpoint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /v2/domains and make sure it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
