### PR TITLE
ADS-532: Zero index the Blaze line charts

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -152,7 +152,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						}
 						// Increase the scale by 40%, this allows extra space for the tooltip
 						const padding = ( max - min ) * 0.4;
-						return [ min, max + padding ];
+						return [ 0, max + padding ];
 					},
 				},
 			},


### PR DESCRIPTION
ADS-532

## Proposed Changes

* Zero index the line charts - stats look artificially low becuase they are indexed form the lowest value and not zero.

## Testing Instructions

Load any campaign with stats and view the campaign details.

`https://site.com/wp-admin/tools.php?page=advertising#!/advertising/campaigns/123/site.com`

**Before**
<img width="643" height="621" alt="Screenshot 2025-10-28 at 11 09 51" src="https://github.com/user-attachments/assets/099c9e80-dc0d-490a-a738-112c7b6a4bd8" />


**After**

<img width="638" height="522" alt="Screenshot 2025-10-28 at 11 09 33" src="https://github.com/user-attachments/assets/5effdff8-7fff-4f26-9492-f3922a739b7c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
