### PR TITLE
SSH Migration: Identify the SSH Migration on the Credentials step

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -530,10 +530,22 @@ const siteMigration: FlowV2< typeof initialize > = {
 				}
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
-					const { action, from, authorizationUrl, platform } = providedDependencies;
+					const { action, from, authorizationUrl, platform, host } = providedDependencies;
 
 					if ( action === 'skip' ) {
 						return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
+					}
+
+					if ( action === 'redirect-to-ssh' ) {
+						// Redirect to SSH verification step
+						return navigate(
+							paths.sshVerificationPath( {
+								siteId,
+								siteSlug,
+								from: from || fromQueryParam,
+								host,
+							} )
+						);
 					}
 
 					if ( action === 'already-wpcom' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -15,7 +15,8 @@ import { SpecialInstructions } from './special-instructions';
 interface CredentialsFormProps {
 	onSubmit: (
 		siteInfo?: UrlData | undefined,
-		applicationPasswordsInfo?: ApplicationPasswordsInfo
+		applicationPasswordsInfo?: ApplicationPasswordsInfo,
+		hostingProviderSlug?: string
 	) => void;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +7,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import DocumentHead from 'calypso/components/data/document-head';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
+import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -15,8 +17,10 @@ import {
 	recordMigrationRequestSubmittedFacebookEvent,
 } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToDomain } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
+import { isHostingSupportedForSSHMigration } from '../site-migration-ssh-share-access/utils/hosting-provider-validation';
 import { CredentialsForm } from './components/credentials-form';
 import { NeedHelpLink } from './components/need-help-link';
 import { ApplicationPasswordsInfo } from './types';
@@ -56,22 +60,28 @@ const SiteMigrationCredentials: StepType< {
 			| 'credentials-required'
 			| 'already-wpcom'
 			| 'site-is-not-using-wordpress'
+			| 'redirect-to-ssh'
 			| 'skip';
 		from?: string;
 		platform?: ImporterPlatform;
 		authorizationUrl?: string;
 		hasError?: 'ticket-creation';
+		host?: string;
 	};
 } > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteId = parseInt( useSiteIdParam() ?? '' );
 	const dispatch = useDispatch();
+	const fromUrl = useQuery().get( 'from' ) || '';
+
+	// Fetch hosting provider based on the from URL
+	const domain = fromUrl ? urlToDomain( fromUrl ) : '';
+	const { data: hostingProviderData } = useHostingProviderQuery( domain, !! domain );
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
 	const locale = useLocale();
 	const siteSlugParam = useSiteSlugParam();
-	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
 	const { sendTicketAsync } = useSubmitMigrationTicket( {
 		onSuccess: () => {
@@ -98,6 +108,29 @@ const SiteMigrationCredentials: StepType< {
 		siteInfo?: UrlData | undefined,
 		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => {
+		const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
+		const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
+		const isHostingSupported = isHostingSupportedForSSHMigration( hostingProviderSlug );
+
+		// Track hosting provider detection
+		recordTracksEvent( 'calypso_site_migration_hosting_detected', {
+			hosting_provider: hostingProviderSlug || 'unknown',
+			is_ssh_supported: isHostingSupported,
+			ssh_feature_enabled: isSSHMigrationAvailable,
+			redirected_to_ssh: isSSHMigrationAvailable && isHostingSupported,
+			step: 'credentials',
+		} );
+
+		// If SSH migration is available and hosting is supported, redirect to SSH flow
+		if ( isSSHMigrationAvailable && isHostingSupported ) {
+			siteId && dispatch( resetSite( siteId ) );
+			return navigation.submit?.( {
+				action: 'redirect-to-ssh',
+				from: siteInfo?.url || fromUrl,
+				host: hostingProviderSlug,
+			} );
+		}
+
 		const action = getAction( siteInfo, applicationPasswordsInfo );
 
 		// Fire Google Ads tracking event when credentials are submitted

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -106,15 +106,6 @@ const SiteMigrationCredentials: StepType< {
 		const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 		const isHostingSupported = isHostingSupportedForSSHMigration( hostingProviderSlug );
 
-		// Track hosting provider detection
-		recordTracksEvent( 'calypso_site_migration_hosting_detected', {
-			hosting_provider: hostingProviderSlug || 'unknown',
-			is_ssh_supported: isHostingSupported,
-			ssh_feature_enabled: isSSHMigrationAvailable,
-			redirected_to_ssh: isSSHMigrationAvailable && isHostingSupported,
-			step: 'credentials',
-		} );
-
 		// If SSH migration is available and hosting is supported, redirect to SSH flow
 		if ( isSSHMigrationAvailable && isHostingSupported ) {
 			siteId && dispatch( resetSite( siteId ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -7,7 +7,6 @@ import { UrlData } from 'calypso/blocks/import/types';
 import DocumentHead from 'calypso/components/data/document-head';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
-import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -17,7 +16,6 @@ import {
 	recordMigrationRequestSubmittedFacebookEvent,
 } from 'calypso/lib/analytics/ad-tracking/record-migration-events';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { urlToDomain } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
 import { isHostingSupportedForSSHMigration } from '../site-migration-ssh-share-access/utils/hosting-provider-validation';
@@ -74,10 +72,6 @@ const SiteMigrationCredentials: StepType< {
 	const dispatch = useDispatch();
 	const fromUrl = useQuery().get( 'from' ) || '';
 
-	// Fetch hosting provider based on the from URL
-	const domain = fromUrl ? urlToDomain( fromUrl ) : '';
-	const { data: hostingProviderData } = useHostingProviderQuery( domain, !! domain );
-
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
 	const locale = useLocale();
@@ -106,9 +100,9 @@ const SiteMigrationCredentials: StepType< {
 
 	const handleSubmit = (
 		siteInfo?: UrlData | undefined,
-		applicationPasswordsInfo?: ApplicationPasswordsInfo
+		applicationPasswordsInfo?: ApplicationPasswordsInfo,
+		hostingProviderSlug?: string
 	) => {
-		const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
 		const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 		const isHostingSupported = isHostingSupportedForSSHMigration( hostingProviderSlug );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15060

## Proposed Changes

* We should redirect the users to the SSH Migration flow if they analyze a site that can be migrated through SSH.
* On the `Tell us about your WordPress site` step, we now redirect the user to the SSH Migration flow if the site is on a allowed host.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the user analyses the site on the `Tell us about your WordPress site` it was supposed to redirect the user to the SSH Migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Go through the **Assisted Migration** flow
* Once you reach on the `Tell us about your WordPress site` step, input a test site for the SSH Migration and click on continue
* This should take you to the SSH Migration Flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
