### PR TITLE
Domains: Prevent NS records from pointing to `*.wordpress.com`

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -294,15 +294,6 @@ class DnsAddNew extends React.Component {
 			return true;
 		}
 
-		// Specific to NS records, avoid invalid state by checking if the target Host field is at *.wordpress.com
-		if (
-			this.state.fields.type.value === 'NS' &&
-			fieldName === 'data' &&
-			/\.wordpress\.com$/i.test( this.state.fields.data.value ) // matches on ns1.wordpress.com, ns2.wordpress.com, *.wordpress.com, etc.
-		) {
-			return false;
-		}
-
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
 	};
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -88,7 +88,8 @@ function isValidData( data, type ) {
 		case 'CNAME':
 		case 'MX':
 		case 'NS':
-			return isValidDomain( data );
+			// NS records can't point to *.wordpress.com
+			return ! data.match( /.wordpress\.com$/i ) && isValidDomain( data );
 		case 'CAA':
 		case 'TXT':
 			return data.length > 0 && data.length <= 2048;


### PR DESCRIPTION
Part of [DOMENG-161](https://linear.app/a8c/issue/DOMENG-161/)

## Proposed Changes

This PR fixes validation in the DNS record form to prevent NS records that point to `*.wordpress.com` from being created.

| Before | After |
| --- | --- |
| <img width="1343" height="670" alt="Screenshot 2025-10-24 at 18 36 33" src="https://github.com/user-attachments/assets/35b01507-2af0-41a8-a4e2-e4a5af8f775e" /> | <img width="1351" height="661" alt="Screenshot 2025-10-24 at 18 35 32" src="https://github.com/user-attachments/assets/e0170abd-03af-4684-8954-6cdc92abab5b" /> |

## Why are these changes being made?

NS records can't point to WPCOM name servers since that doesn't make sense - if the DNS of a domain is managed here, that means it's already using our name servers.

The DNS record form for NS records showed "Invalid host" if a user inputted any host ending in `.wordpress.com`, but it didn't prevent the record from being added. That's because the validation added in #94036 wasn't in the correct place.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the DNS management page of a domain you own
- Try to add an NS record that points to a host ending in `.wordpress.com`
- Ensure the form disables the save button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
