### PR TITLE
Scan Dashboard: fix fetchSiteScanHistory to use `wpcom/v2` apiNamespace

### DIFF
--- a/packages/api-core/src/site-scan/fetchers.ts
+++ b/packages/api-core/src/site-scan/fetchers.ts
@@ -26,6 +26,7 @@ export async function fetchSiteScan( siteId: number ): Promise< SiteScan > {
 export async function fetchSiteScanHistory( siteId: number ): Promise< SiteScanHistory > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/scan/history`,
+		apiNamespace: 'wpcom/v2',
 	} );
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Restore `apiNamespace: 'wpcom/v2'` to `fetchSiteScanHistory` function in `packages/api-core/src/site-scan/fetchers.ts`

<img width="2528" height="672" alt="CleanShot 2025-10-30 at 15 57 43@2x" src="https://github.com/user-attachments/assets/acbe752e-e39d-4d5d-9d37-fcd5c3f3eb05" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `apiNamespace: 'wpcom/v2'` parameter was accidentally removed from `fetchSiteScanHistory` in PR #106729 (commit e84914e78d35). When adding the new `fetchSiteScanCounts` function, the `apiNamespace` line was moved to the new function instead of being duplicated, leaving `fetchSiteScanHistory` without it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch
2. Navigate to `/v2/sites/[site]/scan
3. Navigate to the History panel and ensure it now works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
