### PR TITLE
Add extra logging when creating a fallback convo

### DIFF
--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -192,6 +192,9 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 					createZendeskConversation( {
 						createdFrom: 'empty_response_error',
 						isFromError: true,
+						errorReason: `messages: ${ returnedChat.messages
+							?.map( ( message ) => message.content )
+							.join( '|' ) }`,
 					} );
 				} else {
 					// User is not eligible for premium support - show error message with support buttons

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -252,6 +252,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 				// User is eligible for premium support - transfer to Zendesk
 				createZendeskConversation( {
 					createdFrom: 'api_error',
+					errorReason: error.message || error.toString?.(),
 					isFromError: true,
 				} );
 			} else {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -5,17 +5,7 @@ import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
 
-export const useCreateZendeskConversation = (): ( ( {
-	avoidTransfer,
-	interactionId,
-	createdFrom,
-	isFromError,
-}: {
-	avoidTransfer?: boolean;
-	interactionId?: string;
-	createdFrom?: string;
-	isFromError?: boolean;
-} ) => Promise< string > ) => {
+export const useCreateZendeskConversation = () => {
 	const {
 		selectedSiteId,
 		selectedSiteURL,
@@ -36,11 +26,13 @@ export const useCreateZendeskConversation = (): ( ( {
 		interactionId = '',
 		createdFrom = '',
 		isFromError = false,
+		errorReason = '',
 	}: {
 		avoidTransfer?: boolean;
 		interactionId?: string;
 		createdFrom?: string;
 		isFromError?: boolean;
+		errorReason?: string;
 	} ) => {
 		const currentInteractionID = interactionId || currentSupportInteraction!.uuid;
 
@@ -53,6 +45,7 @@ export const useCreateZendeskConversation = (): ( ( {
 			created_from: createdFrom,
 			avoid_transfer: avoidTransfer,
 			is_from_error: isFromError,
+			error_reason: errorReason || 'Unknown error',
 		} );
 
 		if (


### PR DESCRIPTION
Fixes DOTCOM-15107

## Proposed Changes

Add more logging when fallback tickets are created.

## Why are these changes being made?
Some mysterious tickets are being created.

## Testing Instructions

1. Start a convo with Odie.
2. Open DevTools > Network and filter by `odie/chat/wpcom-support-chat`.
3. Send a message to Odie.
4. Right-click on the request and block its URL.
5. Send one more message.
6. Chat should escalate.
7. A tracks event should be fired, including the error message.