### PR TITLE
GitHub Deployments: hide depenent fields until a repository is selected

### DIFF
--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -362,7 +362,7 @@ export const ConnectRepositoryForm = ( {
 
 			if ( 'selectedRepositoryId' in updates ) {
 				newFormData.branch = '';
-				newFormData.targetDir = '';
+				newFormData.targetDir = '/';
 
 				// If repository is unselected, reset to simple mode since advanced requires a repo
 				if ( updates.selectedRepositoryId === '' ) {
@@ -394,12 +394,15 @@ export const ConnectRepositoryForm = ( {
 	};
 
 	useEffect( () => {
-		if ( ! repositoryChecks?.suggested_directory || formData.targetDir ) {
+		if ( formData.targetDir && formData.targetDir !== '/' ) {
 			return;
 		}
 
-		// Only update target directory when repository changes, not when branch changes
-		setFormData( ( prev ) => ( { ...prev, targetDir: repositoryChecks.suggested_directory } ) );
+		const targetDir = repositoryChecks?.suggested_directory || '/';
+
+		if ( formData.targetDir !== targetDir ) {
+			setFormData( ( prev ) => ( { ...prev, targetDir } ) );
+		}
 	}, [ repositoryChecks?.suggested_directory, formData.targetDir ] );
 
 	const handleSubmit = async () => {
@@ -604,7 +607,6 @@ export const ConnectRepositoryForm = ( {
 			},
 		];
 
-		// Only include dependent fields when a repository is selected
 		if ( selectedRepository ) {
 			baseFields.push(
 				{

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -573,7 +573,7 @@ export const ConnectRepositoryForm = ( {
 	};
 
 	const fields: Field< ConnectRepositoryFormData >[] = useMemo( () => {
-		return [
+		const baseFields: Field< ConnectRepositoryFormData >[] = [
 			{
 				id: 'selectedInstallationId',
 				label: __( 'GitHub account' ),
@@ -602,37 +602,45 @@ export const ConnectRepositoryForm = ( {
 				elements: repositoryOptions,
 				description: repositoryHelpText as string,
 			},
-			{
-				id: 'branch',
-				label: __( 'Deployment branch' ),
-				type: 'text' as const,
-				Edit: 'select',
-				elements: branchOptions,
-				description: ( () => {
-					if ( isLoadingBranches ) {
-						return __( 'Loading branches…' );
-					}
-					if ( allBranchesConnected ) {
-						return __(
-							'All branches for this repository are already connected. Please create a new branch or select a different repository.'
-						);
-					}
-					return __( 'Select the branch to deploy from this repository.' );
-				} )(),
-			},
-			{
-				id: 'targetDir',
-				label: __( 'Destination directory' ),
-				type: 'text' as const,
-				description: __( 'This path is relative to the server root.' ),
-			},
-			{
-				id: 'isAutomated',
-				label: __( 'Automated deployments' ),
-				type: 'text' as const,
-				Edit: AutomatedToggle,
-			},
 		];
+
+		// Only include dependent fields when a repository is selected
+		if ( selectedRepository ) {
+			baseFields.push(
+				{
+					id: 'branch',
+					label: __( 'Deployment branch' ),
+					type: 'text' as const,
+					Edit: 'select',
+					elements: branchOptions,
+					description: ( () => {
+						if ( isLoadingBranches ) {
+							return __( 'Loading branches…' );
+						}
+						if ( allBranchesConnected ) {
+							return __(
+								'All branches for this repository are already connected. Please create a new branch or select a different repository.'
+							);
+						}
+						return __( 'Select the branch to deploy from this repository.' );
+					} )(),
+				},
+				{
+					id: 'targetDir',
+					label: __( 'Destination directory' ),
+					type: 'text' as const,
+					description: __( 'This path is relative to the server root.' ),
+				},
+				{
+					id: 'isAutomated',
+					label: __( 'Automated deployments' ),
+					type: 'text' as const,
+					Edit: AutomatedToggle,
+				}
+			);
+		}
+
+		return baseFields;
 	}, [
 		installationOptions,
 		installationHelpText,
@@ -644,6 +652,7 @@ export const ConnectRepositoryForm = ( {
 		shouldRestoreRepositoryFocus,
 		isLoadingBranches,
 		allBranchesConnected,
+		selectedRepository,
 	] );
 
 	if ( isLoadingInstallations ) {
@@ -684,38 +693,41 @@ export const ConnectRepositoryForm = ( {
 					fields={ fields }
 					form={ {
 						layout: { type: 'regular' as const },
-						fields: [
-							'selectedInstallationId',
-							'selectedRepositoryId',
-							'branch',
-							'targetDir',
-							'isAutomated',
-						],
+						fields: selectedRepository
+							? [
+									'selectedInstallationId',
+									'selectedRepositoryId',
+									'branch',
+									'targetDir',
+									'isAutomated',
+							  ]
+							: [ 'selectedInstallationId', 'selectedRepositoryId' ],
 					} }
 					onChange={ handleChange }
 				/>
 
-				<div>
-					<SectionHeader
-						level={ 3 }
-						title={ __( 'Pick your deployment mode' ) }
-						description={ __(
-							'Simple deployments copy repository files to a directory, while advanced deployments use scripts for custom build steps and testing.'
-						) }
-					/>
+				{ selectedRepository && (
+					<div>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Pick your deployment mode' ) }
+							description={ __(
+								'Simple deployments copy repository files to a directory, while advanced deployments use scripts for custom build steps and testing.'
+							) }
+						/>
 
-					<RadioControl
-						selected={ formData.deploymentMode }
-						onChange={ ( value ) =>
-							handleChange( { deploymentMode: value as 'simple' | 'advanced' } )
-						}
-						options={ [
-							{ label: __( 'Simple' ), value: 'simple' },
-							{ label: __( 'Advanced' ), value: 'advanced' },
-						] }
-						disabled={ ! selectedRepository }
-					/>
-				</div>
+						<RadioControl
+							selected={ formData.deploymentMode }
+							onChange={ ( value ) =>
+								handleChange( { deploymentMode: value as 'simple' | 'advanced' } )
+							}
+							options={ [
+								{ label: __( 'Simple' ), value: 'simple' },
+								{ label: __( 'Advanced' ), value: 'advanced' },
+							] }
+						/>
+					</div>
+				) }
 
 				{ isAdvancedSelected && renderAdvancedWorkflow() }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTMSD-632

## Proposed Changes

* Don't render the fields that are dependent on the selected repository by default
* Update the form logic to have a smaller set of fields by default
* Once a repository is selected, render the fields and adjust the form logic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The fields below the repository selector are only meaningful once a repository is selected. To make the UX straightforward, I propose revealing these fields only after the user selects a repository.

> [!NOTE]
> We also have a similar issue DOTMSD-679 where we discussed disabling the deployment mode controls until the repository is selected. I created https://github.com/Automattic/wp-calypso/pull/106940 to address that, but I think this solution is preferable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run Calypso locally or open the Calypso Live link below
* Using a Business or Commerce site, navigate to a `/v2/sites/:siteSlug/settings/repositories/connect`
* Check that only the account and repository fields are rendered by default
* Select a repository and check that the rest of the fields are revealed
* Check that you can submit the form and there are no regressions


https://github.com/user-attachments/assets/fd7e330c-0114-4b2e-9980-dc9bc5d0ed21


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
