### PR TITLE
Fix sorting issue when loading destination sites

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Button, Dropdown, MenuItemsChoice, NavigableMenu } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import {
@@ -11,7 +12,6 @@ import {
 	ALPHABETICAL_SORTING,
 	MAGIC_SORTING,
 	LAST_PUBLISHED_SORTING,
-	PLAN_SORTING,
 } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { SMALL_MEDIA_QUERY } from '../utils';
 
@@ -40,10 +40,6 @@ export const SitesSortingDropdown = ( {
 	const isSmallScreen = useMediaQuery( SMALL_MEDIA_QUERY );
 	const { __ } = useI18n();
 
-	if ( ! hasSitesSortingPreferenceLoaded ) {
-		return null;
-	}
-
 	const choices = [
 		{
 			...ALPHABETICAL_SORTING,
@@ -61,20 +57,28 @@ export const SitesSortingDropdown = ( {
 			value: stringifySitesSorting( LAST_PUBLISHED_SORTING ),
 			label: __( 'Last published' ),
 		},
-		{
-			...PLAN_SORTING,
-			value: stringifySitesSorting( PLAN_SORTING ),
-			label: __( 'Plan' ),
-		},
 	];
 
-	const currentSortingValue = stringifySitesSorting( sitesSorting );
 	const currentSortingLabel = choices.find( ( { sortKey } ) => sortKey === sitesSorting.sortKey )
 		?.label;
 
-	if ( currentSortingLabel === undefined ) {
-		throw new Error( `invalid sort value ${ sitesSorting }` );
+	// Use ALPHABETICAL_SORTING as fallback if current value doesn't match any dropdown option
+	const validSorting = currentSortingLabel === undefined ? ALPHABETICAL_SORTING : sitesSorting;
+
+	// Reset preference if it was invalid
+	useEffect( () => {
+		if ( hasSitesSortingPreferenceLoaded && currentSortingLabel === undefined ) {
+			onSitesSortingChange( ALPHABETICAL_SORTING );
+		}
+	}, [ hasSitesSortingPreferenceLoaded, currentSortingLabel, onSitesSortingChange ] );
+
+	if ( ! hasSitesSortingPreferenceLoaded ) {
+		return null;
 	}
+
+	const currentSortingValue = stringifySitesSorting( validSorting );
+	const validSortingLabel = choices.find( ( { sortKey } ) => sortKey === validSorting.sortKey )
+		?.label;
 
 	return (
 		<Dropdown
@@ -84,7 +88,7 @@ export const SitesSortingDropdown = ( {
 					icon={ <SortingButtonIcon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }
 					iconSize={ 16 }
 					// translators: %s is the current sorting mode.
-					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), currentSortingLabel ) }
+					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), validSortingLabel ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 					onKeyDown={ ( event: React.KeyboardEvent ) => {
@@ -96,7 +100,7 @@ export const SitesSortingDropdown = ( {
 				>
 					{
 						// translators: %s is the current sorting mode.
-						sprintf( __( 'Sort: %s' ), currentSortingLabel )
+						sprintf( __( 'Sort: %s' ), validSortingLabel )
 					}
 				</SortingButton>
 			) }

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -11,6 +11,7 @@ import {
 	ALPHABETICAL_SORTING,
 	MAGIC_SORTING,
 	LAST_PUBLISHED_SORTING,
+	PLAN_SORTING,
 } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { SMALL_MEDIA_QUERY } from '../utils';
 
@@ -59,6 +60,11 @@ export const SitesSortingDropdown = ( {
 			...LAST_PUBLISHED_SORTING,
 			value: stringifySitesSorting( LAST_PUBLISHED_SORTING ),
 			label: __( 'Last published' ),
+		},
+		{
+			...PLAN_SORTING,
+			value: stringifySitesSorting( PLAN_SORTING ),
+			label: __( 'Plan' ),
 		},
 	];
 

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -77,8 +77,9 @@ export const SitesSortingDropdown = ( {
 	}
 
 	const currentSortingValue = stringifySitesSorting( validSorting );
-	const validSortingLabel = choices.find( ( { sortKey } ) => sortKey === validSorting.sortKey )
-		?.label;
+	const validSortingLabel =
+		currentSortingLabel ??
+		choices.find( ( { sortKey } ) => sortKey === validSorting.sortKey )?.label;
 
 	return (
 		<Dropdown

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -23,6 +23,11 @@ export const LAST_PUBLISHED_SORTING = {
 	sortOrder: 'desc',
 } as const;
 
+export const PLAN_SORTING = {
+	sortKey: 'plan',
+	sortOrder: 'asc',
+} as const;
+
 export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) => {
 	const [ sortKey, sortOrder ] = serializedSorting.split( SEPARATOR );
 

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -23,11 +23,6 @@ export const LAST_PUBLISHED_SORTING = {
 	sortOrder: 'desc',
 } as const;
 
-export const PLAN_SORTING = {
-	sortKey: 'plan',
-	sortOrder: 'asc',
-} as const;
-
 export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) => {
 	const [ sortKey, sortOrder ] = serializedSorting.split( SEPARATOR );
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue for me where the destination sites screen is blank. The problem was that the view was trying to sort my sites based on a key that didn't exist.

<img width="1718" height="922" alt="image" src="https://github.com/user-attachments/assets/cc57c7b6-62b2-454f-b96a-3c4a2a20a841" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I kept getting stuck on the destination site screen when trying to migrate my site.

<img width="1035" height="820" alt="image" src="https://github.com/user-attachments/assets/08420507-86c3-45eb-b87c-9864058547ec" />


<img width="1718" height="922" alt="image" src="https://github.com/user-attachments/assets/cc57c7b6-62b2-454f-b96a-3c4a2a20a841" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a new migration
* Confirm that you can view the destination step and that there's a plan option for sorting.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
