### PR TITLE
Improve the anonymous path check to support multiple languages

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -55,14 +55,19 @@ export function mayWeLoadSurvicateScript() {
  * @returns {boolean} True if the user is on an anonymous path, false otherwise
  */
 export function isUserOnAnonymousPaths() {
-	return [
+	const pathname = window.location.pathname;
+	const anonymousPaths = [
 		'/log-in',
 		'/setup/onboarding/user',
 		'/log-in/lostpassword',
 		'/account/user-social',
 		'/log-in/link',
 		'/log-in/qr',
-	].includes( window.location.pathname );
+	];
+
+	return anonymousPaths.some(
+		( path ) => pathname === path || pathname.startsWith( `${ path }/` )
+	);
 }
 
 export function addSurvicate() {

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -137,9 +137,11 @@ describe( 'survicate', () => {
 		test.each( [
 			// Anonymous paths should return true
 			[ '/log-in', true ],
-			[ '/setup/onboarding/user', true ],
 			[ '/log-in/lostpassword', true ],
 			[ '/account/user-social', true ],
+			[ '/setup/onboarding/user', true ],
+			[ '/setup/onboarding/user/pt-br', true ],
+			[ '/log-in/two-factor', true ],
 			// Non-anonymous paths should return false
 			[ '/sites', false ],
 			[ '/home', false ],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/105641
Slack thread: p1757862761540939-slack-C04H4NY6STW

## Proposed Changes

* We're supporting multiple languages in the anonymous route checks

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, we're seeing about 3k/day of calypso_survicate_user_not_available_error on the Survicate script and we want to fix the root cause of it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable Survicate logs with `localStorage.setItem('debug', 'calypso:analytics:survicate')` on your browser's console
* Make sure that when accessing a non-en version of onboarding like http://calypso.localhost:3000/setup/onboarding/user/pt-br?user_email=paulopmt1+1006%40gmail.com you won't see survicate loading:

<img width="1007" height="841" alt="image" src="https://github.com/user-attachments/assets/10c8978b-5c3f-424e-a717-bf621e83fa04" />

We'll still load the script in anonymous paths as we might want to use that in the future, but we won't set visitor traits:

<img width="1237" height="968" alt="image" src="https://github.com/user-attachments/assets/6c66a6b8-6def-4496-83ab-59e2a4417cff" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?