### PR TITLE
Multi Site Dashboard: Remove site filter on PurchasesList

### DIFF
--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -83,21 +83,9 @@ export default function PurchasesList() {
 		},
 	} );
 
-	const sitesById = useMemo( () => {
-		if ( ! sites ) {
-			return {};
-		}
-		return sites.reduce( ( acc: Record< number, Site >, site ) => {
-			acc[ site.ID ] = site;
-			return acc;
-		}, {} );
-	}, [ sites ] );
-
 	const allSubscriptions = useMemo( () => {
-		return [ ...( purchases ?? [] ), ...( transferredPurchases ?? [] ) ].filter(
-			( subscription ) => !! sitesById[ subscription.blog_id ]
-		);
-	}, [ purchases, transferredPurchases, sitesById ] );
+		return [ ...( purchases ?? [] ), ...( transferredPurchases ?? [] ) ];
+	}, [ purchases, transferredPurchases ] );
 
 	const { data: filteredSubscriptions, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( allSubscriptions, currentView, purchasesDataFields );


### PR DESCRIPTION
Fixes SHILL-1260

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR reverts one of the changes made in https://github.com/Automattic/wp-calypso/pull/106657. That PR has no explanation for why it was made, but we should not hide purchases that a user has paid for. Legally we must provide a way for users to manage their purchases, particularly the ability to cancel or refund them. In addition, filtering purchases by a list of sites will exclude purchases that are for a site the user does not own, even though the user paid for them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users must be able to manage their purchases. If we need to exclude certain purchases for a business reason, it should be carefully discussed and documented so that when those users come to us to complain about being charged for something they cannot see, we are prepared to explain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/104098 to transfer a subscription to another user.
- Visit `calypso.localhost:3000/v2/me/billing/purchases` and verify that you can see your purchase.
