### PR TITLE
Multi-Site Dashboard: Temporarily redirect cancel and remove purchase flow to v1

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -257,13 +257,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function CancelOrRemoveActionButton( {
-	siteSlug,
-	purchase,
-}: {
-	siteSlug: string | undefined;
-	purchase: Purchase;
-} ) {
+function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
 	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
@@ -279,7 +273,7 @@ function CancelOrRemoveActionButton( {
 						onClick={ () =>
 							// FIXME: add refund, cancel, and downgrade action
 							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ siteSlug }/${ purchase.ID }/cancel` )
+							( window.location.href = `/me/purchases/${ purchase.site_slug }/${ purchase.ID }/cancel` )
 						}
 					>
 						{ __( 'Downgrade or cancel' ) }
@@ -300,7 +294,7 @@ function CancelOrRemoveActionButton( {
 						onClick={ () =>
 							// FIXME: add remove action
 							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ siteSlug }/${ purchase.ID }/remove` )
+							( window.location.href = `/me/purchases/${ purchase.site_slug }/${ purchase.ID }/remove` )
 						}
 					>
 						{ __( 'Remove subscription' ) }
@@ -482,7 +476,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
-				<CancelOrRemoveActionButton siteSlug={ purchase.site_slug } purchase={ purchase } />
+				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>
 		</VStack>
 	);
