### PR TITLE
MSD: Support SummaryButton high density in SummaryButtonList.

### DIFF
--- a/client/dashboard/components/summary-button-list/index.stories.tsx
+++ b/client/dashboard/components/summary-button-list/index.stories.tsx
@@ -63,6 +63,13 @@ export const LowDensity: Story = {
 	},
 };
 
+export const HighDensity: Story = {
+	args: {
+		...Default.args,
+		density: 'high',
+	},
+};
+
 export const WithDescriptionsInButtons: Story = {
 	args: {
 		title: 'General Settings',

--- a/client/dashboard/components/summary-button-list/index.tsx
+++ b/client/dashboard/components/summary-button-list/index.tsx
@@ -57,6 +57,17 @@ export function SummaryButtonList( {
 			</Card>
 		);
 	}
+
+	if ( density === 'high' ) {
+		return (
+			<Card className={ className } size="xSmall">
+				{ header && <CardHeader>{ header }</CardHeader> }
+				<CardBody className="dashboard-summary-button-list__children-list-wrapper">
+					{ childrenList }
+				</CardBody>
+			</Card>
+		);
+	}
 	return (
 		<VStack className={ className } spacing={ 6 }>
 			{ header }

--- a/client/dashboard/components/summary-button-list/index.tsx
+++ b/client/dashboard/components/summary-button-list/index.tsx
@@ -56,7 +56,6 @@ export function SummaryButtonList( {
 			</Card>
 		);
 	}
-
 	return (
 		<VStack className={ className } spacing={ 6 }>
 			{ header }

--- a/client/dashboard/components/summary-button-list/index.tsx
+++ b/client/dashboard/components/summary-button-list/index.tsx
@@ -23,7 +23,6 @@ export function SummaryButtonList( {
 	children,
 }: SummaryButtonListProps ) {
 	const titleId = useInstanceId( SummaryButtonList, 'dashboard-summary-button-list__title' );
-	const isMediumDensity = density === 'medium';
 	// Clone children and override their density prop.
 	const clonedChildren = Children.map( children, ( child ) => {
 		if ( isValidElement( child ) ) {
@@ -47,7 +46,7 @@ export function SummaryButtonList( {
 			{ clonedChildren }
 		</ul>
 	);
-	if ( isMediumDensity ) {
+	if ( [ 'medium', 'high' ].includes( density ) ) {
 		return (
 			<Card className={ className }>
 				{ header && <CardHeader>{ header }</CardHeader> }
@@ -58,16 +57,6 @@ export function SummaryButtonList( {
 		);
 	}
 
-	if ( density === 'high' ) {
-		return (
-			<Card className={ className } size="xSmall">
-				{ header && <CardHeader>{ header }</CardHeader> }
-				<CardBody className="dashboard-summary-button-list__children-list-wrapper">
-					{ childrenList }
-				</CardBody>
-			</Card>
-		);
-	}
 	return (
 		<VStack className={ className } spacing={ 6 }>
 			{ header }

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -20,7 +20,8 @@
 		}
 	}
 
-	&.has-density-medium {
+	&.has-density-medium,
+	&.has-density-high {
 		.dashboard-summary-button-list__children-list-wrapper {
 			// TODO: remove once the `CardBody` natively supports having no padding.
 			padding: 0;

--- a/packages/components/src/summary-button/index.stories.tsx
+++ b/packages/components/src/summary-button/index.stories.tsx
@@ -77,3 +77,13 @@ export const MediumDensity: Story = {
 		badges: badgeOptions[ 'Two Badges' ],
 	},
 };
+
+export const HighDensity: Story = {
+	args: {
+		title: 'Email Configuration',
+		description: 'Setup email forwarding for your domain.',
+		density: 'high',
+		decoration: <Icon icon={ envelope } />,
+		badges: badgeOptions[ 'Two Badges' ],
+	},
+};

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -63,7 +63,7 @@ function UnforwardedSummaryButton(
 				as="span"
 			>
 				{ !! decoration && <span className="summary-button-decoration">{ decoration }</span> }
-				<HStack justify="space-between" spacing={ 4 } as="span" wrap>
+				<HStack justify="space-between" spacing={ hasHighDensity ? 2 : 4 } as="span" wrap>
 					<VStack alignment="flex-start" as="span" spacing={ 3 } justify="flex-start">
 						<VStack alignment="flex-start" as="span" spacing={ 2 } justify="flex-start">
 							{ strapline && hasLowDensity && (

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -44,6 +44,7 @@ function UnforwardedSummaryButton(
 	ref: React.ForwardedRef< HTMLAnchorElement | HTMLButtonElement >
 ) {
 	const hasLowDensity = density === 'low';
+	const hasHighDensity = density === 'high';
 	return (
 		<Button
 			// Forward additional props to support standard attributes like mouse events.
@@ -55,7 +56,12 @@ function UnforwardedSummaryButton(
 			disabled={ disabled }
 			accessibleWhenDisabled
 		>
-			<HStack spacing={ 4 } justify="flex-start" alignment="flex-start" as="span">
+			<HStack
+				spacing={ hasHighDensity ? 2 : 4 }
+				justify="flex-start"
+				alignment="flex-start"
+				as="span"
+			>
 				{ !! decoration && <span className="summary-button-decoration">{ decoration }</span> }
 				<HStack justify="space-between" spacing={ 4 } as="span" wrap>
 					<VStack alignment="flex-start" as="span" spacing={ 3 } justify="flex-start">

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -75,7 +75,7 @@
 		border: 1px solid $gray-200;
 		background-color: #fff;
 	}
-	
+
 	&.has-density-medium,
 	&.has-density-high {
 		border-bottom: 1px solid $gray-100;

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -27,8 +27,7 @@
 			}
 		}
 
-		&.has-density-medium,
-		&.has-density-high {
+		&.has-density-medium {
 			&:not(:focus-visible, :last-child) {
 				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
 			}
@@ -71,8 +70,8 @@
 		background-color: #fff;
 	}
 
-	&.has-density-medium,
-	&.has-density-high {
+	&.has-density-medium {
+		padding: $grid-unit-20 $grid-unit-30;
 		border-bottom: 1px solid $gray-100;
 		border-radius: 0;
 
@@ -80,10 +79,6 @@
 			@include body-medium;
 			line-height: $font-line-height-medium;
 		}
-	}
-
-	&.has-density-medium {
-		padding: $grid-unit-20 $grid-unit-30;
 	}
 
 	&.has-density-high {

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -32,6 +32,12 @@
 				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
 			}
 		}
+
+		&.has-density-high {
+			&:not(:focus-visible, :last-child) {
+				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			}
+		}
 	}
 
 	&[aria-disabled="true"] {
@@ -72,6 +78,17 @@
 
 	&.has-density-medium {
 		padding: $grid-unit-20 $grid-unit-30;
+		border-bottom: 1px solid $gray-100;
+		border-radius: 0;
+
+		.summary-button-title {
+			@include body-medium;
+			line-height: $font-line-height-medium;
+		}
+	}
+
+	&.has-density-high {
+		padding: $grid-unit-10 $grid-unit-20;
 		border-bottom: 1px solid $gray-100;
 		border-radius: 0;
 

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -27,12 +27,7 @@
 			}
 		}
 
-		&.has-density-medium {
-			&:not(:focus-visible, :last-child) {
-				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
-			}
-		}
-
+		&.has-density-medium,
 		&.has-density-high {
 			&:not(:focus-visible, :last-child) {
 				border-bottom: 1px solid color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -92,7 +92,7 @@
 	}
 
 	&.has-density-high {
-		padding: $grid-unit-10 $grid-unit-20;
+		padding: $grid-unit-05 $grid-unit-10;
 	}
 
 	&:focus-visible {

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -86,7 +86,8 @@
 
 		.summary-button-title {
 			@include body-small;
-			line-height: $font-line-height-small;
+			/* Ensures the title is aligned with the decoration when content wraps. */
+			line-height: $font-line-height-medium;
 		}
 	}
 

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -75,9 +75,9 @@
 		border: 1px solid $gray-200;
 		background-color: #fff;
 	}
-
-	&.has-density-medium {
-		padding: $grid-unit-20 $grid-unit-30;
+	
+	&.has-density-medium,
+	&.has-density-high {
 		border-bottom: 1px solid $gray-100;
 		border-radius: 0;
 
@@ -87,15 +87,12 @@
 		}
 	}
 
+	&.has-density-medium {
+		padding: $grid-unit-20 $grid-unit-30;
+	}
+
 	&.has-density-high {
 		padding: $grid-unit-10 $grid-unit-20;
-		border-bottom: 1px solid $gray-100;
-		border-radius: 0;
-
-		.summary-button-title {
-			@include body-medium;
-			line-height: $font-line-height-medium;
-		}
 	}
 
 	&:focus-visible {

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -83,6 +83,11 @@
 
 	&.has-density-high {
 		padding: $grid-unit-05 $grid-unit-10;
+
+		.summary-button-title {
+			@include body-small;
+			line-height: $font-line-height-small;
+		}
 	}
 
 	&:focus-visible {

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -1,6 +1,6 @@
 import type { Badge } from '@automattic/ui';
 
-export type Density = 'low' | 'medium';
+export type Density = 'low' | 'medium' | 'high';
 
 /**
  * `badges` property of `SummaryButton` component is used to display `Badge`


### PR DESCRIPTION
Part of DOTMSD-752
Branched from: #106769

## Proposed Changes

Support the high-density SummaryButton state.

## Screenshots

<img width="863" height="314" alt="Screenshot 2025-10-29 at 11 40 36 AM" src="https://github.com/user-attachments/assets/c36bee47-74b5-44cd-9843-799cfe0ee11e" />


## Testing Instructions

1. run `yarn storybook:start`
2. Visit: http://localhost:6006/?path=/docs/client-dashboard-summarybuttonlist--docs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
