### PR TITLE
MSD: Remove site filter on domains

### DIFF
--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -3,7 +3,7 @@ import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { DataViewsCard } from '../components/dataviews-card';
@@ -13,7 +13,7 @@ import PageLayout from '../components/page-layout';
 import { AddDomainButton } from './add-domain-button';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
 import type { DomainsView } from './dataviews';
-import type { DomainSummary, Site } from '@automattic/api-core';
+import type { DomainSummary } from '@automattic/api-core';
 
 export function getDomainId( domain: DomainSummary ): string {
 	return `${ domain.domain }-${ domain.blog_id }`;
@@ -37,23 +37,10 @@ function Domains() {
 		],
 	} ) );
 
-	const sitesById = useMemo( () => {
-		if ( ! sites ) {
-			return {};
-		}
-		return sites.reduce( ( acc: Record< number, Site >, site ) => {
-			acc[ site.ID ] = site;
-			return acc;
-		}, {} );
-	}, [ sites ] );
-
 	const { data: domains, isLoading } = useQuery( {
 		...domainsQuery(),
 		select: ( data ) => {
-			return data.filter(
-				( domain ) =>
-					domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS && !! sitesById[ domain.blog_id ]
-			);
+			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
 		},
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106657, p1761893080542789-slack-C09JEQLTH8R

## Proposed Changes

* The PR at https://github.com/Automattic/wp-calypso/pull/106657 added a “site” filter on domains to restrict the list of domains to only those related to available sites (WP.com sites, CIAB sites and A4A sites). However, this filter is incorrect because a domain may exist and not be attached to any site — meaning the domain would be dropped completely by that filter. As a result, the PR reverts the "site" filter and we now need to decide on how we want to handle this use case.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should display all available domains on Domains page since the domain may not attach to any site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/domains
* It should list all domains even if it's not attached to any site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?