### PR TITLE
Update copy on site info step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
@@ -20,7 +20,7 @@ export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control }
 						<FormRadio
 							id="site-migration-credentials__radio-credentials"
 							htmlFor="site-migration-credentials__radio-credentials"
-							label={ translate( 'WordPress site credentials' ) }
+							label={ translate( 'Site address' ) }
 							checked={ value === 'credentials' }
 							{ ...props }
 							value="credentials"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/backup-file-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/backup-file-field.tsx
@@ -38,7 +38,7 @@ export const BackupFileField: React.FC< CredentialsFormFieldProps > = ( { contro
 			<ErrorMessage error={ errors?.backupFileLocation } />
 			<div className="site-migration-credentials__form-note site-migration-credentials__backup-note">
 				{ translate(
-					"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
+					"Upload your file to a service like Dropbox or Google Drive. Don't forget to make sure that anyone with the link can access it."
 				) }
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,5 +1,4 @@
 import { FormLabel } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Controller } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
@@ -10,7 +9,6 @@ import { ErrorMessage } from './error-message';
 
 export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { control, errors } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 
 	const validateSiteAddress = ( siteAddress: string ) => {
 		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
@@ -18,10 +16,6 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 			return getValidationMessage( siteAddress, translate );
 		}
 	};
-
-	const placeholder = hasEnTranslation( 'Enter your WordPress site address' )
-		? translate( 'Enter your WordPress site address' )
-		: translate( 'Enter your WordPress site address.' );
 
 	return (
 		<div className="site-migration-credentials__form-field">
@@ -34,13 +28,7 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 					validate: validateSiteAddress,
 				} }
 				render={ ( { field } ) => (
-					<FormTextInput
-						id="from_url"
-						isError={ !! errors?.from_url }
-						placeholder={ placeholder }
-						type="text"
-						{ ...field }
-					/>
+					<FormTextInput id="from_url" isError={ !! errors?.from_url } type="text" { ...field } />
 				) }
 			/>
 			<ErrorMessage error={ errors?.from_url } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -166,9 +166,7 @@ const SiteMigrationCredentials: StepType< {
 	}, [ siteId, updateMigrationStatus ] );
 
 	const title = translate( 'Tell us about your WordPress site' );
-	const subHeaderText = translate(
-		'Help us get started by providing some basic details about your current website.'
-	);
+	const subHeaderText = translate( 'Provide the following details to get your migration started.' );
 	const mainForm = <CredentialsForm onSubmit={ handleSubmit } />;
 	const skipButton = <NeedHelpLink onHelpLinkClicked={ handleSkip } />;
 
@@ -176,7 +174,7 @@ const SiteMigrationCredentials: StepType< {
 		<>
 			<DocumentHead title={ title } />
 			<Step.CenteredColumnLayout
-				columnWidth={ 5 }
+				columnWidth={ 4 }
 				topBar={
 					<Step.TopBar
 						leftElement={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -44,7 +44,7 @@ const { getByRole, getByLabelText, getByTestId, getByText, findByText } = screen
 const continueButton = ( name = /Continue/ ) => getByRole( 'button', { name } );
 const siteAddressInput = () => getByLabelText( 'Current WordPress site address' );
 const backupOption = () => getByRole( 'radio', { name: 'Backup file' } );
-const credentialsOption = () => getByRole( 'radio', { name: 'WordPress site credentials' } );
+const credentialsOption = () => getByRole( 'radio', { name: 'Site address' } );
 const backupFileInput = () => getByLabelText( 'Backup file location' );
 //TODO: it requires a testid because there is no accessible name, it is an issue with the component
 const specialInstructionsInput = () => getByTestId( 'special-instructions-textarea' );


### PR DESCRIPTION
## Proposed Changes

This PR tweaks content on the site information step in the migration flow.

**Before**
<img width="1512" height="1191" alt="image" src="https://github.com/user-attachments/assets/78fb1095-5bd5-415f-9535-ff04e49788ca" />


**After**
<img width="1512" height="1191" alt="image" src="https://github.com/user-attachments/assets/e56066e8-b111-4053-bb24-c76c8d5a4c93" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The content width is too wide
* Getting started at this stage feels out of place since people already got started
* We'll be using more than just credentials, it should be site address
* The placeholder is unnecessary

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a DIFM migration. 
* Buy a plan if necessary

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
