### PR TITLE
Dashboard: support reset view action in DataViews

### DIFF
--- a/client/dashboard/app/dataviews/index.ts
+++ b/client/dashboard/app/dataviews/index.ts
@@ -1,1 +1,0 @@
-export * from './use-view';

--- a/client/dashboard/app/dataviews/reset-view-action.tsx
+++ b/client/dashboard/app/dataviews/reset-view-action.tsx
@@ -1,0 +1,10 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function ResetViewAction( { onResetView }: { onResetView: () => void } ) {
+	return (
+		<Button variant="tertiary" size="compact" style={ { order: -1 } } onClick={ onResetView }>
+			{ __( 'Reset view' ) }
+		</Button>
+	);
+}

--- a/client/dashboard/app/dataviews/use-view.ts
+++ b/client/dashboard/app/dataviews/use-view.ts
@@ -32,6 +32,8 @@ interface UseViewOptions {
 export function useView( { slug, defaultView, defaultFields }: UseViewOptions ): {
 	view: View;
 	updateView: ( newView: View ) => void;
+	isViewModified: boolean;
+	resetView: () => void;
 } {
 	const preferenceName = `dashboard-dataviews-view-${ slug }` as const;
 
@@ -82,7 +84,13 @@ export function useView( { slug, defaultView, defaultFields }: UseViewOptions ):
 		[ page, search, queryParams, navigate, baseView, defaultView, persistView ]
 	);
 
-	return { view, updateView };
+	const isViewModified = !! persistedView;
+
+	const resetView = useCallback( () => {
+		persistView( undefined );
+	}, [ persistView ] );
+
+	return { view, updateView, isViewModified, resetView };
 }
 
 function removeQueryParamsFromView( view: View ): Omit< View, 'page' | 'search' > {

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -66,7 +66,7 @@ export default function CIABSites() {
 		isRestoringAccount,
 	} );
 
-	const { view, updateView } = useView( {
+	const { view, updateView, isViewModified, resetView } = useView( {
 		slug: 'sites-ciab',
 		defaultView,
 		defaultFields: getDefaultFields(),
@@ -197,7 +197,9 @@ export default function CIABSites() {
 							}
 						/>
 					}
-					handleViewChange={ handleViewChange }
+					onChangeView={ handleViewChange }
+					isViewModified={ isViewModified }
+					onResetView={ resetView }
 				/>
 			</PageLayout>
 		</>

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,5 +1,6 @@
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { ResetViewAction } from '../../app/dataviews/reset-view-action';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import { SiteLink } from '../site-fields';
@@ -15,7 +16,9 @@ export const SitesDataViews = ( {
 	actions,
 	isLoading,
 	empty,
-	handleViewChange,
+	onChangeView,
+	isViewModified,
+	onResetView,
 }: {
 	view: View;
 	sites: Site[];
@@ -23,7 +26,9 @@ export const SitesDataViews = ( {
 	actions: Action< Site >[];
 	isLoading: boolean;
 	empty: ReactNode;
-	handleViewChange: ( view: View ) => void;
+	onChangeView: ( view: View ) => void;
+	isViewModified: boolean;
+	onResetView: () => void;
 } ) => {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
 
@@ -37,12 +42,13 @@ export const SitesDataViews = ( {
 					actions={ actions }
 					view={ view }
 					isLoading={ isLoading }
-					onChangeView={ handleViewChange }
+					onChangeView={ onChangeView }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					paginationInfo={ paginationInfo }
 					config={ { perPageSizes: DEFAULT_PER_PAGE_SIZES } }
 					empty={ empty }
 					renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
+					header={ isViewModified && <ResetViewAction onResetView={ onResetView } /> }
 				/>
 			</DataViewsCard>
 			<GuidedTourContextProvider

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -71,7 +71,7 @@ export default function Sites() {
 		isRestoringAccount,
 	} );
 
-	const { view, updateView } = useView( {
+	const { view, updateView, isViewModified, resetView } = useView( {
 		slug: 'sites',
 		defaultView,
 		defaultFields: getDefaultFields(),
@@ -196,7 +196,9 @@ export default function Sites() {
 							}
 						/>
 					}
-					handleViewChange={ handleViewChange }
+					onChangeView={ handleViewChange }
+					isViewModified={ isViewModified }
+					onResetView={ resetView }
 				/>
 			</PageLayout>
 			{ /* ExPlat's Evergreen A/A Test Experiment:


### PR DESCRIPTION
Fixes DOTCOM-15085

## Proposed Changes

This PR adds a "Reset view" action in Site List DataViews, which clears the persisted view preference so that the view resets back to its default.

It mimics the one that's already shipped in CIAB Admin:

|CIAB Admin|MSD (this PR)|
|-|-|
|<img width="374" height="112" alt="image" src="https://github.com/user-attachments/assets/a43b7770-1c3c-4d04-b7ca-8b3f7dd7b288" />|<img width="276" height="141" alt="image" src="https://github.com/user-attachments/assets/ffc028a4-0300-44ac-a093-1fa3292f2d25" />|


## Testing Instructions

1. Go to `/v2/sites`; play around with the appearance options; verify you can reset the view.
1. Do the same with `/ciab/sites` and `/sites`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
