### PR TITLE
MSF: Fix core component warnings

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/transfer-auth-code.tsx
@@ -84,6 +84,7 @@ export function TransferAuthCode( { domainName, siteId }: TransferStepComponentP
 						</Text>
 
 						<InputControl
+							__next40pxDefaultSize
 							label={ __( 'Authorization code' ) }
 							placeholder={ __( 'Enter authorization code' ) }
 							value={ authCode }

--- a/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-fields.tsx
@@ -136,6 +136,7 @@ export const getContactFormFields = (
 				return (
 					<HStack spacing={ 0 } alignment="start" justify="flex-start">
 						<CheckboxControl
+							__nextHasNoMarginBottom
 							label=""
 							checked={ getValue( { item: data } ) }
 							onChange={ () => onChange( { [ id ]: ! getValue( { item: data } ) } ) }

--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -123,6 +123,7 @@ export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
 			<VStack spacing={ 4 }>
 				<HStack>
 					<SearchControl
+						__nextHasNoMarginBottom
 						ref={ searchInputRef }
 						size="compact"
 						value={ view.search }

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -150,6 +150,7 @@ export default function NameServersForm( {
 					return (
 						<VStack spacing={ 4 }>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								label={ __( 'Use WordPress.com name servers' ) }
 								checked={ data.useWpcomNameServers }
 								disabled={ isBusy }

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -67,6 +67,7 @@ export default function ChooseDomain() {
 							{ remaining.length > 0 && (
 								<Item>
 									<SearchControl
+										__nextHasNoMarginBottom
 										className="searchbox"
 										value={ search }
 										onChange={ setSearch }

--- a/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
@@ -56,6 +56,7 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 		<Card size="small">
 			<CardBody>
 				<SelectControl
+					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					label={ __( 'Pick your primary data center' ) }
 					help={ createInterpolateElement(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
