### PR TITLE
SSH Migration: Fix racing condition transfering to Atomic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
@@ -24,6 +24,9 @@ interface UseVerifySSHMigrationAtomicTransferOptions {
 	enabled?: boolean;
 }
 
+// Transfer statuses that indicate the transfer is complete or in a final state
+const FINAL_TRANSFER_STATUSES = [ 'completed', 'error', 'reverted' ];
+
 export const useVerifySSHMigrationAtomicTransfer = (
 	siteId: number,
 	{ enabled = true }: UseVerifySSHMigrationAtomicTransferOptions = {}
@@ -34,10 +37,14 @@ export const useVerifySSHMigrationAtomicTransfer = (
 		enabled: enabled && !! siteId,
 		retry: false,
 		refetchInterval: ( query ) => {
-			// Keep polling until transfer_status is 'completed'
-			if ( query.state.data?.transfer_status === 'completed' ) {
+			const transferStatus = query.state.data?.transfer_status;
+
+			// Stop polling if we've reached a final state
+			if ( transferStatus && FINAL_TRANSFER_STATUSES.includes( transferStatus ) ) {
 				return false;
 			}
+
+			// Continue polling if status is in progress or unknown
 			return 2000; // Poll every 2 seconds
 		},
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
@@ -28,11 +28,19 @@ export const useVerifySSHMigrationAtomicTransfer = (
 	siteId: number,
 	{ enabled = true }: UseVerifySSHMigrationAtomicTransferOptions = {}
 ) => {
-	return useQuery( {
+	const query = useQuery( {
 		queryKey: useVerifySSHMigrationAtomicTransferQueryKey( siteId ),
 		queryFn: () => verifySSHMigrationAtomicTransfer( siteId ),
 		enabled: enabled && !! siteId,
 		retry: false,
-		staleTime: Infinity, // Only fetch once
+		refetchInterval: ( query ) => {
+			// Keep polling until transfer_status is 'completed'
+			if ( query.state.data?.transfer_status === 'completed' ) {
+				return false;
+			}
+			return 2000; // Poll every 2 seconds
+		},
 	} );
+
+	return query;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
@@ -31,7 +31,7 @@ export const useVerifySSHMigrationAtomicTransfer = (
 	siteId: number,
 	{ enabled = true }: UseVerifySSHMigrationAtomicTransferOptions = {}
 ) => {
-	const query = useQuery( {
+	return useQuery( {
 		queryKey: useVerifySSHMigrationAtomicTransferQueryKey( siteId ),
 		queryFn: () => verifySSHMigrationAtomicTransfer( siteId ),
 		enabled: enabled && !! siteId,
@@ -48,6 +48,4 @@ export const useVerifySSHMigrationAtomicTransfer = (
 			return 2000; // Poll every 2 seconds
 		},
 	} );
-
-	return query;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-verify-ssh-migration-atomic-transfer.ts
@@ -24,9 +24,6 @@ interface UseVerifySSHMigrationAtomicTransferOptions {
 	enabled?: boolean;
 }
 
-// Transfer statuses that indicate the transfer is complete or in a final state
-const FINAL_TRANSFER_STATUSES = [ 'completed', 'error', 'reverted' ];
-
 export const useVerifySSHMigrationAtomicTransfer = (
 	siteId: number,
 	{ enabled = true }: UseVerifySSHMigrationAtomicTransferOptions = {}
@@ -36,16 +33,6 @@ export const useVerifySSHMigrationAtomicTransfer = (
 		queryFn: () => verifySSHMigrationAtomicTransfer( siteId ),
 		enabled: enabled && !! siteId,
 		retry: false,
-		refetchInterval: ( query ) => {
-			const transferStatus = query.state.data?.transfer_status;
-
-			// Stop polling if we've reached a final state
-			if ( transferStatus && FINAL_TRANSFER_STATUSES.includes( transferStatus ) ) {
-				return false;
-			}
-
-			// Continue polling if status is in progress or unknown
-			return 2000; // Poll every 2 seconds
-		},
+		staleTime: Infinity, // Only fetch once
 	} );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -14,6 +14,7 @@ import { useSSHMigrationStatus } from '../site-migration-ssh-in-progress/hooks/u
 import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
 import { useStartSSHMigration } from './hooks/use-start-ssh-migration';
+import { useVerifySSHMigrationAtomicTransfer } from './hooks/use-verify-ssh-migration-atomic-transfer';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
 import type { Step as StepType } from '../../types';
@@ -38,6 +39,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const transferIdParam = queryParams.get( 'transferId' );
 	const transferId = transferIdParam ? parseInt( transferIdParam, 10 ) : null;
 	const [ migrationStarted, setMigrationStarted ] = useState( false );
+	const [ shouldStartMigration, setShouldStartMigration ] = useState( false );
 
 	// Redirect back to verification step if transferId is missing
 	useEffect( () => {
@@ -69,6 +71,19 @@ const SiteMigrationSshShareAccess: StepType< {
 
 	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
 
+	// Verify SSH migration atomic transfer capability
+	const { data: verificationData } = useVerifySSHMigrationAtomicTransfer( siteId, {
+		enabled: !! transferId && siteId > 0,
+	} );
+
+	const transferStatus = verificationData?.transfer_status;
+
+	// Poll for migration status after starting migration
+	const { data: migrationStatus } = useSSHMigrationStatus( {
+		siteId,
+		enabled: migrationStarted && siteId > 0,
+	} );
+
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
 	useEffect( () => {
 		if ( ! migrationStarted || ! migrationStatus ) {
@@ -86,8 +101,16 @@ const SiteMigrationSshShareAccess: StepType< {
 		}
 	}, [ migrationStarted, migrationStatus, dispatch, siteId, navigation, setMigrationError ] );
 
-	const handleContinue = () => {
+	const handleContinue = useCallback( () => {
 		setMigrationError( null );
+
+		if ( transferStatus !== 'completed' ) {
+			setShouldStartMigration( true );
+			return;
+		}
+
+		setShouldStartMigration( false );
+
 		startMigration(
 			{
 				siteId,
@@ -106,7 +129,23 @@ const SiteMigrationSshShareAccess: StepType< {
 				},
 			}
 		);
-	};
+	}, [
+		transferStatus,
+		setMigrationError,
+		startMigration,
+		siteId,
+		formState.serverAddress,
+		formState.username,
+		formState.password,
+		fromUrl,
+		onMigrationStarted,
+	] );
+
+	useEffect( () => {
+		if ( transferStatus === 'completed' && shouldStartMigration ) {
+			handleContinue();
+		}
+	}, [ transferStatus, shouldStartMigration, handleContinue ] );
 
 	const navigateToDoItForMe = useCallback( () => {
 		navigation.submit?.( { how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME } );
@@ -150,7 +189,7 @@ const SiteMigrationSshShareAccess: StepType< {
 							variant="primary"
 							onClick={ handleContinue }
 							disabled={ ! canStartMigration || isStartingMigration || migrationStarted }
-							isBusy={ isStartingMigration || migrationStarted }
+							isBusy={ isStartingMigration || migrationStarted || shouldStartMigration }
 						>
 							{ translate( 'Continue' ) }
 						</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -13,8 +13,8 @@ import { SupportNudge } from '../site-migration-instructions/support-nudge';
 import { useSSHMigrationStatus } from '../site-migration-ssh-in-progress/hooks/use-ssh-migration-status';
 import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
+import { usePollSSHMigrationAtomicTransfer } from './hooks/use-poll-ssh-migration-atomic-transfer';
 import { useStartSSHMigration } from './hooks/use-start-ssh-migration';
-import { useVerifySSHMigrationAtomicTransfer } from './hooks/use-verify-ssh-migration-atomic-transfer';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
 import type { Step as StepType } from '../../types';
@@ -71,18 +71,15 @@ const SiteMigrationSshShareAccess: StepType< {
 
 	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
 
-	// Verify SSH migration atomic transfer capability
-	const { data: verificationData } = useVerifySSHMigrationAtomicTransfer( siteId, {
-		enabled: !! transferId && siteId > 0,
-	} );
-
-	const transferStatus = verificationData?.transfer_status;
-
-	// Poll for migration status after starting migration
-	const { data: migrationStatus } = useSSHMigrationStatus( {
+	// Poll SSH migration atomic transfer status
+	const { transferStatus, isTransferring } = usePollSSHMigrationAtomicTransfer(
 		siteId,
-		enabled: migrationStarted && siteId > 0,
-	} );
+		transferId,
+		{
+			enabled: !! transferId && siteId > 0,
+			refetchInterval: 2000, // Poll every 2 seconds
+		}
+	);
 
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
 	useEffect( () => {
@@ -125,7 +122,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const handleContinue = () => {
 		setMigrationError( null );
 
-		if ( transferStatus !== 'completed' ) {
+		if ( isTransferring ) {
 			setShouldStartMigration( true );
 			return;
 		}
@@ -182,7 +179,12 @@ const SiteMigrationSshShareAccess: StepType< {
 						<Button
 							variant="primary"
 							onClick={ handleContinue }
-							disabled={ ! canStartMigration || isStartingMigration || migrationStarted }
+							disabled={
+								! canStartMigration ||
+								isStartingMigration ||
+								migrationStarted ||
+								shouldStartMigration
+							}
 							isBusy={ isStartingMigration || migrationStarted || shouldStartMigration }
 						>
 							{ translate( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -101,16 +101,7 @@ const SiteMigrationSshShareAccess: StepType< {
 		}
 	}, [ migrationStarted, migrationStatus, dispatch, siteId, navigation, setMigrationError ] );
 
-	const handleContinue = useCallback( () => {
-		setMigrationError( null );
-
-		if ( transferStatus !== 'completed' ) {
-			setShouldStartMigration( true );
-			return;
-		}
-
-		setShouldStartMigration( false );
-
+	const triggerSSHMigration = () => {
 		startMigration(
 			{
 				siteId,
@@ -129,23 +120,26 @@ const SiteMigrationSshShareAccess: StepType< {
 				},
 			}
 		);
-	}, [
-		transferStatus,
-		setMigrationError,
-		startMigration,
-		siteId,
-		formState.serverAddress,
-		formState.username,
-		formState.password,
-		fromUrl,
-		onMigrationStarted,
-	] );
+	};
 
+	const handleContinue = () => {
+		setMigrationError( null );
+
+		if ( transferStatus !== 'completed' ) {
+			setShouldStartMigration( true );
+			return;
+		}
+
+		triggerSSHMigration();
+	};
+
+	// Auto-start migration when verification completes
 	useEffect( () => {
 		if ( transferStatus === 'completed' && shouldStartMigration ) {
-			handleContinue();
+			setShouldStartMigration( false );
+			triggerSSHMigration();
 		}
-	}, [ transferStatus, shouldStartMigration, handleContinue ] );
+	}, [ transferStatus, shouldStartMigration ] );
 
 	const navigateToDoItForMe = useCallback( () => {
 		navigation.submit?.( { how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Add a seamless mechanism to prevent the user from starting the migration before the transfer to Atomic was finished.
* We allow the user to click on the button to start the migration, but hold the execution until the status of the transfer is complete. This way, it will appear to the user that is unified loading that starts only after they click on the Continue button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed a racing condition that would prevent the user from starting the migration if the transfer to Atomic was not complete yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow with a fresh simple site until you reach the `Securely share your access`
* Fill in the all the data as fast as you can and click on the `Continue` button.
* Looking at the console, you should see the requests to `/wpcom/v2/sites/SITE_ID/atomic/transfer-ssh-migration/TRANSFER_ID` but not the `wpcom/v2/sites/SITE_ID/ssh-migration/start` until the transfer is complete.
* Sometimes the transfer can be faster, and you won't be able to see this behavior.  
   * So if you want to test it more calmly, we can update the fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Sfvgr%2Qngbzvp%2Qgenafsre%2Qffu%2Qzvtengvba.cuc%3Se%3Qon18r646%23105-og to always return `pending`.
   * Make sure your public-API is sandboxed
   * So refresh the `Securely share your access` step, and look for the requests to `/wpcom/v2/sites/SITE_ID/atomic/transfer-ssh-migration/TRANSFER_ID`.
   * Then, fill all the information in the forms and click on continue.
   * Looking at the console, you *should not* see the requests to start the migration yet, because the transfer to atomic didn't finish, but the continue button should be locked and on the loading state.
   * Go back to your sandbox, and update the transfer status to `complete`.
   * After doing that you should see the request starting the migration.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?