### PR TITLE
SSH Migration: Fix the support links UI and open it inline

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
@@ -1,20 +1,25 @@
-import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 interface HelpLinkProps {
-	href: string;
+	supportLink: string;
+	supportPostId?: number;
 }
 
-export const HelpLink: FC< HelpLinkProps > = ( { href } ) => {
+export const HelpLink: FC< HelpLinkProps > = ( { supportLink, supportPostId } ) => {
 	const translate = useTranslate();
 
 	return (
 		<p className="migration-site-ssh__help-link">
 			{ translate( 'Need help?' ) }{ ' ' }
-			<ExternalLink href={ href } icon iconSize={ 14 }>
+			<InlineSupportLink
+				supportLink={ supportLink }
+				supportPostId={ supportPostId }
+				showIcon={ false }
+			>
 				{ translate( 'Follow our guide' ) }
-			</ExternalLink>
+			</InlineSupportLink>
 		</p>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
@@ -18,44 +18,76 @@ export const SSH_HOST_DISPLAY_NAMES: Record< string, string > = {
 	dreamhost: 'DreamHost',
 };
 
+interface SSHSupportDoc {
+	url: string;
+	postId?: number;
+}
+
 /**
- * Mapping of hosting providers to their specific SSH migration support documentation URLs
+ * Mapping of hosting providers to their specific SSH migration support documentation
  */
-const SSH_HOST_SUPPORT_URLS: Record< string, string > = {
-	godaddy: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-godaddy-using-ssh/' ),
-	bluehost: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-bluehost-using-ssh/' ),
-	ionos: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ionos-using-ssh/' ),
-	hostinger: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-hostinger-using-ssh/'
-	),
-	inmotion: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-inmotion-hosting-using-ssh/'
-	),
-	aruba: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-aruba-hosting-using-ssh/'
-	),
-	hostgator: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-hostgator-using-ssh/'
-	),
-	digitalocean: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-digitalocean-using-ssh/'
-	),
-	hetzner: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hetzner-using-ssh/' ),
-	namecheap: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-namecheap-using-ssh/'
-	),
-	ovh: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ovhcloud-using-ssh/' ),
-	dreamhost: localizeUrl(
-		'https://wordpress.com/support/migrate-a-site-from-dreamhost-using-ssh/'
-	),
+const SSH_HOST_SUPPORT_DOCS: Record< string, SSHSupportDoc > = {
+	godaddy: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-godaddy-using-ssh/' ),
+		postId: 445551,
+	},
+	bluehost: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-bluehost-using-ssh/' ),
+		postId: 445540,
+	},
+	ionos: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ionos-using-ssh/' ),
+		postId: 445543,
+	},
+	hostinger: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hostinger-using-ssh/' ),
+		postId: 445542,
+	},
+	inmotion: {
+		url: localizeUrl(
+			'https://wordpress.com/support/migrate-a-site-from-inmotion-hosting-using-ssh/'
+		),
+		postId: 445544,
+	},
+	aruba: {
+		url: localizeUrl(
+			'https://wordpress.com/support/migrate-a-site-from-aruba-hosting-using-ssh/'
+		),
+		postId: 445539,
+	},
+	hostgator: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hostgator-using-ssh/' ),
+		postId: 445541,
+	},
+	digitalocean: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-digitalocean-using-ssh/' ),
+		postId: 445545,
+	},
+	hetzner: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hetzner-using-ssh/' ),
+		postId: 445546,
+	},
+	namecheap: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-namecheap-using-ssh/' ),
+		postId: 445547,
+	},
+	ovh: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ovhcloud-using-ssh/' ),
+		postId: 445548,
+	},
+	dreamhost: {
+		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-dreamhost-using-ssh/' ),
+		postId: 445549,
+	},
 };
 
 /**
- * Generic fallback URL for hosts without specific documentation
+ * Generic fallback for hosts without specific documentation
  */
-const GENERIC_SSH_MIGRATION_SUPPORT_URL = localizeUrl(
-	'https://wordpress.com/support/migrate-a-site-to-wordpress-com-using-ssh/'
-);
+const GENERIC_SSH_MIGRATION_SUPPORT_DOC: SSHSupportDoc = {
+	url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-to-wordpress-com-using-ssh/' ),
+	postId: 445550,
+};
 
 /**
  * Get the display name for a specific hosting provider
@@ -72,15 +104,25 @@ export const getSSHHostDisplayName = ( host?: string ): string | undefined => {
 };
 
 /**
- * Get the support URL for a specific hosting provider
+ * Get the support documentation for a specific hosting provider
  * @param host - The hosting provider name (case-insensitive)
- * @returns The support URL for the host, or the generic fallback if not found
+ * @returns The support doc object for the host, or the generic fallback if not found
  */
