### PR TITLE
Site Settings: Update Database screen to use mutation

### DIFF
--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -106,13 +106,8 @@ export default function SecurityPassword() {
 						/>
 					);
 				},
-				isValid: {
-					custom: ( item ) => {
-						return item.password.length >= 6
-							? null
-							: __( 'Password must be at least 6 characters long.' );
-					},
-				},
+				// TODO: Add validation via isValid.custom.
+				// There is currently a bug that prevents it from working.
 			},
 		],
 		[ isPasswordVisible, isLoading ]

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -106,8 +106,13 @@ export default function SecurityPassword() {
 						/>
 					);
 				},
-				// TODO: Add validation via isValid.custom.
-				// There is currently a bug that prevents it from working.
+				isValid: {
+					custom: ( item ) => {
+						return item.password.length >= 6
+							? null
+							: __( 'Password must be at least 6 characters long.' );
+					},
+				},
 			},
 		],
 		[ isPasswordVisible, isLoading ]

--- a/client/dashboard/sites/settings-database/reset-password-modal.tsx
+++ b/client/dashboard/sites/settings-database/reset-password-modal.tsx
@@ -1,4 +1,5 @@
-import { restoreDatabasePassword } from '@automattic/api-core';
+import { siteDatabaseMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -22,19 +23,21 @@ export default function ResetPasswordModal( {
 	onSuccess,
 	onError,
 }: ResetPasswordModalProps ) {
+	const mutation = useMutation( siteDatabaseMutation( siteId ) );
 	const [ isRestoring, setIsRestoring ] = useState( false );
 
 	const handleRestore = () => {
 		setIsRestoring( true );
-		restoreDatabasePassword( siteId )
-			.then( () => {
+		mutation.mutate( undefined, {
+			onSuccess: () => {
 				setIsRestoring( false );
 				onSuccess();
-			} )
-			.catch( () => {
+			},
+			onError: () => {
 				setIsRestoring( false );
 				onError();
-			} );
+			},
+		} );
 	};
 
 	return (

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -64,6 +64,7 @@ export * from './site-backup-download';
 export * from './site-backup-restore';
 export * from './site-backups';
 export * from './site-cache';
+export * from './site-database';
 export * from './site-defensive-mode';
 export * from './site-deployments';
 export * from './site-do-it-for-me';

--- a/packages/api-queries/src/site-database.ts
+++ b/packages/api-queries/src/site-database.ts
@@ -1,0 +1,7 @@
+import { restoreDatabasePassword } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+
+export const siteDatabaseMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: () => restoreDatabasePassword( siteId ),
+	} );


### PR DESCRIPTION
Fixes DOTMSD-37

## Proposed Changes

Update code to use mutation to follow the MSD technical guidance.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Site Settings Database screen
* Ensure that the password reset modal works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
