### PR TITLE
Update Import vs. migrate step

### DIFF
--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -57,21 +57,15 @@ html[dir="rtl"] {
 				display: block;
 			}
 		}
-
-		.list__importers-primary,
-		.list__importers-secondary {
-			margin: 0 auto 1.5rem auto;
-			min-width: 100%;
-
-			@include break-small {
-				min-width: 433px;
-			}
-		}
 	}
 }
 
 .list__importers {
 	max-width: 430px;
+
+	&.list__importers-primary {
+		margin: 0 auto 16px auto;
+	}
 
 	.select-dropdown > div {
 		width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
@@ -49,11 +49,13 @@ const FlowCard = ( {
 						</FlexItem>
 					) }
 					<FlexBlock>
-						<h3 className={ clsx( 'flow-question__heading', bem( 'heading' ) ) }>
-							{ title }
-							{ badge && <Badge type={ badge.type }>{ badge.text }</Badge> }
-						</h3>
+						<h3 className={ clsx( 'flow-question__heading', bem( 'heading' ) ) }>{ title }</h3>
 						<p className={ clsx( 'flow-question__description', bem( 'description' ) ) }>{ text }</p>
+						{ badge && (
+							<div className={ clsx( 'flow-question__badge', bem( 'badge' ) ) }>
+								<Badge type={ badge.type }>{ badge.text }</Badge>
+							</div>
+						) }
 					</FlexBlock>
 					<FlexItem>
 						<Icon icon={ chevronRight } size={ 24 } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -37,20 +37,18 @@ $blueberry-color: #3858e9;
 	.flow-question__heading {
 		font-weight: 500;
 		font-size: $font-body-large;
-		display: flex;
-		align-items: center;
-		gap: 0.5em;
-		// !important needed here to override unrelated styles from "steps-repository/importer-migrate-message/style.scss"
-		// that are affecting this component in some instances
-		margin-bottom: 0 !important;
-
-		.badge--info-blue {
-			background-color: $blueberry-color;
-		}
 	}
 
 	.flow-question__description {
 		color: var(--studio-gray-60);
 		padding-right: 10px;
+	}
+
+	.flow-question__badge {
+		margin-top: 16px;
+
+		.badge--info-blue {
+			background-color: $blueberry-color;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -35,7 +35,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 
 	const options = useMemo( () => {
 		const upgradeRequiredLabel = translate(
-			'Available on %(planName)s with %(discountPercentage)s off',
+			'Available on %(planName)s plan with %(discountPercentage)s off',
 			{
 				args: {
 					planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -3,6 +3,7 @@ import { BadgeType } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
 import { Step } from '@automattic/onboarding';
 import { canInstallPlugins } from '@automattic/sites';
+import { shuffle, upload } from '@wordpress/icons';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
@@ -33,13 +34,17 @@ const SiteMigrationImportOrMigrate: StepType< {
 	const isUpgradeRequired = ! siteCanInstallPlugins;
 
 	const options = useMemo( () => {
-		const upgradeRequiredLabel = translate( '%(discountPercentage)s off %(planName)s', {
-			args: {
-				planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-				discountPercentage: formatNumber( 0.5, { numberFormatOptions: { style: 'percent' } } ),
-			},
-			comment: 'discountPercentage is a number between 0 and 100 followed or preceded by a % sign',
-		} );
+		const upgradeRequiredLabel = translate(
+			'Available on %(planName)s with %(discountPercentage)s off',
+			{
+				args: {
+					planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+					discountPercentage: formatNumber( 0.5, { numberFormatOptions: { style: 'percent' } } ),
+				},
+				comment:
+					'discountPercentage is a number between 0 and 100 followed or preceded by a % sign',
+			}
+		);
 
 		const migrateOptionDescription = translate(
 			"For WordPress sites. Move all your site's content, themes, plugins, and users to WordPress.com."
@@ -47,6 +52,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 
 		return [
 			{
+				icon: shuffle,
 				label: translate( 'Migrate site' ),
 				description: migrateOptionDescription,
 				value: 'migrate' as const,
@@ -57,6 +63,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 				selected: true,
 			},
 			{
+				icon: upload,
 				label: translate( 'Import content only' ),
 				description: translate( 'Import just posts, pages, comments and media.' ),
 				value: 'import' as const,
@@ -95,6 +102,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 			<div className="import-or-migrate__list">
 				{ options.map( ( option, i ) => (
 					<FlowCard
+						icon={ option.icon }
 						key={ i }
 						title={ option.label }
 						badge={ option.badge }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
@@ -125,7 +125,7 @@ describe( 'Site Migration Import or Migrate Step', () => {
 	it( 'shows the upgrade required badge when the site can not install plugins', () => {
 		render();
 
-		expect( screen.getByText( /50% off Business/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Available on Business plan with 50% off/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the included with your plan badge when the site can install plugins', () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR makes some cosmetic changes to the Import vs. Migration step of the migration flow. 

**Before**
<img width="1691" height="1191" alt="image" src="https://github.com/user-attachments/assets/205c78ad-ee63-4b74-95cb-ba820724bd1d" />


**After**
<img width="1691" height="1191" alt="image" src="https://github.com/user-attachments/assets/5491e806-9f8d-47d5-9f73-347306568d13" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the language around the offer to make it clearer
* Bumps the badge down below the copy to make room for clearer explanation
* Adds icons for a more aesthetic/polished look

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start an import
* Make your way to the import vs. migration step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
