### PR TITLE
Fix useLocale to return the user locale rather than 'en'

### DIFF
--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -134,8 +134,11 @@ async function switchWebpackCSS( isRTL: boolean ) {
 // slug in the route path.
 function useLocaleSlug() {
 	const { user } = useAuth();
-	type BootstrappedLocaleFields = { localeSlug?: string; localeVariant?: string };
-	const u = user as typeof user & BootstrappedLocaleFields;
+	type ComputedAttributes = {
+		localeSlug?: string;
+		localeVariant?: string;
+	};
+	const u = user as typeof user & ComputedAttributes;
 	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }
 

--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -134,7 +134,9 @@ async function switchWebpackCSS( isRTL: boolean ) {
 // slug in the route path.
 function useLocaleSlug() {
 	const { user } = useAuth();
-	return user.locale_variant || user.language || 'en';
+	type BootstrappedLocaleFields = { localeSlug?: string; localeVariant?: string };
+	const u = user as typeof user & BootstrappedLocaleFields;
+	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }
 
 export function I18nProvider( { children }: PropsWithChildren ) {

--- a/client/dashboard/app/locale/index.ts
+++ b/client/dashboard/app/locale/index.ts
@@ -1,12 +1,12 @@
 import { useAuth } from '../auth';
 
-type BootstrappedLocaleFields = {
+type ComputedAttributes = {
 	localeSlug?: string;
 	localeVariant?: string;
 };
 
 export function useLocale() {
 	const { user } = useAuth();
-	const u = user as typeof user & BootstrappedLocaleFields;
+	const u = user as typeof user & ComputedAttributes;
 	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }

--- a/client/dashboard/app/locale/index.ts
+++ b/client/dashboard/app/locale/index.ts
@@ -1,6 +1,12 @@
 import { useAuth } from '../auth';
 
+type BootstrappedLocaleFields = {
+	localeSlug?: string;
+	localeVariant?: string;
+};
+
 export function useLocale() {
 	const { user } = useAuth();
-	return user.locale_variant || user.language || 'en';
+	const u = user as typeof user & BootstrappedLocaleFields;
+	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-282

## Proposed Changes

* Piggyback on localeSlug and localeVariant for the time being so v1 hosting dashboard shows correct locale

## Why are these changes being made?

* V2 hosting dashboard relies on language and locale_variant
* Calypso relies on rewritten properties called localeSlug and localeVariant
* As a result, the V1 dashboard using this function shows incorrect date

This entire change can be undone once we switch dashboards.

## Testing Instructions

* Set the language to Bulgarian
* Visit /sites/SITE - ensure correct dates in Bulgarian
* Visit /v2/sites/SITE - ensure no regression

Before:
<img width="1430" height="645" alt="Screenshot 2025-10-30 at 12 40 36" src="https://github.com/user-attachments/assets/d4a435ac-a5ff-4b17-89c9-cd9e69748fb9" />

After:
<img width="1430" height="645" alt="Screenshot 2025-10-30 at 12 40 14" src="https://github.com/user-attachments/assets/d7de3481-1ab9-4b43-8612-16687eeaef58" />

V2:
<img width="1430" height="645" alt="Screenshot 2025-10-30 at 12 42 10" src="https://github.com/user-attachments/assets/7eb53a78-1e24-48e5-8e53-b9f8dac34d25" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
