### PR TITLE
MSD: Minor fixes related to the Domain Overview screen

### DIFF
--- a/client/dashboard/domains/domain-dns/dns-actions-menu.tsx
+++ b/client/dashboard/domains/domain-dns/dns-actions-menu.tsx
@@ -30,7 +30,7 @@ const DnsActionsMenu = ( {
 							onRestoreDefaultARecords();
 						} }
 					>
-						{ __( 'Restore default A records ↗' ) }
+						{ __( 'Restore default A records' ) }
 					</MenuItem>
 					<MenuItem
 						disabled={ hasDefaultCnameRecord }
@@ -39,7 +39,7 @@ const DnsActionsMenu = ( {
 							onRestoreDefaultCnameRecord();
 						} }
 					>
-						{ __( 'Restore default CNAME record ↗' ) }
+						{ __( 'Restore default CNAME record' ) }
 					</MenuItem>
 					<MenuItem
 						disabled={ hasDefaultEmailRecords }
@@ -48,7 +48,7 @@ const DnsActionsMenu = ( {
 							onRestoreDefaultEmailRecords();
 						} }
 					>
-						{ __( 'Restore default email records ↗' ) }
+						{ __( 'Restore default email records' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -44,6 +44,7 @@ import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
+import { domainRoute } from '../../../app/router/domains';
 import { emailsRoute } from '../../../app/router/emails';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
@@ -208,9 +209,12 @@ function ProductLink( { purchase }: { purchase: Purchase } ) {
 		purchase.site_slug &&
 		purchase.meta
 	) {
-		const url = domainManagementEdit( purchase.site_slug, purchase.meta );
 		const text = __( 'Domain settings' );
-		return <a href={ url }>{ text }</a>;
+		return (
+			<Link to={ domainRoute.fullPath } params={ { domainName: purchase.meta } }>
+				{ text }
+			</Link>
+		);
 	}
 
 	if ( isGoogleWorkspace( purchase ) || isTitanMail( purchase ) ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -211,7 +211,7 @@ function ProductLink( { purchase }: { purchase: Purchase } ) {
 	) {
 		const text = __( 'Domain settings' );
 		return (
-			<Link to={ domainRoute.fullPath } params={ { domainName: purchase.meta } }>
+			<Link to={ domainRoute.to } params={ { domainName: purchase.meta } }>
 				{ text }
 			</Link>
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
