### PR TITLE
MSD: Use better default for Sites host.

### DIFF
--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -15,6 +15,10 @@ const isWordPressComProvider = ( site: Site ) => {
 };
 
 export function getSiteProviderName( site: Site ) {
+	/**
+	 * `hosting_provider_guess` frequently returns 'unknown'.
+	 * Use site properties to determine if we are the provider.
+	 */
 	const provider = site.hosting_provider_guess;
 
 	let providerName;

--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -1,16 +1,31 @@
 import type { Site } from '@automattic/api-core';
 
-export const DEFAULT_PROVIDER_NAME = 'WordPress.com';
+export const DEFAULT_PROVIDER_NAME = 'Unknown';
+
+const isWordPressComProvider = ( site: Site ) => {
+	return (
+		site.is_wpcom_atomic ||
+		site.is_a8c ||
+		site.is_garden ||
+		site.is_wpcom_staging_site ||
+		site.is_vip ||
+		site.is_wpcom_flex ||
+		site.slug.endsWith( 'wordpress.com' )
+	);
+};
 
 export function getSiteProviderName( site: Site ) {
 	const provider = site.hosting_provider_guess;
+
 	let providerName;
 	if ( provider === 'jurassic_ninja' ) {
 		providerName = 'Jurassic Ninja';
 	} else if ( provider === 'pressable' ) {
 		providerName = 'Pressable';
-	} else if ( provider === 'automattic' ) {
+	} else if ( isWordPressComProvider( site ) ) {
 		providerName = 'WordPress.com';
+	} else if ( site.jetpack ) {
+		providerName = 'Jetpack';
 	}
 
 	return providerName;


### PR DESCRIPTION
Fixes: DOTMSD-751

## Proposed Changes

`hosting_provider_guess` is known to be unreliable. This PR removes `WordPress.com` as the default and uses site properties to determine the appropriate host where applicable.

## Why are these changes being made?

We are currently showing "WordPress.com" for all sites.

## Testing Instructions
1. Load you v2 sites list
2. Toggle on the "Host" field for your DataView
3. Expect to see the right host for JetPack and WordPress.com
4. Expect to see "unknown" or the actual host name for the rest.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
