### PR TITLE
Help Center: Avoid cropped sources

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -227,7 +227,7 @@ $blueberry-color: #3858e9;
 
 			&.is-expanded {
 				.foldable-card__content {
-					max-height: 350px;
+					max-height: 450px;
 				}
 			}
 

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -222,7 +222,12 @@ $blueberry-color: #3858e9;
 			&:not( .is-expanded ) {
 				.foldable-card__content {
 					border: none;
-					margin-top: 0;
+				}
+			}
+
+			&.is-expanded {
+				.foldable-card__content {
+					max-height: 350px;
 				}
 			}
 

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -227,7 +227,7 @@ $blueberry-color: #3858e9;
 
 			&.is-expanded {
 				.foldable-card__content {
-					max-height: 450px;
+					max-height: 100vh;
 				}
 			}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-325/ai-sources-are-not-100percent-visible

| Before | After |
|--------|--------|
| <img width="381" height="575" alt="image" src="https://github.com/user-attachments/assets/40a4a6a2-49c9-4de5-91ad-a82ad699f7fc" /> | <img width="432" height="708" alt="image" src="https://github.com/user-attachments/assets/f4c5fd2d-e3c8-4df3-8f5c-35df6de17bdd" /> |

## Testing steps

1. Open a new AI chat
2. Ask "How to add a domain?"
3. Click on "Sources"