### PR TITLE
Multi-site dashboard: Update spacing to body.

### DIFF
--- a/client/dashboard/components/page-layout/style.scss
+++ b/client/dashboard/components/page-layout/style.scss
@@ -1,8 +1,14 @@
 @import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
 
 .dashboard-page-layout {
-	--page-layout-block-padding: #{$grid-unit-40};
-	--page-layout-inline-padding: #{$grid-unit-30};
+	--page-layout-block-padding: #{$grid-unit-20};
+	--page-layout-inline-padding: #{$grid-unit-20};
+
+	@include break-medium {
+		--page-layout-block-padding: #{$grid-unit-40};
+		--page-layout-inline-padding: #{$grid-unit-30};
+	}
 
 	margin: auto;
 	padding: var( --page-layout-block-padding ) var( --page-layout-inline-padding );


### PR DESCRIPTION
Part of DOTMSD-746
Fixes: DOTMSD-745

## Proposed Changes

Updates padding to be `16px` on small screens.

| Before | After |
|--------|--------|
| <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/760458e9-86e5-4f06-aa78-ae8e36dd2140" /> | <img width="1290" height="2796" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/0e7b5295-207b-464f-9e26-3a418535693f" /> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
