### PR TITLE
MSD: Don't show dropdown menu on purchase settings screen if no available action

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -221,37 +221,41 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 		purchase.can_explicit_renew && String( user.ID ) === String( purchase.user_id );
 	const upgradeUrl = getUpgradeUrl( purchase );
 	const { recordTracksEvent } = useAnalytics();
+	const menuItems = [
+		canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
+			<MenuItem
+				onClick={ () => {
+					recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+						status: isExpired( purchase ) ? 'expired' : 'active',
+						plan: purchase.product_name,
+					} );
+					upgradePurchase( upgradeUrl );
+				} }
+			>
+				{ __( 'Upgrade' ) }
+			</MenuItem>
+		),
+		canBeRenewed && (
+			<MenuItem
+				onClick={ () => {
+					recordTracksEvent( 'calypso_purchases_renew_now_click', {
+						product_slug: purchase.product_slug,
+					} );
+					renewPurchase( purchase );
+				} }
+			>
+				{ __( 'Renew' ) }
+			</MenuItem>
+		),
+	].filter( Boolean );
+
+	if ( menuItems.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
-			{ () => (
-				<MenuGroup>
-					{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
-						<MenuItem
-							onClick={ () => {
-								recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-									status: isExpired( purchase ) ? 'expired' : 'active',
-									plan: purchase.product_name,
-								} );
-								upgradePurchase( upgradeUrl );
-							} }
-						>
-							{ __( 'Upgrade' ) }
-						</MenuItem>
-					) }
-					{ canBeRenewed && (
-						<MenuItem
-							onClick={ () => {
-								recordTracksEvent( 'calypso_purchases_renew_now_click', {
-									product_slug: purchase.product_slug,
-								} );
-								renewPurchase( purchase );
-							} }
-						>
-							{ __( 'Renew' ) }
-						</MenuItem>
-					) }
-				</MenuGroup>
-			) }
+			{ () => <MenuGroup>{ menuItems }</MenuGroup> }
 		</DropdownMenu>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Don't show dropdown menu on purchase settings screen if no available action

| Before | After |
| - | - |
|<img width="723" height="165" alt="image" src="https://github.com/user-attachments/assets/10ec2a96-a8f2-492d-9579-9daa88d612ad" />|<img width="718" height="162" alt="image" src="https://github.com/user-attachments/assets/a77b5d2b-a1ae-41c6-a759-c9b7fb50bd3f" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/me/billing/purchases/:purchaseId
* Before this change, it might show the dropdown without any action
* After this change, it won't show the dropdown if no available action

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
