### PR TITLE
SSH Migration: Add SSH Key generation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-generate-ssh-key.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-generate-ssh-key.ts
@@ -1,0 +1,61 @@
+import { useMutation } from '@tanstack/react-query';
+import { urlToDomain } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
+
+interface GenerateSSHKeyParams {
+	siteId: number;
+	remoteUser: string;
+	remoteHost: string;
+	remoteDomain: string;
+}
+
+interface GenerateSSHKeyResponse {
+	ssh_public_key: string;
+}
+
+/**
+ * Generates SSH key for migration
+ * @param params - SSH details including username, host, domain, and port
+ * @returns Promise with SSH key response
+ */
+const generateSSHKey = async (
+	params: GenerateSSHKeyParams
+): Promise< GenerateSSHKeyResponse > => {
+	try {
+		const remoteDomain = urlToDomain( params.remoteDomain );
+
+		if ( ! remoteDomain ) {
+			throw new Error( 'Invalid remote domain' );
+		}
+
+		const body = {
+			remote_user: params.remoteUser,
+			remote_host: params.remoteHost,
+			remote_domain: remoteDomain,
+		};
+
+		const response = await wpcom.req.post( {
+			path: `/sites/${ params.siteId }/ssh-migration/configure`,
+			apiNamespace: 'wpcom/v2',
+			body,
+		} );
+
+		if ( ! response.ssh_public_key ) {
+			throw new Error( 'Failed to generate SSH key' );
+		}
+
+		return response;
+	} catch ( error ) {
+		throw new Error( error instanceof Error ? error.message : 'Failed to generate SSH key' );
+	}
+};
+
+/**
+ * Hook to generate SSH key for migration
+ * @returns Mutation object with generate function and status
+ */
+export const useGenerateSSHKey = () => {
+	return useMutation< GenerateSSHKeyResponse, Error, GenerateSSHKeyParams >( {
+		mutationFn: generateSSHKey,
+	} );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -110,7 +110,7 @@ const SiteMigrationSshShareAccess: StepType< {
 				remoteHost: formState.serverAddress,
 				remoteUser: formState.username,
 				remoteDomain: fromUrl,
-				remotePass: formState.password,
+				remotePass: formState.authMethod === 'key' ? '' : formState.password,
 			},
 			{
 				onSuccess: () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -113,7 +113,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 			</p>
 
 			<Button
-				variant="secondary"
+				variant="primary"
 				onClick={ handleVerify }
 				disabled={ ! canVerify }
 				isBusy={ isPending }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -1,5 +1,8 @@
+import { Button, Icon } from '@wordpress/components';
+import { check, edit, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useState } from 'react';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -9,10 +12,17 @@ interface StepShareSSHAccessProps {
 	authMethod: 'password' | 'key';
 	username: string;
 	password: string;
+	sshPublicKey: string;
+	isGeneratingKey: boolean;
+	isUsernameLockedForKey: boolean;
+	hostDisplayName?: string;
+	generateError?: Error | null;
 	error?: Error | null;
 	onAuthMethodChange: ( method: 'password' | 'key' ) => void;
 	onUsernameChange: ( username: string ) => void;
 	onPasswordChange: ( password: string ) => void;
+	onGenerateSSHKey: () => void;
+	onEditUsername: () => void;
 	helpLink: ReactNode;
 }
 
@@ -20,13 +30,21 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	authMethod,
 	username,
 	password,
+	sshPublicKey,
+	isGeneratingKey,
+	isUsernameLockedForKey,
+	hostDisplayName,
+	generateError,
 	error,
 	onAuthMethodChange,
 	onUsernameChange,
 	onPasswordChange,
+	onGenerateSSHKey,
+	onEditUsername,
 	helpLink,
 } ) => {
 	const translate = useTranslate();
+	const [ copied, setCopied ] = useState( false );
 
 	return (
 		<div className="site-migration-ssh__step-share-ssh">
@@ -47,9 +65,9 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 			) }
 
 			<div className="site-migration-ssh__step-share-ssh-auth-method">
-				<p className="site-migration-ssh__step-share-ssh-auth-label">
+				<label className="site-migration-ssh__step-share-ssh-label">
 					{ translate( 'Authentication method' ) }
-				</p>
+				</label>
 				<div className="site-migration-ssh__step-share-ssh-radio-group">
 					<div className="site-migration-ssh__step-share-ssh-radio-option">
 						<FormRadio
@@ -74,36 +92,130 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 			</div>
 
 			<div className="site-migration-ssh__step-share-ssh-form">
