### PR TITLE
Dashboard v2: Clarify in Activity Log Upsell that the feature is available on all plans

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -19,6 +19,7 @@ export interface UpsellCalloutProps {
 	upsellTitle?: CalloutProps[ 'title' ];
 	upsellTitleAs?: CalloutProps[ 'titleAs' ];
 	upsellDescription?: CalloutProps[ 'description' ];
+	upsellPlanRequirement?: 'any' | 'business-or-commerce';
 	feature?: HostingFeatureSlug;
 }
 
@@ -31,6 +32,7 @@ export default function UpsellCallout( {
 	upsellTitle,
 	upsellTitleAs,
 	upsellDescription,
+	upsellPlanRequirement = 'business-or-commerce',
 	feature,
 }: UpsellCalloutProps ) {
 	const handleUpsellClick = () => {
@@ -67,16 +69,18 @@ export default function UpsellCallout( {
 						<Text variant="muted">{ upsellDescription ?? defaultProps.description }</Text>
 					) }
 					<Text variant="muted">
-						{ sprintf(
-							// translators: %(businessPlanName)s is the name of the Business plan, %(commercePlanName)s is the name of the Commerce plan
-							__(
-								'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.'
-							),
-							{
-								businessPlanName: getPlanNames()[ DotcomPlans.BUSINESS ],
-								commercePlanName: getPlanNames()[ DotcomPlans.ECOMMERCE ],
-							}
-						) }
+						{ upsellPlanRequirement === 'any'
+							? __( 'Available on WordPress.com paid plans.' )
+							: sprintf(
+									// translators: %(businessPlanName)s is the name of the Business plan, %(commercePlanName)s is the name of the Commerce plan
+									__(
+										'Available on the WordPress.com %(businessPlanName)s and %(commercePlanName)s plans.'
+									),
+									{
+										businessPlanName: getPlanNames()[ DotcomPlans.BUSINESS ],
+										commercePlanName: getPlanNames()[ DotcomPlans.ECOMMERCE ],
+									}
+							  ) }
 					</Text>
 				</>
 			}

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -40,6 +40,7 @@ export function ActivityLogsCallout( {
 	return (
 		<UpsellCallout
 			{ ...getActivityLogsCalloutProps() }
+			upsellPlanRequirement="any"
 			upsellTitleAs={ titleAs }
 			site={ { slug: siteSlug } as Site }
 		/>

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -1,3 +1,4 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
@@ -7,7 +8,7 @@ import type { Site } from '@automattic/api-core';
 
 export function getActivityLogsCalloutProps() {
 	return {
-		// note: we're not passing a "feature" field here because the activity logs are available in all paid plans. Selecting the feature field would limit the plan list only to Business/Commerce.
+		feature: HostingFeatures.ACTIVITY_LOG,
 		upsellId: 'site-logs-activity',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Track every action with Jetpack Activity' ),

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -1,4 +1,3 @@
-import { HostingFeatures } from '@automattic/api-core';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
@@ -8,7 +7,6 @@ import type { Site } from '@automattic/api-core';
 
 export function getActivityLogsCalloutProps() {
 	return {
-		feature: HostingFeatures.ACTIVITY_LOG,
 		// note: we're not passing a "feature" field here because the activity logs are available in all paid plans. Selecting the feature field would limit the plan list only to Business/Commerce.
 		upsellId: 'site-logs-activity',
 		upsellIcon: chartBar,

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -9,6 +9,7 @@ import type { Site } from '@automattic/api-core';
 export function getActivityLogsCalloutProps() {
 	return {
 		feature: HostingFeatures.ACTIVITY_LOG,
+		// note: we're not passing a "feature" field here because the activity logs are available in all paid plans. Selecting the feature field would limit the plan list only to Business/Commerce.
 		upsellId: 'site-logs-activity',
 		upsellIcon: chartBar,
 		upsellTitle: __( 'Track every action with Jetpack Activity' ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -935,6 +935,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
 		FEATURE_AUDIO_UPLOADS,
+		WPCOM_FEATURES_FULL_ACTIVITY_LOG,
 		...( hasSummerSpecialSticker ? [ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_BACKUPS ] : [] ),
 	],
 	getInferiorFeatures: () => [],
@@ -1573,6 +1574,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	getIncludedFeatures: ( hasSummerSpecialSticker?: boolean ) => [
 		FEATURE_AUDIO_UPLOADS,
 		WPCOM_FEATURES_ANTISPAM,
+		WPCOM_FEATURES_FULL_ACTIVITY_LOG,
 		...( hasSummerSpecialSticker ? [ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_BACKUPS ] : [] ),
 	],
 	getInferiorFeatures: () => [],


### PR DESCRIPTION

Ref: DOTMSD-734

## Proposed Changes

* Change the Upsell callout to support an upsellPlanRequirement 
* Remove the "feature" from the activity log plan upsell 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Activity Log feature is available on all plans, in our messaging we would say that it was available only on business/commerce, but that wasn't true

## Testing Instructions

* Visit the activity log page on v2
* ensure it says `Available on WordPress.com paid plans.`
* Click on upgrade and check that all plans are visible (not only Business/Ecommerce)

<img width="2928" height="1638" alt="CleanShot 2025-10-27 at 15 42 21@2x" src="https://github.com/user-attachments/assets/89bdb89e-256b-4a44-b592-b8ba67dc459e" />
<img width="3226" height="2388" alt="CleanShot 2025-10-27 at 15 43 55@2x" src="https://github.com/user-attachments/assets/ddee4b66-bba1-4980-a68f-b737519b772a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
