### PR TITLE
e2e tests: Increase timeout for add to cart button wait state in domain search component

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -207,7 +207,7 @@ export class DomainSearchComponent {
 		await addToCartButton.waitFor();
 
 		await addToCartButton.click();
-		await addToCartButton.waitFor( { state: 'detached' } );
+		await addToCartButton.waitFor( { state: 'detached', timeout: 30000 } );
 
 		const continueButton = row.getByRole( 'button', { name: 'Continue' } );
 		await continueButton.waitFor();


### PR DESCRIPTION
Fixes QAO-137

## Proposed Changes

Increase timeout for domain "Add to cart" button detachment from 10s to 30s to prevent intermittent test failures.

## Testing Instructions

- e2e tests pass in CI
- locally:
```
yarn workspace wp-e2e-tests test -- test/e2e/specs/flows/start-domain__purchase-domain-and-plan.ts
```
