### PR TITLE
Ignore site load failures in purchase settings page

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -232,7 +232,9 @@ export const purchaseSettingsIndexRoute = createRoute( {
 		// Preload site and storage data for wpcom plans
 		if ( purchase.site_slug && purchase.blog_id && ! isTemporarySitePurchase( purchase ) ) {
 			await Promise.all( [
-				queryClient.ensureQueryData( siteBySlugQuery( purchase.site_slug ) ),
+				queryClient.ensureQueryData( siteBySlugQuery( purchase.site_slug ) ).catch( () => {
+					// Some sites cannot be reached; like disconnected Jetpack sites. We can safely ignore those.
+				} ),
 				isDotcomPlan( purchase )
 					? queryClient.ensureQueryData( siteMediaStorageQuery( purchase.blog_id ) )
 					: undefined,

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1021,6 +1021,9 @@ export default function PurchaseSettings() {
 	const { data: site } = useQuery( {
 		...siteBySlugQuery( purchase.site_slug ?? '' ),
 		enabled: Boolean( purchase.site_slug ) && ! isTemporarySitePurchase( purchase ),
+		onError: () => {
+			// Some sites cannot be reached; like disconnected Jetpack sites. We can safely ignore those.
+		},
 	} );
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1021,9 +1021,6 @@ export default function PurchaseSettings() {
 	const { data: site } = useQuery( {
 		...siteBySlugQuery( purchase.site_slug ?? '' ),
 		enabled: Boolean( purchase.site_slug ) && ! isTemporarySitePurchase( purchase ),
-		onError: () => {
-			// Some sites cannot be reached; like disconnected Jetpack sites. We can safely ignore those.
-		},
 	} );
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1243/cannot-view-subscription-for-disconnected-jetpack-plan

## Proposed Changes

This PR modifies the site data loading in the MultiSite Dashboard Purchase Settings page so that if the site does not load, we do not throw an error. This is needed for certain situations like a disconnected Jetpack site.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1508" height="399" alt="Screenshot 2025-10-27 at 4 43 40 PM" src="https://github.com/user-attachments/assets/c30321f0-0fc5-4a7a-a8d3-854944e20382" /> | <img width="1509" height="608" alt="Screenshot 2025-10-27 at 6 05 06 PM" src="https://github.com/user-attachments/assets/6d69a9ff-1974-4d4e-8de7-2fcf553efaf9" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase a Jetpack subscription.
- Disconnect the Jetpack site. (eg: delete it)
- View the purchase in the MultiSite Dashboard.
- Verify that the page loads without an error.

