### PR TITLE
e2e tests: fix signup flow: add locator handler for "Continue with email" button

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -26,7 +26,7 @@ class EnvVariables implements SupportedEnvVariables {
 		SLOW_MO: 0,
 		TEST_LOCALES: [ ...getMag16Locales() ],
 		TEST_ON_ATOMIC: false,
-		TIMEOUT: 10000,
+		TIMEOUT: 15000,
 		VIEWPORT_NAME: 'desktop',
 		WOO_BASE_URL: 'https://woocommerce.com',
 		WPCOM_BASE_URL: 'https://wordpress.com',

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -168,11 +168,15 @@ export class UserSignupPage {
 	 * @returns {NewUserResponse} Response from the REST API.
 	 */
 	async signupSocialFirstWithEmail( email: string ): Promise< NewUserResponse > {
-		await this.page
-			.getByRole( 'button', {
-				name: 'Continue with email',
-			} )
-			.click();
+		const continueWithEmailButton = this.page.getByRole( 'button', {
+			name: 'Continue with email',
+		} );
+
+		// The "Continue with email" button is only shown on certain flows
+		await this.page.addLocatorHandler( continueWithEmailButton, async () => {
+			await continueWithEmailButton.click();
+		} );
+
 		return this.signupWithEmail( email );
 	}
 


### PR DESCRIPTION
Fixes [QAO-138](https://linear.app/a8c/issue/QAO-138/add-locator-handler-for-continue-with-email-button-in-signup-flow)

## Proposed Changes

Updated `signupSocialFirstWithEmail` method to use `addLocatorHandler` to conditionally handle the "Continue with email" button.

#106597 updated the `signupSocialFirstWithEmail` to always expect the "Continue with email". This broke some tests in the pre-release group, apparently the button is not always displayed.


## Testing Instructions

```
cd tests/e2e
yarn build
```

Run all affected tests

Jest tests:

```
yarn workspace wp-e2e-tests test -- test/e2e/specs/flows test/e2e/specs/onboarding
```

Playwright Test:

```
yarn test:pw specs/onboarding
```
