### PR TITLE
Do not show the "Free for the first year" discount in domain-only flow

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -355,13 +355,13 @@ const DomainSearchUI = (
 	};
 
 	// For /start flows, we want to show the free domain for a year discount for all flows
-	// except if we're in a site context or in the free or monthly plan flows
+	// except if we're in a site context, in the free or monthly plan flows or in the domain-only flow
 	const isFirstDomainFreeForFirstYear = useMemo( () => {
-		if ( siteSlug || siteId || isMonthlyOrFreeFlow( flowName ) ) {
+		if ( siteSlug || siteId || isMonthlyOrFreeFlow( flowName ) || isDomainOnlyFlow ) {
 			return false;
 		}
 		return true;
-	}, [ flowName, siteSlug, siteId ] );
+	}, [ flowName, siteSlug, siteId, isDomainOnlyFlow ] );
 
 	return (
 		<StepWrapper


### PR DESCRIPTION
Part of [DOMENG-213](https://linear.app/a8c/issue/DOMENG-213)

## Proposed Changes

This PR removes the $0 "Free for the first year" discount from the domain-only flow (`/start/domain`).

### Screenshots

| Before | After |
| --- | --- |
| <img width="1021" height="1063" alt="Screenshot 2025-10-29 at 19 26 52" src="https://github.com/user-attachments/assets/bfcfc94e-95e4-488a-a6de-0b9e357e2cf4" /> | <img width="1021" height="1063" alt="Screenshot 2025-10-29 at 19 22 16" src="https://github.com/user-attachments/assets/3a44d119-1560-43a8-bc51-4871e9ce36fe" /> |

## Why are these changes being made?

This flow shouldn't show that discount since it applies only when domains are bought alongside plans, and the domain-only flow is used to sell standalone domains primarily. We give users the option to upsell by buying a plan, but only in the following step.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain only flow (`/start/domain`)
- Ensure the domains show their normal prices, and not the "Free for the first year" discount
- Visit other `/start/ flows (e.g. `/start/premium`, `/start/business`, `/start/onboarding-with-email`) and ensure the discount is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