-export const getSSHSupportUrl = ( host?: string ): string => {
+export const getSSHSupportDoc = ( host?: string ): SSHSupportDoc => {
 	if ( ! host ) {
-		return GENERIC_SSH_MIGRATION_SUPPORT_URL;
+		return GENERIC_SSH_MIGRATION_SUPPORT_DOC;
 	}
 
 	const normalizedHost = host.toLowerCase().trim();
-	return SSH_HOST_SUPPORT_URLS[ normalizedHost ] ?? GENERIC_SSH_MIGRATION_SUPPORT_URL;
+	return SSH_HOST_SUPPORT_DOCS[ normalizedHost ] ?? GENERIC_SSH_MIGRATION_SUPPORT_DOC;
+};
+
+/**
+ * Get the support URL for a specific hosting provider
+ * @param host - The hosting provider name (case-insensitive)
+ * @returns The support URL for the host, or the generic fallback if not found
+ * @deprecated Use getSSHSupportDoc instead for inline help center support
+ */
+export const getSSHSupportUrl = ( host?: string ): string => {
+	return getSSHSupportDoc( host ).url;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -36,8 +36,12 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 				<Button variant="primary" onClick={ onSuccess }>
 					{ translate( 'I found my SSH details' ) }
 				</Button>
-				<Button variant="link" onClick={ onNoSSHAccess }>
-					{ translate( "I don't have SSH access" ) }
+				<Button
+					variant="link"
+					onClick={ onNoSSHAccess }
+					className="migration-site-ssh__no-ssh-link"
+				>
+					{ translate( "I don't have SSH" ) }
 				</Button>
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { HelpLink } from './help-link';
-import { getSSHHostDisplayName, getSSHSupportUrl } from './ssh-host-support-urls';
+import { getSSHHostDisplayName, getSSHSupportDoc } from './ssh-host-support-urls';
 import { StepAddServerAddress } from './step-add-server-address';
 import { StepFindSSHDetails } from './step-find-ssh-details';
 import { StepShareSSHAccess } from './step-share-ssh-access';
@@ -81,8 +81,8 @@ interface SSHFormState {
 const useStepsData = ( options: StepsDataOptions ): StepsData => {
 	const translate = useTranslate();
 	const hostDisplayName = getSSHHostDisplayName( options.host );
-	const supportUrl = getSSHSupportUrl( options.host );
-	const helpLink = <HelpLink href={ supportUrl } />;
+	const supportDoc = getSSHSupportDoc( options.host );
+	const helpLink = <HelpLink supportLink={ supportDoc.url } supportPostId={ supportDoc.postId } />;
 
 	const stepsData: StepsData = [
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -117,9 +117,20 @@
 	align-items: center;
 }
 
+.migration-site-ssh__no-ssh-link {
+	text-decoration: none !important;
+}
+
 .migration-site-ssh__help-link {
 	margin: 1rem 0;
 	font-size: 0.875rem;
+
+	.inline-support-link,
+	a,
+	a:visited {
+		color: var(--color-neutral-70, #1d2327) !important;
+		text-decoration: underline !important;
+	}
 }
 
 .migration-site-ssh__step-add-server-address-form {
@@ -151,6 +162,8 @@
 	margin-left: 2.5rem;
 	button {
 		width: 100%;
+		height: 48px;
+		font-size: 16px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* The support link should open the in-line modal with the support link.
* Fixes the styling of the support link.
* Fixes the styling of the `I don't have SSH` link.

<img width="714" height="645" alt="Captura de Tela 2025-10-30 às 14 05 49" src="https://github.com/user-attachments/assets/ae6ad0c1-9255-44b9-8620-bfa92cae87aa" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1761579881346829-slack-C09C6B8QDV1

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow with a fresh simple site until you reach the `Securely share your access`
* Now check the styling of the support link, and the `I don't have ssh` button.
* Clicking on the support link, should open a modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?