### PR TITLE
MSD: Improve mobile layout for domain and purchase overview

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-cards.tsx
+++ b/client/dashboard/domains/domain-overview/featured-cards.tsx
@@ -2,18 +2,28 @@ import { DomainSubtype } from '@automattic/api-core';
 import { domainQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { domainRoute } from '../../app/router/domains';
 import FeaturedCardEmails from './featured-card-emails';
 import FeaturedCardPrivacy from './featured-card-privacy';
 import FeaturedCardRenew from './featured-card-renew';
 import FeaturedCardSite from './featured-card-site';
 
+const SPACING = {
+	DEFAULT: 6,
+	SMALL: 4,
+};
+
 export default function FeaturedCards() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const columns = isSmallViewport ? 1 : 2;
+	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+
 	return (
-		<Grid columns={ 2 }>
+		<Grid columns={ columns } gap={ spacing }>
 			{ domain.subtype.id !== DomainSubtype.DOMAIN_CONNECTION && (
 				<FeaturedCardRenew domain={ domain } />
 			) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -34,6 +34,7 @@ import {
 	Notice,
 	ExternalLink,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -83,6 +84,11 @@ import type { User, Purchase, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 import './style.scss';
+
+const SPACING = {
+	DEFAULT: 6,
+	SMALL: 4,
+};
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
@@ -1039,6 +1045,10 @@ export default function PurchaseSettings() {
 		return __( 'Expires' );
 	} )();
 
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const columns = isSmallViewport ? 1 : 2;
+	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+
 	return (
 		<PageLayout
 			size="small"
@@ -1074,7 +1084,7 @@ export default function PurchaseSettings() {
 		>
 			<VStack spacing={ 6 }>
 				<PurchaseNotice purchase={ purchase } />
-				<Grid columns={ 2 } rows={ 2 } gap={ 6 }>
+				<Grid columns={ columns } gap={ spacing }>
 					<OverviewCard
 						icon={ calendar }
 						title={ expiryDateTitle }


### PR DESCRIPTION
## Proposed Changes

Improve layout when viewport width is < 782px.

| Before | After |
| --- | --- |
|<img width="457" height="959" alt="SCR-20251030-nluc" src="https://github.com/user-attachments/assets/e982a4f1-24ed-4db3-a1f2-f852f825935d" /> | <img width="452" height="954" alt="SCR-20251030-nlqb" src="https://github.com/user-attachments/assets/8c8a836a-c41e-4d84-807a-7fd96d8347bd" /> |

| Before | After |
| --- | --- |
| <img width="494" height="974" alt="SCR-20251030-nmmf" src="https://github.com/user-attachments/assets/8b231f8c-7577-4fa4-bdd4-3d28b83275c0" /> | <img width="461" height="968" alt="SCR-20251030-nmhm" src="https://github.com/user-attachments/assets/2f9db5ab-a7e5-4493-9266-c1fefc600f26" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/domains or /v2/me/billing/purchases
* Select any item to see its overview screen
* Ensure that the layout is updated as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
