### PR TITLE
MSD: Update the main action on Site Overview page for CIAB sites

### DIFF
--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -190,12 +190,7 @@ function SiteOverview( {
 
 		if ( isCommerceGardenSite ) {
 			return (
-				<Button
-					ref={ wpAdminButtonRef }
-					__next40pxDefaultSize
-					variant="primary"
-					href={ site.options.admin_url }
-				>
+				<Button __next40pxDefaultSize variant="primary" href={ site.options.admin_url }>
 					{ __( 'Manage store' ) }
 				</Button>
 			);

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -196,7 +196,7 @@ function SiteOverview( {
 					variant="primary"
 					href={ site.options.admin_url }
 				>
-					{ __( 'Store dashboard' ) }
+					{ __( 'Manage store' ) }
 				</Button>
 			);
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1761202572139249-slack-C09JEQLTH8R

## Proposed Changes

* Update the copy to "Manage store"
* Disable the guided tour as "Manage store" is clear enough

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It seems unnecessary to have the guide tour for this button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove the preference, `hosting-dashboard-tours-site-overview`, from the dev tool helpers
  <img width="493" height="106" alt="image" src="https://github.com/user-attachments/assets/fdf01dbf-0d92-417e-8693-092c08c1b0bd" />
* Go to /ciab
* Select any site
* Ensure the main action shows "Manage store"
* Ensure it won't show the guided tour


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?