### PR TITLE
Translate field labels for sites dashboard

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -22,131 +22,133 @@ import {
 import type { Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
-export const DEFAULT_FIELDS: Field< Site >[] = [
-	{
-		id: 'name',
-		label: __( 'Site' ),
-		enableHiding: false,
-		enableGlobalSearch: true,
-		getValue: ( { item } ) => getSiteDisplayName( item ),
-		render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
-	},
-	{
-		id: 'URL',
-		label: __( 'URL' ),
-		enableGlobalSearch: true,
-		getValue: ( { item } ) => getSiteDisplayUrl( item ),
-		render: ( { field, item } ) => <URL site={ item } value={ field.getValue( { item } ) } />,
-	},
-	{
-		id: 'icon.ico',
-		label: __( 'Site icon' ),
-		render: ( { item } ) => <SiteIcon site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'subscribers_count',
-		label: __( 'Subscribers' ),
-	},
-	{
-		id: 'backup',
-		label: __( 'Backup' ),
-		render: ( { item } ) => <LastBackup site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'plan',
-		label: __( 'Plan' ),
-		getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
-		render: ( { item } ) => <Plan site={ item } />,
-	},
-	{
-		id: 'status',
-		label: __( 'Status' ),
-		getValue: ( { item } ) => getSiteStatus( item ),
-		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
-		filterBy: {
-			operators: [ 'isAny' as Operator ],
+export function getDefaultFields(): Field< Site >[] {
+	return [
+		{
+			id: 'name',
+			label: __( 'Site' ),
+			enableHiding: false,
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => getSiteDisplayName( item ),
+			render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
 		},
-		render: ( { item } ) => <Status site={ item } />,
-	},
-	{
-		id: 'wp_version',
-		label: __( 'WP version' ),
-		getValue: ( { item } ) => getFormattedWordPressVersion( item ),
-	},
-	{
-		id: 'is_a8c',
-		type: 'boolean',
-		label: __( 'A8C owned' ),
-		elements: [
-			{ value: true, label: __( 'Yes' ) },
-			{ value: false, label: __( 'No' ) },
-		],
-		filterBy: {
-			operators: [ 'is' as Operator ],
+		{
+			id: 'URL',
+			label: __( 'URL' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => getSiteDisplayUrl( item ),
+			render: ( { field, item } ) => <URL site={ item } value={ field.getValue( { item } ) } />,
 		},
-		render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
-	},
-	{
-		id: 'preview',
-		label: __( 'Preview' ),
-		render: ( { item } ) => <Preview site={ item } />,
-		enableHiding: false,
-		enableSorting: false,
-	},
-	{
-		id: 'last_published',
-		label: __( 'Last published' ),
-		getValue: ( { item } ) => item.options?.updated_at ?? '',
-		render: ( { item } ) =>
-			item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
-	},
-	{
-		id: 'uptime',
-		label: __( '7-day uptime' ),
-		render: ( { item } ) => <Uptime site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'visitors',
-		label: __( '7-day visitors' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
-		enableSorting: false,
-	},
-	{
-		id: 'views',
-		label: __( '7-day views' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="views" />,
-		enableSorting: false,
-	},
-	{
-		id: 'likes',
-		label: __( '7-day likes' ),
-		render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
-		enableSorting: false,
-	},
-	{
-		id: 'php_version',
-		label: __( 'PHP version' ),
-		render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'storage',
-		label: __( 'Storage' ),
-		render: ( { item } ) => <MediaStorage site={ item } />,
-		enableSorting: false,
-	},
-	{
-		id: 'host',
-		label: __( 'Host' ),
-		getValue: ( { item } ) => {
-			return getSiteProviderName( item ) ?? DEFAULT_PROVIDER_NAME;
+		{
+			id: 'icon.ico',
+			label: __( 'Site icon' ),
+			render: ( { item } ) => <SiteIcon site={ item } />,
+			enableSorting: false,
 		},
-		render: ( { field, item } ) => field.getValue( { item } ),
-	},
-];
+		{
+			id: 'subscribers_count',
+			label: __( 'Subscribers' ),
+		},
+		{
+			id: 'backup',
+			label: __( 'Backup' ),
+			render: ( { item } ) => <LastBackup site={ item } />,
+			enableSorting: false,
+		},
+		{
+			id: 'plan',
+			label: __( 'Plan' ),
+			getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
+			render: ( { item } ) => <Plan site={ item } />,
+		},
+		{
+			id: 'status',
+			label: __( 'Status' ),
+			getValue: ( { item } ) => getSiteStatus( item ),
+			elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+			filterBy: {
+				operators: [ 'isAny' as Operator ],
+			},
+			render: ( { item } ) => <Status site={ item } />,
+		},
+		{
+			id: 'wp_version',
+			label: __( 'WP version' ),
+			getValue: ( { item } ) => getFormattedWordPressVersion( item ),
+		},
+		{
+			id: 'is_a8c',
+			type: 'boolean',
+			label: __( 'A8C owned' ),
+			elements: [
+				{ value: true, label: __( 'Yes' ) },
+				{ value: false, label: __( 'No' ) },
+			],
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
+			render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
+		},
+		{
+			id: 'preview',
+			label: __( 'Preview' ),
+			render: ( { item } ) => <Preview site={ item } />,
+			enableHiding: false,
+			enableSorting: false,
+		},
+		{
+			id: 'last_published',
+			label: __( 'Last published' ),
+			getValue: ( { item } ) => item.options?.updated_at ?? '',
+			render: ( { item } ) =>
+				item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
+		},
+		{
+			id: 'uptime',
+			label: __( '7-day uptime' ),
+			render: ( { item } ) => <Uptime site={ item } />,
+			enableSorting: false,
+		},
+		{
+			id: 'visitors',
+			label: __( '7-day visitors' ),
+			render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
+			enableSorting: false,
+		},
+		{
+			id: 'views',
+			label: __( '7-day views' ),
+			render: ( { item } ) => <EngagementStat site={ item } type="views" />,
+			enableSorting: false,
+		},
+		{
+			id: 'likes',
+			label: __( '7-day likes' ),
+			render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
+			enableSorting: false,
+		},
+		{
+			id: 'php_version',
+			label: __( 'PHP version' ),
+			render: ( { item }: { item: Site } ) => <PHPVersion site={ item } />,
+			enableSorting: false,
+		},
+		{
+			id: 'storage',
+			label: __( 'Storage' ),
+			render: ( { item } ) => <MediaStorage site={ item } />,
+			enableSorting: false,
+		},
+		{
+			id: 'host',
+			label: __( 'Host' ),
+			getValue: ( { item } ) => {
+				return getSiteProviderName( item ) ?? DEFAULT_PROVIDER_NAME;
+			},
+			render: ( { field, item } ) => field.getValue( { item } ),
+		},
+	];
+}
 
 export function getFields( {
 	isAutomattician,
@@ -155,7 +157,8 @@ export function getFields( {
 	isAutomattician?: boolean;
 	viewType?: string;
 } ) {
-	return DEFAULT_FIELDS.filter( ( field ) => {
+	const defaultFields = getDefaultFields();
+	return defaultFields.filter( ( field ) => {
 		if ( field.id === 'is_a8c' && ! isAutomattician ) {
 			return false;
 		}

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -1,5 +1,5 @@
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { DEFAULT_FIELDS } from './fields';
+import { getDefaultFields } from './fields';
 import type { AnalyticsClient } from '../../app/analytics';
 import type { User, SitesView, SitesViewPreferences } from '@automattic/api-core';
 import type { Operator, SortDirection, SupportedLayouts } from '@wordpress/dataviews';
@@ -282,7 +282,8 @@ function sanitizeView( view: SitesView ) {
 	}
 
 	if ( sanitized.sort?.field ) {
-		const field = DEFAULT_FIELDS.find( ( field ) => field.id === sanitized.sort?.field );
+		const defaultFields = getDefaultFields();
+		const field = defaultFields.find( ( field ) => field.id === sanitized.sort?.field );
 		if ( ! field || field.enableSorting === false ) {
 			const { sort, ...rest } = sanitized;
 			sanitized = rest;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-281

## Proposed Changes

* Return the array of fields from a function instead of defining it as a constant, to allow translations to be loaded properly.

|Before|After|
|---|---|
|<img width="363" height="605" alt="Screenshot 2025-11-04 at 01 50 39" src="https://github.com/user-attachments/assets/f30e9f52-4628-4e3b-aa3a-108976bee42d" />|<img width="363" height="605" alt="Screenshot 2025-11-04 at 01 50 58" src="https://github.com/user-attachments/assets/6bfed269-a1a3-4119-81db-c4cb6e6340d1" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* At the moment some translations are not loaded by the time the DEFAULT_FIELDS constant is defined which means that the labels remain in English.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch you profile locale to a popular non-English language, like Spanish, German or French.
* Go to /sites on wordpress.com, click on Dataview settings icon and confirm that labels like `7-day visitors` are not translated.
* Test the fix on calypso.localhost or Calypso live.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
