### PR TITLE
A4A > Tiers: Implement updated overview page

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/controller.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/controller.tsx
@@ -3,14 +3,14 @@ import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
 import AgencyTierOverview from './primary/agency-tier-overview';
-import AgencyTierOverviewRevamped from './primary/agency-tier-overview-revamped';
+import AgencyTierOverviewV2 from './primary/agency-tier-overview-v2';
 
 export const agencyTierContext: Callback = ( context, next ) => {
 	const isTiersRevampEnabled = isEnabled( 'tiers-revamp' );
 	context.primary = (
 		<>
 			<PageViewTracker title="Agency Tier" path={ context.path } />
-			{ isTiersRevampEnabled ? <AgencyTierOverviewRevamped /> : <AgencyTierOverview /> }
+			{ isTiersRevampEnabled ? <AgencyTierOverviewV2 /> : <AgencyTierOverview /> }
 		</>
 	);
 	context.secondary = <MainSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -1,0 +1,60 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __, sprintf } from '@wordpress/i18n';
+
+const TARGET_INFLUENCED_REVENUE = {
+	'emerging-partner': 0,
+	'agency-partner': 1000,
+	'pro-agency-partner': 5000,
+	'premier-partner': 250000,
+};
+
+export const ALL_TIERS = [
+	{
+		level: 0,
+		id: 'emerging-partner',
+		name: __( 'Account activated' ),
+		description: 'Joining the program',
+		heading: __( 'Essential benefits' ),
+		subheading: __( 'Tools, earning opportunities, support & training and more' ),
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'emerging-partner' ],
+	},
+	{
+		level: 1,
+		id: 'agency-partner',
+		name: __( 'Agency Partner' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue */
+			__( '%s+ influenced revenue' ),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD' )
+		),
+		heading: __( '2 additional benefits unlocked' ),
+		subheading: __( 'Directory visibility, early access' ),
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],
+	},
+	{
+		level: 2,
+		id: 'pro-agency-partner',
+		name: __( 'Pro Agency Partner' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue */
+			__( '%s+ influenced revenue' ),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ], 'USD' )
+		),
+		heading: __( '3 additional benefits unlocked' ),
+		subheading: __( 'Co-marketing, qualified leads, partner manager & more' ),
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
+	},
+	{
+		level: 3,
+		id: 'premier-partner',
+		name: __( 'Premier Partner' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue */
+			__( '%s+ influenced revenue' ),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'premier-partner' ], 'USD' )
+		),
+		heading: __( '3 premium benefits' ),
+		subheading: __( 'Annual credits, Parse.ly trial, marketing funds' ),
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
+	},
+];

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -1,0 +1,29 @@
+import { Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import InfluencedRevenue from './influenced-revenue';
+import TierCards from './tier-cards';
+import type { AgencyTier } from './types';
+
+export default function AgencyTierOverviewContent( {
+	currentAgencyTier,
+	totalInfluencedRevenue,
+}: {
+	currentAgencyTier?: AgencyTier;
+	totalInfluencedRevenue: number;
+} ) {
+	const isSmallViewport = useViewportMatch( 'huge', '<' );
+
+	return (
+		<VStack spacing={ 6 }>
+			<Card>
+				<CardBody>
+					<InfluencedRevenue
+						currentAgencyTier={ currentAgencyTier }
+						totalInfluencedRevenue={ totalInfluencedRevenue }
+					/>
+				</CardBody>
+			</Card>
+			<TierCards currentAgencyTier={ currentAgencyTier } isSmallViewport={ isSmallViewport } />
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -2,13 +2,13 @@ import { Card, CardBody, __experimentalVStack as VStack } from '@wordpress/compo
 import { useViewportMatch } from '@wordpress/compose';
 import InfluencedRevenue from './influenced-revenue';
 import TierCards from './tier-cards';
-import type { AgencyTier } from './types';
+import type { AgencyTierType } from './types';
 
 export default function AgencyTierOverviewContent( {
-	currentAgencyTier,
+	currentAgencyTierId,
 	totalInfluencedRevenue,
 }: {
-	currentAgencyTier?: AgencyTier;
+	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
 } ) {
 	const isSmallViewport = useViewportMatch( 'huge', '<' );
@@ -18,12 +18,12 @@ export default function AgencyTierOverviewContent( {
 			<Card>
 				<CardBody>
 					<InfluencedRevenue
-						currentAgencyTier={ currentAgencyTier }
+						currentAgencyTierId={ currentAgencyTierId }
 						totalInfluencedRevenue={ totalInfluencedRevenue }
 					/>
 				</CardBody>
 			</Card>
-			<TierCards currentAgencyTier={ currentAgencyTier } isSmallViewport={ isSmallViewport } />
+			<TierCards currentAgencyTierId={ currentAgencyTierId } isSmallViewport={ isSmallViewport } />
 		</VStack>
 	);
 }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -1,0 +1,34 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __ } from '@wordpress/i18n';
+import { Stat } from 'calypso/dashboard/components/stat';
+import { ALL_TIERS } from './constants';
+import type { AgencyTier } from './types';
+
+export default function InfluencedRevenue( {
+	currentAgencyTier,
+	totalInfluencedRevenue,
+}: {
+	currentAgencyTier?: AgencyTier;
+	totalInfluencedRevenue: number;
+} ) {
+	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTier );
+
+	if ( ! currentTier ) {
+		return null;
+	}
+
+	const progressValue = Math.round(
+		( totalInfluencedRevenue / currentTier.influencedRevenue ) * 100
+	);
+
+	return (
+		<Stat
+			density="high"
+			strapline={ __( 'Influenced revenue' ) }
+			metric={ formatCurrency( totalInfluencedRevenue, 'USD' ) }
+			description={ formatCurrency( currentTier.influencedRevenue, 'USD' ) }
+			progressValue={ progressValue }
+			progressLabel={ `${ progressValue }%` }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -2,16 +2,16 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { __ } from '@wordpress/i18n';
 import { Stat } from 'calypso/dashboard/components/stat';
 import { ALL_TIERS } from './constants';
-import type { AgencyTier } from './types';
+import type { AgencyTierType } from './types';
 
 export default function InfluencedRevenue( {
-	currentAgencyTier,
+	currentAgencyTierId,
 	totalInfluencedRevenue,
 }: {
-	currentAgencyTier?: AgencyTier;
+	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
 } ) {
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTier );
+	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
 
 	if ( ! currentTier ) {
 		return null;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -1,0 +1,83 @@
+import { Badge } from '@automattic/ui';
+import {
+	Card,
+	CardBody,
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { SectionHeader } from 'calypso/dashboard/components/section-header';
+import { ALL_TIERS } from './constants';
+import type { AgencyTier } from './types';
+
+export default function TierCards( {
+	currentAgencyTier,
+	isSmallViewport,
+}: {
+	currentAgencyTier?: AgencyTier;
+	isSmallViewport: boolean;
+} ) {
+	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTier );
+
+	const content = ALL_TIERS.map( ( tier ) => {
+		const hasLowerTier = currentTier && currentTier.level > tier.level;
+		const hasHigherTier = currentTier && currentTier.level < tier.level;
+		const isCurrentTier = currentTier === tier;
+		const isSecondary = hasLowerTier || hasHigherTier;
+
+		return (
+			<Card
+				key={ tier.id }
+				style={ {
+					width: isSmallViewport ? '100%' : '33%',
+					...( isCurrentTier && {
+						boxShadow: '0 0 0 1px var(--color-primary-50)',
+					} ),
+				} }
+			>
+				<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
+					<VStack spacing={ 2 } style={ { flex: 1 } }>
+						<HStack>
+							<SectionHeader title={ tier.name } />
+							{ isCurrentTier && (
+								<Badge
+									style={ { minWidth: 'fit-content' } }
+									intent="default"
+									children={ __( 'Your tier' ) }
+								/>
+							) }
+						</HStack>
+						<Text style={ { color: '#757575' } }>{ tier.description }</Text>
+						<Text style={ { color: '#757575' } } weight={ 700 }>
+							{ tier.heading }
+						</Text>
+						<Text style={ { color: '#757575' } }>{ tier.subheading }</Text>
+					</VStack>
+					<Button
+						href={ `#${ tier.id }` }
+						variant={ isSecondary ? 'secondary' : 'primary' }
+						style={ { marginTop: '24px', alignSelf: 'flex-start' } }
+					>
+						{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
+					</Button>
+				</CardBody>
+			</Card>
+		);
+	} );
+
+	if ( isSmallViewport ) {
+		return (
+			<VStack spacing={ 6 } style={ { alignItems: 'center' } }>
+				{ content }
+			</VStack>
+		);
+	}
+
+	return (
+		<HStack spacing={ 6 } style={ { justifyContent: 'space-between' } } alignment="stretch">
+			{ content }
+		</HStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -10,16 +10,16 @@ import {
 import { __ } from '@wordpress/i18n';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import { ALL_TIERS } from './constants';
-import type { AgencyTier } from './types';
+import type { AgencyTierType } from './types';
 
 export default function TierCards( {
-	currentAgencyTier,
+	currentAgencyTierId,
 	isSmallViewport,
 }: {
-	currentAgencyTier?: AgencyTier;
+	currentAgencyTierId?: AgencyTierType;
 	isSmallViewport: boolean;
 } ) {
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTier );
+	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
 
 	const content = ALL_TIERS.map( ( tier ) => {
 		const hasLowerTier = currentTier && currentTier.level > tier.level;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
@@ -1,0 +1,5 @@
+export type AgencyTier =
+	| 'emerging-partner'
+	| 'agency-partner'
+	| 'pro-agency-partner'
+	| 'premier-partner';

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
@@ -1,4 +1,4 @@
-export type AgencyTier =
+export type AgencyTierType =
 	| 'emerging-partner'
 	| 'agency-partner'
 	| 'pro-agency-partner'

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
@@ -17,7 +17,7 @@ export default function AgencyTierOverviewV2() {
 	const agency = useSelector( getActiveAgency );
 
 	const title = translate( 'Your agency tier and benefits' );
-	const currentAgencyTier = agency?.tier?.id;
+	const currentAgencyTierId = agency?.tier?.id;
 
 	// FIXME: Replace with actual influenced revenue
 	const totalInfluencedRevenue = 2000;
@@ -35,7 +35,7 @@ export default function AgencyTierOverviewV2() {
 
 			<LayoutBody>
 				<AgencyTierOverviewContent
-					currentAgencyTier={ currentAgencyTier }
+					currentAgencyTierId={ currentAgencyTierId }
 					totalInfluencedRevenue={ totalInfluencedRevenue }
 				/>
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
@@ -7,14 +7,23 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import AgencyTierOverviewContent from '../../overview-content';
 
-export default function AgencyTierOverviewRevamped() {
+export default function AgencyTierOverviewV2() {
 	const translate = useTranslate();
 
+	const agency = useSelector( getActiveAgency );
+
 	const title = translate( 'Your agency tier and benefits' );
+	const currentAgencyTier = agency?.tier?.id;
+
+	// FIXME: Replace with actual influenced revenue
+	const totalInfluencedRevenue = 2000;
 
 	return (
-		<Layout className="agency-tier-overview-revamped" title={ title } wide>
+		<Layout title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>
@@ -24,7 +33,12 @@ export default function AgencyTierOverviewRevamped() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Content</LayoutBody>
+			<LayoutBody>
+				<AgencyTierOverviewContent
+					currentAgencyTier={ currentAgencyTier }
+					totalInfluencedRevenue={ totalInfluencedRevenue }
+				/>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -16,6 +16,7 @@
 	--color-text-white: var(--studio-white);
 	--color-text-black: var(--studio-black);
 	--wp-components-color-accent: var(--studio-automattic-blue-50);
+	--wp-admin-theme-color: var(--studio-automattic-blue-50);
 
 	// FIXME: Need to move this colors to a color scheme file
 	--color-scary-0: var(--studio-red-0);

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -69,6 +69,15 @@
 	}
 }
 
+/* A4A */
+.theme-a8c-for-agencies {
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--color-primary);
+		--wp-components-color-accent-darker-10: var(--color-primary-60);
+		--wp-components-color-accent-darker-20: var(--color-primary-60);
+	}
+}
+
 /* Gravatar & WP Job Manager */
 .is-grav-powered-client {
 	.components-button:not(.is-destructive) {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -69,15 +69,6 @@
 	}
 }
 
-/* A4A */
-.theme-a8c-for-agencies {
-	.components-button:not(.is-destructive) {
-		--wp-components-color-accent: var(--color-primary);
-		--wp-components-color-accent-darker-10: var(--color-primary-60);
-		--wp-components-color-accent-darker-20: var(--color-primary-60);
-	}
-}
-
 /* Gravatar & WP Job Manager */
 .is-grav-powered-client {
 	.components-button:not(.is-destructive) {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-1677/ui-implement-the-updated-agency-tier-page

Resolves https://linear.app/a8c/issue/A4A-1691/implement-influenced-revenue-section
Resolves https://linear.app/a8c/issue/A4A-1692/implement-tier-cards

## Proposed Changes

This PR implements the updated overview page for Agency Tiers. All the components here are designed to be able to move to the Multi-site Dashboard later with minimal changes.

## Why are these changes being made?

* To add the new overview page for Agency Tiers

## Testing Instructions

* Open the A4A live link
* Go to Agency Tier > Verify the UI looks as displayed below

<img width="1511" height="603" alt="Screenshot 2025-10-28 at 4 05 02 PM" src="https://github.com/user-attachments/assets/c2c4e004-11d9-45ec-8be1-037a73f33686" />

<img width="187" height="597" alt="Screenshot 2025-10-28 at 4 13 14 PM" src="https://github.com/user-attachments/assets/be571776-9c15-4bee-9757-77b1e7935026" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
