### PR TITLE
Exploring a Domain backport approach

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -27,12 +27,13 @@ import {
 	domainManagementRoot,
 } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import DashboardBackportDomains from 'calypso/sites/v2/domains';
 import { getSite } from 'calypso/state/sites/selectors';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getQueryParams } from './dataviews/query-params';
 import { getSubpageParams } from './subpage-wrapper/subpages';
 import DomainManagement from '.';
-import DashboardBackportDomains from 'calypso/sites/v2/domains';
 
 const sitesDashboardGlobalStyles = css`
 	body.is-bulk-all-domains-page {
@@ -382,9 +383,22 @@ export default {
 		next();
 	},
 
-	dashboardBackportDomains( pageContext, next ) {
-		pageContext.primary = <DashboardBackportDomains />;
-		next();
+	dashboardBackportDomains( feature ) {
+		return ( pageContext, next ) => {
+			// pageContext.store.dispatch( setAllSitesSelected() );
+			const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+
+			pageContext.primary = (
+				<DashboardBackportDomains
+					store={ pageContext.store }
+					siteSlug={ pageContext.params.site }
+					feature={ feature }
+					selectedDomain={ selectedDomainName }
+					selectedFeature={ feature }
+				/>
+			);
+			next();
+		};
 	},
 
 	// The domain overview pane. Has a tabbed layout with the domain overview and email management.

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -32,6 +32,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getQueryParams } from './dataviews/query-params';
 import { getSubpageParams } from './subpage-wrapper/subpages';
 import DomainManagement from '.';
+import DashboardBackportDomains from 'calypso/sites/v2/domains';
 
 const sitesDashboardGlobalStyles = css`
 	body.is-bulk-all-domains-page {
@@ -378,6 +379,11 @@ export default {
 				needsDomains
 			/>
 		);
+		next();
+	},
+
+	dashboardBackportDomains( pageContext, next ) {
+		pageContext.primary = <DashboardBackportDomains />;
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
@@ -1,8 +1,10 @@
 export const DOMAIN_OVERVIEW = 'domain-overview';
+export const DOMAIN_OVERVIEW2 = 'domain-overview2';
 export const EMAIL_MANAGEMENT = 'email-management';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOMAIN_OVERVIEW ]: 'domains/manage/all/overview/:domain/:site',
