### PR TITLE
A4A: Update the Purchase Licenses section to support BD for cancellation

### DIFF
--- a/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
@@ -19,6 +19,7 @@ interface APILicense {
 	parent_license_id: number | null;
 	meta: APILicenseMeta | null;
 	referral: ReferralAPIResponse;
+	subscription?: APILicenseSubscription | null;
 }
 
 export interface APILicenseMeta {
@@ -28,6 +29,18 @@ export interface APILicenseMeta {
 	a4a_dev_site_period_start?: string;
 	a4a_transferred_subscription_id?: string;
 	a4a_transferred_subscription_expiration?: string;
+}
+
+interface APILicenseSubscription {
+	id: string;
+	product_name: string;
+	purchase_price: number;
+	purchase_currency: string;
+	billing_interval_unit: string;
+	status: string;
+	expiry: string | null;
+	is_auto_renew_enabled: boolean;
+	is_refundable: boolean;
 }
 
 export default function formatLicenses( items: APILicense[] ): License[] {
@@ -49,6 +62,7 @@ export default function formatLicenses( items: APILicense[] ): License[] {
 		parentLicenseId: item.parent_license_id,
 		meta: formatLicenseMeta( item.meta ),
 		referral: item.referral,
+		subscription: formatLicenseSubscription( item.subscription ),
 	} ) );
 }
 
