### PR TITLE
Update DIFM theme step

### DIFF
--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -23,7 +23,7 @@ export const getMShotOptions = ( {
 	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
 	//
 	// See #88786 for more info.
-	let w = 500;
+	let w = 1200;
 	let screen_height = 1100;
 	if ( oldHighResImageLoading ) {
 		w = highRes ? 1199 : 600;

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -265,19 +265,6 @@ const MShotsImageControl = ( {
 		visible ? 'mshots-image-visible' : 'mshots-image__loader'
 	);
 
-	if ( options?.oldHighResImageLoading ) {
-		return scrollable ? (
-			<div className={ className } style={ style } aria-labelledby={ labelledby }>
-				<img ref={ imgRef } className="mshots-dummy-image" aria-hidden="true" alt="" />
-			</div>
-		) : (
-			<img
-				ref={ imgRef }
-				{ ...{ className, style, src, alt, loading } }
-				aria-labelledby={ labelledby }
-			/>
-		);
-	} // else, prettier doesn't like having an else after a return
 	return scrollable ? (
 		<div className={ className } style={ style } aria-labelledby={ labelledby }>
 			<img
@@ -396,6 +383,7 @@ const MShotsImage = ( {
 			/>
 		);
 	}
+
 	return (
 		<MShotsImageControl
 			url={ url }

--- a/packages/onboarding/src/mshots-image/style.scss
+++ b/packages/onboarding/src/mshots-image/style.scss
@@ -5,6 +5,7 @@
 }
 
 .mshots-image__container {
+	cursor: pointer;
 	height: 100%;
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-62

## Proposed Changes

* Increase `w` (the output width) on the mShots settings used for the design picker thumbnails.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The images on the theme step of the DIFM flow are low quality:

<img width="3452" height="1972" alt="image" src="https://github.com/user-attachments/assets/1cd69f30-8e53-46a9-abd4-b30f14d421b4" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/start/do-it-for-me/new-or-existing-site`
* Click next steps until you reach the `Design` step
* Check that the images have a higher resolution than on production

|Before|After|
|---|---|
|<img width="3583" height="1925" alt="image" src="https://github.com/user-attachments/assets/d6bea783-ef6c-4544-a3cb-3eb22ed99753" />|<img width="3583" height="1925" alt="image" src="https://github.com/user-attachments/assets/1cd94454-4e85-4ffe-bcfe-63fd32a76ab3" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
