### PR TITLE
Garden: Update so CIAB sites appear in the transfer list

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -54,13 +54,20 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const isAtomic = site?.options?.is_automated_transfer ?? false;
 		const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
 
-		return Boolean(
-			site?.capabilities?.manage_options &&
-				! ( site.jetpack && ! isAtomic ) && // Simple and Atomic sites. Not Jetpack sites.
+		const hasManageOptions = site?.capabilities?.manage_options;
+		const isJetpackNonAtomic = site.jetpack && ! isAtomic && ! site?.is_garden;
+		const isDomainOnly = site?.options?.is_domain_only ?? false;
+		const isSameSite = site.ID === this.props.selectedSite?.ID;
+
+		const eligible = Boolean(
+			hasManageOptions &&
+				! isJetpackNonAtomic && // Simple, Garden, and Atomic sites. Not Jetpack sites.
 				! isWpcomStagingSite &&
-				! ( site?.options?.is_domain_only ?? false ) &&
-				site.ID !== this.props.selectedSite?.ID
+				! isDomainOnly &&
+				! isSameSite
 		);
+
+		return eligible;
 	};
 
 	handleSiteSelect = ( targetSiteId: number ) => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -15,6 +15,7 @@ type SiteDataExtraInfo = SiteDetails & {
 	};
 	title: string;
 	capabilities?: Record< string, boolean >;
+	is_garden?: boolean;
 };
 
 // props passed to the component

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -7,6 +7,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_private',
 	'is_coming_soon',
 	'is_vip',
+	'is_garden',
 	'jetpack',
 	'jetpack_connection',
 	'jetpack_modules',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-1196

## Proposed Changes

Update so that CIAB sites appear in the list of sites that are eligible to transfer a stand-alone domain to. Previously, we filtered out CIAB sites so it was impossible to attach a standalone domain to a CIAB site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Garden site using the `/tools/garden` MC tool.
* Purchase a new domain (preferably using `.blog`, and remember to delete the domain when you're done testing) and _don't_ attach it to a site.
<img width="465" height="152" alt="CleanShot 2025-11-04 at 13 00 44" src="https://github.com/user-attachments/assets/348ef0d2-ae22-4008-9704-d492a0f91d86" />
* Go to http://calypso.localhost:3000/ciab/ (or use the calypso.live url)
* Click on "Actions" for your CIAB site and click "Domains". You may need to access the wp-admin for the site before this action is available.
* Click "Add a domain name" and "Use a domain I own".
* Enter the domain name you just purchased.
* Click the "move it to this site" link
![JWkIeycJewYrFVeVCUdZ6jZSMxK5CrrC2AdpnTF2.jpg](https://github.com/user-attachments/assets/9c43f4d4-fda6-44b5-8846-b6e042c3d0eb)
* You'll be taken to `/domains/manage` where you should see your CIAB site in the list.
* Click on the CIAB site and click "Confirm Attachment"
<img width="770" height="223" alt="CleanShot 2025-11-04 at 13 04 56" src="https://github.com/user-attachments/assets/416811c0-d1a3-43cb-8147-c13f9dcf9cb5" />
* NOTE: You'll be redirected back to `/domains/manage/` with a "Domains are not available for this site" message. This will be fixed in another PR.
* Manually go back to `/ciab` and click "Domains" in the "Actions" list.
* You should see your domain in the list of domains for the CIAB site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?