### PR TITLE
Checkout: fix mobile visual inconsistencies

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -110,17 +110,13 @@ body.is-mobile-app-view {
 		background-color: var(--studio-white);
 		border-bottom: none 0;
 		color: var(--color-checkout-masterbar-text);
-		height: var(--masterbar-height);
+		height: var(--masterbar-checkout-height);
 		position: absolute;
 		padding-inline-end: 1.5em;
 
 		&.masterbar--is-akismet,
 		&.masterbar--is-jetpack {
 			padding-inline-start: 1.5em;
-		}
-
-		@include break-mobile {
-			height: var(--masterbar-checkout-height);
 		}
 
 		@include breakpoint-deprecated( ">960px" ) {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1119,6 +1119,7 @@ const CheckoutSummaryTitleContent = styled.span`
 
 const CheckoutSummaryTitle = styled.span`
 	display: flex;
+	align-items: center;
 `;
 
 const CheckoutSummaryTitleIcon = styled( Gridicon )`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1532,7 +1532,7 @@ const WPCheckoutCompletedMainContent = styled.div`
 const WPCheckoutSidebarContent = styled.div`
 	background: ${ ( props ) => props.theme.colors.background };
 	grid-area: sidebar-content;
-	margin-top: var( --masterbar-height );
+	margin-top: var( --masterbar-checkout-height );
 
 	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
 		margin-top: var( --masterbar-checkout-height );

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1108,6 +1108,7 @@ const CheckoutSummaryTitleContent = styled.span`
 	font-size: 16px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	justify-content: space-between;
+	align-items: center;
 	margin: 0 auto;
 	padding: 24px;
 	max-width: 600px;

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -4,7 +4,7 @@
 }
 
 .promo-card.checkout-sidebar-plan-upsell {
-	padding: 20px;
+	padding: 24px;
 }
 
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {
@@ -18,6 +18,7 @@
 .promo-card {
 	max-width: 384px;
 	width: 100%;
+	border-radius: 3px;
 }
 .promo-card .action-panel__body {
 	overflow: visible;

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -33,14 +33,12 @@ const UpsellWrapper = styled.div`
 	.cart__upsell-header {
 		border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		box-shadow: none;
-		padding-left: 20px;
-		padding-right: 20px;
+		padding-left: 24px;
+		padding-right: 24px;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 			border-top: none;
 			border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-			padding-left: 24px;
-			padding-right: 24px;
 		}
 
 		.section-header__label {
@@ -51,7 +49,7 @@ const UpsellWrapper = styled.div`
 	}
 
 	.cart__upsell-body {
-		padding: 0 20px 20px;
+		padding: 0 24px 24px;
 		font-size: 14px;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -773,9 +773,9 @@ const pulse = keyframes`
 
 const CheckoutSummaryCard = styled.div`
 	border: none;
-	border-radius: 4px;
+	border-radius: 3px;
 	background: #fff;
-	padding: 28px;
+	padding: 24px;
 	box-shadow:
 		0 3px 1px rgb( 0 0 0 / 4% ),
 		0 3px 8px rgb( 0 0 0 / 12% );

--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -26,7 +26,7 @@ const BillingFormFields = styled.div< BillingFormFieldsProps >`
 	input[type='search'].form-text-input,
 	.form-select,
 	.form-fieldset.contact-details-form-fields select {
-		border-radius: 3px;
+		border-radius: 2px;
 		color: ${ ( props ) => props.theme.colors.textColorDark };
 	}
 

--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -27,7 +27,7 @@ const BillingFormFields = styled.div< BillingFormFieldsProps >`
 	.form-select,
 	.form-fieldset.contact-details-form-fields select {
 		border-radius: 3px;
-		color: ${ ( props ) => props.theme.colors.textColor };
+		color: ${ ( props ) => props.theme.colors.textColorDark };
 	}
 
 	& .form-input-validation {

--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -27,6 +27,7 @@ const BillingFormFields = styled.div< BillingFormFieldsProps >`
 	.form-select,
 	.form-fieldset.contact-details-form-fields select {
 		border-radius: 3px;
+		color: ${ ( props ) => props.theme.colors.textColor };
 	}
 
 	& .form-input-validation {

--- a/packages/composite-checkout/src/components/field.tsx
+++ b/packages/composite-checkout/src/components/field.tsx
@@ -18,6 +18,7 @@ const Label = styled.label< { disabled?: boolean } & LabelHTMLAttributes< HTMLLa
 const Input = styled.input<
 	{ isError?: boolean; icon?: React.ReactNode } & InputHTMLAttributes< HTMLInputElement >
 >`
+	color: ${ ( props ) => props.theme.colors.textColorDark };
 	display: block;
 	width: 100%;
 	box-sizing: border-box;

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -113,6 +113,7 @@ const Input = styled.input< {
 	line-height: 1.5;
 	font-size: 14px;
 	padding: 7px 14px;
+	max-width: 100%;
 
 	::-webkit-inner-spin-button,
 	::-webkit-outer-spin-button {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1269/

## Proposed Changes

This addresses some of the feedback for Checkout from p58i-od0-p2

- makes input color consistent
- fixes vertical alignment of some icons
- fixes grid alignment for fields and buttons
- fixes alignment, padding, and border radius for checkout summary

| Before | After |
| ----------- | ----------- |
| <img width="361" height="221" alt="Screenshot 2025-11-04 at 09 47 01" src="https://github.com/user-attachments/assets/879c9c56-464b-4b04-81e9-da62f4bce7f4" /> | <img width="364" height="241" alt="Screenshot 2025-11-04 at 09 47 29" src="https://github.com/user-attachments/assets/6a6ed4d0-7352-4857-8ac5-daac864ea9bd" /> |
| <img width="360" height="772" alt="Screenshot 2025-11-04 at 09 46 13" src="https://github.com/user-attachments/assets/c50b37b4-66e5-4956-8f78-4f81fcd39f37" /> | <img width="362" height="771" alt="Screenshot 2025-11-04 at 09 45 54" src="https://github.com/user-attachments/assets/95180354-ed04-415e-8aaa-1aaa1c3be2fa" /> |

## Testing Instructions

* Visit Checkout with different cart combinations (plan, plan and domain, emails, siteless, etc.)
* Verify that things visually look correct on desktop first
* Use devtools to view different mobile sizes
* Verify that things still look correct