### PR TITLE
MSD: Fix issue with zombie snackbars reappearing

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -11,6 +11,7 @@ import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
+import limitTotalSnackbars from './snackbars/limit-total-snackbars';
 import type { AppConfig } from './context';
 
 import './style.scss';
@@ -23,6 +24,7 @@ function boot( config: AppConfig ) {
 	maybeInitializeSupportSession( wpcom );
 	loadDevHelpers();
 	loadPreferencesHelper();
+	limitTotalSnackbars();
 
 	const rootElement = document.getElementById( 'wpcom' );
 	if ( rootElement === null ) {

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -6,9 +6,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useEffect } from 'react';
 import './style.scss';
 
-// Last three notices. Slices from the tail end of the list.
-const MAX_VISIBLE_NOTICES = -3;
-
 const statusIcon: Record< string, React.JSX.Element > = {
 	success: published,
 	error,
@@ -58,8 +55,7 @@ export default function Snackbars() {
 				<Icon icon={ statusIcon[ status ] } style={ { fill: 'currentcolor' } } />
 			),
 			...notice,
-		} ) )
-		.slice( MAX_VISIBLE_NOTICES );
+		} ) );
 
 	return (
 		<SnackbarList

--- a/client/dashboard/app/snackbars/limit-total-snackbars.tsx
+++ b/client/dashboard/app/snackbars/limit-total-snackbars.tsx
@@ -1,0 +1,35 @@
+import { subscribe, dispatch, select } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+const MAX_NOTICES = 3;
+
+/**
+ * Limits the number of snackbars presented to the user.
+ *
+ * Subscribes to the notice store and removes any notices that exceed
+ * our limit. Returns an unsubscribe function for consistency, but it
+ * is expected that this store subscription will last for the life of
+ * the dashboard.
+ * @returns Unsubscribe function.
+ */
+export default function limitTotalSnackbars() {
+	let isRemovingNotices = false;
+
+	return subscribe( () => {
+		if ( isRemovingNotices ) {
+			return;
+		}
+
+		const idsToRemove = select( noticesStore )
+			.getNotices()
+			.slice( 0, -MAX_NOTICES )
+			.map( ( n ) => n.id );
+
+		try {
+			isRemovingNotices = true;
+			dispatch( noticesStore ).removeNotices( idsToRemove );
+		} finally {
+			isRemovingNotices = false;
+		}
+	}, noticesStore );
+}

--- a/client/dashboard/app/snackbars/limit-total-snackbars.tsx
+++ b/client/dashboard/app/snackbars/limit-total-snackbars.tsx
@@ -22,6 +22,7 @@ export default function limitTotalSnackbars() {
 
 		const idsToRemove = select( noticesStore )
 			.getNotices()
+			.filter( ( { type } ) => type === 'snackbar' )
 			.slice( 0, -MAX_NOTICES )
 			.map( ( n ) => n.id );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

The number of snackbar messages is limited to 3 at a time. This has been handled in the `<Snackbars>` component by only showing a subset of the store.

https://github.com/Automattic/wp-calypso/blob/8471b905d6ecf1e9e74f8a5f497198419260672b/client/dashboard/app/snackbars/index.tsx#L62

This PR changes the logic so that we limit the number of snackbars at the store level.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Issue discovered here https://github.com/Automattic/wp-calypso/pull/106723#issuecomment-3449000099

https://github.com/user-attachments/assets/69f79b40-5876-4337-bad0-e1c1b59cfe2d

The issue is the timer which auto-removes removes the snackbars is implemented at the component level, but should probably be implemented in the data layer.

The timer is here:

https://github.com/WordPress/gutenberg/blob/b2cfd066c25f11f80ef8547413b5c2eed7229329/packages/components/src/snackbar/index.tsx#L107-L112

Notice how it starts up the timer when the snackbar component mounts.

When a 4th snackbar is added, the oldest snackbar gets removed from the DOM, and so its timeout never fires. That means the data for the oldest snackbar is still in the data store. When one of the other snackbars gets removed, now that oldest snackbar is one of the 3 latest snackbars again! It remounts and the timer is started up again!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Create lots of snackbars and make sure zombie snackbars don't come back! The site notification settings are probably the easiest place to make lots of snackbars.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
