### PR TITLE
Developer QoL: e2e tests check at start up for a running Calypso server

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -5,7 +5,27 @@ import { TestAccount } from '../lib/test-account';
 import pwConfig from './playwright-config';
 
 export default async (): Promise< void > => {
-	const { AUTHENTICATE_ACCOUNTS } = envVariables;
+	const { AUTHENTICATE_ACCOUNTS, CALYPSO_BASE_URL } = envVariables;
+
+	try {
+		const response = await fetch( CALYPSO_BASE_URL, {
+			method: 'HEAD',
+			signal: AbortSignal.timeout( 5000 ),
+		} );
+		if ( ! response.ok ) {
+			throw new Error( `Server responded with status ${ response.status }` );
+		}
+	} catch ( e ) {
+		console.error( `Failed to ping a Calypso server running at ${ CALYPSO_BASE_URL }` );
+		if ( e instanceof Error ) {
+			console.error( `Error: ${ e.message }` );
+		}
+		console.error( 'Either:' );
+		console.error( '  make sure the Calypso development server is running with: `yarn start`, or' );
+		console.error( '  set the CALYPSO_BASE_URL environment variable to the appropriate value.' );
+		console.error( 'Refer to the documentation in `test/e2e/docs/environment_variables.md`.' );
+		process.exit( 1 );
+	}
 
 	// If PWDEBUG mode is enabled (stepping through each step)
 	// don't execute the cookie refresh.

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -10,7 +10,7 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | --------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
 | ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                             | `./results/`                                        | Optional |
 | AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                  | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
-| CALYPSO_BASE_URL      | The base URL to use for Calypso.                                                                                     | `http://calypso.localhost:3000`                     | Optional |
+| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. https://wordpress.com, http://calypso.localhost:3000, etc.                      | `http://calypso.localhost:3000`                     | Optional |
 | COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                | `false`                                             | Optional |
 | COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                     | `./cookies/`                                        | Optional |
 | GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                               | `false`                                             | Optional |

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -10,7 +10,7 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | --------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
 | ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                             | `./results/`                                        | Optional |
 | AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                  | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
-| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. https://wordpress.com, http://calypso.localhost:3000, etc.                      | `http://calypso.localhost:3000`                     | Optional |
+| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. https://wordpress.com, http://calypso.localhost:3000, etc.                      | <http://calypso.localhost:3000>                     | Optional |
 | COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                | `false`                                             | Optional |
 | COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                     | `./cookies/`                                        | Optional |
 | GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                               | `false`                                             | Optional |
@@ -20,5 +20,5 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | TEST_LOCALES          | The locales to target for I18N testing (see more: [supported locales](../../../packages/i18n-utils/src/locales.ts)). | `en, es, fr`                                        | Optional |
 | TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                                      | `false`                                             | Optional |
 | VIEWPORT_NAME         | Specify the viewport to be used.                                                                                     | `desktop`                                           | Optional |
-| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                      | `https://woocommerce.com`                           | Optional |
-| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                        | `https://wordpress.com`                             | Optional |
+| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                      | <https://woocommerce.com>                           | Optional |
+| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                        | <https://wordpress.com>                             | Optional |

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -10,7 +10,7 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | --------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
 | ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                             | `./results/`                                        | Optional |
 | AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                  | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
-| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. https://wordpress.com, http://calypso.localhost:3000, etc.                      | <http://calypso.localhost:3000>                     | Optional |
+| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. `https://wordpress.com`, `http://calypso.localhost:3000`, etc.                  | `http://calypso.localhost:3000`                     | Optional |
 | COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                | `false`                                             | Optional |
 | COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                     | `./cookies/`                                        | Optional |
 | GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                               | `false`                                             | Optional |
@@ -20,5 +20,5 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | TEST_LOCALES          | The locales to target for I18N testing (see more: [supported locales](../../../packages/i18n-utils/src/locales.ts)). | `en, es, fr`                                        | Optional |
 | TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                                      | `false`                                             | Optional |
 | VIEWPORT_NAME         | Specify the viewport to be used.                                                                                     | `desktop`                                           | Optional |
-| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                      | <https://woocommerce.com>                           | Optional |
-| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                        | <https://wordpress.com>                             | Optional |
+| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                      | `https://woocommerce.com`                           | Optional |
+| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                        | `https://wordpress.com`                             | Optional |


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

The e2e tests check whether the calypso server is running at start up, and print a useful message if it is not.

<img width="2410" height="330" alt="CleanShot 2025-11-04 at 15 12 50@2x" src="https://github.com/user-attachments/assets/8ce3aa8c-ca54-4744-ba65-e3a171823efe" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The default value for `CALYPSO_BASE_URL` was changed to `calypso.localhost` for a better dotcom dev experience p4TIVU-b3G-p2

However this was unexpected for Jetpack devs, who _do_ test against production.

The early exit and error message should help point folks in the right direction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Stop the calypso dev server
* `yarn workspace wp-e2e-tests test`
* You should see the error message
* `CALYPSO_BASE_URL=https://wordpress.com yarn workspace wp-e2e-tests test`
* The tests will run against production
* Start your dev server
* `yarn workspace wp-e2e-tests test`
* The tests will run against the dev server

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?