### PR TITLE
A4A > Tiers: Add Tiers revamp feature flag & remove unused feature flags

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -46,6 +46,7 @@ const useMainMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const agency = useSelector( getActiveAgency );
+	const isTiersRevampEnabled = config.isEnabled( 'tiers-revamp' );
 
 	const menuItems = useMemo( () => {
 		let referralItems = [] as any[];
@@ -88,6 +89,19 @@ const useMainMenuItems = ( path: string ) => {
 					menu_item: 'Automattic for Agencies / Overview',
 				},
 			},
+			...( isTiersRevampEnabled
+				? [
+						{
+							icon: starEmpty,
+							path: '/',
+							link: A4A_AGENCY_TIER_LINK,
+							title: translate( 'Agency Tier' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Agency Tier',
+							},
+						},
+				  ]
+				: [] ),
 			{
 				icon: category,
 				path: '/',
@@ -158,21 +172,16 @@ const useMainMenuItems = ( path: string ) => {
 				},
 				withChevron: true,
 			},
-			...( config.isEnabled( 'a4a-partner-directory' ) ||
-			config.isEnabled( 'a8c-for-agencies-agency-tier' )
-				? [
-						{
-							icon: commentAuthorAvatar,
-							path: '/dashboard',
-							link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
-							title: translate( 'Partner Directories' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Partner Directory',
-							},
-							withChevron: true,
-						},
-				  ]
-				: [] ),
+			{
+				icon: commentAuthorAvatar,
+				path: '/dashboard',
+				link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+				title: translate( 'Partner Directories' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Partner Directory',
+				},
+				withChevron: true,
+			},
 			...( isSectionNameEnabled( 'a8c-for-agencies-settings' )
 				? [
 						{
@@ -199,7 +208,7 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-agency-tier' )
+			...( ! isTiersRevampEnabled
 				? [
 						{
 							icon: starEmpty,
@@ -215,7 +224,7 @@ const useMainMenuItems = ( path: string ) => {
 		]
 			.map( ( item ) => createItem( item, path ) )
 			.filter( ( item ) => isPathAllowed( item.link, agency ) );
-	}, [ agency, path, translate ] );
+	}, [ agency, isTiersRevampEnabled, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -89,7 +88,7 @@ export const requireTierAccessContext: Callback = ( context, next ) => {
 	const agency = getActiveAgency( state );
 	const pathname = context.pathname;
 
-	if ( isEnabled( 'a8c-for-agencies-agency-tier' ) && ! isPathAllowedForTier( pathname, agency ) ) {
+	if ( ! isPathAllowedForTier( pathname, agency ) ) {
 		context.primary = <TierPermissionError section={ context.section.name } />;
 		next();
 		return;

--- a/client/a8c-for-agencies/sections/agency-tier/controller.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/controller.tsx
@@ -1,13 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
 import AgencyTierOverview from './primary/agency-tier-overview';
+import AgencyTierOverviewRevamped from './primary/agency-tier-overview-revamped';
 
 export const agencyTierContext: Callback = ( context, next ) => {
+	const isTiersRevampEnabled = isEnabled( 'tiers-revamp' );
 	context.primary = (
 		<>
 			<PageViewTracker title="Agency Tier" path={ context.path } />
-			<AgencyTierOverview />
+			{ isTiersRevampEnabled ? <AgencyTierOverviewRevamped /> : <AgencyTierOverview /> }
 		</>
 	);
 	context.secondary = <MainSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-revamped/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-revamped/index.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+
+export default function AgencyTierOverviewRevamped() {
+	const translate = useTranslate();
+
+	const title = translate( 'Your agency tier and benefits' );
+
+	return (
+		<Layout className="agency-tier-overview-revamped" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>Content</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -160,13 +159,11 @@ function useIssueAndAssignLicenses(
 			// We have issued the licenses successfully so we can now call onSuccess callback regardless if it was able to assign it.
 			options.onSuccess?.();
 
-			if ( isEnabled( 'a8c-for-agencies-agency-tier' ) ) {
-				// Refresh the list of agencies if we don't have the tier to get the updated tier
-				if ( ! agency?.tier ) {
-					// We need to show the agency tier celebration modal after the first purchase
-					sessionStorage.setItem( AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY, 'true' );
-					dispatch( fetchAgencies() );
-				}
+			// Refresh the list of agencies if we don't have the tier to get the updated tier
+			if ( ! agency?.tier ) {
+				// We need to show the agency tier celebration modal after the first purchase
+				sessionStorage.setItem( AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY, 'true' );
+				dispatch( fetchAgencies() );
 			}
 
 			const issuedKeys = issuedLicenses

--- a/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/index.tsx
@@ -31,7 +31,7 @@ const OverviewSidebar = () => {
 					<OverviewSidebarGrowthAccelerator />
 				</>
 			) }
-			{ isEnabled( 'a8c-for-agencies-agency-tier' ) && <OverviewSidebarAgencyTier /> }
+			<OverviewSidebarAgencyTier />
 			{ ! isNewArrangement && <OverviewSidebarQuickLinks /> }
 			<OverviewSidebarFeaturedWooPayments />
 			<PressablePremiumPlanMigrationCard />

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,15 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_PARTNER_DIRECTORY_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
@@ -101,13 +96,6 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	// Wait until the agency is fetched
 	if ( ! hasAgency || isFetching ) {
 		return null;
-	}
-
-	// Check if the Partner Directory is allowed for the agency
-	if ( ! agency?.partner_directory.allowed && ! isEnabled( 'a8c-for-agencies-agency-tier' ) ) {
-		// Redirect user to the Overview page
-		page.redirect( A4A_OVERVIEW_LINK );
-		return;
 	}
 
 	// Set the selected section

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,7 +41,6 @@
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
-		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
@@ -50,7 +49,8 @@
 		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"tiers-revamp": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,7 +34,6 @@
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
-		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
@@ -43,7 +42,8 @@
 		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"tiers-revamp": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,7 +34,6 @@
 		"oauth": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
-		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,7 +36,6 @@
 		"a4a/site-migration": false,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
-		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1670/add-feature-flag-and-section-that-enables-this-feature

## Proposed Changes

This PR:

- Adds the feature flags for the tiers revamp
- Removes the feature flag & its logic for the existing tiers screen

## Why are these changes being made?

* To support the implementation of the revamped tiers screen and code cleanup

## Testing Instructions

* Open the A4A live link
* Verify the new "Agency Tier" menu item is added after the "Overview", and the screen looks like below:

<img width="1037" height="680" alt="Screenshot 2025-10-27 at 2 07 20 PM" src="https://github.com/user-attachments/assets/e3a9be58-7eb2-40a6-adac-6138d88a5743" />


* Append the URL with `?flags=-tiers-revamp` & verify the old UI is shown: https://agencies.automattic.com/agency-tier

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
