### PR TITLE
A4A > Tiers: Implement agency tier progress card on the Overview page

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -31,6 +31,9 @@ export const ALL_TIERS: TierItem[] = [
 		heading: __( 'Essential benefits' ),
 		subheading: __( 'Tools, earning opportunities, support & training and more' ),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],
+		progressCardDescription: __(
+			'You’re just getting started. Explore your benefits and learn how to grow your influenced revenue.'
+		),
 		benefits: [
 			{
 				icon: tool,
@@ -118,6 +121,9 @@ export const ALL_TIERS: TierItem[] = [
 		),
 		heading: __( '2 additional benefits unlocked' ),
 		subheading: __( 'Directory visibility, early access' ),
+		progressCardDescription: __(
+			'You’re making great progress! Keep growing your influenced revenue to unlock Pro Partner benefits.'
+		),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ],
 		benefits: [
 			{
@@ -158,6 +164,9 @@ export const ALL_TIERS: TierItem[] = [
 		),
 		heading: __( '3 additional benefits unlocked' ),
 		subheading: __( 'Co-marketing, qualified leads, partner manager & more' ),
+		progressCardDescription: __(
+			'Congratulations! You’ve unlocked all Pro Partner benefits including co-marketing opportunities and your dedicated partner manager.'
+		),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
 		benefits: [
 			{
@@ -200,6 +209,9 @@ export const ALL_TIERS: TierItem[] = [
 		),
 		heading: __( '3 premium benefits' ),
 		subheading: __( 'Annual credits, Parse.ly trial, marketing funds' ),
+		progressCardDescription: __(
+			'You’ve reached the highest tier! Enjoy all Premier Partner benefits including annual credits, Parse.ly trial, and marketing development funds.'
+		),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'premier-partner' ],
 		benefits: [
 			{

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/types.ts
@@ -24,6 +24,7 @@ export interface TierItem {
 	description: string;
 	heading: string;
 	subheading: string;
+	progressCardDescription: string;
 	influencedRevenue: number;
 	benefits: Benefit[];
 }

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -1,0 +1,85 @@
+import {
+	Card,
+	CardBody,
+	Button,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { ButtonStack } from 'calypso/dashboard/components/button-stack';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { ALL_TIERS } from '../overview-content/constants';
+import InfluencedRevenue from '../overview-content/influenced-revenue';
+import type { AgencyTierType } from '../overview-content/types';
+
+export default function AgencyTierProgressCard( {
+	currentAgencyTierId,
+	influencedRevenue,
+	isEarlyAccess,
+}: {
+	currentAgencyTierId?: AgencyTierType;
+	influencedRevenue: number;
+	isEarlyAccess: boolean;
+} ) {
+	const dispatch = useDispatch();
+
+	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
+
+	if ( ! currentTier ) {
+		return null;
+	}
+
+	const handleExploreTiersAndBenefits = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agency_tier_progress_card_explore_click', {
+				agency_tier: currentAgencyTierId,
+			} )
+		);
+	};
+
+	return (
+		<Spacer marginBottom={ 4 }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 4 }>
+						<Heading level={ 4 } weight={ 500 }>
+							{ __( 'Your agency tier and benefits' ) }
+						</Heading>
+						<VStack spacing={ 3 }>
+							<Heading level={ 3 } weight={ 500 }>
+								{ currentTier.name }
+								{ isEarlyAccess && ` (${ __( 'Early access' ) })` }
+							</Heading>
+							<Text color="#757575">
+								{ isEarlyAccess
+									? sprintf(
+											/* translators: %s is the tier name */
+											'You’ve been given early access to %s tier benefits. Keep up the great work!',
+											currentTier.name
+									  )
+									: currentTier.progressCardDescription }
+							</Text>
+							<InfluencedRevenue
+								currentAgencyTierId={ currentAgencyTierId }
+								totalInfluencedRevenue={ influencedRevenue }
+							/>
+							<ButtonStack justify="flex-start">
+								<Button
+									onClick={ handleExploreTiersAndBenefits }
+									href={ A4A_AGENCY_TIER_LINK }
+									variant="secondary"
+								>
+									{ __( 'Explore Tiers and benefits' ) }
+								</Button>
+							</ButtonStack>
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		</Spacer>
+	);
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -42,7 +42,7 @@ export default function OverviewSidebarAgencyTier() {
 				<AgencyTierProgressCard
 					currentAgencyTierId={ currentAgencyTierId }
 					influencedRevenue={ influencedRevenue ?? 0 }
-					isEarlyAccess={ isEarlyAccess }
+					isEarlyAccess={ !! isEarlyAccess }
 				/>
 			) : (
 				<Card className="agency-tier__card">

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, FoldableCard } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, arrowRight } from '@wordpress/icons';
@@ -5,6 +6,7 @@ import { clsx } from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getAgencyTierInfo from 'calypso/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info';
+import AgencyTierProgressCard from 'calypso/a8c-for-agencies/sections/agency-tier/progress-card';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -19,61 +21,73 @@ export default function OverviewSidebarAgencyTier() {
 
 	const agency = useSelector( getActiveAgency );
 
-	const currentAgencyTier = agency?.tier?.id;
-	const currentAgencyTierInfo = getAgencyTierInfo( currentAgencyTier, translate );
+	const currentAgencyTierId = agency?.tier?.id;
+	const influencedRevenue = agency?.influenced_revenue;
+	const isEarlyAccess = agency?.tier?.is_early_access;
+	const currentAgencyTierInfo = getAgencyTierInfo( currentAgencyTierId, translate );
 
 	if ( ! currentAgencyTierInfo ) {
 		return null;
 	}
 
+	const isTiersRevampEnabled = isEnabled( 'tiers-revamp' );
+
 	return (
 		<>
 			<AgencyTierCelebrationModal
 				agencyTierInfo={ currentAgencyTierInfo }
-				currentAgencyTier={ currentAgencyTier }
+				currentAgencyTier={ currentAgencyTierId }
 			/>
-			<Card className="agency-tier__card">
-				<FoldableCard
-					className="foldable-nav"
-					header={ translate( 'Your progress' ) }
-					expanded
-					compact
-					iconSize={ 18 }
-				>
-					<div className="agency-tier__bottom-content">
-						<div
-							className={ clsx( 'agency-tier__current-agency-tier-header', {
-								'is-default': ! currentAgencyTier,
-							} ) }
-						>
-							<span className="agency-tier__current-agency-tier-icon">
-								<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
-							</span>
-							<span className="agency-tier__current-agency-tier-title">
-								{ preventWidows( currentAgencyTierInfo.title ) }
-							</span>
-						</div>
-						{ currentAgencyTierInfo && (
-							<div className="agency-tier__current-agency-tier-description">
-								{ currentAgencyTierInfo.description }
+			{ isTiersRevampEnabled ? (
+				<AgencyTierProgressCard
+					currentAgencyTierId={ currentAgencyTierId }
+					influencedRevenue={ influencedRevenue ?? 0 }
+					isEarlyAccess={ isEarlyAccess }
+				/>
+			) : (
+				<Card className="agency-tier__card">
+					<FoldableCard
+						className="foldable-nav"
+						header={ translate( 'Your progress' ) }
+						expanded
+						compact
+						iconSize={ 18 }
+					>
+						<div className="agency-tier__bottom-content">
+							<div
+								className={ clsx( 'agency-tier__current-agency-tier-header', {
+									'is-default': ! currentAgencyTierId,
+								} ) }
+							>
+								<span className="agency-tier__current-agency-tier-icon">
+									<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
+								</span>
+								<span className="agency-tier__current-agency-tier-title">
+									{ preventWidows( currentAgencyTierInfo.title ) }
+								</span>
 							</div>
-						) }
-						<Button
-							href={ A4A_AGENCY_TIER_LINK }
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_agency_tier_explore_tiers_and_benefits_click', {
-										agency_tier: currentAgencyTier,
-									} )
-								)
-							}
-						>
-							<Icon icon={ arrowRight } size={ 18 } />
-							{ translate( 'Explore Tiers and benefits' ) }
-						</Button>
-					</div>
-				</FoldableCard>
-			</Card>
+							{ currentAgencyTierInfo && (
+								<div className="agency-tier__current-agency-tier-description">
+									{ currentAgencyTierInfo.description }
+								</div>
+							) }
+							<Button
+								href={ A4A_AGENCY_TIER_LINK }
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_agency_tier_explore_tiers_and_benefits_click', {
+											agency_tier: currentAgencyTierId,
+										} )
+									)
+								}
+							>
+								<Icon icon={ arrowRight } size={ 18 } />
+								{ translate( 'Explore Tiers and benefits' ) }
+							</Button>
+						</div>
+					</FoldableCard>
+				</Card>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1676/ui-implement-a-tier-card-on-the-overview-page-to-showcase-the-current
Resolves https://linear.app/a8c/issue/A4A-1776/add-event-tracking

