### PR TITLE
MSD: Truncate long titles of the OverviewCard on Domains Overview

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -524,6 +524,7 @@ module.exports = {
 					'__experimentalNavigatorScreen',
 					'__experimentalUseNavigator',
 					'__experimentalNumberControl',
+					'__experimentalTruncate',
 					'__unstableComposite',
 					'__unstableCompositeItem',
 					'__unstableUseCompositeState',

--- a/client/dashboard/components/truncate/index.tsx
+++ b/client/dashboard/components/truncate/index.tsx
@@ -1,0 +1,35 @@
+import { __experimentalTruncate as WPTruncate, Tooltip } from '@wordpress/components';
+import { useMergeRefs, useResizeObserver } from '@wordpress/compose';
+import { useState, forwardRef } from 'react';
+
+export interface TruncateProps extends React.ComponentProps< typeof WPTruncate > {
+	tooltip: string;
+}
+
+function UnforwardedTruncate(
+	{ tooltip, numberOfLines = 0, ...props }: TruncateProps,
+	forwardedRef: React.ForwardedRef< HTMLElement >
+) {
+	const [ isTruncated, setIsTruncated ] = useState( false );
+	const resizeObserverRef = useResizeObserver( ( [ entry ] ) => {
+		const style = window.getComputedStyle( entry.target );
+		const lineHeight = parseFloat( style.lineHeight );
+		setIsTruncated( entry.target.scrollHeight > lineHeight * numberOfLines );
+	} );
+
+	const children = (
+		<WPTruncate
+			ref={ useMergeRefs( [ resizeObserverRef, forwardedRef ] ) }
+			numberOfLines={ numberOfLines }
+			{ ...props }
+		/>
+	);
+
+	if ( ! isTruncated ) {
+		return children;
+	}
+
+	return <Tooltip text={ tooltip }>{ children }</Tooltip>;
+}
+
+export const Truncate = forwardRef( UnforwardedTruncate );

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 import { emailsRoute } from '../../app/router/emails';
 import OverviewCard from '../../components/overview-card';
+import { Truncate } from '../../components/truncate';
 import type { EmailProvider, Mailbox } from '@automattic/api-core';
 
 const getAccountTypeLabel = ( accountType: EmailProvider ) => {
@@ -63,7 +64,11 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 	return (
 		<OverviewCard
 			title={ __( 'Emails' ) }
-			heading={ <span style={ { wordBreak: 'break-all' } }>{ email }</span> }
+			heading={
+				<Truncate tooltip={ email } numberOfLines={ 1 }>
+					{ email }
+				</Truncate>
+			}
 			link={
 				router.buildLocation( {
 					to: emailsRoute.fullPath,

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 import SiteIcon from '../../components/site-icon';
+import { Truncate } from '../../components/truncate';
 
 interface Props {
 	domain: Domain;
@@ -27,9 +28,13 @@ export default function FeaturedCardSite( { domain }: Props ) {
 		<OverviewCard
 			title={ shouldShowAddAttachSite ? __( 'Attach to a site' ) : __( 'Site' ) }
 			heading={
-				<span style={ { wordBreak: 'break-all' } }>
-					{ shouldShowAddAttachSite ? __( 'No site attached' ) : site.name }
-				</span>
+				shouldShowAddAttachSite ? (
+					__( 'No site attached' )
+				) : (
+					<Truncate tooltip={ site.name } numberOfLines={ 1 }>
+						{ site.name }
+					</Truncate>
+				)
 			}
 			link={
 				shouldShowAddAttachSite
@@ -38,9 +43,13 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			}
 			icon={ shouldShowAddAttachSite ? <Icon icon={ layout } /> : <SiteIcon site={ site } /> }
 			description={
-				shouldShowAddAttachSite
-					? __( 'Attach this domain name to an existing site.' )
-					: domain.site_slug
+				shouldShowAddAttachSite ? (
+					__( 'Attach this domain name to an existing site.' )
+				) : (
+					<Truncate tooltip={ domain.site_slug } numberOfLines={ 1 }>
+						{ domain.site_slug }
+					</Truncate>
+				)
 			}
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-786

## Proposed Changes

* Implement `Truncate` component - It will truncate the context by the given number of lines. Also, it displays tooltip only when the content is truncated
* Apply `Truncate` component to both `FeaturedCardEmails` and `FeaturedCardSite`

| Before | After |
| - | - |
|<img width="693" height="416" alt="image" src="https://github.com/user-attachments/assets/7609fde7-348e-4027-807a-c0aceb7d8130" />|<img width="696" height="338" alt="image" src="https://github.com/user-attachments/assets/a4b12c70-a39a-4c54-9570-26cdde6548eb" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should display clean and consistent layout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/domains
* Select any domain that has been attached to a site with long title
* Ensure the long title is truncated
* Hover on the site overview card
* Ensure it displays the tooltip with the entire long title

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
