### PR TITLE
Flex sites: Enable copy-site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
@@ -172,11 +172,25 @@ const copySite: Flow = {
 					setSignupCompleteSlug( siteSlug );
 					setSignupCompleteFlowName( flowName );
 					const returnUrl = encodeURIComponent( destination );
-					const plan =
-						urlQueryParams.get( 'plan' ) ??
-						getPlanPath( sourceSite?.plan?.product_slug ?? 'business' );
+					// For Flex sites (wpcom-flexible), default to business-bundle plan since Flex is not a purchasable plan
+					const sourcePlanSlug =
+						sourceSite?.plan?.product_slug === 'wpcom-flexible'
+							? 'business-bundle'
+							: sourceSite?.plan?.product_slug ?? 'business-bundle';
+					const plan = urlQueryParams.get( 'plan' ) ?? getPlanPath( sourcePlanSlug );
+
+					// eslint-disable-next-line no-console
+					console.log( 'Copy-site checkout redirect:', {
+						sourceSiteProductSlug: sourceSite?.plan?.product_slug,
+						sourcePlanSlug,
+						plan,
+						siteSlug,
+					} );
+
+					// If plan is undefined/null/empty, fall back to 'business'
+					const planPath = plan || 'business';
 					return window.location.assign(
-						`/checkout/${ plan }/${ encodeURIComponent(
+						`/checkout/${ planPath }/${ encodeURIComponent(
 							( siteSlug as string ) ?? ''
 						) }?redirect_to=${ returnUrl }&signup=1`
 					);

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -52,7 +52,11 @@ function getMarketplaceProducts( purchases: Purchase[] | null, siteId: number ) 
 }
 
 function getPlanProduct( plan: SiteExcerptData[ 'plan' ] ) {
-	return { product_slug: plan?.product_slug as string };
+	// Flex sites use 'wpcom-flexible' which is not a purchasable plan.
+	// Default to 'business-bundle' for Flex sites since they have Business-level features.
+	const productSlug =
+		plan?.product_slug === 'wpcom-flexible' ? 'business-bundle' : plan?.product_slug;
+	return { product_slug: productSlug as string };
 }
 
 export const useSiteCopy = (
@@ -73,6 +77,11 @@ export const useSiteCopy = (
 			site && options.enabled && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site?.ID ),
 		[ site, options.enabled ]
 	);
+	const isFlex = useSelect(
+		( select ) =>
+			site && options.enabled && ( select( SITE_STORE ) as SiteSelect ).isSiteFlex( site?.ID ),
+		[ site, options.enabled ]
+	);
 	const plan = site?.plan;
 	const isSiteOwner = site?.site_owner === userId;
 
@@ -86,8 +95,10 @@ export const useSiteCopy = (
 	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const shouldShowSiteCopyItem = useMemo( () => {
-		return hasCopySiteFeature && isSiteOwner && plan && isAtomic && ! isLoadingPurchases;
-	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchases, isAtomic ] );
+		return (
+			hasCopySiteFeature && isSiteOwner && plan && ( isAtomic || isFlex ) && ! isLoadingPurchases
+		);
+	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchases, isAtomic, isFlex ] );
 
 	const startSiteCopy = useCallback( () => {
 		if ( ! shouldShowSiteCopyItem || ! site?.ID ) {
@@ -139,8 +150,13 @@ export const useSiteCopy = (
 	);
 };
 
-export const withSiteCopy = createHigherOrderComponent(
-	( Wrapped ) => ( props ) => {
+export const withSiteCopy = createHigherOrderComponent( ( Wrapped ) => {
+	const WithSiteCopy = (
+		props: { site?: Pick< SiteExcerptData, 'ID' | 'site_owner' | 'plan' > } & Record<
+			string,
+			unknown
+		>
+	) => {
 		const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( props.site );
 		return (
 			<Wrapped
@@ -149,6 +165,6 @@ export const withSiteCopy = createHigherOrderComponent(
 				startSiteCopy={ startSiteCopy }
 			/>
 		);
-	},
-	'withSiteCopy'
-);
+	};
+	return WithSiteCopy;
+}, 'withSiteCopy' );

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -63,6 +63,10 @@ export const isSiteAtomic: ( _: State, siteId: number | string ) => boolean = ( 
 	return ( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.options?.is_wpcom_atomic === true;
 };
 
+export const isSiteFlex: ( _: State, siteId: number | string ) => boolean = ( state, siteId ) => {
+	return ( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.is_wpcom_flex === true;
+};
+
 export const isSiteWPForTeams: ( _: State, siteId: number | string ) => boolean = (
 	state,
 	siteId


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTMART-52/check-if-the-copy-site-signup-flow-works

## Proposed Changes

Requires backed PR: 194964-ghe-Automattic/wpcom

The PR enables the copy-site flow for Flex sites:
* Option available in v2 HD under Site Settings > Duplicate
* Adds the Business plan since the plan selection is automatic

### Changes

- New Selector - `packages/data-stores/src/site/selectors.ts`
  - Added `isSiteFlex()` selector to check if a site has `is_wpcom_flex === true`
- Copy Hook Updates - `client/landing/stepper/hooks/use-site-copy.tsx`
  - Added `isFlex` check alongside `isAtomic`
  - Updated `shouldShowSiteCopyItem` condition to: `isAtomic || isFlex`
  - Fixed cart preparation: Modified `getPlanProduct()` to convert wpcom-flexible → business-bundle
- Flow Updates - `client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx`
  - Fixed checkout redirect: Converts wpcom-flexible → business-bundle before calling `getPlanPath()`
  - Added fallback to 'business' if plan is undefined/null/empty

### Media

| Initiation | End |
|--------|--------|
| <img width="1091" height="638" alt="Screenshot 2025-10-29 at 3 45 08 PM" src="https://github.com/user-attachments/assets/c80fe454-676d-4f96-8067-0a53cfd3559f" /> | <img width="737" height="300" alt="Screenshot 2025-10-29 at 3 20 23 PM" src="https://github.com/user-attachments/assets/ad4c9993-7d85-470c-b826-9a7d52f95d69" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTMART-52/check-if-the-copy-site-signup-flow-works

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions in 192692-ghe-Automattic/wpcom to create a Flex site
* Go to `/sites/:flex/settings` > Duplicate
* Go through the flow, checkout, and confirm you land on the "Creating your site" page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?