### PR TITLE
Fix flash message when opting in to the hosting dashboard

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -101,7 +101,7 @@ export default function PreferencesOptInForm() {
 
 	return (
 		<Card>
-			<FlashMessage value="dashboard" message={ __( 'Successfully saved preference.' ) } />
+			<FlashMessage value="dashboard" message={ __( 'New Hosting Dashboard enabled.' ) } />
 			<CardBody>
 				<VStack as="form" onSubmit={ handleSubmit } spacing={ 3 } alignment="flex-start">
 					<SectionHeader title={ __( 'Try the new Hosting Dashboard' ) } level={ 3 } />

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -73,7 +73,7 @@ export default function HostingDashboardOptInForm() {
 			);
 		} else if ( enabled ) {
 			setIsRedirecting( true );
-			window.location.href = '/v2/me/preferences?dashboard=true';
+			window.location.href = '/v2/me/preferences?flash=dashboard';
 		} else {
 			dispatch(
 				successNotice( translate( 'Successfully saved preference.' ), {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

* Fixes the flash message that should appear after the user updates the opt-in preference in `/me/account`

<img width="2345" height="1373" alt="CleanShot 2025-10-29 at 16 24 49@2x" src="https://github.com/user-attachments/assets/6f97517e-3599-463e-bbfc-a9e34537225d" />

* Update flash message copy to match our standard approach.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

After much discussion in https://github.com/Automattic/wp-calypso/pull/105695 the `<FlashMessage>` was changed so that we always used consistent query parameters for this pattern. Nice.

However the link from the `/me/account` page to the `/v2/me/preferences` page which shows the flash message was not updated because it exists outside of v2. And so the message got broken.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Opt out of the hosting dashboard
* Go to `/me/account`
* Enable the hosting dashboard
* Confirm you see a flash message
* Optional: you should be able to opt out from `/v2/me/preferences` and you get in a virtuous loop of notification pop ups.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