@@ -72,5 +86,25 @@ export function formatLicenseMeta( meta: APILicenseMeta | null ): LicenseMeta {
 		devSitePeriodStart, // unix timestamp
 		transferredSubscriptionId,
 		transferredSubscriptionExpiration, // e.g.: "2025-09-15"
+	};
+}
+
+function formatLicenseSubscription(
+	subscription: APILicenseSubscription | null | undefined
+): License[ 'subscription' ] {
+	if ( ! subscription ) {
+		return undefined;
+	}
+
+	return {
+		id: subscription.id,
+		productName: subscription.product_name,
+		purchasePrice: subscription.purchase_price,
+		purchaseCurrency: subscription.purchase_currency,
+		billingIntervalUnit: subscription.billing_interval_unit,
+		status: subscription.status,
+		expiry: subscription.expiry,
+		isAutoRenewEnabled: subscription.is_auto_renew_enabled,
+		isRefundable: subscription.is_refundable,
 	};
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -22,6 +22,7 @@ import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import useLicenseDownloadUrlMutation from '../revoke-license-dialog/hooks/use-license-download-url-mutation';
+import type { LicenseSubscription } from 'calypso/state/partner-portal/types';
 
 interface Props {
 	licenseKey: string;
@@ -34,6 +35,7 @@ interface Props {
 	isClientLicense?: boolean;
 	isDevSite?: boolean;
 	productId?: number;
+	subscription?: LicenseSubscription | null;
 }
 
 export default function LicenseDetailsActions( {
@@ -47,6 +49,7 @@ export default function LicenseDetailsActions( {
 	isClientLicense,
 	isDevSite,
 	productId,
+	subscription,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -59,6 +62,8 @@ export default function LicenseDetailsActions( {
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const isWPCOMHostingLicense = isWPCOMHostingProduct( licenseKey );
 	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
+	const isCancellationScheduled =
+		subscription?.status === 'active' && ! subscription.isAutoRenewEnabled;
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
@@ -141,7 +146,8 @@ export default function LicenseDetailsActions( {
 			{ ( isPressableLicense || isWPCOMHostingLicense ) &&
 				licenseState !== LicenseState.Revoked &&
 				! isDevSite &&
-				! isClientLicense && (
+				! isClientLicense &&
+				! isCancellationScheduled && (
 					<Button
 						compact
 						href={
@@ -159,7 +165,8 @@ export default function LicenseDetailsActions( {
 				( isChildLicense
 					? licenseState === LicenseState.Attached
 					: licenseState !== LicenseState.Revoked ) &&
-				licenseType === LicenseType.Partner && (
+				licenseType === LicenseType.Partner &&
+				! isCancellationScheduled && (
 					<Button compact onClick={ openRevokeDialog } scary>
 						{ translate( 'Revoke' ) }
 					</Button>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -62,7 +62,7 @@ export default function LicenseDetailsActions( {
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const isWPCOMHostingLicense = isWPCOMHostingProduct( licenseKey );
 	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
-	const isCancellationScheduled =
+	const isAutoRenewDisabled =
 		subscription?.status === 'active' && ! subscription.isAutoRenewEnabled;
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
@@ -147,7 +147,7 @@ export default function LicenseDetailsActions( {
 				licenseState !== LicenseState.Revoked &&
 				! isDevSite &&
 				! isClientLicense &&
-				! isCancellationScheduled && (
+				! isAutoRenewDisabled && (
 					<Button
 						compact
 						href={
@@ -166,7 +166,7 @@ export default function LicenseDetailsActions( {
 					? licenseState === LicenseState.Attached
 					: licenseState !== LicenseState.Revoked ) &&
 				licenseType === LicenseType.Partner &&
-				! isCancellationScheduled && (
+				! isAutoRenewDisabled && (
 					<Button compact onClick={ openRevokeDialog } scary>
 						{ translate( 'Revoke' ) }
 					</Button>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -72,7 +72,7 @@ export default function LicenseDetails( {
 		return '';
 	} )();
 	const subscriptionIntervalLabel = ( () => {
-		if ( ! shouldShowSubscription ) {
+		if ( ! shouldShowSubscription || ! subscription.isAutoRenewEnabled ) {
 			return '';
 		}
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -57,16 +57,18 @@ export default function LicenseDetails( {
 		if ( subscription?.status === 'active' ) {
 			return subscription.isAutoRenewEnabled
 				? translate( 'Renews on:' )
-				: translate( 'Cancellation requested | Expires on:' );
+				: translate( 'Auto-renew is OFF | Expires on:' );
 		}
 
 		return translate( 'Expired on:' );
 	} )();
 	const subscriptionBadgeLabel = ( () => {
-		if ( shouldShowSubscription && subscription?.isRefundable ) {
-			return subscription.status === 'inactive'
-				? translate( 'Refunded' )
-				: translate( 'Refundable' );
+		if (
+			shouldShowSubscription &&
+			subscription?.isRefundable &&
+			subscription.status === 'inactive'
+		) {
+			return translate( 'Refundable' );
 		}
 
 		return '';
@@ -125,11 +127,6 @@ export default function LicenseDetails( {
 
 						{ shouldShowSubscription && (
 							<>
-								<span className="license-details__subscription-id">
-									{ translate( 'Subscription ID: %(subscriptionId)s', {
-										args: { subscriptionId: subscription.id },
-									} ) }
-								</span>
 								<div className="license-details__subscription-row">
 									{ subscriptionBadgeLabel && (
 										<Badge

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Badge, Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
@@ -43,10 +43,57 @@ export default function LicenseDetails( {
 	const attachedAt = license.attachedAt;
 	const revokedAt = license.revokedAt;
 	const productId = license.productId;
+	const subscription = license.subscription;
 
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const shouldShowSubscription = subscription && licenseState !== LicenseState.Revoked;
+	const subscriptionDateLabel = ( () => {
+		if ( ! shouldShowSubscription ) {
+			return '';
+		}
+
+		if ( subscription?.status === 'active' ) {
+			return subscription.isAutoRenewEnabled
+				? translate( 'Renews on:' )
+				: translate( 'Expires on:' );
+		}
+
+		return translate( 'Expired on:' );
+	} )();
+	const subscriptionBadgeLabel = ( () => {
+		if ( shouldShowSubscription && subscription?.isRefundable ) {
+			return subscription.status === 'inactive'
+				? translate( 'Refunded' )
+				: translate( 'Refundable' );
+		}
+
+		return '';
+	} )();
+	const subscriptionIntervalLabel = ( () => {
+		if ( ! shouldShowSubscription ) {
+			return '';
+		}
+
+		const intervalUnit = subscription?.billingIntervalUnit;
+
+		if ( intervalUnit === 'month' ) {
+			return translate( '(monthly)' );
+		}
+
+		if ( intervalUnit === 'year' ) {
+			return translate( '(yearly)' );
+		}
+
+		if ( intervalUnit ) {
+			return translate( '(%(interval)s)', {
+				args: { interval: intervalUnit },
+			} );
+		}
+
+		return '';
+	} )();
 
 	const pressablePlan = useGetPressablePlanByProductId( { product_id: productId } );
 
@@ -75,6 +122,44 @@ export default function LicenseDetails( {
 								<Gridicon icon="clipboard" />
 							</ClipboardButton>
 						</div>
+
+						{ shouldShowSubscription && (
+							<>
+								<span className="license-details__subscription-id">
+									{ translate( 'Subscription ID: %(subscriptionId)s', {
+										args: { subscriptionId: subscription.id },
+									} ) }
+								</span>
+								<div className="license-details__subscription-row">
+									{ subscriptionBadgeLabel && (
+										<Badge
+											type={ subscription?.status === 'inactive' ? 'info-green' : 'info' }
+											className="license-details__subscription-badge"
+										>
+											{ subscriptionBadgeLabel }
+										</Badge>
+									) }
+									<span className="license-details__subscription-label">
+										{ subscriptionDateLabel }
+									</span>
+									<span className="license-details__subscription-date">
+										{ subscription?.expiry ? (
+											<FormattedDate
+												date={ subscription.expiry }
+												format={ DETAILS_DATE_FORMAT_SHORT }
+											/>
+										) : (
+											'-'
+										) }
+										{ subscriptionIntervalLabel && (
+											<span className="license-details__subscription-interval">
+												{ ` ${ subscriptionIntervalLabel }` }
+											</span>
+										) }
+									</span>
+								</div>
+							</>
+						) }
 					</li>
 				) }
 				{ isPressableLicense && licenseState !== LicenseState.Revoked && (
@@ -133,6 +218,7 @@ export default function LicenseDetails( {
 				isClientLicense={ !! referral }
 				isDevSite={ isDevSite }
 				productId={ productId }
+				subscription={ subscription }
 			/>
 		</Card>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -57,7 +57,7 @@ export default function LicenseDetails( {
 		if ( subscription?.status === 'active' ) {
 			return subscription.isAutoRenewEnabled
 				? translate( 'Renews on:' )
-				: translate( 'Auto-renew is OFF | Expires on:' );
+				: translate( 'Auto-renew: OFF | Expires on:' );
 		}
 
 		return translate( 'Expired on:' );
@@ -66,7 +66,7 @@ export default function LicenseDetails( {
 		if (
 			shouldShowSubscription &&
 			subscription?.isRefundable &&
-			subscription.status === 'inactive'
+			subscription.status === 'active'
 		) {
 			return translate( 'Refundable' );
 		}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -57,7 +57,7 @@ export default function LicenseDetails( {
 		if ( subscription?.status === 'active' ) {
 			return subscription.isAutoRenewEnabled
 				? translate( 'Renews on:' )
-				: translate( 'Expires on:' );
+				: translate( 'Cancellation requested | Expires on:' );
 		}
 
 		return translate( 'Expired on:' );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -30,6 +30,13 @@
 				grid-column-start: span 2;
 			}
 		}
+
+		.badge {
+			font-size: $font-size-x-small;
+			padding: 0 10px;
+			font-weight: 400;
+			border-radius: 0;
+		}
 	}
 
 	.license-details__list-item-small {
@@ -70,6 +77,12 @@
 		font-weight: bold;
 	}
 
+	.license-details__subscription-id {
+		display: block;
+		font-size: $font-size-x-small;
+		color: var(--color-neutral-50);
+	}
+
 	.license-details__actions {
 		margin-block-start: 1rem;
 		display: flex;
@@ -107,6 +120,35 @@
 
 	.pressable-usage-details__card {
 		margin: 24px 0 8px;
+	}
+
+	.license-details__subscription-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.license-details__subscription-badge {
+		margin: 0;
+	}
+
+	.license-details__subscription-label {
+		@include body-medium;
+		font-weight: 600;
+		margin-inline-end: 2px;
+	}
+
+	.license-details__subscription-date {
+		@include body-medium;
+		font-style: italic;
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		white-space: nowrap;
+	}
+
+	.license-details__subscription-interval {
+		font-style: inherit;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -77,12 +77,6 @@
 		font-weight: bold;
 	}
 
-	.license-details__subscription-id {
-		display: block;
-		font-size: $font-size-x-small;
-		color: var(--color-neutral-50);
-	}
-
 	.license-details__actions {
 		margin-block-start: 1rem;
 		display: flex;

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -257,6 +257,7 @@ export interface License {
 	parentLicenseId: number | null;
 	meta: LicenseMeta;
 	referral: ReferralAPIResponse | null;
+	subscription?: LicenseSubscription | null;
 }
 
 export interface LicenseMeta {
@@ -266,6 +267,18 @@ export interface LicenseMeta {
 	devSitePeriodEnd?: string;
 	transferredSubscriptionId?: string;
 	transferredSubscriptionExpiration?: string;
+}
+
+export interface LicenseSubscription {
+	id: string;
+	productName: string;
+	purchasePrice: number;
+	purchaseCurrency: string;
+	billingIntervalUnit: string;
+	status: string;
+	expiry: string | null;
+	isAutoRenewEnabled: boolean;
+	isRefundable: boolean;
 }
 
 export interface LicenseCounts {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2958

Part of `A4A-1685/ui-display-the-license-status-if-its-cancellation-is-scheduled`

## Proposed Changes

This PR updates the Purchases - Licenses section to support BD licenses to display and manage the different cancellation scenarios. 

- **Revokable license**

<img width="460" height="267" alt="image" src="https://github.com/user-attachments/assets/1421dcb7-cd1a-4444-9869-92fa3e981a65" />

- **Auto-renew OFF**

<img width="425" height="303" alt="image" src="https://github.com/user-attachments/assets/e8925718-5d02-4c9b-8fdd-f4fa74b0f6a2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A4A Billing Dragon for agencies (Phase 2)

## Testing Instructions

- Check the code
- You need this PR:
- If you have an agency with a license billed by BD, check each case (Cancellation request and normal state). You should see the subscription data.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
