### PR TITLE
Revert "actions for view response and move to trash are now just view and trash (#106686)"

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -51,7 +51,7 @@ export class FeedbackInboxPage {
 				.filter( { hasText: text } )
 				.waitFor();
 		} else {
-			await responseRowLocator.getByRole( 'button', { name: 'View' } ).click();
+			await responseRowLocator.getByRole( 'button', { name: 'View response' } ).click();
 			await this.page
 				.getByRole( 'dialog' )
 				.filter( { has: this.page.getByRole( 'heading', { name: 'Response' } ) } )
@@ -227,7 +227,7 @@ export class FeedbackInboxPage {
 	 */
 	async clickMoveToTrashAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
-		await this.page.getByRole( 'button', { name: 'Trash' } ).last().click();
+		await this.page.getByRole( 'button', { name: 'Move to trash' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			// On mobile, the modal closes after the action
 			await this.page.waitForTimeout( 1000 );


### PR DESCRIPTION
This reverts commit fe211c977ffb351ef618faa4e2e3cff8da373e0e.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

I merged Automattic/jetpack#45597 prematurely, and it may have some design issues we need resolved before we roll it out in an alpha release.

We tweaked the E2E tests as a result, and this PR will roll back that merge as needed; otherwise we can close it.

See discussion from here: p1761222734127199/1761040836.961939-slack-CDLH4C1UZ

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?