### PR TITLE
Dashboard: add card number masking to purchase settings

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -54,7 +54,7 @@ export const purchasesDataView: View = {
 function BillingPurchaseInfoPopover( { children }: { children: ReactNode } ) {
 	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
 	return (
-		<span>
+		<span className="purchase-payment-method__backup-icon">
 			<Icon icon={ info } onClick={ () => setIsTooltipVisible( ( val ) => ! val ) } />
 			{ isTooltipVisible && (
 				<Popover className="billing-purchase-info-popover">{ children }</Popover>
@@ -422,10 +422,10 @@ export function getFields( {
 				}
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<div>
+					<>
 						<PurchasePaymentMethod purchase={ item } isDisconnectedSite={ ! site } />
 						{ isBackupMethodAvailable && isRenewing( item ) && <BackupPaymentMethodNotice /> }
-					</div>
+					</>
 				);
 			},
 		},

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -72,7 +72,7 @@ export function PurchasePaymentMethod( {
 			);
 
 			return (
-				<HStack>
+				<HStack className="purchase-payment-method__wrapper">
 					<HStack justify="flex-start">
 						<PaymentMethodImage paymentMethodType={ paymentMethodType } />
 						<span>{ maskedCardNumber }</span>

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, Link } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _x } from '@wordpress/i18n';
 import { changePaymentMethodRoute } from '../../app/router/me';
 import { isExpired, isRenewing, isAkismetFreeProduct } from '../../utils/purchase';
 import { PaymentMethodImage } from './payment-method-image';
@@ -65,11 +65,17 @@ export function PurchasePaymentMethod( {
 				? purchase.payment_card_display_brand
 				: purchase.payment_card_type || purchase.payment_card_processor || '';
 
+			const maskedCardNumber = sprintf(
+				/** Translators: %s is last four digits of card number */
+				_x( '**** **** **** %s', 'Long-form masked credit card number.' ),
+				purchase.payment_details
+			);
+
 			return (
 				<HStack>
 					<HStack justify="flex-start">
 						<PaymentMethodImage paymentMethodType={ paymentMethodType } />
-						<span>{ purchase.payment_details }</span>
+						<span>{ maskedCardNumber }</span>
 					</HStack>
 					{ showUpdateButton && (
 						<Button

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -559,8 +559,9 @@ function getFields( {
 }
 
 const form = {
-	type: 'regular' as const,
-	labelPosition: 'top' as const,
+	layout: {
+		type: 'regular' as const,
+	},
 	fields: [
 		{
 			id: 'autoRenew',

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -12,6 +12,18 @@ img.payment-method-image {
 	justify-content: center;
 }
 
+.purchase-payment-method__wrapper {
+	width: fit-content;
+}
+
+.purchase-payment-method__backup-icon {
+	height: 24px;
+
+	& path {
+		fill: #757575;
+	}
+}
+
 button.purchase-payment-method__update {
 	// This button is inside a flexbox (HStack) which has `min-width: 0` set on
 	// all its children, but this overrides the default of `min-width: auto`

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -12,7 +12,7 @@ img.payment-method-image {
 	justify-content: center;
 }
 
-.purchase-payment-method__wrapper {
+.dataviews-view-table__cell-content-wrapper .purchase-payment-method__wrapper {
 	width: fit-content;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1240/dashboard-add-masking-to-credit-card-last-four

## Proposed Changes

This adds masked numbers to the front of the payment method's last 4 digits (e.g. `**** **** **** 1234`) on the purchase management screen and the purchases list. On the list view, it additionally adjusts the backup icon to render on the same line, vertically aligned, in the same color as the payment method number.

It also fixes the `form` layout prop for the auto-renew toggle, but the props don't seem to have an effect on the layout of the toggle/label.

Requested here: pfOicC-M3-p2#comment-740

| Before  | After |
| ----------- | ----------- |
| <img width="691" height="189" alt="Screenshot 2025-10-27 at 15 32 11" src="https://github.com/user-attachments/assets/33db0cf0-ee4b-47c3-85f9-84d6bf4de3bd" /> | <img width="686" height="188" alt="Screenshot 2025-10-27 at 15 32 18" src="https://github.com/user-attachments/assets/90f52802-a76b-4442-babc-9731bf4d31ce" /> |
| <img width="751" height="235" alt="Screenshot 2025-10-27 at 17 18 07" src="https://github.com/user-attachments/assets/cf462af2-5988-46cf-88a6-e9e3e212e704" /> | <img width="684" height="228" alt="Screenshot 2025-10-27 at 17 17 54" src="https://github.com/user-attachments/assets/f23944ff-375f-4125-9dab-f39914f15e05" /> |

## Testing Instructions

- Visit http://calypso.localhost:3000/v2/me/billing/
- Pick a payment method with a credit card attached
- Verify that the card number has masked numerals in front of it