### PR TITLE
Activity logs: update event title font-weight

### DIFF
--- a/client/dashboard/components/logs-activity/activity-event.scss
+++ b/client/dashboard/components/logs-activity/activity-event.scss
@@ -19,3 +19,7 @@
 		color: $gray-700;
 	}
 }
+
+.site-activity-logs__event-title {
+	font-weight: 500;
+}

--- a/client/dashboard/components/logs-activity/activity-event.tsx
+++ b/client/dashboard/components/logs-activity/activity-event.tsx
@@ -25,7 +25,7 @@ export function ActivityEvent( { activity }: { activity: Activity } ) {
 				alignment="start"
 				className="site-activity-logs__event-content"
 			>
-				<span className="site-activity-logs__event-title">{ activityTitle }</span>
+				<strong className="site-activity-logs__event-title">{ activityTitle }</strong>
 				{ formattedContent && <span>{ formattedContent }</span> }
 			</HStack>
 		</HStack>

--- a/client/dashboard/components/logs-activity/activity-event.tsx
+++ b/client/dashboard/components/logs-activity/activity-event.tsx
@@ -25,7 +25,7 @@ export function ActivityEvent( { activity }: { activity: Activity } ) {
 				alignment="start"
 				className="site-activity-logs__event-content"
 			>
-				<strong>{ activityTitle }</strong>
+				<span className="site-activity-logs__event-title">{ activityTitle }</span>
 				{ formattedContent && <span>{ formattedContent }</span> }
 			</HStack>
 		</HStack>


### PR DESCRIPTION
## Proposed Changes

* Update `font-weight` on Activity log event titles.

Before | After
--|--
<img width="708" height="223" alt="image" src="https://github.com/user-attachments/assets/69c49783-8654-475c-a761-5be7aa694953" /> | <img width="707" height="218" alt="image" src="https://github.com/user-attachments/assets/96fa6049-920d-402c-9d12-0a9c580808dc" />


## Why are these changes being made?

* Currently in the design system, only two weights are being used globally: `400` and `500`.
* However, in the code we were using a `<strong>` tag that translated into a `bolder` attribute, forcing a weight of `700`.

<img width="218" height="54" alt="image" src="https://github.com/user-attachments/assets/8fe8341a-8dd8-461b-91c4-9f3ab9aa267e" />


## Testing Instructions

* Fire up this PR.
* Visit Dashboard v2 and go into Activity logs.
* Ensure that the weight of the event titles is now the same as other elements on the screen (selected item in the top nav, site name in switcher, environment badge, selected item in the secondary nav, etc.).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
