### PR TITLE
Update add new menu options

### DIFF
--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
-import { download, reusableBlock, Icon } from '@wordpress/icons';
+import { reusableBlock } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useContext } from 'react';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
@@ -46,12 +46,6 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 			action: 'migrate',
 		} );
 	};
-	const importClick = () => {
-		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
-		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
-			action: 'import',
-		} );
-	};
 	const offerClick = () => {
 		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
 			action: 'offer',
@@ -72,7 +66,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 
 	return (
 		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 6 }>
-			<Column title={ __( 'Add new site' ) }>
+			<Column title={ __( 'Start a new site' ) }>
 				{ isFlexEligible && (
 					<MenuItem
 						icon={ <WordPressLogo /> }
@@ -116,6 +110,16 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					} ) }
 					aria-label={ __( 'Build a new site with AI' ) }
 				/>
+			</Column>
+			<Column title={ __( 'Bring an existing site' ) }>
+				<MenuItem
+					icon={ reusableBlock }
+					title={ __( 'Migrate' ) }
+					description={ __( "Bring your site to the world's best WordPress host." ) }
+					onClick={ migrateClick }
+					href={ `/setup/site-migration?source=${ context }&ref=new-site-popover` }
+					aria-label={ __( 'Migrate an existing WordPress site' ) }
+				/>
 				<MenuItem
 					icon={ <JetpackLogo /> }
 					title={ __( 'Via the Jetpack plugin' ) }
@@ -123,24 +127,6 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					onClick={ jetpackClick }
 					href={ `/jetpack/connect?cta_from=${ context }&cta_id=add-site` }
 					aria-label={ __( 'Add site via the Jetpack plugin' ) }
-				/>
-			</Column>
-			<Column title={ __( 'Migrate and import' ) }>
-				<MenuItem
-					icon={ reusableBlock }
-					title={ __( 'Migrate' ) }
-					description={ __( 'Bring your entire WordPress site to WordPress.com.' ) }
-					onClick={ migrateClick }
-					href={ `/setup/site-migration?source=${ context }&ref=new-site-popover&action=migrate` }
-					aria-label={ __( 'Migrate an existing WordPress site' ) }
-				/>
-				<MenuItem
-					icon={ <Icon icon={ download } size={ 18 } /> }
-					title={ __( 'Import' ) }
-					description={ __( 'Use a backup to only import content from other platforms.' ) }
-					onClick={ importClick }
-					href={ `/setup/site-migration/create-site?source=${ context }&ref=new-site-popover&action=import` }
-					aria-label={ __( 'Import content from other platforms' ) }
 				/>
 			</Column>
 

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -115,7 +115,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 				<MenuItem
 					icon={ reusableBlock }
 					title={ __( 'Migrate' ) }
-					description={ __( "Bring your site to the world's best WordPress host." ) }
+					description={ __( 'Bring your site to the world’s best WordPress host.' ) }
 					onClick={ migrateClick }
 					href={ `/setup/site-migration?source=${ context }&ref=new-site-popover` }
 					aria-label={ __( 'Migrate an existing WordPress site' ) }


### PR DESCRIPTION
## Proposed Changes

This PR updates the Add new sites menu with simpler option. We've simplified the Migrate vs Import options into a single option and remove the `?=action` associated with each. This improves some issues with the subsequent flow since we only have a single option now. 

**Before**

<img width="1379" height="1191" alt="image" src="https://github.com/user-attachments/assets/5b58bdcb-5047-4f94-aa15-26598c6fb232" />


**After**

<img width="1379" height="1191" alt="image" src="https://github.com/user-attachments/assets/57928183-9983-4439-8177-003a1a8bcd56" />

Please note this doesn't remove the previous logic to use the `?action` query string for imports vs. migrations. That can be done separately. 


## Why are these changes being made?
* The Import vs. Migrate options aren't clear at this stage.
* Selecting migrate causes some issues down the line where picking a platform doesn't actually let you pick a platform.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/sites`
* Press Migrate

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
