### PR TITLE
Add Medium severity for threat in the UI

### DIFF
--- a/client/components/jetpack/threat-fix-header/index.tsx
+++ b/client/components/jetpack/threat-fix-header/index.tsx
@@ -27,7 +27,8 @@ export default function ThreatFixHeader( { threat, fixAllDialog, onCheckFix, act
 	const severityClassNames = ( severity: number ) => {
 		return {
 			'is-critical': severity >= 5,
-			'is-high': severity >= 3 && severity < 5,
+			'is-high': severity >= 4 && severity < 5,
+			'is-medium': severity >= 3 && severity < 4,
 			'is-low': severity < 3,
 		};
 	};

--- a/client/components/jetpack/threat-item-header/index.tsx
+++ b/client/components/jetpack/threat-item-header/index.tsx
@@ -18,7 +18,8 @@ interface Props {
 const severityClassNames = ( severity: number ) => {
 	return {
 		'is-critical': severity >= 5,
-		'is-high': severity >= 3 && severity < 5,
+		'is-high': severity >= 4 && severity < 5,
+		'is-medium': severity >= 3 && severity < 4,
 		'is-low': severity < 3,
 	};
 };

--- a/client/components/jetpack/threat-severity-badge/index.tsx
+++ b/client/components/jetpack/threat-severity-badge/index.tsx
@@ -6,7 +6,8 @@ import './style.scss';
 const severityClassNames = ( severity: number ) => {
 	return {
 		'is-critical': severity >= 5,
-		'is-high': severity >= 3 && severity < 5,
+		'is-high': severity >= 4 && severity < 5,
+		'is-medium': severity >= 3 && severity < 4,
 		'is-low': severity < 3,
 	};
 };
@@ -15,9 +16,11 @@ const severityText = ( severity: number ) => {
 	if ( severity >= 5 ) {
 		return translate( 'Critical' );
 	}
-
-	if ( severity >= 3 ) {
+	if ( severity >= 4 ) {
 		return translate( 'High' );
+	}
+	if ( severity >= 3 ) {
+		return translate( 'Medium' );
 	}
 
 	return translate( 'Low' );

--- a/client/components/jetpack/threat-severity-badge/style.scss
+++ b/client/components/jetpack/threat-severity-badge/style.scss
@@ -36,6 +36,11 @@
 		color: #7d5600;
 	}
 
+	&__content.is-medium {
+		background: #f5e6b3;
+		color: #7d5600;
+	}
+
 	&__content.is-low {
 		background: #f6f7f7;
 		color: #646970;

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -6,9 +6,13 @@ export const getSeverityLabel = ( severity: number ): string => {
 		/** translators: severity label for critical threats */
 		return __( 'Critical' );
 	}
-	if ( severity >= 3 ) {
+	if ( severity >= 4 ) {
 		/** translators: severity label for high threats */
 		return __( 'High' );
+	}
+	if ( severity >= 3 ) {
+		/** translators: severity label for medium threats */
+		return __( 'Medium' );
 	}
 
 	/** translators: severity label for low threats */
@@ -19,7 +23,7 @@ export const getSeverityIntent = ( severity: number ): 'default' | 'error' | 'wa
 	if ( severity >= 5 ) {
 		return 'error';
 	}
-	if ( severity >= 3 ) {
+	if ( severity >= 4 ) {
 		return 'warning';
 	}
 	return 'default';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Adds a medium priority between low and high for >=3 <4 severity

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed we were over-reporting severity since we lacked a 'Medium' case

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check live branch for an atomic site currently that has a Medium severity issue with Gutenberg.  On production you'll see 'High' and with the patch should properly see 'Medium' in various areas outlined below.

https://cloud.jetpack.com/scan/<domain>
https://cloud.jetpack.com/scan/history/<domain>
http://calypso.localhost:3000/v2/sites/jwebbdevtest.wpcomstaging.com/scan/active (hosting dashboard)

<img width="2878" height="682" alt="image" src="https://github.com/user-attachments/assets/1aad22b9-e5d5-494b-8beb-b6de6ec5d1df" />
<img width="793" height="783" alt="Screenshot 2025-11-05 at 3 01 40 PM" src="https://github.com/user-attachments/assets/56f23a49-d9e7-4a75-9bd7-cfb5f017ecb6" />
<img width="801" height="856" alt="Screenshot 2025-11-05 at 2 47 17 PM" src="https://github.com/user-attachments/assets/9d39823d-036f-4156-bafd-18d06fd21cc3" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
