### PR TITLE
SSH Migration: Lock the user/password while running preflight

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -78,6 +78,8 @@ const SiteMigrationSshShareAccess: StepType< {
 		}
 	);
 
+	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
+
 	const { steps, formState, canStartMigration, onMigrationStarted, setMigrationError } = useSteps( {
 		fromUrl,
 		siteId,
@@ -86,9 +88,8 @@ const SiteMigrationSshShareAccess: StepType< {
 		onNoSSHAccess: handleNoSSHAccess,
 		migrationStatus: migrationStatus?.status,
 		isTransferring,
+		isInputDisabled: isStartingMigration || migrationStarted || shouldStartMigration,
 	} );
-
-	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
 
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -79,6 +79,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 						<FormRadio
 							name="auth-method"
 							value="password"
+							disabled={ isInputDisabled }
 							checked={ authMethod === 'password' }
 							onChange={ () => onAuthMethodChange( 'password' ) }
 							label={ translate( 'Username and password' ) }
@@ -89,6 +90,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 						<FormRadio
 							name="auth-method"
 							value="key"
+							disabled={ isInputDisabled }
 							checked={ authMethod === 'key' }
 							onChange={ () => onAuthMethodChange( 'key' ) }
 							label={ translate( 'SSH key' ) }
@@ -112,6 +114,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 								}
 								placeholder={ translate( 'Enter your SSH username' ) }
 								disabled={ isInputDisabled }
+								className={ isInputDisabled ? 'is-disabled' : '' }
 							/>
 						</div>
 
@@ -127,6 +130,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 								}
 								placeholder={ translate( 'Enter your SSH password' ) }
 								disabled={ isInputDisabled }
+								className={ isInputDisabled ? 'is-disabled' : '' }
 							/>
 						</div>
 					</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -26,6 +26,7 @@ interface StepShareSSHAccessProps {
 	helpLink: ReactNode;
 	isTransferring: boolean;
 	shouldGenerateKey: boolean;
+	isInputDisabled: boolean;
 }
 
 export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
@@ -46,6 +47,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	helpLink,
 	isTransferring,
 	shouldGenerateKey,
+	isInputDisabled,
 } ) => {
 	const translate = useTranslate();
 	const [ copied, setCopied ] = useState( false );
@@ -109,6 +111,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 									onUsernameChange( e.target.value )
 								}
 								placeholder={ translate( 'Enter your SSH username' ) }
+								disabled={ isInputDisabled }
 							/>
 						</div>
 
@@ -123,6 +126,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 									onPasswordChange( e.target.value )
 								}
 								placeholder={ translate( 'Enter your SSH password' ) }
+								disabled={ isInputDisabled }
 							/>
 						</div>
 					</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -41,6 +41,7 @@ interface StepsDataOptions {
 	onNoSSHAccess: () => void;
 	isTransferring: boolean;
 	shouldGenerateKey: boolean;
+	isInputDisabled: boolean;
 }
 
 interface StepData {
@@ -77,6 +78,7 @@ interface UseStepsOptions {
 	onNoSSHAccess: () => void;
 	migrationStatus?: 'queued' | 'in-progress' | 'migrating' | 'completed' | 'failed';
 	isTransferring: boolean;
+	isInputDisabled: boolean;
 }
 
 interface SSHFormState {
@@ -148,6 +150,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					helpLink={ helpLink }
 					isTransferring={ options.isTransferring }
 					shouldGenerateKey={ options.shouldGenerateKey }
+					isInputDisabled={ options.isInputDisabled }
 				/>
 			),
 		},
@@ -164,6 +167,7 @@ export const useSteps = ( {
 	host,
 	migrationStatus,
 	isTransferring,
+	isInputDisabled,
 }: UseStepsOptions ): StepsObject => {
 	const [ currentStep, setCurrentStep ] = useState( -1 );
 	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
@@ -317,6 +321,7 @@ export const useSteps = ( {
 		host,
 		isTransferring,
 		shouldGenerateKey,
+		isInputDisabled,
 	} );
 
 	const isComplete = ( stepKey: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -180,6 +180,14 @@
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
+
+		input.is-disabled {
+			background-color: var(--studio-gray-0, #f0f0f0);
+			border: 1px solid var(--color-neutral-5, #dcdcde) !important;
+			border-color: var(--color-neutral-5, #dcdcde) !important;
+			color: var(--color-neutral-70, #1d2327);
+			cursor: default;
+		}
 	}
 
 	&-label {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15090

## Proposed Changes

* Locks the username and password inputs while the preflight are running.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When you initiate a migration, the UI is still interactive. This could lead to some unintended side-effects. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Go through the flow until you reach the `Securely share your access` step
* Go through the steps and input the username and the password
* Clicking on `Continue` should lock the username and the password inputs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
