### PR TITLE
MSD: Update user account dropdown menu

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -73,7 +73,7 @@ export const profileRoute = createRoute( {
 	)
 );
 
-const preferencesRoute = createRoute( {
+export const preferencesRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -270,6 +270,7 @@ function UserProfile() {
 				render={
 					<Button
 						className="dashboard-secondary-menu__item"
+						label={ __( 'My profile' ) }
 						variant="tertiary"
 						icon={
 							user.avatar_URL ? (
@@ -285,7 +286,7 @@ function UserProfile() {
 					/>
 				}
 			/>
-			<Menu.Popover>
+			<Menu.Popover style={ { minWidth: '250px' } }>
 				<Menu.Item disabled>
 					<Text>{ user.display_name }</Text>
 					<Text variant="muted">@{ user.username }</Text>

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -1,14 +1,15 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	Button,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 	Spinner,
+	privateApis,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -22,18 +23,25 @@ import {
 	help,
 	commentAuthorAvatar,
 } from '@wordpress/icons';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Suspense, lazy, useCallback, useState } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
-import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAnalytics } from '../analytics';
 import { useAuth } from '../auth';
-import { useOpenCommandPalette } from '../command-palette/utils';
 import { useAppContext } from '../context';
 import { useHelpCenter } from '../help-center';
 import Notifications from '../notifications';
+import { billingRoute, profileRoute, preferencesRoute, securityRoute } from '../router/me';
+import type { AnyRoute } from '@tanstack/react-router';
 
 import './style.scss';
 
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Menu } = unlock( privateApis );
 const AsyncHelpCenterApp = lazy( () => import( '../help-center/help-center-app' ) );
 
 function Help() {
@@ -227,81 +235,99 @@ function Help() {
 // User profile dropdown component
 function UserProfile() {
 	const { user, logout } = useAuth();
-	const { supports } = useAppContext();
-	const openCommandPalette = useOpenCommandPalette();
+	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
 	const [ isLoggingOut, setIsLoggingOut ] = useState( false );
 
+	const handleAccountItemClick = ( itemId: string ) => {
+		let route: AnyRoute | undefined;
+		switch ( itemId ) {
+			case 'billing':
+				route = billingRoute;
+				break;
+			case 'profile':
+				route = profileRoute;
+				break;
+			case 'preferences':
+				route = preferencesRoute;
+				break;
+			case 'security':
+				route = securityRoute;
+				break;
+		}
+
+		if ( ! route ) {
+			return;
+		}
+
+		navigate( { to: route.fullPath } );
+		recordTracksEvent( 'calypso_dashboard_user_profile_menu_item_click', { item_id: itemId } );
+	};
+
 	return (
-		<DropdownMenu
-			popoverProps={ {
-				placement: 'bottom-end',
-				offset: 8,
-			} }
-			label={ __( 'My profile' ) }
-			icon={
-				user.avatar_URL ? (
-					<img
-						className="dashboard-secondary-menu__avatar"
-						src={ user.avatar_URL }
-						alt={ __( 'User avatar' ) }
+		<Menu>
+			<Menu.TriggerButton
+				render={
+					<Button
+						className="dashboard-secondary-menu__item"
+						variant="tertiary"
+						icon={
+							user.avatar_URL ? (
+								<img
+									className="dashboard-secondary-menu__avatar"
+									src={ user.avatar_URL }
+									alt={ __( 'User avatar' ) }
+								/>
+							) : (
+								commentAuthorAvatar
+							)
+						}
 					/>
-				) : (
-					commentAuthorAvatar
-				)
-			}
-			toggleProps={ {
-				className: 'dashboard-secondary-menu__item',
-				variant: 'tertiary',
-			} }
-		>
-			{ ( { onClose } ) => (
-				<VStack spacing={ 0 }>
-					<VStack style={ { padding: '16px', borderBottom: '1px solid #ccc' } } spacing={ 1 }>
-						<Text>{ user.display_name }</Text>
-						<Text variant="muted">@{ user.username }</Text>
-					</VStack>
-					<MenuGroup>
-						<RouterLinkMenuItem to="/me/profile" onClick={ onClose }>
-							{ __( 'Account' ) }
-						</RouterLinkMenuItem>
-					</MenuGroup>
-					{ supports.commandPalette && (
-						<MenuGroup>
-							<MenuItem
-								onClick={ () => {
-									// First close the dropdown
-									onClose();
-									// Then open the command palette after a tiny delay
-									// to ensure the dropdown is fully closed
-									requestAnimationFrame( () => {
-										openCommandPalette();
-									} );
-								} }
-								shortcut="⌘K"
-							>
-								{ __( 'Command palette' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-					<MenuGroup>
-						<MenuItem
-							disabled={ isLoggingOut }
-							onClick={ () => {
-								setIsLoggingOut( true );
-								logout().catch( () => setIsLoggingOut( false ) );
-							} }
-						>
+				}
+			/>
+			<Menu.Popover>
+				<Menu.Item disabled>
+					<Text>{ user.display_name }</Text>
+					<Text variant="muted">@{ user.username }</Text>
+				</Menu.Item>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>{ __( 'Account' ) }</Menu.GroupLabel>
+					<Menu.Item onClick={ () => handleAccountItemClick( 'profile' ) }>
+						<Menu.ItemLabel>{ __( 'Profile' ) }</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Item onClick={ () => handleAccountItemClick( 'preferences' ) }>
+						<Menu.ItemLabel>{ __( 'Preferences' ) }</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Item onClick={ () => handleAccountItemClick( 'billing' ) }>
+						<Menu.ItemLabel>{ __( 'Billing' ) }</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Item onClick={ () => handleAccountItemClick( 'security' ) }>
+						<Menu.ItemLabel>{ __( 'Security' ) }</Menu.ItemLabel>
+					</Menu.Item>
+				</Menu.Group>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.Item
+						disabled={ isLoggingOut }
+						hideOnClick={ false }
+						onClick={ () => {
+							setIsLoggingOut( true );
+							logout().catch( () => setIsLoggingOut( false ) );
+						} }
+					>
+						<Menu.ItemLabel>
 							<HStack justify="left">
 								<span>{ isLoggingOut ? __( 'Logging out…' ) : __( 'Log out' ) }</span>
 								{ isLoggingOut && (
-									<Spinner style={ { width: 24, height: 24, padding: 4, margin: 0 } } />
+									<Spinner style={ { width: 16, height: 16, padding: 4, margin: 0 } } />
 								) }
 							</HStack>
-						</MenuItem>
-					</MenuGroup>
-				</VStack>
-			) }
-		</DropdownMenu>
+						</Menu.ItemLabel>
+					</Menu.Item>
+				</Menu.Group>
+			</Menu.Popover>
+		</Menu>
 	);
 }
 


### PR DESCRIPTION
Fixes DOTMSD-826

## Proposed Changes

This PR updates the user account dropdown menu by adding entry points to preferences, billing, and security.
This PR also updates the component to use the private component [Menu](https://wordpress.github.io/gutenberg/?path=/docs/components-menu--docs).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that the dropdown works as expected
* Ensure that the entry points work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
