### PR TITLE
Enable the V1 hosting dashboard's performance tab for Flex sites

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -20,6 +20,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getRequest from 'calypso/state/selectors/get-request';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { launchSite } from 'calypso/state/sites/launch/actions';
+import { isWpcomFlexSite } from 'calypso/state/sites/selectors';
 import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -54,6 +55,7 @@ const SitePerformanceContent = () => {
 	const blog_public = getSiteSetting( 'blog_public' );
 	const isSitePublic = site && blog_public === 1;
 	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isSiteFlex = useSelector( ( state ) => isWpcomFlexSite( state, siteId ) );
 
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
@@ -279,7 +281,7 @@ const SitePerformanceContent = () => {
 					}
 			  );
 
-	if ( ! isSiteAtomic ) {
+	if ( ! isSiteAtomic && ! isSiteFlex ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-57

## Proposed Changes

* Performance tab is limited to Atomic sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Go to /sites
* Select a flex site
* Go to performance tab.

Without the change, a white screen is visible
With it, the tab works (one endpoint returns 404, which doesn't impact the display)

<img width="1430" height="614" alt="Screenshot 2025-10-24 at 15 56 12" src="https://github.com/user-attachments/assets/0e44356f-3204-4c90-b495-64e90f862b6d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
