### PR TITLE
Hosting Dashboard: Fix performance subtitle language explaining when test was run.

### DIFF
--- a/client/dashboard/sites/performance/subtitle.tsx
+++ b/client/dashboard/sites/performance/subtitle.tsx
@@ -33,9 +33,7 @@ export default function Subtitle( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: %s: relative time since last test run */
-				__(
-					'Last test ran <b>%s</b>. Test again if your site has changed. <button>Test again</button>'
-				),
+				__( 'Last test ran <b>%s</b>. If your site has changed, <button>test again</button>.' ),
 				timeSince
 			),
 			{

--- a/client/dashboard/sites/performance/subtitle.tsx
+++ b/client/dashboard/sites/performance/subtitle.tsx
@@ -1,7 +1,7 @@
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useTimeSince } from '../../components/time-since';
+import { getRelativeTimeString } from '../../utils/datetime';
 
 const REPORT_REFRESH_THRESHOLD_HOURS = 48;
 
@@ -23,12 +23,11 @@ export default function Subtitle( {
 	timestamp: string | undefined;
 	onClick: () => void;
 } ) {
-	const timeSince = useTimeSince( timestamp ?? '' );
-
 	if ( ! timestamp ) {
 		return <Text variant="muted">{ __( 'Testing your site may take around 30 seconds.' ) }</Text>;
 	}
 
+	const timeSince = getRelativeTimeString( new Date( timestamp ?? '' ) );
 	if ( isReportOlderThan( timestamp, REPORT_REFRESH_THRESHOLD_HOURS ) ) {
 		return createInterpolateElement(
 			sprintf(


### PR DESCRIPTION
Fixes: DOTMSD-740

## Proposed Changes

This PR improves the subtitle language for the performance page.

**Changes:**
- Replace `useTimeSince` with `getRelativeTimeString`, which does a better job handling historical dates.
- Improved content based on feedback from [this comment](https://github.com/Automattic/wp-calypso/pull/106664#discussion_r2453868119).

### Screenshots
<img width="299" height="107" alt="Screenshot 2025-10-27 at 9 17 51 PM" src="https://github.com/user-attachments/assets/967f4e0b-dec5-48f4-9c73-39c54aa2ffe5" />
<img width="463" height="100" alt="Screenshot 2025-10-27 at 9 17 25 PM" src="https://github.com/user-attachments/assets/0e5ced2a-47ff-401b-a2ea-12989476217d" />
<img width="509" height="110" alt="Screenshot 2025-10-27 at 9 16 54 PM" src="https://github.com/user-attachments/assets/efb9ec2e-a16f-4bf9-a5b5-4fd79f9f22ae" />
<img width="439" height="104" alt="Screenshot 2025-10-27 at 9 16 39 PM" src="https://github.com/user-attachments/assets/9515841e-61be-430a-9e0e-a426b2984ad3" />
<img width="299" height="107" alt="Screenshot 2025-10-27 at 9 16 35 PM" src="https://github.com/user-attachments/assets/d8c7dd83-e5fd-41ce-a848-6b829a485e6f" />


## Testing Instructions

1. Run a performance test on `/v2/sites/{site}/performance`, verify the subtitle is working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
