### PR TITLE
A4A: Clear A4A Billing Dragon cart on successful checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -26,9 +26,11 @@ const debug = debugFactory( 'a4a:bd-checkout' );
 function BillingDragonCheckoutContent( {
 	cartItems,
 	withA8cLogo = true,
+	onClearCart,
 }: {
 	cartItems: ShoppingCartItem[];
 	withA8cLogo?: boolean;
+	onClearCart?: () => void;
 } ) {
 	const translate = useTranslate();
 	const [ isReady, setIsReady ] = useState( false );
@@ -138,6 +140,8 @@ function BillingDragonCheckoutContent( {
 				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/purchases/licenses' }
 				customizedPreviousPath="/marketplace"
+				onCheckoutSuccess={ onClearCart }
+				disabledThankYouPage
 				siteSlug=""
 				siteId={ 0 }
 			/>
@@ -148,9 +152,11 @@ function BillingDragonCheckoutContent( {
 export default function BillingDragonCheckout( {
 	cartItems,
 	withA8cLogo = true,
+	onClearCart,
 }: {
 	cartItems: ShoppingCartItem[];
 	withA8cLogo?: boolean;
+	onClearCart?: () => void;
 } ) {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -162,7 +168,11 @@ export default function BillingDragonCheckout( {
 			<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 				<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
-						<BillingDragonCheckoutContent cartItems={ cartItems } withA8cLogo={ withA8cLogo } />
+						<BillingDragonCheckoutContent
+							cartItems={ cartItems }
+							withA8cLogo={ withA8cLogo }
+							onClearCart={ onClearCart }
+						/>
 					</RazorpayHookProvider>
 				</StripeHookProvider>
 			</CalypsoShoppingCartProvider>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
@@ -17,7 +17,7 @@ import './style-v2.scss';
 function CheckoutV2() {
 	const translate = useTranslate();
 
-	const { selectedCartItems } = useShoppingCart();
+	const { selectedCartItems, onClearCart } = useShoppingCart();
 
 	const title = translate( 'Checkout' );
 
@@ -46,7 +46,11 @@ function CheckoutV2() {
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				<BillingDragonCheckout withA8cLogo={ false } cartItems={ selectedCartItems } />
+				<BillingDragonCheckout
+					withA8cLogo={ false }
+					cartItems={ selectedCartItems }
+					onClearCart={ onClearCart }
+				/>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -105,6 +105,7 @@ export interface CheckoutMainProps {
 	fromSiteSlug?: string;
 	adminUrl?: string;
 	hostingIntent?: string | undefined;
+	onCheckoutSuccess?: () => void;
 }
 
 export default function CheckoutMain( {
@@ -133,6 +134,7 @@ export default function CheckoutMain( {
 	fromSiteSlug,
 	adminUrl,
 	hostingIntent,
+	onCheckoutSuccess,
 }: CheckoutMainProps ) {
 	const translate = useTranslate();
 
@@ -702,6 +704,7 @@ export default function CheckoutMain( {
 		connectAfterCheckout,
 		adminUrl,
 		fromSiteSlug,
+		onCheckoutSuccess,
 	} );
 
 	const handleStepChanged = useCallback(

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -63,6 +63,7 @@ export default function useCreatePaymentCompleteCallback( {
 	connectAfterCheckout,
 	adminUrl: wpAdminUrl,
 	fromSiteSlug,
+	onCheckoutSuccess,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
 	productAliasFromUrl?: string | undefined;
@@ -84,6 +85,7 @@ export default function useCreatePaymentCompleteCallback( {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
+	onCheckoutSuccess?: () => void;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();
 	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
@@ -178,6 +180,7 @@ export default function useCreatePaymentCompleteCallback( {
 			debug( 'transactionResult was', transactionResult );
 
 			reduxDispatch( clearPurchases() );
+			onCheckoutSuccess?.();
 
 			// Removes the destination cookie only if redirecting to the signup destination.
 			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
@@ -296,6 +299,7 @@ export default function useCreatePaymentCompleteCallback( {
 			sitePlanSlug,
 			connectAfterCheckout,
 			fromSiteSlug,
+			onCheckoutSuccess,
 		]
 	);
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2959

Part of Linear: `A4A-1686/ui-empty-the-cart-after-the-bd-purchase-is-done-successfully`

## Proposed Changes

- Wire the A4A Billing Dragon checkout flow to call `onClearCart` when CheckoutMain reports a successful purchase.
- Extend `CheckoutMain` and `useCreatePaymentCompleteCallback` with an optional `onCheckoutSuccess` callback so callers can react to completed purchases.

## Why are these changes being made?

- Checkout V2 for agencies previously carried cart items across successful Billing Dragon purchases, forcing partners to clear the cart manually. Triggering the cart hook on success aligns V2 with V1 behaviour and prevents repeated purchases of the same items.

## Testing Instructions

- Check the code.
- Launch an A4A live site.
- Using an agency with Billing Dragon enabled, add a product to the cart.
- Proceed to checkout; you should be routed to the Billing Dragon checkout page.
- Complete the purchase.
- After the purchase completes you are sent to Purchases. Navigate back to Marketplace and open the cart; it should be empty. On trunk the cart still contains the item you just bought.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
