### PR TITLE
Check for valid TLD during email validation

### DIFF
--- a/client/lib/email-validation/index.ts
+++ b/client/lib/email-validation/index.ts
@@ -1,8 +1,6 @@
 import { getTld } from '@automattic/domain-search';
 import tlds from 'tlds';
-import * as emailValidatorModule from '../../../node_modules/email-validator/index.js';
-
-const emailValidator = emailValidatorModule.default || emailValidatorModule;
+import { validate as baseEmailValidate } from '../../../node_modules/email-validator/index.js';
 
 export interface EmailValidationResult {
 	isValid: boolean;
@@ -42,7 +40,7 @@ export function validateEmail( email: string ): EmailValidationResult {
 
 	const trimmedEmail = email.trim();
 
-	if ( ! emailValidator.validate( trimmedEmail ) ) {
+	if ( ! baseEmailValidate( trimmedEmail ) ) {
 		return { isValid: false, error: 'invalid_format' };
 	}
 
@@ -83,5 +81,3 @@ export const validate = isValidEmail;
 export default {
 	validate: isValidEmail,
 };
-
-export { emailValidator as legacyEmailValidator };

--- a/client/lib/email-validation/index.ts
+++ b/client/lib/email-validation/index.ts
@@ -44,27 +44,13 @@ export function validateEmail( email: string ): EmailValidationResult {
 		return { isValid: false, error: 'invalid_format' };
 	}
 
-	const atIndex = trimmedEmail.lastIndexOf( '@' );
-	if ( atIndex === -1 ) {
-		return { isValid: false, error: 'invalid_format' };
-	}
-
-	const domain = trimmedEmail.substring( atIndex + 1 );
-	if ( ! domain ) {
-		return { isValid: false, error: 'invalid_format' };
-	}
-
-	if ( ! /^[a-z0-9.-]+$/i.test( domain ) ) {
-		return { isValid: false, error: 'invalid_format' };
-	}
-
+	const domain = trimmedEmail.substring( trimmedEmail.lastIndexOf( '@' ) + 1 );
 	const tld = getTld( domain );
 	if ( ! tld ) {
 		return { isValid: false, error: 'invalid_tld' };
 	}
 
 	const tldLower = tld.toLowerCase();
-
 	const tldToCheck = tldLower.includes( '.' )
 		? tldLower.substring( tldLower.lastIndexOf( '.' ) + 1 )
 		: tldLower;

--- a/client/lib/email-validation/index.ts
+++ b/client/lib/email-validation/index.ts
@@ -1,0 +1,87 @@
+import { getTld } from '@automattic/domain-search';
+import tlds from 'tlds';
+import * as emailValidatorModule from '../../../node_modules/email-validator/index.js';
+
+const emailValidator = emailValidatorModule.default || emailValidatorModule;
+
+export interface EmailValidationResult {
+	isValid: boolean;
+	error?: 'empty' | 'invalid_format' | 'invalid_tld';
+}
+
+const VALID_TLDS = new Set( tlds );
+
+/**
+ * Validates an email address.
+ *
+ * Checks both RFC compliance and TLD validity against the official IANA TLD list.
+ * This prevents acceptance of emails like "user@gmail.comExtraText" (see GitHub issue #106738).
+ *
+ * @param email - The email address to validate
+ * @returns True if the email is valid, false otherwise
+ */
+export function isValidEmail( email: string ): boolean {
+	return validateEmail( email ).isValid;
+}
+
+/**
+ * Validates an email address with detailed error information.
+ *
+ * Performs comprehensive validation:
+ * - RFC format compliance via email-validator package
+ * - TLD validation against official IANA list (1,438 TLDs)
+ * - Supports multi-level TLDs (e.g., co.uk, com.au)
+ *
+ * @param email - The email address to validate
+ * @returns Validation result with isValid flag and optional error type
+ */
+export function validateEmail( email: string ): EmailValidationResult {
+	if ( ! email || email.trim() === '' ) {
+		return { isValid: false, error: 'empty' };
+	}
+
+	const trimmedEmail = email.trim();
+
+	if ( ! emailValidator.validate( trimmedEmail ) ) {
+		return { isValid: false, error: 'invalid_format' };
+	}
+
+	const atIndex = trimmedEmail.lastIndexOf( '@' );
+	if ( atIndex === -1 ) {
+		return { isValid: false, error: 'invalid_format' };
+	}
+
+	const domain = trimmedEmail.substring( atIndex + 1 );
+	if ( ! domain ) {
+		return { isValid: false, error: 'invalid_format' };
+	}
+
+	if ( ! /^[a-z0-9.-]+$/i.test( domain ) ) {
+		return { isValid: false, error: 'invalid_format' };
+	}
+
+	const tld = getTld( domain );
+	if ( ! tld ) {
+		return { isValid: false, error: 'invalid_tld' };
+	}
+
+	const tldLower = tld.toLowerCase();
+
+	const tldToCheck = tldLower.includes( '.' )
+		? tldLower.substring( tldLower.lastIndexOf( '.' ) + 1 )
+		: tldLower;
+
+	if ( ! VALID_TLDS.has( tldToCheck ) ) {
+		return { isValid: false, error: 'invalid_tld' };
+	}
+
+	return { isValid: true };
+}
+
+export const validate = isValidEmail;
+
+export default {
+	validate: isValidEmail,
+};
+
+export { emailValidator as legacyEmailValidator };

--- a/client/lib/email-validation/test/index.ts
+++ b/client/lib/email-validation/test/index.ts
@@ -1,0 +1,87 @@
+import { isValidEmail, validateEmail } from '../index';
+
+describe( 'Email Validation', () => {
+	describe( 'isValidEmail', () => {
+		test.each( [
+			[ 'user@gmail.com', 'standard email' ],
+			[ 'test@example.org', 'standard email with .org' ],
+			[ 'admin@domain.net', 'standard email with .net' ],
+			[ 'user@mail.example.com', 'email with subdomain' ],
+			[ 'test@subdomain.domain.org', 'email with multi-level subdomain' ],
+			[ 'user@example.co.uk', 'email with multi-level TLD' ],
+			[ 'test@domain.com.au', 'email with .com.au TLD' ],
+			[ 'first.last@example.com', 'email with dots in local part' ],
+			[ 'user+tag@gmail.com', 'email with plus sign' ],
+			[ 'user_name@example.org', 'email with underscore' ],
+			[ 'user123@example.com', 'email with numbers in local part' ],
+			[ 'test1@domain.org', 'email with numbers' ],
+			[ 'user@example.io', 'email with .io TLD' ],
+			[ 'test@site.dev', 'email with .dev TLD' ],
+			[ 'admin@company.tech', 'email with .tech TLD' ],
+		] )( 'should accept %s (%s)', ( email ) => {
+			expect( isValidEmail( email ) ).toBe( true );
+		} );
+
+		describe( 'Invalid emails - TLD issues (Issue #106738)', () => {
+			test.each( [
+				[ 'user@gmail.comExtraText', 'extra text after .com' ],
+				[ 'test@example.comOh', 'extra characters after TLD' ],
+				[ 'admin@domain.orgIcanEnterWhateverTextIwant', 'arbitrary text after .org' ],
+				[ 'mahangu+wpcom20251027@gmail.comIcan', 'reported case from issue #106738' ],
+				[ 'user@example.commmm', 'repeated TLD characters' ],
+				[ 'test@domain.commm', 'extended TLD' ],
+				[ 'user@domain.co.uk.fake', 'fake multi-level TLD' ],
+				[ 'test@example.com.invalid', 'invalid multi-level TLD' ],
+			] )( 'should reject %s (%s)', ( email ) => {
+				expect( isValidEmail( email ) ).toBe( false );
+			} );
+		} );
+
+		describe( 'Invalid emails - format issues', () => {
+			test.each( [
+				[ '', 'empty string' ],
+				[ '   ', 'whitespace only' ],
+				[ 'usergmail.com', 'missing @ symbol' ],
+				[ 'test.example.org', 'missing @ symbol' ],
+				[ 'user@', 'missing domain' ],
+				[ '@example.com', 'missing local part' ],
+				[ 'user@@example.com', 'double @ symbol' ],
+				[ 'test@user@example.com', 'multiple @ symbols' ],
+				[ 'user@domain', 'missing TLD' ],
+				[ 'test@localhost', 'localhost without TLD' ],
+				[ 'user@exam ple.com', 'space in domain' ],
+				[ 'test@domain!.org', 'invalid character in domain' ],
+			] )( 'should reject %s (%s)', ( email ) => {
+				expect( isValidEmail( email ) ).toBe( false );
+			} );
+		} );
+	} );
+
+	describe( 'validateEmail', () => {
+		test( 'should return detailed validation results for valid emails', () => {
+			expect( validateEmail( 'user@gmail.com' ) ).toEqual( {
+				isValid: true,
+			} );
+		} );
+
+		test( 'should return error type for empty emails', () => {
+			expect( validateEmail( '' ) ).toEqual( {
+				isValid: false,
+				error: 'empty',
+			} );
+		} );
+
+		test( 'should return error type for invalid format', () => {
+			expect( validateEmail( 'notanemail' ) ).toEqual( {
+				isValid: false,
+				error: 'invalid_format',
+			} );
+		} );
+
+		test( 'should return error for invalid TLD', () => {
+			const result = validateEmail( 'user@gmail.comExtraText' );
+			expect( result.isValid ).toBe( false );
+			expect( result.error ).toBeDefined();
+		} );
+	} );
+} );

--- a/client/package.json
+++ b/client/package.json
@@ -218,6 +218,7 @@
 		"superagent": "^3.8.3",
 		"supertest": "^7.1.4",
 		"textarea-caret": "^3.1.0",
+		"tlds": "^1.261.0",
 		"to-title-case": "^1.0.0",
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.6",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -292,6 +292,8 @@ const webpackConfig = {
 			// Alias calypso to ./client. This allows for smaller bundles, as it ensures that
 			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
 			calypso: __dirname,
+			// Override email-validator with enhanced validator that includes TLD validation
+			'email-validator': path.join( __dirname, 'lib', 'email-validation' ),
 
 			util: findPackage( 'util/' ), //Trailing `/` stops node from resolving it to the built-in module
 		} ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -15843,6 +15843,7 @@ __metadata:
     superagent: "npm:^3.8.3"
     supertest: "npm:^7.1.4"
     textarea-caret: "npm:^3.1.0"
+    tlds: "npm:^1.261.0"
     to-title-case: "npm:^1.0.0"
     tracekit: "npm:^0.4.5"
     twemoji: "npm:^12.1.6"
@@ -37290,6 +37291,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.3"
   checksum: face56f686060f777b43a180d371407124d201eb4238c19d9e97030fd54859696ca4e2ca499cc232f8700f24f2414cc08aab9fdf6d39acff055dd825a4d86d6a
+  languageName: node
+  linkType: hard
+
+"tlds@npm:^1.261.0":
+  version: 1.261.0
+  resolution: "tlds@npm:1.261.0"
+  bin:
+    tlds: bin.js
+  checksum: ce05d266618312dd52efe0c958ebd668da70b9b752b7ec1f1b8c4b8fabc6e0f044159f80fec6c3a78df02572afbeb343208df7ef8e83a43e9f8e6c26134c76ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Looks to address - https://github.com/Automattic/wp-calypso/issues/106738

## Proposed Changes

* Enhanced email validation to check against official IANA TLD list (1,438 TLDs atm)
* Added [`tlds` package](https://www.npmjs.com/package/tlds) dependency for TLD validation
* Used webpack alias to globally override `email-validator` throughout codebase
* Added 39 tests covering valid/invalid email cases

## Why are these changes being made?

The `email-validator` package only validates [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322) format but doesn't verify TLD legitimacy. This allows invalid emails like `user@gmail.comExtraText` to pass validation.

**Solution:** Enhanced validation now checks both RFC compliance AND TLD validity against the official IANA list using the `tlds` package. Webpack aliasing provides automatic enhancement across all 14+ usage points with minimal diff (5 files).


## Before / After

### Before

<img width="1076" height="714" alt="Screenshot 2025-10-27 at 14 36 53" src="https://github.com/user-attachments/assets/b98625a1-ea9e-4d7f-93a5-087c503177e5" />

### After

<img width="1094" height="755" alt="Screenshot 2025-10-28 at 07 30 25" src="https://github.com/user-attachments/assets/8057444a-4034-4342-bcf3-f5c89e69b3e7" />



## Testing Instructions

### Test Invalid Emails Are Rejected

Navigate to `start/account/user-social` and try:
- `user@gmail.comExtraText` ❌
- `admin@domain.co.uk.fake` ❌

**Expected:** Validation errors appear, form cannot submit

### Test Valid Emails Still Work

Try these valid addresses:
- `user@gmail.com` ✅
- `test+tag@example.org` ✅
- `admin@domain.co.uk` ✅

**Expected:** No errors, form submits successfully

---

## Additional Notes

⚠️ **Backend/API validation** still needed? This only fixes frontend validation.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
