### PR TITLE
SSH Migration: Fix the polling logic for retries

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -1,4 +1,5 @@
 import { Step } from '@automattic/onboarding';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
@@ -53,6 +54,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	}, [ navigation ] );
 
 	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
 
 	// Poll for migration status after starting migration
 	const { data: migrationStatus } = useSSHMigrationStatus( {
@@ -99,6 +101,9 @@ const SiteMigrationSshShareAccess: StepType< {
 	}, [ migrationStarted, migrationStatus, dispatch, siteId, navigation, setMigrationError ] );
 
 	const triggerSSHMigration = () => {
+		// Reset the migration status query to clear any stale data from previous attempts
+		queryClient.resetQueries( { queryKey: [ 'ssh-migration-status', siteId ] } );
+
 		startMigration(
 			{
 				siteId,
@@ -114,6 +119,7 @@ const SiteMigrationSshShareAccess: StepType< {
 				},
 				onError: ( error ) => {
 					setMigrationError( error );
+					setMigrationStarted( false );
 				},
 			}
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Invalidates the cache for the `useSSHMigrationStatus()` hook, to prevent the polling for failing right after trying the migration for the second time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we executed the migration for the second time after a failure, the polling would fail on the second run and would display the error alert right in the first execution of the `/status` endpoint. This was because `useSSHMigrationStatus()` was being cached, and we needed to invalidate the query.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow with a fresh simple site until you reach the `Securely share your access`
* Now, go through the three steps, and input a wrong password so the preflights fails
* Once it fails for the second time, start the migration again and it should execute several `/status` requests.
* This proves that this code works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
