### PR TITLE
e2e tests: Increase timeout for redirect URL in selectPlan method

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -46,7 +46,7 @@ export class SignupPickPlanPage {
 
 		const actions = [
 			this.page.waitForResponse( /.*sites\/new\?.*/, { timeout: 30 * 1000 } ),
-			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
+			this.page.waitForURL( redirectUrl, { timeout: 60 * 1000 } ),
 			this.plansPage.selectPlan( name ),
 		];
 


### PR DESCRIPTION
## Proposed Changes

Increase the timeout waiting for the URL in selectPlan method. It should address e2e tests failures caused by this step taking longer.

This should only be a temporary solution to cut the noise, until we better understand why this timeout of 30s is not enough.


## Testing Instructions

* all e2e tests should pass