### PR TITLE
Help Center: remove touchstart from close button

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -255,7 +255,6 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 					tooltipPosition="top left"
 					icon={ close }
 					onClick={ onDismiss }
-					onTouchStart={ onDismiss }
 				/>
 			</Flex>
 		</CardHeader>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-277/

## Proposed Changes

This removes the `touchstart` event from the close button for the help center.

## Why are these changes being made?

Using `touchstart` to close the help center means that once the help center is closed, the click event will fire against any element rendered under the help center close button. In the case where the help center open button is underneath the close button, the user will end up in a loop of closing and re-opening the help center.

See: peP6yB-2py-p2#comment-1375

## Testing Instructions

- On a mobile device or with devtools mocking a mobile view
- Visit Checkout with the `&signup=1` url parameter to mock coming to Checkout from Signup
- Click the help icon in the top-right
- Verify that Help Center is open
- Click the X to close Help Center
- Verify that Help Center is closed and doesn't automatically reopen