### PR TITLE
A4A > Tiers: Enable revamped tiers UI on staging & minor UI enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -204,7 +204,7 @@ export const ALL_TIERS: TierItem[] = [
 		name: __( 'Premier Partner' ),
 		description: sprintf(
 			/* translators: %s is the influenced revenue */
-			__( '%s+ influenced revenue' ),
+			__( '%s+ influenced revenue and invitation to the tier.' ),
 			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'premier-partner' ], 'USD' )
 		),
 		heading: __( '3 premium benefits' ),

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -44,12 +44,17 @@ export default function TierCards( {
 		setShowEarlyAccessModal( true );
 	};
 
-	const handleViewBenefits = () => {
+	const handleViewBenefits = ( tierId: string ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_agency_tier_view_benefits_click', {
 				agency_tier: currentAgencyTierId,
 			} )
 		);
+
+		const element = document.getElementById( tierId );
+		if ( element ) {
+			element.scrollIntoView( { behavior: 'smooth' } );
+		}
 	};
 
 	const content = (
@@ -107,8 +112,7 @@ export default function TierCards( {
 								<Text style={ { color: '#757575' } }>{ tier.subheading }</Text>
 							</VStack>
 							<Button
-								onClick={ handleViewBenefits }
-								href={ `#${ tier.id }` }
+								onClick={ () => handleViewBenefits( tier.id as string ) }
 								variant={ isSecondary ? 'secondary' : 'primary' }
 								style={ { marginTop: '24px', alignSelf: 'flex-start' } }
 							>

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -32,62 +32,61 @@ export default function OverviewSidebarAgencyTier() {
 
 	const isTiersRevampEnabled = isEnabled( 'tiers-revamp' );
 
-	return (
+	return isTiersRevampEnabled ? (
+		<AgencyTierProgressCard
+			currentAgencyTierId={ currentAgencyTierId }
+			influencedRevenue={ influencedRevenue ?? 0 }
+			isEarlyAccess={ !! isEarlyAccess }
+		/>
+	) : (
 		<>
 			<AgencyTierCelebrationModal
 				agencyTierInfo={ currentAgencyTierInfo }
 				currentAgencyTier={ currentAgencyTierId }
 			/>
-			{ isTiersRevampEnabled ? (
-				<AgencyTierProgressCard
-					currentAgencyTierId={ currentAgencyTierId }
-					influencedRevenue={ influencedRevenue ?? 0 }
-					isEarlyAccess={ !! isEarlyAccess }
-				/>
-			) : (
-				<Card className="agency-tier__card">
-					<FoldableCard
-						className="foldable-nav"
-						header={ translate( 'Your progress' ) }
-						expanded
-						compact
-						iconSize={ 18 }
-					>
-						<div className="agency-tier__bottom-content">
-							<div
-								className={ clsx( 'agency-tier__current-agency-tier-header', {
-									'is-default': ! currentAgencyTierId,
-								} ) }
-							>
-								<span className="agency-tier__current-agency-tier-icon">
-									<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
-								</span>
-								<span className="agency-tier__current-agency-tier-title">
-									{ preventWidows( currentAgencyTierInfo.title ) }
-								</span>
-							</div>
-							{ currentAgencyTierInfo && (
-								<div className="agency-tier__current-agency-tier-description">
-									{ currentAgencyTierInfo.description }
-								</div>
-							) }
-							<Button
-								href={ A4A_AGENCY_TIER_LINK }
-								onClick={ () =>
-									dispatch(
-										recordTracksEvent( 'calypso_a4a_agency_tier_explore_tiers_and_benefits_click', {
-											agency_tier: currentAgencyTierId,
-										} )
-									)
-								}
-							>
-								<Icon icon={ arrowRight } size={ 18 } />
-								{ translate( 'Explore Tiers and benefits' ) }
-							</Button>
+
+			<Card className="agency-tier__card">
+				<FoldableCard
+					className="foldable-nav"
+					header={ translate( 'Your progress' ) }
+					expanded
+					compact
+					iconSize={ 18 }
+				>
+					<div className="agency-tier__bottom-content">
+						<div
+							className={ clsx( 'agency-tier__current-agency-tier-header', {
+								'is-default': ! currentAgencyTierId,
+							} ) }
+						>
+							<span className="agency-tier__current-agency-tier-icon">
+								<img src={ currentAgencyTierInfo.logo } alt={ currentAgencyTierInfo.id } />
+							</span>
+							<span className="agency-tier__current-agency-tier-title">
+								{ preventWidows( currentAgencyTierInfo.title ) }
+							</span>
 						</div>
-					</FoldableCard>
-				</Card>
-			) }
+						{ currentAgencyTierInfo && (
+							<div className="agency-tier__current-agency-tier-description">
+								{ currentAgencyTierInfo.description }
+							</div>
+						) }
+						<Button
+							href={ A4A_AGENCY_TIER_LINK }
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_agency_tier_explore_tiers_and_benefits_click', {
+										agency_tier: currentAgencyTierId,
+									} )
+								)
+							}
+						>
+							<Icon icon={ arrowRight } size={ 18 } />
+							{ translate( 'Explore Tiers and benefits' ) }
+						</Button>
+					</div>
+				</FoldableCard>
+			</Card>
 		</>
 	);
 }

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -69,6 +69,15 @@
 	}
 }
 
+/* A4A */
+.theme-a8c-for-agencies {
+	.components-button:not(.is-destructive) {
+		--wp-components-color-accent: var(--color-primary);
+		--wp-components-color-accent-darker-10: var(--color-primary-60);
+		--wp-components-color-accent-darker-20: var(--color-primary-60);
+	}
+}
+
 /* Gravatar & WP Job Manager */
 .is-grav-powered-client {
 	.components-button:not(.is-destructive) {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -44,7 +44,8 @@
 		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"tiers-revamp": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1672/janitorial-enable-feature-flag-on-staging

## Proposed Changes

* Enable revamped tiers UI on staging.


## Testing Instructions

* Verify the "tiers-revamp" feature flag is enabled on staging only.
* Use the MC tool to update the agency tier so that we can trigger the celebration modal
* Open the A4A live link > Verify the celebration modal is not displayed. Append the URL with ?flags=-tiers-revamp and verify that it shows now.
* Go to Agency Tiers > Verify the Premier Partner card now shows "invite" text:

<img width="401" height="319" alt="Screenshot 2025-11-05 at 4 22 43 PM" src="https://github.com/user-attachments/assets/8dfa2b3d-409f-4661-8d0c-9d21fb90693b" />

* Click the CTA on any card > Verify it scrolls down with a smooth animation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