-				<div>
-					<label htmlFor="ssh-username" className="site-migration-ssh__step-share-ssh-label">
-						{ translate( 'SSH username' ) }
-					</label>
-					<FormTextInput
-						id="ssh-username"
-						value={ username }
-						onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
-							onUsernameChange( e.target.value )
-						}
-						placeholder={ translate( 'Enter your SSH username' ) }
-					/>
-				</div>
+				{ authMethod === 'password' && (
+					<>
+						<div>
+							<label htmlFor="ssh-username" className="site-migration-ssh__step-share-ssh-label">
+								{ translate( 'SSH username' ) }
+							</label>
+							<FormTextInput
+								id="ssh-username"
+								value={ username }
+								onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+									onUsernameChange( e.target.value )
+								}
+								placeholder={ translate( 'Enter your SSH username' ) }
+							/>
+						</div>
 
-				{ authMethod === 'password' ? (
-					<div>
-						<label htmlFor="ssh-password" className="site-migration-ssh__step-share-ssh-label">
-							{ translate( 'SSH password' ) }
-						</label>
-						<FormPasswordInput
-							id="ssh-password"
-							value={ password }
-							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
-								onPasswordChange( e.target.value )
-							}
-							placeholder={ translate( 'Enter your SSH password' ) }
-						/>
-					</div>
-				) : (
-					<>{ /* Private key form */ }</>
+						<div>
+							<label htmlFor="ssh-password" className="site-migration-ssh__step-share-ssh-label">
+								{ translate( 'SSH password' ) }
+							</label>
+							<FormPasswordInput
+								id="ssh-password"
+								value={ password }
+								onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+									onPasswordChange( e.target.value )
+								}
+								placeholder={ translate( 'Enter your SSH password' ) }
+							/>
+						</div>
+					</>
+				) }
+
+				{ authMethod === 'key' && (
+					<>
+						<div className="site-migration-ssh__step-share-ssh-username-container">
+							<div className="site-migration-ssh__step-share-ssh-username-field">
+								<label htmlFor="ssh-username" className="site-migration-ssh__step-share-ssh-label">
+									{ translate( 'SSH username' ) }
+								</label>
+								<FormTextInput
+									id="ssh-username"
+									value={ username }
+									onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+										onUsernameChange( e.target.value )
+									}
+									placeholder={ translate( 'Enter your SSH username' ) }
+									disabled={ isUsernameLockedForKey }
+									className={ isUsernameLockedForKey ? 'is-disabled' : '' }
+								/>
+							</div>
+							{ isUsernameLockedForKey && (
+								<Button
+									icon={ edit }
+									label={ translate( 'Edit username' ) }
+									className="site-migration-ssh__step-share-ssh-edit-button"
+									onClick={ onEditUsername }
+								/>
+							) }
+						</div>
+
+						{ generateError && (
+							<AccordionNotice variant="error">
+								{ translate(
+									'We ran into a problem generating the SSH key. Please check your details and try again.'
+								) }
+							</AccordionNotice>
+						) }
+
+						{ ! sshPublicKey && (
+							<div>
+								<Button
+									variant="secondary"
+									onClick={ onGenerateSSHKey }
+									disabled={ ! username || isGeneratingKey }
+									isBusy={ isGeneratingKey }
+								>
+									{ translate( 'Generate SSH key' ) }
+								</Button>
+							</div>
+						) }
+
+						{ sshPublicKey && (
+							<div>
+								<label
+									htmlFor="ssh-public-key"
+									className="site-migration-ssh__step-share-ssh-label"
+								>
+									{ translate( 'SSH public key' ) }
+								</label>
+								<div className="site-migration-ssh__step-share-ssh-key-container">
+									<textarea
+										id="ssh-public-key"
+										className="site-migration-ssh__step-share-ssh-textarea"
+										value={ sshPublicKey }
+										readOnly
+										rows={ 5 }
+									/>
+									<ClipboardButton
+										text={ sshPublicKey }
+										transparent
+										className="site-migration-ssh__step-share-ssh-copy-button"
+										onCopy={ () => {
+											setCopied( true );
+											setTimeout( () => setCopied( false ), 2000 );
+										} }
+									>
+										<Icon icon={ copied ? check : copy } />
+									</ClipboardButton>
+								</div>
+								<p className="site-migration-ssh__step-share-ssh-help-text">
+									{ hostDisplayName
+										? translate(
+												'Copy and paste your SSH key in your %(hostName)s account. Then come back to start your migration.',
+												{
+													args: { hostName: hostDisplayName },
+												}
+										  )
+										: translate(
+												'Copy and paste your SSH key in your hosting account. Then come back to start your migration.'
+										  ) }
+								</p>
+							</div>
+						) }
+					</>
 				) }
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useGenerateSSHKey } from '../hooks/use-generate-ssh-key';
 import { HelpLink } from './help-link';
 import { getSSHHostDisplayName, getSSHSupportDoc } from './ssh-host-support-urls';
 import { StepAddServerAddress } from './step-add-server-address';
