### PR TITLE
Forms tests: Update locators for tabs and view and trash actions

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -51,7 +51,10 @@ export class FeedbackInboxPage {
 				.filter( { hasText: text } )
 				.waitFor();
 		} else {
-			await responseRowLocator.getByRole( 'button', { name: 'View response' } ).click();
+			await responseRowLocator.getByRole( 'button', { name: 'Actions' } ).click();
+			// The menu item is on a popover portal, so outside of the response row locator
+			const viewMenuItem = this.page.getByRole( 'menuitem', { name: 'View' } ).first();
+			await viewMenuItem.click();
 			await this.page
 				.getByRole( 'dialog' )
 				.filter( { has: this.page.getByRole( 'heading', { name: 'Response' } ) } )
@@ -142,11 +145,8 @@ export class FeedbackInboxPage {
 	 * @param {string} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash').
 	 */
 	async clickFolderTab( folderName: string ): Promise< void > {
-		await this.page
-			.getByRole( 'radio', {
-				name: folderName,
-			} )
-			.click();
+		const tablist = this.page.getByRole( 'tablist' );
+		await tablist.getByRole( 'tab', { name: folderName } ).click();
 		await this.page.waitForTimeout( 500 ); // Wait for the data to load
 	}
 
@@ -173,7 +173,7 @@ export class FeedbackInboxPage {
 	 */
 	async clickMarkAsSpamAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
-		await this.page.getByRole( 'button', { name: 'Mark as spam' } ).last().click();
+		await this.page.getByRole( 'button', { name: 'Spam' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			// On mobile, the modal closes after the action
 			await this.page.waitForTimeout( 1000 );
@@ -227,7 +227,7 @@ export class FeedbackInboxPage {
 	 */
 	async clickMoveToTrashAction(): Promise< void > {
 		// Use .last() to get the button in the side panel, not in the table row
-		await this.page.getByRole( 'button', { name: 'Move to trash' } ).last().click();
+		await this.page.getByRole( 'button', { name: 'Trash' } ).last().click();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			// On mobile, the modal closes after the action
 			await this.page.waitForTimeout( 1000 );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Update of https://github.com/Automattic/wp-calypso/pull/106722 due to recent changes on Jetpack code.

## Proposed Changes
Actions for "View response" and "Move to trash" are now just View and Trash.
The dashboard tabs have changes as well. This PR updates the locators labels.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
Failing e2e tests.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run these tests, see that they pass:

```bash
yarn workspace wp-e2e-tests build &&
ATOMIC_VARIATION="wp-previous" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"

yarn workspace wp-e2e-tests build &&
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"


yarn workspace wp-e2e-tests build &&
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
