### PR TITLE
Dashboard: prevent race condition when activating hosting features from Overview

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -47,13 +47,8 @@ export default function HostingFeatureGatedWithOverviewCard( {
 					upsellFeatureId={ upsellFeatureId ?? upsellId }
 				/>
 			) }
-			renderActivationComponent={ ( { onClick } ) => (
-				<OverviewCard
-					{ ...cardProps }
-					icon={ featureIcon }
-					title={ __( 'Activate to unlock' ) }
-					onClick={ onClick }
-				/>
+			renderActivationComponent={ () => (
+				<OverviewCard { ...cardProps } icon={ featureIcon } title={ __( 'Activate to unlock' ) } />
 			) }
 		/>
 	);


### PR DESCRIPTION
## Proposed Changes

This PR fixes a race condition when you click the `Activate to unlock` button from Site Overview.

I think this is a regression after we finish implementing the activation flow in v2. Previously, we try to load the eligibility warning modal if a certain condition is met, or redirect to /hosting-features. However, as we finish all tabs in v1 and v2, we are redirecting the user to the corresponding tab instead, which already contains the hosting activation callout. But the eligibility warning modal is still trying to load, which crashes for a flash second in v1. See:

https://github.com/user-attachments/assets/46a9f5b7-21e9-4590-bf2d-19a8bd93a896


## Why are these changes being made?

MSD bug audit.

## Testing Instructions

1. Purchase a Business site, go to `/sites/:slug` and verify you can activate hosting features by clicking on an `Activate to unlock` card.
1. Purchase a Business site, go to `/v2/sites/:slug` and verify you can activate hosting features by clicking on an `Activate to unlock` card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
