### PR TITLE
Multi-site dashboard: Add responsive styles for dataviews.

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -1,4 +1,5 @@
 @import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/breakpoints';
 
 // We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
 .components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
@@ -20,5 +21,35 @@ a.dataviews-url-field {
 
 	span {
 		text-decoration: none;
+	}
+}
+
+// Temporary overrides for the dataviews wrapper to match the new design system.
+.components-card__body:has(> .dataviews-wrapper) .dataviews-filters__container,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-footer,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-view-grid,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-loading,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-no-results,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews__view-actions,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-filters__container,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-footer,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-view-grid,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-loading,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-no-results,
+.components-card__body:has(> .dataviews-wrapper) .dataviews__view-actions,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-view-table tr td:first-child,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-view-table tr th:first-child,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-view-table tr td:first-child,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-view-table tr th:first-child,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-view-table tr td:last-child,
+.components-card__body:has(> .dataviews-wrapper) .dataviews-view-table tr th:last-child,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-view-table tr td:last-child,
+.components-card__body:has(> .dataviews-picker-wrapper) .dataviews-view-table tr th:last-child,
+.dataviews-view-list div[role="row"] .dataviews-view-list__item-wrapper,
+.dataviews-view-list div[role="article"] .dataviews-view-list__item-wrapper {
+	padding-inline: #{$grid-unit-20};
+
+	@include break-medium {
+		padding-inline: #{$grid-unit-30};
 	}
 }


### PR DESCRIPTION
Part of DOTMSD-746
Fixes: DOTMSD-706

## Proposed Changes

This PR adds CSS styles that override DataView styling to make the padding `16px` on small screens. I've looked for different ways to do this with the current component but can't find a way without using CSS.

### Screenshots
| Before | After |
|--------|--------|
 | <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog(iPhone 14 Pro Max) (2)" src="https://github.com/user-attachments/assets/7fb43b2f-ee37-4f22-b1a7-201232213c08" /> | <img width="1290" height="2796" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/39d6c248-dd97-414a-9444-262bc8a52c04" /> |
| <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog(iPhone 14 Pro Max) (3)" src="https://github.com/user-attachments/assets/ef543c3a-ee91-4263-b1c0-1ad9f83319a9" /> | <img width="1290" height="2796" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max) (2)" src="https://github.com/user-attachments/assets/b647df9e-094d-4302-9a56-7d8195132d3c" />  | 
| <img width="1290" height="2796" alt="wpcalypso wordpress com_v2(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/c19461f7-871f-43b9-8a26-d48f50dcc478" /> | <img width="1290" height="2796" src="https://github.com/user-attachments/assets/505bad87-fa02-47cd-90cf-a86f76b1566c" /> |


## Considerations

We could try to land a PR on Gutenberg's side that collapses to `16px` by default. Most of the code to add the `24px` padding is [here](https://github.com/WordPress/gutenberg/blob/907287d9c0e4dd9cc0b9744ea482634d305a2e56/packages/dataviews/src/components/dataviews/style.scss#L112).

@youknowriad @jasmussen @jameskoster I don't know how feasible that would be.


## Testing Instructions
TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
