### PR TITLE
SSH Migration: Improve the accordion navigation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/components/accordion.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/components/accordion.tsx
@@ -32,6 +32,7 @@ const AccordionStatusIcon: FC< { completed: boolean } > = ( { completed } ) => {
 };
 
 export const AccordionStep: FC< AccordionStepProps > = ( { step, index } ) => {
+	const isClickable = !! step.onClick;
 	const onClick = step.onClick ?? function () {};
 	return (
 		<div
@@ -40,12 +41,13 @@ export const AccordionStep: FC< AccordionStepProps > = ( { step, index } ) => {
 				'is-completed': step.task.completed,
 				'is-disabled': step.task.disabled,
 				'is-open': step.expandable?.isOpen ?? false,
+				'is-clickable': isClickable,
 			} ) }
 		>
 			<button
 				className="migration-site-ssh__accordion-header"
 				onClick={ onClick }
-				disabled={ step.task.disabled }
+				disabled={ step.task.disabled || ! isClickable }
 				aria-expanded={ step.expandable?.isOpen ?? false }
 			>
 				<div className="migration-site-ssh__accordion-title">
@@ -54,9 +56,11 @@ export const AccordionStep: FC< AccordionStepProps > = ( { step, index } ) => {
 						{ index + 1 }. { step.task.title }
 					</span>
 				</div>
-				<div className="migration-site-ssh__accordion-chevron">
-					<Icon icon={ step.expandable?.isOpen ?? false ? chevronUp : chevronDown } size={ 24 } />
-				</div>
+				{ isClickable && (
+					<div className="migration-site-ssh__accordion-chevron">
+						<Icon icon={ step.expandable?.isOpen ?? false ? chevronUp : chevronDown } size={ 24 } />
+					</div>
+				) }
 			</button>
 			{ step.expandable?.isOpen && (
 				<div className="migration-site-ssh__accordion-content">{ step.expandable?.content }</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -52,21 +52,22 @@ const SiteMigrationSshShareAccess: StepType< {
 
 	const dispatch = useDispatch();
 
+	// Poll for migration status after starting migration
+	const { data: migrationStatus } = useSSHMigrationStatus( {
+		siteId,
+		enabled: migrationStarted && siteId > 0,
+	} );
+
 	const { steps, formState, canStartMigration, onMigrationStarted, setMigrationError } = useSteps( {
 		fromUrl,
 		siteId,
 		siteName: site?.name ?? '',
 		host,
 		onNoSSHAccess: handleNoSSHAccess,
+		migrationStatus: migrationStatus?.status,
 	} );
 
 	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
-
-	// Poll for migration status after starting migration
-	const { data: migrationStatus } = useSSHMigrationStatus( {
-		siteId,
-		enabled: migrationStarted && siteId > 0,
-	} );
 
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -36,6 +36,10 @@
 	cursor: pointer;
 	transition: background-color 0.2s ease;
 	text-align: left;
+
+	&:disabled {
+		cursor: default;
+	}
 }
 
 .migration-site-ssh__accordion-title {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

- Hide chevron for non-clickable steps - Modified the accordion component to only display the chevron arrow icon when a step has an `onClick` handler defined, making it visually clear which steps users can interact with.
- Disable non-clickable steps - Added logic to set the button's disabled attribute when a step isn't clickable, preventing any interaction with steps that haven't been unlocked yet and adding an is-clickable CSS class for potential styling customization.
- Remove pointer cursor from disabled steps - Added CSS styling so that disabled accordion steps show the default cursor instead of a pointer, providing better visual feedback that these steps aren't interactive.
- Start with all steps collapsed - Changed the initial `currentStep` state from 0 to -1 so that all accordion steps are collapsed when users first land on the page, providing a cleaner initial view.
- Allow clicking first step and completed steps - Implemented smart clickability logic where the first step is always accessible, users can review any previously completed steps, and they can click the next uncompleted step to progress, while future steps remain locked.
- Invalidate subsequent steps when server info changes - When users modify the server address or port in step 2, the code now resets both the verification status and migration status, resets `lastCompleteStep` to step 1, and locks step 3 until the server is re-verified.
- Mark step 3 complete only when migration actually starts - Refactored the completion logic to check the actual migration status from the API instead of just the local state, so step 3 only shows the success checkmark when the status is 'migrating' or 'completed', not when there's an error or the migration is still queued.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The navigation of the Accordion was somewhat troublesome because all steps appeared clickable and showed chevrons even when they couldn't actually be accessed, creating a confusing user experience where clicking on future steps did nothing. This made the interface feel broken and unclear about which steps were actually available to interact with.
* Also applied the feedback provided by @fditrapani here: p1761579881346829-slack-C09C6B8QDV1

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow until you reach the `Securely share your access`
* Now, go through the three steps, and test moving back and forth, and updating the data on the second step.
* Verify that it should as expect. For example, if you edit the information on the second step, we should block navigating to the third step, because the provided server/port was not validated yet.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?