### PR TITLE
A4A: Update Signup flow to warn for duplicate Agency name or URL.

### DIFF
--- a/client/a8c-for-agencies/components/form/utils/index.ts
+++ b/client/a8c-for-agencies/components/form/utils/index.ts
@@ -38,3 +38,29 @@ export async function isSiteActive( url: string ) {
 		return false;
 	}
 }
+
+export async function isAgencyNameExists( agencyName: string ) {
+	const response = await wpcom.req.get( {
+		path: `/agency/exists/name?value=${ encodeURIComponent( agencyName ) }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	if ( response?.exists ) {
+		return true;
+	}
+
+	return false;
+}
+
+export async function isDomainExists( domain: string ) {
+	const response = await wpcom.req.get( {
+		path: `/agency/exists/domain?value=${ encodeURIComponent( domain ) }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	if ( response?.exists ) {
+		return true;
+	}
+
+	return false;
+}

--- a/client/a8c-for-agencies/components/form/utils/index.ts
+++ b/client/a8c-for-agencies/components/form/utils/index.ts
@@ -52,9 +52,9 @@ export async function isAgencyNameExists( agencyName: string ) {
 	return false;
 }
 
-export async function isDomainExists( domain: string ) {
+export async function isAgencyUrlExists( url: string ) {
 	const response = await wpcom.req.get( {
-		path: `/agency/exists/domain?value=${ encodeURIComponent( domain ) }`,
+		path: `/agency/exists/url?value=${ encodeURIComponent( url ) }`,
 		apiNamespace: 'wpcom/v2',
 	} );
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -124,6 +124,10 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 		[ validate, formData, onContinue, dispatch ]
 	);
 
+	const closeDuplicateAgencyWarning = () => {
+		setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
+	};
+
 	return (
 		<Form
 			className="signup-contact-form"
@@ -313,19 +317,14 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 							</Text>
 						) }
 						<ButtonStack justify="flex-end">
-							<Button
-								variant="secondary"
-								onClick={ () => {
-									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
-								} }
-							>
+							<Button variant="secondary" onClick={ closeDuplicateAgencyWarning }>
 								{ translate( 'Cancel' ) }
 							</Button>
 							<Button
 								variant="primary"
 								onClick={ () => {
 									onContinue( formData );
-									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
+									closeDuplicateAgencyWarning();
 								} }
 							>
 								{ translate( 'Continue creating new agency account' ) }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -84,21 +84,26 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				return;
 			}
 
-			const [ duplicateAgencyName, duplicateURL ] = await Promise.all( [
-				isAgencyNameExists( formData.agencyName ?? '' ),
-				isAgencyUrlExists( formData.agencyUrl ?? '' ),
-			] );
+			try {
+				const [ duplicateAgencyName, duplicateURL ] = await Promise.all( [
+					isAgencyNameExists( formData.agencyName ?? '' ),
+					isAgencyUrlExists( formData.agencyUrl ?? '' ),
+				] );
 
-			setDuplicateAgencyFields( {
-				agencyName: duplicateAgencyName,
-				agencyUrl: duplicateURL,
-			} );
+				setDuplicateAgencyFields( {
+					agencyName: duplicateAgencyName,
+					agencyUrl: duplicateURL,
+				} );
 
-			if ( ! duplicateAgencyName && ! duplicateURL ) {
+				if ( ! duplicateAgencyName && ! duplicateURL ) {
+					onContinue( formData );
+				}
+			} catch ( error ) {
+				// In case the verification fails, we just let the user continue with the form submission.
 				onContinue( formData );
+			} finally {
+				setIsProceeding( false );
 			}
-
-			setIsProceeding( false );
 		},
 		[ formData, onContinue, validate, setDuplicateAgencyFields ]
 	);
@@ -299,7 +304,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
 								} }
 							>
