### PR TITLE
Add Flex sites to v1 hosting dashboard's sidebar

### DIFF
--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -39,12 +39,14 @@ export function getSiteAdminUrl( site: SiteExcerptNetworkData ) {
 }
 
 export const isNotAtomicJetpack = ( site: SiteExcerptNetworkData ) => {
-	return site.jetpack && ! site?.is_wpcom_atomic;
+	return site.jetpack && ! site?.is_wpcom_atomic && ! site?.is_wpcom_flex;
 };
 
 // Sites connected through A4A plugin are listed on wordpress.com/sites even when Jetpack is deactivated.
 export const isDisconnectedJetpackAndNotAtomic = ( site: SiteExcerptNetworkData ) => {
-	return ! site?.is_wpcom_atomic && site?.jetpack_connection && ! site?.jetpack;
+	return (
+		! site?.is_wpcom_atomic && site?.jetpack_connection && ! site?.jetpack && ! site?.is_wpcom_flex
+	);
 };
 
 export const isSimpleSite = ( site: SiteExcerptNetworkData ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* This is a non-essential change as we don't plan using V1 Hosting Dashboard for Flex but it is still confusing for development.
* It enables the left sidebar in v1 dashboard for flex sites


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The isSitePreviewPaneEligible returning false prevents the left sidebar from properly linking to the right overview page for flex sites and points them to wp-admin

## Testing Instructions

* On a user that has flex sites, go to /sites
* select a site. Then select a flex site

<img width="490" height="653" alt="Screenshot 2025-10-24 at 15 50 40" src="https://github.com/user-attachments/assets/796903d2-40a5-4da0-9172-3b09903c4dd4" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
