### PR TITLE
MSD: Add Holiday snow settings

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1050,6 +1050,28 @@ export const siteSettingsRepositoriesManageRoute = createRoute( {
 	)
 );
 
+export const siteSettingsHolidaySnowRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Holiday snow' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsRoute,
+	path: 'holiday-snow',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/settings-holiday-snow' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-holiday-snow' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 export const siteTrialEndedRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1275,6 +1297,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 				siteSettingsSubscriptionGiftingRoute,
 				siteSettingsAgencyRoute,
 				siteSettingsHundredYearPlanRoute,
+				siteSettingsHolidaySnowRoute,
 			];
 
 			if ( config.supports.sites.settings.general.redirect ) {

--- a/client/dashboard/sites/settings-holiday-snow/icons.tsx
+++ b/client/dashboard/sites/settings-holiday-snow/icons.tsx
@@ -1,0 +1,16 @@
+import { SVG, Path } from '@wordpress/primitives';
+
+export const snow = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+		<Path d="M20 11.25V12.75H4V11.25H20Z" fill="#757575" />
+		<Path d="M11.25 4L12.75 4L12.75 20H11.25L11.25 4Z" fill="#757575" />
+		<Path
+			d="M17.1265 5.81282L18.1872 6.87348L6.87348 18.1872L5.81282 17.1265L17.1265 5.81282Z"
+			fill="#757575"
+		/>
+		<Path
+			d="M5.81282 6.87348L6.87348 5.81282L18.1872 17.1265L17.1265 18.1872L5.81282 6.87348Z"
+			fill="#757575"
+		/>
+	</SVG>
+);

