### PR TITLE
MSD: Use CSS to control SummaryButton padding in SummaryButtonList on small screens.

### DIFF
--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .dashboard-summary-button-list {
 	.dashboard-summary-button-list__children-list {

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -1,5 +1,4 @@
 @import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/breakpoints";
 
 .dashboard-summary-button-list {
 	.dashboard-summary-button-list__children-list {
@@ -15,9 +14,16 @@
 
 		.summary-button {
 			@media (max-width: #{$break-medium - 1px}) {
-			  padding-inline: $grid-unit-20;
+				padding-inline: $grid-unit-20;
 			}
-		  }
+		}
+	}
+
+	&.has-density-low {
+		// Do not add a bottom margin to the last (non-empty) child.
+		.dashboard-summary-button-list__children-list-item:not(:nth-last-child(1 of :not(:empty))) {
+			margin-bottom: $grid-unit-30;
+		}
 	}
 
 	&.has-density-medium {

--- a/client/dashboard/components/summary-button-list/style.scss
+++ b/client/dashboard/components/summary-button-list/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .dashboard-summary-button-list {
 	.dashboard-summary-button-list__children-list {
@@ -11,13 +12,12 @@
 		&:empty {
 			display: none;
 		}
-	}
 
-	&.has-density-low {
-		// Do not add a bottom margin to the last (non-empty) child.
-		.dashboard-summary-button-list__children-list-item:not(:nth-last-child(1 of :not(:empty))) {
-			margin-bottom: $grid-unit-30;
-		}
+		.summary-button {
+			@media (max-width: #{$break-medium - 1px}) {
+			  padding-inline: $grid-unit-20;
+			}
+		  }
 	}
 
 	&.has-density-medium {


### PR DESCRIPTION
Fixes: DOTMSD-752

## Proposed Changes

Use CSS to reduce `summary-button` padding on devices smaller than `medium` in the SummaryButtonList.

## Why are these changes being made?

I tried my best to not use CSS to make this change. I experimented with the SummaryButton high-density state in #106769, with the hopes of levering that. Ultimately, that state is too crowded for this interface.

Seeing that `SummaryButtonList` is a hosting dashboard component, I think it's ok to wait for more responsive consistency to exist in the base components.

The downside is that we target the `summary-button` to update the padding. That can break if the classname changes.

I'm open to other suggestions/approaches.

## Testing Instructions
1. Navigate to `/v2/sites/{site}/settings`
1. On a small screen, expect the summary button `padding-inline` to be `16px`.
1. On a large screen, expect the summary button `padding-inline` to be `24px`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
