### PR TITLE
v2 HD - Scheduled Updates: Show notice when a new schedule is created, add isBusy status to the button.

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
+++ b/client/dashboard/plugins/scheduled-updates/components/schedule-form.tsx
@@ -169,6 +169,7 @@ export function ScheduledUpdatesForm( {
 						<Button
 							variant="primary"
 							disabled={ ! isValid || isSubmitting || isPrecheckLoading }
+							isBusy={ isSubmitting }
 							onClick={ handleSave }
 							__next40pxDefaultSize
 						>

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useMemo, useState } from 'react';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import {
@@ -16,6 +18,7 @@ import { useCreateSchedules } from '../hooks/use-create-schedules';
 
 function ScheduledUpdatesNew() {
 	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
 	const siteIdsAsNumbers = useMemo(
 		() => selectedSiteIds.map( ( id ) => Number( id ) ),
@@ -26,9 +29,10 @@ function ScheduledUpdatesNew() {
 	const handleSave: ScheduledUpdatesFormOnSubmit = useCallback(
 		async ( inputs ) => {
 			await runCreate( inputs );
+			createSuccessNotice( __( 'Schedule created successfully.' ), { type: 'snackbar' } );
 			navigate( { to: pluginsScheduledUpdatesRoute.to } );
 		},
-		[ navigate, runCreate ]
+		[ navigate, runCreate, createSuccessNotice ]
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/implement-new-schedule-screen-in-v2-hd

## Proposed Changes

Minor visual tweaks to the Schedules Updates form to improve the UX a bit:
- Show a snackbar notice when a new schedule is created and the user is redirected to the list view (this is used for editing and deleting schedules, so it feels consistent)
- Update the button status to `isBusy` while the operation is in progress

### Media

| Notice | Busy btn |
|--------|--------|
| <img width="1036" height="673" alt="Screenshot 2025-11-05 at 1 55 41 PM" src="https://github.com/user-attachments/assets/523a2082-32f1-42ec-9a03-704cece33839" /> | <img width="773" height="395" alt="Screenshot 2025-11-05 at 1 53 54 PM" src="https://github.com/user-attachments/assets/7435ea62-6dbc-479d-a912-3d5550982dc6" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DSGCOM-214/implement-new-schedule-screen-in-v2-hd
Minor UX tweaks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/plugins/scheduled-updates/new`
* Create a new schedule (confirm CTA switches to "busy")
* Once back to `/v2/plugins/scheduled-updates`, confirm the notice is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
