### PR TITLE
SSH Migration: Update button copy while processing migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-rotating-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-rotating-loading-messages.ts
@@ -2,21 +2,16 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useMemo } from 'react';
 
 interface UseRotatingLoadingMessagesOptions {
-	isStartingMigration: boolean;
-	migrationStarted: boolean;
-	shouldStartMigration: boolean;
+	isBusy: boolean;
 	rotationInterval?: number;
 }
 
 export const useRotatingLoadingMessages = ( {
-	isStartingMigration,
-	migrationStarted,
-	shouldStartMigration,
+	isBusy,
 	rotationInterval = 3000,
 }: UseRotatingLoadingMessagesOptions ) => {
 	const translate = useTranslate();
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
-	const isBusy = isStartingMigration || migrationStarted || shouldStartMigration;
 
 	const loadingMessages = useMemo(
 		() => [
@@ -45,8 +40,6 @@ export const useRotatingLoadingMessages = ( {
 	const currentMessage = loadingMessages[ currentMessageIndex ];
 
 	return {
-		isBusy,
-		currentMessage,
 		buttonText: isBusy ? currentMessage : translate( 'Continue' ),
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-rotating-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-rotating-loading-messages.ts
@@ -1,0 +1,52 @@
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect, useMemo } from 'react';
+
+interface UseRotatingLoadingMessagesOptions {
+	isStartingMigration: boolean;
+	migrationStarted: boolean;
+	shouldStartMigration: boolean;
+	rotationInterval?: number;
+}
+
+export const useRotatingLoadingMessages = ( {
+	isStartingMigration,
+	migrationStarted,
+	shouldStartMigration,
+	rotationInterval = 3000,
+}: UseRotatingLoadingMessagesOptions ) => {
+	const translate = useTranslate();
+	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
+	const isBusy = isStartingMigration || migrationStarted || shouldStartMigration;
+
+	const loadingMessages = useMemo(
+		() => [
+			translate( 'Provisioning site' ),
+			translate( 'Verifying server details' ),
+			translate( 'Checking document root' ),
+			translate( 'Validating credentials' ),
+			translate( 'Setting up SSH Key' ),
+		],
+		[ translate ]
+	);
+
+	useEffect( () => {
+		if ( ! isBusy ) {
+			setCurrentMessageIndex( 0 );
+			return;
+		}
+
+		const interval = setInterval( () => {
+			setCurrentMessageIndex( ( prevIndex ) => ( prevIndex + 1 ) % loadingMessages.length );
+		}, rotationInterval );
+
+		return () => clearInterval( interval );
+	}, [ isBusy, loadingMessages.length, rotationInterval ] );
+
+	const currentMessage = loadingMessages[ currentMessageIndex ];
+
+	return {
+		isBusy,
+		currentMessage,
+		buttonText: isBusy ? currentMessage : translate( 'Continue' ),
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -183,11 +183,11 @@ const SiteMigrationSshShareAccess: StepType< {
 	const displaySiteName = urlToDomain( fromUrl );
 	const hostDisplayName = getSSHHostDisplayName( host );
 
+	const isBusy = isStartingMigration || migrationStarted || shouldStartMigration;
+
 	// Rotating loading messages for continue button
-	const { isBusy, buttonText } = useRotatingLoadingMessages( {
-		shouldStartMigration,
-		isStartingMigration,
-		migrationStarted,
+	const { buttonText } = useRotatingLoadingMessages( {
+		isBusy,
 	} );
 
 	const title = translate( 'Securely share your access' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -18,6 +18,7 @@ import { useSSHMigrationStatus } from '../site-migration-ssh-in-progress/hooks/u
 import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
 import { usePollSSHMigrationAtomicTransfer } from './hooks/use-poll-ssh-migration-atomic-transfer';
+import { useRotatingLoadingMessages } from './hooks/use-rotating-loading-messages';
 import { useStartSSHMigration } from './hooks/use-start-ssh-migration';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
@@ -182,6 +183,13 @@ const SiteMigrationSshShareAccess: StepType< {
 	const displaySiteName = urlToDomain( fromUrl );
 	const hostDisplayName = getSSHHostDisplayName( host );
 
+	// Rotating loading messages for continue button
+	const { isBusy, buttonText } = useRotatingLoadingMessages( {
+		shouldStartMigration,
+		isStartingMigration,
+		migrationStarted,
+	} );
+
 	const title = translate( 'Securely share your access' );
 	const subtitle = hostDisplayName
 		? translate(
@@ -222,9 +230,9 @@ const SiteMigrationSshShareAccess: StepType< {
 								migrationStarted ||
 								shouldStartMigration
 							}
-							isBusy={ isStartingMigration || migrationStarted || shouldStartMigration }
+							isBusy={ isBusy }
 						>
-							{ translate( 'Continue' ) }
+							{ buttonText }
 						</Button>
 					</div>
 				</SshMigrationContainer>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15091

## Proposed Changes

* Alternate the text in the main submit button to reflect the loading state.

<img width="609" height="612" alt="Captura de Tela 2025-11-03 às 16 59 35" src="https://github.com/user-attachments/assets/163af7af-ff5e-4378-93e6-dacdf129af68" />

* The text in the button should alternate between:
    * Provisioning site
    * Verifying server details
    * Checking document root
    * Validating credentials
    * Setting up SSH Key

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When you initiate a migration, it could take a moment or two for the migration to start as we check whether we have everything we need to start. The wait can feel long. Let's update the button copy to reflect some of the possible things we can be doing to make the wait not feel as long. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Go through the flow until you reach the `Securely share your access` step
* Go through the steps and input the username and the password
* Clicking on `Continue`, the text on the button should alternate every 3 seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