@@ -21,6 +22,11 @@ interface StepsDataOptions {
 	authMethod: 'password' | 'key';
 	username: string;
 	password: string;
+	sshPublicKey: string;
+	isGeneratingKey: boolean;
+	isUsernameLockedForKey: boolean;
+	hostDisplayName?: string;
+	generateKeyError?: Error | null;
 	migrationError?: Error | null;
 	onServerAddressChange: ( address: string ) => void;
 	onPortChange: ( port: number ) => void;
@@ -28,6 +34,8 @@ interface StepsDataOptions {
 	onAuthMethodChange: ( method: 'password' | 'key' ) => void;
 	onUsernameChange: ( username: string ) => void;
 	onPasswordChange: ( password: string ) => void;
+	onGenerateSSHKey: () => void;
+	onEditUsername: () => void;
 	onFindSSHDetailsSuccess: () => void;
 	host?: string;
 	onNoSSHAccess: () => void;
@@ -76,6 +84,7 @@ interface SSHFormState {
 	authMethod: 'password' | 'key';
 	username: string;
 	password: string;
+	sshPublicKey: string;
 	migrationStarted: boolean;
 }
 
@@ -122,10 +131,17 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					authMethod={ options.authMethod }
 					username={ options.username }
 					password={ options.password }
+					sshPublicKey={ options.sshPublicKey }
+					isGeneratingKey={ options.isGeneratingKey }
+					isUsernameLockedForKey={ options.isUsernameLockedForKey }
+					hostDisplayName={ options.hostDisplayName }
+					generateError={ options.generateKeyError }
 					error={ options.migrationError }
 					onAuthMethodChange={ options.onAuthMethodChange }
 					onUsernameChange={ options.onUsernameChange }
 					onPasswordChange={ options.onPasswordChange }
+					onGenerateSSHKey={ options.onGenerateSSHKey }
+					onEditUsername={ options.onEditUsername }
 					helpLink={ helpLink }
 				/>
 			),
@@ -156,8 +172,16 @@ export const useSteps = ( {
 		authMethod: 'password',
 		username: '',
 		password: '',
+		sshPublicKey: '',
 		migrationStarted: false,
 	} );
+
+	// SSH Key generation hook
+	const {
+		mutate: generateSSHKey,
+		isPending: isGeneratingKey,
+		error: generateKeyError,
+	} = useGenerateSSHKey();
 
 	// State update handlers
 	const handleServerAddressChange = ( address: string ) => {
@@ -218,6 +242,28 @@ export const useSteps = ( {
 		setFormState( ( prev ) => ( { ...prev, migrationStarted: true } ) );
 	};
 
+	const handleGenerateSSHKey = () => {
+		generateSSHKey(
+			{
+				siteId,
+				remoteUser: formState.username,
+				remoteHost: formState.serverAddress,
+				remoteDomain: fromUrl,
+			},
+			{
+				onSuccess: ( data ) => {
+					setFormState( ( prev ) => ( { ...prev, sshPublicKey: data.ssh_public_key } ) );
+				},
+			}
+		);
+	};
+
+	const handleEditUsername = () => {
+		setFormState( ( prev ) => ( { ...prev, sshPublicKey: '' } ) );
+	};
+
+	const hostDisplayName = getSSHHostDisplayName( host );
+
 	const stepsData = useStepsData( {
 		fromUrl,
 		siteId,
@@ -228,6 +274,11 @@ export const useSteps = ( {
 		authMethod: formState.authMethod,
 		username: formState.username,
 		password: formState.password,
+		sshPublicKey: formState.sshPublicKey,
+		isGeneratingKey,
+		isUsernameLockedForKey: !! formState.sshPublicKey,
+		hostDisplayName,
+		generateKeyError,
 		migrationError,
 		onServerAddressChange: handleServerAddressChange,
 		onPortChange: handlePortChange,
@@ -235,6 +286,8 @@ export const useSteps = ( {
 		onAuthMethodChange: handleAuthMethodChange,
 		onUsernameChange: handleUsernameChange,
 		onPasswordChange: handlePasswordChange,
+		onGenerateSSHKey: handleGenerateSSHKey,
+		onEditUsername: handleEditUsername,
 		onFindSSHDetailsSuccess: handleFindSSHDetailsSuccess,
 		onNoSSHAccess,
 		host,
@@ -290,7 +343,7 @@ export const useSteps = ( {
 		formState.isServerVerified &&
 		formState.username.length > 0 &&
 		( ( formState.authMethod === 'password' && formState.password.length > 0 ) ||
-			( formState.authMethod === 'key' && false ) );
+			( formState.authMethod === 'key' && formState.sshPublicKey.length > 0 ) );
 
 	return {
 		steps,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -223,7 +223,7 @@ export const useSteps = ( {
 	};
 
 	const handleUsernameChange = ( username: string ) => {
-		setFormState( ( prev ) => ( { ...prev, username } ) );
+		setFormState( ( prev ) => ( { ...prev, username, sshPublicKey: '' } ) );
 	};
 
 	const handlePasswordChange = ( password: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -158,16 +158,16 @@
 
 .migration-site-ssh__step-add-server-address-note {
 	margin: 0.5rem 0 1rem 0;
-	color: var(--studio-gray-40);
-	font-size: 0.875rem;
+	color: var(--studio-gray-50);
+	font-size: 0.75rem;
 }
 
 .migration-site-ssh__continue-button {
 	margin-left: 2.5rem;
 	button {
 		width: 100%;
-		height: 48px;
-		font-size: 16px;
+		font-size: 1rem;
+		padding: 1.5rem;
 	}
 }
 
@@ -187,4 +187,77 @@
 		font-weight: 600;
 		margin-bottom: 0.5rem;
 	}
+
+	&-key-container {
+		position: relative;
+	}
+
+	&-textarea {
+		width: 100%;
+		padding: 0.5rem 2.5rem 0.5rem 0.5rem;
+		font-size: 0.75rem;
+		line-height: 1.5;
+		color: var(--color-neutral-70, #1d2327);
+		background-color: var(--studio-gray-0, #f0f0f0);
+		border: 1px solid var(--color-neutral-5, #dcdcde);
+		border-radius: 4px;
+		resize: none;
+		outline: none;
+		box-sizing: border-box;
+		word-break: break-all;
+	}
+
+	&-username-container {
+		position: relative;
+	}
+
+	&-username-field {
+		input.is-disabled {
+			padding-right: 2.5rem;
+			background-color: var(--studio-gray-0, #f0f0f0);
+			border: 1px solid var(--color-neutral-5, #dcdcde) !important;
+			border-color: var(--color-neutral-5, #dcdcde) !important;
+			color: var(--color-neutral-70, #1d2327);
+			cursor: default;
+		}
+	}
+
+	&-edit-button,
+	&-copy-button {
+		position: absolute;
+		right: 0.5rem;
+		padding: 0.25rem;
+		background: transparent;
+		border: none;
+		box-shadow: none;
+
+		&:hover,
+		&:focus,
+		&:active {
+			background: transparent;
+			border: none;
+			box-shadow: none;
+		}
+	}
+
+	&-edit-button {
+		bottom: 0.1875rem;
+		right: 0.375rem;
+		min-width: auto;
+	}
+
+	&-copy-button {
+		top: 0.5rem;
+	}
+
+	&-help-text {
+		margin-top: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--color-neutral-50, #646970);
+		line-height: 1.5;
+	}
+}
+
+.site-migration-ssh__step-share-ssh-auth-method {
+	margin-bottom: 1rem;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Add the `SSH Key` form on the `Share SSH Access` section.
* This form will allow the user to copy the SSH Key so they can use it to start the migration.

<img width="722" height="675" alt="Captura de Tela 2025-10-30 às 12 01 40" src="https://github.com/user-attachments/assets/5d8d2084-e939-471c-a9eb-6f14e788cd1c" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to allow the users to migrate using the SSH Key we generate when we create a migration. This way, they can choose to not share the Username/Password, but instead use the SSH Key so we can have access to their site. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 194149-ghe-Automattic/wpcom to your sandbox, and ensure the public-API is sandboxed. 
* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the migration flow with a fresh simple site until you reach the `Securely share your access`
* Go through the accordion, and on the third step, click on the `SSH Key` radio option
* Add a username and click on `Generate SSH key`
* After it finishes loading, you should see the SSH Key.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?