### PR TITLE
Domain Search: Track the search query when submit button is clicked

### DIFF
--- a/client/components/domains/wpcom-domain-search/analytics.ts
+++ b/client/components/domains/wpcom-domain-search/analytics.ts
@@ -49,10 +49,15 @@ export const recordUseYourDomainButtonClick = (
 		} )
 	);
 
-export const recordSearchFormSubmitButtonClick = ( section: string, flowName: string ) =>
+export const recordSearchFormSubmitButtonClick = (
+	query: string,
+	section: string,
+	flowName: string
+) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Clicked "Search domains" Button' ),
 		recordTracksEvent( 'calypso_domain_search_submit_button_click', {
+			search_query: query,
 			section,
 			flow_name: flowName,
 		} )

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -696,6 +696,7 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		expect( onSubmitButtonClick ).toHaveBeenCalledWith( 'my-domain.com' );
 
 		expect( recordSearchFormSubmitButtonClick ).toHaveBeenCalledWith(
+			'my-domain.com',
 			'analytics-section',
 			'flow-name'
 		);

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -117,8 +117,8 @@ export const useWPCOMDomainSearchEvents = ( {
 			onExternalDomainClick: () => {
 				dispatch( recordUseYourDomainButtonClick( analyticsSection, null, flowName ) );
 			},
-			onSubmitButtonClick: () => {
-				dispatch( recordSearchFormSubmitButtonClick( analyticsSection, flowName ) );
+			onSubmitButtonClick: ( query ) => {
+				dispatch( recordSearchFormSubmitButtonClick( query, analyticsSection, flowName ) );
 			},
 			onQueryAvailabilityCheck: ( status, domainName, responseTime ) => {
 				dispatch(

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -55,7 +55,7 @@ export const SearchForm = () => {
 						autoFocus
 					/>
 					{ activeQuery === 'large' && (
-						<DomainSearchControls.Submit onClick={ onSubmitButtonClick } />
+						<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />
 					) }
 				</HStack>
 				{ showSearchHint && (

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -41,7 +41,7 @@ export interface DomainSearchEvents {
 	onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => void;
 	onCheckTransferStatusClick: ( domainName: string ) => void;
 	onMapDomainClick: ( domainName: string ) => void;
-	onSubmitButtonClick: () => void;
+	onSubmitButtonClick: ( query: string ) => void;
 	onQueryChange: ( query: string ) => void;
 	onQueryClear: () => void;
 	onAddDomainToCart: (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1778](https://linear.app/a8c/issue/DOMAINS-1778/add-exposure-event-to-the-domain-search-submit-button)

## Proposed Changes

* This PR adds the search query when we track the "Search domains" button click.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This will allow us to filter out users who didn't fill out the form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/domains`
* Enable analytics debugging by entering the following in the browser's console: `localStorage.debug='calypso:analytics'`
* Don't fill the form and click the "Search domains" button.
* Check the console and make sure the `calypso_domain_search_submit_button_click` event is fired.
* Make sure the "search_query" is an empty string.
* Fill the form and click the "Search domains" button.
* Make sure the "search_query" has the filled value.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
