### PR TITLE
MSD: Fix the style of the PurchaseItemSiteIcon

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -183,10 +183,9 @@ function OwnerInfo( {
 
 export function PurchaseSettingLink( {
 	purchase,
-	isTransferred,
+	disabled,
 	...props
-}: ComponentProps< typeof Link > & { purchase: Purchase; isTransferred: boolean } ) {
-	const disabled = isTransferred;
+}: ComponentProps< typeof Link > & { purchase: Purchase; disabled: boolean } ) {
 	return (
 		<Link
 			{ ...props }
@@ -247,11 +246,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				const isTransferred = isTransferredOwnership( item.ID, transferredPurchases );
 				return (
-					<PurchaseSettingLink
-						purchase={ item }
-						isTransferred={ isTransferred }
-						style={ { zIndex: 1 } }
-					>
+					<PurchaseSettingLink purchase={ item } disabled={ isTransferred } style={ { zIndex: 1 } }>
 						<PurchaseItemSiteIcon purchase={ item } site={ site } />
 					</PurchaseSettingLink>
 				);
@@ -282,7 +277,7 @@ export function getFields( {
 				const isTransferred = isTransferredOwnership( item.ID, transferredPurchases );
 				return (
 					<HStack justify="flex-start" spacing={ 1 }>
-						<PurchaseSettingLink purchase={ item } isTransferred={ isTransferred }>
+						<PurchaseSettingLink purchase={ item } disabled={ isTransferred }>
 							{ getTitleForDisplay( item ) }
 						</PurchaseSettingLink>
 						<OwnerInfo purchase={ item } isTransferredOwnership={ isTransferred } />

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -1,6 +1,6 @@
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { Popover, Icon } from '@wordpress/components';
+import { __experimentalHStack as HStack, Popover, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
@@ -23,7 +23,7 @@ import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
 import type { StoredPaymentMethod, Purchase, Site } from '@automattic/api-core';
 import type { SortDirection, View, Fields } from '@wordpress/dataviews';
-import type { ReactNode } from 'react';
+import type { ReactNode, ComponentProps } from 'react';
 
 import './style.scss';
 
@@ -53,9 +53,15 @@ export const purchasesDataView: View = {
 
 function BillingPurchaseInfoPopover( { children }: { children: ReactNode } ) {
 	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
+	const handleClick = ( event: React.MouseEvent< HTMLButtonElement > ) => {
+		event.preventDefault();
+		event.stopPropagation();
+		setIsTooltipVisible( ( val ) => ! val );
+	};
+
 	return (
-		<span className="purchase-payment-method__backup-icon">
-			<Icon icon={ info } onClick={ () => setIsTooltipVisible( ( val ) => ! val ) } />
+		<span style={ { display: 'inline-flex', pointerEvents: 'auto' } }>
+			<Button icon={ info } iconSize={ 24 } size="small" onClick={ handleClick } />
 			{ isTooltipVisible && (
 				<Popover className="billing-purchase-info-popover">{ children }</Popover>
 			) }
@@ -156,7 +162,7 @@ function OwnerInfo( {
 			{ createInterpolateElement(
 				// translators: domain is a domain name
 				__(
-					"This license was activated on <domain /> by another user. If you haven't given the license to them on purpose, <link>contact our support team</link> for more assistance."
+					'This license was activated on <domain /> by another user. If you haven’t given the license to them on purpose, <link>contact our support team</link> for more assistance.'
 				),
 				{
 					domain: <strong>{ purchase.domain || purchase.site_slug || __( 'a site' ) }</strong>,
@@ -173,6 +179,30 @@ function OwnerInfo( {
 	);
 
 	return <BillingPurchaseInfoPopover>{ tooltipContent }</BillingPurchaseInfoPopover>;
+}
+
+export function PurchaseSettingLink( {
+	purchase,
+	isTransferred,
+	...props
+}: ComponentProps< typeof Link > & { purchase: Purchase; isTransferred: boolean } ) {
+	const disabled = isTransferred;
+	return (
+		<Link
+			{ ...props }
+			to={ purchaseSettingsRoute.fullPath }
+			params={ { purchaseId: purchase.ID } }
+			title={ __( 'Manage purchase' ) }
+			disabled={ disabled }
+			style={ {
+				width: 'auto',
+				minWidth: 'unset',
+				textDecoration: 'none',
+				pointerEvents: disabled ? 'none' : undefined,
+				...props.style,
+			} }
+		/>
+	);
 }
 
 export function getFields( {
@@ -215,14 +245,15 @@ export function getFields( {
 			// Render the site icon
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
+				const isTransferred = isTransferredOwnership( item.ID, transferredPurchases );
 				return (
-					<Link
-						to={ purchaseSettingsRoute.fullPath }
-						params={ { purchaseId: item.ID } }
-						title={ __( 'Manage purchase' ) }
+					<PurchaseSettingLink
+						purchase={ item }
+						isTransferred={ isTransferred }
+						style={ { zIndex: 1 } }
 					>
 						<PurchaseItemSiteIcon purchase={ item } site={ site } />
-					</Link>
+					</PurchaseSettingLink>
 				);
 			},
 		},
@@ -250,20 +281,12 @@ export function getFields( {
 			render: ( { item }: { item: Purchase } ) => {
 				const isTransferred = isTransferredOwnership( item.ID, transferredPurchases );
 				return (
-					<div>
-						{ isTransferred ? (
-							getTitleForDisplay( item ) + '&nbsp;'
-						) : (
-							<Link
-								to={ purchaseSettingsRoute.fullPath }
-								params={ { purchaseId: item.ID } }
-								title={ __( 'Manage purchase' ) }
-							>
-								{ getTitleForDisplay( item ) }
-							</Link>
-						) }
+					<HStack justify="flex-start" spacing={ 1 }>
+						<PurchaseSettingLink purchase={ item } isTransferred={ isTransferred }>
+							{ getTitleForDisplay( item ) }
+						</PurchaseSettingLink>
 						<OwnerInfo purchase={ item } isTransferredOwnership={ isTransferred } />
-					</div>
+					</HStack>
 				);
 			},
 		},
@@ -422,10 +445,10 @@ export function getFields( {
 				}
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<>
+					<HStack justify="flex-start" spacing={ 1 }>
 						<PurchasePaymentMethod purchase={ item } isDisconnectedSite={ ! site } />
 						{ isBackupMethodAvailable && isRenewing( item ) && <BackupPaymentMethodNotice /> }
-					</>
+					</HStack>
 				);
 			},
 		},

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -191,7 +191,7 @@ export function PurchaseSettingLink( {
 		<Link
 			{ ...props }
 			to={ purchaseSettingsRoute.fullPath }
-			params={ { purchaseId: purchase.ID } }
+			params={ Object.assign( {}, props.params, { purchaseId: purchase.ID } ) }
 			title={ __( 'Manage purchase' ) }
 			disabled={ disabled }
 			style={ {

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -181,7 +181,7 @@ function OwnerInfo( {
 	return <BillingPurchaseInfoPopover>{ tooltipContent }</BillingPurchaseInfoPopover>;
 }
 
-export function PurchaseSettingLink( {
+function PurchaseSettingLink( {
 	purchase,
 	disabled,
 	...props

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -16,14 +16,6 @@ img.payment-method-image {
 	width: fit-content;
 }
 
-.purchase-payment-method__backup-icon {
-	height: 24px;
-
-	& path {
-		fill: #757575;
-	}
-}
-
 button.purchase-payment-method__update {
 	// This button is inside a flexbox (HStack) which has `min-width: 0` set on
 	// all its children, but this overrides the default of `min-width: auto`


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Remove the underline of the letter icon
* Fix the icon is not clickable
* Fix the single quote

| Before | After |
| - | - |
|<img width="318" height="63" alt="image" src="https://github.com/user-attachments/assets/d4d53c4d-c7be-4eec-89c5-5b7280fdad07" />|<img width="311" height="59" alt="image" src="https://github.com/user-attachments/assets/5cac5869-0986-4938-bed9-8cb53f55c8ec" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the styles issue on letter icon and make it clickable

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/me/billing/purchases
* Ensure the letter icon won't have underline
* Ensure the icon is clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
