### PR TITLE
MSD perf: show skeleton cards in domain overview instead of blocking navigation

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -115,12 +115,9 @@ export const domainOverviewRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
-		const [ site, mailboxes ] = await Promise.all( [
-			queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) ),
-			queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) ),
-		] );
 
-		return { domain, site, mailboxes };
+		queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
+		queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) );
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-overview' ).then( ( d ) =>

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -1,6 +1,6 @@
 import { Domain } from '@automattic/api-core';
 import { mailboxesQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -48,14 +48,17 @@ interface Props {
 }
 
 export default function FeaturedCardEmails( { domain }: Props ) {
-	const { data: mailboxes } = useSuspenseQuery( mailboxesQuery( domain.blog_id ) );
+	const router = useRouter();
+
+	const { data: mailboxes } = useQuery( mailboxesQuery( domain.blog_id ) );
+	if ( mailboxes === undefined ) {
+		return <OverviewCard icon={ <Icon icon={ envelope } /> } title={ __( 'Emails' ) } isLoading />;
+	}
 
 	const email = mailboxes.length
 		? `${ mailboxes[ 0 ].mailbox }@${ domain.domain }`
 		: // translators: %s is the mailbox name: youremail@example.com
 		  sprintf( __( 'youremail@%s' ), domain.domain );
-
-	const router = useRouter();
 
 	return (
 		<OverviewCard

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -1,6 +1,6 @@
 import { Domain, DomainSubtype } from '@automattic/api-core';
 import { siteByIdQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
@@ -12,10 +12,10 @@ interface Props {
 }
 
 export default function FeaturedCardSite( { domain }: Props ) {
-	const { data: site } = useSuspenseQuery( siteByIdQuery( domain.blog_id ) );
+	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 
 	if ( ! site ) {
-		return null;
+		return <OverviewCard icon={ <Icon icon={ layout } /> } title={ __( 'Site' ) } isLoading />;
 	}
 
 	const shouldShowAddAttachSite =


### PR DESCRIPTION
## Proposed Changes

Don't await the `mailboxesQuery()` and `siteByIdQuery()` in the loader, when showing MSD's `/domains/:domainName` overview page. Instead, we show loading state of the emails and site cards:

<img width="632" height="391" alt="image" src="https://github.com/user-attachments/assets/97e0d364-00d7-43c3-a35c-abbfdd3df974" />


## Why are these changes being made?

MSD perf audit.

## Testing Instructions

1. Go to /v2/domains
2. Click a domain
3. Verify that it's faster than before.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