--- a/client/dashboard/sites/settings-holiday-snow/index.tsx
+++ b/client/dashboard/sites/settings-holiday-snow/index.tsx
@@ -1,0 +1,122 @@
+import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { notFound } from '@tanstack/react-router';
+import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { isHolidaySnowAvailable } from './utils';
+import type { SiteSettings } from '@automattic/api-core';
+import type { Field, SimpleFormField } from '@wordpress/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'jetpack_holiday_snow_enabled',
+		label: __( 'Show falling snow on my site until January 4th' ),
+		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+			const { id, getValue } = field;
+			return (
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ hideLabelFromVision ? '' : field.label }
+					checked={ getValue( { item: data } ) }
+					onChange={ () => {
+						onChange( { [ id ]: ! getValue( { item: data } ) } );
+					} }
+				/>
+			);
+		},
+	},
+];
+
+const form = {
+	layout: { type: 'regular' as const },
+	fields: [ { id: 'jetpack_holiday_snow_enabled' } as SimpleFormField ],
+};
+
+export default function HolidaySnowSettings( { siteSlug }: { siteSlug: string } ) {
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { data } = useQuery( siteSettingsQuery( site.ID ) );
+	const mutation = useMutation( {
+		...siteSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				error: __( 'Failed to save holiday snow settings.' ),
+			},
+		},
+	} );
+
+	const [ formData, setFormData ] = useState( {
+		jetpack_holiday_snow_enabled: data?.jetpack_holiday_snow_enabled,
+	} );
+
+	if ( ! data ) {
+		return null;
+	}
+
+	if ( ! isHolidaySnowAvailable( site ) ) {
+		throw notFound();
+	}
+
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => !! data[ key as keyof SiteSettings ] !== value
+	);
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate(
+			{ ...formData },
+			{
+				onSuccess: () => {
+					createSuccessNotice(
+						formData.jetpack_holiday_snow_enabled
+							? __( 'Holiday snow enabled.' )
+							: __( 'Holiday snow disabled.' ),
+						{ type: 'snackbar' }
+					);
+				},
+			}
+		);
+	};
+
+	return (
+		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }>
+			<Card>
+				<CardBody>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< SiteSettings >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: Partial< SiteSettings > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+							<ButtonStack justify="flex-start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isPending }
+									disabled={ isPending || ! isDirty }
+								>
+									{ __( 'Save' ) }
+								</Button>
+							</ButtonStack>
+						</VStack>
+					</form>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-holiday-snow/index.tsx
+++ b/client/dashboard/sites/settings-holiday-snow/index.tsx
@@ -55,7 +55,7 @@ export default function HolidaySnowSettings( { siteSlug }: { siteSlug: string } 
 	} );
 
 	const [ formData, setFormData ] = useState( {
-		jetpack_holiday_snow_enabled: data?.jetpack_holiday_snow_enabled,
+		jetpack_holiday_snow_enabled: !! data?.jetpack_holiday_snow_enabled,
 	} );
 
 	if ( ! data ) {

--- a/client/dashboard/sites/settings-holiday-snow/summary.tsx
+++ b/client/dashboard/sites/settings-holiday-snow/summary.tsx
@@ -1,0 +1,38 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { snow } from './icons';
+import { isHolidaySnowAvailable } from './utils';
+import type { Site, SiteSettings } from '@automattic/api-core';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function SettingsHolidaySnowSummary( {
+	site,
+	settings,
+	density,
+}: {
+	site: Site;
+	settings?: SiteSettings;
+	density?: Density;
+} ) {
+	let badges;
+	if ( settings ) {
+		badges = settings.jetpack_holiday_snow_enabled
+			? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
+			: [ { text: __( 'Disabled' ) } ];
+	}
+
+	if ( ! isHolidaySnowAvailable( site ) ) {
+		return null;
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/holiday-snow` }
+			title={ __( 'Holiday snow' ) }
+			density={ density }
+			decoration={ <Icon icon={ snow } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-holiday-snow/utils.ts
+++ b/client/dashboard/sites/settings-holiday-snow/utils.ts
@@ -1,0 +1,18 @@
+import { isWithinInterval, startOfDay } from 'date-fns';
+import { isSimple } from '../../utils/site-types';
+import type { Site } from '@automattic/api-core';
+
+// Holiday Snow is available on WordPress.com sites only from December 1 through January 4.
+export function isHolidaySnowAvailable( site: Site ) {
+	if ( ! isSimple( site ) && ! site.is_wpcom_atomic ) {
+		return false;
+	}
+
+	const today = startOfDay( new Date() );
+
+	const year = today.getFullYear();
+	const start = new Date( year, 11, 1 );
+	const end = new Date( year + 1, 0, 4 );
+
+	return isWithinInterval( today, { start, end } );
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -11,6 +11,7 @@ import AgencySettingsSummary from '../settings-agency/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
 import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
+import HolidaySnowSummary from '../settings-holiday-snow/summary';
 import HundredYearPlanSettingsSummary from '../settings-hundred-year-plan/summary';
 import PHPSettingsSummary from '../settings-php/summary';
 import PlanSettingsSummary from '../settings-plan/summary';
@@ -51,6 +52,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 						<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
 						<AgencySettingsSummary site={ site } />
 						<HundredYearPlanSettingsSummary site={ site } settings={ settings } />
+						<HolidaySnowSummary site={ site } settings={ settings } />
 						<PlanSettingsSummary site={ site } />
 					</SummaryButtonList>
 				</VStack>

--- a/packages/api-core/src/site-settings/types.ts
+++ b/packages/api-core/src/site-settings/types.ts
@@ -15,6 +15,7 @@ export interface SiteSettings {
 	wpcom_legacy_contact?: string;
 	wpcom_locked_mode?: boolean;
 	mcp_abilities?: SiteMcpAbilities;
+	jetpack_holiday_snow_enabled?: boolean;
 }
 
 export type SiteMcpAbilities = Record<


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-208

## Proposed Changes

* Add Holiday snow settings

<img width="678" height="71" alt="image" src="https://github.com/user-attachments/assets/9c39c5eb-fe10-4105-91f1-6f8c94c65afc" />

<img width="753" height="300" alt="image" src="https://github.com/user-attachments/assets/38aa6162-f653-45bb-9a5c-1cf08c653b06" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your endpoint and your site
* Add the following filter to your sandbox
```php
add_filter( 'jetpack_is_holiday_snow_season', '__return_true' );
```

* Apply diff to make the feature available

```diff
  1 diff --git a/client/dashboard/sites/settings-holiday-snow/utils.ts b/client/dashboard/sites/settings-holiday-snow/utils.ts
  2 index e1734b67da4..e45abaa0fdd 100644
  3 --- a/client/dashboard/sites/settings-holiday-snow/utils.ts
  4 +++ b/client/dashboard/sites/settings-holiday-snow/utils.ts
  5 @@ -14,5 +14,5 @@ export function isHolidaySnowAvailable( site: Site ) {
  6         const start = new Date( year, 11, 1 );
  7         const end = new Date( year + 1, 0, 4 );
  8
  9 -       return isWithinInterval( today, { start, end } );
 10 +       return ! isWithinInterval( today, { start, end } );
 11  }
  ```

* Go to your simple site > Settings
* Ensure you can see the `Holiday snow` setting
* Navigate to the setting
* Enable the `Holiday snow`
* Go to your site
* Ensure you can see Holiday snow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
