### PR TITLE
Garden: Domain mapping plan check

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -3,17 +3,35 @@ import { __ } from '@wordpress/i18n';
 import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
-export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
+export function AddDomainButton( {
+	siteSlug,
+	redirectTo,
+}: {
+	siteSlug?: string;
+	redirectTo?: string;
+} ) {
 	const onSearchClick = () => {
-		window.location.href = siteSlug
-			? addQueryArgs( '/setup/domain', { siteSlug } )
-			: '/setup/domain';
+		const queryArgs: Record< string, string > = {};
+		if ( siteSlug ) {
+			queryArgs.siteSlug = siteSlug;
+		}
+		if ( redirectTo ) {
+			queryArgs.redirect_to = redirectTo;
+		}
+		window.location.href = siteSlug ? addQueryArgs( '/setup/domain', queryArgs ) : '/start/domain';
 		return false;
 	};
 
 	const onTransferClick = () => {
+		const queryArgs: Record< string, string > = {};
+		if ( siteSlug ) {
+			queryArgs.siteSlug = siteSlug;
+		}
+		if ( redirectTo ) {
+			queryArgs.redirect_to = redirectTo;
+		}
 		window.location.href = siteSlug
-			? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
+			? addQueryArgs( '/setup/domain/use-my-domain', queryArgs )
 			: '/setup/domain-transfer';
 		return false;
 	};

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -53,12 +53,14 @@ function SiteDomains() {
 		fields
 	);
 
+	const redirectTo = `/ciab/sites/${ site.slug }/domains`;
+
 	return (
 		<PageLayout
 			header={
 				<PageHeader
 					title={ __( 'Domains' ) }
-					actions={ <AddDomainButton siteSlug={ site.slug } /> }
+					actions={ <AddDomainButton siteSlug={ site.slug } redirectTo={ redirectTo } /> }
 				/>
 			}
 		>

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,6 +1,6 @@
 import { domainsQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -53,7 +53,8 @@ function SiteDomains() {
 		fields
 	);
 
-	const redirectTo = `/ciab/sites/${ site.slug }/domains`;
+	const routerState = useRouterState();
+	const redirectTo = routerState.location.pathname;
 
 	return (
 		<PageLayout

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -9,7 +9,7 @@ import type {
 
 // Returns whether the plan supports a specific feature.
 export function hasPlanFeature(
-	site: Site,
+	site: { plan?: { features: { active: string[] } } },
 	feature: `${ DotcomFeatureSlug | JetpackFeatureSlug }`
 ) {
 	if ( ! site.plan ) {

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -41,6 +41,7 @@ export type DotcomPlanSlug = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
 export const DotcomFeatures = {
 	ATOMIC: 'atomic',
 	BACKUPS: 'backups',
+	DOMAIN_MAPPING: 'domain-mapping',
 	SUBSCRIPTION_GIFTING: 'subscription-gifting',
 	COPY_SITE: 'copy-site',
 	FULL_ACTIVITY_LOG: 'full-activity-log',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-1121
Part of ARC-1093

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/106489, we made a change so that we skipped checkout for mapping a domain for all garden sites (as a temporary workaround). 

Now we have 194871-ghe-Automattic/wpcom which adds domain mapping features for the appropriate CIAB plans so we're changing the `/ciab` dashboard to do a plan check to decide if we can skip checkout.

Garden sites will be redirected back to `/ciab/sites/somesite.com/domains` while other sites will be redirected to the normal domain management page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new garden site using the `/tools/garden` MC tool.
* Add a `woo_hosted_basic_monthly` plan to the site by going to `https://wordpress.com/checkout/your-new-site.commerce-garden.com/woo_hosted_basic_plan_monthly/`.
* Now use the calypso.live url (or run this locally) and go to `/ciab/sites/your-new-site.commerce-garden.com/domains`.
* You should see the following banner instead of the banner saying that changing the primary site address requires a plan.
<img width="754" height="190" alt="CleanShot 2025-10-29 at 14 14 04" src="https://github.com/user-attachments/assets/9d51bb87-bff5-4ad8-8726-98d2d492eef2" />

* Click "Add domain name" and then "Use a domain name I own", then enter a domain name. (I've been using `random-subdomain.biek.dev` but it doesn't really matter since we're not configuring DNS for the domain).
* Click "Continue", then click "Select" under "Connect your domain".
* Your should return to the site overview.
* Click the "Domains" link at the top of the page.
* Click on the "..." Actions menu for the newly mapped domain.
* Click "Make primary site address".
  - Note that there's a 30 minute delay before you can set a new domain to primary. You can skip this by modifying [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/domains/dataviews/actions.tsx#L194) from `! isRecentlyRegistered( item.registration_date )` to `( true || ! isRecentlyRegistered( item.registration_date ) )`. You may also need to comment out line 1244 of `class.wpcom-store-domains-api-endpoints.php` on your sandbox and sandbox the public-api.
* The domain should be made primary

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?