### PR TITLE
WIP: Flex site flow: Start the flow with Checkout 

### DIFF
--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,13 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-<<<<<<< HEAD
 import { AuthProvider } from '../../dashboard/app/auth';
-=======
-import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { AuthContext } from '../../dashboard/app/auth';
->>>>>>> 185a5a577d7 (Show Flex site creation button for eligible users)
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
@@ -21,7 +15,6 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser ) as User;
 
 	return (
 		<AuthProvider>

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -21,7 +21,7 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser ) as any;
+	const user = useSelector( getCurrentUser ) as User;
 
 	return (
 		<AuthProvider>

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,7 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+<<<<<<< HEAD
 import { AuthProvider } from '../../dashboard/app/auth';
+=======
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { AuthContext } from '../../dashboard/app/auth';
+>>>>>>> 185a5a577d7 (Show Flex site creation button for eligible users)
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
@@ -15,6 +21,7 @@ interface Props extends PropsWithChildren {
 
 export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 	const translate = useTranslate();
+	const user = useSelector( getCurrentUser ) as any;
 
 	return (
 		<AuthProvider>

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -1,19 +1,88 @@
+import { PLAN_WPCOM_FLEXIBLE } from '@automattic/calypso-products';
+import { Visibility } from '@automattic/data-stores';
 import { FLEX_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { setSignupCompleteFlowName, persistSignupDestination } from 'calypso/signup/storageUtils';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { useSiteData } from '../../../hooks/use-site-data';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import type { FlowV2, SubmitHandler } from '../../internals/types';
+import type { Store } from 'redux';
 
-async function initialize() {
-	// Add the flex site creation form step, create-site step, and processing step
-	return stepsWithRequiredLogin( [
-		STEPS.FLEX_SITE_CREATION,
-		STEPS.SITE_CREATION_STEP,
-		STEPS.PROCESSING,
-	] );
+async function initialize( reduxStore: Store ) {
+	const steps = [ STEPS.POST_CHECKOUT_ONBOARDING, STEPS.FLEX_SITE_CREATION, STEPS.PROCESSING ];
+	// Clear any selected site to ensure we start fresh
+	reduxStore.dispatch( setSelectedSiteId( null ) as any );
+
+	// Check if user is logged in
+	const state = reduxStore.getState();
+	const userIsLoggedIn = state?.currentUser?.id != null;
+
+	// Check if we have a site in the URL params or are returning from checkout
+	const urlParams = new URLSearchParams( window.location.search );
+	const hasSiteParam = urlParams.has( 'siteSlug' ) || urlParams.has( 'siteId' );
+	const currentPath = window.location.pathname;
+	const isReturningFromCheckout = currentPath.includes( '/post-checkout-onboarding' );
+
+	// If no site exists and we're not returning from checkout, redirect to checkout
+	if ( ! hasSiteParam && ! isReturningFromCheckout ) {
+		// Set completion tracking for post-checkout site creation
+		setSignupCompleteFlowName( FLEX_SITE_FLOW );
+
+		// Set the post-checkout destination to return to this flow
+		persistSignupDestination( `/setup/${ FLEX_SITE_FLOW }/post-checkout-onboarding` );
+
+		// Create siteParams for post-checkout site creation (similar to onboarding-unified)
+		const siteParams = {
+			blog_name: '', // Will be auto-generated from username if empty
+			blog_title: translate( 'My Flex Site' ), // Default site title
+			public: Visibility.PublicNotIndexed, // Coming soon by default
+			options: {
+				site_creation_flow: FLEX_SITE_FLOW, // Track which flow created the site
+				wpcom_public_coming_soon: 1, // Launch as coming soon
+			},
+			find_available_url: true, // Auto-find available URL
+			validate: false,
+		};
+
+		// Save siteParams to localStorage for checkout to use
+		try {
+			window.localStorage.setItem( 'siteParams', JSON.stringify( siteParams ) );
+		} catch ( error ) {
+			// Silently fail if localStorage is not available
+		}
+
+		// Build checkout URL - use unified checkout for both logged-in and logged-out users
+		const checkoutParams: Record< string, string | number > = {
+			flow: FLEX_SITE_FLOW,
+		};
+
+		// Only add signup=1 for logged-out users to avoid account creation conflicts
+		if ( ! userIsLoggedIn ) {
+			checkoutParams.signup = 1;
+		}
+
+		const checkoutUrl = addQueryArgs(
+			`/checkout/unified/${ PLAN_WPCOM_FLEXIBLE }`,
+			checkoutParams
+		);
+
+		// Redirect to checkout
+		window.location.assign( checkoutUrl );
+
+		// Return false since we're redirecting (no steps to render)
+		return false;
+	}
+
+	// If we have a site, proceed with the normal flow
+	// Start with post-checkout-onboarding for any post-purchase setup,
+	// flex-site-creation for title customization, and processing for final setup
+	return stepsWithRequiredLogin( steps );
 }
 
 const flexSite: FlowV2< typeof initialize > = {
@@ -25,25 +94,34 @@ const flexSite: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: true,
 	initialize,
-	useStepNavigation( _currentStep, navigate ) {
-		const { setSiteTitle } = useDispatch( ONBOARD_STORE );
+	useStepNavigation( currentStep, navigate ) {
+		const { setSiteTitle, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { saveSiteSettings } = useDispatch( SITE_STORE );
+		const { site, siteSlug } = useSiteData();
 
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
-			const { slug, providedDependencies } = submittedStep;
+			const { slug, providedDependencies } = submittedStep as any;
 
 			switch ( slug ) {
-				case 'flex-site-creation':
-					// Store site title in ONBOARD_STORE so create-site step can use it
-					if ( providedDependencies?.siteName ) {
-						setSiteTitle( providedDependencies.siteName );
-					}
-					// After user fills out the form, navigate to create-site step
-					// The create-site step will use the data stored in the onboard store
-					return navigate( STEPS.SITE_CREATION_STEP.slug );
+				case 'post-checkout-onboarding':
+					// Site created after checkout, now navigate to flex-site-creation
+					// to allow user to set/update the site title
+					return navigate( STEPS.FLEX_SITE_CREATION.slug );
 
-				case 'create-site':
-					// Navigate to processing step which will execute the site creation
-					// Pass true to remove create-site from history so back button works properly
+				case 'flex-site-creation':
+					// Store site title and set up pending action to update it
+					if ( providedDependencies?.siteName && site?.ID ) {
+						setSiteTitle( providedDependencies.siteName );
+
+						// Set pending action to update site title
+						setPendingAction( async () => {
+							await saveSiteSettings( site.ID, { blogname: providedDependencies.siteName } );
+							return {
+								siteSlug: siteSlug || site.slug,
+							};
+						} );
+					}
+					// Navigate to processing step to update site title
 					return navigate( STEPS.PROCESSING.slug, undefined, true );
 
 				case 'processing': {
@@ -55,6 +133,10 @@ const flexSite: FlowV2< typeof initialize > = {
 						return window.location.replace(
 							`https://${ providedDependencies.siteSlug }/wp-admin/?logmein=direct`
 						);
+					}
+					// Use siteSlug from hook if available
+					if ( siteSlug ) {
+						return window.location.replace( `https://${ siteSlug }/wp-admin/?logmein=direct` );
 					}
 					// Fallback to sites dashboard
 					return window.location.replace( '/sites' );

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -4,6 +4,7 @@ import { FLEX_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import wpcomRequest from 'wpcom-proxy-request';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { setSignupCompleteFlowName, persistSignupDestination } from 'calypso/signup/storageUtils';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -110,16 +111,45 @@ const flexSite: FlowV2< typeof initialize > = {
 
 				case 'flex-site-creation':
 					// Store site title and set up pending action to update it
-					if ( providedDependencies?.siteName && site?.ID ) {
+					if ( providedDependencies?.siteName ) {
 						setSiteTitle( providedDependencies.siteName );
 
-						// Set pending action to update site title
-						setPendingAction( async () => {
-							await saveSiteSettings( site.ID, { blogname: providedDependencies.siteName } );
-							return {
-								siteSlug: siteSlug || site.slug,
-							};
-						} );
+						if ( site?.ID ) {
+							const currentSiteId = site.ID;
+							const currentSiteSlug = siteSlug || site.slug;
+							const selectedSiteName = providedDependencies.siteName;
+							const isFlexSite = Boolean(
+								( site as { is_wpcom_flex?: boolean } | null )?.is_wpcom_flex
+							);
+
+							// Set pending action to update site title on both the shadow site and the Atomic site.
+							setPendingAction( async () => {
+								const requests: Array< Promise< unknown > > = [
+									saveSiteSettings( currentSiteId, { blogname: selectedSiteName } ),
+								];
+
+								if ( isFlexSite ) {
+									const formData: Array< [ string, string ] > = [
+										[ 'settings', JSON.stringify( { blogname: selectedSiteName } ) ],
+									];
+
+									requests.push(
+										wpcomRequest( {
+											path: `/sites/${ currentSiteId }/onboarding-customization`,
+											apiNamespace: 'wpcom/v2',
+											method: 'POST',
+											formData,
+										} )
+									);
+								}
+
+								await Promise.all( requests );
+
+								return {
+									siteSlug: currentSiteSlug,
+								};
+							} );
+						}
 					}
 					// Navigate to processing step to update site title
 					return navigate( STEPS.PROCESSING.slug, undefined, true );

--- a/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
+++ b/client/landing/stepper/declarative-flow/flows/flex-site/flex-site.ts
@@ -98,7 +98,7 @@ const flexSite: FlowV2< typeof initialize > = {
 	useStepNavigation( currentStep, navigate ) {
 		const { setSiteTitle, setPendingAction } = useDispatch( ONBOARD_STORE );
 		const { saveSiteSettings } = useDispatch( SITE_STORE );
-		const { site, siteSlug } = useSiteData();
+		const { site, siteSlug, siteId } = useSiteData();
 
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep as any;
@@ -114,41 +114,51 @@ const flexSite: FlowV2< typeof initialize > = {
 					if ( providedDependencies?.siteName ) {
 						setSiteTitle( providedDependencies.siteName );
 
-						if ( site?.ID ) {
-							const currentSiteId = site.ID;
-							const currentSiteSlug = siteSlug || site.slug;
-							const selectedSiteName = providedDependencies.siteName;
-							const isFlexSite = Boolean(
-								( site as { is_wpcom_flex?: boolean } | null )?.is_wpcom_flex
-							);
+						const currentSiteId = site?.ID ?? siteId;
+						const currentSiteSlug =
+							siteSlug || site?.slug || ( providedDependencies?.siteSlug as string | undefined );
+						const siteIdentifierForApi = currentSiteId ?? currentSiteSlug;
+						const selectedSiteName = providedDependencies.siteName;
+						const isFlexSite = Boolean(
+							( site as { is_wpcom_flex?: boolean } | null )?.is_wpcom_flex
+						);
 
+						if ( siteIdentifierForApi && ( currentSiteId || isFlexSite ) ) {
 							// Set pending action to update site title on both the shadow site and the Atomic site.
 							setPendingAction( async () => {
-								const requests: Array< Promise< unknown > > = [
-									saveSiteSettings( currentSiteId, { blogname: selectedSiteName } ),
-								];
+								const requests: Array< Promise< unknown > > = [];
+
+								if ( currentSiteId ) {
+									requests.push(
+										saveSiteSettings( currentSiteId, { blogname: selectedSiteName } )
+									);
+								}
 
 								if ( isFlexSite ) {
-									const formData: Array< [ string, string ] > = [
-										[ 'settings', JSON.stringify( { blogname: selectedSiteName } ) ],
-									];
+									const encodedSiteIdentifier = encodeURIComponent(
+										String( siteIdentifierForApi )
+									);
 
 									requests.push(
 										wpcomRequest( {
-											path: `/sites/${ currentSiteId }/onboarding-customization`,
-											apiNamespace: 'wpcom/v2',
+											path: `/sites/${ encodedSiteIdentifier }/settings`,
+											apiNamespace: 'wp/v2',
 											method: 'POST',
-											formData,
+											body: { title: selectedSiteName },
 										} )
 									);
 								}
 
 								await Promise.all( requests );
 
-								return {
-									siteSlug: currentSiteSlug,
-								};
+								return currentSiteSlug
+									? {
+											siteSlug: currentSiteSlug,
+									  }
+									: {};
 							} );
+						} else {
+							setPendingAction( undefined );
 						}
 					}
 					// Navigate to processing step to update site title

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -28,9 +28,6 @@ const FlexSiteCreation: StepType< {
 
 		setIsLoading( true );
 
-		// Store site title in ONBOARD_STORE so create-site step can use it
-		setSiteTitle( siteName );
-
 		submit?.( {
 			siteName,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -31,10 +31,6 @@ const FlexSiteCreation: StepType< {
 		// Store site title in ONBOARD_STORE so create-site step can use it
 		setSiteTitle( siteName );
 
-		recordTracksEvent( 'calypso_flex_site_creation_submit', {
-			site_name: siteName,
-		} );
-
 		submit?.( {
 			siteName,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -2,9 +2,10 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Step } from '@automattic/onboarding';
 import { TextControl, Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { useSiteData } from '../../../../hooks/use-site-data';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -15,9 +16,17 @@ const FlexSiteCreation: StepType< {
 } > = function FlexSiteCreation( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+	const { site } = useSiteData();
 
 	const [ siteName, setSiteName ] = useState( '' );
 	const [ isLoading, setIsLoading ] = useState( false );
+
+	// Pre-populate site name from existing site
+	useEffect( () => {
+		if ( site?.name ) {
+			setSiteName( site.name );
+		}
+	}, [ site ] );
 
 	const handleSubmit = ( event: FormEvent ) => {
 		event.preventDefault();
@@ -48,8 +57,12 @@ const FlexSiteCreation: StepType< {
 				}
 				heading={
 					<Step.Heading
-						text={ __( 'Create a new site' ) }
-						subText={ __( 'No-hassle WordPress install in one click.' ) }
+						text={ site ? __( 'Customize your site' ) : __( 'Create a new site' ) }
+						subText={
+							site
+								? __( 'Update your site title to personalize your flex site.' )
+								: __( 'No-hassle WordPress install in one click.' )
+						}
 					/>
 				}
 			>
@@ -73,7 +86,7 @@ const FlexSiteCreation: StepType< {
 							type="submit"
 							disabled={ isLoading }
 						>
-							{ __( 'Create a site' ) }
+							{ site ? __( 'Continue' ) : __( 'Create a site' ) }
 						</Button>
 					</div>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -28,6 +28,13 @@ const FlexSiteCreation: StepType< {
 
 		setIsLoading( true );
 
+		// Store site title in ONBOARD_STORE so create-site step can use it
+		setSiteTitle( siteName );
+
+		recordTracksEvent( 'calypso_flex_site_creation_submit', {
+			site_name: siteName,
+		} );
+
 		submit?.( {
 			siteName,
 		} );
@@ -66,6 +73,8 @@ const FlexSiteCreation: StepType< {
 								__nextHasNoMarginBottom
 							/>
 						</FormFieldset>
+
+						<div className="flex-site-creation__form-row" />
 
 						<Button
 							className="flex-site-creation__submit-button"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/flex-site-creation/index.tsx
@@ -67,8 +67,6 @@ const FlexSiteCreation: StepType< {
 							/>
 						</FormFieldset>
 
-						<div className="flex-site-creation__form-row" />
-
 						<Button
 							className="flex-site-creation__submit-button"
 							variant="primary"

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -318,13 +318,10 @@ export default function getThankYouPageUrl( {
 			return `/checkout/thank-you/${ siteId }/${ receiptIdOrPlaceholder }`;
 		}
 
-		// Get the post-checkout destination URL from cookie (set during onboarding-unified plans step)
+		// Get the post-checkout destination URL from cookie (set during flows using post-checkout-onboarding)
 		const urlFromCookie = getUrlFromCookie();
 
-		if (
-			urlFromCookie &&
-			urlFromCookie.includes( '/setup/onboarding-unified/post-checkout-onboarding' )
-		) {
+		if ( urlFromCookie && urlFromCookie.includes( '/post-checkout-onboarding' ) ) {
 			debug( 'redirecting to the saved post-checkout destination' );
 			return addQueryArgs( { siteId }, urlFromCookie );
 		}

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -87,7 +87,7 @@ export const PLAN_CHARGEBACK = 'chargeback';
 export const PLAN_VIP = 'vip';
 export const PLAN_P2_PLUS = 'wp_p2_plus_monthly';
 export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed WP.com Free for the P2 project.
-export const PLAN_WPCOM_FLEXIBLE = 'wpcom-flexible'; // Not a real plan; it's a renamed WP.com Free for the plans overhaul.
+export const PLAN_WPCOM_FLEXIBLE = 'flex-hosting-plan-monthly';
 export const PLAN_WPCOM_PRO = 'pro-plan';
 export const PLAN_WPCOM_PRO_MONTHLY = 'pro-plan-monthly';
 export const PLAN_WPCOM_PRO_2_YEARS = 'pro-plan-2y';
@@ -159,6 +159,7 @@ export const WPCOM_MONTHLY_PLANS = < const >[
 	PLAN_WPCOM_PRO_MONTHLY,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_FREE,
+	PLAN_WPCOM_FLEXIBLE,
 ];
 
 export const WOO_EXPRESS_PLANS = < const >[

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -3771,14 +3771,20 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 };
 
 PLANS_LIST[ PLAN_WPCOM_FLEXIBLE ] = {
-	// Inherits the free plan
+	// Base flexible plan on the free experience but with its own catalog entry
 	...PLANS_LIST[ PLAN_FREE ],
-	group: GROUP_WPCOM,
 	type: TYPE_FLEXIBLE,
-	getTitle: () => i18n.translate( 'WordPress Free' ),
-	getBillingTimeFrame: () => i18n.translate( 'upgrade when you need' ),
+	...getMonthlyTimeframe(),
+	getTitle: () => i18n.translate( 'WordPress.com Flex' ),
+	getProductId: () => 1200,
+	getStoreSlug: () => PLAN_WPCOM_FLEXIBLE,
+	getPathSlug: () => 'flex-hosting-plan-monthly',
+	getPlanTagline: () =>
+		i18n.translate( 'Only pay for the hosting tools you need, when you need them.' ),
 	getDescription: () =>
-		i18n.translate( 'Start your free WordPress.com website. Limited functionality and storage.' ),
+		i18n.translate(
+			'Start with flexible WordPress.com hosting and add extras whenever you are ready.'
+		),
 	getPlanCompareFeatures: () => [ FEATURE_1GB_STORAGE ],
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTMART-17](https://linear.app/a8c/issue/DOTMART-17/create-a-flow-for-building-a-new-flex-site)

## Proposed Changes

* adds the Flex hosting monthly plan
* adds the checkout as the first step of the flow
* the checkout creates the sites
* the post-checkout step allows the site title be set (updated)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* follow up to https://github.com/Automattic/wp-calypso/pull/106433 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
