### PR TITLE
Help Center: Make the interaction the source of botSlug - Take II

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -7,4 +7,5 @@ window.configData = {
 		'help/gpt-response': true,
 	},
 	wapuu: false,
+	i18n_default_locale_slug: 'en',
 };

--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -65,6 +65,10 @@ function HelpCenterContent() {
 		</>
 	);
 
+	const botProps = helpCenterData.isCommerceGarden
+		? { botNameSlug: 'ciab-workflow-support_chat' }
+		: {};
+
 	return (
 		<>
 			{ showHelpIcon &&
@@ -81,6 +85,7 @@ function HelpCenterContent() {
 				onboardingUrl="https://wordpress.com/start"
 				handleClose={ closeCallback }
 				isCommerceGarden={ helpCenterData.isCommerceGarden }
+				{ ...botProps }
 			/>
 		</>
 	);
@@ -101,6 +106,10 @@ if ( helpCenterData.isNextAdmin ) {
 		const container = document.createElement( 'div' );
 		container.id = 'jetpack-help-center';
 		document.body.appendChild( container );
+		const botProps = helpCenterData.isCommerceGarden
+			? { botNameSlug: 'ciab-workflow-support_chat' }
+			: {};
+
 		createRoot( container ).render(
 			<QueryClientProvider client={ queryClient }>
 				<HelpCenter
@@ -112,6 +121,7 @@ if ( helpCenterData.isNextAdmin ) {
 					onboardingUrl="https://wordpress.com/start"
 					handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
 					isCommerceGarden={ helpCenterData.isCommerceGarden }
+					{ ...botProps }
 				/>
 			</QueryClientProvider>,
 			document.getElementById( 'jetpack-help-center' )

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -101,6 +101,10 @@ function AdminHelpCenterContent() {
 		};
 	}, [] );
 
+	const botProps = helpCenterData.isCommerceGarden
+		? { botNameSlug: 'ciab-workflow-support_chat' }
+		: {};
+
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<HelpCenter
@@ -112,6 +116,7 @@ function AdminHelpCenterContent() {
 				onboardingUrl="https://wordpress.com/start"
 				handleClose={ closeCallback }
 				isCommerceGarden={ helpCenterData.isCommerceGarden }
+				{ ...botProps }
 			/>
 		</QueryClientProvider>
 	);

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -23,7 +23,7 @@ export function HelpCenterChat( {
 	const shouldUseWapuu = useShouldUseWapuu();
 	// Before issuing a redirect, make sure the status is loaded.
 	const preventOdieAccess = ! shouldUseWapuu && ! isUserEligibleForPaidSupport && ! isLoadingStatus;
-	const { currentUser, site, isCommerceGarden } = useHelpCenterContext();
+	const { currentUser, site, isCommerceGarden, botNameSlug } = useHelpCenterContext();
 	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging();
 	const { search } = useLocation();
 	const { data } = useSupportStatus( ! isCommerceGarden );
@@ -49,6 +49,7 @@ export function HelpCenterChat( {
 
 	return (
 		<OdieAssistantProvider
+			defaultBotNameSlug={ botNameSlug }
 			currentUser={ currentUser }
 			canConnectToZendesk={ canConnectToZendesk }
 			isLoadingCanConnectToZendesk={ isLoading }

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -2,6 +2,7 @@ import { useContext, createContext } from '@wordpress/element';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
 
 export type HelpCenterRequiredInformation = {
+	botNameSlug: string;
 	locale: string;
 	sectionName: string;
 	currentUser: CurrentUser;
@@ -15,6 +16,7 @@ export type HelpCenterRequiredInformation = {
 };
 
 const defaultContext: HelpCenterRequiredInformation = {
+	botNameSlug: 'wpcom-support-chat',
 	locale: '',
 	sectionName: '',
 	currentUser: {

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -1,3 +1,4 @@
+import { ODIE_DEFAULT_BOT_SLUG } from '@automattic/odie-client/src/constants';
 import { useContext, createContext } from '@wordpress/element';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
 
@@ -16,7 +17,7 @@ export type HelpCenterRequiredInformation = {
 };
 
 const defaultContext: HelpCenterRequiredInformation = {
-	botNameSlug: 'wpcom-support-chat',
+	botNameSlug: ODIE_DEFAULT_BOT_SLUG,
 	locale: '',
 	sectionName: '',
 	currentUser: {

--- a/packages/help-center/src/hooks/use-get-history-chats.ts
+++ b/packages/help-center/src/hooks/use-get-history-chats.ts
@@ -142,7 +142,7 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 	const { data: odieSupportInteractions, isLoading: isLoadingOdieSupportInteractions } =
 		useGetSupportInteractions( 'odie' );
 	const { data: odieConversations, isLoading: isLoadingOdieConversations } =
-		useGetOdieConversations();
+		useGetOdieConversations( odieSupportInteractions );
 
 	const isLoadingInteractions =
 		isLoadingOtherSupportInteractions ||

--- a/packages/odie-client/README.md
+++ b/packages/odie-client/README.md
@@ -33,7 +33,7 @@ const MyApp = () => (
 `OdieAssistantProviderProps`
 
 - `botName?: string` - Display the bot's name in the chat.
-- `botNameSlug: OdieAllowedBots` - Configure bot settings in WordPress.com.
+- `botNameSlug: OdieAllowedBots` - Set the botSlug that will be used when creating interactions.
 - `enabled?: boolean` - Toggle chat component visibility.
 - `initialUserMessage?: string | null | undefined` - Set an initial message from the user.
 - `isMinimized?: boolean` - Tells if parent component app is minimized.
@@ -47,7 +47,7 @@ const MyApp = () => (
 const defaultContextInterfaceValues = {
 	addMessage: noop, // Function to add a new message to the chat.
 	botName: 'Wapuu', // Default name of the chat bot.
-	botNameSlug: 'wpcom-support-chat', // Identifier for the chat bot configuration.
+	botNameSlug: 'wpcom-support-chat', // Identifier for the chat bot configuration. It is only used when creating new interactions. Existing interactions used their `botSlug` attribute.
 	chat: { context: { section_name: '', site_id: null }, messages: [] }, // Current chat state, including context and messages.
 	clearChat: noop, // Function to clear the current chat.
 	isLoading: false, // Flag for general loading state.

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import { NavigationType, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom';
 import { getOdieInitialMessage } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
+import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
 import {
 	useAutoScroll,
 	useCreateZendeskConversation,
@@ -28,7 +29,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport } =
+	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport } =
 		useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const { resetSupportInteraction } = useResetSupportInteraction();
@@ -39,6 +40,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
 	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
 	const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
+	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const navType: NavigationType = useNavigationType();
 	const typingStatus = useSelect(
 		( select ) =>
@@ -139,6 +141,11 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		setSearchParams,
 	] );
 
+	// This case never happens. This is just a type guard.
+	if ( ! supportInteraction ) {
+		return null;
+	}
+
 	return (
 		<div
 			className={ clx( 'chatbox-messages', {
@@ -168,7 +175,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				</div>
 				{ ( chat.odieId || chat.provider === 'odie' ) && (
 					<ChatMessage
-						message={ getOdieInitialMessage( botNameSlug, currentUser?.display_name ) }
+						message={ getOdieInitialMessage(
+							supportInteraction.bot_slug,
+							currentUser?.display_name
+						) }
 						key={ 0 }
 						currentUser={ currentUser }
 						displayChatWithSupportLabel={ false }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -171,7 +171,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ ( chat.odieId || chat.provider === 'odie' ) && (
 					<ChatMessage
 						message={ getOdieInitialMessage(
-							supportInteraction?.bot_slug ?? ODIE_DEFAULT_BOT_SLUG,
+							supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG,
 							currentUser?.display_name
 						) }
 						key={ 0 }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 import clx from 'classnames';
 import { useEffect, useRef, useState } from 'react';
 import { NavigationType, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom';
-import { getOdieInitialMessage } from '../../constants';
+import { getOdieInitialMessage, ODIE_DEFAULT_BOT_SLUG } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
 import {
@@ -171,7 +171,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ ( chat.odieId || chat.provider === 'odie' ) && (
 					<ChatMessage
 						message={ getOdieInitialMessage(
-							supportInteraction?.bot_slug ?? 'wpcom-support-chat',
+							supportInteraction?.bot_slug ?? ODIE_DEFAULT_BOT_SLUG,
 							currentUser?.display_name
 						) }
 						key={ 0 }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -141,11 +141,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		setSearchParams,
 	] );
 
-	// This case never happens. This is just a type guard.
-	if ( ! supportInteraction ) {
-		return null;
-	}
-
 	return (
 		<div
 			className={ clx( 'chatbox-messages', {
@@ -176,7 +171,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ ( chat.odieId || chat.provider === 'odie' ) && (
 					<ChatMessage
 						message={ getOdieInitialMessage(
-							supportInteraction.bot_slug,
+							supportInteraction?.bot_slug ?? 'wpcom-support-chat',
 							currentUser?.display_name
 						) }
 						key={ 0 }

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -163,4 +163,5 @@ export const getOdieInitialMessage = (
 
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;
-export const ODIE_ALLOWED_BOTS = [ 'wpcom-support-chat', 'wpcom-plan-support' ];
+export const ODIE_DEFAULT_BOT_SLUG = 'wpcom-support-chat';
+export const ODIE_ALLOWED_BOTS = [ ODIE_DEFAULT_BOT_SLUG, 'wpcom-plan-support' ];

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -32,7 +32,7 @@ export const emptyChat: Chat = {
 export const OdieAssistantContext = createContext< OdieAssistantContextInterface >( {
 	addMessage: noop,
 	botName: 'Wapuu',
-	botNameSlug: 'wpcom-support-chat' as OdieAllowedBots,
+	botNameSlug: '',
 	chat: emptyChat,
 	canConnectToZendesk: false,
 	isLoadingCanConnectToZendesk: false,
@@ -64,6 +64,7 @@ export const odieBroadcastClientId = Math.random().toString( 36 ).substring( 2, 
  */
 export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	botName = 'Wapuu assistant',
+	defaultBotNameSlug,
 	isUserEligibleForPaidSupport = true,
 	canConnectToZendesk = false,
 	isLoadingCanConnectToZendesk = false,
@@ -77,19 +78,22 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	isChatRestricted = false,
 	children,
 } ) => {
-	const { botNameSlug, isMinimized, isChatLoaded } = useSelect( ( select ) => {
-		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+	const { botNameSlug, isMinimized, isChatLoaded } = useSelect(
+		( select ) => {
+			const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 
-		const odieBotNameSlug = isOdieAllowedBot( store.getOdieBotNameSlug() )
-			? store.getOdieBotNameSlug()
-			: 'wpcom-support-chat';
+			const odieBotNameSlug = isOdieAllowedBot( store.getOdieBotNameSlug() )
+				? store.getOdieBotNameSlug()
+				: defaultBotNameSlug;
 
-		return {
-			botNameSlug: odieBotNameSlug as OdieAllowedBots,
-			isMinimized: store.getIsMinimized(),
-			isChatLoaded: store.getIsChatLoaded(),
-		};
-	}, [] );
+			return {
+				botNameSlug: odieBotNameSlug as OdieAllowedBots,
+				isMinimized: store.getIsMinimized(),
+				isChatLoaded: store.getIsChatLoaded(),
+			};
+		},
+		[ defaultBotNameSlug ]
+	);
 
 	const navigate = useNavigate();
 

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -3,6 +3,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { createContext, useCallback, useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ODIE_DEFAULT_BOT_SLUG } from '../constants';
 import { useOdieBroadcastWithCallbacks } from '../data';
 import { useGetCombinedChat } from '../hooks';
 import { isOdieAllowedBot, getIsRequestingHumanSupport } from '../utils';
@@ -32,7 +33,7 @@ export const emptyChat: Chat = {
 export const OdieAssistantContext = createContext< OdieAssistantContextInterface >( {
 	addMessage: noop,
 	botName: 'Wapuu',
-	botNameSlug: '',
+	botNameSlug: ODIE_DEFAULT_BOT_SLUG,
 	chat: emptyChat,
 	canConnectToZendesk: false,
 	isLoadingCanConnectToZendesk: false,

--- a/packages/odie-client/src/data/use-get-odie-conversations.ts
+++ b/packages/odie-client/src/data/use-get-odie-conversations.ts
@@ -3,16 +3,30 @@ import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
 import { getTimestamp } from '../utils';
-import type { OdieConversation } from '../types';
+import type { OdieConversation, SupportInteraction } from '../types';
 
 /**
  * Retrieves the list of conversations handled by AI.
  */
-export const useGetOdieConversations = ( enabled = true ) => {
-	const { botNameSlug, version } = useOdieAssistantContext();
+export const useGetOdieConversations = (
+	supportInteractions: SupportInteraction[] = [],
+	enabled = true
+) => {
+	const { version } = useOdieAssistantContext();
+	const botSlugs = encodeURIComponent(
+		Array.from(
+			new Set(
+				supportInteractions?.map( ( interaction ) => {
+					// Fallback to `wpcom-support-chat` in case this is an old interaction without bot_slug property.
+					// In the Help Center, up to October 2025, all interactions were created with `wpcom-support-chat` bot.
+					return interaction.bot_slug || 'wpcom-support-chat';
+				} )
+			)
+		).join( ',' )
+	);
 
 	return useQuery< OdieConversation[], Error >( {
-		queryKey: [ 'odie-interactions', botNameSlug, version ],
+		queryKey: [ 'odie-interactions', botSlugs, version ],
 		queryFn: async (): Promise< OdieConversation[] > => {
 			const queryParams = new URLSearchParams( {
 				page_number: '1',
@@ -23,11 +37,11 @@ export const useGetOdieConversations = ( enabled = true ) => {
 			const response: any[] = canAccessWpcomApis()
 				? await wpcomRequest( {
 						method: 'GET',
-						path: `/odie/conversations/${ botNameSlug }?${ queryParams }`,
+						path: `/odie/conversations/${ botSlugs }?${ queryParams }`,
 						apiNamespace: 'wpcom/v2',
 				  } )
 				: await apiFetch( {
-						path: `/help-center/odie/conversations/${ botNameSlug }?${ queryParams }`,
+						path: `/help-center/odie/conversations/${ botSlugs }?${ queryParams }`,
 						method: 'GET',
 				  } );
 
@@ -50,7 +64,7 @@ export const useGetOdieConversations = ( enabled = true ) => {
 		},
 		refetchOnMount: true,
 		refetchOnWindowFocus: false,
-		enabled,
+		enabled: enabled && supportInteractions?.length > 0,
 		staleTime: 1000 * 30, // 30 seconds
 	} );
 };

--- a/packages/odie-client/src/data/use-get-odie-conversations.ts
+++ b/packages/odie-client/src/data/use-get-odie-conversations.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { ODIE_DEFAULT_BOT_SLUG } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { getTimestamp } from '../utils';
 import type { OdieConversation, SupportInteraction } from '../types';
@@ -19,7 +20,7 @@ export const useGetOdieConversations = (
 				supportInteractions?.map( ( interaction ) => {
 					// Fallback to `wpcom-support-chat` in case this is an old interaction without bot_slug property.
 					// In the Help Center, up to October 2025, all interactions were created with `wpcom-support-chat` bot.
-					return interaction.bot_slug || 'wpcom-support-chat';
+					return interaction.bot_slug || ODIE_DEFAULT_BOT_SLUG;
 				} )
 			)
 		).join( ',' )

--- a/packages/odie-client/src/data/use-odie-chat.ts
+++ b/packages/odie-client/src/data/use-odie-chat.ts
@@ -3,16 +3,22 @@ import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
 import { generateUUID } from '../utils';
+import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import type { OdieChat, ReturnedChat } from '../types';
 
 /**
  * Get the ODIE chat and manage the cache to save on API calls.
  */
 export const useOdieChat = ( chatId: number | null ) => {
-	const { botNameSlug, version } = useOdieAssistantContext();
+	const { version } = useOdieAssistantContext();
+	const { data: supportInteraction } = useCurrentSupportInteraction();
+
+	// Fallback to `wpcom-support-chat` in case this is an old interaction without bot_slug property.
+	// In the Help Center, up to October 2025, all interactions were created with `wpcom-support-chat` bot.
+	const botSlug = supportInteraction?.bot_slug || 'wpcom-support-chat';
 
 	return useQuery< OdieChat, Error >( {
-		queryKey: [ 'odie-chat', botNameSlug, chatId, version ],
+		queryKey: [ 'odie-chat', botSlug, chatId, version ],
 		queryFn: async (): Promise< OdieChat > => {
 			const queryParams = new URLSearchParams( {
 				page_number: '1',
@@ -25,11 +31,11 @@ export const useOdieChat = ( chatId: number | null ) => {
 				canAccessWpcomApis()
 					? await wpcomRequest( {
 							method: 'GET',
-							path: `/odie/chat/${ botNameSlug }/${ chatId }?${ queryParams }`,
+							path: `/odie/chat/${ botSlug }/${ chatId }?${ queryParams }`,
 							apiNamespace: 'wpcom/v2',
 					  } )
 					: await apiFetch( {
-							path: `/help-center/odie/chat/${ botNameSlug }/${ chatId }?${ queryParams }`,
+							path: `/help-center/odie/chat/${ botSlug }/${ chatId }?${ queryParams }`,
 							method: 'GET',
 					  } )
 			) as ReturnedChat;
@@ -45,7 +51,7 @@ export const useOdieChat = ( chatId: number | null ) => {
 		},
 		refetchOnMount: true,
 		refetchOnWindowFocus: false,
-		enabled: !! chatId,
+		enabled: !! chatId && !! supportInteraction,
 		staleTime: 3600, // 1 hour
 	} );
 };

--- a/packages/odie-client/src/data/use-odie-chat.ts
+++ b/packages/odie-client/src/data/use-odie-chat.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { ODIE_DEFAULT_BOT_SLUG } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { generateUUID } from '../utils';
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
@@ -15,7 +16,7 @@ export const useOdieChat = ( chatId: number | null ) => {
 
 	// Fallback to `wpcom-support-chat` in case this is an old interaction without bot_slug property.
 	// In the Help Center, up to October 2025, all interactions were created with `wpcom-support-chat` bot.
-	const botSlug = supportInteraction?.bot_slug || 'wpcom-support-chat';
+	const botSlug = supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG;
 
 	return useQuery< OdieChat, Error >( {
 		queryKey: [ 'odie-chat', botSlug, chatId, version ],

--- a/packages/odie-client/src/data/use-send-odie-feedback.ts
+++ b/packages/odie-client/src/data/use-send-odie-feedback.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
+import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import type { Chat } from '../types';
 
 /**
@@ -8,20 +9,21 @@ import type { Chat } from '../types';
  * @returns useMutation return object.
  */
 export const useSendOdieFeedback = () => {
-	const { botNameSlug, chat, version } = useOdieAssistantContext();
+	const { chat, version } = useOdieAssistantContext();
+	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
 	return useMutation( {
 		mutationFn: ( { messageId, ratingValue }: { messageId: number; ratingValue: number } ) => {
 			return wpcomRequest( {
 				method: 'POST',
-				path: `/odie/chat/${ botNameSlug }/${ chat.odieId }/${ messageId }/feedback`,
+				path: `/odie/chat/${ supportInteraction?.bot_slug }/${ chat.odieId }/${ messageId }/feedback`,
 				apiNamespace: 'wpcom/v2',
 				body: { rating_value: ratingValue, ...( version && { version } ) },
 			} );
 		},
 		onSuccess: ( data, { messageId, ratingValue } ) => {
-			const queryKey = [ 'chat', botNameSlug, chat.odieId, 1, 30, true ];
+			const queryKey = [ 'chat', supportInteraction?.bot_slug, chat.odieId, 1, 30, true ];
 			queryClient.setQueryData( queryKey, ( currentChatCache: Chat ) => {
 				if ( ! currentChatCache ) {
 					return;

--- a/packages/odie-client/src/data/use-send-odie-feedback.ts
+++ b/packages/odie-client/src/data/use-send-odie-feedback.ts
@@ -13,17 +13,19 @@ export const useSendOdieFeedback = () => {
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
+	const botSlug = supportInteraction?.bot_slug ?? 'wpcom-support-chat';
+
 	return useMutation( {
 		mutationFn: ( { messageId, ratingValue }: { messageId: number; ratingValue: number } ) => {
 			return wpcomRequest( {
 				method: 'POST',
-				path: `/odie/chat/${ supportInteraction?.bot_slug }/${ chat.odieId }/${ messageId }/feedback`,
+				path: `/odie/chat/${ botSlug }/${ chat.odieId }/${ messageId }/feedback`,
 				apiNamespace: 'wpcom/v2',
 				body: { rating_value: ratingValue, ...( version && { version } ) },
 			} );
 		},
 		onSuccess: ( data, { messageId, ratingValue } ) => {
-			const queryKey = [ 'chat', supportInteraction?.bot_slug, chat.odieId, 1, 30, true ];
+			const queryKey = [ 'chat', botSlug, chat.odieId, 1, 30, true ];
 			queryClient.setQueryData( queryKey, ( currentChatCache: Chat ) => {
 				if ( ! currentChatCache ) {
 					return;

--- a/packages/odie-client/src/data/use-send-odie-feedback.ts
+++ b/packages/odie-client/src/data/use-send-odie-feedback.ts
@@ -14,7 +14,7 @@ export const useSendOdieFeedback = () => {
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
-	const botSlug = supportInteraction?.bot_slug ?? ODIE_DEFAULT_BOT_SLUG;
+	const botSlug = supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG;
 
 	return useMutation( {
 		mutationFn: ( { messageId, ratingValue }: { messageId: number; ratingValue: number } ) => {

--- a/packages/odie-client/src/data/use-send-odie-feedback.ts
+++ b/packages/odie-client/src/data/use-send-odie-feedback.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { ODIE_DEFAULT_BOT_SLUG } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import type { Chat } from '../types';
@@ -13,7 +14,7 @@ export const useSendOdieFeedback = () => {
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
-	const botSlug = supportInteraction?.bot_slug ?? 'wpcom-support-chat';
+	const botSlug = supportInteraction?.bot_slug ?? ODIE_DEFAULT_BOT_SLUG;
 
 	return useMutation( {
 		mutationFn: ( { messageId, ratingValue }: { messageId: number; ratingValue: number } ) => {

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -68,7 +68,6 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 	}, [ newConversation, shouldCreateConversation ] );
 
 	const {
-		botNameSlug,
 		selectedSiteId,
 		version,
 		setChat,
@@ -155,7 +154,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			return canAccessWpcomApis()
 				? wpcomRequest< ReturnedChat >( {
 						method: 'POST',
-						path: `/odie/chat/${ botNameSlug }${ chatIdSegment }`,
+						path: `/odie/chat/${ currentSupportInteraction?.bot_slug }${ chatIdSegment }`,
 						apiNamespace: 'wpcom/v2',
 						signal,
 						body: {
@@ -165,7 +164,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						},
 				  } )
 				: apiFetch< ReturnedChat >( {
-						path: `/help-center/odie/chat/${ botNameSlug }${ chatIdSegment }`,
+						path: `/help-center/odie/chat/${ currentSupportInteraction?.bot_slug }${ chatIdSegment }`,
 						method: 'POST',
 						signal,
 						data: {
@@ -232,7 +231,9 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		},
 		onSettled: () => {
 			setChatStatus( 'loaded' );
-			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botNameSlug, odieId ] } );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'odie-chat', currentSupportInteraction?.bot_slug, odieId ],
+			} );
 		},
 		onError: ( error ) => {
 			if ( error instanceof Event && error.type === 'abort' ) {

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -8,6 +8,7 @@ import {
 	getOdieEmailFallbackMessage,
 	getOdieErrorMessageNonEligible,
 	getExistingConversationMessage,
+	ODIE_DEFAULT_BOT_SLUG,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -149,7 +150,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 
 	return useMutation< ReturnedChat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
-			const botSlug = currentSupportInteraction?.bot_slug || 'wpcom-support-chat';
+			const botSlug = currentSupportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG;
 			const chatIdSegment = odieId ? `/${ odieId }` : '';
 			const path = window.location.pathname + window.location.search;
 			return canAccessWpcomApis()

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -149,12 +149,13 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 
 	return useMutation< ReturnedChat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
+			const botSlug = currentSupportInteraction?.bot_slug || 'wpcom-support-chat';
 			const chatIdSegment = odieId ? `/${ odieId }` : '';
 			const path = window.location.pathname + window.location.search;
 			return canAccessWpcomApis()
 				? wpcomRequest< ReturnedChat >( {
 						method: 'POST',
-						path: `/odie/chat/${ currentSupportInteraction?.bot_slug }${ chatIdSegment }`,
+						path: `/odie/chat/${ botSlug }${ chatIdSegment }`,
 						apiNamespace: 'wpcom/v2',
 						signal,
 						body: {
@@ -164,7 +165,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						},
 				  } )
 				: apiFetch< ReturnedChat >( {
-						path: `/help-center/odie/chat/${ currentSupportInteraction?.bot_slug }${ chatIdSegment }`,
+						path: `/help-center/odie/chat/${ botSlug }${ chatIdSegment }`,
 						method: 'POST',
 						signal,
 						data: {

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -31,10 +31,10 @@ export type OdieAssistantContextInterface = {
 };
 
 export type OdieAssistantProviderProps = {
+	defaultBotNameSlug: OdieAllowedBots;
 	canConnectToZendesk?: boolean;
 	isLoadingCanConnectToZendesk?: boolean;
 	botName?: string;
-	botNameSlug?: OdieAllowedBots;
 	isUserEligibleForPaidSupport?: boolean;
 	isMinimized?: boolean;
 	currentUser: CurrentUser;
@@ -297,6 +297,7 @@ export type SupportInteractionEvent = {
 };
 
 export type SupportInteraction = {
+	bot_slug: string;
 	uuid: string;
 	status: InteractionStatus;
 	start_date: string;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -7,7 +7,7 @@ export type OdieAssistantContextInterface = {
 	isLoadingCanConnectToZendesk: boolean;
 	addMessage: ( message: Message | Message[] ) => void;
 	botName?: string;
-	botNameSlug: OdieAllowedBots;
+	botNameSlug: string;
 	chat: Chat;
 	clearChat: () => void;
 	currentUser: CurrentUser;


### PR DESCRIPTION
Take II of #106743 with an extra commit [`f5db80e` (#106790)](https://github.com/Automattic/wp-calypso/pull/106790/commits/f5db80ede2c3c86b9d44c24aa24e97e1019913c2). I had forgotten to fall back to the default botSlug for new interactions.

Fixes DOTCOM-15035 and DOTCOM-15036

## Proposed Changes

The easiest way to think about this is to distinguish between the environment's botSlug and the interaction botSlug. Before this change, the only variant of `botSlug` was the environment one, which means moving from one env to another gave you a different bot and a different conversation history. In the context of the Help Center, this can be perplexing because the Help Center runs everywhere and your conversations should follow you.

This PR makes `botSlug` an attribute of the interaction. Each interaction will remember its own botSlug. This allows the interactions to function well regardless of the environment. And the environment's botSlug will be used as a source of truth only when creating a new interaction. This means if you create a new interaction in Commerce Garden, you'll get Commerce Garden Bot. And this interaction will continue to target that bot wherever and whenever you access it. 

**Note:** This PR intentionally does not populate new interactions' `bot_slug` value. This makes testing backwards compatibility more robust. This way even new tickets have unpopulated `bot_slug` (up to this point, this is true for all tickets). Once we know this PR fully supports tickets without `bot_slug`, I'll send another PR that populates the field.

## Why are these changes being made?
To allow rendering multiple conversations across multiple bots.

## Testing Instructions

1. Open DevTools > Application > IndexedDB and delete the Calypso DB. 
2. Open the HC.
2. Go to support history.
3. The support history should be intact. Please compare to production.
4. Start a new conversation. Send something to Odie.
5. Go back to support history.
6. The new interaction should appear.
8. Go to DevTools > Network and filter by `v2/odie/conversations`.
9. The request should occur to `v2/odie/conversations/wpcom-support-chat` (one bot).
10. Start a new interaction.
11. Send a message to Odie.
12. It should respond.

