### PR TITLE
MSD: Update performance overview card display state. Stop new report queue.

### DIFF
--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -151,11 +151,12 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 		);
 	}
 
-	if ( ! pages || pages.length === 0 ) {
+	const homePage = pages?.[ 0 ] ?? null;
+	if ( ! homePage || ! homePage.wpcom_performance_report_hash ) {
 		return <PerformanceCardContentWithoutTests site={ site } />;
 	}
 
-	return <PerformanceCardContentWithTests site={ site } page={ pages[ 0 ] } />;
+	return <PerformanceCardContentWithTests site={ site } page={ homePage } />;
 }
 
 export default function PerformanceCard( { site }: { site: Site } ) {

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -32,7 +32,7 @@ function PerformanceCardContentWithoutTests( { site }: { site: Site } ) {
 		<OverviewCard
 			{ ...CARD_PROPS }
 			heading={ __( 'Run a test' ) }
-			description={ __( 'Your site hasn’t been tested yet.' ) }
+			description={ __( 'We don’t have performance data for your site.' ) }
 			link={ getPerformanceUrl( site ) }
 		/>
 	);
@@ -84,10 +84,15 @@ function PerformanceCardContentWithTests( {
 	site: Site;
 	page: SitePerformancePage;
 } ) {
-	const { getReport, hasCompleted } = useSitePerformanceData(
+	const { getReport, hasCompleted, hasError } = useSitePerformanceData(
 		page.link,
 		page.wpcom_performance_report_hash
 	);
+
+	// If we have an error, show the without tests card so they can navigate and try again.
+	if ( hasError( 'desktop' ) || hasError( 'mobile' ) ) {
+		return <PerformanceCardContentWithoutTests site={ site } />;
+	}
 
 	if ( ! hasCompleted ) {
 		return <OverviewCard { ...CARD_PROPS } isLoading />;

--- a/client/dashboard/sites/performance/use-site-performance-data.ts
+++ b/client/dashboard/sites/performance/use-site-performance-data.ts
@@ -104,7 +104,9 @@ export function useSitePerformanceData(
 		getReport,
 		hasCompleted: !! getReport( 'desktop' ) && !! getReport( 'mobile' ),
 		hasError: ( type: ReportType ) =>
-			isReportFailed( getReport( type ) ) || isBasicMetricsError || isInsightsError,
+			isReportFailed( performanceData?.pagespeed?.[ type ] ) ||
+			isBasicMetricsError ||
+			isInsightsError,
 		isLoadingExistingReport,
 		isLoadingNewReport,
 	};


### PR DESCRIPTION
Fixes DOTMSD-827
Related: DOTMSD-822

## Proposed Changes

The `useSitePerformanceData` automatically queues a new report if it doesn't exist. Since we use the same hook on the site overview, we don't want to queue a new test; otherwise, the user will have a Performance Overview Card in a loading state for some time while the report is running.

This PR makes sure it doesn't queue a new report and handles a missing error case.

| State | Display |
|--------|--------|
| Loading | <img width="341" height="183" alt="Screenshot 2025-11-06 at 9 42 34 AM" src="https://github.com/user-attachments/assets/32de3a21-6253-48d1-b7ae-6b0ce0432c18" /> | 
| Not Launched | <img width="332" height="180" alt="Screenshot 2025-11-06 at 9 24 03 AM" src="https://github.com/user-attachments/assets/263bc24d-aecc-42ff-bb19-1c58d0c00c5b" /> | 
| Coming Soon/Private | <img width="334" height="178" alt="Screenshot 2025-11-06 at 9 41 40 AM" src="https://github.com/user-attachments/assets/22d5a044-e7e2-4af2-a524-0f13a5a55689" /> |
| Features not activated |  <img width="345" height="172" alt="Screenshot 2025-11-06 at 10 01 35 AM" src="https://github.com/user-attachments/assets/e3884678-507e-4e42-b820-f553f5c202cc" /> |
| No Report/ Error | <img width="332" height="188" alt="Screenshot 2025-11-06 at 9 25 41 AM" src="https://github.com/user-attachments/assets/2a4cb934-bc91-42d7-b050-8625685e5d07" /> | 
| Existing Report | <img width="330" height="181" alt="Screenshot 2025-11-06 at 9 43 23 AM" src="https://github.com/user-attachments/assets/87c21fdb-a454-4805-a308-d52071030dd2" /> | 


## Testing Instructions

- With a new business plan and activated features, not launched, navigate the site overview.
  - Don't visit your performance page!! It will queue a test.
- Click on the tile, launch site.
- Set site to private
- Go back to Site Overview, expect to see the relevant card.
- Set site to public
- Go back to Site overview
- Expect to see "run a test" card
- Click, card, navigate to performance, and let the test run.
- Go back to Site Overview, notice the result card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
