### PR TITLE
Hosting Dashboard: Scan threats can be null.

### DIFF
--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -27,7 +27,7 @@ function getScanURL( site: Site ) {
 }
 
 function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {
-	const threatCount = scan.threats.length;
+	const threatCount = scan.threats?.length ?? 0;
 	const description = sprintf(
 		/* translators: %d: number of risks */
 		_n( '%d risk found', '%d risks found', threatCount ),

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -75,7 +75,7 @@ function ScanCardContent( { site }: { site: Site } ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;
 	}
 
-	if ( ! scan ) {
+	if ( ! scan || ! scan.threats ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -42,7 +42,7 @@ export function ActiveThreatsDataViews( {
 
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const { data: scan, isLoading } = useQuery( siteScanQuery( site.ID ) );
-	const threats = scan?.threats.filter( ( threat ) => threat.status === 'current' ) || [];
+	const threats = scan?.threats?.filter( ( threat ) => threat.status === 'current' ) || [];
 
 	const fields = getFields( timezoneString, gmtOffset );
 	const actions = useMemo( () => getActions( site, selection.length ), [ site, selection.length ] );

--- a/packages/api-core/src/site-scan/types.ts
+++ b/packages/api-core/src/site-scan/types.ts
@@ -50,7 +50,7 @@ export interface Threat {
 
 export interface SiteScan {
 	state: 'unavailable' | 'idle' | 'scanning' | 'provisioning';
-	threats: Threat[];
+	threats: Threat[] | null;
 	has_cloud: boolean;
 	current: {
 		is_initial: boolean;


### PR DESCRIPTION
## Proposed Changes

When testing #106717, I changed my site to atomic by uploading a plugin. When I returned to my overview, I was getting a 500 error because `scan.threats` was `null`.

This state appears to be temporary. At some point, it returns the expected value.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Broko

## Testing Instructions

* Buy a plan that contains hosting upgrades
* Navigate to your site's WP Admin plugins, upload plugin (switch to Atomic)
* Return to Site Overview
* Expect the Site Overview to load.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
