### PR TITLE
MSD: Users can filter sites list by plan.

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -29,7 +29,7 @@ import PageLayout from '../components/page-layout';
 import {
 	SitesDataViews,
 	useActions,
-	getFields,
+	useFields,
 	getView,
 	mergeViews,
 	recordViewChanges,
@@ -89,7 +89,7 @@ export default function CIABSites() {
 		placeholderData: keepPreviousData,
 	} );
 
-	const fields = getFields( { isAutomattician, viewType: view.type } );
+	const fields = useFields( { isAutomattician, viewType: view.type, sites: sites ?? [] } );
 	const actions = useActions();
 
 	const handleAddNewStore = () => {

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import SiteIcon from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
@@ -59,6 +60,9 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Plan' ),
 		getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
 		render: ( { item } ) => <Plan site={ item } />,
+		filterBy: {
+			operators: [ 'isAny' as Operator ],
+		},
 	},
 	{
 		id: 'status',
@@ -148,26 +152,64 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 ];
 
-export function getFields( {
+function getPlanFilterElements( sites: Site[] ) {
+	if ( ! sites || sites.length === 0 ) {
+		return [];
+	}
+
+	const uniquePlans = new Map< string, string >();
+
+	for ( const site of sites ) {
+		const planDisplayName = getSitePlanDisplayName( site );
+		if ( planDisplayName ) {
+			// Use the display name as both value and label for consistency
+			uniquePlans.set( planDisplayName, planDisplayName );
+		}
+	}
+
+	return Array.from( uniquePlans.entries() )
+		.map( ( [ value, label ] ) => ( { value, label } ) )
+		.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+}
+
+export function useFields( {
 	isAutomattician,
 	viewType,
+	sites,
 }: {
 	isAutomattician?: boolean;
 	viewType?: string;
-} ) {
-	return DEFAULT_FIELDS.filter( ( field ) => {
-		if ( field.id === 'is_a8c' && ! isAutomattician ) {
-			return false;
-		}
+	sites?: Site[];
+} ): Field< Site >[] {
+	return useMemo( () => {
+		const fields = DEFAULT_FIELDS.map( ( field ) => {
+			if ( field.id === 'plan' && sites ) {
+				const planElements = getPlanFilterElements( sites );
+				if ( planElements.length > 0 ) {
+					return {
+						...field,
+						elements: planElements,
+					};
+				}
+			}
 
-		if ( field.id === 'icon.ico' && viewType === 'grid' ) {
-			return false;
-		}
+			return field;
+		} );
 
-		if ( field.id === 'preview' && viewType === 'table' ) {
-			return false;
-		}
+		return fields.filter( ( field ) => {
+			if ( field.id === 'is_a8c' && ! isAutomattician ) {
+				return false;
+			}
 
-		return true;
-	} );
+			if ( field.id === 'icon.ico' && viewType === 'grid' ) {
+				return false;
+			}
+
+			if ( field.id === 'preview' && viewType === 'table' ) {
+				return false;
+			}
+
+			return true;
+		} );
+	}, [ isAutomattician, viewType, sites ] );
 }

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -153,22 +153,21 @@ export const DEFAULT_FIELDS: Field< Site >[] = [
 ];
 
 function getPlanFilterElements( sites: Site[] ) {
-	if ( ! sites || sites.length === 0 ) {
+	if ( sites.length === 0 ) {
 		return [];
 	}
 
-	const uniquePlans = new Map< string, string >();
+	const uniquePlans = new Set< string >();
 
 	for ( const site of sites ) {
 		const planDisplayName = getSitePlanDisplayName( site );
 		if ( planDisplayName ) {
-			// Use the display name as both value and label for consistency
-			uniquePlans.set( planDisplayName, planDisplayName );
+			uniquePlans.add( planDisplayName );
 		}
 	}
 
-	return Array.from( uniquePlans.entries() )
-		.map( ( [ value, label ] ) => ( { value, label } ) )
+	return Array.from( uniquePlans )
+		.map( ( planName ) => ( { value: planName, label: planName } ) )
 		.sort( ( a, b ) => a.label.localeCompare( b.label ) );
 }
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -30,7 +30,7 @@ import AddNewSite from './add-new-site';
 import {
 	SitesDataViews,
 	useActions,
-	getFields,
+	useFields,
 	getView,
 	mergeViews,
 	recordViewChanges,
@@ -92,7 +92,7 @@ export default function Sites() {
 		placeholderData: keepPreviousData,
 	} );
 
-	const fields = getFields( { isAutomattician, viewType: view.type } );
+	const fields = useFields( { isAutomattician, viewType: view.type, sites: sites ?? [] } );
 	const actions = useActions();
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );


### PR DESCRIPTION
Fixes: DOTMSD-729

## Proposed Changes

Give users the ability to filter their site list based on their plan.

### Screenshot

<img width="274" height="208" alt="Screenshot 2025-11-03 at 5 13 04 PM" src="https://github.com/user-attachments/assets/eaa514a0-76f0-4400-8b3b-01a8938e153f" />

## Why are these changes being made?

.

## Testing Instructions

1. Navigate to your `v2` sites list
2. Add a plan filter
3. Expect to see a list of plans that exist for your sites
4. Filter on one or many
5. Expect the dataview to filter your sites propery.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
