### PR TITLE
Theme Showcase: Show only locally installed themes in My Themes on Summer Special Personal sites

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,7 +1,4 @@
-import {
-	FEATURE_INSTALL_THEMES,
-	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-} from '@automattic/calypso-products';
+import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import pageRouter from '@automattic/calypso-router';
 import { compact } from 'lodash';
 import PropTypes from 'prop-types';
@@ -13,7 +10,6 @@ import ThemesList from 'calypso/components/themes-list';
 import { getThemeShowcaseEventRecorder } from 'calypso/my-sites/themes/events/theme-showcase-tracks';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
@@ -325,14 +321,8 @@ export const ConnectedThemesSelection = connect(
 		state,
 		{ filter, page, search, tier, vertical, siteId, source, forceWpOrgSearch, tabFilter }
 	) => {
-		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
 		const hiddenFilters = getThemeHiddenFilters( state, siteId, tabFilter );
-		const hasUnlimitedPremiumThemes = siteHasFeature(
-			state,
-			siteId,
-			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED
-		);
 		const canInstallThemes = siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
 
 		let sourceSiteId;
@@ -340,10 +330,6 @@ export const ConnectedThemesSelection = connect(
 			sourceSiteId = source;
 		} else {
 			sourceSiteId = siteId ? siteId : 'wpcom';
-		}
-
-		if ( isAtomic && ! hasUnlimitedPremiumThemes ) {
-			sourceSiteId = 'wpcom';
 		}
 
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-115

## Proposed Changes

* Remove an unnecessary downgraded Atomic workaround from the Calypso My Themes screen.

| Before | After |
|--------|--------|
| <img width="2540" height="2192" alt="Screenshot 2025-11-04 at 17 08 00" src="https://github.com/user-attachments/assets/41c646f6-53cd-4a67-bc80-2051162b1c3b" /> | <img width="2540" height="2192" alt="Screenshot 2025-11-04 at 17 08 11" src="https://github.com/user-attachments/assets/44a1cccb-0b8c-49bb-8e68-73e0a8ff6706" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The My Themes tab in the Calypso Theme Showcase has different behaviors on Simple and Atomic.

The idea is to show all the locally installed themes, mimicking the wp-admin counterpart. This works fine on Atomic, but on Simple, all Dotcom themes are locally installed.

For this reason, for a long time, the My Themes tab was only available on Atomic, until we started displaying it on all sites [in January 2024](https://github.com/Automattic/wp-calypso/pull/86660). On Simple, instead of showing all Dotcom themes, we only show those that were previously activated on the site.

In that PR, we missed [a workaround from February 2022](https://github.com/Automattic/wp-calypso/pull/61468), intended to prevent showing all themes on downgraded Atomic sites during the brief transitional period where a site was on Atomic but not on Business (when only Business was supposed to have access to Atomic features).

With our My Themes changes, that workaround was practically unreachable.

Alas, it came into play again with Summer Special opening Atomic features to all plans, creating an unexpected inconsistency.

Summer Special sites on Personal would hit that condition, accidentally showing all Dotcom themes even though the site has access to external themes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Grab one Summer Special site on Personal and one on Premium.
* Install an external theme by uploading the theme's zip.
* Navigate to My Themes (`/themes/my-themes/:SITE`).
* Ensure the screen only contains themes that are locally installed on the site, including the newly uploaded one.
* Test for regression on an Atomic site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