@@ -1135,7 +1129,7 @@ export default function PurchaseSettings() {
 				</Grid>
 				{ site && <WPComResourceMeters purchase={ purchase } site={ site } /> }
 				<ManageSubscriptionCard purchase={ purchase } />
-				<PurchaseSettingsActions siteSlug={ purchase.site_slug } purchase={ purchase } />
+				<PurchaseSettingsActions purchase={ purchase } />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -257,7 +257,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
+function CancelOrRemoveActionButton( { site, purchase }: { site: Site; purchase: Purchase } ) {
 	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
 	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
@@ -270,9 +270,11 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 					<Button
 						variant="secondary"
 						size="compact"
-						onClick={ () => ( {
+						onClick={ () =>
 							// FIXME: add refund, cancel, and downgrade action
-						} ) }
+							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
+							( window.location.href = `/me/purchases/${ site.slug }/${ purchase.ID }/cancel` )
+						}
 					>
 						{ __( 'Downgrade or cancel' ) }
 					</Button>
@@ -289,9 +291,11 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 					<Button
 						variant="secondary"
 						size="compact"
-						onClick={ () => ( {
+						onClick={ () =>
+							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
 							// FIXME: add remove action
-						} ) }
+							( window.location.href = `/me/purchases/${ site.slug }/${ purchase.ID }/remove` )
+						}
 					>
 						{ __( 'Remove subscription' ) }
 					</Button>
@@ -463,7 +467,7 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
+function PurchaseSettingsActions( { site, purchase }: { site: Site; purchase: Purchase } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
@@ -472,7 +476,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
-				<CancelOrRemoveActionButton purchase={ purchase } />
+				<CancelOrRemoveActionButton site={ site } purchase={ purchase } />
 			</ActionList>
 		</VStack>
 	);
@@ -1125,7 +1129,7 @@ export default function PurchaseSettings() {
 				</Grid>
 				{ site && <WPComResourceMeters purchase={ purchase } site={ site } /> }
 				<ManageSubscriptionCard purchase={ purchase } />
-				<PurchaseSettingsActions purchase={ purchase } />
+				<PurchaseSettingsActions site={ site } purchase={ purchase } />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -257,7 +257,13 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function CancelOrRemoveActionButton( { site, purchase }: { site: Site; purchase: Purchase } ) {
+function CancelOrRemoveActionButton( {
+	siteSlug,
+	purchase,
+}: {
+	siteSlug: string | undefined;
+	purchase: Purchase;
+} ) {
 	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
 	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
@@ -273,7 +279,7 @@ function CancelOrRemoveActionButton( { site, purchase }: { site: Site; purchase:
 						onClick={ () =>
 							// FIXME: add refund, cancel, and downgrade action
 							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ site.slug }/${ purchase.ID }/cancel` )
+							( window.location.href = `/me/purchases/${ siteSlug }/${ purchase.ID }/cancel` )
 						}
 					>
 						{ __( 'Downgrade or cancel' ) }
@@ -294,7 +300,7 @@ function CancelOrRemoveActionButton( { site, purchase }: { site: Site; purchase:
 						onClick={ () =>
 							// FIXME: add remove action
 							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ site.slug }/${ purchase.ID }/remove` )
+							( window.location.href = `/me/purchases/${ siteSlug }/${ purchase.ID }/remove` )
 						}
 					>
 						{ __( 'Remove subscription' ) }
@@ -467,7 +473,7 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
-function PurchaseSettingsActions( { site, purchase }: { site: Site; purchase: Purchase } ) {
+function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	return (
 		<VStack spacing={ 4 }>
 			<ActionList>
@@ -476,7 +482,7 @@ function PurchaseSettingsActions( { site, purchase }: { site: Site; purchase: Pu
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
-				<CancelOrRemoveActionButton site={ site } purchase={ purchase } />
+				<CancelOrRemoveActionButton siteSlug={ purchase.site_slug } purchase={ purchase } />
 			</ActionList>
 		</VStack>
 	);
@@ -1129,7 +1135,7 @@ export default function PurchaseSettings() {
 				</Grid>
 				{ site && <WPComResourceMeters purchase={ purchase } site={ site } /> }
 				<ManageSubscriptionCard purchase={ purchase } />
-				<PurchaseSettingsActions site={ site } purchase={ purchase } />
+				<PurchaseSettingsActions siteSlug={ purchase.site_slug } purchase={ purchase } />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -292,8 +292,8 @@ function CancelOrRemoveActionButton( { site, purchase }: { site: Site; purchase:
 						variant="secondary"
 						size="compact"
 						onClick={ () =>
-							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
 							// FIXME: add remove action
+							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
 							( window.location.href = `/me/purchases/${ site.slug }/${ purchase.ID }/remove` )
 						}
 					>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -91,6 +91,34 @@ export function addCreditCard( context, next ) {
 	next();
 }
 
+export function removePurchase( context, next ) {
+	const ManagePurchasesWrapper = localize( () => {
+		const classes = 'manage-purchase';
+		const purchaseListUrl = usePreviousUrlIfPurchasesList();
+
+		return (
+			<PurchasesWrapper title={ titles.managePurchase }>
+				<Main wideLayout className={ classes }>
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+					<PageViewTracker
+						path="/me/purchases/:site/:purchaseId"
+						title="Purchases > Manage Purchase"
+					/>
+					<ManagePurchase
+						showRemovePurchaseDialog
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+						purchaseListUrl={ purchaseListUrl }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <ManagePurchasesWrapper />;
+	next();
+}
+
 export function cancelPurchase( context, next ) {
 	const CancelPurchaseWrapper = localize( () => {
 		return (

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -123,6 +123,14 @@ export default ( router ) => {
 	);
 
 	router(
+		paths.removePurchase( ':site', ':purchaseId' ),
+		sidebar,
+		controller.removePurchase,
+		makeLayout,
+		clientRender
+	);
+
+	router(
 		paths.downgradePurchase( ':site', ':purchaseId' ),
 		sidebar,
 		controller.downgradePurchase,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -198,6 +198,7 @@ export interface ManagePurchaseProps {
 	purchaseId: number;
 	redirectTo?: string;
 	siteSlug: string;
+	showRemovePurchaseDialog: boolean | null;
 
 	/**
 	 * Note: this defaults to true.
@@ -745,6 +746,7 @@ class ManagePurchase extends Component<
 
 		return (
 			<RemovePurchase
+				showDialog={ this.props.showRemovePurchaseDialog }
 				hasLoadedSites={ hasLoadedSites }
 				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedPurchasesFromServer }
 				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -198,7 +198,7 @@ export interface ManagePurchaseProps {
 	purchaseId: number;
 	redirectTo?: string;
 	siteSlug: string;
-	showRemovePurchaseDialog: boolean | null;
+	showRemovePurchaseDialog?: boolean | undefined;
 
 	/**
 	 * Note: this defaults to true.

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -38,6 +38,15 @@ export function managePurchaseByOwnership( ownershipId ) {
 	return '/me/purchases-by-owner/' + ownershipId;
 }
 
+export function removePurchase( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
+	return managePurchase( siteName, purchaseId ) + '/remove';
+}
+
 export function cancelPurchase( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -65,6 +65,7 @@ class RemovePurchase extends Component {
 		linkIcon: PropTypes.string,
 		primaryDomain: PropTypes.object,
 		skipRemovePlanSurvey: PropTypes.bool,
+		showDialog: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -100,12 +101,7 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	openDialog = ( event ) => {
-		event.preventDefault();
-
-		if ( this.props.onClickTracks ) {
-			this.props.onClickTracks( event );
-		}
+	actuallyOpenDialog = () => {
 		if (
 			this.shouldShowNonPrimaryDomainWarning() &&
 			! this.state.isShowingNonPrimaryDomainWarning
@@ -143,6 +139,20 @@ class RemovePurchase extends Component {
 				isShowingWordAdsEligibilityWarningDialog: false,
 				isDialogVisible: true,
 			} );
+		}
+	};
+
+	openDialog = ( event ) => {
+		event.preventDefault();
+		if ( this.props.onClickTracks ) {
+			this.props.onClickTracks( event );
+		}
+		this.actuallyOpenDialog();
+	};
+
+	componentDidMount = () => {
+		if ( this.props.showDialog ) {
+			this.actuallyOpenDialog();
 		}
 	};
 
@@ -414,6 +424,15 @@ class RemovePurchase extends Component {
 
 			return null;
 		};
+
+		if ( this.props.showDialog ) {
+			return (
+				<>
+					{ getWarningDialog() }
+					{ this.renderDialog() }
+				</>
+			);
+		}
 
 		return (
 			<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1236/multi-site-dashboard-temporarily-redirect-cancel-and-remove-purchase
Part of CHE-237
Closes SHILL-1236

## Proposed Changes

* Temporarily redirect the user to the v1 cancel / remove flows until #105459 is ready.

![2025-10-24 13 53 02](https://github.com/user-attachments/assets/81b458fb-6074-45ac-be85-11ff5c123337)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* #105459 is almost but not quite ready. Rather than subject the customer to poor UX from bugs, temporarily redirect them back to v1 just when cancelling or removing purchases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start on the hosting dashboard, go to billing, active purchases, find and manage a purchase by clicking the menu for that row and selecting "Manage purchase"
* Select "Downgrade or cancel" or "Remove .." for the purchase.
* You should be redirected to v1 for that flow.
* You should be able to complete the cancel / remove flow and cancel / remove your purchase.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
