### PR TITLE
Add support to persistent user events on Survicate

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -1,4 +1,4 @@
-import { getCurrentUser, recordTracksEvent } from '@automattic/calypso-analytics';
+import { getCurrentUser, recordTracksEvent, analyticsEvents } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { isMobile } from '@automattic/viewport';
 import debug from 'debug';
@@ -7,6 +7,335 @@ const survicateDebug = debug( 'calypso:analytics:survicate' );
 
 let survicateScriptLoaded = false;
 const workspaceId = 'e4794374cce15378101b63de24117572';
+
+const SURVICATE_BRIDGED_EVENTS = [
+	'calypso_launchpad_task_clicked',
+	'calypso_customer_home_my_site_edit_homepage_click',
+	'calypso_customer_home_my_site_change_theme_click',
+	'calypso_customer_home_my_site_write_post_click',
+];
+
+const SURVICATE_DEFERRED_EVENTS = SURVICATE_BRIDGED_EVENTS;
+const SURVICATE_PENDING_EVENTS_STORAGE_KEY = 'calypso:survicate:pending-events';
+const SURVICATE_PENDING_EVENT_TTL_IN_MS = 1000 * 60 * 60 * 24;
+
+let cachedSessionStorage;
+
+const getSessionStorage = () => {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	if ( cachedSessionStorage !== undefined ) {
+		return cachedSessionStorage || undefined;
+	}
+
+	try {
+		cachedSessionStorage = window.sessionStorage;
+	} catch ( error ) {
+		cachedSessionStorage = null;
+		survicateDebug( 'Session storage not accessible', error );
+	}
+
+	return cachedSessionStorage || undefined;
+};
+
+const getCurrentPathSignature = () => {
+	if ( typeof window === 'undefined' ) {
+		return '';
+	}
+
+	return window.location.pathname || '';
+};
+
+const normalisePathSignature = ( path ) => {
+	if ( typeof path !== 'string' || ! path ) {
+		return '';
+	}
+
+	const queryIndex = path.indexOf( '?' );
+	const hashIndex = path.indexOf( '#' );
+	let endIndex = path.length;
+
+	if ( queryIndex !== -1 ) {
+		endIndex = queryIndex;
+	}
+
+	if ( hashIndex !== -1 && hashIndex < endIndex ) {
+		endIndex = hashIndex;
+	}
+
+	return path.slice( 0, endIndex );
+};
+
+const pruneExpiredPendingSurvicateEvents = ( events ) => {
+	const now = Date.now();
+
+	return events.filter(
+		( event ) =>
+			event &&
+			typeof event.eventName === 'string' &&
+			typeof event.path === 'string' &&
+			typeof event.timestamp === 'number' &&
+			now - event.timestamp < SURVICATE_PENDING_EVENT_TTL_IN_MS
+	);
+};
+
+const readPendingSurvicateEvents = () => {
+	const storage = getSessionStorage();
+
+	if ( ! storage ) {
+		return [];
+	}
+
+	try {
+		const raw = storage.getItem( SURVICATE_PENDING_EVENTS_STORAGE_KEY );
+
+		if ( ! raw ) {
+			return [];
+		}
+
+		const parsed = JSON.parse( raw );
+
+		if ( Array.isArray( parsed ) ) {
+			return pruneExpiredPendingSurvicateEvents( parsed );
+		}
+	} catch ( error ) {
+		survicateDebug( 'Failed to read Survicate pending events', error );
+	}
+
+	return [];
+};
+
+const writePendingSurvicateEvents = ( events ) => {
+	const storage = getSessionStorage();
+
+	if ( ! storage ) {
+		return;
+	}
+
+	try {
+		if ( ! events.length ) {
+			storage.removeItem( SURVICATE_PENDING_EVENTS_STORAGE_KEY );
+			return;
+		}
+
+		storage.setItem( SURVICATE_PENDING_EVENTS_STORAGE_KEY, JSON.stringify( events ) );
+	} catch ( error ) {
+		survicateDebug( 'Failed to write Survicate pending events', error );
+	}
+};
+
+const persistPendingSurvicateEvent = ( eventName, path = getCurrentPathSignature() ) => {
+	const storage = getSessionStorage();
+
+	if ( ! storage ) {
+		return;
+	}
+
+	const normalisedPath = normalisePathSignature( path );
+
+	if ( ! normalisedPath ) {
+		return;
+	}
+
+	const pendingEvents = readPendingSurvicateEvents();
+	const existingIndex = pendingEvents.findIndex(
+		( event ) => event.eventName === eventName && event.path === normalisedPath
+	);
+	const timestamp = Date.now();
+
+	if ( existingIndex > -1 ) {
+		pendingEvents[ existingIndex ].timestamp = timestamp;
+	} else {
+		pendingEvents.push( { eventName, path: normalisedPath, timestamp } );
+	}
+
+	writePendingSurvicateEvents( pendingEvents );
+};
+
+const takePendingSurvicateEventsForPath = ( path ) => {
+	const storage = getSessionStorage();
+
+	if ( ! storage ) {
+		return [];
+	}
+
+	const normalisedPath = normalisePathSignature( path );
+
+	if ( ! normalisedPath ) {
+		return [];
+	}
+
+	const pendingEvents = readPendingSurvicateEvents();
+
+	if ( ! pendingEvents.length ) {
+		return [];
+	}
+
+	const eventsForPath = [];
+	const remainingEvents = [];
+
+	pendingEvents.forEach( ( event ) => {
+		if ( event.path === normalisedPath ) {
+			eventsForPath.push( event );
+		} else {
+			remainingEvents.push( event );
+		}
+	} );
+
+	if ( remainingEvents.length !== pendingEvents.length ) {
+		writePendingSurvicateEvents( remainingEvents );
+	}
+
+	return eventsForPath.map( ( event ) => event.eventName );
+};
+
+const removePendingSurvicateEvent = ( eventName, path ) => {
+	const storage = getSessionStorage();
+
+	if ( ! storage ) {
+		return;
+	}
+
+	const normalisedPath = normalisePathSignature( path );
+
+	if ( ! normalisedPath ) {
+		return;
+	}
+
+	const pendingEvents = readPendingSurvicateEvents();
+
+	if ( ! pendingEvents.length ) {
+		return;
+	}
+
+	const filteredEvents = pendingEvents.filter(
+		( event ) => ! ( event.eventName === eventName && event.path === normalisedPath )
+	);
+
+	if ( filteredEvents.length === pendingEvents.length ) {
+		return;
+	}
+
+	writePendingSurvicateEvents( filteredEvents );
+};
+
+const survicateEventQueue = [];
+let isSurvicateEventListenerRegistered = false;
+
+const isSurvicateAvailable = () => {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	// eslint-disable-next-line no-undef
+	return typeof _sva !== 'undefined' && typeof _sva.invokeEvent === 'function';
+};
+
+const invokeSurvicateEvent = ( eventName ) => {
+	// eslint-disable-next-line no-undef
+	_sva.invokeEvent( eventName );
+	survicateDebug( 'Survicate event invoked: ' + eventName );
+};
+
+const flushSurvicateEventQueue = () => {
+	if ( ! isSurvicateAvailable() || ! survicateEventQueue.length ) {
+		return;
+	}
+
+	while ( survicateEventQueue.length ) {
+		const queuedEventName = survicateEventQueue.shift();
+
+		try {
+			invokeSurvicateEvent( queuedEventName );
+			removePendingSurvicateEvent( queuedEventName, getCurrentPathSignature() );
+		} catch ( error ) {
+			survicateDebug( 'Failed to invoke Survicate event: ' + queuedEventName, error );
+			persistPendingSurvicateEvent( queuedEventName, getCurrentPathSignature() );
+		}
+	}
+};
+
+const queuePendingSurvicateEventsForPath = ( path ) => {
+	const normalisedPath = normalisePathSignature( path );
+
+	if ( ! normalisedPath ) {
+		return;
+	}
+
+	const pendingEvents = takePendingSurvicateEventsForPath( normalisedPath );
+
+	if ( ! pendingEvents.length ) {
+		return;
+	}
+
+	pendingEvents.forEach( ( eventName ) => {
+		survicateEventQueue.push( eventName );
+	} );
+	survicateDebug( 'Recovered Survicate events for path: ' + normalisedPath, pendingEvents );
+	flushSurvicateEventQueue();
+};
+
+const handleTracksRecordEvent = ( eventName, eventProperties = {} ) => {
+	if ( SURVICATE_BRIDGED_EVENTS.includes( eventName ) ) {
+		const targetPathForPersistence =
+			typeof eventProperties === 'object' &&
+			typeof eventProperties.survicate_target_path === 'string'
+				? eventProperties.survicate_target_path
+				: getCurrentPathSignature();
+
+		if ( ! mayWeLoadSurvicateScript() ) {
+			survicateDebug( 'Skipping Survicate event because script is disabled', eventName );
+			return;
+		}
+
+		const shouldDeferEvent = SURVICATE_DEFERRED_EVENTS.includes( eventName );
+
+		if ( shouldDeferEvent ) {
+			persistPendingSurvicateEvent( eventName, targetPathForPersistence );
+			survicateDebug( 'Deferred Survicate event until matching page load: ' + eventName );
+			return;
+		}
+
+		if ( isSurvicateAvailable() ) {
+			try {
+				invokeSurvicateEvent( eventName );
+			} catch ( error ) {
+				survicateDebug( 'Failed to invoke Survicate event: ' + eventName, error );
+				persistPendingSurvicateEvent( eventName, targetPathForPersistence );
+			}
+			return;
+		}
+
+		survicateDebug( 'Queueing Survicate event until script is ready: ' + eventName );
+		survicateEventQueue.push( eventName );
+		persistPendingSurvicateEvent( eventName, targetPathForPersistence );
+		return;
+	}
+
+	if ( eventName === 'calypso_page_view' ) {
+		const targetPath =
+			typeof eventProperties === 'object' &&
+			typeof eventProperties.path === 'string' &&
+			eventProperties.path
+				? eventProperties.path
+				: getCurrentPathSignature();
+
+		queuePendingSurvicateEventsForPath( targetPath );
+	}
+};
+
+const registerSurvicateEventListener = () => {
+	if ( isSurvicateEventListenerRegistered || SURVICATE_BRIDGED_EVENTS.length === 0 ) {
+		return;
+	}
+
+	isSurvicateEventListenerRegistered = true;
+	analyticsEvents.on( 'record-event', handleTracksRecordEvent );
+};
+registerSurvicateEventListener();
+queuePendingSurvicateEventsForPath( getCurrentPathSignature() );
 
 /**
  * Sets Survicate visitor traits with current user data
@@ -41,6 +370,7 @@ const setSurvicateVisitorTraits = () => {
 			email: user.email,
 		} );
 		survicateDebug( 'Survicate visitor traits set with email: ' + user.email );
+		flushSurvicateEventQueue();
 	} else {
 		survicateDebug( 'Survicate _sva object not available' );
 	}
@@ -78,7 +408,10 @@ export function addSurvicate() {
 	}
 
 	if ( survicateScriptLoaded ) {
-		setTimeout( setSurvicateVisitorTraits, 1000 );
+		setTimeout( () => {
+			setSurvicateVisitorTraits();
+			flushSurvicateEventQueue();
+		}, 1000 );
 		survicateDebug( 'Survicate script already loaded' );
 		return;
 	}
@@ -96,7 +429,10 @@ export function addSurvicate() {
 		// Wait for the script to load before setting visitor traits
 		s.onload = function () {
 			survicateDebug( 'Survicate script loaded' );
-			setTimeout( setSurvicateVisitorTraits, 1000 );
+			setTimeout( () => {
+				setSurvicateVisitorTraits();
+				flushSurvicateEventQueue();
+			}, 1000 );
 		};
 
 		s.onerror = function () {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This is a POC to understand what's needed to have user events with a persistent strategy on Survicate
Slack thread: p1761770314363039/1760355528.402659-slack-C06FCT6EEHH

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?