### PR TITLE
Dashboard Billing: update "manage subscription" design

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -33,6 +33,8 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
 
+import './style.scss';
+
 function AutoRenewButton( {
 	disableAutoRenew,
 	enableAutoRenew,
@@ -92,6 +94,7 @@ function AutoRenewButton( {
 				return (
 					<ToggleControl
 						__nextHasNoMarginBottom
+						className="purchase-settings__toggle-control"
 						label={ title }
 						checked={ isAutoRenewing }
 						disabled={ isUpdating }
@@ -122,18 +125,16 @@ function AutoRenewButton( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack spacing={ 4 } alignment="left">
-					<DataForm
-						fields={ fields }
-						data={ subscription }
-						form={ form }
-						onChange={ () => {
-							isAutoRenewing
-								? disableAutoRenew( null, { onError: onError } )
-								: enableAutoRenew( null, { onError: onError } );
-						} }
-					/>
-				</VStack>
+				<DataForm
+					fields={ fields }
+					data={ subscription }
+					form={ form }
+					onChange={ () => {
+						isAutoRenewing
+							? disableAutoRenew( null, { onError: onError } )
+							: enableAutoRenew( null, { onError: onError } );
+					} }
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/me/billing-monetize-subscriptions/style.scss
+++ b/client/dashboard/me/billing-monetize-subscriptions/style.scss
@@ -1,0 +1,8 @@
+.purchase-settings__toggle-control {
+	.components-form-toggle {
+		order: 2;
+	}
+	.components-toggle-control__help {
+		margin-inline-start: 0;
+	}
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -554,6 +554,12 @@ function getFields( {
 				);
 			},
 		},
+		{
+			id: 'purchase_payment_method',
+			Edit: ( { data: purchase } ) => {
+				return <PurchasePaymentMethod purchase={ purchase } showUpdateButton />;
+			},
+		},
 	];
 }
 
@@ -565,7 +571,7 @@ const form = {
 		{
 			id: 'autoRenew',
 			label: __( 'Manage subscription' ),
-			children: [ 'is_auto_renew_enabled' ],
+			children: [ 'is_auto_renew_enabled', 'purchase_payment_method' ],
 		},
 	],
 };
@@ -580,26 +586,22 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	return (
 		<Card>
 			<CardBody>
-				<VStack spacing={ 4 } alignment="left">
-					<DataForm< Purchase >
-						data={ purchase }
-						fields={ getFields( { isMutationPending, user } ) }
-						form={ form }
-						onChange={ ( newData ) => {
-							if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
-								setAutoRenew( newData.is_auto_renew_enabled );
-							}
-						} }
-					/>
+				<DataForm< Purchase >
+					data={ purchase }
+					fields={ getFields( { isMutationPending, user } ) }
+					form={ form }
+					onChange={ ( newData ) => {
+						if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
+							setAutoRenew( newData.is_auto_renew_enabled );
+						}
+					} }
+				/>
 
-					{ error && (
-						<Notice status="error" isDismissible={ false }>
-							{ error.message }
-						</Notice>
-					) }
-
-					<PurchasePaymentMethod purchase={ purchase } showUpdateButton />
-				</VStack>
+				{ error && (
+					<Notice status="error" isDismissible={ false }>
+						{ error.message }
+					</Notice>
+				) }
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -541,6 +541,7 @@ function getFields( {
 				return (
 					<ToggleControl
 						__nextHasNoMarginBottom
+						className="purchase-settings__toggle-control"
 						label={
 							shouldAllowExpiredAutoRenewToggle( purchase )
 								? __( 'Re-activate subscription' )

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -4,3 +4,12 @@
 div.components-modal__screen-overlay.upcoming-renewals-dialog {
 	z-index: 500;
 }
+
+.purchase-settings__toggle-control {
+	.components-form-toggle {
+		order: 2;
+	}
+	.components-toggle-control__help {
+		margin-inline-start: 0;
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1249/

## Proposed Changes

Mostly, this makes the billing auto-renew toggle full-width and aligned with other subscription actions, as requested here: pfOicC-M3-p2#comment-734

It also slightly refactors the "manage subscription" card to add both controls as fields in the `DataForm` and drop unnecessary components, like the card's `VStack`. We could go even further here by dropping the card entirely and changing the `DataForm` to use `type: card`, but then the overall styling will change slightly.

| Before  | After |
| ----------- | ----------- |
| <img width="685" height="184" alt="Screenshot 2025-10-29 at 09 21 31" src="https://github.com/user-attachments/assets/a0504ba8-7fa3-4645-a15f-28dd3bea4e06" /> | <img width="685" height="188" alt="Screenshot 2025-10-29 at 09 21 14" src="https://github.com/user-attachments/assets/876b6960-abb8-4635-8623-f111f3903524" /> |

## Testing Instructions

- In the multi-site dashboard, visit Me > Billing > Active Upgrades
- Click on a purchase
- Verify that the "Manage Subscription" section renders correctly, that you can toggle on and off auto-renew, and that you add or update a payment method by clicking the button
- Visit Me > Billing > Monetize subscriptions
- Click on a recurring monetize purchase
- Verify that the "Manage Subscription" section renders correctly and that you can toggle on and off auto-renew