### PR TITLE
MSD: Load legacy or new domain connection flow based on feature flag

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -16,6 +16,7 @@ import {
 	domainAvailabilityQuery,
 	domainInboundTransferStatusQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import {
 	createRoute,
 	createLazyRoute,
@@ -553,11 +554,17 @@ export const domainConnectionSetupRoute = createRoute( {
 		);
 	},
 } ).lazy( () =>
-	import( '../../domains/domain-connection-setup' ).then( ( d ) =>
-		createLazyRoute( 'domain-connection-setup' )( {
-			component: d.default,
-		} )
-	)
+	config.isEnabled( 'domain-connection-redesign/verification' )
+		? import( '../../domains/domain-connection-setup' ).then( ( d ) =>
+				createLazyRoute( 'domain-connection-verification' )( {
+					component: d.default,
+				} )
+		  )
+		: import( '../../domains/domain-connection-setup/legacy-connection-flow' ).then( ( d ) =>
+				createLazyRoute( 'domain-connection-setup' )( {
+					component: d.default,
+				} )
+		  )
 );
 
 export const domainTransferSetupRoute = createRoute( {

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -554,7 +554,7 @@ export const domainConnectionSetupRoute = createRoute( {
 		);
 	},
 } ).lazy( () =>
-	config.isEnabled( 'domain-connection-redesign/verification' )
+	config.isEnabled( 'domain-connection-redesign' )
 		? import( '../../domains/domain-connection-setup' ).then( ( d ) =>
 				createLazyRoute( 'domain-connection-verification' )( {
 					component: d.default,

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -556,7 +556,7 @@ export const domainConnectionSetupRoute = createRoute( {
 } ).lazy( () =>
 	config.isEnabled( 'domain-connection-redesign' )
 		? import( '../../domains/domain-connection-setup' ).then( ( d ) =>
-				createLazyRoute( 'domain-connection-verification' )( {
+				createLazyRoute( 'domain-connection-setup' )( {
 					component: d.default,
 				} )
 		  )

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -1,0 +1,25 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '../../components/card';
+import type { DomainMappingSetupInfo } from '@automattic/api-core';
+
+interface DomainConnectionSetupProps {
+	domainName: string;
+	siteSlug: string;
+	domainConnectionSetupInfo: DomainMappingSetupInfo;
+}
+
+export default function DomainConnectionSetup( { domainName }: DomainConnectionSetupProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<Text>
+						{ __( 'Domain connection setup workflow' ) }
+						{ domainName }
+					</Text>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -1,15 +1,30 @@
-import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	DomainConnectionSetupMode,
+	DomainMappingSetupInfo,
+	type DomainConnectionSetupModeValue,
+} from '@automattic/api-core';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
-import type { DomainMappingSetupInfo } from '@automattic/api-core';
 
 interface DomainConnectionSetupProps {
 	domainName: string;
 	siteSlug: string;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
+	onVerifyConnection: ( mode: DomainConnectionSetupModeValue ) => void;
+	isUpdatingConnectionMode: boolean;
 }
 
-export default function DomainConnectionSetup( { domainName }: DomainConnectionSetupProps ) {
+export default function DomainConnectionSetup( {
+	domainName,
+	onVerifyConnection,
+	isUpdatingConnectionMode,
+}: DomainConnectionSetupProps ) {
 	return (
 		<Card>
 			<CardBody>
@@ -18,6 +33,23 @@ export default function DomainConnectionSetup( { domainName }: DomainConnectionS
 						{ __( 'Domain connection setup workflow' ) }
 						{ domainName }
 					</Text>
+
+					<ButtonStack justify="flex-start">
+						<Button
+							variant="primary"
+							onClick={ () => onVerifyConnection( DomainConnectionSetupMode.SUGGESTED ) }
+							isBusy={ isUpdatingConnectionMode }
+						>
+							{ __( 'Verify Connection (Suggested)' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ () => onVerifyConnection( DomainConnectionSetupMode.ADVANCED ) }
+							isBusy={ isUpdatingConnectionMode }
+						>
+							{ __( 'Verify Connection (Advanced)' ) }
+						</Button>
+					</ButtonStack>
 				</VStack>
 			</CardBody>
 		</Card>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,6 +1,4 @@
-import { domainMappingStatusQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Icon,
 	__experimentalText as Text,
@@ -16,12 +14,13 @@ import Notice from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { isMappingVerificationSuccess } from './utils';
 import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
-import type { DomainMappingSetupInfo } from '@automattic/api-core';
+import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
 
 interface DomainConnectionVerificationProps {
 	domainName: string;
 	siteSlug: string;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
+	domainMappingStatus: DomainMappingStatus;
 	queryError: string | null;
 	queryErrorDescription: string | null;
 }
@@ -29,8 +28,8 @@ interface DomainConnectionVerificationProps {
 export default function DomainConnectionVerification( {
 	domainName,
 	siteSlug,
+	domainMappingStatus,
 }: DomainConnectionVerificationProps ) {
-	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 	const status = isMappingVerificationSuccess( domainMappingStatus.mode, domainMappingStatus )
 		? 'connected'
 		: 'verifying';

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -40,8 +40,8 @@ export default function DomainConnection() {
 	);
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	const [ connectionMode, setConnectionMode ] = useState< DomainConnectionSetupModeValue >(
-		domainMappingStatus.mode
+	const [ connectionMode, setConnectionMode ] = useState< DomainConnectionSetupModeValue | null >(
+		domainConnectionSetupInfo.connection_mode
 	);
 
 	// Update connection mode mutation

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,4 +1,4 @@
-import { type DomainConnectionSetupModeValue } from '@automattic/api-core';
+import { DomainMappingStatus, type DomainConnectionSetupModeValue } from '@automattic/api-core';
 import {
 	domainConnectionSetupInfoQuery,
 	domainMappingStatusQuery,
@@ -10,6 +10,7 @@ import { useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
 import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -39,6 +40,10 @@ export default function DomainConnection() {
 	);
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
+	const [ connectionMode, setConnectionMode ] = useState< DomainConnectionSetupModeValue >(
+		domainMappingStatus.mode
+	);
+
 	// Update connection mode mutation
 	const { mutate: updateConnectionMode, isPending: isUpdatingConnectionMode } = useMutation(
 		updateConnectionModeMutation( domainName, domain.blog_id )
@@ -46,6 +51,9 @@ export default function DomainConnection() {
 
 	const onVerifyConnection = ( mode: DomainConnectionSetupModeValue ) => {
 		updateConnectionMode( mode, {
+			onSuccess: ( data: DomainMappingStatus ) => {
+				setConnectionMode( data.mode );
+			},
 			onError: () => {
 				createErrorNotice(
 					__( 'We couldn’t verify the connection for your domain, please try again.' ),
@@ -57,7 +65,7 @@ export default function DomainConnection() {
 		} );
 	};
 	// If the connection mode is not null, it means we are on the verification step
-	const isVerificationStep = !! domainConnectionSetupInfo.connection_mode;
+	const isVerificationStep = !! connectionMode;
 
 	return (
 		<PageLayout

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -41,7 +41,7 @@ export default function DomainConnection() {
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
 	const [ connectionMode, setConnectionMode ] = useState< DomainConnectionSetupModeValue | null >(
-		domainConnectionSetupInfo.connection_mode
+		domainMappingStatus.mode
 	);
 
 	// Update connection mode mutation
@@ -64,6 +64,7 @@ export default function DomainConnection() {
 			},
 		} );
 	};
+
 	// If the connection mode is not null, it means we are on the verification step
 	const isVerificationStep = !! connectionMode;
 

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,55 +1,26 @@
-import { DomainConnectionSetupMode, DomainMappingStatus } from '@automattic/api-core';
 import {
 	domainConnectionSetupInfoQuery,
+	domainMappingStatusQuery,
 	domainQuery,
-	updateConnectionModeMutation,
 } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	Button,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { __, isRTL } from '@wordpress/i18n';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { isSubdomain } from '../../utils/domain';
-import HelpMessage from './components/help-message';
-import Progress from './components/progress';
-import SwitchSetup from './components/switch-setup';
+import DomainConnectionSetup from './domain-connection-setup';
 import DomainConnectionVerification from './domain-connection-verification';
-import {
-	connectADomainDomainConnectionStepsMap,
-	connectASubdomainDomainConnectionStepsMap,
-} from './steps-map';
-import { DomainConnectionStepsMap, StepName, type StepNameValue } from './types';
-import { getProgressStepList, isMappingVerificationSuccess, resolveStepName } from './utils';
 
 import './style.scss';
 
-export default function DomainConnectionSetup() {
+export default function DomainConnection() {
 	const { domainName } = domainRoute.useParams();
-
-	const {
-		step: intialStepName,
-		showErrors,
-		isFirstVisit,
-		error: queryError,
-		error_description: queryErrorDescription,
-	} = domainRoute.useSearch();
+	const { error: queryError, error_description: queryErrorDescription } = domainRoute.useSearch();
 
 	// Load domain data
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const siteSlug = domain.site_slug;
-
-	const redesign = config.isEnabled( 'domain-connection-redesign/verification' );
 
 	// Load domain connection setup info
 	const router = useRouter();
@@ -61,176 +32,38 @@ export default function DomainConnectionSetup() {
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
 		domainConnectionSetupInfoQuery( domainName, domain.blog_id, returnUrl )
 	);
-	const { createErrorNotice } = useDispatch( noticesStore );
-	// Update connection mode mutation
-	const { mutate: updateConnectionMode, isPending: isUpdatingConnectionMode } = useMutation(
-		updateConnectionModeMutation( domainName, domain.blog_id )
-	);
-	const [ verificationStatus, setVerificationStatus ] = useState< DomainMappingStatus | undefined >(
-		undefined
-	);
+	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	// currentStepName is initizialized considering this sequence of priority:
-	// 1. initialStepName (from query string)
-	// 2. calculated step name based on api response data
-	// 3. firstStepName (default first step)
-	const firstStepName: StepNameValue = isSubdomain( domainName )
-		? StepName.SUBDOMAIN_SUGGESTED_START
-		: StepName.SUGGESTED_START;
-	const [ currentStepName, setCurrentStepName ] = useState< StepNameValue >(
-		resolveStepName(
-			domainConnectionSetupInfo.connection_mode,
-			!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting,
-			domainName,
-			intialStepName as StepNameValue,
-			firstStepName
-		)
-	);
-
-	const stepsDefinition: DomainConnectionStepsMap = isSubdomain( domainName )
-		? connectASubdomainDomainConnectionStepsMap
-		: connectADomainDomainConnectionStepsMap;
-
-	const currentStep = stepsDefinition[ currentStepName as StepNameValue ];
-	if ( ! currentStep ) {
-		return null;
-	}
-
-	const verifyConnection = ( setStepAfterVerify = true ): void => {
-		let connectedSlug: StepNameValue =
-			DomainConnectionSetupMode.SUGGESTED === currentStep.mode
-				? StepName.SUGGESTED_CONNECTED
-				: StepName.ADVANCED_CONNECTED;
-		let verifyingSlug: StepNameValue =
-			DomainConnectionSetupMode.SUGGESTED === currentStep.mode
-				? StepName.SUGGESTED_VERIFYING
-				: StepName.ADVANCED_VERIFYING;
-
-		if ( isSubdomain( domainName ) ) {
-			connectedSlug =
-				DomainConnectionSetupMode.SUGGESTED === currentStep.mode
-					? StepName.SUBDOMAIN_SUGGESTED_CONNECTED
-					: StepName.SUBDOMAIN_ADVANCED_CONNECTED;
-			verifyingSlug =
-				DomainConnectionSetupMode.SUGGESTED === currentStep.mode
-					? StepName.SUBDOMAIN_SUGGESTED_VERIFYING
-					: StepName.SUBDOMAIN_ADVANCED_VERIFYING;
-		}
-		updateConnectionMode( currentStep.mode, {
-			onSuccess: ( data: DomainMappingStatus ) => {
-				setVerificationStatus( data );
-				if ( redesign ) {
-					return;
-				}
-				if ( setStepAfterVerify ) {
-					if ( isMappingVerificationSuccess( currentStep.mode, data ) ) {
-						setCurrentStepName( connectedSlug );
-					} else {
-						setCurrentStepName( verifyingSlug );
-					}
-				}
-			},
-			onError: () => {
-				if ( setStepAfterVerify ) {
-					setCurrentStepName( verifyingSlug );
-				}
-				createErrorNotice(
-					__( 'We couldn’t verify the connection for your domain, please try again.' ),
-					{
-						type: 'snackbar',
-					}
-				);
-			},
-		} );
-	};
-
-	const setNextStepName = () => {
-		const next = stepsDefinition[ currentStepName as StepNameValue ]?.next;
-		next && setCurrentStepName( next );
-	};
-
-	const goBack = () => {
-		if ( currentStep.prev ) {
-			setCurrentStepName( currentStep.prev );
-		}
-	};
-
-	const showProgress = Object.keys(
-		getProgressStepList( currentStep.mode, stepsDefinition )
-	).includes( currentStepName as string );
-
-	const StepsComponent = currentStep.component;
-	if ( StepsComponent === null ) {
-		return null;
-	}
-
-	const renderLegacyLayout = () => {
-		return (
-			<>
-				{ currentStep.prev && (
-					<HStack>
-						<Button icon={ isRTL() ? chevronRight : chevronLeft } onClick={ goBack }>
-							{ __( 'Back' ) }
-						</Button>
-					</HStack>
-				) }
-				{ showProgress && (
-					<Progress
-						steps={ getProgressStepList( currentStep.mode, stepsDefinition ) }
-						currentStepName={ currentStepName }
-					/>
-				) }
-				<VStack spacing={ 6 }>
-					<StepsComponent
-						domainName={ domainName }
-						stepName={ currentStepName }
-						stepType={ currentStep.stepType }
-						mode={ currentStep.mode }
-						onNextStep={ setNextStepName }
-						setPage={ setCurrentStepName }
-						domainSetupInfo={ domainConnectionSetupInfo }
-						verificationStatus={ verificationStatus }
-						onVerifyConnection={ verifyConnection }
-						verificationInProgress={ isUpdatingConnectionMode }
-						showErrors={ showErrors === 'true' || showErrors === '1' }
-						isFirstVisit={ isFirstVisit === 'true' || isFirstVisit === '1' }
-						queryError={ queryError }
-						queryErrorDescription={ queryErrorDescription }
-						isOwnershipVerificationFlow={ false }
-					/>
-					<VStack spacing={ 2 }>
-						{ ( currentStep.mode === DomainConnectionSetupMode.SUGGESTED ||
-							currentStep.mode === DomainConnectionSetupMode.ADVANCED ||
-							currentStep.mode === DomainConnectionSetupMode.DONE ) && (
-							<HelpMessage mode={ currentStep.mode } />
-						) }
-						<SwitchSetup
-							currentStepType={ currentStep.stepType }
-							currentMode={ currentStep.mode }
-							supportsDomainConnect={
-								!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
-							}
-							isSubdomain={ isSubdomain( domainName ) }
-							setPage={ setCurrentStepName }
-						/>
-					</VStack>
-				</VStack>
-			</>
-		);
-	};
+	const isVerificationStep = domainConnectionSetupInfo.connection_mode;
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain connection setup' ) } /> }>
-			{ ( domainConnectionSetupInfo.connection_mode || verificationStatus?.mode ) && redesign ? (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={
+						isVerificationStep
+							? __( 'Domain connection verification' )
+							: __( 'Domain connection setup' )
+					}
+				/>
+			}
+		>
+			{ isVerificationStep ? (
 				<DomainConnectionVerification
 					domainName={ domainName }
 					siteSlug={ siteSlug }
 					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					domainMappingStatus={ domainMappingStatus }
 					queryError={ queryError }
 					queryErrorDescription={ queryErrorDescription }
 				/>
 			) : (
-				renderLegacyLayout()
+				<DomainConnectionSetup
+					domainName={ domainName }
+					siteSlug={ siteSlug }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
 			) }
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -34,7 +34,8 @@ export default function DomainConnection() {
 	);
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	const isVerificationStep = domainConnectionSetupInfo.connection_mode;
+	// If the connection mode is not null, it means we are on the verification step
+	const isVerificationStep = !! domainConnectionSetupInfo.connection_mode;
 
 	return (
 		<PageLayout

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,11 +1,15 @@
+import { type DomainConnectionSetupModeValue } from '@automattic/api-core';
 import {
 	domainConnectionSetupInfoQuery,
 	domainMappingStatusQuery,
 	domainQuery,
+	updateConnectionModeMutation,
 } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -15,6 +19,7 @@ import DomainConnectionVerification from './domain-connection-verification';
 import './style.scss';
 
 export default function DomainConnection() {
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
 	const { error: queryError, error_description: queryErrorDescription } = domainRoute.useSearch();
 
@@ -34,6 +39,23 @@ export default function DomainConnection() {
 	);
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
+	// Update connection mode mutation
+	const { mutate: updateConnectionMode, isPending: isUpdatingConnectionMode } = useMutation(
+		updateConnectionModeMutation( domainName, domain.blog_id )
+	);
+
+	const onVerifyConnection = ( mode: DomainConnectionSetupModeValue ) => {
+		updateConnectionMode( mode, {
+			onError: () => {
+				createErrorNotice(
+					__( 'We couldn’t verify the connection for your domain, please try again.' ),
+					{
+						type: 'snackbar',
+					}
+				);
+			},
+		} );
+	};
 	// If the connection mode is not null, it means we are on the verification step
 	const isVerificationStep = !! domainConnectionSetupInfo.connection_mode;
 
@@ -64,6 +86,8 @@ export default function DomainConnection() {
 					domainName={ domainName }
 					siteSlug={ siteSlug }
 					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					onVerifyConnection={ onVerifyConnection }
+					isUpdatingConnectionMode={ isUpdatingConnectionMode }
 				/>
 			) }
 		</PageLayout>

--- a/client/dashboard/domains/domain-connection-setup/legacy-connection-flow.tsx
+++ b/client/dashboard/domains/domain-connection-setup/legacy-connection-flow.tsx
@@ -1,0 +1,217 @@
+import { DomainConnectionSetupMode, DomainMappingStatus } from '@automattic/api-core';
+import {
+	domainConnectionSetupInfoQuery,
+	domainQuery,
+	updateConnectionModeMutation,
+} from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { isSubdomain } from '../../utils/domain';
+import HelpMessage from './components/help-message';
+import Progress from './components/progress';
+import SwitchSetup from './components/switch-setup';
+import {
+	connectADomainDomainConnectionStepsMap,
+	connectASubdomainDomainConnectionStepsMap,
+} from './steps-map';
+import { DomainConnectionStepsMap, StepName, type StepNameValue } from './types';
+import { getProgressStepList, isMappingVerificationSuccess, resolveStepName } from './utils';
+
+import './style.scss';
+
+export default function LegacyConnectionFlow() {
+	const { domainName } = domainRoute.useParams();
+
+	const {
+		step: intialStepName,
+		showErrors,
+		isFirstVisit,
+		error: queryError,
+		error_description: queryErrorDescription,
+	} = domainRoute.useSearch();
+
+	// Load domain data
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
+	const redesign = config.isEnabled( 'domain-connection-redesign/verification' );
+
+	// Load domain connection setup info
+	const router = useRouter();
+	const relativePath = router.buildLocation( {
+		to: domainConnectionSetupRoute.fullPath,
+		params: { domainName },
+	} ).href;
+	const returnUrl = new URL( relativePath, window.location.origin ).href + '?step=dc_return';
+	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
+		domainConnectionSetupInfoQuery( domainName, domain.blog_id, returnUrl )
+	);
+	const { createErrorNotice } = useDispatch( noticesStore );
+	// Update connection mode mutation
+	const { mutate: updateConnectionMode, isPending: isUpdatingConnectionMode } = useMutation(
+		updateConnectionModeMutation( domainName, domain.blog_id )
+	);
+	const [ verificationStatus, setVerificationStatus ] = useState< DomainMappingStatus | undefined >(
+		undefined
+	);
+
+	// currentStepName is initizialized considering this sequence of priority:
+	// 1. initialStepName (from query string)
+	// 2. calculated step name based on api response data
+	// 3. firstStepName (default first step)
+	const firstStepName: StepNameValue = isSubdomain( domainName )
+		? StepName.SUBDOMAIN_SUGGESTED_START
+		: StepName.SUGGESTED_START;
+	const [ currentStepName, setCurrentStepName ] = useState< StepNameValue >(
+		resolveStepName(
+			domainConnectionSetupInfo.connection_mode,
+			!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting,
+			domainName,
+			intialStepName as StepNameValue,
+			firstStepName
+		)
+	);
+
+	const stepsDefinition: DomainConnectionStepsMap = isSubdomain( domainName )
+		? connectASubdomainDomainConnectionStepsMap
+		: connectADomainDomainConnectionStepsMap;
+
+	const currentStep = stepsDefinition[ currentStepName as StepNameValue ];
+	if ( ! currentStep ) {
+		return null;
+	}
+
+	const verifyConnection = ( setStepAfterVerify = true ): void => {
+		let connectedSlug: StepNameValue =
+			DomainConnectionSetupMode.SUGGESTED === currentStep.mode
+				? StepName.SUGGESTED_CONNECTED
+				: StepName.ADVANCED_CONNECTED;
+		let verifyingSlug: StepNameValue =
+			DomainConnectionSetupMode.SUGGESTED === currentStep.mode
+				? StepName.SUGGESTED_VERIFYING
+				: StepName.ADVANCED_VERIFYING;
+
+		if ( isSubdomain( domainName ) ) {
+			connectedSlug =
+				DomainConnectionSetupMode.SUGGESTED === currentStep.mode
+					? StepName.SUBDOMAIN_SUGGESTED_CONNECTED
+					: StepName.SUBDOMAIN_ADVANCED_CONNECTED;
+			verifyingSlug =
+				DomainConnectionSetupMode.SUGGESTED === currentStep.mode
+					? StepName.SUBDOMAIN_SUGGESTED_VERIFYING
+					: StepName.SUBDOMAIN_ADVANCED_VERIFYING;
+		}
+		updateConnectionMode( currentStep.mode, {
+			onSuccess: ( data: DomainMappingStatus ) => {
+				setVerificationStatus( data );
+				if ( redesign ) {
+					return;
+				}
+				if ( setStepAfterVerify ) {
+					if ( isMappingVerificationSuccess( currentStep.mode, data ) ) {
+						setCurrentStepName( connectedSlug );
+					} else {
+						setCurrentStepName( verifyingSlug );
+					}
+				}
+			},
+			onError: () => {
+				if ( setStepAfterVerify ) {
+					setCurrentStepName( verifyingSlug );
+				}
+				createErrorNotice(
+					__( 'We couldn’t verify the connection for your domain, please try again.' ),
+					{
+						type: 'snackbar',
+					}
+				);
+			},
+		} );
+	};
+
+	const setNextStepName = () => {
+		const next = stepsDefinition[ currentStepName as StepNameValue ]?.next;
+		next && setCurrentStepName( next );
+	};
+
+	const goBack = () => {
+		if ( currentStep.prev ) {
+			setCurrentStepName( currentStep.prev );
+		}
+	};
+
+	const showProgress = Object.keys(
+		getProgressStepList( currentStep.mode, stepsDefinition )
+	).includes( currentStepName as string );
+
+	const StepsComponent = currentStep.component;
+	if ( StepsComponent === null ) {
+		return null;
+	}
+
+	return (
+		<PageLayout size="small" header={ <PageHeader title={ __( 'Domain connection setup' ) } /> }>
+			{ currentStep.prev && (
+				<HStack>
+					<Button icon={ isRTL() ? chevronRight : chevronLeft } onClick={ goBack }>
+						{ __( 'Back' ) }
+					</Button>
+				</HStack>
+			) }
+			{ showProgress && (
+				<Progress
+					steps={ getProgressStepList( currentStep.mode, stepsDefinition ) }
+					currentStepName={ currentStepName }
+				/>
+			) }
+			<VStack spacing={ 6 }>
+				<StepsComponent
+					domainName={ domainName }
+					stepName={ currentStepName }
+					stepType={ currentStep.stepType }
+					mode={ currentStep.mode }
+					onNextStep={ setNextStepName }
+					setPage={ setCurrentStepName }
+					domainSetupInfo={ domainConnectionSetupInfo }
+					verificationStatus={ verificationStatus }
+					onVerifyConnection={ verifyConnection }
+					verificationInProgress={ isUpdatingConnectionMode }
+					showErrors={ showErrors === 'true' || showErrors === '1' }
+					isFirstVisit={ isFirstVisit === 'true' || isFirstVisit === '1' }
+					queryError={ queryError }
+					queryErrorDescription={ queryErrorDescription }
+					isOwnershipVerificationFlow={ false }
+				/>
+				<VStack spacing={ 2 }>
+					{ ( currentStep.mode === DomainConnectionSetupMode.SUGGESTED ||
+						currentStep.mode === DomainConnectionSetupMode.ADVANCED ||
+						currentStep.mode === DomainConnectionSetupMode.DONE ) && (
+						<HelpMessage mode={ currentStep.mode } />
+					) }
+					<SwitchSetup
+						currentStepType={ currentStep.stepType }
+						currentMode={ currentStep.mode }
+						supportsDomainConnect={
+							!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
+						}
+						isSubdomain={ isSubdomain( domainName ) }
+						setPage={ setCurrentStepName }
+					/>
+				</VStack>
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/legacy-connection-flow.tsx
+++ b/client/dashboard/domains/domain-connection-setup/legacy-connection-flow.tsx
@@ -4,7 +4,6 @@ import {
 	domainQuery,
 	updateConnectionModeMutation,
 } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -46,8 +45,6 @@ export default function LegacyConnectionFlow() {
 
 	// Load domain data
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-
-	const redesign = config.isEnabled( 'domain-connection-redesign/verification' );
 
 	// Load domain connection setup info
 	const router = useRouter();
@@ -117,9 +114,6 @@ export default function LegacyConnectionFlow() {
 		updateConnectionMode( currentStep.mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
 				setVerificationStatus( data );
-				if ( redesign ) {
-					return;
-				}
 				if ( setStepAfterVerify ) {
 					if ( isMappingVerificationSuccess( currentStep.mode, data ) ) {
 						setCurrentStepName( connectedSlug );

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign/verification": true,
+		"domain-connection-redesign": true,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": false,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,7 +30,7 @@
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign/verification": false,
+		"domain-connection-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,7 @@
 		"current-site/notice": true,
 		"dashboard/v2/backport/site-overview": true,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign/verification": false,
+		"domain-connection-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign/verification": false,
+		"domain-connection-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign/verification": false,
+		"domain-connection-redesign": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Closes [DOMAINS-1786](https://linear.app/a8c/issue/DOMAINS-1786/create-new-connection-flow-preliminary-setup)

## Proposed Changes

- Refactor domain connection setup flow to support a simplified redesigned UI behind a feature flag
- Move existing multi-step domain connection flow into a new component `LegacyConnectionFlow`
- Create new entry point component `DomainConnection` for the redesigned flow
- Extract verification step into standalone `DomainConnectionVerification` component (moved from legacy flow)
- Add temporary placeholder `DomainConnectionSetup` component with verification trigger buttons
- Update `domainConnectionSetupRoute` to conditionally load new or legacy flow based on `domain-connection-redesign` feature flag
- Rename feature flag from `domain-connection-redesign/verification` to `domain-connection-redesign`
- Lift connection mode state management to parent component for better flow control

## Why are these changes being made?

The existing domain connection setup flow uses a complex multi-step state machine that was becoming difficult to extend with new verification-focused UI. This PR simplifies the architecture by:

1. **Separating concerns**: The new flow focuses on two distinct states - initial setup and verification - rather than managing multiple intermediate steps
2. **Enabling iterative development**: The feature flag allows us to develop and test the new simplified flow in production without affecting existing users
3. **Reducing complexity**: The legacy flow's step resolution logic, progress tracking, and state management are no longer needed for the redesigned experience

**Current implementation status**: This PR implements the verification step UI. The setup step component is a temporary placeholder that will be completed in a follow-up PR. The feature flag remains disabled in all environments except development.


## Testing Instructions
### Testing the New Flow (Feature Flag Enabled)
1. Navigate to a domain's connection setup page (`/v2/domains/[DOMAIN]/domain-connection-setup`)
2. **Test initial setup state** (when `connection_mode` is `null`):
   - Verify the placeholder setup component displays with domain name
   - Click "Verify Connection (Suggested)" button
   - Confirm loading state is shown during API call
   - Verify transition to verification step after successful API response
3. **Test verification state** (when `connection_mode` has a value):
   - Verify the verification component displays with appropriate status
   - Confirm connection status badge shows "Connected" or "Verifying"

### Testing Legacy Flow (Feature Flag Disabled)
1. Disable the feature flag: `"domain-connection-redesign": false`
2. Navigate to domain connection setup page (`/v2/domains/[DOMAIN]/domain-connection-setup`)
3. Verify the existing multi-step flow works as expected
4. Confirm all step navigation, progress indicators, and help messages display correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
