### PR TITLE
Notification Settings: Show the updated settings name

### DIFF
--- a/client/dashboard/me/notifications-comments/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/device-settings/test/index.test.tsx
@@ -298,7 +298,7 @@ describe( 'DevicesSettings', () => {
 			expect( savedSettingsApi.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/notifications-comments/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/email-settings/test/index.test.tsx
@@ -115,7 +115,7 @@ describe( 'EmailSettings', () => {
 			expect( updatedSettings.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/notifications-comments/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/web-settings/test/index.test.tsx
@@ -115,7 +115,7 @@ describe( 'WebSettings', () => {
 			expect( updatedSettings.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/notifications-extras/extras-config.ts
+++ b/client/dashboard/me/notifications-extras/extras-config.ts
@@ -70,3 +70,10 @@ export const JETPACK_DESCRIPTIONS: Record< JetpackOptionKey, string > = {
 	jetpack_news: __( 'Jetpack news, announcements, and product spotlights.' ),
 	jetpack_reports: __( 'Jetpack security and performance reports.' ),
 };
+
+export const getSettingsTitle = ( settingsName: string ) => {
+	return (
+		WPCOM_TITLES[ settingsName as WpcomOptionKey ] ??
+		JETPACK_TITLES[ settingsName as JetpackOptionKey ]
+	);
+};

--- a/client/dashboard/me/notifications-sites/hooks/index.ts
+++ b/client/dashboard/me/notifications-sites/hooks/index.ts
@@ -1,26 +1,10 @@
-import {
-	userNotificationsSettingsQuery,
-	userNotificationsSettingsMutation,
-} from '@automattic/api-queries';
-import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { userNotificationsSettingsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useSiteSettings = ( blogId: number ) => {
 	return useSuspenseQuery( {
 		...userNotificationsSettingsQuery(),
 		select: ( data ) => data?.blogs.find( ( blog ) => blog.blog_id === blogId ),
 		staleTime: 1000 * 60 * 5,
-	} );
-};
-
-export const useSettingsMutation = () => {
-	return useMutation( {
-		...userNotificationsSettingsMutation(),
-		meta: {
-			snackbar: {
-				success: __( 'Settings saved successfully.' ),
-				error: __( 'There was a problem saving your changes. Please, try again.' ),
-			},
-		},
 	} );
 };

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
@@ -400,7 +400,7 @@ describe( 'DevicesSettings', () => {
 			expect( updatedSettingsApi.isDone() ).toBe( true );
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 } );

--- a/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
@@ -165,7 +165,7 @@ describe( 'EmailSettings', () => {
 
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
@@ -164,7 +164,7 @@ describe( 'WebSettings', () => {
 
 			const snackbar = notificationSnackBar();
 			expect( snackbar ).toBeVisible();
-			expect( snackbar ).toHaveTextContent( 'Settings saved successfully.' );
+			expect( snackbar ).toHaveTextContent( '"Likes on my comments" settings saved.' );
 		} );
 	} );
 


### PR DESCRIPTION
Closes: DOTMSD-697

## Proposed Changes
* Show the updated settings name when it is updated

## Why are these changes being made?
As discussed in the thread p1761220877506959-slack-C0982082MSR, we decided to display the setting name when a setting is updated. 

## Testing Instructions
* Go to `/v2/me/notifications/sites` 
* Update any settings options from any site. 
* Check if you can see a notification with the settings name

---

* Go to `/v2/me/notifications/comments`
* Update any settings
* Check if you can see a notification with the settings name

---


* Go to `/v2/me/notifications/extras`
* Update any settings options
* Check if you can see a notification with the settings name

---
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?