### PR TITLE
MSD: show 'Back to Overview' snackbar when clicking on upsell on Site Overview screen

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -966,9 +966,9 @@ export const siteSettingsRepositoriesRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'repositories',
-	validateSearch: ( search ): { from?: 'deployments' } => {
+	validateSearch: ( search ): { back_to?: 'deployments' } => {
 		return {
-			from: search.from === 'deployments' ? 'deployments' : undefined,
+			back_to: search.back_to === 'deployments' ? 'deployments' : undefined,
 		};
 	},
 } );
@@ -1023,9 +1023,9 @@ export const siteSettingsRepositoriesManageRoute = createRoute( {
 	parseParams: ( params ) => ( {
 		deploymentId: Number( params.deploymentId ),
 	} ),
-	validateSearch: ( search ): { from?: 'deployments' } => {
+	validateSearch: ( search ): { back_to?: 'deployments' } => {
 		return {
-			from: search.from === 'deployments' ? 'deployments' : undefined,
+			back_to: search.back_to === 'deployments' ? 'deployments' : undefined,
 		};
 	},
 	loader: async ( { params: { siteSlug, deploymentId } } ) => {

--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -10,6 +10,6 @@
 	margin: $grid-unit-20;
 }
 
-body:has( .back-to-deployments-button ) .dashboard-snackbars {
+body:has( .dashboard-snackbar-back-button ) .dashboard-snackbars {
 	margin-bottom: calc( $grid-unit-20 + 52px );
 }

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useRouter, useCanGoBack } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
@@ -6,14 +6,13 @@ import { ReactNode } from 'react';
 
 import './style.scss';
 
-export default function SnackbarBackButton( {
-	backUrl,
-	children,
-}: {
-	backUrl: string;
-	children: ReactNode;
-} ) {
-	const navigate = useNavigate();
+export default function SnackbarBackButton( { children }: { children: ReactNode } ) {
+	const router = useRouter();
+	const canGoBack = useCanGoBack();
+
+	if ( ! canGoBack ) {
+		return null;
+	}
 
 	return (
 		<div
@@ -29,9 +28,7 @@ export default function SnackbarBackButton( {
 				variant="primary"
 				icon={ isRTL() ? chevronRight : chevronLeft }
 				iconPosition="left"
-				onClick={ () => {
-					navigate( { to: backUrl } );
-				} }
+				onClick={ () => router.history.back() }
 			>
 				{ children }
 			</Button>

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -4,6 +4,8 @@ import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { ReactNode } from 'react';
 
+import './style.scss';
+
 export default function SnackbarBackButton( {
 	backUrl,
 	children,
@@ -24,15 +26,9 @@ export default function SnackbarBackButton( {
 			} }
 		>
 			<Button
-				variant="secondary"
+				variant="primary"
 				icon={ isRTL() ? chevronRight : chevronLeft }
 				iconPosition="left"
-				style={ {
-					backgroundColor: '#1e1e1e',
-					color: '#ffffff',
-					borderColor: '#1e1e1e',
-					boxShadow: 'none',
-				} }
 				onClick={ () => {
 					navigate( { to: backUrl } );
 				} }

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -1,0 +1,44 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { ReactNode } from 'react';
+
+export default function SnackbarBackButton( {
+	backUrl,
+	children,
+}: {
+	backUrl: string;
+	children: ReactNode;
+} ) {
+	const navigate = useNavigate();
+
+	return (
+		<div
+			className="dashboard-snackbar-back-button"
+			style={ {
+				position: 'fixed',
+				bottom: '16px',
+				insetInlineStart: '16px',
+				zIndex: 3,
+			} }
+		>
+			<Button
+				variant="secondary"
+				icon={ isRTL() ? chevronRight : chevronLeft }
+				iconPosition="left"
+				style={ {
+					backgroundColor: '#1e1e1e',
+					color: '#ffffff',
+					borderColor: '#1e1e1e',
+					boxShadow: 'none',
+				} }
+				onClick={ () => {
+					navigate( { to: backUrl } );
+				} }
+			>
+				{ children }
+			</Button>
+		</div>
+	);
+}

--- a/client/dashboard/components/snackbar-back-button/style.scss
+++ b/client/dashboard/components/snackbar-back-button/style.scss
@@ -1,0 +1,13 @@
+.dashboard-snackbar-back-button {
+	button.components-button.is-primary {
+		&, &:hover {
+			color: var(--dashboard__background-color);
+			background-color: var(--dashboard__text-color);
+			border-color: var(--dashboard__text-color);
+		}
+
+		&:not(:focus) {
+			--wp-admin-theme-color: var(--dashboard__text-color);
+		}
+	}
+}

--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -48,7 +48,7 @@ export function useDeploymentFields( {
 						<Link
 							to={ siteSettingsRepositoriesManageRoute.fullPath }
 							params={ { siteSlug, deploymentId: item.code_deployment_id } }
-							search={ { from: 'deployments' } }
+							search={ { back_to: 'deployments' } }
 						>
 							{ repo }
 						</Link>

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -182,7 +182,7 @@ function DeploymentsList() {
 							<RouterLinkButton
 								to={ siteSettingsRepositoriesRoute.fullPath }
 								params={ { siteSlug } }
-								search={ { from: 'deployments' } }
+								search={ { back_to: 'deployments' } }
 								variant="secondary"
 								__next40pxDefaultSize
 							>

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -1,4 +1,8 @@
+import { useRouter, useRouterState } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { siteOverviewRoute } from '../../app/router/sites';
 import { CalloutOverlay } from '../../components/callout-overlay';
+import SnackbarBackButton from '../../components/snackbar-back-button';
 import HostingFeatureGate from '../hosting-feature-gate';
 import ActivationCallout from './activation';
 import UpsellCallout, { UpsellCalloutProps } from './upsell';
@@ -26,13 +30,31 @@ export default function HostingFeatureGatedWithCallout( {
 	upsellDescription,
 	...props
 }: HostingFeatureGatedWithCalloutProps ) {
+	const router = useRouter();
+	const {
+		location: { search },
+	} = useRouterState();
+
 	const { site, upsellId, upsellFeatureId, feature } = props;
+
+	const backButton = search.back_to === 'overview' && (
+		<SnackbarBackButton
+			backUrl={
+				router.buildLocation( {
+					to: siteOverviewRoute.fullPath,
+					params: { siteSlug: site.slug },
+				} ).href
+			}
+		>
+			{ __( 'Back to Overview' ) }
+		</SnackbarBackButton>
+	);
 
 	return (
 		<HostingFeatureGate
 			{ ...props }
 			renderUpsellComponent={ () => {
-				const callout = (
+				let callout = (
 					<UpsellCallout
 						site={ site }
 						upsellId={ upsellId }
@@ -46,13 +68,21 @@ export default function HostingFeatureGatedWithCallout( {
 				);
 
 				if ( asOverlay || overlay ) {
-					return <CalloutOverlay callout={ callout } main={ overlay } />;
+					callout = <CalloutOverlay callout={ callout } main={ overlay } />;
 				}
 
-				return callout;
+				return (
+					<>
+						{ callout }
+						{ backButton }
+					</>
+				);
 			} }
 			renderActivationComponent={ ( { onClick } ) => (
-				<ActivationCallout main={ overlay } onClick={ onClick } />
+				<>
+					<ActivationCallout main={ overlay } onClick={ onClick } />
+					{ backButton }
+				</>
 			) }
 		/>
 	);

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -1,6 +1,5 @@
-import { useRouter, useRouterState } from '@tanstack/react-router';
+import { useRouterState } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { siteOverviewRoute } from '../../app/router/sites';
 import { CalloutOverlay } from '../../components/callout-overlay';
 import SnackbarBackButton from '../../components/snackbar-back-button';
 import HostingFeatureGate from '../hosting-feature-gate';
@@ -30,7 +29,6 @@ export default function HostingFeatureGatedWithCallout( {
 	upsellDescription,
 	...props
 }: HostingFeatureGatedWithCalloutProps ) {
-	const router = useRouter();
 	const {
 		location: { search },
 	} = useRouterState();
@@ -38,16 +36,7 @@ export default function HostingFeatureGatedWithCallout( {
 	const { site, upsellId, upsellFeatureId, feature } = props;
 
 	const backButton = search.back_to === 'overview' && (
-		<SnackbarBackButton
-			backUrl={
-				router.buildLocation( {
-					to: siteOverviewRoute.fullPath,
-					params: { siteSlug: site.slug },
-				} ).href
-			}
-		>
-			{ __( 'Back to Overview' ) }
-		</SnackbarBackButton>
+		<SnackbarBackButton>{ __( 'Back to Overview' ) }</SnackbarBackButton>
 	);
 
 	return (

--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { upsell } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
+import { isRelativeUrl } from '../../utils/url';
 import HostingFeatureGate from '../hosting-feature-gate';
 import type { OverviewCardProps } from '../../components/overview-card';
 import type { HostingFeatureGateProps } from '../hosting-feature-gate';
@@ -27,7 +29,11 @@ export default function HostingFeatureGatedWithOverviewCard( {
 		icon: upsell,
 		description: upsellDescription,
 		intent: 'upsell' as const,
-		link: upsellLink,
+		link: isRelativeUrl( upsellLink )
+			? addQueryArgs( upsellLink, {
+					back_to: 'overview',
+			  } )
+			: upsellLink,
 	};
 
 	return (

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -23,7 +23,7 @@ function getScanURL( site: Site ) {
 
 	return isDashboardBackport()
 		? `https://wordpress.com/scan/${ site.slug }`
-		: `/sites/${ site.slug }/scan`;
+		: `/sites/${ site.slug }/scan/active`;
 }
 
 function ScanCardWithThreats( { site, scan }: { site: Site; scan: SiteScan } ) {

--- a/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
+++ b/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
@@ -1,41 +1,21 @@
-import { useNavigate } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { siteDeploymentsListRoute, siteRoute } from '../../app/router/sites';
+import { useRouter } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { siteDeploymentsListRoute } from '../../app/router/sites';
+import SnackbarBackButton from '../../components/snackbar-back-button';
+import type { Site } from '@automattic/api-core';
 
-export function BackToDeploymentsButton() {
-	const { siteSlug } = siteRoute.useParams();
-	const navigate = useNavigate();
-
+export function BackToDeploymentsButton( { site }: { site: Site } ) {
+	const router = useRouter();
 	return (
-		<div
-			className="back-to-deployments-button"
-			style={ {
-				position: 'fixed',
-				bottom: '16px',
-				insetInlineStart: '16px',
-			} }
+		<SnackbarBackButton
+			backUrl={
+				router.buildLocation( {
+					to: siteDeploymentsListRoute.fullPath,
+					params: { siteSlug: site.slug },
+				} ).href
+			}
 		>
-			<Button
-				variant="secondary"
-				icon={ isRTL() ? chevronRight : chevronLeft }
-				iconPosition="left"
-				onClick={ () => {
-					navigate( {
-						to: siteDeploymentsListRoute.fullPath,
-						params: { siteSlug },
-					} );
-				} }
-				style={ {
-					backgroundColor: '#1e1e1e',
-					color: '#ffffff',
-					borderColor: '#1e1e1e',
-					boxShadow: 'none',
-				} }
-			>
-				{ __( 'Back to Deployments' ) }
-			</Button>
-		</div>
+			{ __( 'Back to Deployments' ) }
+		</SnackbarBackButton>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
+++ b/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
@@ -1,21 +1,6 @@
-import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { siteDeploymentsListRoute } from '../../app/router/sites';
 import SnackbarBackButton from '../../components/snackbar-back-button';
-import type { Site } from '@automattic/api-core';
 
-export function BackToDeploymentsButton( { site }: { site: Site } ) {
-	const router = useRouter();
-	return (
-		<SnackbarBackButton
-			backUrl={
-				router.buildLocation( {
-					to: siteDeploymentsListRoute.fullPath,
-					params: { siteSlug: site.slug },
-				} ).href
-			}
-		>
-			{ __( 'Back to Deployments' ) }
-		</SnackbarBackButton>
-	);
+export function BackToDeploymentsButton() {
+	return <SnackbarBackButton>{ __( 'Back to Deployments' ) }</SnackbarBackButton>;
 }

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -29,7 +29,7 @@ export default function ConfigureRepository() {
 		from: navigateFrom,
 	} );
 	const search = siteSettingsRepositoriesManageRoute.useSearch();
-	const showBackToDeployments = search?.from === 'deployments';
+	const showBackToDeployments = search?.back_to === 'deployments';
 
 	const handleCancel = () => {
 		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -84,7 +84,7 @@ export default function ConfigureRepository() {
 					</CardBody>
 				</Card>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton /> }
+			{ showBackToDeployments && <BackToDeploymentsButton site={ site } /> }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -84,7 +84,7 @@ export default function ConfigureRepository() {
 					</CardBody>
 				</Card>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton site={ site } /> }
+			{ showBackToDeployments && <BackToDeploymentsButton /> }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -161,7 +161,7 @@ function SiteRepositories() {
 	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
 	const search = siteSettingsRepositoriesRoute.useSearch();
-	const showBackToDeployments = search?.from === 'deployments';
+	const showBackToDeployments = search?.back_to === 'deployments';
 
 	const handleConnectRepository = () => {
 		navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } );

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -201,7 +201,7 @@ function SiteRepositories() {
 					<RepositoriesList />
 				</HostingFeatureGatedWithCallout>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton /> }
+			{ showBackToDeployments && <BackToDeploymentsButton site={ site } /> }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -201,7 +201,7 @@ function SiteRepositories() {
 					<RepositoriesList />
 				</HostingFeatureGatedWithCallout>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton site={ site } /> }
+			{ showBackToDeployments && <BackToDeploymentsButton /> }
 		</>
 	);
 }


### PR DESCRIPTION
Fixes DOTMSD-728

## Proposed Changes

This PR shows a "Back to Overview" button at the bottom-left corner of the screen, when we click on an upsell card from the Site Overview.

I refactored and reused the existing `<BackToDeploymentsButton>` component.

|<img width="626" height="419" alt="image" src="https://github.com/user-attachments/assets/bab0345d-e791-4303-90c3-602c0290f9e9" />|<img width="868" height="633" alt="image" src="https://github.com/user-attachments/assets/a009a34d-0412-41ea-a338-6f4c56243abd" />|
|-|-|


## Testing Instructions

### Simple Free

1. Go to `/v2/sites/:site` of a Simple Free site.
2. Click one of the upsell cards (Backup or Scan cards)
3. Verify you see the snackbar as shown above. 

### Simple Business

1. Go to `/v2/sites/:site` of a Simple Business site.
2. Click one of the activation cards (Backup or Scan cards)
3. Verify you see the snackbar as shown above. 

### Atomic

1. Go to `/v2/sites/:site` of an Atomic site.
2. Click the same cards
3. Verify you see the features, without the snackbar

### Atomic -> Deployments (regression test)

1. Go to `/v2/sites/:site/deployments` of an Atomic site.
2. Click the `Go to repositories`
3. Verify you see the `Back to Deployments` snackbar. Click it
4. Verify you land in Deployments again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
