### PR TITLE
Login (QR Code): Fix QR login styling/alignment issues

### DIFF
--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -188,7 +188,7 @@ function QRCodeLogin( { redirectToAfterLoginUrl, isJetpack = false } ) {
 	// Fetch QR code data.
 	useEffect( () => {
 		fetchQRCodeData( tokenState, anonymousUserId );
-	}, [ tokenState, anonymousUserId ] );
+	}, [ tokenState, anonymousUserId, fetchQRCodeData ] );
 
 	// Fetch the Auth Data.
 	useInterval( () => {

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import qrCenter from 'calypso/assets/images/qr-login/app.png';
 import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import { useInterval } from 'calypso/lib/interval';
+import { useLoginContext } from 'calypso/login/login-context';
 import { postLoginRequest, getErrorFromHTTPError } from 'calypso/state/login/utils';
 import { JetpackQRCodeLogin } from './jetpack';
 
@@ -80,8 +81,9 @@ function QRCodeErrorCard() {
 	return (
 		<div className="qr-code-login is-error">
 			<div className="qr-code-login__token-error">
-				<h1 className="qr-code-login-page__heading">{ translate( 'Log in via Jetpack app' ) }</h1>
-				<p>{ translate( 'Mobile App QR Code login is currently unavailable.' ) }</p>
+				<p className="qr-code-login__error-message">
+					{ translate( 'Please try again later or enter your password instead.' ) }
+				</p>
 			</div>
 		</div>
 	);
@@ -93,6 +95,20 @@ function QRCodeLogin( { redirectToAfterLoginUrl, isJetpack = false } ) {
 	const [ authState, setAuthState ] = useState( false );
 	const [ isErrorState, setIsErrorState ] = useState( false );
 	const [ pullInterval, setPullInterval ] = useState( AUTH_PULL_INTERVAL );
+	const { setHeaders } = useLoginContext();
+
+	const headingText = translate( 'Log in via Jetpack app' );
+	const instructionsSubHeading = translate(
+		'Open the Jetpack app on your phone to scan this code.'
+	);
+	const errorSubHeading = translate( 'Mobile App QR Code login is currently unavailable.' );
+
+	useEffect( () => {
+		setHeaders( {
+			heading: headingText,
+			subHeading: isErrorState ? errorSubHeading : instructionsSubHeading,
+		} );
+	}, [ errorSubHeading, headingText, instructionsSubHeading, isErrorState, setHeaders ] );
 
 	const anonymousUserId = getTracksAnonymousUserId();
 
@@ -249,7 +265,6 @@ function QRCodeLogin( { redirectToAfterLoginUrl, isJetpack = false } ) {
 			</div>
 
 			<div className="qr-code-login__instructions">
-				<h1 className="qr-code-login-page__heading">{ translate( 'Log in via Jetpack app' ) }</h1>
 				<Notice isDismissible={ false } status="warning">
 					<p>{ notice }</p>
 				</Notice>

--- a/client/blocks/qr-code-login/style.scss
+++ b/client/blocks/qr-code-login/style.scss
@@ -66,6 +66,26 @@
 	margin-bottom: 0;
 }
 
+.qr-code-login.is-error {
+	align-items: center;
+	text-align: center;
+
+	.qr-code-login__token-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.qr-code-login__token-error p {
+		margin-bottom: 0;
+	}
+}
+
+.qr-code-login__error-message {
+	max-width: 24rem;
+}
+
 .qr-code-login__placeholder {
 	width: 100%;
 	height: 100%;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -190,11 +190,13 @@ export function qrCodeLogin( context, next ) {
 	const isJetpack = context.path.includes( '/jetpack' );
 
 	context.primary = (
-		<QrCodeLoginPage
-			locale={ context.params.lang }
-			redirectTo={ redirect_to }
-			isJetpack={ isJetpack }
-		/>
+		<LoginContextProvider>
+			<QrCodeLoginPage
+				locale={ context.params.lang }
+				redirectTo={ redirect_to }
+				isJetpack={ isJetpack }
+			/>
+		</LoginContextProvider>
 	);
 
 	next();

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -1,9 +1,13 @@
 import { Card } from '@automattic/components';
+import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import Main from 'calypso/components/main';
 import { login } from 'calypso/lib/paths';
+import { useLoginContext } from 'calypso/login/login-context';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
+import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 
 import './style.scss';
 
@@ -13,40 +17,18 @@ function QrCodeLoginPlaceholder() {
 
 function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 	const translate = useTranslate();
+	const { setHeaders } = useLoginContext();
 
-	return (
+	useEffect( () => {
+		setHeaders( {
+			heading: translate( 'Log in via Jetpack app' ),
+			subHeading: translate( 'Open the Jetpack app on your phone to scan this code.' ),
+		} );
+	}, [ setHeaders, translate ] );
+
+	const mainContent = (
 		<Main className={ clsx( 'qr-code-login-page', { 'is-jetpack': isJetpack } ) }>
 			<div className="qr-code-login-page__form">
-				{ isJetpack ? (
-					<div className="magic-login__gutenboarding-wordpress-logo">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							fill="none"
-						>
-							<path
-								d="M12 0C9.62663 0 7.30655 0.703788 5.33316 2.02236C3.35977 3.34094 1.8217 5.21508 0.913451 7.4078C0.00519938 9.60051 -0.232441 12.0133 0.230582 14.3411C0.693605 16.6689 1.83649 18.807 3.51472 20.4853C5.19295 22.1635 7.33115 23.3064 9.65892 23.7694C11.9867 24.2324 14.3995 23.9948 16.5922 23.0865C18.7849 22.1783 20.6591 20.6402 21.9776 18.6668C23.2962 16.6934 24 14.3734 24 12C24 8.8174 22.7357 5.76515 20.4853 3.51472C18.2348 1.26428 15.1826 0 12 0ZM11.3684 13.9895H5.40632L11.3684 2.35579V13.9895ZM12.5811 21.6189V9.98526H18.5621L12.5811 21.6189Z"
-								fill="#069E08"
-							/>
-						</svg>
-					</div>
-				) : (
-					<div className="magic-login__gutenboarding-wordpress-logo">
-						<svg
-							aria-hidden="true"
-							role="img"
-							focusable="false"
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 20 20"
-						>
-							<path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path>
-						</svg>
-					</div>
-				) }
 				<AsyncLoad
 					require="calypso/blocks/qr-code-login"
 					placeholder={ <QrCodeLoginPlaceholder /> }
@@ -55,13 +37,21 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 					redirectToAfterLoginUrl={ redirectTo }
 					isJetpack={ isJetpack }
 				/>
-				<div className="qr-code-login-page__footer">
-					<a href={ login( { locale, redirectTo, isJetpack } ) }>
+			</div>
+			<OneLoginFooter
+				loginLink={
+					<a className="one-login__footer-link" href={ login( { locale, redirectTo, isJetpack } ) }>
 						{ translate( 'Enter a password instead' ) }
 					</a>
-				</div>
-			</div>
+				}
+			/>
 		</Main>
+	);
+
+	return (
+		<OneLoginLayout isJetpack={ isJetpack } columnWidth={ 8 }>
+			{ mainContent }
+		</OneLoginLayout>
 	);
 }
 

--- a/client/login/qr-code-login-page/style.scss
+++ b/client/login/qr-code-login-page/style.scss
@@ -3,7 +3,6 @@
 
 .qr-code-login-page {
 	margin: 0 auto;
-	max-width: 700px;
 	text-align: center;
 
 	&.is-jetpack {
@@ -11,32 +10,8 @@
 	}
 }
 
-.layout:has(.qr-code-login-page:not(.is-jetpack)) {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.qr-code-login-page__heading {
-	@include onboarding-heading-text-mobile;
-	margin-bottom: 16px;
-	text-align: left !important;
-}
-
-.qr-code-login-page__footer {
-	a {
-		display: block;
-		font-size: $font-body-small;
-		color: var(--color-text);
-		font-weight: 600;
-		padding: 0 24px;
-		text-align: center;
-		text-decoration: underline;
-
-		&:hover {
-			color: var(--color-primary);
-		}
-	}
+.qr-code-login-page__form {
+	margin-block-end: 2em;
 }
 
 .qr-code-login-page__placeholder {

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -24,6 +24,10 @@ interface OneLoginLayoutProps {
 	loginUrl?: string;
 	isLostPasswordView?: boolean;
 	noThanksRedirectUrl?: string;
+	/**
+	 * Optional override for the content column width passed to `Step.CenteredColumnLayout`. Defaults to 6.
+	 */
+	columnWidth?: 4 | 5 | 6 | 8 | 10;
 }
 
 const OneLoginLayout = ( {
@@ -34,6 +38,7 @@ const OneLoginLayout = ( {
 	loginUrl,
 	isLostPasswordView,
 	noThanksRedirectUrl,
+	columnWidth,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const urlLocale = useLocale();
@@ -116,8 +121,14 @@ const OneLoginLayout = ( {
 		return <Step.TopBar rightElement={ rightElement } compactLogo="always" />;
 	};
 
+	const effectiveColumnWidth: 4 | 5 | 6 | 8 | 10 = ( columnWidth ?? 6 ) as 4 | 5 | 6 | 8 | 10;
+
 	return (
-		<Step.CenteredColumnLayout columnWidth={ 6 } topBar={ topBar() } verticalAlign="center">
+		<Step.CenteredColumnLayout
+			columnWidth={ effectiveColumnWidth }
+			topBar={ topBar() }
+			verticalAlign="center"
+		>
 			<div className="wp-login__one-login-layout-content-wrapper">
 				<div className="wp-login__one-login-layout-heading">
 					<HeadingLogo isJetpack={ isJetpack } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/DOTCOM-13816/login-qr-code-mobile-spacing-issues

## Proposed Changes

The PR addresses various layout issues on the QR code login page, aligning it more closely with the other unified Login pages.
- Incorporates the `OneLoginLayout` component into the page, so the header and layout become consistent with the unified ones (there are design changes in effect - title moving above the QR block, and the default header added)
- Incorporates the `OneLoginFooter` component so the footer adapts the unified styles

> [!NOTE]
> I think the changes surface a (known) issue with the Login layout - the footer component being rendered outside of the `OneLoginLayout` component. It happens here and in magic-login pages. This is mapped to an issue from earlier: https://linear.app/a8c/issue/DOTCOM-13832/login-pass-login-footer-into-oneloginlayout-component-for-alignment

### Media

Some before/after images below.

| Error state (before) | Error state (after) |
|--------|--------|
| <img width="415" height="441" alt="Screenshot 2025-11-03 at 6 45 32 PM" src="https://github.com/user-attachments/assets/b2c302d7-5998-474f-842d-5c4284bfe5fc" /> | <img width="419" height="429" alt="Screenshot 2025-11-03 at 6 45 11 PM" src="https://github.com/user-attachments/assets/66f5f2ec-2f99-46a8-8740-c08546bd1d3d" /> |

| QR page (before) | QR page (after) |
|--------|--------|
| <img width="695" height="491" alt="Screenshot 2025-11-03 at 6 46 32 PM" src="https://github.com/user-attachments/assets/58f67c53-1c1a-4e63-b933-183212e73655" /> | <img width="692" height="506" alt="Screenshot 2025-11-03 at 6 46 15 PM" src="https://github.com/user-attachments/assets/abf686ea-2d7b-4713-bc4b-9c56cdb79801" /> |
| <img width="328" height="539" alt="Screenshot 2025-11-03 at 6 47 44 PM" src="https://github.com/user-attachments/assets/47053d80-7e92-49c2-8244-82f9ff5315d3" /> | <img width="325" height="544" alt="Screenshot 2025-11-03 at 6 47 25 PM" src="https://github.com/user-attachments/assets/8ecc77f6-f58c-4dbd-a858-b2d95e426e5d" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/DOTCOM-13816/login-qr-code-mobile-spacing-issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/qr` logged out and confirm media

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
