### PR TITLE
Use purchaseSettingsRoute for purchase link in DomainExpiryField

### DIFF
--- a/client/dashboard/domains/dataviews/field-expiry.tsx
+++ b/client/dashboard/domains/dataviews/field-expiry.tsx
@@ -2,8 +2,8 @@ import { DomainSubtype, DomainStatus } from '@automattic/api-core';
 import { Link } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { purchaseSettingsRoute } from '../../app/router/me';
 import { Text } from '../../components/text';
-import { getPurchaseUrlForId } from '../../me/billing-purchases/urls';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainExpiryField = ( {
@@ -38,7 +38,10 @@ export const DomainExpiryField = ( {
 				{ domain.auto_renewing ? (
 					__( 'Auto-renew is on' )
 				) : (
-					<Link to={ getPurchaseUrlForId( domain.subscription_id ?? 0 ) }>
+					<Link
+						to={ purchaseSettingsRoute.fullPath }
+						params={ { purchaseId: domain.subscription_id } }
+					>
 						{ __( 'Turn on auto-renew' ) }
 					</Link>
 				) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This fixes a small bug in https://github.com/Automattic/wp-calypso/pull/106562 where code used a function (`getPurchaseUrlForId`) that was removed in https://github.com/Automattic/wp-calypso/pull/106694

