### PR TITLE
A4A > Tiers: Implement agency tier actions on benefits section

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -13,9 +13,9 @@ import DownloadLink from './download-link';
 import './style.scss';
 
 export default function DownloadBadges( {
-	buttonProps,
+	buttonProps = {},
 }: {
-	buttonProps: ComponentProps< typeof Button >;
+	buttonProps?: ComponentProps< typeof Button >;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { Icon, download } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { ComponentProps, useState } from 'react';
 import A4AThemedModal from 'calypso/a8c-for-agencies/components/a4a-themed-modal';
 import AgencyTierLevels from 'calypso/assets/images/a8c-for-agencies/agency-tier/agency-tier-levels.svg';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -12,7 +12,11 @@ import DownloadLink from './download-link';
 
 import './style.scss';
 
-export default function DownloadBadges() {
+export default function DownloadBadges( {
+	buttonProps,
+}: {
+	buttonProps: ComponentProps< typeof Button >;
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -44,9 +48,12 @@ export default function DownloadBadges() {
 				className="agency-tier-download-badge__button"
 				variant="secondary"
 				onClick={ handleDownloadBadgeClick }
+				icon={ <Icon icon={ download } /> }
+				iconPosition="right"
+				iconSize={ 18 }
+				{ ...buttonProps }
 			>
 				{ translate( 'Download your badges' ) }
-				<Icon icon={ download } size={ 18 } />
 			</Button>
 			{ showDownloadModal && (
 				<A4AThemedModal

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -30,7 +30,7 @@ export const ALL_TIERS: TierItem[] = [
 		description: 'Joining the program',
 		heading: __( 'Essential benefits' ),
 		subheading: __( 'Tools, earning opportunities, support & training and more' ),
-		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'emerging-partner' ],
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],
 		benefits: [
 			{
 				icon: tool,
@@ -118,7 +118,7 @@ export const ALL_TIERS: TierItem[] = [
 		),
 		heading: __( '2 additional benefits unlocked' ),
 		subheading: __( 'Directory visibility, early access' ),
-		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
 		benefits: [
 			{
 				icon: commentAuthorAvatar,
@@ -126,6 +126,17 @@ export const ALL_TIERS: TierItem[] = [
 				description: __(
 					'Eligible for inclusion in Automattic’s agency directories and increased exposure to potential clients.'
 				),
+				actions: [
+					{
+						id: 'manage-profile',
+						label: __( 'Manage your profile' ),
+						href: '/partner-directory/dashboard',
+					},
+					{
+						id: 'download-badge',
+						label: __( 'Download your badges' ),
+					},
+				],
 			},
 			{
 				icon: store,
@@ -147,7 +158,7 @@ export const ALL_TIERS: TierItem[] = [
 		),
 		heading: __( '3 additional benefits unlocked' ),
 		subheading: __( 'Co-marketing, qualified leads, partner manager & more' ),
-		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
+		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
 		benefits: [
 			{
 				icon: starHalf,
@@ -169,6 +180,12 @@ export const ALL_TIERS: TierItem[] = [
 				description: __(
 					'Pro partners receive access to an assigned agency partner manager for strategic guidance.'
 				),
+				actions: [
+					{
+						id: 'schedule-call',
+						label: __( 'Book time with your partner manager' ),
+					},
+				],
 			},
 		],
 	},


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1695/implement-tier-actions

Part of https://linear.app/a8c/issue/A4A-1677/ui-implement-the-updated-agency-tier-page

## Proposed Changes

This PR implements agency tier actions on the benefits section.

## Testing Instructions

* Open the A4A live link
* Set your agency to the "Pro Partner Agency" tier from the MC tool
* Go to `client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx`, comment out the following lines

```
// if ( ! partnerDirectories.length || ! currentAgencyTier ) {
// 	return null;
// }
```
* Go to Agency Tier > Verify you can see the actions:

Pro Partner Agency section: `Book time with your partner manager`
Agency Partner section: `Manage your profile` & `Download your badges`

* Verify the buttons work as expected.

<img width="1354" height="823" alt="Screenshot 2025-11-03 at 2 48 50 PM" src="https://github.com/user-attachments/assets/1acd50f9-89fa-4714-a91d-f42aeef1d7ab" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