-								{ translate( 'Continue for free' ) }
+								{ translate( 'Create new agency account' ) }
 							</Button>
 							<Button
 								variant="secondary"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -20,7 +20,10 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useGetSupportedSMSCountries } from 'calypso/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/hooks';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useContactFormValidation from './hooks/use-contact-form-validation';
+
 import './style.scss';
 
 type Props = {
@@ -31,6 +34,8 @@ type Props = {
 
 const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const { validate, validationError, updateValidationError } = useContactFormValidation( {
 		withEmail,
 	} );
@@ -97,6 +102,17 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 
 				if ( ! duplicateAgencyName && ! duplicateURL ) {
 					onContinue( formData );
+				} else {
+					// Fire track event to track the view of the duplicate agency warning dialog
+					dispatch(
+						recordTracksEvent(
+							'calypso_a4a_agency_signup_form_duplicate_agency_warning_dialog_view',
+							{
+								agencyName: formData.agencyName ?? '',
+								agencyUrl: formData.agencyUrl ?? '',
+							}
+						)
+					);
 				}
 			} catch ( error ) {
 				// In case the verification fails, we just let the user continue with the form submission.
@@ -105,7 +121,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				setIsProceeding( false );
 			}
 		},
-		[ formData, onContinue, validate, setDuplicateAgencyFields ]
+		[ validate, formData, onContinue, dispatch ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -304,7 +304,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
 								} }
 							>
-								{ translate( 'Create new agency account' ) }
+								{ translate( 'Continue' ) }
 							</Button>
 							<Button
 								variant="secondary"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -298,6 +298,14 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 						) }
 						<ButtonStack justify="flex-end">
 							<Button
+								variant="secondary"
+								onClick={ () => {
+									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
+								} }
+							>
+								{ translate( 'Cancel' ) }
+							</Button>
+							<Button
 								variant="primary"
 								onClick={ () => {
 									onContinue( formData );
@@ -305,14 +313,6 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 								} }
 							>
 								{ translate( 'Continue creating new agency account' ) }
-							</Button>
-							<Button
-								variant="secondary"
-								onClick={ () => {
-									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
-								} }
-							>
-								{ translate( 'Cancel' ) }
 							</Button>
 						</ButtonStack>
 					</VStack>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -1,17 +1,26 @@
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	Modal,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
+import {
+	isAgencyNameExists,
+	isAgencyUrlExists,
+} from 'calypso/a8c-for-agencies/components/form/utils';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useGetSupportedSMSCountries } from 'calypso/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/hooks';
 import { preventWidows } from 'calypso/lib/formatting';
 import useContactFormValidation from './hooks/use-contact-form-validation';
