### PR TITLE
Admin Bar: Hide empty Status item from the site menu

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -493,7 +493,7 @@ class MasterbarLoggedIn extends Component {
 		if ( ! site?.is_wpcom_staging_site ) {
 			menuItems.push( {
 				label: (
-					<div className="masterbar__site-info">
+					<div className="masterbar__site-info masterbar__site-plan">
 						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
 						<div className="masterbar__info-badges">
 							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
@@ -511,11 +511,9 @@ class MasterbarLoggedIn extends Component {
 		if ( siteBadges && siteBadges.length > 0 ) {
 			menuItems.push( {
 				label: (
-					<div className="masterbar__site-infos">
-						<div className="masterbar__site-info">
-							<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
-							<div className="masterbar__info-badges">{ siteBadges }</div>
-						</div>
+					<div className="masterbar__site-info masterbar__site-status">
+						<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
+						<div className="masterbar__info-badges">{ siteBadges }</div>
 					</div>
 				),
 			} );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -482,55 +482,44 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 
-		const siteHomeOrAdminItem = isClassicView
-			? {
-					label: translate( 'Dashboard' ),
-					url: siteAdminUrl,
-			  }
-			: {
-					label: translate( 'My Home' ),
-					url: siteHomeUrl,
-			  };
+		const menuItems = [ { label: translate( 'Visit Site' ), url: siteUrl } ];
 
-		// Get site badges
-		const siteBadges = this.renderSiteBadges();
+		if ( isClassicView ) {
+			menuItems.push( { label: translate( 'Dashboard' ), url: siteAdminUrl } );
+		} else {
+			menuItems.push( { label: translate( 'My Home' ), url: siteHomeUrl } );
+		}
 
-		// Create a site status item for the dropdown if we have badges
-		const menuItems = [
-			[ { label: translate( 'Visit Site' ), url: siteUrl }, siteHomeOrAdminItem ],
-			[
-				...( ! site?.is_wpcom_staging_site
-					? [
-							{
-								label: (
-									<div className="masterbar__site-info">
-										<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
-										<div className="masterbar__info-badges">
-											<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
-										</div>
-									</div>
-								),
-								onClick: () => {
-									this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
-									page( `/plans/${ siteSlug }` );
-								},
-							},
-					  ]
-					: [] ),
-				{
-					label: (
-						<div className="masterbar__site-infos">
-							{ siteBadges && siteBadges.length > 0 && (
-								<div className="masterbar__site-info">
-									<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
-									<div className="masterbar__info-badges">{ siteBadges }</div>
-								</div>
-							) }
+		if ( ! site?.is_wpcom_staging_site ) {
+			menuItems.push( {
+				label: (
+					<div className="masterbar__site-info">
+						<span className="masterbar__site-info-label">{ translate( 'Plan' ) }</span>
+						<div className="masterbar__info-badges">
+							<Badge className="masterbar__info-badge">{ sitePlanName }</Badge>
 						</div>
-					),
+					</div>
+				),
+				onClick: () => {
+					this.props.recordTracksEvent( 'calypso_masterbar_plan_clicked' );
+					page( `/plans/${ siteSlug }` );
 				},
-			],
-		];
+			} );
+		}
+
+		const siteBadges = this.renderSiteBadges();
+		if ( siteBadges && siteBadges.length > 0 ) {
+			menuItems.push( {
+				label: (
+					<div className="masterbar__site-infos">
+						<div className="masterbar__site-info">
+							<span className="masterbar__site-info-label">{ translate( 'Status' ) }</span>
+							<div className="masterbar__info-badges">{ siteBadges }</div>
+						</div>
+					</div>
+				),
+			} );
+		}
 
 		return (
 			<Item
@@ -538,7 +527,7 @@ class MasterbarLoggedIn extends Component {
 				url={ siteUrl }
 				icon={ <span className="dashicons-before dashicons-admin-home" /> }
 				tipTarget="visit-site"
-				subItems={ menuItems }
+				subItems={ [ menuItems ] }
 			>
 				{ siteTitle.length > 40 ? `${ siteTitle.substring( 0, 40 ) }\u2026` : siteTitle }
 			</Item>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -947,23 +947,15 @@ body.is-mobile-app-view {
 	}
 }
 
-.masterbar__site-infos {
-	box-sizing: border-box;
-	min-width: 260px;
-	margin: 6px -6px -6px;
-	padding: 12px;
-	background-color: var(--color-global-masterbar-site-info-background, color-mix(in srgb, var(--color-masterbar-item-hover-background), $white 15% ));
-	color: var(--color-masterbar-submenu-text);
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-
 .masterbar__site-info {
+	align-items: center;
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	align-items: center;
+	margin: 6px -6px -6px;
+	min-width: 248px;
+	padding: 12px;
 
 	.masterbar__site-info-label {
 		margin-bottom: 4px;
@@ -983,7 +975,13 @@ body.is-mobile-app-view {
 }
 
 .button > .masterbar__site-info {
-	padding: 6px 0;
+	margin: 0 -6px;
+		padding: 6px;
+	}
+
+.masterbar__site-status {
+	background-color: var(--color-global-masterbar-site-info-background, color-mix(in srgb, var(--color-masterbar-item-hover-background), $white 15%));
+	color: var(--color-masterbar-submenu-text);
 }
 
 .masterbar__item-reader-label {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-13959

## Proposed Changes

* Refactor the Admin Bar's site menu creation and ensure the Status item is fully hidden when there are no status badges to render.

| Before | After |
|--------|--------|
| <img width="608" height="318" alt="Screenshot 2025-11-05 at 10 58 49" src="https://github.com/user-attachments/assets/1e8513d0-5c78-469a-9931-1ec353ebf3b0" /> | <img width="606" height="272" alt="Screenshot 2025-11-05 at 10 58 44" src="https://github.com/user-attachments/assets/4329a39f-3f9f-4fca-aa0e-29856715b487" />|
| <img width="608" height="380" alt="Screenshot 2025-11-05 at 10 59 00" src="https://github.com/user-attachments/assets/626bc4b4-dea5-48b5-9999-6480189ffe6a" /> | <img width="604" height="380" alt="Screenshot 2025-11-05 at 10 58 55" src="https://github.com/user-attachments/assets/5cbdec6b-c5d8-4d8f-84b0-72927d639fd0" /><br>(no change) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In #104533, I've moved the Plan item outside of the light-gray container, leaving only the Status item inside it. I failed to account that, when there are no status badges, the container would render empty but padded, becoming unsightly visible. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the site context in Calypso (e.g. /home/:SITE). Front-end or wp-admin are handled elsewhere, and this bug doesn't affect them.
* Select a launched site.
* Hover on the Admin Bar's site menu and ensure the empty light-gray container is not rendered.
* To test for regressions, select a "coming soon" site.
* Hover on the Admin Bar's site menu and ensure the light-gray container is rendered and contains the status badge.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
