### PR TITLE
MSD: Use the description for the subtitle on the overview.

### DIFF
--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -216,10 +216,11 @@ function SiteOverview( {
 		<PageLayout
 			size={ isCommerceGardenSite ? 'small' : 'large' }
 			header={
-				<VStack>
-					<PageHeader title={ getSiteDisplayName( site ) } actions={ renderActions() } />
-					<SiteOverviewFields site={ site } />
-				</VStack>
+				<PageHeader
+					title={ getSiteDisplayName( site ) }
+					description={ <SiteOverviewFields site={ site } /> }
+					actions={ renderActions() }
+				/>
 			}
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>


### PR DESCRIPTION
Part of DOTMSD-746.

## Proposed Changes

| Header | Header |
|--------|--------|
| <img width="1290" height="2795" alt="wpcalypso wordpress com_v2_sites_dufresnesteven6 wpcomstaging com(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/be7d1b3e-a749-4560-af4e-6a7846ab4acf" /> | <img width="1290" height="2795" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max) (4)" src="https://github.com/user-attachments/assets/dfb86bb0-0bca-4e6f-9ae6-8e45e1741017" /> | 


## Why are these changes being made?

This brings it in alignment with the other pages.

## Known issues

Currently, the tabbing order is a bit weird, seeing that you tab through the description first because of how the components are structured in `PageHeader`. This is the same for all pages.

 I'm not sure if this should change or not in a follow-up PR.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
