### PR TITLE
fixup feedback form

### DIFF
--- a/packages/odie-client/src/components/message/feedback-form.tsx
+++ b/packages/odie-client/src/components/message/feedback-form.tsx
@@ -7,7 +7,7 @@ import { Button, TextareaControl, SelectControl, Spinner } from '@wordpress/comp
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
-import { useSendChatMessage } from '../../hooks';
+import { useSendZendeskMessageOnce } from '../../hooks';
 import { Message, MessageAction } from '../../types';
 import { ThumbsDownIcon, ThumbsUpIcon } from './thumbs-icons';
 
@@ -28,8 +28,7 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 		}
 		return chatFeedbackOptions[ 0 ]?.metadata?.ticket_id ?? null;
 	}, [ chatFeedbackOptions ] );
-	const { sendMessage } = useSendChatMessage();
-
+	const sendZendeskMessage = useSendZendeskMessageOnce();
 	const badRatingReasons = getBadRatingReasons();
 
 	const { isPending: isSubmitting, mutateAsync: rateChat } = useRateChat();
@@ -63,9 +62,9 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 			}
 
 			setScore( score );
-			await sendMessage( generateFeedbackMessage( score ) );
+			sendZendeskMessage( generateFeedbackMessage( score ) );
 		},
-		[ sendMessage, generateFeedbackMessage ]
+		[ sendZendeskMessage, generateFeedbackMessage ]
 	);
 
 	const postCSAT = useCallback( async () => {

--- a/packages/odie-client/src/hooks/index.ts
+++ b/packages/odie-client/src/hooks/index.ts
@@ -4,5 +4,5 @@ export { useZendeskMessageListener } from './use-zendesk-message-listener';
 export { useCreateZendeskConversation } from './use-create-zendesk-conversation';
 export { useGetCombinedChat } from './use-get-combined-chat';
 export { useOdieUserTracking } from './use-odie-user-tracking';
-export { useSendZendeskMessage } from './use-send-zendesk-message';
+export { useSendZendeskMessage, useSendZendeskMessageOnce } from './use-send-zendesk-message';
 export { useUpdateDocumentTitle } from './use-update-document-title';

--- a/packages/odie-client/src/hooks/use-send-zendesk-message.ts
+++ b/packages/odie-client/src/hooks/use-send-zendesk-message.ts
@@ -7,6 +7,31 @@ import { useCreateZendeskConversation } from './use-create-zendesk-conversation'
 import type { Message } from '../types';
 
 /**
+ * Send a message to the Zendesk conversation once.
+ */
+export const useSendZendeskMessageOnce = () => {
+	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
+	const currentConversationId = getConversationIdFromInteraction( currentSupportInteraction );
+
+	const { chat } = useOdieAssistantContext();
+	const conversationId = currentConversationId || chat.conversationId;
+
+	return ( message: Message ) => {
+		if ( ! conversationId ) {
+			return;
+		}
+
+		const messageToSend = {
+			type: 'text',
+			text: message.content as string,
+			...( message.payload && { payload: message.payload } ),
+			...( message.metadata && { metadata: message.metadata } ),
+		};
+
+		Smooch.sendMessage( messageToSend, conversationId );
+	};
+};
+/**
  * Send a message to the Zendesk conversation.
  */
 export const useSendZendeskMessage = ( signal: AbortSignal ) => {

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -26,6 +26,13 @@ export const useZendeskMessageListener = () => {
 			const zendeskMessage = message as ZendeskMessage;
 
 			if ( data.conversation.id === chat.conversationId ) {
+				// Skip form messages with fields (like CSAT forms)
+				if ( zendeskMessage.type === 'form' && 'fields' in zendeskMessage ) {
+					// We don't want to mark the conversation as read if it's a form message with fields.
+					Smooch.markAllAsRead( data.conversation.id );
+					return;
+				}
+
 				const convertedMessage = zendeskMessageConverter( zendeskMessage );
 				setChat( ( prevChat ) => ( {
 					...prevChat,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTSUP-335

## Proposed Changes

* Filter received messages of type 'form' that contain 'fields' and no message content
* Send csat messages without retries

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The form field messages interrupts the CSAT flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Open HC and escalate to support on staging
* Assign yourself the ticket and mark it as closed
* Test if CSAT is working as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
