### PR TITLE
Bump wpcom.js version to 7.1.0

### DIFF
--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -1,5 +1,9 @@
 # History
 
+## 7.0.2 / 2025-10-27
+
+- Added type declarations for APIs provided in the library.
+
 ## 7.0.1 / 2025-10-09
 
 - Fixed package versions in `devDependencies`.

--- a/packages/wpcom.js/History.md
+++ b/packages/wpcom.js/History.md
@@ -1,6 +1,6 @@
 # History
 
-## 7.0.2 / 2025-10-27
+## 7.1.0 / 2025-10-28
 
 - Added type declarations for APIs provided in the library.
 

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -3,7 +3,7 @@
 	"description": "Official JavaScript library for the WordPress.com REST API.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",
-	"version": "7.0.2",
+	"version": "7.1.0",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.js",

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -3,7 +3,7 @@
 	"description": "Official JavaScript library for the WordPress.com REST API.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"calypso:src": "src/index.js",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

I propose to bump the version to 7.1.0.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To release the latest changes in the wpcom.js package:
- https://github.com/Automattic/wp-calypso/pull/106576

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm if the build goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
