### PR TITLE
Site Settings: Implement Manage Plan for sites with purchase screens

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -2,7 +2,6 @@ import { DotcomPlans } from '@automattic/api-core';
 import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/api-queries';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
@@ -12,14 +11,13 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
-import { purchaseSettingsRoute, purchasesRoute } from '../../app/router/me';
 import { commerceGardenPlan } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
-import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import {
 	getJetpackProductsForSite,
 	getSitePlanDisplayName,
+	useSitePlanManageURL,
 	JETPACK_PRODUCTS,
 } from '../../utils/site-plan';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
@@ -62,6 +60,7 @@ function JetpackPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
+	const url = useSitePlanManageURL( site );
 	const products = getJetpackProductsForSite( site );
 	const productsToDisplay = products.length > 0 ? products : JETPACK_PRODUCTS;
 
@@ -71,7 +70,7 @@ function JetpackPlanCard( {
 			icon={ <JetpackLogo /> }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			externalLink={ `https://cloud.jetpack.com/purchases/subscriptions/${ site.slug }` }
+			link={ url }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={
@@ -108,35 +107,14 @@ function WpcomPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const router = useRouter();
-	const isFreePlan = site.plan?.is_free;
-
-	const getBillingLinkProps = () => {
-		if ( isFreePlan ) {
-			return { externalLink: `/setup/plan-upgrade?siteSlug=${ site.slug }` };
-		}
-
-		if ( ! isDashboardBackport() ) {
-			return {
-				link: purchase
-					? router.buildLocation( {
-							to: purchaseSettingsRoute.fullPath,
-							params: { purchaseId: purchase.ID },
-					  } ).href
-					: purchasesRoute.fullPath,
-			};
-		}
-
-		return { externalLink: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }` };
-	};
-
+	const url = useSitePlanManageURL( site, purchase );
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			{ ...getBillingLinkProps() }
+			link={ url }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
@@ -169,13 +147,14 @@ function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
 }
 
 function AgencyPlanCard( { site, isLoading }: { site: Site; isLoading: boolean } ) {
+	const url = useSitePlanManageURL( site );
 	return (
 		<OverviewCard
 			title={ __( 'Development license' ) }
 			icon={ wordpress }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ __( 'Managed by Automattic for Agencies.' ) }
-			externalLink={ `https://agencies.automattic.com/sites/overview/${ site.slug }` }
+			link={ url }
 			tracksId="site-overview-plan"
 			isLoading={ isLoading }
 			bottom={ <SitePlanStats site={ site } /> }
@@ -192,33 +171,14 @@ function CommerceGardenPlanCard( {
 	purchase?: Purchase;
 	isLoading: boolean;
 } ) {
-	const router = useRouter();
-	const getBillingLinkProps = () => {
-		if ( site.plan?.is_free ) {
-			return { externalLink: `/plans/${ site.slug }` };
-		}
-
-		if ( ! isDashboardBackport() ) {
-			return {
-				link: purchase
-					? router.buildLocation( {
-							to: purchaseSettingsRoute.fullPath,
-							params: { purchaseId: purchase.ID },
-					  } ).href
-					: purchasesRoute.fullPath,
-			};
-		}
-
-		return { externalLink: `/purchases/subscriptions/${ site.slug }/${ purchase?.ID }` };
-	};
-
+	const url = useSitePlanManageURL( site, purchase );
 	return (
 		<OverviewCard
 			title={ __( 'Plan' ) }
 			icon={ commerceGardenPlan }
 			heading={ getSitePlanDisplayName( site ) }
 			description={ getCardDescription( site, purchase ) }
-			{ ...getBillingLinkProps() }
+			link={ url }
 			tracksId="plan"
 			isLoading={ isLoading }
 		/>

--- a/client/dashboard/sites/overview-subscribers-card/index.tsx
+++ b/client/dashboard/sites/overview-subscribers-card/index.tsx
@@ -10,7 +10,7 @@ export default function SubscribersCard( { site }: { site: Site } ) {
 			title={ __( 'Subscribers' ) }
 			heading={ site.subscribers_count }
 			description={ __( 'Total subscribers.' ) }
-			externalLink={ `https://cloud.jetpack.com/subscribers/${ site.slug }` }
+			link={ `https://cloud.jetpack.com/subscribers/${ site.slug }` }
 			intent="success"
 			tracksId="site-overview-subscribers"
 		/>

--- a/client/dashboard/sites/settings-plan/summary.tsx
+++ b/client/dashboard/sites/settings-plan/summary.tsx
@@ -1,4 +1,4 @@
-import { siteCurrentPlanQuery, sitePurchaseQuery } from '@automattic/api-queries';
+import { siteCurrentPlanQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -18,7 +18,8 @@ export default function SettingsPlanSummary( {
 } ) {
 	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
-		...sitePurchaseQuery( site.ID, parseInt( plan?.id ?? '' ) ),
+		...sitePurchasesQuery( site.ID ),
+		select: ( data ) => data.find( ( purchase ) => purchase.ID === plan?.id ),
 		enabled: !! plan?.id,
 	} );
 

--- a/client/dashboard/sites/settings-plan/summary.tsx
+++ b/client/dashboard/sites/settings-plan/summary.tsx
@@ -1,0 +1,44 @@
+import { siteCurrentPlanQuery, sitePurchaseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { payment } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { getSitePlanDisplayName, useSitePlanManageURL } from '../../utils/site-plan';
+import { isRelativeUrl } from '../../utils/url';
+import type { Site } from '@automattic/api-core';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function SettingsPlanSummary( {
+	site,
+	density,
+}: {
+	site: Site;
+	density?: Density;
+} ) {
+	const { data: plan, isLoading: isLoadingPlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
+	const { data: purchase, isLoading: isLoadingPurchase } = useQuery( {
+		...sitePurchaseQuery( site.ID, parseInt( plan?.id ?? '' ) ),
+		enabled: !! plan?.id,
+	} );
+
+	const url = useSitePlanManageURL( site, purchase );
+	if ( ! url || ( url && ! isRelativeUrl( url ) ) ) {
+		return null;
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ url }
+			title={ __( 'Manage plan' ) }
+			density={ density }
+			decoration={ <Icon icon={ payment } /> }
+			disabled={ isLoadingPlan || isLoadingPurchase }
+			badges={ [
+				{
+					text: getSitePlanDisplayName( site ),
+				},
+			] }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-plan/summary.tsx
+++ b/client/dashboard/sites/settings-plan/summary.tsx
@@ -24,7 +24,7 @@ export default function SettingsPlanSummary( {
 	} );
 
 	const url = useSitePlanManageURL( site, purchase );
-	if ( ! url || ( url && ! isRelativeUrl( url ) ) ) {
+	if ( ! url || ! isRelativeUrl( url ) ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -13,6 +13,7 @@ import DatabaseSettingsSummary from '../settings-database/summary';
 import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
 import HundredYearPlanSettingsSummary from '../settings-hundred-year-plan/summary';
 import PHPSettingsSummary from '../settings-php/summary';
+import PlanSettingsSummary from '../settings-plan/summary';
 import PrimaryDataCenterSettingsSummary from '../settings-primary-data-center/summary';
 import SiteRedirectSettingsSummary from '../settings-redirect/summary';
 import RepositoriesSettingsSummary from '../settings-repositories/summary';
@@ -50,6 +51,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 						<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
 						<AgencySettingsSummary site={ site } />
 						<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
+						<PlanSettingsSummary site={ site } />
 					</SummaryButtonList>
 				</VStack>
 			) }


### PR DESCRIPTION
Part of DOTMSD-668

## Proposed Changes

This PR implements the Manage Plan entry point in the Site Settings screen. This entry point is added only for sites that have a corresponding purchase screen. In other words, the following site plans/types will not have the Manage Plan entry point:

* Free sites. It should take users to `/setup/plan-upgrade/plans?siteSlug=$siteSlug`.
* Staging sites. Only the production site has a purchase screen.
* Jetpack-connected sites. It should link to Jetpack.
* A4A sites. It should link to A4A.

This PR also doesn't include the retrofitted Site Settings screen, as the logic is already complex enough. Happy to consider adding it in a follow up PR if needed.

<img width="732" height="864" alt="SCR-20251029-mtvh" src="https://github.com/user-attachments/assets/923f08b1-bb2f-418d-840d-5b6b7cfebb5f" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the Manage Plan entry point is available for the site plans/types as described above
* Ensure that the entry point lands correctly in the expected screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
