### PR TITLE
Replace "premium styles" with "global styles" in the main GS upgrade …

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -80,7 +80,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 				{ isLoaded ? (
 					<>
 						<div className="upgrade-modal__col">
-							<h1 className="upgrade-modal__heading">{ translate( 'Unlock premium styles' ) }</h1>
+							<h1 className="upgrade-modal__heading">{ translate( 'Unlock global styles' ) }</h1>
 							{ description ?? (
 								<>
 									<p>{ translations.description }</p>

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -43,16 +43,16 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		} ),
 		features: useSiteGlobalStylesOnPersonal() ? personalFeatures : premiumFeatures,
 		description: translate(
-			'You’ve selected a premium style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
-			'You’ve selected premium styles that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			'You’ve selected a style variation that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			'You’ve selected style variations that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
 			{
 				count: numOfSelectedGlobalStyles,
 				args: { planTitle },
 			}
 		),
 		promotion: translate(
-			'Upgrade now to unlock your premium style and get access to tons of other features. Or you can decide later and try it out first.',
-			'Upgrade now to unlock your premium styles and get access to tons of other features. Or you can decide later and try them out first.',
+			'Upgrade now to unlock your style variation and get access to tons of other features. Or you can decide later and try it out first.',
+			'Upgrade now to unlock your style variations and get access to tons of other features. Or you can decide later and try them out first.',
 			{ count: numOfSelectedGlobalStyles }
 		),
 		try: translate( 'Decide later' ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-81

## Proposed Changes

* Update the phrasing of the main Limited Global Styles referring to "global styles" instead of "premium styles". 

| Before | After |
|--------|--------|
| <img width="2560" height="2248" alt="Screenshot 2025-11-04 at 17 46 10" src="https://github.com/user-attachments/assets/62b0ec9e-297b-4d1a-96d8-740184be15fe" /> | <img width="2560" height="2248" alt="Screenshot 2025-11-04 at 17 46 26" src="https://github.com/user-attachments/assets/9c84dae9-3efa-4d85-9944-4d130a4bf485" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A recent feedback requested to use the widely recognized "global styles" phrasing instead of "premium styles".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick a free site.
* Navigate to the Theme Showcase, and select a free theme with style variations (e.g. Retrospect).
  * Note: the theme must be free, otherwise the modal will be overridden by a redirect to Checkout.
* Check that the phrasing in the modal makes sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
