### PR TITLE
Hosting Dashboard Emails: Wrong max email forwards error

### DIFF
--- a/client/dashboard/emails/add-forwarder/hooks/use-domain-max-forwards.ts
+++ b/client/dashboard/emails/add-forwarder/hooks/use-domain-max-forwards.ts
@@ -1,11 +1,13 @@
 import { emailForwardersQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 
+export const DEFAULT_MAX_DOMAIN_FORWARDS = 100;
+
 export const useDomainMaxForwards = ( domain: string ) => {
 	const { data, isLoading } = useQuery( { ...emailForwardersQuery( domain ), enabled: !! domain } );
 
 	if ( ! data ) {
-		return { isLoading, forwards: [], maxForwards: 100 };
+		return { isLoading, forwards: [], maxForwards: DEFAULT_MAX_DOMAIN_FORWARDS };
 	}
 
 	const { forwards, max_forwards } = data;

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -131,7 +131,7 @@ function AddEmailForwarder() {
 	const allFieldsSet = formData.localPart && formData.domain && formData.forwardingAddresses.length;
 
 	const isDomainMaxForwardsReached =
-		forwards?.length ?? 0 >= ( maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS );
+		( forwards?.length ?? 0 ) >= ( maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS );
 	const willDomainMaxForwardsBeReached =
 		( forwards?.length ?? 0 ) + formData.forwardingAddresses.length >
 		( maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS );

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -20,7 +20,7 @@ import { Text } from '../../components/text';
 import AddNewDomain from '../components/add-new-domain';
 import { BackToEmailsPrefix } from '../components/back-to-emails-prefix';
 import { useDomains } from '../hooks/use-domains';
-import { useDomainMaxForwards } from './hooks/use-domain-max-forwards';
+import { DEFAULT_MAX_DOMAIN_FORWARDS, useDomainMaxForwards } from './hooks/use-domain-max-forwards';
 import { useForwardingAddresses } from './hooks/use-forwarding-addresses';
 import type { Field } from '@wordpress/dataviews';
 
@@ -129,9 +129,13 @@ function AddEmailForwarder() {
 		isLoadingDomainMaxForwards ||
 		isLoadingNewForwardingAddresses;
 	const allFieldsSet = formData.localPart && formData.domain && formData.forwardingAddresses.length;
-	const isDomainMaxForwardsReached = ( forwards?.length ?? 0 ) >= maxForwards;
+
+	const isDomainMaxForwardsReached =
+		forwards?.length ?? 0 >= ( maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS );
 	const willDomainMaxForwardsBeReached =
-		( forwards?.length ?? 0 ) + formData.forwardingAddresses.length > maxForwards;
+		( forwards?.length ?? 0 ) + formData.forwardingAddresses.length >
+		( maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS );
+
 	const duplicateForwardAddress = formData.forwardingAddresses.find(
 		( addr ) => forwardsByMailbox.get( `${ formData.localPart }@${ formData.domain }` ) === addr
 	);

--- a/packages/api-core/src/domain-email/fetchers.ts
+++ b/packages/api-core/src/domain-email/fetchers.ts
@@ -11,9 +11,9 @@ type EmailForwarder = {
 
 type EmailForwardersResult = {
 	type: 'forward';
-	forwards: EmailForwarder[];
+	forwards: null | EmailForwarder[];
 	mx_servers: null | string[];
-	max_forwards: number;
+	max_forwards: null | number;
 };
 
 export async function fetchEmailForwarders( domain: string ): Promise< EmailForwardersResult > {

--- a/packages/api-core/src/domain-email/fetchers.ts
+++ b/packages/api-core/src/domain-email/fetchers.ts
@@ -11,9 +11,9 @@ type EmailForwarder = {
 
 type EmailForwardersResult = {
 	type: 'forward';
-	forwards: null | EmailForwarder[];
-	mx_servers: null | string[];
-	max_forwards: null | number;
+	forwards: EmailForwarder[] | null;
+	mx_servers: string[] | null;
+	max_forwards: number | null;
 };
 
 export async function fetchEmailForwarders( domain: string ): Promise< EmailForwardersResult > {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-747

## Proposed Changes

* There's an error message showing `NaN` as the maximum number of email forwards. That happens because after removing a google subscription the data returned by the `/domains/${ domain }/email` API endpoint is `null` for both `forwards` and `max_forwards`. In those cases, we'll fall back to the default `max_forwards`, which is 100.

<img width="1424" height="1208" alt="image" src="https://github.com/user-attachments/assets/66774dbc-6ebd-4a39-bb9f-9e661091721f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to modernize the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/v2/emails`.
* You need to have a google workspace mailbox.
* Cancel and remove the subscription for that mailbox, so that it doesn't show up on the emails dashboard.
* Check that you can add a forwarder to that domain after removing the subscription, and that it works:

<img width="3007" height="1280" alt="image" src="https://github.com/user-attachments/assets/71a8d587-0ae6-4d06-8926-4c640acc6a17" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
