### PR TITLE
Domain Search: Add search form submit button tracking

### DIFF
--- a/client/components/domains/wpcom-domain-search/analytics.ts
+++ b/client/components/domains/wpcom-domain-search/analytics.ts
@@ -49,6 +49,15 @@ export const recordUseYourDomainButtonClick = (
 		} )
 	);
 
+export const recordSearchFormSubmitButtonClick = ( section: string, flowName: string ) =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Search', 'Clicked "Search domains" Button' ),
+		recordTracksEvent( 'calypso_domain_search_submit_button_click', {
+			section,
+			flow_name: flowName,
+		} )
+	);
+
 export const recordSearchFormSubmit = (
 	searchBoxValue: string,
 	section: string,

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -10,7 +10,11 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import { renderHookWithProvider } from '../../../../test-helpers/testing-library';
-import { recordDomainSearchStepSubmit, recordUseYourDomainButtonClick } from '../analytics';
+import {
+	recordDomainSearchStepSubmit,
+	recordUseYourDomainButtonClick,
+	recordSearchFormSubmitButtonClick,
+} from '../analytics';
 import { getCartKey, useWPCOMDomainSearchProps } from '../use-wpcom-domain-search-props';
 
 jest.mock( '@automattic/shopping-cart', () => ( {
@@ -24,6 +28,9 @@ jest.mock( '../analytics', () => ( {
 		type: 'test',
 	} ),
 	recordUseYourDomainButtonClick: jest.fn().mockReturnValue( {
+		type: 'test',
+	} ),
+	recordSearchFormSubmitButtonClick: jest.fn().mockReturnValue( {
 		type: 'test',
 	} ),
 } ) );
@@ -667,6 +674,29 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		expect( recordUseYourDomainButtonClick ).toHaveBeenCalledWith(
 			'analytics-section',
 			null,
+			'flow-name'
+		);
+	} );
+
+	it( 'calls the submit button tracking when onSubmitButtonClick is invoked', () => {
+		const onSubmitButtonClick = jest.fn();
+
+		const { result } = renderHookWithProvider( () =>
+			useWPCOMDomainSearchProps( {
+				...defaultProps,
+				events: {
+					...defaultProps.events,
+					onSubmitButtonClick,
+				},
+			} )
+		);
+
+		result.current.events.onSubmitButtonClick( 'my-domain.com' );
+
+		expect( onSubmitButtonClick ).toHaveBeenCalledWith( 'my-domain.com' );
+
+		expect( recordSearchFormSubmitButtonClick ).toHaveBeenCalledWith(
+			'analytics-section',
 			'flow-name'
 		);
 	} );

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -17,6 +17,7 @@ import {
 	recordSearchResultsReceive,
 	recordDomainAvailabilityReceive,
 	recordSearchFormSubmit,
+	recordSearchFormSubmitButtonClick,
 	recordDomainAddAvailabilityPreCheck,
 	recordDomainClickMissing,
 	recordFiltersReset,
@@ -115,6 +116,9 @@ export const useWPCOMDomainSearchEvents = ( {
 			},
 			onExternalDomainClick: () => {
 				dispatch( recordUseYourDomainButtonClick( analyticsSection, null, flowName ) );
+			},
+			onSubmitButtonClick: () => {
+				dispatch( recordSearchFormSubmitButtonClick( analyticsSection, flowName ) );
 			},
 			onQueryAvailabilityCheck: ( status, domainName, responseTime ) => {
 				dispatch(

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -23,7 +23,10 @@ const PLACEHOLDER_PHRASES = [
 ];
 
 export const SearchForm = () => {
-	const { setQuery } = useDomainSearch();
+	const {
+		setQuery,
+		events: { onSubmitButtonClick },
+	} = useDomainSearch();
 	const [ localQuery, setLocalQuery ] = useState( '' );
 	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, false );
 	const [ showSearchHint, setShowSearchHint ] = useState( false );
@@ -51,7 +54,9 @@ export const SearchForm = () => {
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus
 					/>
-					{ activeQuery === 'large' && <DomainSearchControls.Submit /> }
+					{ activeQuery === 'large' && (
+						<DomainSearchControls.Submit onClick={ onSubmitButtonClick } />
+					) }
 				</HStack>
 				{ showSearchHint && (
 					<Text variant="muted">

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -20,6 +20,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onRegisterDomainClick: noop,
 		onCheckTransferStatusClick: noop,
 		onMapDomainClick: noop,
+		onSubmitButtonClick: noop,
 		onQueryChange: noop,
 		onQueryClear: noop,
 		onAddDomainToCart: noop,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -41,6 +41,7 @@ export interface DomainSearchEvents {
 	onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onCheckTransferStatusClick: ( domainName: string ) => void;
 	onMapDomainClick: ( domainName: string ) => void;
+	onSubmitButtonClick: () => void;
 	onQueryChange: ( query: string ) => void;
 	onQueryClear: () => void;
 	onAddDomainToCart: (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Solves [DOMAINS-1778](https://linear.app/a8c/issue/DOMAINS-1778/add-exposure-event-to-the-domain-search-submit-button)

## Proposed Changes

* This PR adds tracking when the "Search domains" button is clicked.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This will be used as an exposure event for the upcoming experiment. We've considered using other events like `calypso_domain_search` and `calypso_domain_search_results_suggestions_receive `, but none were appropriate. We need to make sure that the exposure event is triggered before user experience is diverging. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/domains`
* Enable analytics debugging by entering the following in the browser's console: `localStorage.debug='calypso:analytics'`
* Click the "Search domains" button.
* Check the console and make sure the `calypso_domain_search_submit_button_click` event is fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
