### PR TITLE
Domain Connections Redesign: Add DNS records table

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
@@ -1,4 +1,4 @@
 /* The Type and Name columns should be narrow */
-.update-dns-records-table .dataviews-view-table__cell-content-wrapper {
+.dns-records-table .dataviews-view-table__cell-content-wrapper {
 	min-width: initial;
 }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
@@ -1,0 +1,4 @@
+/* The Type and Name columns should be narrow */
+.update-dns-records-table .dataviews-view-table__cell-content-wrapper {
+	min-width: initial;
+}

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,3 +1,6 @@
+import { domainMappingStatusQuery, domainQuery } from '@automattic/api-queries';
+import { Badge } from '@automattic/ui';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
@@ -9,7 +12,7 @@ interface FormData {
 	name: string;
 	currentValue: string;
 	expectedValue: string;
-	status: string;
+	status: React.ReactNode;
 }
 
 const DEFAULT_VIEW: ViewTable = {
@@ -20,84 +23,93 @@ const DEFAULT_VIEW: ViewTable = {
 		direction: 'asc',
 	},
 	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
-	layout: {
-		styles: {
-			type: {
-				width: '10%',
-			},
-			name: {
-				width: '10%',
-			},
-			currentValue: {
-				width: '30%',
-			},
-			expectedValue: {
-				width: '30%',
-			},
-			status: {
-				width: '10%',
-			},
-		},
-	},
 };
 
-export default function DnsRecordsTable() {
-	const formData = [
-		{
-			type: 'A',
-			name: '@',
-			currentValue: '192.168.1.2',
-			expectedValue: '192.168.1.1',
-			status: 'verifying',
-		},
-		{
-			type: 'CNAME',
-			name: 'www',
-			currentValue: 'foo.com',
-			expectedValue: 'bar.com',
-			status: 'verifying',
-		},
-	];
+const fields: Field< FormData >[] = [
+	{
+		id: 'type',
+		label: __( 'Type' ),
+		type: 'text' as const,
+		readOnly: true,
+	},
+	{
+		id: 'name',
+		label: __( 'Name' ),
+		type: 'text' as const,
+		readOnly: true,
+	},
+	{
+		id: 'currentValue',
+		label: __( 'Current Value' ),
+		type: 'text' as const,
+		readOnly: true,
+	},
+	{
+		id: 'expectedValue',
+		label: __( 'Expected Value' ),
+		type: 'text' as const,
+		readOnly: true,
+	},
+	{
+		id: 'status',
+		label: __( 'Status' ),
+		type: 'text' as const,
+		readOnly: true,
+	},
+];
 
-	const fields: Field< FormData >[] = useMemo(
-		() => [
-			{
-				id: 'type',
-				label: __( 'Type' ),
-				type: 'text' as const,
-				readOnly: true,
-			},
-			{
-				id: 'name',
-				label: __( 'Name' ),
-				type: 'text' as const,
-				readOnly: true,
-			},
-			{
-				id: 'currentValue',
-				label: __( 'Current Value' ),
-				type: 'text' as const,
-				readOnly: true,
-			},
-			{
-				id: 'expectedValue',
-				label: __( 'Expected Value' ),
-				type: 'text' as const,
-				readOnly: true,
-			},
-			{
-				id: 'status',
-				label: __( 'Status' ),
-				type: 'text' as const,
-				readOnly: true,
-			},
-		],
-		[]
-	);
+const VerifiedBadge = () => {
+	return <Badge intent="success">{ __( 'Verified' ) }</Badge>;
+};
+
+const VerifyingBadge = () => {
+	return <Badge intent="warning">{ __( 'Verifying' ) }</Badge>;
+};
+
+export default function DnsRecordsTable( { domainName }: { domainName: string } ) {
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
+
+	const formData = useMemo( (): FormData[] => {
+		const data: FormData[] = [];
+
+		const hostIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
+		const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
+		const longestArray = Math.max( hostIpAddresses.length, expectedIpAddresses.length );
+
+		for ( let i = 0; i < longestArray; i++ ) {
+			const isVerified = hostIpAddresses[ i ] === expectedIpAddresses[ i ];
+
+			data.push( {
+				type: 'A',
+				name: '@',
+				currentValue: hostIpAddresses[ i ] || '-',
+				expectedValue: expectedIpAddresses[ i ] || '-',
+				status: isVerified ? <VerifiedBadge /> : <VerifyingBadge />,
+			} );
+		}
+
+		if ( domainMappingStatus.www_cname_record_target ) {
+			const isVerified = domainMappingStatus.www_cname_record_target === domainName;
+
+			data.push( {
+				type: 'CNAME',
+				name: 'www',
+				currentValue: domainMappingStatus.www_cname_record_target,
+				expectedValue: domainName,
+				status: isVerified ? <VerifiedBadge /> : <VerifyingBadge />,
+			} );
+		}
+
+		return data;
+	}, [ domain, domainName, domainMappingStatus ] );
 
 	const [ view, setView ] = useState< ViewTable >( DEFAULT_VIEW );
 
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( formData, view, fields );
+	const { data: filteredData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( formData, view, fields ),
+		[ formData, view ]
+	);
 
 	return (
 		<DataViewsCard>
@@ -108,7 +120,9 @@ export default function DnsRecordsTable() {
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ paginationInfo }
 				onChangeView={ ( view: View ) => setView( view as ViewTable ) }
-				getItemId={ ( item: FormData ) => `${ item.type }-${ item.name }` }
+				getItemId={ ( item: FormData ) =>
+					`${ item.type }-${ item.name }-${ item.currentValue }-${ item.expectedValue }`
+				}
 			>
 				<>
 					<DataViews.Layout />

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -33,8 +33,15 @@ interface DnsRecordVerification {
 	name?: string; // only present in advanced mode
 	currentValue: string;
 	expectedValue: string;
-	status: React.ReactNode;
 }
+
+const VerificationBadge = ( { isVerified }: { isVerified: boolean } ) => {
+	return (
+		<Badge intent={ isVerified ? 'success' : 'warning' }>
+			{ isVerified ? __( 'Verified' ) : __( 'Verifying' ) }
+		</Badge>
+	);
+};
 
 const fieldsSuggested: Field< DnsRecordVerification >[] = [
 	{
@@ -63,6 +70,8 @@ const fieldsSuggested: Field< DnsRecordVerification >[] = [
 		enableHiding: false,
 		enableSorting: false,
 		filterBy: false,
+		getValue: ( { item } ) => item.currentValue === item.expectedValue,
+		render: ( { field, item } ) => <VerificationBadge isVerified={ field.getValue( { item } ) } />,
 	},
 ];
 
@@ -88,21 +97,12 @@ const fieldsAdvanced: Field< DnsRecordVerification >[] = [
 	...fieldsSuggested,
 ];
 
-const VerifiedBadge = () => {
-	return <Badge intent="success">{ __( 'Verified' ) }</Badge>;
-};
-
-const VerifyingBadge = () => {
-	return <Badge intent="warning">{ __( 'Verifying' ) }</Badge>;
-};
-
 const aRecordData = ( currentValue: string, expectedValue: string ) => {
 	return {
 		type: 'A',
 		name: '@',
 		currentValue: currentValue,
 		expectedValue: expectedValue,
-		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
 	};
 };
 
@@ -112,7 +112,6 @@ const wwwCnameRecordData = ( currentValue: string, expectedValue: string ) => {
 		name: 'www',
 		currentValue: currentValue,
 		expectedValue: expectedValue,
-		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
 	};
 };
 
@@ -120,7 +119,6 @@ const nameServerRecordData = ( currentValue: string, expectedValue: string ) => 
 	return {
 		currentValue: currentValue,
 		expectedValue: expectedValue,
-		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
 	};
 };
 

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -42,7 +42,25 @@ const VerificationBadge = ( { isVerified }: { isVerified: boolean } ) => {
 	);
 };
 
-const fieldsSuggested: Field< DnsRecordVerification >[] = [
+const fields: Field< DnsRecordVerification >[] = [
+	{
+		id: 'type',
+		label: __( 'Type' ),
+		type: 'text' as const,
+		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+	},
+	{
+		id: 'name',
+		label: __( 'Name' ),
+		type: 'text' as const,
+		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+	},
 	{
 		id: 'currentValue',
 		label: __( 'Current Value' ),
@@ -74,28 +92,6 @@ const fieldsSuggested: Field< DnsRecordVerification >[] = [
 		getValue: ( { item } ) => item.currentValue === item.expectedValue,
 		render: ( { field, item } ) => <VerificationBadge isVerified={ field.getValue( { item } ) } />,
 	},
-];
-
-const fieldsAdvanced: Field< DnsRecordVerification >[] = [
-	{
-		id: 'type',
-		label: __( 'Type' ),
-		type: 'text' as const,
-		readOnly: true,
-		enableHiding: false,
-		enableSorting: false,
-		filterBy: false,
-	},
-	{
-		id: 'name',
-		label: __( 'Name' ),
-		type: 'text' as const,
-		readOnly: true,
-		enableHiding: false,
-		enableSorting: false,
-		filterBy: false,
-	},
-	...fieldsSuggested,
 ];
 
 const aRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
@@ -167,7 +163,7 @@ export default function DnsRecordsTable( {
 		<DataViewsCard className="dns-records-table">
 			<DataViews< DnsRecordVerification >
 				data={ dnsRecords }
-				fields={ isSuggestedMode ? fieldsSuggested : fieldsAdvanced }
+				fields={ fields }
 				view={ isSuggestedMode ? viewSuggested : viewAdvanced }
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,5 +1,9 @@
-import { DomainConnectionSetupMode, DomainMappingSetupInfo } from '@automattic/api-core';
-import { domainMappingStatusQuery, domainQuery } from '@automattic/api-queries';
+import {
+	DomainConnectionSetupMode,
+	DomainMappingSetupInfo,
+	DomainMappingStatus,
+} from '@automattic/api-core';
+import { domainQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { DataViews } from '@wordpress/dataviews';
@@ -120,21 +124,22 @@ const nameServerRecordData = ( currentValue: string, expectedValue: string ) => 
 
 export default function DnsRecordsTable( {
 	domainName,
+	domainConnectionStatus,
 	domainConnectionSetupInfo,
 }: {
 	domainName: string;
+	domainConnectionStatus: DomainMappingStatus;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
 } ) {
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	const isSuggestedMode = domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED;
+	const isSuggestedMode = domainConnectionStatus.mode === DomainConnectionSetupMode.SUGGESTED;
 
 	const dnsRecords = useMemo( () => {
 		const data: DnsRecordVerification[] = [];
 
 		if ( isSuggestedMode ) {
-			const currentNameServers = ( domainMappingStatus?.name_servers || [] ).sort();
+			const currentNameServers = ( domainConnectionStatus?.name_servers || [] ).sort();
 			const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers;
 			const longestLength = Math.max( currentNameServers.length, expectedNameServers.length );
 
@@ -144,7 +149,7 @@ export default function DnsRecordsTable( {
 				);
 			}
 		} else {
-			const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
+			const currentIpAddresses = ( domainConnectionStatus?.host_ip_addresses || [] ).sort();
 			const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 
@@ -152,12 +157,12 @@ export default function DnsRecordsTable( {
 				data.push( aRecordData( currentIpAddresses[ i ] || '-', expectedIpAddresses[ i ] || '-' ) );
 			}
 
-			const wwwCnameRecordTarget = domainMappingStatus.www_cname_record_target || '-';
+			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target || '-';
 			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
 		}
 
 		return data;
-	}, [ domain, domainName, domainMappingStatus, domainConnectionSetupInfo, isSuggestedMode ] );
+	}, [ domain, domainName, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
 
 	return (
 		<DataViewsCard className="dns-records-table">

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -7,6 +7,8 @@ import { useMemo, useState } from 'react';
 import { DataViewsCard } from '../../../components/dataviews-card';
 import type { Field, ViewTable, View } from '@wordpress/dataviews';
 
+import './dns-records-table-style.scss';
+
 interface FormData {
 	type: string;
 	name: string;
@@ -112,7 +114,7 @@ export default function DnsRecordsTable( { domainName }: { domainName: string } 
 	);
 
 	return (
-		<DataViewsCard>
+		<DataViewsCard className="update-dns-records-table">
 			<DataViews< FormData >
 				data={ filteredData }
 				fields={ fields }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,15 +1,21 @@
 import { domainMappingStatusQuery, domainQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { DataViewsCard } from '../../../components/dataviews-card';
-import type { Field, ViewTable, View } from '@wordpress/dataviews';
+import type { Field, ViewTable } from '@wordpress/dataviews';
 
 import './dns-records-table-style.scss';
 
-interface FormData {
+const view: ViewTable = {
+	type: 'table',
+	page: 1,
+	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
+};
+
+interface DnsRecordVerification {
 	type: string;
 	name: string;
 	currentValue: string;
@@ -17,17 +23,7 @@ interface FormData {
 	status: React.ReactNode;
 }
 
-const DEFAULT_VIEW: ViewTable = {
-	type: 'table',
-	page: 1,
-	sort: {
-		field: 'type',
-		direction: 'asc',
-	},
-	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
-};
-
-const fields: Field< FormData >[] = [
+const fields: Field< DnsRecordVerification >[] = [
 	{
 		id: 'type',
 		label: __( 'Type' ),
@@ -68,68 +64,60 @@ const VerifyingBadge = () => {
 	return <Badge intent="warning">{ __( 'Verifying' ) }</Badge>;
 };
 
+const aRecordData = ( currentValue: string, expectedValue: string ) => {
+	return {
+		type: 'A',
+		name: '@',
+		currentValue: currentValue,
+		expectedValue: expectedValue,
+		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
+	};
+};
+
+const wwwCnameRecordData = ( currentValue: string, expectedValue: string ) => {
+	return {
+		type: 'CNAME',
+		name: 'www',
+		currentValue: currentValue,
+		expectedValue: expectedValue,
+		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
+	};
+};
+
 export default function DnsRecordsTable( { domainName }: { domainName: string } ) {
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	const formData = useMemo( (): FormData[] => {
-		const data: FormData[] = [];
+	const dnsRecords = useMemo( (): DnsRecordVerification[] => {
+		const data: DnsRecordVerification[] = [];
 
-		const hostIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
+		const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
 		const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
-		const longestArray = Math.max( hostIpAddresses.length, expectedIpAddresses.length );
 
-		for ( let i = 0; i < longestArray; i++ ) {
-			const isVerified = hostIpAddresses[ i ] === expectedIpAddresses[ i ];
-
-			data.push( {
-				type: 'A',
-				name: '@',
-				currentValue: hostIpAddresses[ i ] || '-',
-				expectedValue: expectedIpAddresses[ i ] || '-',
-				status: isVerified ? <VerifiedBadge /> : <VerifyingBadge />,
-			} );
+		for ( let i = 0; i < Math.max( currentIpAddresses.length, expectedIpAddresses.length ); i++ ) {
+			data.push( aRecordData( currentIpAddresses[ i ], expectedIpAddresses[ i ] ) );
 		}
 
-		if ( domainMappingStatus.www_cname_record_target ) {
-			const isVerified = domainMappingStatus.www_cname_record_target === domainName;
-
-			data.push( {
-				type: 'CNAME',
-				name: 'www',
-				currentValue: domainMappingStatus.www_cname_record_target,
-				expectedValue: domainName,
-				status: isVerified ? <VerifiedBadge /> : <VerifyingBadge />,
-			} );
-		}
+		const wwwCnameRecordTarget = domainMappingStatus.www_cname_record_target || '-';
+		data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
 
 		return data;
 	}, [ domain, domainName, domainMappingStatus ] );
 
-	const [ view, setView ] = useState< ViewTable >( DEFAULT_VIEW );
-
-	const { data: filteredData, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( formData, view, fields ),
-		[ formData, view ]
-	);
-
 	return (
-		<DataViewsCard className="update-dns-records-table">
-			<DataViews< FormData >
-				data={ filteredData }
+		<DataViewsCard className="dns-records-table">
+			<DataViews< DnsRecordVerification >
+				data={ dnsRecords }
 				fields={ fields }
 				view={ view }
 				defaultLayouts={ { table: {} } }
-				paginationInfo={ paginationInfo }
-				onChangeView={ ( view: View ) => setView( view as ViewTable ) }
-				getItemId={ ( item: FormData ) =>
-					`${ item.type }-${ item.name }-${ item.currentValue }-${ item.expectedValue }`
+				paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
+				onChangeView={ () => {} }
+				getItemId={ ( item: DnsRecordVerification ) =>
+					`${ item.type }-${ item.name }-${ item.currentValue }`
 				}
 			>
-				<>
-					<DataViews.Layout />
-					<DataViews.Pagination />
-				</>
+				<DataViews.Layout />
 			</DataViews>
 		</DataViewsCard>
 	);

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -179,8 +179,7 @@ export default function DnsRecordsTable( { domainName }: { domainName: string } 
 				);
 			}
 		} else {
-			// const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
-			const currentIpAddresses = [ '1.1.1.1' ];
+			const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
 			const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -20,12 +20,8 @@ const viewSuggested: ViewTable = {
 };
 
 const viewAdvanced: ViewTable = {
-	type: 'table',
-	page: 1,
+	...viewSuggested,
 	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
-	layout: {
-		enableMoving: false,
-	},
 };
 
 interface DnsRecordVerification {

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,4 +1,4 @@
-import { DomainConnectionSetupMode } from '@automattic/api-core';
+import { DomainConnectionSetupMode, DomainMappingSetupInfo } from '@automattic/api-core';
 import { domainMappingStatusQuery, domainQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -156,7 +156,13 @@ const nameServerRecordData = ( currentValue: string, expectedValue: string ) => 
 	};
 };
 
-export default function DnsRecordsTable( { domainName }: { domainName: string } ) {
+export default function DnsRecordsTable( {
+	domainName,
+	domainConnectionSetupInfo,
+}: {
+	domainName: string;
+	domainConnectionSetupInfo: DomainMappingSetupInfo;
+} ) {
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
@@ -170,7 +176,7 @@ export default function DnsRecordsTable( { domainName }: { domainName: string } 
 
 		if ( isSuggestedMode ) {
 			const currentNameServers = ( domainMappingStatus?.name_servers || [] ).sort();
-			const expectedNameServers = [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ];
+			const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers;
 			const longestLength = Math.max( currentNameServers.length, expectedNameServers.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,0 +1,120 @@
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from 'react';
+import { DataViewsCard } from '../../../components/dataviews-card';
+import type { Field, ViewTable, View } from '@wordpress/dataviews';
+
+interface FormData {
+	type: string;
+	name: string;
+	currentValue: string;
+	expectedValue: string;
+	status: string;
+}
+
+const DEFAULT_VIEW: ViewTable = {
+	type: 'table',
+	page: 1,
+	sort: {
+		field: 'type',
+		direction: 'asc',
+	},
+	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
+	layout: {
+		styles: {
+			type: {
+				width: '10%',
+			},
+			name: {
+				width: '10%',
+			},
+			currentValue: {
+				width: '30%',
+			},
+			expectedValue: {
+				width: '30%',
+			},
+			status: {
+				width: '10%',
+			},
+		},
+	},
+};
+
+export default function DnsRecordsTable() {
+	const formData = [
+		{
+			type: 'A',
+			name: '@',
+			currentValue: '192.168.1.2',
+			expectedValue: '192.168.1.1',
+			status: 'verifying',
+		},
+		{
+			type: 'CNAME',
+			name: 'www',
+			currentValue: 'foo.com',
+			expectedValue: 'bar.com',
+			status: 'verifying',
+		},
+	];
+
+	const fields: Field< FormData >[] = useMemo(
+		() => [
+			{
+				id: 'type',
+				label: __( 'Type' ),
+				type: 'text' as const,
+				readOnly: true,
+			},
+			{
+				id: 'name',
+				label: __( 'Name' ),
+				type: 'text' as const,
+				readOnly: true,
+			},
+			{
+				id: 'currentValue',
+				label: __( 'Current Value' ),
+				type: 'text' as const,
+				readOnly: true,
+			},
+			{
+				id: 'expectedValue',
+				label: __( 'Expected Value' ),
+				type: 'text' as const,
+				readOnly: true,
+			},
+			{
+				id: 'status',
+				label: __( 'Status' ),
+				type: 'text' as const,
+				readOnly: true,
+			},
+		],
+		[]
+	);
+
+	const [ view, setView ] = useState< ViewTable >( DEFAULT_VIEW );
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( formData, view, fields );
+
+	return (
+		<DataViewsCard>
+			<DataViews< FormData >
+				data={ filteredData }
+				fields={ fields }
+				view={ view }
+				defaultLayouts={ { table: {} } }
+				paginationInfo={ paginationInfo }
+				onChangeView={ ( view: View ) => setView( view as ViewTable ) }
+				getItemId={ ( item: FormData ) => `${ item.type }-${ item.name }` }
+			>
+				<>
+					<DataViews.Layout />
+					<DataViews.Pagination />
+				</>
+			</DataViews>
+		</DataViewsCard>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -31,8 +31,8 @@ const viewAdvanced: ViewTable = {
 interface DnsRecordVerification {
 	type?: string; // only present in advanced mode
 	name?: string; // only present in advanced mode
-	currentValue: string;
-	expectedValue: string;
+	currentValue: string | null;
+	expectedValue: string | null;
 }
 
 const VerificationBadge = ( { isVerified }: { isVerified: boolean } ) => {
@@ -52,6 +52,7 @@ const fieldsSuggested: Field< DnsRecordVerification >[] = [
 		enableHiding: false,
 		enableSorting: false,
 		filterBy: false,
+		render: ( { field, item } ) => field.getValue( { item } ) || '-',
 	},
 	{
 		id: 'expectedValue',
@@ -61,6 +62,7 @@ const fieldsSuggested: Field< DnsRecordVerification >[] = [
 		enableHiding: false,
 		enableSorting: false,
 		filterBy: false,
+		render: ( { field, item } ) => field.getValue( { item } ) || '-',
 	},
 	{
 		id: 'status',
@@ -97,7 +99,7 @@ const fieldsAdvanced: Field< DnsRecordVerification >[] = [
 	...fieldsSuggested,
 ];
 
-const aRecordData = ( currentValue: string, expectedValue: string ) => {
+const aRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
 	return {
 		type: 'A',
 		name: '@',
@@ -106,7 +108,7 @@ const aRecordData = ( currentValue: string, expectedValue: string ) => {
 	};
 };
 
-const wwwCnameRecordData = ( currentValue: string, expectedValue: string ) => {
+const wwwCnameRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
 	return {
 		type: 'CNAME',
 		name: 'www',
@@ -115,7 +117,7 @@ const wwwCnameRecordData = ( currentValue: string, expectedValue: string ) => {
 	};
 };
 
-const nameServerRecordData = ( currentValue: string, expectedValue: string ) => {
+const nameServerRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
 	return {
 		currentValue: currentValue,
 		expectedValue: expectedValue,
@@ -144,9 +146,7 @@ export default function DnsRecordsTable( {
 			const longestLength = Math.max( currentNameServers.length, expectedNameServers.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
-				data.push(
-					nameServerRecordData( currentNameServers[ i ] || '-', expectedNameServers[ i ] || '-' )
-				);
+				data.push( nameServerRecordData( currentNameServers[ i ], expectedNameServers[ i ] ) );
 			}
 		} else {
 			const currentIpAddresses = ( domainConnectionStatus?.host_ip_addresses || [] ).sort();
@@ -154,10 +154,10 @@ export default function DnsRecordsTable( {
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
-				data.push( aRecordData( currentIpAddresses[ i ] || '-', expectedIpAddresses[ i ] || '-' ) );
+				data.push( aRecordData( currentIpAddresses[ i ], expectedIpAddresses[ i ] ) );
 			}
 
-			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target || '-';
+			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target;
 			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
 		}
 

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,11 +1,10 @@
 import {
+	Domain,
 	DomainConnectionSetupMode,
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
 } from '@automattic/api-core';
-import { domainQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -124,17 +123,17 @@ const nameServerRecordData = ( currentValue: string | null, expectedValue: strin
 	};
 };
 
-export default function DnsRecordsTable( {
-	domainName,
-	domainConnectionStatus,
-	domainConnectionSetupInfo,
-}: {
-	domainName: string;
+interface DnsRecordVerificationProps {
+	domainData: Domain;
 	domainConnectionStatus: DomainMappingStatus;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
-} ) {
-	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+}
 
+export default function DnsRecordsTable( {
+	domainData,
+	domainConnectionStatus,
+	domainConnectionSetupInfo,
+}: DnsRecordVerificationProps ) {
 	const isSuggestedMode = domainConnectionStatus.mode === DomainConnectionSetupMode.SUGGESTED;
 
 	const dnsRecords = useMemo( () => {
@@ -150,7 +149,7 @@ export default function DnsRecordsTable( {
 			}
 		} else {
 			const currentIpAddresses = ( domainConnectionStatus?.host_ip_addresses || [] ).sort();
-			const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
+			const expectedIpAddresses = ( domainData?.a_records_required_for_mapping || [] ).sort();
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
@@ -158,11 +157,11 @@ export default function DnsRecordsTable( {
 			}
 
 			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target;
-			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
+			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainData.domain ) );
 		}
 
 		return data;
-	}, [ domain, domainName, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
+	}, [ domainData, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
 
 	return (
 		<DataViewsCard className="dns-records-table">

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -13,6 +13,9 @@ const view: ViewTable = {
 	type: 'table',
 	page: 1,
 	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
+	layout: {
+		enableMoving: false,
+	},
 };
 
 interface DnsRecordVerification {
@@ -29,30 +32,45 @@ const fields: Field< DnsRecordVerification >[] = [
 		label: __( 'Type' ),
 		type: 'text' as const,
 		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
 	},
 	{
 		id: 'name',
 		label: __( 'Name' ),
 		type: 'text' as const,
 		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
 	},
 	{
 		id: 'currentValue',
 		label: __( 'Current Value' ),
 		type: 'text' as const,
 		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
 	},
 	{
 		id: 'expectedValue',
 		label: __( 'Expected Value' ),
 		type: 'text' as const,
 		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
 	},
 	{
 		id: 'status',
 		label: __( 'Status' ),
 		type: 'text' as const,
 		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
 	},
 ];
 

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,3 +1,4 @@
+import { DomainConnectionSetupMode } from '@automattic/api-core';
 import { domainMappingStatusQuery, domainQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -9,7 +10,16 @@ import type { Field, ViewTable } from '@wordpress/dataviews';
 
 import './dns-records-table-style.scss';
 
-const view: ViewTable = {
+const viewSuggested: ViewTable = {
+	type: 'table',
+	page: 1,
+	fields: [ 'currentValue', 'expectedValue', 'status' ],
+	layout: {
+		enableMoving: false,
+	},
+};
+
+const viewAdvanced: ViewTable = {
 	type: 'table',
 	page: 1,
 	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
@@ -18,7 +28,13 @@ const view: ViewTable = {
 	},
 };
 
-interface DnsRecordVerification {
+interface DnsRecordSuggestedVerification {
+	currentValue: string;
+	expectedValue: string;
+	status: React.ReactNode;
+}
+
+interface DnsRecordAdvancedVerification {
 	type: string;
 	name: string;
 	currentValue: string;
@@ -26,7 +42,37 @@ interface DnsRecordVerification {
 	status: React.ReactNode;
 }
 
-const fields: Field< DnsRecordVerification >[] = [
+const fieldsSuggested: Field< DnsRecordSuggestedVerification >[] = [
+	{
+		id: 'currentValue',
+		label: __( 'Current Value' ),
+		type: 'text' as const,
+		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+	},
+	{
+		id: 'expectedValue',
+		label: __( 'Expected Value' ),
+		type: 'text' as const,
+		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+	},
+	{
+		id: 'status',
+		label: __( 'Status' ),
+		type: 'text' as const,
+		readOnly: true,
+		enableHiding: false,
+		enableSorting: false,
+		filterBy: false,
+	},
+];
+
+const fieldsAdvanced: Field< DnsRecordAdvancedVerification >[] = [
 	{
 		id: 'type',
 		label: __( 'Type' ),
@@ -102,41 +148,84 @@ const wwwCnameRecordData = ( currentValue: string, expectedValue: string ) => {
 	};
 };
 
+const nameServerRecordData = ( currentValue: string, expectedValue: string ) => {
+	return {
+		currentValue: currentValue,
+		expectedValue: expectedValue,
+		status: currentValue === expectedValue ? <VerifiedBadge /> : <VerifyingBadge />,
+	};
+};
+
 export default function DnsRecordsTable( { domainName }: { domainName: string } ) {
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: domainMappingStatus } = useSuspenseQuery( domainMappingStatusQuery( domainName ) );
 
-	const dnsRecords = useMemo( (): DnsRecordVerification[] => {
-		const data: DnsRecordVerification[] = [];
+	const isSuggestedMode = domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED;
 
-		const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
-		const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
+	const dnsRecords = useMemo( (): (
+		| DnsRecordAdvancedVerification
+		| DnsRecordSuggestedVerification
+	)[] => {
+		const data: ( DnsRecordAdvancedVerification | DnsRecordSuggestedVerification )[] = [];
 
-		for ( let i = 0; i < Math.max( currentIpAddresses.length, expectedIpAddresses.length ); i++ ) {
-			data.push( aRecordData( currentIpAddresses[ i ], expectedIpAddresses[ i ] ) );
+		if ( isSuggestedMode ) {
+			const currentNameServers = ( domainMappingStatus?.name_servers || [] ).sort();
+			const expectedNameServers = [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ];
+			const longestLength = Math.max( currentNameServers.length, expectedNameServers.length );
+
+			for ( let i = 0; i < longestLength; i++ ) {
+				data.push(
+					nameServerRecordData( currentNameServers[ i ] || '-', expectedNameServers[ i ] || '-' )
+				);
+			}
+		} else {
+			// const currentIpAddresses = ( domainMappingStatus?.host_ip_addresses || [] ).sort();
+			const currentIpAddresses = [ '1.1.1.1' ];
+			const expectedIpAddresses = ( domain?.a_records_required_for_mapping || [] ).sort();
+			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
+
+			for ( let i = 0; i < longestLength; i++ ) {
+				data.push( aRecordData( currentIpAddresses[ i ] || '-', expectedIpAddresses[ i ] || '-' ) );
+			}
+
+			const wwwCnameRecordTarget = domainMappingStatus.www_cname_record_target || '-';
+			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
 		}
 
-		const wwwCnameRecordTarget = domainMappingStatus.www_cname_record_target || '-';
-		data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
-
 		return data;
-	}, [ domain, domainName, domainMappingStatus ] );
+	}, [ domain, domainName, domainMappingStatus, isSuggestedMode ] );
 
 	return (
 		<DataViewsCard className="dns-records-table">
-			<DataViews< DnsRecordVerification >
-				data={ dnsRecords }
-				fields={ fields }
-				view={ view }
-				defaultLayouts={ { table: {} } }
-				paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
-				onChangeView={ () => {} }
-				getItemId={ ( item: DnsRecordVerification ) =>
-					`${ item.type }-${ item.name }-${ item.currentValue }`
-				}
-			>
-				<DataViews.Layout />
-			</DataViews>
+			{ isSuggestedMode ? (
+				<DataViews< DnsRecordSuggestedVerification >
+					data={ dnsRecords as DnsRecordSuggestedVerification[] }
+					fields={ fieldsSuggested }
+					view={ viewSuggested }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
+					onChangeView={ () => {} }
+					getItemId={ ( item: DnsRecordSuggestedVerification ) =>
+						`${ item.currentValue }-${ item.expectedValue }`
+					}
+				>
+					<DataViews.Layout />
+				</DataViews>
+			) : (
+				<DataViews< DnsRecordAdvancedVerification >
+					data={ dnsRecords as DnsRecordAdvancedVerification[] }
+					fields={ fieldsAdvanced }
+					view={ viewAdvanced }
+					defaultLayouts={ { table: {} } }
+					paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
+					onChangeView={ () => {} }
+					getItemId={ ( item: DnsRecordAdvancedVerification ) =>
+						`${ item.type }-${ item.name }-${ item.currentValue }`
+					}
+				>
+					<DataViews.Layout />
+				</DataViews>
+			) }
 		</DataViewsCard>
 	);
 }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -28,21 +28,15 @@ const viewAdvanced: ViewTable = {
 	},
 };
 
-interface DnsRecordSuggestedVerification {
+interface DnsRecordVerification {
+	type?: string; // only present in advanced mode
+	name?: string; // only present in advanced mode
 	currentValue: string;
 	expectedValue: string;
 	status: React.ReactNode;
 }
 
-interface DnsRecordAdvancedVerification {
-	type: string;
-	name: string;
-	currentValue: string;
-	expectedValue: string;
-	status: React.ReactNode;
-}
-
-const fieldsSuggested: Field< DnsRecordSuggestedVerification >[] = [
+const fieldsSuggested: Field< DnsRecordVerification >[] = [
 	{
 		id: 'currentValue',
 		label: __( 'Current Value' ),
@@ -72,7 +66,7 @@ const fieldsSuggested: Field< DnsRecordSuggestedVerification >[] = [
 	},
 ];
 
-const fieldsAdvanced: Field< DnsRecordAdvancedVerification >[] = [
+const fieldsAdvanced: Field< DnsRecordVerification >[] = [
 	{
 		id: 'type',
 		label: __( 'Type' ),
@@ -91,33 +85,7 @@ const fieldsAdvanced: Field< DnsRecordAdvancedVerification >[] = [
 		enableSorting: false,
 		filterBy: false,
 	},
-	{
-		id: 'currentValue',
-		label: __( 'Current Value' ),
-		type: 'text' as const,
-		readOnly: true,
-		enableHiding: false,
-		enableSorting: false,
-		filterBy: false,
-	},
-	{
-		id: 'expectedValue',
-		label: __( 'Expected Value' ),
-		type: 'text' as const,
-		readOnly: true,
-		enableHiding: false,
-		enableSorting: false,
-		filterBy: false,
-	},
-	{
-		id: 'status',
-		label: __( 'Status' ),
-		type: 'text' as const,
-		readOnly: true,
-		enableHiding: false,
-		enableSorting: false,
-		filterBy: false,
-	},
+	...fieldsSuggested,
 ];
 
 const VerifiedBadge = () => {
@@ -168,11 +136,8 @@ export default function DnsRecordsTable( {
 
 	const isSuggestedMode = domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED;
 
-	const dnsRecords = useMemo( (): (
-		| DnsRecordAdvancedVerification
-		| DnsRecordSuggestedVerification
-	)[] => {
-		const data: ( DnsRecordAdvancedVerification | DnsRecordSuggestedVerification )[] = [];
+	const dnsRecords = useMemo( () => {
+		const data: DnsRecordVerification[] = [];
 
 		if ( isSuggestedMode ) {
 			const currentNameServers = ( domainMappingStatus?.name_servers || [] ).sort();
@@ -198,39 +163,23 @@ export default function DnsRecordsTable( {
 		}
 
 		return data;
-	}, [ domain, domainName, domainMappingStatus, isSuggestedMode ] );
+	}, [ domain, domainName, domainMappingStatus, domainConnectionSetupInfo, isSuggestedMode ] );
 
 	return (
 		<DataViewsCard className="dns-records-table">
-			{ isSuggestedMode ? (
-				<DataViews< DnsRecordSuggestedVerification >
-					data={ dnsRecords as DnsRecordSuggestedVerification[] }
-					fields={ fieldsSuggested }
-					view={ viewSuggested }
-					defaultLayouts={ { table: {} } }
-					paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
-					onChangeView={ () => {} }
-					getItemId={ ( item: DnsRecordSuggestedVerification ) =>
-						`${ item.currentValue }-${ item.expectedValue }`
-					}
-				>
-					<DataViews.Layout />
-				</DataViews>
-			) : (
-				<DataViews< DnsRecordAdvancedVerification >
-					data={ dnsRecords as DnsRecordAdvancedVerification[] }
-					fields={ fieldsAdvanced }
-					view={ viewAdvanced }
-					defaultLayouts={ { table: {} } }
-					paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
-					onChangeView={ () => {} }
-					getItemId={ ( item: DnsRecordAdvancedVerification ) =>
-						`${ item.type }-${ item.name }-${ item.currentValue }`
-					}
-				>
-					<DataViews.Layout />
-				</DataViews>
-			) }
+			<DataViews< DnsRecordVerification >
+				data={ dnsRecords }
+				fields={ isSuggestedMode ? fieldsSuggested : fieldsAdvanced }
+				view={ isSuggestedMode ? viewSuggested : viewAdvanced }
+				defaultLayouts={ { table: {} } }
+				paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
+				onChangeView={ () => {} }
+				getItemId={ ( item: DnsRecordVerification ) =>
+					`${ item.currentValue }-${ item.expectedValue }`
+				}
+			>
+				<DataViews.Layout />
+			</DataViews>
 		</DataViewsCard>
 	);
 }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,3 +1,4 @@
+import { DomainConnectionSetupMode } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import {
 	Icon,
@@ -63,7 +64,9 @@ export default function DomainConnectionVerification( {
 					) }
 
 					<Text size="medium" weight={ 500 }>
-						{ __( 'DNS record verification' ) }
+						{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
+							? __( 'Name server verification' )
+							: __( 'DNS record verification' ) }
 					</Text>
 
 					<DnsRecordsTable domainName={ domainName } />

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,4 +1,4 @@
-import { DomainConnectionSetupMode } from '@automattic/api-core';
+import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import {
 	Icon,
@@ -19,6 +19,7 @@ import VerificationInProgressNextSteps from './verification-in-progress-next-ste
 import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
 
 interface DomainConnectionVerificationProps {
+	domainData: Domain;
 	domainName: string;
 	siteSlug: string;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
@@ -28,6 +29,7 @@ interface DomainConnectionVerificationProps {
 }
 
 export default function DomainConnectionVerification( {
+	domainData,
 	domainName,
 	siteSlug,
 	domainMappingStatus,
@@ -71,7 +73,7 @@ export default function DomainConnectionVerification( {
 					</Text>
 
 					<DnsRecordsTable
-						domainName={ domainName }
+						domainData={ domainData }
 						domainConnectionStatus={ domainMappingStatus }
 						domainConnectionSetupInfo={ domainConnectionSetupInfo }
 					/>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -66,7 +66,7 @@ export default function DomainConnectionVerification( {
 						{ __( 'DNS record verification' ) }
 					</Text>
 
-					<DnsRecordsTable />
+					<DnsRecordsTable domainName={ domainName } />
 
 					{ status === 'verifying' && (
 						<Text size="medium" weight={ 500 }>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -12,6 +12,7 @@ import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import DnsRecordsTable from './components/dns-records-table';
 import { isMappingVerificationSuccess } from './utils';
 import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
 import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
@@ -52,18 +53,27 @@ export default function DomainConnectionVerification( {
 							{ status === 'connected' ? __( 'Active' ) : __( 'Verifying' ) }
 						</Badge>
 					</HStack>
+
 					{ status === 'verifying' && (
-						<>
-							<Notice variant="info">
-								{ __(
-									'We’re checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
-								) }
-							</Notice>
-							<Text size="medium" weight={ 500 }>
-								{ __( 'While you wait' ) }
-							</Text>
-						</>
+						<Notice variant="info">
+							{ __(
+								'We’re checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
+							) }
+						</Notice>
 					) }
+
+					<Text size="medium" weight={ 500 }>
+						{ __( 'DNS record verification' ) }
+					</Text>
+
+					<DnsRecordsTable />
+
+					{ status === 'verifying' && (
+						<Text size="medium" weight={ 500 }>
+							{ __( 'While you wait' ) }
+						</Text>
+					) }
+
 					{ status === 'connected' && (
 						<RouterLinkSummaryButton
 							to={ siteDomainsRoute.fullPath }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -72,6 +72,7 @@ export default function DomainConnectionVerification( {
 
 					<DnsRecordsTable
 						domainName={ domainName }
+						domainConnectionStatus={ domainMappingStatus }
 						domainConnectionSetupInfo={ domainConnectionSetupInfo }
 					/>
 

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -31,6 +31,7 @@ export default function DomainConnectionVerification( {
 	domainName,
 	siteSlug,
 	domainMappingStatus,
+	domainConnectionSetupInfo,
 }: DomainConnectionVerificationProps ) {
 	const status = isMappingVerificationSuccess( domainMappingStatus.mode, domainMappingStatus )
 		? 'connected'
@@ -69,7 +70,10 @@ export default function DomainConnectionVerification( {
 							: __( 'DNS record verification' ) }
 					</Text>
 
-					<DnsRecordsTable domainName={ domainName } />
+					<DnsRecordsTable
+						domainName={ domainName }
+						domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					/>
 
 					{ status === 'verifying' && (
 						<Text size="medium" weight={ 500 }>

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -83,6 +83,7 @@ export default function DomainConnection() {
 		>
 			{ isVerificationStep ? (
 				<DomainConnectionVerification
+					domainData={ domain }
 					domainName={ domainName }
 					siteSlug={ siteSlug }
 					domainConnectionSetupInfo={ domainConnectionSetupInfo }

--- a/packages/api-core/src/domain-connection-setup/types.ts
+++ b/packages/api-core/src/domain-connection-setup/types.ts
@@ -20,6 +20,7 @@ export type DomainMappingStatus = {
 	host_ip_addresses: string[];
 	name_servers: string[];
 	mode: DomainConnectionSetupModeValue;
+	www_cname_record_target: string | null;
 };
 
 // GET response

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -35,6 +35,7 @@ export interface TitanEmailSubscription extends EmailSubscription {
 }
 
 export interface Domain extends DomainSummary {
+	a_records_required_for_mapping?: string[];
 	auth_code_required: boolean;
 	aftermarket_auction: boolean;
 	auto_renewal_date: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1782](https://linear.app/a8c/issue/DOMAINS-1782)

## Proposed Changes

This PR adds the DNS records verification table to the Domain Connection verification page.

It shows the suggested records table, with name server records, or the advanced records table, with A and CNAME records.

### Screenshots

- Suggested mode

<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 29 49" src="https://github.com/user-attachments/assets/876ec001-022c-4771-bf52-4a79cd5f211f" />
<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 31 29" src="https://github.com/user-attachments/assets/800f7079-d70e-421a-a482-038743e2fef0" />
<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 30 51" src="https://github.com/user-attachments/assets/7e9c95d9-ffff-458a-b236-a95a18c34b95" />

- Advanced mode

<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 32 00" src="https://github.com/user-attachments/assets/f031c6ca-ff4a-4266-b507-8072cb4bbfd1" />
<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 34 09" src="https://github.com/user-attachments/assets/db9c8b91-e869-4028-9a14-904584c4fe5b" />
<img width="983" height="1143" alt="Screenshot 2025-11-03 at 20 33 01" src="https://github.com/user-attachments/assets/7404ffab-d73f-4dd4-9f28-fc3420e9ae99" />

## Why are these changes being made?

This is part of the [Domain Connection Redesign project](https://linear.app/a8c/project/implement-new-domain-connections-design-3a81d9f541d6/overview) to improve the whole domain connection flow, adding more guidance and information for users.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain connection setup page for a connected domain (e.g. `v2/domains/<DOMAIN>/domain-connection-setup`)
- Ensure the DNS records shown in the table are the ones configured for your domain
- Check both connection modes (suggested and advanced)
  - You can change between modes by calling `Domains_API::set_connection_mode_flag_setting` from your sandbox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
