### PR TITLE
Onboarding: Fix back navigation from Plans step when returning from checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -23,7 +23,7 @@ import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
-import { ONBOARD_STORE } from '../../../stores';
+import { ONBOARD_STORE, STEPPER_INTERNAL_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
@@ -74,6 +74,13 @@ const onboarding: FlowV2< typeof initialize > = {
 			} ),
 			[]
 		);
+
+		// Read previous step from Stepper internal store so Back from Plans can return
+		// to either 'domains' or 'use-my-domain' depending on where the user came from.
+		const previousStep = useSelect( ( select ) => {
+			const data = ( select( STEPPER_INTERNAL_STORE ) as any ).getStepData?.();
+			return data?.previousStep as string | undefined;
+		}, [] );
 		const coupon = useQuery().get( 'coupon' );
 
 		const { setShouldShowNotification } = usePurchasePlanNotification();
@@ -264,7 +271,34 @@ const onboarding: FlowV2< typeof initialize > = {
 					return;
 			}
 		};
-		return { submit };
+
+		/**
+		 * This is a special case for the Plans step because it can be directly re-entered
+		 * without prior in-flow navigation (e.g. returning from Checkout).
+		 * When on the Plans step, the canonical previous step in this flow is the domains
+		 * step, so we send users there instead of relying on browser history or
+		 * transient post-submit steps.
+		 */
+		const plansGoBack = () => {
+			// Prefer the actual previously visited step when available.
+			if ( previousStep === 'use-my-domain' || previousStep === 'domains' ) {
+				return navigate( previousStep );
+			}
+
+			// Fallback: infer from onboarding state when returning from checkout.
+			if ( signupDomainOrigin === SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN ) {
+				return navigate( 'use-my-domain' );
+			}
+
+			return navigate( 'domains' );
+		};
+
+		return {
+			submit,
+			...( currentStepSlug === 'plans' && {
+				goBack: plansGoBack,
+			} ),
+		};
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/CHE-259/back-button-on-plans-page-returns-me-to-shopping-cart

## Proposed Changes

When going through the onboarding flow to checkout and back to the plans step, the "Back" button (on the Plans step) redirects to checkout. This is flagged as an issue to resolve; the back navigation from the "plans" step should be to "domains" (or the auxiliary "use-my-domain"). This is what the PR accomplishes.

This is a tricky one. The PR uses the deprecated `goBack` method for fixing this. The flow ultimately defines the canonical step order and branching semantics (domains vs. use-my-domain). So it authoritatively decides that the predecessor for Plans is Domains when there’s no in-flow history, avoiding brittle heuristics. That's the essence of the approach, but hopefully there are other fixes (I only later saw that `goBack` is marked as deprecated).

Deferring to @alshakero or @Automattic/quake team for direction (as I believe they own signup).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/CHE-259/back-button-on-plans-page-returns-me-to-shopping-cart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start from `/v2/sites` and create a new site
* On the Domains step, pick a domain
* On the Plans step, pick a plan
* On Checkout, hit the Back button
* On the Plans step, hit the Back button
* You should land back on the Domains step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
