### PR TITLE
Multi site dashboard emails: Checkout returns to emails

### DIFF
--- a/client/dashboard/emails/add-professional-email/index.tsx
+++ b/client/dashboard/emails/add-professional-email/index.tsx
@@ -5,6 +5,7 @@ import { __experimentalVStack as VStack, Button, Card, CardBody } from '@wordpre
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { ButtonStack } from '../../components/button-stack';
@@ -144,12 +145,15 @@ const AddProfessionalEmail = () => {
 			numberOfMailboxes
 		);
 
-		const checkoutPath = getEmailCheckoutPath(
+		const checkoutBasePath = getEmailCheckoutPath(
 			site?.slug || '',
 			domain.domain,
 			router.state.location.pathname,
 			mailboxOperations.mailboxes[ 0 ].getAsCartItem().email
 		);
+
+		const backUrl = window.location.origin + '/v2/emails';
+		const checkoutPath = addQueryArgs( checkoutBasePath, { checkoutBackUrl: backUrl } );
 
 		await shoppingCartManagerClient
 			.forCartKey( site?.ID )


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-726/multi-site-dashboard-emails-paying-for-a-mailbox-returns-to-the-wrong

## Proposed Changes

* Added a backUrl so that we can land on `/v2/emails` instead of landing on the site version.


https://github.com/user-attachments/assets/a1a7670f-d8bd-4039-8ceb-cd2930d5c83d


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/emails`
* Add a new mailbox (Titan mail)
* When you reach checkout, if you close, you should land on `/v2/emails`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