-
 import './style.scss';
 
 type Props = {
@@ -22,8 +31,11 @@ type Props = {
 
 const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: Props ) => {
 	const translate = useTranslate();
-	const { validate, validationError, updateValidationError, isValidating } =
-		useContactFormValidation( { withEmail } );
+	const { validate, validationError, updateValidationError } = useContactFormValidation( {
+		withEmail,
+	} );
+
+	const [ isProcessing, setIsProceeding ] = useState( false );
 
 	const countriesList = useGetSupportedSMSCountries();
 	const noCountryList = countriesList.length === 0;
@@ -35,6 +47,14 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 		agencyName: initialFormData.agencyName || '',
 		agencyUrl: initialFormData.agencyUrl || '',
 		phoneNumber: initialFormData.phoneNumber || '',
+	} );
+
+	const [ duplicateAgencyFields, setDuplicateAgencyFields ] = useState< {
+		agencyName: boolean;
+		agencyUrl: boolean;
+	} >( {
+		agencyName: false,
+		agencyUrl: false,
 	} );
 
 	const handlePhoneInputChange = ( data: { phoneNumberFull: string } ) => {
@@ -57,13 +77,30 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 	const handleSubmit = useCallback(
 		async ( e: React.FormEvent ) => {
 			e.preventDefault();
+			setIsProceeding( true );
 			const error = await validate( formData );
 			if ( error ) {
+				setIsProceeding( false );
 				return;
 			}
-			onContinue( formData );
+
+			const [ duplicateAgencyName, duplicateURL ] = await Promise.all( [
+				isAgencyNameExists( formData.agencyName ?? '' ),
+				isAgencyUrlExists( formData.agencyUrl ?? '' ),
+			] );
+
+			setDuplicateAgencyFields( {
+				agencyName: duplicateAgencyName,
+				agencyUrl: duplicateURL,
+			} );
+
+			if ( ! duplicateAgencyName && ! duplicateURL ) {
+				onContinue( formData );
+			}
+
+			setIsProceeding( false );
 		},
-		[ formData, onContinue, validate ]
+		[ formData, onContinue, validate, setDuplicateAgencyFields ]
 	);
 
 	return (
@@ -207,13 +244,75 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 			<FormFooter>
 				<Button
 					__next40pxDefaultSize
-					disabled={ isValidating }
+					disabled={ isProcessing }
 					variant="primary"
 					onClick={ handleSubmit }
 				>
 					{ translate( 'Continue for free' ) }
 				</Button>
 			</FormFooter>
+
+			{ ( duplicateAgencyFields.agencyName || duplicateAgencyFields.agencyUrl ) && (
+				<Modal
+					isDismissible
+					size="medium"
+					onRequestClose={ () =>
+						setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } )
+					}
+					title={ translate( 'Duplicate Agency' ) }
+				>
+					<VStack spacing={ 8 }>
+						{ duplicateAgencyFields.agencyName ? (
+							<Text>
+								{ translate(
+									'An agency with the name {{b}}%(agencyName)s{{/b}} already exists. Do you want to proceed with creating a new agency account? Alternatively, ask your team for an invite.',
+									{
+										args: {
+											agencyName: formData.agencyName ?? '',
+										},
+										components: {
+											b: <b />,
+										},
+									}
+								) }
+							</Text>
+						) : (
+							<Text>
+								{ translate(
+									'An agency with the domain {{b}}%(agencyUrl)s{{/b}} already exists. Do you want to proceed with creating a new agency account? Alternatively, ask your team for an invite.',
+									{
+										args: {
+											agencyUrl: formData.agencyUrl ?? '',
+										},
+										components: {
+											b: <b />,
+										},
+									}
+								) }
+							</Text>
+						) }
+						<ButtonStack justify="flex-end">
+							<Button
+								variant="primary"
+								onClick={ () => {
+									onContinue( formData );
+									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
+								} }
+							>
+								{ translate( 'Continue for free' ) }
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
+								} }
+							>
+								{ translate( 'Cancel' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</Modal>
+			) }
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -304,7 +304,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 									setDuplicateAgencyFields( { agencyName: false, agencyUrl: false } );
 								} }
 							>
-								{ translate( 'Continue' ) }
+								{ translate( 'Continue creating new agency account' ) }
 							</Button>
 							<Button
 								variant="secondary"


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1589/reduce-duplicate-agency-signups
Depends on 194984-ghe-Automattic/wpcom

## Proposed Changes

* Update the signup flow so that it warns for Agency for a duplicate name or URL.
<img width="566" height="288" alt="Screenshot 2025-10-30 at 12 35 13 AM" src="https://github.com/user-attachments/assets/7d3fc35c-0088-4abe-a937-fd57a52be039" />

<img width="668" height="355" alt="Screenshot 2025-10-30 at 12 33 20 AM" src="https://github.com/user-attachments/assets/3179785b-f155-4ca9-a693-4b0fcdc8f069" />


## Why are these changes being made?

* This reduces duplicate agency signups 

## Testing Instructions

* Follow instructions from 194984-ghe-Automattic/wpcom
* Use the A4A live link and navigate to `/signup`.
* Input an Agency name that already exist.
* Confirm you see the confirmation dialog.
* Input an Agency URL that already exist.
* Confirm you see the confirmation dialog.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?