### PR TITLE
Multi-site dashboard: Update overview card responsive padding.

### DIFF
--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -16,14 +16,23 @@
 
 	.dashboard-callout {
 		.dashboard-callout__h-container {
-			padding: 24px;
+			padding: #{$grid-unit-20};
+
+			@include break-medium {
+				padding: #{$grid-unit-30};
+			}
 		}
 	}
 }
 
 .dashboard-overview-card__content {
 	border-radius: $radius-large;
-	padding: 24px;
+	padding: #{$grid-unit-20};
+
+	@include break-medium {
+		padding: #{$grid-unit-30};
+	}
+
 	// HStacks are width 100% and will try to grow as wide as the card body.
 	// We need to ensure this new padding is included as part of that 100%.
 	box-sizing: border-box;


### PR DESCRIPTION
Part of DOTMSD-746
Fixes: DOTMSD-708

## Proposed Changes

This PR updates the OverviewCard to have `16px` on small screens.

| Before | After |
|--------|--------|
| <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog(iPhone 14 Pro Max) (4)" src="https://github.com/user-attachments/assets/2fb76402-67e1-4ff9-a2f6-8a8ad73e5c88" /> | <img width="1290" height="2796" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max) (3)" src="https://github.com/user-attachments/assets/27d42ae2-7f38-4fc9-97ce-3a180d0657a7" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
