### PR TITLE
Experiment: Remove `<RequiredSelect>` component and use the standard from dataforms

### DIFF
--- a/client/dashboard/components/required-select/index.tsx
+++ b/client/dashboard/components/required-select/index.tsx
@@ -1,35 +1,35 @@
-import { SelectControl } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
-import type { DataFormControlProps } from '@wordpress/dataviews';
+import type { Field } from '@wordpress/dataviews';
 
-// A verbatim copy of @wordpress/dataviews/src/dataform-controls/select.tsx,
-// but without the first placeholder option.
-export default function RequiredSelect< Item >( {
-	data,
-	field,
-	onChange,
-	hideLabelFromVision,
-}: DataFormControlProps< Item > ) {
-	const { id, label } = field;
-	const value = field.getValue( { item: data } ) ?? '';
-	const onChangeControl = useCallback(
-		( newValue: any ) =>
-			onChange( {
-				[ id ]: newValue,
-			} as Partial< Item > ),
-		[ id, onChange ]
-	);
+// Utility type used ensure a select field is being passed to `removeSelectItemOption`.
+// If you get an error due to this type, make sure that the field description being
+// passed to `removeSelectItemOption` has the correct `Edit` and `elements` fields expected
+// for a select form field.
+type SelectField< Item > = Omit< Field< Item >, 'Edit' | 'elements' > & {
+	Edit: 'select';
+	elements: NonNullable< Field< Item >[ 'elements' ] >;
+};
 
-	return (
-		<SelectControl
-			label={ label }
-			value={ value }
-			help={ field.description }
-			options={ field.elements }
-			onChange={ onChangeControl }
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			hideLabelFromVision={ hideLabelFromVision }
-		/>
-	);
+// Wrapper for removing the default "Select item" option from select fields.
+// The dataform will not show the "Select item" text if one of the elements has
+// an empty value (that's because it treats that one as the default/empty state).
+// This wrapper works by transforming the first option in `elements` into an
+// empty option and then using getValue/setValue to transform the value from/to
+// the real value.
+export function removeSelectItemOption< Item >( field: SelectField< Item > ): Field< Item > {
+	const defaultElementValue = field.elements[ 0 ].value;
+
+	return {
+		...field,
+		elements: [ { value: '', label: field.elements[ 0 ].label }, ...field.elements.slice( 1 ) ],
+		getValue: ( args ) => {
+			const value = field.getValue ? field.getValue( args ) : args.item[ field.id as keyof Item ];
+			return value === defaultElementValue ? '' : value;
+		},
+		setValue: ( args ) => {
+			const value = args.value === '' ? defaultElementValue : args.value;
+			return field.setValue
+				? field.setValue( { item: args.item, value } )
+				: ( { [ field.id ]: value } as Partial< Item > );
+		},
+	};
 }

--- a/client/dashboard/components/tax-location-form.tsx
+++ b/client/dashboard/components/tax-location-form.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import RequiredSelect from './required-select';
+import { removeSelectItemOption } from './required-select';
 import type { CountryListItem, StoredPaymentMethodTaxLocation } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
@@ -13,17 +13,17 @@ function getFields( {
 	countryList: CountryListItem[];
 } ): Field< StoredPaymentMethodTaxLocation >[] {
 	return [
-		{
+		removeSelectItemOption( {
 			id: 'country_code',
 			label: __( 'Country' ),
-			Edit: RequiredSelect,
+			Edit: 'select',
 			elements: countryList
 				.filter( ( countryItem ) => countryItem.name )
 				.map( ( countryItem ) => ( {
 					label: countryItem.name,
 					value: countryItem.code,
 				} ) ),
-		},
+		} ),
 		{
 			id: 'postal_code',
 			label: __( 'Postal code' ),

--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -3,7 +3,7 @@ import { DataForm, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
-import RequiredSelect from '../../components/required-select';
+import { removeSelectItemOption } from '../../components/required-select';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
 import type { DnsRecord, DnsRecordType } from '@automattic/api-core';
@@ -78,10 +78,10 @@ export default function DNSRecordForm( {
 	const config = DNS_RECORD_CONFIGS[ typeFormData.type ];
 
 	const typeFields: Field< DnsRecordTypeFormData >[] = [
-		{
+		removeSelectItemOption( {
 			id: 'type',
 			label: __( 'Type' ),
-			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
+			Edit: 'select',
 			elements: [
 				{ label: 'A', value: 'A' },
 				{ label: 'AAAA', value: 'AAAA' },
@@ -94,7 +94,7 @@ export default function DNSRecordForm( {
 				{ label: 'TXT', value: 'TXT' },
 			],
 			description: config.description,
-		},
+		} ),
 	];
 
 	const handleCancel = ( e: React.MouseEvent< HTMLButtonElement > ) => {

--- a/client/dashboard/domains/dns/records/caa-record.tsx
+++ b/client/dashboard/domains/dns/records/caa-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import RequiredSelect from '../../../components/required-select';
+import { removeSelectItemOption } from '../../../components/required-select';
 import { getNormalizedName } from '../utils';
 import {
 	hostnameValidator,
@@ -34,20 +34,17 @@ export const CAARecordConfig: DnsRecordConfig = {
 				custom: numberRangeValidator( 0, 255, __( 'Please enter a valid flags value.' ) ),
 			},
 		},
-		{
+		removeSelectItemOption( {
 			id: 'tag',
 			label: __( 'Tag' ),
-			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
+			Edit: 'select',
 			elements: [
 				{ label: 'issue', value: 'issue' },
 				{ label: 'issuewild', value: 'issuewild' },
 				{ label: 'issueemail', value: 'issueemail' },
 				{ label: 'iodef', value: 'iodef' },
 			],
-			isValid: {
-				required: true,
-			},
-		},
+		} ),
 		{
 			id: 'value',
 			type: 'text',

--- a/client/dashboard/domains/dns/records/srv-record.tsx
+++ b/client/dashboard/domains/dns/records/srv-record.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import RequiredSelect from '../../../components/required-select';
+import { removeSelectItemOption } from '../../../components/required-select';
 import { getFieldWithDot, getNormalizedName } from '../utils';
 import {
 	domainValidator,
@@ -36,19 +36,16 @@ export const SRVRecordConfig: DnsRecordConfig = {
 				custom: serviceValidator(),
 			},
 		},
-		{
+		removeSelectItemOption( {
 			id: 'protocol',
 			label: __( 'Protocol' ),
-			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
+			Edit: 'select',
 			elements: [
 				{ label: '_tcp', value: '_tcp' },
 				{ label: '_udp', value: '_udp' },
 				{ label: '_tls', value: '_tls' },
 			],
-			isValid: {
-				required: true,
-			},
-		},
+		} ),
 		{
 			id: 'aux',
 			type: 'integer',

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -14,7 +14,7 @@ import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RequiredSelect from '../../components/required-select';
+import { removeSelectItemOption } from '../../components/required-select';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
@@ -43,10 +43,10 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	const { phpVersions } = getPHPVersions();
 
 	const fields: Field< { version: string } >[] = [
-		{
+		removeSelectItemOption( {
 			id: 'version',
 			label: __( 'PHP version' ),
-			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
+			Edit: 'select',
 			elements: phpVersions.filter( ( option ) => {
 				// Show disabled PHP version only if the site is still using it.
 				if ( option.disabled && option.value !== currentVersion ) {
@@ -54,7 +54,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 				}
 				return true;
 			} ),
-		},
+		} ),
 	];
 
 	const form = {

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -21,7 +21,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import RequiredSelect from '../../components/required-select';
+import { removeSelectItemOption } from '../../components/required-select';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { canViewWordPressSettings } from '../features';
 import type { Field } from '@wordpress/dataviews';
@@ -49,15 +49,15 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 	} );
 
 	const fields: Field< { version: string } >[] = [
-		{
+		removeSelectItemOption( {
 			id: 'version',
 			label: __( 'WordPress version' ),
-			Edit: RequiredSelect, // TODO: use DataForm's validation when available. See: DOTCOM-13298
+			Edit: 'select',
 			elements: [
 				{ value: 'latest', label: getFormattedWordPressVersion( site, 'latest' ) },
 				{ value: 'beta', label: getFormattedWordPressVersion( site, 'beta' ) },
 			],
-		},
+		} ),
 	];
 
 	const form = {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Removes our custom `<RequiredSelect>` component from MSD
* Use the select fields "custom empty option" feature to fake hide the "Select item" text

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to use core components where we can.

This PR is just an experiment though. What do you think @fushar? I think we thought we would eventually be able to remove `<RequiredSelect>` when core added validation, because they wouldn't have the "Select item" text for required select controls. But that's not quite true. It's not really anything to do with being a required field, and it is more to do whether the data form is for editing an existing entity or creating a new entity.

E.g. the data form for creating a new DNS entry can show "Select item" since the user needs to choose one before entering. But the form for _editing_ a DNS entry it doesn't make as much sense. The select control will start with an existing option selected. In both situations it is a required field though.

The main downside is that this is incompatible with marking the field as "required". Otherwise we can see a validation error when the user selects the first item.

<img width="1416" height="280" alt="CleanShot 2025-10-28 at 17 14 14@2x" src="https://github.com/user-attachments/assets/b8653c8f-74e6-479b-b09b-19e3c1d32bfd" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
