### PR TITLE
MSD Site Overview: Add Domain DataViews

### DIFF
--- a/client/dashboard/components/callout-skeleton/index.tsx
+++ b/client/dashboard/components/callout-skeleton/index.tsx
@@ -1,0 +1,16 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Card, CardBody } from '../card';
+import { TextSkeleton } from '../text-skeleton';
+
+export function CalloutSkeleton() {
+	return (
+		<Card>
+			<CardBody style={ { padding: '24px' } }>
+				<VStack spacing="4">
+					<TextSkeleton length={ 15 } />
+					<TextSkeleton length={ 30 } />
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,13 +1,9 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { Badge } from '@automattic/ui';
 import { Link } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { domainOverviewRoute } from '../../app/router/domains';
+import { Text } from '../../components/text';
 import { textOverflowStyles } from './utils';
 import type { DomainSummary, Site } from '@automattic/api-core';
 
@@ -28,19 +24,27 @@ export const DomainNameField = ( {
 		<Link
 			to={ domainOverviewRoute.fullPath }
 			params={ { siteSlug, domainName: domain.domain } }
-			disabled={ domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS }
+			disabled={ ! domain.subscription_id }
 		>
 			<VStack spacing={ 1 }>
-				<HStack spacing={ 1 }>
-					<span style={ textOverflowStyles }>{ value }</span>
-					{ showPrimaryDomainBadge && domain.primary_domain && (
-						<span style={ { flexShrink: 0 } }>
-							<Badge>{ __( 'Primary' ) }</Badge>
-						</span>
-					) }
-				</HStack>
+				<span style={ textOverflowStyles }>{ value }</span>
+				{ showPrimaryDomainBadge && domain.primary_domain && (
+					<span
+						style={ {
+							...textOverflowStyles,
+							color: 'var(--dashboard__foreground-color-success)',
+							fontWeight: 'normal',
+							textDecoration: 'underline',
+							textDecorationStyle: 'dotted',
+						} }
+					>
+						{ __( 'Primary site address' ) }
+					</span>
+				) }
 				{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
-					<Text variant="muted">{ domain.subtype.label }</Text>
+					<Text variant="muted" style={ { ...textOverflowStyles, fontWeight: 'normal' } }>
+						{ domain.subtype.label }
+					</Text>
 				) }
 			</VStack>
 		</Link>

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -47,7 +47,7 @@ export const useFields = ( {
 		() => [
 			{
 				id: 'domain',
-				label: __( 'Domain' ),
+				label: __( 'Domain name' ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -12,6 +12,7 @@ import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
 import DomainUpsellCard from '../overview-domain-upsell-card';
@@ -42,7 +43,7 @@ const SiteDomainDataViews = ( {
 		() => ( {
 			...initialView,
 			type,
-			fields: [ 'ssl_status', 'domain_status' ],
+			fields: [ 'expiry', 'domain_status' ],
 		} ),
 		[ initialView, type ]
 	);
@@ -62,7 +63,7 @@ const SiteDomainDataViews = ( {
 				} }
 			>
 				<SectionHeader
-					title={ __( 'Domains' ) }
+					title={ __( 'Domain names' ) }
 					level={ 3 }
 					actions={
 						<RouterLinkButton
@@ -126,6 +127,10 @@ export default function DomainsCard( { site, isCompact }: { site: Site; isCompac
 
 	if ( ! siteDomains.find( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS ) ) {
 		return <DomainUpsellCard site={ site } />;
+	}
+
+	if ( isDashboardBackport() ) {
+		return null;
 	}
 
 	return (

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,13 +1,78 @@
-import { DomainSubtype } from '@automattic/api-core';
-import { domainsQuery } from '@automattic/api-queries';
+import { DomainSubtype, type DomainSummary, type Site } from '@automattic/api-core';
+import { domainsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo } from 'react';
+import { CalloutSkeleton } from '../../components/callout-skeleton';
+import { Card, CardHeader, CardBody } from '../../components/card';
+import { SectionHeader } from '../../components/section-header';
+import { useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import DomainTransferUpsellCard from '../overview-domain-transfer-upsell-card';
 import DomainUpsellCard from '../overview-domain-upsell-card';
-import type { Site } from '@automattic/api-core';
+import type { DomainsView } from '../../domains/dataviews';
+
+const getDomainId = ( domain: DomainSummary ): string => {
+	return `${ domain.domain }-${ domain.blog_id }`;
+};
+
+const SiteDomainDataViews = ( { site, domains }: { site: Site; domains: DomainSummary[] } ) => {
+	const fields = useFields( { site, inOverview: true } );
+
+	const [ initialView, setView ] = useState< DomainsView >( {
+		...DEFAULT_VIEW,
+		type: 'table',
+	} );
+
+	const view = useMemo(
+		() => ( {
+			...initialView,
+			type: 'table',
+			fields: [ 'domain_status', 'ssl_status' ],
+		} ),
+		[ initialView ]
+	);
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
+		domains,
+		view as View,
+		fields
+	);
+
+	return (
+		<Card>
+			<CardHeader
+				style={ {
+					flexDirection: 'column',
+					alignItems: 'stretch',
+				} }
+			>
+				<SectionHeader title={ __( 'Domains' ) } level={ 3 } />
+			</CardHeader>
+			<CardBody>
+				<DataViews< DomainSummary >
+					data={ filteredData || [] }
+					fields={ fields }
+					onChangeView={ ( nextView ) => setView( nextView as DomainsView ) }
+					view={ view as View }
+					paginationInfo={ paginationInfo }
+					getItemId={ getDomainId }
+					defaultLayouts={ DEFAULT_LAYOUTS }
+				>
+					<>
+						<DataViews.Layout />
+						<DataViews.Pagination />
+					</>
+				</DataViews>
+			</CardBody>
+		</Card>
+	);
+};
 
 export default function DomainsCard( { site }: { site: Site } ) {
+	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( {
 		...domainsQuery(),
 		select: ( data ) => {
@@ -19,8 +84,8 @@ export default function DomainsCard( { site }: { site: Site } ) {
 		return null;
 	}
 
-	if ( ! siteDomains ) {
-		return null;
+	if ( ! sitePlan || ! siteDomains ) {
+		return <CalloutSkeleton />;
 	}
 
 	if (
@@ -34,5 +99,5 @@ export default function DomainsCard( { site }: { site: Site } ) {
 		return <DomainUpsellCard site={ site } />;
 	}
 
-	return null;
+	return <SiteDomainDataViews site={ site } domains={ siteDomains } />;
 }

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -1,11 +1,14 @@
 import { DomainSubtype, type DomainSummary, type Site } from '@automattic/api-core';
 import { domainsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
+import { siteDomainsRoute } from '../../app/router/sites';
 import { CalloutSkeleton } from '../../components/callout-skeleton';
 import { Card, CardHeader, CardBody } from '../../components/card';
+import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from '../../domains/dataviews';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
@@ -18,21 +21,30 @@ const getDomainId = ( domain: DomainSummary ): string => {
 	return `${ domain.domain }-${ domain.blog_id }`;
 };
 
-const SiteDomainDataViews = ( { site, domains }: { site: Site; domains: DomainSummary[] } ) => {
+const SiteDomainDataViews = ( {
+	site,
+	domains,
+	type,
+}: {
+	site: Site;
+	domains: DomainSummary[];
+	type: DomainsView[ 'type' ];
+} ) => {
+	const router = useRouter();
 	const fields = useFields( { site, inOverview: true } );
 
 	const [ initialView, setView ] = useState< DomainsView >( {
 		...DEFAULT_VIEW,
-		type: 'table',
+		type,
 	} );
 
 	const view = useMemo(
 		() => ( {
 			...initialView,
-			type: 'table',
-			fields: [ 'domain_status', 'ssl_status' ],
+			type,
+			fields: [ 'ssl_status', 'domain_status' ],
 		} ),
-		[ initialView ]
+		[ initialView, type ]
 	);
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
@@ -49,7 +61,24 @@ const SiteDomainDataViews = ( { site, domains }: { site: Site; domains: DomainSu
 					alignItems: 'stretch',
 				} }
 			>
-				<SectionHeader title={ __( 'Domains' ) } level={ 3 } />
+				<SectionHeader
+					title={ __( 'Domains' ) }
+					level={ 3 }
+					actions={
+						<RouterLinkButton
+							variant="secondary"
+							size="compact"
+							to={
+								router.buildLocation( {
+									to: siteDomainsRoute.fullPath,
+									params: { siteSlug: site.slug },
+								} ).href
+							}
+						>
+							{ __( 'Manage domains' ) }
+						</RouterLinkButton>
+					}
+				/>
 			</CardHeader>
 			<CardBody>
 				<DataViews< DomainSummary >
@@ -71,7 +100,7 @@ const SiteDomainDataViews = ( { site, domains }: { site: Site; domains: DomainSu
 	);
 };
 
-export default function DomainsCard( { site }: { site: Site } ) {
+export default function DomainsCard( { site, isCompact }: { site: Site; isCompact: boolean } ) {
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
 	const { data: siteDomains } = useQuery( {
 		...domainsQuery(),
@@ -99,5 +128,11 @@ export default function DomainsCard( { site }: { site: Site } ) {
 		return <DomainUpsellCard site={ site } />;
 	}
 
-	return <SiteDomainDataViews site={ site } domains={ siteDomains } />;
+	return (
+		<SiteDomainDataViews
+			type={ isCompact ? 'list' : 'table' }
+			site={ site }
+			domains={ siteDomains }
+		/>
+	);
 }

--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -115,6 +115,12 @@ export default function DomainsCard( { site, isCompact }: { site: Site; isCompac
 	}
 
 	if ( ! sitePlan || ! siteDomains ) {
+		// Given that the SiteDomainsDataViews is disabled for the backport,
+		// we skip rendering the skeleton here as it might not result in any component being rendered at all.
+		if ( isDashboardBackport() ) {
+			return null;
+		}
+
 		return <CalloutSkeleton />;
 	}
 

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -150,7 +150,7 @@ function SiteOverviewSecondaryCards( {
 					{ showFlexUsageCard && <OverviewFlexUsageCard site={ site } /> }
 					{ ! isSelfHostedJetpackConnectedSite && ! site.is_wpcom_staging_site && (
 						<>
-							<DomainsCard site={ site } />
+							<DomainsCard site={ site } isCompact={ isSmallViewport } />
 							<DIFMUpsellCard site={ site } />
 						</>
 					) }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -150,8 +150,8 @@ function SiteOverviewSecondaryCards( {
 					{ showFlexUsageCard && <OverviewFlexUsageCard site={ site } /> }
 					{ ! isSelfHostedJetpackConnectedSite && ! site.is_wpcom_staging_site && (
 						<>
-							<DIFMUpsellCard site={ site } />
 							<DomainsCard site={ site } />
+							<DIFMUpsellCard site={ site } />
 						</>
 					) }
 				</VStack>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -150,8 +150,8 @@ function SiteOverviewSecondaryCards( {
 					{ showFlexUsageCard && <OverviewFlexUsageCard site={ site } /> }
 					{ ! isSelfHostedJetpackConnectedSite && ! site.is_wpcom_staging_site && (
 						<>
-							<DomainsCard site={ site } isCompact={ isSmallViewport } />
 							<DIFMUpsellCard site={ site } />
+							<DomainsCard site={ site } isCompact={ isSmallViewport } />
 						</>
 					) }
 				</VStack>

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -21,6 +21,14 @@
 			flex-basis: 0;
 		}
 	}
+
+	&:not( .is-large ) {
+		> * {
+			&:empty {
+				display: none;
+			}
+		}
+	}
 }
 
 .site-overview-card__badge {

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -21,14 +21,6 @@
 			flex-basis: 0;
 		}
 	}
-
-	&:not( .is-large ) {
-		> * {
-			&:empty {
-				display: none;
-			}
-		}
-	}
 }
 
 .site-overview-card__badge {


### PR DESCRIPTION
## Proposed Changes

See: p1761823424697279-slack-C08JZTRS6NA.

<img width="1172" height="1105" alt="SCR-20251031-nfkd" src="https://github.com/user-attachments/assets/4bff672a-353a-4831-b93c-6aadb7fdf5d9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a launched site with custom domain
* Ensure you see the domains DataViews
* Ensure that the "Manage domains" button takes you to the site-level Domains tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?