### PR TITLE
Backup: pluralize storage status messages

### DIFF
--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -18,11 +18,12 @@ const useStorageStatusText = (
 					'You are very close to reaching your storage limit. Once you do, we will delete your oldest backups to make space for new ones.'
 				);
 			case StorageUsageLevels.Full:
-				//@TODO: we can use `_n` for pluralization here
 				return sprintf(
 					// translators: %(daysOfBackupsSaved)d is a number of days.
-					__(
-						'You have reached your storage limit with %(daysOfBackupsSaved)d day(s) of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.'
+					_n(
+						'You have reached your storage limit with %(daysOfBackupsSaved)d day of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
+						'You have reached your storage limit with %(daysOfBackupsSaved)d days of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
+						daysOfBackupsSaved
 					),
 					{ daysOfBackupsSaved }
 				);
@@ -37,11 +38,12 @@ const useStorageStatusText = (
 					{ daysOfBackupsSaved }
 				);
 			case StorageUsageLevels.BackupsDiscarded:
-				//@TODO: we can use `_n` for pluralization here
 				return sprintf(
 					// translators: %(minDaysOfBackupsAllowed)d is a number of days.
-					__(
-						'We removed your oldest backup(s) to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d days.'
+					_n(
+						'We removed your oldest backup to make space for new ones. We will continue to remove old backups as needed, keeping the last %(minDaysOfBackupsAllowed)d day.',
+						'We removed your oldest backups to make space for new ones. We will continue to remove old backups as needed, keeping the last %(minDaysOfBackupsAllowed)d days.',
+						minDaysOfBackupsAllowed
 					),
 					{ minDaysOfBackupsAllowed }
 				);

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -41,7 +41,7 @@ const useStorageStatusText = (
 				return sprintf(
 					// translators: %(minDaysOfBackupsAllowed)d is a number of days.
 					_n(
-						'We removed your oldest backup to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d day.',
+						'We removed your oldest backups to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d day.',
 						'We removed your oldest backups to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d days.',
 						minDaysOfBackupsAllowed
 					),

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -41,8 +41,8 @@ const useStorageStatusText = (
 				return sprintf(
 					// translators: %(minDaysOfBackupsAllowed)d is a number of days.
 					_n(
-						'We removed your oldest backup to make space for new ones. We will continue to remove old backups as needed, keeping the last %(minDaysOfBackupsAllowed)d day.',
-						'We removed your oldest backups to make space for new ones. We will continue to remove old backups as needed, keeping the last %(minDaysOfBackupsAllowed)d days.',
+						'We removed your oldest backup to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d day.',
+						'We removed your oldest backups to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d days.',
 						minDaysOfBackupsAllowed
 					),
 					{ minDaysOfBackupsAllowed }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/106561

## Proposed Changes

* pluralize storage status messages for the `Full` storage level using `_n`
* pluralize storage status messages for the `BackupsDiscarded` storage level using `_n`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* ensures singular and plural variants render correctly and can be localized following WP guidelines

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify `useStorageStatusText` returns the singular string when `daysOfBackupsSaved` or `minDaysOfBackupsAllowed` equals 1
* verify `useStorageStatusText` returns the plural string when the corresponding counts are greater than 1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
