### PR TITLE
Domain Connection redesign: shows new verification in connection mode is enable

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,4 +1,6 @@
+import { domainMappingStatusQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Icon,
 	__experimentalText as Text,
@@ -12,19 +14,27 @@ import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { isMappingVerificationSuccess } from './utils';
 import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
+import type { DomainMappingSetupInfo } from '@automattic/api-core';
 
 interface DomainConnectionVerificationProps {
 	domainName: string;
 	siteSlug: string;
-	status: 'verifying' | 'connected';
+	domainConnectionSetupInfo: DomainMappingSetupInfo;
+	queryError: string | null;
+	queryErrorDescription: string | null;
 }
 
 export default function DomainConnectionVerification( {
 	domainName,
 	siteSlug,
-	status,
 }: DomainConnectionVerificationProps ) {
+	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
+	const status = isMappingVerificationSuccess( domainMappingStatus.mode, domainMappingStatus )
+		? 'connected'
+		: 'verifying';
+
 	return (
 		<Card
 			className={ `dashboard-domain-connection-verification dashboard-domain-connection-verification--${ status }` }

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -29,7 +29,7 @@ import {
 	connectADomainDomainConnectionStepsMap,
 	connectASubdomainDomainConnectionStepsMap,
 } from './steps-map';
-import { DomainConnectionStepsMap, StepName, type StepNameValue, StepType } from './types';
+import { DomainConnectionStepsMap, StepName, type StepNameValue } from './types';
 import { getProgressStepList, isMappingVerificationSuccess, resolveStepName } from './utils';
 
 import './style.scss';
@@ -119,6 +119,9 @@ export default function DomainConnectionSetup() {
 		updateConnectionMode( currentStep.mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
 				setVerificationStatus( data );
+				if ( redesign ) {
+					return;
+				}
 				if ( setStepAfterVerify ) {
 					if ( isMappingVerificationSuccess( currentStep.mode, data ) ) {
 						setCurrentStepName( connectedSlug );
@@ -218,13 +221,13 @@ export default function DomainConnectionSetup() {
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain connection setup' ) } /> }>
-			{ ( currentStep.stepType === StepType.VERIFYING ||
-				currentStep.stepType === StepType.CONNECTED ) &&
-			redesign ? (
+			{ ( domainConnectionSetupInfo.connection_mode || verificationStatus?.mode ) && redesign ? (
 				<DomainConnectionVerification
 					domainName={ domainName }
 					siteSlug={ siteSlug }
-					status={ currentStep.stepType }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					queryError={ queryError }
+					queryErrorDescription={ queryErrorDescription }
 				/>
 			) : (
 				renderLegacyLayout()

--- a/packages/api-core/src/domain-connection-setup/fetchers.ts
+++ b/packages/api-core/src/domain-connection-setup/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DomainMappingSetupInfo } from './types';
+import type { DomainMappingSetupInfo, DomainMappingStatus } from './types';
 
 export function fetchDomainMappingSetupInfo(
 	domainName: string,
@@ -9,4 +9,8 @@ export function fetchDomainMappingSetupInfo(
 	return wpcom.req.get( `/domains/${ domainName }/mapping-setup-info/${ siteId }`, {
 		redirect_uri: redirectURL,
 	} );
+}
+
+export function fetchDomainMappingStatus( domainName: string ): Promise< DomainMappingStatus > {
+	return wpcom.req.get( `/domains/${ domainName }/mapping-status` );
 }

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -1,5 +1,6 @@
 import {
 	fetchDomainMappingSetupInfo,
+	fetchDomainMappingStatus,
 	updateConnectionModeAndGetMappingStatus,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
@@ -15,11 +16,18 @@ export const domainConnectionSetupInfoQuery = (
 		queryFn: () => fetchDomainMappingSetupInfo( domainName, siteId, redirectURL || '' ),
 	} );
 
+export const domainMappingStatusQuery = ( domainName: string ) =>
+	queryOptions( {
+		queryKey: [ 'domain-mapping-status', domainName ],
+		queryFn: () => fetchDomainMappingStatus( domainName ),
+	} );
+
 export const updateConnectionModeMutation = ( domainName: string, siteId: number ) =>
 	mutationOptions( {
 		mutationFn: ( connectionMode: string ) =>
 			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainConnectionSetupInfoQuery( domainName, siteId ) );
+			queryClient.invalidateQueries( domainMappingStatusQuery( domainName ) );
 		},
 	} );


### PR DESCRIPTION
Closes [DOMAIN-1779](https://linear.app/a8c/issue/DOMAINS-1779/default-to-verification-step-once-the-verification-process-has-started)

## Proposed Changes
Force the new verification step to render when the connection mode has been set.  
We may want to revisit this logic once the new setup step is implemented.

## Why are these changes being made?
In the new domain connection flow, the final step checks the verification status and displays errors if the connection is misconfigured.  
Therefore, there' no need to show the connection setup instructions once verification has started.

## Testing Instructions
**Page:** `/v2/domains/[DOMAIN]/domain-connection-setup`

1. Visit the URL for a domain **with a connection mode set** that **resolves to WordPress.com** → the new page should render, showing the **“Connected”** status.  
2. Visit the URL for a domain **with a connection mode set** that **does not resolve to WordPress.com** → the new page should render, showing the **“Verifying”** status.  
3. Visit the URL for a domain **without a connection mode set** (cancel the `connection_mode_flag`) → the **setup screen** should be rendered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