+	// [ DOMAIN_OVERVIEW2 ]: 'domains/manage/all/overview/v2/:domain/:site',
 	[ EMAIL_MANAGEMENT ]: 'domains/manage/all/email/:domain/:site',
 };
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -799,6 +799,7 @@ const Settings = ( {
 			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
+			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);
 };

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -799,7 +799,6 @@ const Settings = ( {
 			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
-			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);
 };

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -424,6 +424,16 @@ export default function () {
 	);
 
 	page(
+		paths.domainManagementV2Root() + '/*',
+		noSite,
+		siteSelection,
+		navigation,
+		domainManagementController.dashboardBackportDomains,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		paths.domainManagementAllEmailRoot() + '/:domain/:site',
 		siteSelection,
 		navigation,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -413,7 +413,7 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementOverviewRoot() + '/:domain/:site',
+		paths.domainManagementOverviewRoot() + '/:domain/v2/:site',
 		siteSelection,
 		navigation,
 		domainManagementController.domainManagementV2,
@@ -424,13 +424,19 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementV2Root() + '/*',
-		noSite,
+		paths.domainManagementOverviewRoot() + '/v2/*',
 		siteSelection,
 		navigation,
-		domainManagementController.dashboardBackportDomains,
+		domainManagementController.domainManagementV2,
+		domainManagementController.dashboardBackportDomains( DOMAIN_OVERVIEW ),
+		domainManagementController.domainDashboardLayout,
 		makeLayout,
 		clientRender
+		// noSite,
+		// navigation,
+		// domainManagementController.dashboardBackportDomains,
+		// makeLayout,
+		// clientRender
 	);
 
 	page(

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -101,6 +101,10 @@ export function domainManagementOverviewRoot() {
 	return domainManagementAllRoot() + '/overview';
 }
 
+export function domainManagementV2Root() {
+	return domainManagementOverviewRoot() + '/v2';
+}
+
 export function domainSiteContextRoot() {
 	return '/overview/site-domain';
 }

--- a/client/sites/v2/domains/index.tsx
+++ b/client/sites/v2/domains/index.tsx
@@ -8,8 +8,18 @@ import { useAnalyticsClient } from '../hooks/use-analytics-client';
 import DomainLayout from './layout';
 import router from './router';
 import './style.scss';
+import type { Store } from 'redux';
 
-export default function DashboardBackportDomains() {
+export default function DashboardBackportDomains( {
+	store,
+	siteSlug,
+	feature,
+}: {
+	store: Store;
+	siteSlug?: string;
+	feature?: string;
+} ) {
+	// return <div>DashboardBackportDomains</div>;
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const user = useSelector( ( state ) => getCurrentUser( state ) );
@@ -32,16 +42,31 @@ export default function DashboardBackportDomains() {
 
 	useEffect( () => {
 		if ( ! rootInstanceRef.current ) {
+			console.log( 'rootInstanceRef.current is null' );
 			return;
 		}
 
+		// Promise.all( [
+		// 	persistQueryClientPromise,
+		// 	queryClient.ensureQueryData( domainsQuery() ),
+		// ] ).then( () => {
 		Promise.all( [
 			persistQueryClientPromise,
-			queryClient.ensureQueryData( domainsQuery() ),
+			router.preloadRoute( {
+				to: `/domains/${ siteSlug }`,
+			} ),
 		] ).then( () => {
-			rootInstanceRef.current?.render( <DomainLayout analyticsClient={ analyticsClient } /> );
+			console.log( 'rendering DomainLayout' );
+			rootInstanceRef.current?.render(
+				<DomainLayout
+					store={ store }
+					analyticsClient={ analyticsClient }
+					siteSlug={ siteSlug }
+					feature={ feature }
+				/>
+			);
 		} );
-	}, [ analyticsClient ] );
+	}, [ analyticsClient, user, siteSlug ] );
 
 	useEffect( () => {
 		if ( user ) {

--- a/client/sites/v2/domains/index.tsx
+++ b/client/sites/v2/domains/index.tsx
@@ -1,0 +1,53 @@
+import { persistQueryClientPromise, queryClient, domainsQuery } from '@automattic/api-queries';
+import { useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { useAnalyticsClient } from '../hooks/use-analytics-client';
+import DomainLayout from './layout';
+import router from './router';
+import './style.scss';
+
+export default function DashboardBackportDomains() {
+	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
+	const containerRef = useRef< HTMLDivElement >( null );
+	const user = useSelector( ( state ) => getCurrentUser( state ) );
+	const analyticsClient = useAnalyticsClient( router );
+
+	useEffect( () => {
+		if ( ! containerRef.current || rootInstanceRef.current ) {
+			return;
+		}
+
+		rootInstanceRef.current = createRoot( containerRef.current );
+		return () => {
+			const currentRoot = rootInstanceRef.current;
+			if ( currentRoot ) {
+				currentRoot.unmount();
+				rootInstanceRef.current = null;
+			}
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( ! rootInstanceRef.current ) {
+			return;
+		}
+
+		Promise.all( [
+			persistQueryClientPromise,
+			queryClient.ensureQueryData( domainsQuery() ),
+		] ).then( () => {
+			rootInstanceRef.current?.render( <DomainLayout analyticsClient={ analyticsClient } /> );
+		} );
+	}, [ analyticsClient ] );
+
+	useEffect( () => {
+		if ( user ) {
+			queryClient.setQueryData( AUTH_QUERY_KEY, user );
+		}
+	}, [ user ] );
+
+	return <div className="dashboard-backport-domains-root" ref={ containerRef } />;
+}

--- a/client/sites/v2/domains/layout.tsx
+++ b/client/sites/v2/domains/layout.tsx
@@ -2,28 +2,34 @@ import { queryClient } from '@automattic/api-queries';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
 import { useEffect } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
 import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import {
+	AppProvider,
+	APP_CONTEXT_DEFAULT_CONFIG,
+	type AppConfig,
+} from 'calypso/dashboard/app/context';
 import router, {
 	routerConfig,
 	syncBrowserHistoryToRouter,
 	syncMemoryRouterToBrowserHistory,
 } from './router';
+import type { Store } from 'redux';
 
-function RouterProviderWithAuth() {
+function RouterProviderWithAuth( { siteSlug, feature }: { siteSlug?: string; feature?: string } ) {
 	const auth = useAuth();
 
 	useEffect( () => {
 		syncBrowserHistoryToRouter( router );
-	}, [] );
+	}, [ siteSlug, feature ] );
 
 	useEffect( () => {
-		const unsubscribe = syncMemoryRouterToBrowserHistory( router );
-
 		const handlePopstate = () => {
 			syncBrowserHistoryToRouter( router );
 		};
 
+		const unsubscribe = syncMemoryRouterToBrowserHistory( router );
 		window.addEventListener( 'popstate', handlePopstate );
 
 		return () => {
@@ -35,14 +41,44 @@ function RouterProviderWithAuth() {
 	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
 }
 
-export default function DomainLayout( { analyticsClient }: { analyticsClient: AnalyticsClient } ) {
+export default function DomainLayout( {
+	store,
+	analyticsClient,
+	siteSlug,
+	feature,
+}: {
+	store: Store;
+	analyticsClient: AnalyticsClient;
+	siteSlug?: string;
+	feature?: string;
+} ) {
+	console.log( 'DomainLayout rendered for site:', siteSlug, 'and feature:', feature );
+	const APP_CONFIG = {
+		...APP_CONTEXT_DEFAULT_CONFIG,
+		supports: {
+			sites: {
+				settings: {
+					general: {
+						redirect: true,
+					},
+					server: true,
+					security: true,
+				},
+			},
+		},
+	};
+
 	return (
-		<QueryClientProvider client={ queryClient }>
-			<AuthProvider>
-				<AnalyticsProvider client={ analyticsClient }>
-					<RouterProviderWithAuth />
-				</AnalyticsProvider>
-			</AuthProvider>
-		</QueryClientProvider>
+		<AppProvider config={ APP_CONFIG as AppConfig }>
+			<QueryClientProvider client={ queryClient }>
+				<AuthProvider>
+					<AnalyticsProvider client={ analyticsClient }>
+						<ReduxProvider store={ store }>
+							<RouterProviderWithAuth siteSlug={ siteSlug } feature={ feature } />
+						</ReduxProvider>
+					</AnalyticsProvider>
+				</AuthProvider>
+			</QueryClientProvider>
+		</AppProvider>
 	);
 }

--- a/client/sites/v2/domains/layout.tsx
+++ b/client/sites/v2/domains/layout.tsx
@@ -1,0 +1,48 @@
+import { queryClient } from '@automattic/api-queries';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { AnalyticsProvider, type AnalyticsClient } from 'calypso/dashboard/app/analytics';
+import { AuthProvider, useAuth } from 'calypso/dashboard/app/auth';
+import router, {
+	routerConfig,
+	syncBrowserHistoryToRouter,
+	syncMemoryRouterToBrowserHistory,
+} from './router';
+
+function RouterProviderWithAuth() {
+	const auth = useAuth();
+
+	useEffect( () => {
+		syncBrowserHistoryToRouter( router );
+	}, [] );
+
+	useEffect( () => {
+		const unsubscribe = syncMemoryRouterToBrowserHistory( router );
+
+		const handlePopstate = () => {
+			syncBrowserHistoryToRouter( router );
+		};
+
+		window.addEventListener( 'popstate', handlePopstate );
+
+		return () => {
+			unsubscribe();
+			window.removeEventListener( 'popstate', handlePopstate );
+		};
+	}, [] );
+
+	return <RouterProvider router={ router } context={ { auth, config: routerConfig } } />;
+}
+
+export default function DomainLayout( { analyticsClient }: { analyticsClient: AnalyticsClient } ) {
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AuthProvider>
+				<AnalyticsProvider client={ analyticsClient }>
+					<RouterProviderWithAuth />
+				</AnalyticsProvider>
+			</AuthProvider>
+		</QueryClientProvider>
+	);
+}

--- a/client/sites/v2/domains/router.tsx
+++ b/client/sites/v2/domains/router.tsx
@@ -1,0 +1,618 @@
+import {
+	domainQuery,
+	domainDnsQuery,
+	domainForwardingQuery,
+	domainGlueRecordsQuery,
+	domainNameServersQuery,
+	sslDetailsQuery,
+	domainsQuery,
+	mailboxesQuery,
+	siteByIdQuery,
+	queryClient,
+	domainTransferRequestQuery,
+	domainWhoisQuery,
+	domainConnectionSetupInfoQuery,
+	rawUserPreferencesQuery,
+	domainAvailabilityQuery,
+	domainInboundTransferStatusQuery,
+} from '@automattic/api-queries';
+import {
+	createRoute,
+	createLazyRoute,
+	createRouter,
+	redirect,
+	notFound,
+	lazyRouteComponent,
+} from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { StepName } from 'calypso/dashboard/domains/domain-connection-setup/types';
+import {
+	checkDomainNameServersPermissions,
+	checkDomainTransferPermissions,
+	checkDomainContactInfoPermissions,
+	checkDomainDnsRecordsPermissions,
+	checkDomainContactVerificationPermissions,
+} from 'calypso/dashboard/utils/domain-permissions';
+import { rootRoute } from '../router';
+import { getRouterOptions, createBrowserHistoryAndMemoryRouterSync } from '../utils/router';
+
+const domainsListRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Domains' ),
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: '/',
+	loader: async () => {
+		queryClient.ensureQueryData( domainsQuery() );
+		queryClient.ensureQueryData( rawUserPreferencesQuery() );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains' ).then( ( d ) =>
+		createLazyRoute( 'domains' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainRoute = createRoute( {
+	head: ( { params } ) => ( {
+		meta: [
+			{
+				title: params.domainName,
+			},
+		],
+	} ),
+	getParentRoute: () => rootRoute,
+	path: 'domain/$domainName',
+	loader: async ( { params: { domainName }, location } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
+		const isTransferSubRoute = location.pathname.includes( '/transfer' );
+		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
+		const isDnsSubRoute = location.pathname.includes( '/dns' );
+		const isContactVerificationSubRoute = location.pathname.includes( '/contact-verification' );
+
+		if ( isNameServersSubRoute ) {
+			checkDomainNameServersPermissions( domain );
+		}
+
+		if ( isTransferSubRoute ) {
+			checkDomainTransferPermissions( domain );
+		}
+
+		if ( isContactInfoSubRoute ) {
+			checkDomainContactInfoPermissions( domain );
+		}
+
+		if ( isDnsSubRoute ) {
+			checkDomainDnsRecordsPermissions( domain );
+		}
+
+		if ( isContactVerificationSubRoute ) {
+			checkDomainContactVerificationPermissions( domain );
+		}
+
+		return domain;
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain' ).then( ( d ) =>
+		createLazyRoute( 'domain' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainOverviewRoute = createRoute( {
+	getParentRoute: () => domainRoute,
+	path: '/',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const [ site, mailboxes ] = await Promise.all( [
+			queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) ),
+			queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) ),
+		] );
+
+		return { domain, site, mailboxes };
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-overview' ).then( ( d ) =>
+		createLazyRoute( 'domain-overview' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainDnsRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'DNS records' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'dns',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainDnsQuery( domainName ) ),
+} );
+
+const domainDnsIndexRoute = createRoute( {
+	getParentRoute: () => domainDnsRoute,
+	path: '/',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-dns' ).then( ( d ) =>
+		createLazyRoute( 'domain-dns' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainDnsAddRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add a new DNS record' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainDnsRoute,
+	path: 'add',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/dns/add' ).then( ( d ) =>
+		createLazyRoute( 'domain-dns-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainDnsEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit DNS record' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainDnsRoute,
+	path: 'edit',
+	beforeLoad: async ( { params: { domainName }, search } ) => {
+		const { recordId } = search as { recordId: string | undefined };
+		const dnsRecords = await queryClient.ensureQueryData( domainDnsQuery( domainName ) );
+		const record = dnsRecords?.records.find( ( dnsRecord ) => dnsRecord.id === recordId );
+		if ( ! record ) {
+			throw redirect( { to: 'domain/$domainName/dns', params: { domainName } } );
+		}
+	},
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainDnsQuery( domainName ) ),
+	validateSearch: ( search ): { recordId: string | undefined } => ( {
+		recordId: typeof search.recordId === 'string' ? search.recordId : undefined,
+	} ),
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/dns/edit' ).then( ( d ) =>
+		createLazyRoute( 'domain-dns-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainForwardingRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Domain forwarding' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'forwarding',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainForwardingQuery( domainName ) ),
+		] );
+	},
+} );
+
+const domainForwardingIndexRoute = createRoute( {
+	getParentRoute: () => domainForwardingRoute,
+	path: '/',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-forwarding' ).then( ( d ) =>
+		createLazyRoute( 'domain-forwarding' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainForwardingAddRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add domain forwarding' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainForwardingRoute,
+	path: 'add',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainForwardingQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-forwarding/add' ).then( ( d ) =>
+		createLazyRoute( 'domain-forwarding-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainForwardingEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit domain forwarding' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainForwardingRoute,
+	path: 'edit/$forwardingId',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainForwardingQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-forwarding/edit' ).then( ( d ) =>
+		createLazyRoute( 'domain-forwarding-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainContactInfoRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Contact details' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'contact-info',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainWhoisQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-contact-details' ).then( ( d ) =>
+		createLazyRoute( 'domain-contact-info' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainContactVerificationRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Contact verification' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'contact-verification',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainQuery( domainName ) ),
+			queryClient.ensureQueryData( domainWhoisQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-contact-verification' ).then( ( d ) =>
+		createLazyRoute( 'domain-contact-verification' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainNameServersRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Name servers' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'name-servers',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainNameServersQuery( domainName ) ),
+	component: lazyRouteComponent( () => import( 'calypso/dashboard/domains/name-servers' ) ),
+	errorComponent: lazyRouteComponent(
+		() => import( 'calypso/dashboard/domains/name-servers/error' )
+	),
+} );
+
+const domainGlueRecordsRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Glue records' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'glue-records',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainGlueRecordsQuery( domainName ) ),
+} );
+
+const domainGlueRecordsIndexRoute = createRoute( {
+	getParentRoute: () => domainGlueRecordsRoute,
+	path: '/',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-glue-records' ).then( ( d ) =>
+		createLazyRoute( 'domain-glue-records' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainGlueRecordsAddRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Add glue record' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainGlueRecordsRoute,
+	path: 'add',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-glue-records/add' ).then( ( d ) =>
+		createLazyRoute( 'domain-glue-records-add' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainGlueRecordsEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit glue record' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainGlueRecordsRoute,
+	path: 'edit/$nameServer',
+	beforeLoad: async ( { params: { domainName, nameServer } } ) => {
+		const glueRecordsData = await queryClient.ensureQueryData(
+			domainGlueRecordsQuery( domainName )
+		);
+		const glueRecord = glueRecordsData.find( ( record ) => record.nameserver === nameServer );
+
+		if ( ! glueRecord ) {
+			throw notFound();
+		}
+	},
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainGlueRecordsQuery( domainName ) ),
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-glue-records/edit' ).then( ( d ) =>
+		createLazyRoute( 'domain-glue-records-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainSecurityRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Security' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'security',
+	loader: ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( sslDetailsQuery( domainName ) ),
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-security' ).then( ( d ) =>
+		createLazyRoute( 'domain-security' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainTransferRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Transfer' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'transfer',
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-transfer' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainTransferToAnyUserRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Transfer to another user' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'transfer/any-user',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-transfer/transfer-domain-to-any-user' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-to-any-user' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainTransferToOtherUserRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Transfer to another user' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'transfer/other-user',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-transfer/transfer-domain-to-other-user' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-to-other-user' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainTransferToOtherSiteRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Attach to another site' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'transfer/other-site',
+	loader: async ( { params: { domainName } } ) =>
+		queryClient.ensureQueryData( domainQuery( domainName ) ),
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-transfer/transfer-domain-to-other-site' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-to-other-site' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainConnectionSetupRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Domain connection setup' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'domain-connection-setup',
+	loader: async ( { params: { domainName } } ) => {
+		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		await queryClient.ensureQueryData(
+			domainConnectionSetupInfoQuery(
+				domainName,
+				domain.blog_id,
+				`${ window.location.href }?step=${ StepName.DC_RETURN }`
+			)
+		);
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-connection-setup' ).then( ( d ) =>
+		createLazyRoute( 'domain-connection-setup' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const domainTransferSetupRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Domain transfer setup' ),
+			},
+		],
+	} ),
+	getParentRoute: () => domainRoute,
+	path: 'domain-transfer-setup',
+	loader: async ( { params: { domainName } } ) => {
+		await Promise.all( [
+			queryClient.ensureQueryData( domainAvailabilityQuery( domainName ) ),
+			queryClient.ensureQueryData( domainInboundTransferStatusQuery( domainName ) ),
+		] );
+	},
+} ).lazy( () =>
+	import( 'calypso/dashboard/domains/domain-connection-setup/transfer-setup' ).then( ( d ) =>
+		createLazyRoute( 'domain-transfer-setup' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const createRouteTree = () =>
+	rootRoute.addChildren( [
+		domainsListRoute,
+		domainRoute.addChildren( [
+			domainOverviewRoute,
+			domainDnsRoute.addChildren( [ domainDnsIndexRoute, domainDnsAddRoute, domainDnsEditRoute ] ),
+			domainConnectionSetupRoute,
+			domainTransferSetupRoute,
+			domainForwardingRoute.addChildren( [
+				domainForwardingIndexRoute,
+				domainForwardingAddRoute,
+				domainForwardingEditRoute,
+			] ),
+			domainContactInfoRoute,
+			domainContactVerificationRoute,
+			domainNameServersRoute,
+			domainGlueRecordsRoute.addChildren( [
+				domainGlueRecordsIndexRoute,
+				domainGlueRecordsAddRoute,
+				domainGlueRecordsEditRoute,
+			] ),
+			domainTransferRoute,
+			domainTransferToAnyUserRoute,
+			domainTransferToOtherUserRoute,
+			domainTransferToOtherSiteRoute,
+			domainSecurityRoute,
+		] ),
+	] );
+
+export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =
+	createBrowserHistoryAndMemoryRouterSync();
+
+export const routerConfig = {
+	basePath: '/domains/manage/all/overview/v2',
+};
+
+export const getRouter = ( { basePath }: { basePath: string } ) => {
+	const routeTree = createRouteTree();
+	return createRouter( {
+		...getRouterOptions(),
+		routeTree,
+		basepath: basePath,
+	} );
+};
+
+export default getRouter( routerConfig );

--- a/client/sites/v2/domains/router.tsx
+++ b/client/sites/v2/domains/router.tsx
@@ -24,6 +24,7 @@ import {
 	notFound,
 	lazyRouteComponent,
 } from '@tanstack/react-router';
+import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { StepName } from 'calypso/dashboard/domains/domain-connection-setup/types';
 import {
@@ -67,8 +68,9 @@ const domainRoute = createRoute( {
 		],
 	} ),
 	getParentRoute: () => rootRoute,
-	path: 'domain/$domainName',
+	path: '$domain',
 	loader: async ( { params: { domainName }, location } ) => {
+		console.log( '### domainRoute loader for domain:', domainName );
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
 		const isTransferSubRoute = location.pathname.includes( '/transfer' );
@@ -110,6 +112,7 @@ const domainOverviewRoute = createRoute( {
 	getParentRoute: () => domainRoute,
 	path: '/',
 	loader: async ( { params: { domainName } } ) => {
+		console.log( '### domainOverviewRoute loader for domain:', domainName );
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		const [ site, mailboxes ] = await Promise.all( [
 			queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) ),
@@ -570,6 +573,20 @@ const domainTransferSetupRoute = createRoute( {
 	)
 );
 
+const DummyRouteComponent = () =>
+	createElement( 'div', null, createElement( 'h3', null, "it's working" ) );
+
+const domainSiteRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: '$domain/$site',
+} );
+
+const dummyRoute = createRoute( {
+	getParentRoute: () => domainSiteRoute,
+	path: 'dummy',
+	component: DummyRouteComponent,
+} );
+
 const createRouteTree = () =>
 	rootRoute.addChildren( [
 		domainsListRoute,
@@ -597,6 +614,7 @@ const createRouteTree = () =>
 			domainTransferToOtherSiteRoute,
 			domainSecurityRoute,
 		] ),
+		domainSiteRoute.addChildren( [ dummyRoute ] ),
 	] );
 
 export const { syncBrowserHistoryToRouter, syncMemoryRouterToBrowserHistory } =

--- a/client/sites/v2/domains/style.scss
+++ b/client/sites/v2/domains/style.scss
@@ -1,0 +1,14 @@
+@import 'calypso/dashboard/app/dataforms-overrides.scss';
+@import 'calypso/dashboard/app/dataviews-overrides.scss';
+@import 'calypso/dashboard/app-dotcom/style.scss';
+
+.dashboard-backport-domains-root {
+	.dashboard-root__layout {
+		min-height: 100%;
+	}
+
+	.dashboard-page-layout {
+		margin: 0;
+		padding: 0;
+	}
+}


### PR DESCRIPTION
# Exploring Domains V2 Backport Plan

This is the plan I'm playing with AI to backport this.

1. Set Up V2 Domain

- Create `client/sites/v2/domains/` with router/layout mirroring `site-settings` and reuse `createDomainsRoutes` so `/domains/manage/all/overview/v2` becomes the router base.
- Ensure analytics/query providers follow the existing backport pattern and surface snackbars/page-view tracking.

2. Wire Legacy Routing To The New Shell

- Add a new controller in `client/my-sites/domains/domain-management` that renders the V2 React shell when the `/domains/manage/all/overview/v2/*` path is hit.
- Register the Page.js route in `client/my-sites/domains/index.js` (and update helpers in `client/my-sites/domains/paths.js` if needed) without touching current `/domains/manage/**` handlers.

3. Integrate With Surrounding Systems

- Update sidebar/path detection (e.g. `client/state/global-sidebar/selectors.ts`) so the new v2 URLs map to existing Domains navigation items.
- Verify hostname/path utilities or redirects don’t interfere with the `/v2` opt-in routes and adjust tests or add new ones if required.


Currently, this url is working: http://calypso.localhost:3000/domains/manage/all/overview/v2/{domain}/{site}/dummy

<img width="1608" height="706" alt="image" src="https://github.com/user-attachments/assets/9d43de91-f45f-4450-9187-f8c601f96c59" />
