### PR TITLE
Dashboard Billing: fix Monetize site link in subscription list

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -41,11 +41,11 @@ export const MonetizeSubscriptionTerms = ( {
 };
 
 export const MonetizeSiteLink = ( { subscription }: { subscription: MonetizeSubscription } ) => {
-	const siteUrl = subscription.site_url.replace( /^https?:\/\//, '' );
+	const displayUrl = subscription.site_url.replace( /^https?:\/\//, '' );
 
 	return (
-		<ExternalLink href={ siteUrl } rel="noreferrer" title={ siteUrl }>
-			{ siteUrl }
+		<ExternalLink href={ subscription.site_url } rel="noreferrer" title={ subscription.site_url }>
+			{ displayUrl }
 		</ExternalLink>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1250/

## Proposed Changes

This fixes the link to a monetize subscription's site in the monetize subscription list by only stripping the url scheme for the link text, not the link href. By stripping the scheme for the href, we're making these relative links to broken dashboard views.

## Testing Instructions

- For a user with a monetize purchase
- Visit the multi-site dashboard Me > Billing > Monetize Subscriptions
- Click the external link to the site in the subscription list
- Verify that you're taken to the subscription site in a new tab
