### PR TITLE
Fix how we render the Add Domain buttons actions

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -20,23 +20,23 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 			) }
 			renderContent={ () => (
 				<>
-					<MenuItem iconPosition="left" icon={ search }>
-						<Button
-							href={ siteSlug ? addQueryArgs( '/setup/domain', { siteSlug } ) : '/start/domain' }
-						>
-							{ __( 'Search domain names' ) }
-						</Button>
+					<MenuItem
+						iconPosition="left"
+						icon={ search }
+						href={ siteSlug ? addQueryArgs( '/setup/domain', { siteSlug } ) : '/start/domain' }
+					>
+						{ __( 'Search domain names' ) }
 					</MenuItem>
-					<MenuItem iconPosition="left" icon={ globe }>
-						<Button
-							href={
-								siteSlug
-									? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
-									: '/setup/domain-transfer'
-							}
-						>
-							{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
-						</Button>
+					<MenuItem
+						iconPosition="left"
+						icon={ globe }
+						href={
+							siteSlug
+								? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
+								: '/setup/domain-transfer'
+						}
+					>
+						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
 					</MenuItem>
 				</>
 			) }

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -4,6 +4,20 @@ import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
+	const onSearchClick = () => {
+		window.location.href = siteSlug
+			? addQueryArgs( '/setup/domain', { siteSlug } )
+			: '/start/domain';
+		return false;
+	};
+
+	const onTransferClick = () => {
+		window.location.href = siteSlug
+			? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
+			: '/setup/domain-transfer';
+		return false;
+	};
+
 	return (
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -20,22 +34,10 @@ export function AddDomainButton( { siteSlug }: { siteSlug?: string } ) {
 			) }
 			renderContent={ () => (
 				<>
-					<MenuItem
-						iconPosition="left"
-						icon={ search }
-						href={ siteSlug ? addQueryArgs( '/setup/domain', { siteSlug } ) : '/start/domain' }
-					>
+					<MenuItem iconPosition="left" icon={ search } onClick={ onSearchClick }>
 						{ __( 'Search domain names' ) }
 					</MenuItem>
-					<MenuItem
-						iconPosition="left"
-						icon={ globe }
-						href={
-							siteSlug
-								? addQueryArgs( '/setup/domain/use-my-domain', { siteSlug } )
-								: '/setup/domain-transfer'
-						}
-					>
+					<MenuItem iconPosition="left" icon={ globe } onClick={ onTransferClick }>
 						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
 					</MenuItem>
 				</>


### PR DESCRIPTION
We were using a Button component inside the MenuItem which is also a Button so the items inside the Add Domain Name button were weird - bigger padding between the icon and the label + weird behavior if you use your keyboard to navigate (press Tab)

| before | after |
| -- | -- |
| <img width="261" height="200" alt="Screenshot 2025-10-31 at 9 14 39" src="https://github.com/user-attachments/assets/ac4a9f96-b406-4818-9e04-17096c2a32d0" /> | <img width="259" height="210" alt="Screenshot 2025-10-31 at 9 15 00" src="https://github.com/user-attachments/assets/a7ee710f-f49d-4ecf-a687-7c2a8a63e681" /> |
| <img width="255" height="200" alt="Screenshot 2025-10-31 at 9 15 16" src="https://github.com/user-attachments/assets/b1a24f0f-0095-4c3f-ad78-33ad1265e5ab" /> | <img width="271" height="188" alt="Screenshot 2025-10-31 at 9 15 07" src="https://github.com/user-attachments/assets/7bb5d36c-7197-4610-b210-326a2c8cc4ae" /> |


Part of [DOTMSD-775: Focus styling on "Add domain name" dropdown elements](https://linear.app/a8c/issue/DOTMSD-775/focus-styling-on-add-domain-name-dropdown-elements)

## Proposed Changes

* Move the href inside the MenuItem

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There's an incorrect padding + two focusable items

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/domains and click on the Add domain name button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
