### PR TITLE
SSH Migration: Sanitize the remote domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { urlToDomain } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 
 interface StartSSHMigrationParams {
@@ -37,7 +38,7 @@ const startSSHMigration = async (
 		const body = {
 			remote_host: params.remoteHost,
 			remote_user: params.remoteUser,
-			remote_domain: params.remoteDomain,
+			remote_domain: urlToDomain( params.remoteDomain ),
 			...optionalFields,
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
@@ -35,10 +35,16 @@ const startSSHMigration = async (
 			...( params.sshIdPass && { ssh_id_pass: params.sshIdPass } ),
 		};
 
+		const remoteDomain = urlToDomain( params.remoteDomain );
+
+		if ( ! remoteDomain ) {
+			throw new Error( 'Invalid remote domain' );
+		}
+
 		const body = {
 			remote_host: params.remoteHost,
 			remote_user: params.remoteUser,
-			remote_domain: urlToDomain( params.remoteDomain ),
+			remote_domain: remoteDomain,
 			...optionalFields,
 		};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Sanitize the `remoteDomain` on the `useStartSSHMigration()` hook, to prevent sending a URL to the server.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we send a URL instead of the actual domain, the migration won't work. We need to sanitize the Remote Domain before starting the migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A Visual inspection should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
