### PR TITLE
SSH Migration: Remove timeframe from the How to Migrate step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,6 +1,6 @@
 import { PLAN_BUSINESS, getPlan, isWpComBusinessPlan } from '@automattic/calypso-products';
 import { NextButton, Step } from '@automattic/onboarding';
-import { Icon, copy, globe, lockOutline, scheduled } from '@wordpress/icons';
+import { Icon, copy, globe, lockOutline } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -42,12 +42,6 @@ const SiteMigrationHowToMigrate: StepType< {
 				icon: copy,
 				description: translate(
 					"We'll bring over a copy of your site, without affecting the current live version."
-				),
-			},
-			{
-				icon: scheduled,
-				description: translate(
-					"You'll get an update on the progress of your migration within 2-3 business days."
 				),
 			},
 			{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15089

## Proposed Changes

* Removes the timeline referencing from the How to Migrate step.

<img width="835" height="609" alt="Captura de Tela 2025-11-03 às 17 15 25" src="https://github.com/user-attachments/assets/068582c4-d5dc-402c-8637-907bf3920017" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If you don't supply a URL at the beginning of the migration flow, we take you through the regular migration screens. As a result you'll eventually land on the How to Migrate step.

<img width="3456" height="1986" alt="image (9)" src="https://github.com/user-attachments/assets/ce0667aa-918f-4e73-a475-de4d633b14df" />

* We need to remove the third bullet referencing the timeline since that won't be the case for SSH migrations.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Navigate to `/setup/site-migration`
* Click on `Or pick your current platform from a list`
* Go through the Assisted flow until you reach the `Let us migrate your site`
* Now notice that the `You'll get an update on the progress of your migration within 2-3 business days.` message is not present anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
