### PR TITLE
Site settings: Allow PHP 8.4 to be selected

### DIFF
--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -9,22 +9,6 @@ export const getPHPVersions = ( siteId ) => {
 
 	const phpVersions = [
 		{
-			label: '7.3',
-			value: '7.3',
-			disabled: true, // EOL 6th December, 2021
-		},
-		{
-			// translators: PHP Version for a version switcher
-			label: sprintf( __( '%s (Deprecated)' ), '7.4' ),
-			value: '7.4',
-			disabled: true, // EOL 1st July, 2024
-		},
-		{
-			label: '8.0',
-			value: '8.0',
-			disabled: true, // EOL 26th November, 2023
-		},
-		{
 			// translators: PHP Version for a version switcher
 			label: sprintf( __( '%s (Deprecated)' ), '8.1' ),
 			value: '8.1',

--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -1,7 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 export const getPHPVersions = ( siteId ) => {
-	// PHP 8.3 is now the default recommended version
+	// PHP 8.3 is the default recommended version
 	const recommendedValue = '8.3';
 	// translators: PHP Version for a version switcher
 	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
@@ -28,17 +28,22 @@ export const getPHPVersions = ( siteId ) => {
 			// translators: PHP Version for a version switcher
 			label: sprintf( __( '%s (Deprecated)' ), '8.1' ),
 			value: '8.1',
-			disabled: ! PHP81BrokenSites.includes( siteId ?? 0 ), // EOL 31st December, 2025
+			disabled: ! PHP81BrokenSites.includes( siteId ?? 0 ), // EOL 31 December 2025
 		},
 		{
 			label: '8.2',
 			value: '8.2',
-			disabled: false, // EOL 31st December, 2026
+			disabled: false, // EOL 31 December 2026
 		},
 		{
 			label: recommendedLabel,
 			value: recommendedValue,
-			disabled: false, // EOL 31st December, 2027
+			disabled: false, // EOL 31 December 2027
+		},
+		{
+			label: '8.4',
+			value: '8.4',
+			disabled: false, // EOL 31 December 2028
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTDEV-254 - add PHP 8.4 to available versions

<img width="1446" height="778" alt="image" src="https://github.com/user-attachments/assets/c741a908-2027-4390-a3d6-0c78d93a08a0" />

I also removed several long-since-disabled versions.

More discussion here: p1761663880579329-slack-C7YPW6K40

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/sites/{yoursite}/settings/php`
2. Select PHP 8.4 and save.
3. Refresh and verify PHP 8.4 remains selected.
4. Go here: `{yoursite}/wp-admin/site-health.php?tab=debug`
5. In the Server section, verify the PHP version is 8.4.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?