### PR TITLE
MSD: Don't use the disabled state for the performance card. 

### DIFF
--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -8,7 +8,7 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
-import { getVisibilityURL } from '../../utils/site-url';
+import { getSiteVisibilityURL } from '../../utils/site-url';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
@@ -135,7 +135,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Launch your site to test performance.' ) }
-				link={ getVisibilityURL( site ) }
+				link={ getSiteVisibilityURL( site ) }
 			/>
 		);
 	}
@@ -146,7 +146,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Make your site public to test performance.' ) }
-				link={ getVisibilityURL( site ) }
+				link={ getSiteVisibilityURL( site ) }
 			/>
 		);
 	}

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -8,6 +8,7 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getPerformanceStatus, getStatusIntent, getStatusText } from '../../utils/site-performance';
+import { getVisibilityURL } from '../../utils/site-url';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import { useSitePerformanceData } from '../performance/use-site-performance-data';
 import type { SitePerformanceReport, Site } from '@automattic/api-core';
@@ -134,7 +135,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Launch your site to test performance.' ) }
-				disabled
+				link={ getVisibilityURL( site ) }
 			/>
 		);
 	}
@@ -145,7 +146,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Make your site public to test performance.' ) }
-				disabled
+				link={ getVisibilityURL( site ) }
 			/>
 		);
 	}

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -4,21 +4,13 @@ import { __ } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { getVisibilityURL } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
 	title: __( 'Visibility' ),
 	trackId: 'site-overview-visibility',
 };
-
-function getVisibilityURL( site: Site ) {
-	if ( isSelfHostedJetpackConnected( site ) ) {
-		return undefined;
-	}
-
-	return `/sites/${ site.slug }/settings/site-visibility`;
-}
 
 function getLaunchpadChecklistSlug( site: Site ) {
 	const intent = site.options?.site_intent;

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
-import { getVisibilityURL } from '../../utils/site-url';
+import { getSiteVisibilityURL } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
@@ -46,7 +46,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				? {
 						heading: __( 'Launch site' ),
 						description: __( 'Ready to go public?' ),
-						link: getVisibilityURL( site ),
+						link: getSiteVisibilityURL( site ),
 				  }
 				: {
 						heading: __( 'Coming soon' ),
@@ -74,7 +74,7 @@ function VisibilityCardComingSoon( { site }: { site: Site } ) {
 					? __( 'Visitors will see a coming soon page.' )
 					: __( 'Ready to go public?' )
 			}
-			link={ getVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site ) }
 		/>
 	);
 }
@@ -86,7 +86,7 @@ function VisibilityCardPrivate( { site }: { site: Site } ) {
 			icon={ lockOutline }
 			heading={ __( 'Private' ) }
 			description={ __( 'Only invited users can view your site.' ) }
-			link={ getVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site ) }
 		/>
 	);
 }
@@ -102,7 +102,7 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 			icon={ published }
 			heading={ __( 'Public' ) }
 			description={ description }
-			link={ getVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site ) }
 			intent="success"
 		/>
 	);

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -1,4 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
+import { isSelfHostedJetpackConnected } from './site-types';
 import type { Site } from '@automattic/api-core';
 
 /**
@@ -46,4 +47,15 @@ export function getSiteEditUrl( site: Site, isSiteUsingBlockTheme?: boolean ) {
 	}
 
 	return addQueryArgs( `${ siteAdminUrl }customize.php`, queryArgs );
+}
+
+/**
+ * Returns the URL for the site visibility settings page.
+ */
+export function getVisibilityURL( site: Site ) {
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return undefined;
+	}
+
+	return `/sites/${ site.slug }/settings/site-visibility`;
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -52,7 +52,7 @@ export function getSiteEditUrl( site: Site, isSiteUsingBlockTheme?: boolean ) {
 /**
  * Returns the URL for the site visibility settings page.
  */
-export function getVisibilityURL( site: Site ) {
+export function getSiteVisibilityURL( site: Site ) {
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		return undefined;
 	}


### PR DESCRIPTION
Related to DOTMSD-822

## Proposed Changes

Don't disable the performance card when private or coming soon. Update the copy and link to the Site Visibility settings.

| Before | After |
|--------|--------|
| <img width="1405" height="515" alt="Screenshot 2025-11-05 at 11 12 15 AM" src="https://github.com/user-attachments/assets/92be1d6a-91ae-4859-b348-19204ed334d4" /> | <img width="1389" height="507" alt="Screenshot 2025-11-05 at 11 16 14 AM" src="https://github.com/user-attachments/assets/3a6b59a0-0acf-47e0-90e9-c50b47c51318" /> |
| <img width="1397" height="496" alt="Screenshot 2025-11-05 at 11 17 50 AM" src="https://github.com/user-attachments/assets/7f35d20d-814d-43e0-b895-8bcbd83a50a0" /> | <img width="1406" height="510" alt="Screenshot 2025-11-05 at 11 17 33 AM" src="https://github.com/user-attachments/assets/7e043f5b-f5c5-4d1d-90af-22d862296b6a" /> |



## Why are these changes being made?

In looking at DOTMSD-822, I found the disabled performance card to be distracting. It's the only card in the Site Overview that exhibits this state, and while it communicates things clearly, it doesn't help users.

I thought it was a good idea to make it link to site visibility settings. Maybe not thought. 

Maybe the fact that it takes you somewhere else in this state than it usually does is bad UX. Nonetheless, I wanted to open a PR to discuss.


## Testing Instructions

1. With your business site in private or coming soon
2. Go to your Site Overview (v2)
3. Click on the performance overview card.
4. Expect to be in your settings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
