### PR TITLE
Domain Connection: Redesign the "Use a domain I own" screen

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useEffect, useRef, useId } from 'react';
@@ -10,7 +9,6 @@ import illustration from 'calypso/assets/images/domains/domain.svg';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { bulb } from 'calypso/signup/icons';
 
 import './style.scss';
 
@@ -90,17 +88,6 @@ function UseMyDomainInput( {
 					) }
 					{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
 				</FormFieldset>
-
-				{ ! isDomainConnectionRedesign && (
-					<p className={ baseClassName + '__domain-input-note' }>
-						<Icon
-							className={ baseClassName + '__domain-input-note-icon' }
-							icon={ bulb }
-							size={ 14 }
-						/>
-						{ __( 'This won’t affect your existing site.' ) }
-					</p>
-				) }
 
 				<FormButton
 					className={ baseClassName + '__domain-input-button' }

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
-import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
+import { Button, FormInputValidation, Gridicon } from '@automattic/components';
+import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
@@ -49,56 +50,58 @@ function UseMyDomainInput( {
 	};
 
 	return (
-		<Card className={ clsx( baseClassName, classNameModifier ) }>
-			{ ! isSignupStep && (
-				<div className={ baseClassName + '__domain-illustration' }>
-					<img src={ illustration } alt="" width={ 160 } />
-				</div>
-			) }
-			<div className={ baseClassName + '__domain-input' }>
-				<label htmlFor={ inputId }>
-					{ isDomainConnectionRedesign
-						? __( 'Domain name' )
-						: __( 'Enter the domain you would like to use:' ) }
-				</label>
-				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
-					<FormTextInput
-						id={ inputId }
-						placeholder={ __( 'yourgroovydomain.com' ) }
-						value={ domainName }
-						onChange={ onChange }
-						onKeyDown={ keyDown }
-						isError={ !! validationError }
-						ref={ domainNameInput }
-						autoCapitalize="none"
-						autoCorrect="off"
-					/>
-					{ domainName && (
-						<Button
-							className={ baseClassName + '__domain-input-clear' }
-							borderless
-							onClick={ onClear }
-						>
-							<Gridicon
-								className={ baseClassName + '__domain-input-clear-icon' }
-								icon="cross"
-								size={ 12 }
-							/>
-						</Button>
-					) }
-					{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
-				</FormFieldset>
+		<Card className={ clsx( baseClassName, classNameModifier ) } isBorderless>
+			<CardBody size="none">
+				{ ! isSignupStep && (
+					<div className={ baseClassName + '__domain-illustration' }>
+						<img src={ illustration } alt="" width={ 160 } />
+					</div>
+				) }
+				<div className={ baseClassName + '__domain-input' }>
+					<label htmlFor={ inputId }>
+						{ isDomainConnectionRedesign
+							? __( 'Domain name' )
+							: __( 'Enter the domain you would like to use:' ) }
+					</label>
+					<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
+						<FormTextInput
+							id={ inputId }
+							placeholder={ __( 'yourgroovydomain.com' ) }
+							value={ domainName }
+							onChange={ onChange }
+							onKeyDown={ keyDown }
+							isError={ !! validationError }
+							ref={ domainNameInput }
+							autoCapitalize="none"
+							autoCorrect="off"
+						/>
+						{ domainName && (
+							<Button
+								className={ baseClassName + '__domain-input-clear' }
+								borderless
+								onClick={ onClear }
+							>
+								<Gridicon
+									className={ baseClassName + '__domain-input-clear-icon' }
+									icon="cross"
+									size={ 12 }
+								/>
+							</Button>
+						) }
+						{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
+					</FormFieldset>
 
-				<FormButton
-					className={ baseClassName + '__domain-input-button' }
-					primary
-					busy={ isBusy }
-					disabled={ isBusy }
-					onClick={ onNext }
-				>
-					{ __( 'Continue' ) }
-				</FormButton>
-			</div>
+					<FormButton
+						className={ baseClassName + '__domain-input-button' }
+						primary
+						busy={ isBusy }
+						disabled={ isBusy }
+						onClick={ onNext }
+					>
+						{ __( 'Continue' ) }
+					</FormButton>
+				</div>
+			</CardBody>
 		</Card>
 	);
 }

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,6 +1,8 @@
+import config from '@automattic/calypso-config';
 import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useEffect, useRef, useId } from 'react';
 import { connect } from 'react-redux';
@@ -25,6 +27,8 @@ function UseMyDomainInput( {
 } ) {
 	const domainNameInput = useRef( null );
 	const inputId = 'use-my-domain-input-' + useId();
+	const isDomainConnectionRedesign = config.isEnabled( 'domain-connection-redesign' );
+	const classNameModifier = isDomainConnectionRedesign ? baseClassName + '--redesign' : '';
 
 	useEffect( () => {
 		shouldSetFocus && domainNameInput.current.focus();
@@ -47,14 +51,18 @@ function UseMyDomainInput( {
 	};
 
 	return (
-		<Card className={ baseClassName }>
+		<Card className={ clsx( baseClassName, classNameModifier ) }>
 			{ ! isSignupStep && (
 				<div className={ baseClassName + '__domain-illustration' }>
 					<img src={ illustration } alt="" width={ 160 } />
 				</div>
 			) }
 			<div className={ baseClassName + '__domain-input' }>
-				<label htmlFor={ inputId }>{ __( 'Enter the domain you would like to use:' ) }</label>
+				<label htmlFor={ inputId }>
+					{ isDomainConnectionRedesign
+						? __( 'Domain name' )
+						: __( 'Enter the domain you would like to use:' ) }
+				</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
 					<FormTextInput
 						id={ inputId }
@@ -83,14 +91,16 @@ function UseMyDomainInput( {
 					{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
 				</FormFieldset>
 
-				<p className={ baseClassName + '__domain-input-note' }>
-					<Icon
-						className={ baseClassName + '__domain-input-note-icon' }
-						icon={ bulb }
-						size={ 14 }
-					/>
-					{ __( 'This won’t affect your existing site.' ) }
-				</p>
+				{ ! isDomainConnectionRedesign && (
+					<p className={ baseClassName + '__domain-input-note' }>
+						<Icon
+							className={ baseClassName + '__domain-input-note-icon' }
+							icon={ bulb }
+							size={ 14 }
+						/>
+						{ __( 'This won’t affect your existing site.' ) }
+					</p>
+				) }
 
 				<FormButton
 					className={ baseClassName + '__domain-input-button' }

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -5,36 +5,19 @@
 
 .use-my-domain {
 	display: flex;
-	align-items: center;
 	flex-direction: column;
-	padding: 36px 24px;
 	background-color: inherit;
 
 	& &--redesign {
-		padding: 0;
-		background: transparent;
-
-		.use-my-domain {
-			&__domain-input {
-				max-width: none;
-
-				@include break-small {
-					max-width: 464px;
-				}
-			}
-
-			&__domain-input-fieldset {
-				margin: 0;
-			}
+		.components-card__body {
+			max-width: none;
+			margin: 0;
 		}
 	}
 
-	& .card, &.card {
-		box-shadow: none;
-	}
-
-	&.card {
-		display: flex; // NOTE: To increase specificity
+	.components-card__body {
+		max-width: 370px;
+		margin: 36px auto 0;
 	}
 
 	& &__page-heading {
@@ -88,8 +71,6 @@
 		display: flex;
 		flex-direction: column;
 		row-gap: 8px;
-		width: 100%;
-		max-width: 370px;
 
 		.form-text-input {
 			padding: 9px 28px 9px 10px;

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -9,6 +9,26 @@
 	flex-direction: column;
 	padding: 36px 24px;
 	background-color: inherit;
+
+	& &--redesign {
+		padding: 0;
+		background: transparent;
+
+		.use-my-domain {
+			&__domain-input {
+				max-width: none;
+
+				@include break-small {
+					max-width: 464px;
+				}
+			}
+
+			&__domain-input-fieldset {
+				margin: 0;
+			}
+		}
+	}
+
 	& .card, &.card {
 		box-shadow: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useState } from '@wordpress/element';
@@ -30,6 +31,7 @@ const UseMyDomain: StepType< {
 	const { __ } = useI18n();
 	const { goNext, goBack, submit } = navigation;
 	const location = useLocation();
+	const isDomainConnectionRedesign = config.isEnabled( 'domain-connection-redesign' );
 
 	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
 		inputMode.domainInput
@@ -112,17 +114,27 @@ const UseMyDomain: StepType< {
 	const shouldHideButtons = isStartWritingFlow( flow );
 
 	if ( shouldUseStepContainerV2( flow ) ) {
-		const [ columnWidth, headingText ] =
-			useMyDomainMode === 'domain-input'
-				? [ 4 as const, __( 'Use a domain I own' ) ]
-				: [
-						10 as const,
-						<>
-							{ __( 'Use a domain I own' ) }
-							<br />
-							{ getInitialQuery() }
-						</>,
-				  ];
+		let columnWidth;
+		let headingText;
+
+		if ( useMyDomainMode === 'domain-input' ) {
+			if ( isDomainConnectionRedesign ) {
+				columnWidth = 5 as const;
+				headingText = __( 'Your domain name' );
+			} else {
+				columnWidth = 4 as const;
+				headingText = __( 'Use a domain I own' );
+			}
+		} else {
+			columnWidth = 10 as const;
+			headingText = (
+				<>
+					{ __( 'Use a domain I own' ) }
+					<br />
+					{ getInitialQuery() }
+				</>
+			);
+		}
 
 		return (
 			<>
@@ -136,7 +148,17 @@ const UseMyDomain: StepType< {
 						/>
 					}
 					columnWidth={ columnWidth }
-					heading={ <Step.Heading text={ headingText } /> }
+					heading={
+						<Step.Heading
+							text={ headingText }
+							subText={
+								isDomainConnectionRedesign
+									? __( 'Enter the domain name your visitors already know.' )
+									: undefined
+							}
+						/>
+					}
+					verticalAlign={ isDomainConnectionRedesign ? 'center' : undefined }
 				>
 					{ getBlogOnboardingFlowStepContent() }
 				</Step.CenteredColumnLayout>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -118,11 +118,11 @@ const UseMyDomain: StepType< {
 		let headingText;
 
 		if ( useMyDomainMode === 'domain-input' ) {
+			columnWidth = 4 as const;
+
 			if ( isDomainConnectionRedesign ) {
-				columnWidth = 5 as const;
 				headingText = __( 'Your domain name' );
 			} else {
-				columnWidth = 4 as const;
 				headingText = __( 'Use a domain I own' );
 			}
 		} else {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves [DOMAINS-1729](https://linear.app/a8c/issue/DOMAINS-1729/update-use-a-domain-i-own-form-step)

## Proposed Changes

* Update the design of the "Use a domain I own" screen following PbASOWMNujLKRajYEuktNg-fi-1_31.

| Before | After |
| --- | --- |
| <img width="1496" height="848" alt="image" src="https://github.com/user-attachments/assets/5470f872-5c63-4d46-bec7-6ed686843f51" /> | <img width="1496" height="849" alt="image" src="https://github.com/user-attachments/assets/1d80291d-0d12-4cf3-82da-db0e8ef72b0b" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain connection redesign project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/domain/use-my-domain`.
* Make sure it follows the new design.
* Make sure it looks good on mobile.
* Make sure there are no visual changes when the `domain-connection-redesign` is disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?