### PR TITLE
A4A > Tiers: Implement agency tier early access screen

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -14,9 +14,11 @@ import './style.scss';
 export default function AgencyTierOverviewContent( {
 	currentAgencyTierId,
 	totalInfluencedRevenue,
+	isEarlyAccess,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
+	isEarlyAccess: boolean;
 } ) {
 	return (
 		<VStack spacing={ 6 }>
@@ -28,7 +30,7 @@ export default function AgencyTierOverviewContent( {
 					/>
 				</CardBody>
 			</Card>
-			<TierCards currentAgencyTierId={ currentAgencyTierId } />
+			<TierCards currentAgencyTierId={ currentAgencyTierId } isEarlyAccess={ isEarlyAccess } />
 			<Divider orientation="horizontal" margin={ 4 } style={ { color: '#F0F0F0' } } />
 			<TierBenefits currentAgencyTierId={ currentAgencyTierId } />
 		</VStack>

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -1,72 +1,157 @@
+import { formatCurrency } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import {
 	Card,
 	CardBody,
 	Button,
+	Modal,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ALL_TIERS } from './constants';
 import type { AgencyTierType } from './types';
 
 export default function TierCards( {
 	currentAgencyTierId,
+	isEarlyAccess,
 }: {
 	currentAgencyTierId?: AgencyTierType;
+	isEarlyAccess: boolean;
 } ) {
+	const dispatch = useDispatch();
+
 	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
 
 	const isSmallViewport = useViewportMatch( 'huge', '<' );
 
-	const content = ALL_TIERS.map( ( tier ) => {
-		const hasLowerTier = currentTier && currentTier.level > tier.level;
-		const hasHigherTier = currentTier && currentTier.level < tier.level;
-		const isCurrentTier = currentTier === tier;
-		const isSecondary = hasLowerTier || hasHigherTier;
+	const [ showEarlyAccessModal, setShowEarlyAccessModal ] = useState( false );
 
-		return (
-			<Card
-				key={ tier.id }
-				style={ {
-					width: isSmallViewport ? '100%' : '33%',
-					...( isCurrentTier && {
-						boxShadow: '0 0 0 1px var(--color-primary-50)',
-					} ),
-				} }
-			>
-				<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
-					<VStack spacing={ 2 } style={ { flex: 1 } }>
-						<HStack>
-							<SectionHeader title={ tier.name } />
-							{ isCurrentTier && (
-								<Badge
-									style={ { minWidth: 'fit-content' } }
-									intent="default"
-									children={ __( 'Your tier' ) }
-								/>
-							) }
-						</HStack>
-						<Text style={ { color: '#757575' } }>{ tier.description }</Text>
-						<Text style={ { color: '#757575' } } weight={ 700 }>
-							{ tier.heading }
-						</Text>
-						<Text style={ { color: '#757575' } }>{ tier.subheading }</Text>
-					</VStack>
-					<Button
-						href={ `#${ tier.id }` }
-						variant={ isSecondary ? 'secondary' : 'primary' }
-						style={ { marginTop: '24px', alignSelf: 'flex-start' } }
-					>
-						{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
-					</Button>
-				</CardBody>
-			</Card>
+	const handleLearnMore = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agency_tier_early_access_learn_more_click', {
+				agency_tier: currentAgencyTierId,
+			} )
 		);
-	} );
+		setShowEarlyAccessModal( true );
+	};
+
+	const handleViewBenefits = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agency_tier_view_benefits_click', {
+				agency_tier: currentAgencyTierId,
+			} )
+		);
+	};
+
+	const content = (
+		<>
+			{ ALL_TIERS.map( ( tier ) => {
+				const hasLowerTier = currentTier && currentTier.level > tier.level;
+				const hasHigherTier = currentTier && currentTier.level < tier.level;
+				const isCurrentTier = currentTier === tier;
+				const isSecondary = hasLowerTier || hasHigherTier;
+
+				return (
+					<Card
+						key={ tier.id }
+						style={ {
+							width: isSmallViewport ? '100%' : '33%',
+							...( isCurrentTier && {
+								boxShadow: '0 0 0 1px var(--color-primary-50)',
+							} ),
+						} }
+					>
+						<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
+							<VStack spacing={ 2 } style={ { flex: 1, justifyContent: 'flex-start' } }>
+								<HStack>
+									<SectionHeader title={ tier.name } />
+									{ isCurrentTier && ! isEarlyAccess && (
+										<Badge
+											style={ { minWidth: 'fit-content' } }
+											intent="default"
+											children={ __( 'Your tier' ) }
+										/>
+									) }
+								</HStack>
+								{ isCurrentTier && isEarlyAccess && (
+									<Badge
+										style={ { width: 'fit-content' } }
+										intent="default"
+										children={ __( 'Your Tier — Early Access' ) }
+									/>
+								) }
+								<Text style={ { color: '#757575' } }>{ tier.description }</Text>
+								{ isCurrentTier && isEarlyAccess && (
+									<Text style={ { color: '#757575', fontStyle: 'italic' } } weight={ 700 }>
+										{ createInterpolateElement( __( 'You’re in early. <a>Learn more</a>' ), {
+											a: (
+												<Button onClick={ handleLearnMore } variant="link">
+													{ __( 'Learn more.' ) }
+												</Button>
+											),
+										} ) }
+									</Text>
+								) }
+								<Text style={ { color: '#757575' } } weight={ 700 }>
+									{ tier.heading }
+								</Text>
+								<Text style={ { color: '#757575' } }>{ tier.subheading }</Text>
+							</VStack>
+							<Button
+								onClick={ handleViewBenefits }
+								href={ `#${ tier.id }` }
+								variant={ isSecondary ? 'secondary' : 'primary' }
+								style={ { marginTop: '24px', alignSelf: 'flex-start' } }
+							>
+								{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
+							</Button>
+						</CardBody>
+					</Card>
+				);
+			} ) }
+			{ showEarlyAccessModal && (
+				<Modal
+					isDismissible
+					size="medium"
+					onRequestClose={ () => setShowEarlyAccessModal( false ) }
+					title={ __( 'You’ve been granted early access' ) }
+				>
+					<VStack spacing={ 8 }>
+						<Text>
+							{ __(
+								'You’ve been given early access to the Pro Partner tier in recognition of your partnership with Automattic. This is your head start to unlock powerful benefits, tools, and resources.'
+							) }
+						</Text>
+						<Text>
+							{ createInterpolateElement(
+								sprintf(
+									'To make the most of your early access and stay on track toward your %s Influenced Automattic Revenue goal, <b>stay connected with your Partner Manager</b>. Your manager is here to help you reach that goal by providing strategic guidance, growth opportunities, and ensure you maximize every advantage during this phase.',
+									formatCurrency( 5000, 'USD' )
+								),
+								{
+									b: <b />,
+								}
+							) }
+						</Text>
+						<ButtonStack justify="flex-end">
+							<Button variant="primary" onClick={ () => setShowEarlyAccessModal( false ) }>
+								{ __( 'Got it' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</Modal>
+			) }
+		</>
+	);
 
 	if ( isSmallViewport ) {
 		return (

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -134,11 +134,14 @@ export default function TierCards( {
 						<Text>
 							{ createInterpolateElement(
 								sprintf(
-									'To make the most of your early access and stay on track toward your %s Influenced Automattic Revenue goal, <b>stay connected with your Partner Manager</b>. Your manager is here to help you reach that goal by providing strategic guidance, growth opportunities, and ensure you maximize every advantage during this phase.',
+									/* translators: %s is the influenced revenue */
+									__(
+										'To make the most of your early access and stay on track toward your %s Influenced Automattic Revenue goal, <b>stay connected with your Partner Manager</b>. Your manager is here to help you reach that goal by providing strategic guidance, growth opportunities, and ensure you maximize every advantage during this phase.'
+									),
 									formatCurrency( 5000, 'USD' )
 								),
 								{
-									b: <b />,
+									b: <strong />,
 								}
 							) }
 						</Text>

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview-v2/index.tsx
@@ -19,10 +19,10 @@ export default function AgencyTierOverviewV2() {
 	const agency = useSelector( getActiveAgency );
 
 	const title = translate( 'Your agency tier and benefits' );
-	const currentAgencyTierId = agency?.tier?.id;
 
-	// FIXME: Replace with actual influenced revenue
-	const totalInfluencedRevenue = 2000;
+	const currentAgencyTierId = agency?.tier?.id;
+	const totalInfluencedRevenue = agency?.influenced_revenue ?? 0;
+	const isEarlyAccess = agency?.tier?.is_early_access ?? false;
 
 	return (
 		<Layout title={ title } wide>
@@ -39,6 +39,7 @@ export default function AgencyTierOverviewV2() {
 				<AgencyTierOverviewContent
 					currentAgencyTierId={ currentAgencyTierId }
 					totalInfluencedRevenue={ totalInfluencedRevenue }
+					isEarlyAccess={ isEarlyAccess }
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -110,7 +110,9 @@ export interface Agency {
 		id: AgencyTier;
 		label: string;
 		features: string[];
+		is_early_access: boolean;
 	};
+	influenced_revenue: number;
 	approval_status: ApprovalStatus | '';
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1678/ui-implement-the-special-early-access-state

## Proposed Changes

This PR implements the agency tier early access screen.

## Why are these changes being made?

* To indicate to the agency if they have given early access to a higher tier.

## Testing Instructions

* Patch 195139-ghe-Automattic/wpcom
* Open the A4A live link
* Go to Agency Tier > Follow the instructions in the patch to test all three 3 scenarios > Verify the same is reflected on the UI.

Early access state:

<img width="1920" height="900" alt="Screenshot 2025-11-04 at 11 00 18 AM" src="https://github.com/user-attachments/assets/8dda96d5-542c-4263-a114-bf9f43f090d1" />

* Verify the "Learn more" link opens up the modal below

<img width="579" height="442" alt="Screenshot 2025-11-04 at 11 00 29 AM" src="https://github.com/user-attachments/assets/bdaea520-e410-4c29-be32-e106b416168b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?