### PR TITLE
GitHub Deployments: grey out disabled controls

### DIFF
--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -695,7 +695,12 @@ export const ConnectRepositoryForm = ( {
 					onChange={ handleChange }
 				/>
 
-				<div>
+				<div
+					style={ {
+						opacity: selectedRepository ? 1 : 0.5,
+						pointerEvents: selectedRepository ? 'auto' : 'none',
+					} }
+				>
 					<SectionHeader
 						level={ 3 }
 						title={ __( 'Pick your deployment mode' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTMSD-679

## Proposed Changes

* Grey out the "Pick deployment mode" heading and radio controls when no repository is selected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This area looks clickable but it's not until a repository is selected, which can be confusing for users.

> [!NOTE] 
> We also have a similar issue DOTMSD-632 where we discussed hiding the dependant fields until the repository is selected. I raised https://github.com/Automattic/wp-calypso/pull/106941 to address that, and if we prefer that solution, then this change won't be needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run Calypso locally or open the Calypso Live link below
* Using a Business or Commerce site, navigate to a `/v2/sites/:siteSlug/settings/repositories/connect`
* Check that the "Pick your deployment mode" heading and its contents are greyed out by default, and you can't update the radio buttons
* Select a repository and check that the radio buttons are now clickable


https://github.com/user-attachments/assets/e5fcfd97-7e99-463e-8efc-bcc92f6d0a71


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
