### PR TITLE
MSD Domains: Add breadcrumbs to domain transfer screens

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -458,6 +458,11 @@ export const domainTransferRoute = createRoute( {
 	} ),
 	getParentRoute: () => domainRoute,
 	path: 'transfer',
+} );
+
+export const domainTransferIndexRoute = createRoute( {
+	getParentRoute: () => domainTransferRoute,
+	path: '/',
 } ).lazy( () =>
 	import( '../../domains/domain-transfer' ).then( ( d ) =>
 		createLazyRoute( 'domain-transfer' )( {
@@ -474,8 +479,8 @@ export const domainTransferToAnyUserRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => domainRoute,
-	path: 'transfer/any-user',
+	getParentRoute: () => domainTransferRoute,
+	path: 'any-user',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
@@ -496,8 +501,8 @@ export const domainTransferToOtherUserRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => domainRoute,
-	path: 'transfer/other-user',
+	getParentRoute: () => domainTransferRoute,
+	path: 'other-user',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
@@ -518,8 +523,8 @@ export const domainTransferToOtherSiteRoute = createRoute( {
 			},
 		],
 	} ),
-	getParentRoute: () => domainRoute,
-	path: 'transfer/other-site',
+	getParentRoute: () => domainTransferRoute,
+	path: 'other-site',
 	loader: async ( { params: { domainName } } ) => {
 		return queryClient.ensureQueryData( domainQuery( domainName ) );
 	},
@@ -604,10 +609,12 @@ export const createDomainsRoutes = () => {
 				domainGlueRecordsAddRoute,
 				domainGlueRecordsEditRoute,
 			] ),
-			domainTransferRoute,
-			domainTransferToAnyUserRoute,
-			domainTransferToOtherUserRoute,
-			domainTransferToOtherSiteRoute,
+			domainTransferRoute.addChildren( [
+				domainTransferIndexRoute,
+				domainTransferToAnyUserRoute,
+				domainTransferToOtherUserRoute,
+				domainTransferToOtherSiteRoute,
+			] ),
 			domainSecurityRoute,
 		] ),
 	];

--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -18,6 +18,7 @@ import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
@@ -210,7 +211,10 @@ export default function DomainTransfer() {
 	// TO DO: render notices if the domain is not transferable
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer' ) } /> }>
+		<PageLayout
+			size="small"
+			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Transfer' ) } /> }
+		>
 			{ renderTransferInfo() }
 			{ isDomainTransferable && <InternalTransferOptions domain={ domain } /> }
 			{ isDomainTransferable && domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -18,6 +18,7 @@ import { DataForm, isItemValid } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
@@ -309,7 +310,15 @@ export default function TransferDomainToAnyUser() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ __( 'Transfer to another user' ) }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<VStack spacing={ 3 }>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
@@ -13,6 +13,7 @@ import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainTransferToOtherSiteRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
@@ -57,6 +58,7 @@ export default function DomainTransferToOtherSite() {
 			size="small"
 			header={
 				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Attach to another site' ) }
 					description={ sprintf(
 						// translators: %s is the domain name

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -19,6 +19,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAuth } from '../../app/auth';
+import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainsRoute } from '../../app/router/domains';
 import { ButtonStack } from '../../components/button-stack';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -264,7 +265,15 @@ export default function TransferDomainToOtherUser() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Transfer to another user' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					title={ __( 'Transfer to another user' ) }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<VStack spacing={ 3 }>


### PR DESCRIPTION
Fixes DOTMSD-659

## Proposed Changes

Implements breadcrumbs to domain transfer screens.
<img width="789" height="713" alt="SCR-20251028-pdsv" src="https://github.com/user-attachments/assets/184657c8-ee51-4585-9d21-ace7f505bf74" />

<img width="777" height="561" alt="SCR-20251028-pdxf" src="https://github.com/user-attachments/assets/0b5efb3c-c219-4feb-9052-47965ef0c798" />

<img width="745" height="720" alt="SCR-20251028-peda" src="https://github.com/user-attachments/assets/3b04d005-4a9a-40f5-8eee-233a10a96562" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the breadcrumbs are added as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
