### PR TITLE
Flex sites: Enable site-migration flow

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -9,7 +9,8 @@ export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	design_tier: null,
 };
 
-export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
+// Request both classic wp.com and WP Cloud (Atomic + Flex) via 'wpcloud'
+export const SITE_PICKER_FILTER_CONFIG: string[] = [ 'wpcom', 'wpcloud' ];
 export const HOW_TO_MIGRATE_OPTIONS = {
 	DO_IT_FOR_ME: 'difm',
 	DO_IT_MYSELF: 'myself',

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -122,6 +122,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const userHasOtherWPComSites = siteCount && siteCount > 1;
 		const entryPoint = get( 'flow' )?.entryPoint;
 		const canInstallPlugins = site?.plan?.features?.active.includes( 'install-plugins' ) ?? false;
+		const isFlexDestination = site?.is_wpcom_flex === true;
 		const exitFlow = ( to: string, replace = false ) => {
 			if ( replace ) {
 				return window.location.replace(
@@ -349,9 +350,14 @@ const siteMigration: FlowV2< typeof initialize > = {
 						);
 					}
 
-					//NOTE: There are links pointing to this step with the action=migrate query param, so we need to ignore the platform
+					// NOTE: There are links pointing to this step with the action=migrate query param, so we need to ignore the platform
 					if ( actionQueryParam === 'migrate' ) {
 						if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
+							if ( isFlexDestination ) {
+								return replace(
+									paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } )
+								);
+							}
 							return replace(
 								paths.upgradePlanPath( {
 									siteId,
@@ -426,6 +432,19 @@ const siteMigration: FlowV2< typeof initialize > = {
 				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
 					// Take the user to the upgrade plan step.
 					if ( providedDependencies?.destination === 'upgrade' ) {
+						if ( isFlexDestination ) {
+							if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+								return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+							}
+							if ( providedDependencies?.how === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
+								return navigate(
+									paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } )
+								);
+							}
+							return navigate(
+								paths.instructionsPath( { siteId, siteSlug, from: fromQueryParam } )
+							);
+						}
 						return replace(
 							paths.upgradePlanPath( {
 								siteId,
@@ -445,6 +464,17 @@ const siteMigration: FlowV2< typeof initialize > = {
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					if ( isFlexDestination ) {
+						if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
+							return navigate( paths.sshVerificationPath( { siteId, siteSlug } ) );
+						}
+						if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
+							return navigate(
+								paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } )
+							);
+						}
+						return navigate( paths.instructionsPath( { siteId, siteSlug, from: fromQueryParam } ) );
+					}
 					if ( providedDependencies?.goToCheckout ) {
 						let redirectAfterCheckout: string = STEPS.SITE_MIGRATION_INSTRUCTIONS.slug;
 						if ( urlQueryParams.get( 'ssh' ) === 'true' ) {
@@ -462,13 +492,17 @@ const siteMigration: FlowV2< typeof initialize > = {
 							},
 							`/setup/${ flowPath }/${ redirectAfterCheckout }`
 						);
+						const requestedPlan = providedDependencies.plan as string;
+						const planToUse =
+							requestedPlan === 'wpcom-flexible' ? 'business-bundle' : requestedPlan;
+
 						goToCheckout( {
 							flowName: flowPath,
 							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 							siteSlug: siteSlug,
 							destination: destination,
 							from: fromQueryParam ?? undefined,
-							plan: providedDependencies.plan as string,
+							plan: planToUse,
 							historyBack: true,
 							extraQueryParams:
 								providedDependencies?.sendIntentWhenCreatingTrial &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -42,7 +42,17 @@ const SitePicker = function SitePicker( props: Props ) {
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		SITE_PICKER_FILTER_CONFIG,
-		( site ) => ! site.is_wpcom_staging_site && ! site.is_deleted
+		( site ) => {
+			if ( site.is_deleted ) {
+				return false;
+			}
+			// Always allow Flex sites (destination), even if staging-flagged
+			if ( site.is_wpcom_flex || site?.plan?.product_slug === 'wpcom-flexible' ) {
+				return true;
+			}
+			// For all other sites, exclude staging variants
+			return ! site.is_wpcom_staging_site;
+		}
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTMART-67/investigate-how-we-can-use-a-migrate-flow-that-leads-to-flex
Requires backend PR: 195165-ghe-Automattic/wpcom

## Proposed Changes

The PR enables the site-migration flow for Flex sites.

WIP

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTMART-67/investigate-how-we-can-use-a-migrate-flow-that-leads-to-flex


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup/site-migration`
- You should be able to select a Flex site from the site-picker and go through the full flow without issues
- ... 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?