### PR TITLE
Freshly Pressed: Fix railcar tracking support on the /discover

### DIFF
--- a/client/reader/stats/index.ts
+++ b/client/reader/stats/index.ts
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import debugFactory from 'debug';
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -254,7 +254,7 @@ export function recordTrackForPost(
 		// check for overrides for the railcar
 		recordTracksRailcarInteract(
 			eventName,
-			pick( post, [ 'railcar' ] ),
+			get( post, 'railcar' ),
 			pick( additionalProps, [ 'ui_position', 'ui_algo' ] )
 		);
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {

--- a/client/reader/stats/test/index.test.ts
+++ b/client/reader/stats/test/index.test.ts
@@ -295,6 +295,33 @@ describe( 'reader stats', () => {
 			);
 		} );
 
+		it( 'should track calypso_traintracks_interact when the post has a railcar', () => {
+			const post = {
+				ID: 123,
+				site_ID: 456,
+				railcar: {
+					railcar: 'test_railcar',
+					fetch_algo: 'test_algo',
+					fetch_lang: 'en',
+					fetch_position: 1,
+					rec_blog_id: '123',
+				},
+			} as unknown as TrackPostData;
+
+			recordTrackForPost( 'calypso_reader_article_opened', post );
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_traintracks_interact',
+				expect.objectContaining( {
+					railcar: 'test_railcar',
+					action: 'article_opened',
+					fetch_algo: 'test_algo',
+					fetch_lang: 'en',
+					fetch_position: 1,
+					rec_blog_id: '123',
+				} )
+			);
+		} );
+
 		it( 'should record track for post without railcar', () => {
 			const post = { ID: 123, site_ID: 456 } as unknown as TrackPostData;
 


### PR DESCRIPTION
Closes CML-983

## Proposed Changes

* Fix the issue that was preventing the /reader from using the railcar value correctly.

## Testing Instructions
* Make sure the wpcom pr was merged 194615-ghe-Automattic/wpcom or sandbox the public api from the PR branch.
* Go to the `/discover` 
* Check if the event `calypso_traintracks_render`


<img width="766" height="484" alt="CleanShot 2025-10-24 at 14 12 20@2x" src="https://github.com/user-attachments/assets/fdac9334-19ad-4ef9-8e24-b0d8bb76c9a7" />
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?