### PR TITLE
Add sentry logging to multi-site dashboard

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
 							'!@automattic/api-queries',
 							'!@automattic/calypso-analytics',
 							'!@automattic/calypso-config',
+							'!@automattic/calypso-sentry',
 							'!@automattic/calypso-support-session',
 							'!@automattic/charts',
 							'!@automattic/components',

--- a/client/dashboard/app/logging/index.ts
+++ b/client/dashboard/app/logging/index.ts
@@ -1,0 +1,22 @@
+import { initSentry } from '@automattic/calypso-sentry';
+import type { User } from '@automattic/api-core';
+import type { AnyRouter } from '@tanstack/react-router';
+
+export function setupErrorLogging( user: User, router: AnyRouter ) {
+	initSentry( {
+		userId: user.ID,
+		beforeSend: ( event ) => {
+			const lastMatch = router.state.matches.at( -1 );
+			const site_slug = lastMatch?.params?.siteSlug;
+			const full_path = lastMatch?.fullPath;
+
+			event.tags = {
+				site_slug,
+				full_path,
+				...event.tags,
+			};
+
+			return event;
+		},
+	} );
+}

--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -6,9 +6,11 @@ import { LoadingLine } from '../../components/loading-line';
 import { PageViewTracker } from '../../components/page-view-tracker';
 import NotFound from '../404';
 import { bumpStat } from '../analytics';
+import { useAuth } from '../auth';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import Header from '../header';
+import { setupErrorLogging } from '../logging';
 import Snackbars from '../snackbars';
 import './style.scss';
 
@@ -25,7 +27,9 @@ const VERY_SLOW_THRESHOLD_MS = 6000;
 function Root() {
 	const { name, supports, LoadingLogo = WordPressLogo } = useAppContext();
 	const isFetching = useIsFetching();
+	const { user } = useAuth();
 	const router = useRouter();
+	useEffect( () => setupErrorLogging( user, router ), [ user, router ] );
 	const { routeMeta, isNavigating, isInitialLoad } = useRouterState( {
 		select: ( state ) => ( {
 			routeMeta: state.matches.map( ( match ) => match.meta! ).filter( Boolean ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
