### PR TITLE
MSD: Update domain callout for free sites.

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -147,15 +147,23 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 		);
 	}
 
+	let description = __(
+		'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
+	);
+	let upsellCTAButtonText = __( 'Get this domain' );
+
+	if ( site.plan?.is_free ) {
+		description = __( 'Get <domain /> free for one year with an annual paid plan.' );
+		upsellCTAButtonText = __( 'Select a plan' );
+	}
+
 	return (
 		<DomainUpsellCardContent
 			site={ site }
 			title={ __( 'The perfect domain awaits' ) }
-			description={ __(
-				'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
-			) }
+			description={ description }
 			upsellId="site-overview-get-this-domain"
-			upsellCTAButtonText={ __( 'Get this domain' ) }
+			upsellCTAButtonText={ upsellCTAButtonText }
 		/>
 	);
 };

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -13,6 +13,13 @@ import UpsellCTAButton from '../../components/upsell-cta-button';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
 
+/**
+ * Returns true if the site requires a plan upgrade.
+ */
+const requiresPlanUpgrade = ( site: Site ) => {
+	return site.plan?.is_free || site.plan?.billing_period === 'Monthly';
+};
+
 const useDomainSuggestion = ( site: Site ) => {
 	const search = site.slug.split( '.' )[ 0 ];
 	const { data: allDomainSuggestions } = useQuery(
@@ -61,7 +68,7 @@ const DomainUpsellCardContent = ( {
 			] );
 		}
 
-		if ( site.plan?.is_free || site.plan?.billing_period === 'Monthly' ) {
+		if ( requiresPlanUpgrade( site ) ) {
 			window.location.href = getDomainAndPlanUpsellUrl( {
 				siteSlug: site.slug,
 				backUrl,
@@ -147,23 +154,31 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 		);
 	}
 
-	let description = __(
-		'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
-	);
-	let upsellCTAButtonText = __( 'Get this domain' );
-
-	if ( site.plan?.is_free ) {
-		description = __( 'Get <domain /> free for one year with an annual paid plan.' );
-		upsellCTAButtonText = __( 'Select a plan' );
+	if ( requiresPlanUpgrade( site ) ) {
+		return (
+			<DomainUpsellCardContent
+				site={ site }
+				title={ __( 'The perfect domain awaits' ) }
+				description={ __( 'Get <domain /> free for one year with an annual paid plan.' ) }
+				upsellId="site-overview-get-this-domain"
+				upsellCTAButtonText={ __( 'Choose a plan' ) }
+			/>
+		);
 	}
 
+	/**
+	 * A site may have used their domain credit but detached the domain from the site (for whatever reason).
+	 * In this case, we should show the domain upsell card.
+	 */
 	return (
 		<DomainUpsellCardContent
 			site={ site }
 			title={ __( 'The perfect domain awaits' ) }
-			description={ description }
+			description={ __(
+				'<domain /> is a perfect domain for your site. Grab it now or <link>choose your own</link>.'
+			) }
 			upsellId="site-overview-get-this-domain"
-			upsellCTAButtonText={ upsellCTAButtonText }
+			upsellCTAButtonText={ __( 'Get this domain' ) }
 		/>
 	);
 };

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -159,7 +159,9 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 			<DomainUpsellCardContent
 				site={ site }
 				title={ __( 'The perfect domain awaits' ) }
-				description={ __( 'Get <domain /> free for one year with an annual paid plan.' ) }
+				description={ __(
+					'Upgrade to an annual paid plan to get <domain /> free for one year. You can also <link>choose your own domain name</link>.'
+				) }
 				upsellId="site-overview-get-this-domain"
 				upsellCTAButtonText={ __( 'Choose a plan' ) }
 			/>


### PR DESCRIPTION
Fixes: DOTMSD-824

Props: @kriskarkoski 

## Proposed Changes

Update the copy of the Domain upsell to explain to users that they need to select a plan first. Currently, it says "Get this domain" but leaves you on the plan page without the domain.


| Before | After |
|--------|--------|
| <img width="711" height="226" alt="Screenshot 2025-11-05 at 10 13 21 AM" src="https://github.com/user-attachments/assets/cdf243e6-466a-4cef-abe8-a6c6ecb18246" /> | <img width="687" height="197" alt="Screenshot 2025-11-05 at 12 17 37 PM" src="https://github.com/user-attachments/assets/97a4df71-75a0-4426-9500-a03b61660767" /> | 




## Considerations?

### Why not include a different callout that suggests plans?

It's a good idea and something to pursue in a future iteration. We don't have designs for that.

I think this is a viable solution in the meantime because many users equate websites with domain names, and leading with that may be more attractive than a generic callout for plans.

## Testing Instructions

**Free site**
* Navigate to `/v2/sites/{siteSlug}`
* Expect these updates.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
