### PR TITLE
SSH Migration: Add host lookup for /move users

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -87,6 +87,7 @@ export const processingPath = buildPathHelper<
 			from?: string | null;
 			platform: ImporterPlatform;
 			action: string | null;
+			host?: string | null;
 		};
 	},
 	typeof STEPS.PROCESSING.slug

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -9,8 +9,10 @@ import { defer } from 'lodash';
 import React, { useState, useEffect } from 'react';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToDomain } from 'calypso/lib/url';
 import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -25,6 +27,7 @@ const SitePickerStep: Step< {
 		action: 'update-query' | 'create-site' | 'select-site';
 		queryParams?: Partial< SitesDashboardQueryParams >;
 		site?: SiteExcerptData;
+		host?: string;
 	};
 } > = function SitePickerStep( { navigation } ) {
 	const { __ } = useI18n();
@@ -35,17 +38,24 @@ const SitePickerStep: Step< {
 		( urlQueryParams.get( 'status' ) as GroupableSiteLaunchStatuses ) ||
 		DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
+	const ref = urlQueryParams.get( 'ref' );
 	const [ destinationSite, setDestinationSite ] = useState< SiteExcerptData >();
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const siteCount = useSelector( getCurrentUserSiteCount );
 
+	// Fetch hosting provider when ref=move-lp and we have a from URL
+	const domain = sourceSiteSlug ? urlToDomain( sourceSiteSlug ) : '';
+	const shouldFetchHosting = ref === 'move-lp' && !! domain;
+	const { data: hostingProviderData } = useHostingProviderQuery( domain, shouldFetchHosting );
+
 	useEffect( () => {
 		// If the user has no sites, we should skip the site picker and go straight to the site creation step
 		if ( siteCount === 0 ) {
-			navigation.submit?.( { action: 'create-site' } );
+			const host = hostingProviderData?.hosting_provider?.slug;
+			navigation.submit?.( { action: 'create-site', host } );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteCount ] );
+	}, [ siteCount, hostingProviderData ] );
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );
@@ -54,7 +64,8 @@ const SitePickerStep: Step< {
 
 	const createNewSite = () => {
 		recordTracksEvent( 'calypso_import_site_picker_create_new_site' );
-		navigation.submit?.( { action: 'create-site' } );
+		const host = hostingProviderData?.hosting_provider?.slug;
+		navigation.submit?.( { action: 'create-site', host } );
 	};
 
 	const selectSite = ( site: SiteExcerptData ) => {
@@ -63,7 +74,8 @@ const SitePickerStep: Step< {
 			slug: site?.slug,
 			title: site?.title,
 		} );
-		navigation.submit?.( { action: 'select-site', site } );
+		const host = hostingProviderData?.hosting_provider?.slug;
+		navigation.submit?.( { action: 'select-site', site, host } );
 	};
 
 	const onSelectSite = ( site: SiteExcerptData ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -46,16 +46,24 @@ const SitePickerStep: Step< {
 	// Fetch hosting provider when ref=move-lp and we have a from URL
 	const domain = sourceSiteSlug ? urlToDomain( sourceSiteSlug ) : '';
 	const shouldFetchHosting = ref === 'move-lp' && !! domain;
-	const { data: hostingProviderData } = useHostingProviderQuery( domain, shouldFetchHosting );
+	const { data: hostingProviderData, isFetching: isFetchingHosting } = useHostingProviderQuery(
+		domain,
+		shouldFetchHosting
+	);
 
 	useEffect( () => {
 		// If the user has no sites, we should skip the site picker and go straight to the site creation step
 		if ( siteCount === 0 ) {
+			// If we're fetching hosting data for move-lp, wait for it to complete
+			if ( shouldFetchHosting && isFetchingHosting ) {
+				return;
+			}
+
 			const host = hostingProviderData?.hosting_provider?.slug;
 			navigation.submit?.( { action: 'create-site', host } );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteCount, hostingProviderData ] );
+	}, [ siteCount, shouldFetchHosting, isFetchingHosting ] );
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15092

## Proposed Changes

* We should check if the provided site can be migrated through the SSH flow when the user arrives from the `/move` page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were not verifying the host of the site when the users navigated from the `/move` page into the stepper flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `https://wordpress.com/move` and submit it with a site that can be migrated through the SSH flow.
* Enable the feature flag:
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Now copy the path you get after you analyze your site
* Use calypso live or apply this PR to your local environment
* Use the path you copied, to navigate to the site picker step
* Create a new site
* After that, you should see `ssh=true` in the URL
* You can proceed until you reach the `Securely share your access step`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