## Proposed Changes

This PR implements the agency tier progress card on the Overview page. 

## Why are these changes being made?

* To indicate the current agency tier and the influenced revenue. 

## Testing Instructions

* Open the A4A live link
* Set the agency tiers starting from emerging partner using the MC tool
* Go to Agency Tiers > Verify it shows the screen below for different scenarios

Emerging Partner

<img width="512" height="281" alt="Screenshot 2025-11-04 at 4 38 44 PM" src="https://github.com/user-attachments/assets/80ba9749-e354-4dc3-b547-a5796000a07b" />

Agency Partner

<img width="512" height="276" alt="Screenshot 2025-11-04 at 4 39 17 PM" src="https://github.com/user-attachments/assets/7af1ef5d-fe92-451d-babf-dbab2e96c532" />

Pro Agency Partner

<img width="512" height="276" alt="Screenshot 2025-11-04 at 4 39 42 PM" src="https://github.com/user-attachments/assets/e36fafd9-bd58-4811-9b5e-a2bc4aac23b3" />

Premier Partner

<img width="512" height="292" alt="Screenshot 2025-11-04 at 4 40 47 PM" src="https://github.com/user-attachments/assets/9b6a5c61-5179-4ed6-b4d6-31325057718e" />

* Patch 195139-ghe-Automattic/wpcom
* Follow the instructions in the patch to test the early access scenario > Verify that the same is reflected on the UI.

<img width="512" height="280" alt="Screenshot 2025-11-04 at 4 44 43 PM" src="https://github.com/user-attachments/assets/f287cc23-84e9-4891-aa6e-ceb0ffc4a6a3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?