### PR TITLE
A4A: Remove limited migration offer hint on the Onboarding tour.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -244,19 +244,6 @@ export default function useOnboardingTourSections() {
 							'We offer 5 free development licenses on WordPress.com (only pay when you launch) and a free Pressable demo. See the difference for yourself.'
 						),
 					],
-					hint: translate(
-						'{{b}}Limited time offer:{{/b}} Migrate your sites to Pressable or WordPress.com and earn up to %(commission)s',
-						{
-							components: {
-								b: <b />,
-							},
-							args: {
-								commission: formatCurrency( 10000, 'USD', {
-									stripZeros: true,
-								} ),
-							},
-						}
-					),
 				},
 				renderableActions: ( { onNext, onClose }: RenderableActionProps ): RenderableAction[] => {
 					return [


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1668/agency-tour-at-signup-still-includes-dollar10k-migration-offer

## Proposed Changes

* Remove the 'Limited time offer' message from the Migration onboarding tour section.

| Before | After |
|--------|--------|
|  <img width="727" height="653" alt="Screenshot 2025-10-27 at 5 41 18 PM" src="https://github.com/user-attachments/assets/a6abd0a7-3852-4bfd-b54e-c9d0eaea35c6" /> | <img width="730" height="648" alt="Screenshot 2025-10-27 at 5 41 12 PM" src="https://github.com/user-attachments/assets/32254568-4414-4380-96b6-86773106e714" /> | 

## Why are these changes being made?

* This offer is no longer available and should be removed to avoid confusion.

## Testing Instructions

* Use the live link and navigate to `/overview` page.
* Relaunch the onboarding tour and navigate to migrations section.
* Confirm that the hint no longer appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
