### PR TITLE
Help Center Menu Panel: Open panel on click, wp-admin

### DIFF
--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -88,12 +88,27 @@ function AdminHelpCenterContent() {
 
 	const handleMenuPanelClick = () => {
 		trackIconInteraction();
-		if ( button.classList.contains( 'open-click' ) ) {
-			button.classList.remove( 'open-click' );
-		} else {
-			button.classList.add( 'open-click' );
-		}
+		// Toggle submenu visibility by toggling the hover class
+		button.classList.toggle( 'open-click' );
 	};
+
+	// Close submenu when clicking outside
+	useEffect( () => {
+		if ( ! hasHelpCenterMenuPanel ) {
+			return;
+		}
+
+		const handleClickOutside = ( event ) => {
+			if ( ! button.contains( event.target ) && button.classList.contains( 'open-click' ) ) {
+				button.classList.remove( 'open-click' );
+			}
+		};
+
+		document.addEventListener( 'click', handleClickOutside );
+		return () => {
+			document.removeEventListener( 'click', handleClickOutside );
+		};
+	}, [ button, hasHelpCenterMenuPanel ] );
 
 	const handleToggleHelpCenter = () => {
 		trackIconInteraction();

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -86,6 +86,15 @@ function AdminHelpCenterContent() {
 		} );
 	}, [ isShown, hasHelpCenterMenuPanel ] );
 
+	const handleMenuPanelClick = () => {
+		trackIconInteraction();
+		if ( button.classList.contains( 'open-click' ) ) {
+			button.classList.remove( 'open-click' );
+		} else {
+			button.classList.add( 'open-click' );
+		}
+	};
+
 	const handleToggleHelpCenter = () => {
 		trackIconInteraction();
 		recordTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
@@ -97,7 +106,7 @@ function AdminHelpCenterContent() {
 		setShowHelpCenter( ! isShown );
 	};
 
-	button.onclick = hasHelpCenterMenuPanel ? trackIconInteraction : handleToggleHelpCenter;
+	button.onclick = hasHelpCenterMenuPanel ? handleMenuPanelClick : handleToggleHelpCenter;
 
 	const handleMenuClick = useCallback(
 		( destination, isExternal = false ) => {

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -118,6 +118,17 @@
 			color: #7b90ff;
 			cursor: pointer;
 		}
+
+		// Disable hover behavior for submenu - require click instead
+		&.menupop.hover > .ab-sub-wrapper,
+		&.menupop > .ab-sub-wrapper {
+			display: none !important;
+		}
+
+		// Only show submenu when the hover class is applied via click
+		&.menupop.open-click > .ab-sub-wrapper {
+			display: block !important;
+		}
 	}
 
 	.ab-icon:hover {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-15077/wp-admin-add-icons-and-remove-hover

We do not want the menu to open on hover in wp-admin, so we change it to on click

## Testing steps

1. `yarn dev --sync` from `apps/help-center`
2. Append ?flags=help-center-menu-panel to the url