### PR TITLE
SSH Migration: Wait for atomic transfer before generating SSH key

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -62,17 +62,6 @@ const SiteMigrationSshShareAccess: StepType< {
 		enabled: migrationStarted && siteId > 0,
 	} );
 
-	const { steps, formState, canStartMigration, onMigrationStarted, setMigrationError } = useSteps( {
-		fromUrl,
-		siteId,
-		siteName: site?.name ?? '',
-		host,
-		onNoSSHAccess: handleNoSSHAccess,
-		migrationStatus: migrationStatus?.status,
-	} );
-
-	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
-
 	// Poll SSH migration atomic transfer status
 	const { transferStatus, isTransferring } = usePollSSHMigrationAtomicTransfer(
 		siteId,
@@ -82,6 +71,18 @@ const SiteMigrationSshShareAccess: StepType< {
 			refetchInterval: 2000, // Poll every 2 seconds
 		}
 	);
+
+	const { steps, formState, canStartMigration, onMigrationStarted, setMigrationError } = useSteps( {
+		fromUrl,
+		siteId,
+		siteName: site?.name ?? '',
+		host,
+		onNoSSHAccess: handleNoSSHAccess,
+		migrationStatus: migrationStatus?.status,
+		isTransferring,
+	} );
+
+	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
 
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -24,6 +24,8 @@ interface StepShareSSHAccessProps {
 	onGenerateSSHKey: () => void;
 	onEditUsername: () => void;
 	helpLink: ReactNode;
+	isTransferring: boolean;
+	shouldGenerateKey: boolean;
 }
 
 export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
@@ -42,6 +44,8 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	onGenerateSSHKey,
 	onEditUsername,
 	helpLink,
+	isTransferring,
+	shouldGenerateKey,
 } ) => {
 	const translate = useTranslate();
 	const [ copied, setCopied ] = useState( false );
@@ -165,8 +169,10 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 								<Button
 									variant="secondary"
 									onClick={ onGenerateSSHKey }
-									disabled={ ! username || isGeneratingKey }
-									isBusy={ isGeneratingKey }
+									disabled={
+										! username || isGeneratingKey || ( isTransferring && shouldGenerateKey )
+									}
+									isBusy={ isGeneratingKey || ( isTransferring && shouldGenerateKey ) }
 								>
 									{ translate( 'Generate SSH key' ) }
 								</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-14739

## Proposed Changes

* Ensures the "Generate SSH key" button waits for the site's atomic transfer to complete before making the SSH key generation request, similar to how the Continue button works. The loading state only appears when the user has actually clicked the button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If the user clicked on `Generate SSH key` before the transfer to atomic was complete, they would get an error because the site needs to be Atomic so we can generate the SSH key.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  - Use Calypso Live or apply this PR to your local environment
  - Execute the following code on the Console to enable the flag
```js
  sessionStorage.setItem('flags', '+migration/ssh-migration')
```
  - Go through the migration flow with a fresh simple site until you reach the Securely share your access
  - After the checkout, you need to do the steps quickly. We need to verify that clicking on the `Generate SSH key` will wait for the transfer to Atomic to finish, before retrieving the SSH key.
  - Go through the accordion, and on the third step, click on the SSH Key radio option
  - Add a username and click on Generate SSH key
  - Expected: Button shows loading state while waiting for atomic transfer (if still in progress) and then generates the key
  - After it finishes loading, you should see the SSH Key

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
