### PR TITLE
Cancellations: Change language to favor 'subscription' over 'plan'

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { Button as GutenbergButton } from '@wordpress/components';
-import { hasTranslation } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
@@ -692,16 +691,10 @@ class CancelPurchaseForm extends Component {
 				return translate( 'Cancel domain and refund' );
 			}
 			if ( isPlan( purchase ) ) {
-				if ( hasTranslation( 'Cancel plan and refund' ) ) {
-					return translate( 'Cancel plan and refund' );
-				}
-				return translate( 'Cancel plan' );
+				return translate( 'Cancel plan and refund' );
 			}
 			if ( isSubscription( purchase ) ) {
-				if ( hasTranslation( 'Cancel subscription and refund' ) ) {
-					return translate( 'Cancel subscription and refund' );
-				}
-				return translate( 'Cancel subscription' );
+				return translate( 'Cancel subscription and refund' );
 			}
 			if ( isOneTimePurchase( purchase ) ) {
 				return translate( 'Cancel and refund' );
@@ -709,10 +702,7 @@ class CancelPurchaseForm extends Component {
 		}
 
 		if ( isDomainRegistration( purchase ) ) {
-			if ( hasTranslation( 'Cancel domain subscription' ) ) {
-				return translate( 'Cancel domain subscription' );
-			}
-			return translate( 'Cancel domain' );
+			return translate( 'Cancel domain subscription' );
 		}
 
 		if ( isSubscription( purchase ) ) {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -3,9 +3,11 @@ import {
 	isPlan,
 	isWpComMonthlyPlan,
 	WPCOM_FEATURES_BACKUPS,
+	isDomainRegistration,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { Button as GutenbergButton } from '@wordpress/components';
+import { hasTranslation } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
@@ -22,7 +24,6 @@ import {
 	isRefundable,
 	hasAmountAvailableToRefund,
 	isOneTimePurchase,
-	isDomainRegistration,
 	isSubscription,
 } from 'calypso/lib/purchases';
 import { cancelPurchaseSurveyCompleted, submitSurvey } from 'calypso/lib/purchases/actions';
@@ -690,7 +691,16 @@ class CancelPurchaseForm extends Component {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate( 'Cancel domain and refund' );
 			}
+			if ( isPlan( purchase ) ) {
+				if ( hasTranslation( 'Cancel plan and refund' ) ) {
+					return translate( 'Cancel plan and refund' );
+				}
+				return translate( 'Cancel plan' );
+			}
 			if ( isSubscription( purchase ) ) {
+				if ( hasTranslation( 'Cancel subscription and refund' ) ) {
+					return translate( 'Cancel subscription and refund' );
+				}
 				return translate( 'Cancel subscription' );
 			}
 			if ( isOneTimePurchase( purchase ) ) {
@@ -699,6 +709,9 @@ class CancelPurchaseForm extends Component {
 		}
 
 		if ( isDomainRegistration( purchase ) ) {
+			if ( hasTranslation( 'Cancel domain subscription' ) ) {
+				return translate( 'Cancel domain subscription' );
+			}
 			return translate( 'Cancel domain' );
 		}
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -16,7 +16,15 @@ import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { isAgencyPartnerType, isPartnerPurchase, isRefundable } from 'calypso/lib/purchases';
+import {
+	isAgencyPartnerType,
+	isPartnerPurchase,
+	isRefundable,
+	hasAmountAvailableToRefund,
+	isOneTimePurchase,
+	isDomainRegistration,
+	isSubscription,
+} from 'calypso/lib/purchases';
 import { cancelPurchaseSurveyCompleted, submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
@@ -678,9 +686,26 @@ class CancelPurchaseForm extends Component {
 			return translate( 'Remove product' );
 		}
 
-		if ( isPlan( purchase ) ) {
-			return translate( 'Cancel plan' );
+		if ( hasAmountAvailableToRefund( purchase ) ) {
+			if ( isDomainRegistration( purchase ) ) {
+				return translate( 'Cancel domain and refund' );
+			}
+			if ( isSubscription( purchase ) ) {
+				return translate( 'Cancel subscription' );
+			}
+			if ( isOneTimePurchase( purchase ) ) {
+				return translate( 'Cancel and refund' );
+			}
 		}
+
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Cancel domain' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Cancel subscription' );
+		}
+
 		return translate( 'Cancel product' );
 	}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -54,6 +54,7 @@ import {
 import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
+import { hasTranslation } from '@wordpress/i18n';
 import {
 	column,
 	download,
@@ -950,7 +951,7 @@ class ManagePurchase extends Component<
 			recordTracksEvent( 'calypso_purchases_manage_purchase_cancel_click', {
 				product_slug: purchase.productSlug,
 				is_atomic: isAtomicSite,
-				link_text: getCancelPurchaseNavText( purchase, translate ),
+				link_text: getCancelPurchaseNavText( purchase, translate, canRefund ),
 			} );
 
 			if ( this.shouldShowWordAdsEligibilityWarning() ) {
@@ -967,7 +968,7 @@ class ManagePurchase extends Component<
 		return (
 			<CompactCard href={ link } className="remove-purchase__card" onClick={ onClick }>
 				<Icon icon={ trash } className="card__icon" />
-				{ getCancelPurchaseNavText( purchase, translate ) }
+				{ getCancelPurchaseNavText( purchase, translate, canRefund ) }
 				{ this.renderRefundText() }
 			</CompactCard>
 		);
@@ -1815,16 +1816,45 @@ function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 
 function getCancelPurchaseNavText(
 	purchase: Purchase,
-	translate: LocalizeProps[ 'translate' ]
+	translate: LocalizeProps[ 'translate' ],
+	refundAvailable: boolean
 ): string {
 	let text = '';
 
+	if ( refundAvailable ) {
+		if ( isDomainRegistration( purchase ) ) {
+			if ( hasTranslation( 'Remove domain subscription' ) ) {
+				text = translate( 'Remove domain subscription' );
+			} else {
+				text = translate( 'Cancel domain' );
+			}
+		} else if ( isPlan( purchase ) ) {
+			if ( hasTranslation( 'Remove plan' ) ) {
+				text = translate( 'Remove plan' );
+			} else {
+				text = translate( 'Cancel plan' );
+			}
+		} else if ( isSubscription( purchase ) ) {
+			if ( hasTranslation( 'Remove subscription' ) ) {
+				text = translate( 'Remove subscription' );
+			} else {
+				text = translate( 'Cancel subscription' );
+			}
+		} else if ( isOneTimePurchase( purchase ) ) {
+			if ( hasTranslation( 'Remove' ) ) {
+				text = translate( 'Remove' );
+			} else {
+				text = translate( 'Cancel' );
+			}
+		}
+		return text;
+	}
 	if ( isDomainRegistration( purchase ) ) {
 		text = translate( 'Cancel domain' );
-	} else if ( isSubscription( purchase ) ) {
-		text = translate( 'Cancel subscription' );
 	} else if ( isPlan( purchase ) ) {
 		text = translate( 'Cancel plan' );
+	} else if ( isSubscription( purchase ) ) {
+		text = translate( 'Cancel subscription' );
 	} else if ( isOneTimePurchase( purchase ) ) {
 		text = translate( 'Cancel' );
 	}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -774,7 +774,11 @@ class ManagePurchase extends Component<
 				<Icon icon={ trash } className="card__icon" />
 				{ text }
 				{ this.renderActionDetails(
-					String( translate( 'Will expire immediately and be removed' ) )
+					String(
+						purchase.expiryStatus === 'expired'
+							? translate( 'Expired purchase will be removed.' )
+							: translate( 'Will expire immediately and be removed' )
+					)
 				) }
 			</RemovePurchase>
 		);

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1821,10 +1821,10 @@ function getCancelPurchaseNavText(
 
 	if ( isDomainRegistration( purchase ) ) {
 		text = translate( 'Cancel domain' );
-	} else if ( isPlan( purchase ) ) {
-		text = translate( 'Cancel plan' );
 	} else if ( isSubscription( purchase ) ) {
 		text = translate( 'Cancel subscription' );
+	} else if ( isPlan( purchase ) ) {
+		text = translate( 'Cancel plan' );
 	} else if ( isOneTimePurchase( purchase ) ) {
 		text = translate( 'Cancel' );
 	}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -67,7 +67,8 @@ import {
 } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
-import { Component, Fragment } from 'react';
+import moment from 'moment';
+import { Component, ComponentProps, Fragment, ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
@@ -695,7 +696,7 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderRefundText() {
+	renderActionDetails( nonRefundableTranslatedActionDetails?: string ) {
 		const { purchase, translate } = this.props;
 
 		if ( ! purchase ) {
@@ -704,12 +705,24 @@ class ManagePurchase extends Component<
 
 		// Hide if refund window has lapsed.
 		if ( ! hasAmountAvailableToRefund( purchase ) || ! purchase?.mostRecentRenewDate ) {
-			return;
+			if ( ! nonRefundableTranslatedActionDetails ) {
+				return null;
+			}
+			return this.renderActionDetailsText( nonRefundableTranslatedActionDetails, {
+				className: 'manage-purchase__refund-text',
+			} );
 		}
 
-		return (
-			<span className="manage-purchase__refund-text">{ translate( 'Refund available' ) }</span>
-		);
+		return this.renderActionDetailsText( translate( 'Refund available' ), {
+			className: 'manage-purchase__refund-text',
+		} );
+	}
+
+	renderActionDetailsText(
+		translatedActionDetails: string,
+		props?: ComponentProps< 'span' >
+	): ReactElement {
+		return <span { ...props }>{ translatedActionDetails }</span>;
 	}
 
 	renderRemovePurchaseNavItem() {
@@ -732,16 +745,16 @@ class ManagePurchase extends Component<
 		}
 
 		const isPlanPurchase = isPlan( purchase );
-		let text = translate( 'Remove subscription' );
+		let text = translate( 'Cancel subscription' );
 
 		if ( isPlanPurchase ) {
-			text = translate( 'Remove plan' );
+			text = translate( 'Cancel plan' );
 		} else if ( isDomainRegistration( purchase ) ) {
 			// 100-year domains cannot be removed by the user
 			if ( this.isHundredYearDomain( purchase ) ) {
 				return null;
 			}
-			text = translate( 'Remove domain' );
+			text = translate( 'Cancel domain subscription' );
 		}
 
 		return (
@@ -760,7 +773,9 @@ class ManagePurchase extends Component<
 			>
 				<Icon icon={ trash } className="card__icon" />
 				{ text }
-				{ this.renderRefundText() }
+				{ this.renderActionDetails(
+					String( translate( 'Will expire immediately and be removed' ) )
+				) }
 			</RemovePurchase>
 		);
 	}
@@ -951,7 +966,7 @@ class ManagePurchase extends Component<
 			recordTracksEvent( 'calypso_purchases_manage_purchase_cancel_click', {
 				product_slug: purchase.productSlug,
 				is_atomic: isAtomicSite,
-				link_text: getCancelPurchaseNavText( purchase, translate, canRefund ),
+				link_text: getCancelPurchaseNavText( purchase, translate ),
 			} );
 
 			if ( this.shouldShowWordAdsEligibilityWarning() ) {
@@ -968,8 +983,14 @@ class ManagePurchase extends Component<
 		return (
 			<CompactCard href={ link } className="remove-purchase__card" onClick={ onClick }>
 				<Icon icon={ trash } className="card__icon" />
-				{ getCancelPurchaseNavText( purchase, translate, canRefund ) }
-				{ this.renderRefundText() }
+				{ getCancelPurchaseNavText( purchase, translate ) }
+				{ this.renderActionDetails(
+					String(
+						translate( 'Will remain active until %(expiryDate)s', {
+							args: { expiryDate: moment( purchase.expiryDate ).format( 'LL' ) },
+						} )
+					)
+				) }
 			</CompactCard>
 		);
 	}
@@ -993,7 +1014,7 @@ class ManagePurchase extends Component<
 			<CompactCard href={ link }>
 				<Icon icon={ download } className="card__icon" />
 				{ translate( 'Downgrade plan' ) }
-				{ this.renderRefundText() }
+				{ this.renderActionDetails() }
 			</CompactCard>
 		);
 	}
@@ -1816,47 +1837,19 @@ function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 
 function getCancelPurchaseNavText(
 	purchase: Purchase,
-	translate: LocalizeProps[ 'translate' ],
-	refundAvailable: boolean
+	translate: LocalizeProps[ 'translate' ]
 ): string {
-	let text = '';
-
-	if ( refundAvailable ) {
-		if ( isDomainRegistration( purchase ) ) {
-			if ( hasTranslation( 'Remove domain subscription' ) ) {
-				text = translate( 'Remove domain subscription' );
-			} else {
-				text = translate( 'Cancel domain' );
-			}
-		} else if ( isPlan( purchase ) ) {
-			if ( hasTranslation( 'Remove plan' ) ) {
-				text = translate( 'Remove plan' );
-			} else {
-				text = translate( 'Cancel plan' );
-			}
-		} else if ( isSubscription( purchase ) ) {
-			if ( hasTranslation( 'Remove subscription' ) ) {
-				text = translate( 'Remove subscription' );
-			} else {
-				text = translate( 'Cancel subscription' );
-			}
-		} else if ( isOneTimePurchase( purchase ) ) {
-			if ( hasTranslation( 'Remove' ) ) {
-				text = translate( 'Remove' );
-			} else {
-				text = translate( 'Cancel' );
-			}
-		}
-		return text;
-	}
 	if ( isDomainRegistration( purchase ) ) {
-		text = translate( 'Cancel domain' );
+		if ( hasTranslation( 'Cancel domain subscription' ) ) {
+			return translate( 'Cancel domain subscription' );
+		}
+		return translate( 'Cancel domain' );
 	} else if ( isPlan( purchase ) ) {
-		text = translate( 'Cancel plan' );
+		return translate( 'Cancel plan' );
 	} else if ( isSubscription( purchase ) ) {
-		text = translate( 'Cancel subscription' );
+		return translate( 'Cancel subscription' );
 	} else if ( isOneTimePurchase( purchase ) ) {
-		text = translate( 'Cancel' );
+		return translate( 'Cancel' );
 	}
-	return text;
+	return '';
 }

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -165,7 +165,7 @@ describe( 'Purchase Management Buttons', () => {
 				</ReduxProvider>
 			</QueryClientProvider>
 		);
-		expect( await screen.findByText( /remove/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /and be removed/ ) ).toBeInTheDocument();
 		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -165,8 +165,8 @@ describe( 'Purchase Management Buttons', () => {
 				</ReduxProvider>
 			</QueryClientProvider>
 		);
-		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /remove/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders a cancel button with remove language when auto-renew is OFF and the purchase is an Akismet purchase attached to an akismet siteless holding site', async () => {
@@ -194,8 +194,8 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /remove/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
 	it( "does't render renew buttons for domain with pending registration at registry", async () => {

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -147,7 +147,7 @@ describe( 'Purchase Management Buttons', () => {
 		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders a remove button when auto-renew is OFF', async () => {
+	it( 'renders a cancel button with remove language when auto-renew is OFF', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );
@@ -165,11 +165,12 @@ describe( 'Purchase Management Buttons', () => {
 				</ReduxProvider>
 			</QueryClientProvider>
 		);
-		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
+		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
+		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders a remove button when auto-renew is OFF and the purchase is an Akismet purchase attached to an akismet siteless holding site', async () => {
+	it( 'renders a cancel button with remove language when auto-renew is OFF and the purchase is an Akismet purchase attached to an akismet siteless holding site', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
@@ -194,8 +195,9 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
+		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
+		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
 	it( "does't render renew buttons for domain with pending registration at registry", async () => {

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -166,7 +166,7 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
+		expect( await screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
@@ -196,7 +196,7 @@ describe( 'Purchase Management Buttons', () => {
 		);
 
 		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
+		expect( await screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -166,7 +166,6 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( await screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 
@@ -196,7 +195,6 @@ describe( 'Purchase Management Buttons', () => {
 		);
 
 		expect( await screen.findByText( /removed/ ) ).toBeInTheDocument();
-		expect( await screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 		expect( screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [CHE-164](https://linear.app/a8c/issue/CHE-164/update-cancel-language-for-purchases)

## Proposed Changes

* Favor "Cancel" language over "remove" language when cancelling and removing.
* To distinguish between cancel and removal flows, include extra text in the "Cancel" button explaining what will happen.

## Screenshots

When the plan is active and a refund is available, we see this (on trunk, the PR does not modify this screenshot)
<img width="329" height="169" alt="Screenshot 2025-12-30 at 12 50 57 PM" src="https://github.com/user-attachments/assets/60131bc9-d0dc-48df-9055-f076c7db76e9" />

Instead of saying "Refund available", this PR adds a short description of what will happen (see below).

When someone wants to cancel a purchase outside of the refund window, they would previously just see "Cancel plan", but now they see:
<img width="376" height="116" alt="Screenshot 2025-12-30 at 12 53 10 PM" src="https://github.com/user-attachments/assets/166c1d5d-3a9d-412a-84f3-7bfa048bb717" />

After that same plan is cancelled, it can be removed with the following button. Notice that the button still says "Cancel" which is intentional, but it also describes that the plan will be removed (this replaces the previous "Remove plan" button):
<img width="369" height="107" alt="Screenshot 2025-12-30 at 12 53 42 PM" src="https://github.com/user-attachments/assets/9832d666-5739-4a7e-a400-e451d646ff83" />

If a plan has expired, the remove button is replaced with:
<img width="340" height="136" alt="Screenshot 2025-12-30 at 12 44 56 PM" src="https://github.com/user-attachments/assets/45a6e499-c82a-41e8-b2af-398ae0643cac" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To include language mentioning "cancel" to help avoid confusion and help the customer understand that this step will "cancel" the plan. The first time the user clicks "cancel" it simply disables auto-renew, which effectively cancels the subscription / plan because the customer will not automatically be charged again, but lets the customer keep the plan until it expires. If the customer wanted to stop all services of a subscription that has auto-renew disabled, they would previously need to click the "Remove plan" button, which may not be intuitive if the customer is looking for something that would "cancel" the plan. For this reason, we wanted to include "Cancel" in any place where the customer wants to cancel / remove.
* To avoid confusion with what the cancel button would do in various situations, we've included another line that explains exactly what will happen if the customer goes through this process. This includes text like "Will expire immediately and be removed" or "The expired plan will be removed" or "Will remain active until (date)".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to cancel various products in various states (with auto renew enabled, with auto renew disabled, with an expired plan, etc..)
* Ensure you see "subscription" instead of "plan" on the cancel buttons.
* Make sure that "cancel" and "remove" language makes sense ("remove" language only appears when in the removal flow, removing purchases which were already cancelled).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
