### PR TITLE
dev: Set CI environment variable to TeamCity settings

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -22,7 +22,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.LOCALE", "en")
 		param("env.AUTHENTICATE_ACCOUNTS", "simpleSitePersonalPlanUser,gutenbergSimpleSiteUser,defaultUser")
-		param("env.CI", "true")
 		param("PROJECT", "desktop")
 		text("TEST_GROUP", "")
 		text("CALYPSO_BASE_URL", "")

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -60,6 +60,7 @@ project {
 	template(CalypsoE2ETestsBuildTemplate)
 
 	params {
+		param("env.CI", "true")
 		// Force color support in chalk. For some reason it doesn't detect TeamCity
 		// as supported (even though both TeamCity and chalk support that.)
 		param("env.FORCE_COLOR", "1")


### PR DESCRIPTION
Fixes [QAO-144](https://linear.app/a8c/issue/QAO-144/set-ci-environment-variable-in-teamcity-configuration)

## Proposed Changes

Set the CI environment variable in TeamCity config. 

Context: p1762334672853329/1762292937.260099-slack-C02DQP0FP