### PR TITLE
Dashboard Billing: increase breadcrumb depth on individual receipt page

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -75,7 +75,7 @@ export default function Receipt() {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader title={ __( 'Receipt' ) } prefix={ <Breadcrumbs length={ 2 } /> } /> }
+			header={ <PageHeader title={ __( 'Receipt' ) } prefix={ <Breadcrumbs length={ 3 } /> } /> }
 		>
 			<Card>
 				<CardBody>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1246/

## Proposed Changes

This increases the breadcrumb depth on the individual receipt page to account for the Billing History parent.

| Before | After |
| ----------- | ----------- |
| <img width="715" height="282" alt="Screenshot 2025-10-28 at 17 27 22" src="https://github.com/user-attachments/assets/bcbb1f14-3e05-4462-869d-62203611744c" /> | <img width="715" height="281" alt="Screenshot 2025-10-28 at 17 27 06" src="https://github.com/user-attachments/assets/b7f9c524-4946-4e8f-9190-fc58fe261f95" /> |

## Testing Instructions

- Visit Me > Billing > Billing History
- Click on a receipt
- Verify that the Breadcrumbs show `Billing \ Billing History \`
