### PR TITLE
A4A > Tiers: UI fixes & minor refactor

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-current-agency-tier.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-current-agency-tier.ts
@@ -1,0 +1,6 @@
+import { ALL_TIERS } from '../overview-content/constants';
+import type { AgencyTierType } from '../overview-content/types';
+
+export default function getCurrentAgencyTier( agencyTier?: AgencyTierType ) {
+	return ALL_TIERS.find( ( tier ) => tier.id === agencyTier || tier.level === 0 );
+}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -17,7 +17,7 @@ import type { TierItem } from './types';
 
 const TARGET_INFLUENCED_REVENUE = {
 	'emerging-partner': 0,
-	'agency-partner': 1000,
+	'agency-partner': 1200,
 	'pro-agency-partner': 5000,
 	'premier-partner': 250000,
 };

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -11,7 +11,9 @@ export default function InfluencedRevenue( {
 	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
 } ) {
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
+	const currentTier =
+		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
+		ALL_TIERS.find( ( tier ) => tier.level === 0 );
 
 	if ( ! currentTier ) {
 		return null;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -1,7 +1,7 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { __ } from '@wordpress/i18n';
 import { Stat } from 'calypso/dashboard/components/stat';
-import { ALL_TIERS } from './constants';
+import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import type { AgencyTierType } from './types';
 
 export default function InfluencedRevenue( {
@@ -11,9 +11,7 @@ export default function InfluencedRevenue( {
 	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
 } ) {
-	const currentTier =
-		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
-		ALL_TIERS.find( ( tier ) => tier.level === 0 );
+	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
 	if ( ! currentTier ) {
 		return null;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -1,5 +1,9 @@
 @import "@wordpress/base-styles/colors";
 
+:root {
+	--color-gray-700: #{$gray-700};
+}
+
 .agency-tier-overview-revamped {
 	// Hacks to make DataViews look non-interactive
 	// Upstream issue: https://github.com/WordPress/gutenberg/issues/71127
@@ -12,10 +16,9 @@
 			&, &:hover {
 				background-color: $white;
 				.dataviews-view-list__fields {
-						color: $gray-700;
-					}
+					color: $gray-700;
 				}
-
+			}
 		}
 	}
 	&.is-small-viewport {
@@ -30,11 +33,14 @@
 	}
 }
 
-.agency-tier-overview-revamped__icon {
-	display: block;
-	position: relative;
-	top: 50%;
-	inset-inline-start: 50%;
-	transform: translate(-50%, -50%);
-	fill: $gray-700;
+.agency-tier-overview-revamped__icon-container {
+	align-items: center;
+	background: $gray-100;
+	display: flex;
+	height: 100%;
+	justify-content: center;
+
+	svg {
+		fill: $gray-700;
+	}
 }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
@@ -77,7 +77,9 @@ export default function TierBenefits( {
 			id: 'icon',
 			render: ( { item } ) =>
 				item.icon ? (
-					<Icon icon={ item.icon } size={ 32 } className="agency-tier-overview-revamped__icon" />
+					<div className="agency-tier-overview-revamped__icon-container">
+						<Icon icon={ item.icon } size={ 32 } />
+					</div>
 				) : null,
 		},
 		{

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
@@ -32,7 +32,9 @@ export default function TierBenefits( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
+	const currentTier =
+		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
+		ALL_TIERS.find( ( tier ) => tier.level === 0 );
 
 	const isSmallViewport = useViewportMatch( 'large', '<' );
 	const isMediumViewport = useViewportMatch( 'huge', '<' );

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
@@ -18,6 +18,7 @@ import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import DownloadBadges from '../download-badges';
+import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import { ALL_TIERS } from './constants';
 import type { AgencyTierType, Benefit } from './types';
 import type { Field } from '@wordpress/dataviews';
@@ -32,9 +33,7 @@ export default function TierBenefits( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier =
-		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
-		ALL_TIERS.find( ( tier ) => tier.level === 0 );
+	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
 	const isSmallViewport = useViewportMatch( 'large', '<' );
 	const isMediumViewport = useViewportMatch( 'huge', '<' );

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -20,6 +20,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ALL_TIERS } from './constants';
 import type { AgencyTierType } from './types';
 
+const TEXT_COLOR = 'var(--color-gray-700)';
+
 export default function TierCards( {
 	currentAgencyTierId,
 	isEarlyAccess,
@@ -94,9 +96,9 @@ export default function TierCards( {
 										children={ __( 'Your Tier — Early Access' ) }
 									/>
 								) }
-								<Text style={ { color: '#757575' } }>{ tier.description }</Text>
+								<Text color={ TEXT_COLOR }>{ tier.description }</Text>
 								{ isCurrentTier && isEarlyAccess && (
-									<Text style={ { color: '#757575', fontStyle: 'italic' } } weight={ 700 }>
+									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
 										{ createInterpolateElement( __( 'You’re in early. <a>Learn more</a>' ), {
 											a: (
 												<Button onClick={ handleLearnMore } variant="link">
@@ -106,10 +108,10 @@ export default function TierCards( {
 										} ) }
 									</Text>
 								) }
-								<Text style={ { color: '#757575' } } weight={ 700 }>
+								<Text color={ TEXT_COLOR } weight={ 700 }>
 									{ tier.heading }
 								</Text>
-								<Text style={ { color: '#757575' } }>{ tier.subheading }</Text>
+								<Text color={ TEXT_COLOR }>{ tier.subheading }</Text>
 							</VStack>
 							<Button
 								onClick={ () => handleViewBenefits( tier.id as string ) }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -17,6 +17,7 @@ import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import { ALL_TIERS } from './constants';
 import type { AgencyTierType } from './types';
 
@@ -31,9 +32,7 @@ export default function TierCards( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier =
-		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
-		ALL_TIERS.find( ( tier ) => tier.level === 0 );
+	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
 	const isSmallViewport = useViewportMatch( 'huge', '<' );
 

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -31,7 +31,9 @@ export default function TierCards( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
+	const currentTier =
+		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
+		ALL_TIERS.find( ( tier ) => tier.level === 0 );
 
 	const isSmallViewport = useViewportMatch( 'huge', '<' );
 

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -12,7 +12,7 @@ import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sideba
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { ALL_TIERS } from '../overview-content/constants';
+import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import InfluencedRevenue from '../overview-content/influenced-revenue';
 import type { AgencyTierType } from '../overview-content/types';
 
@@ -27,9 +27,7 @@ export default function AgencyTierProgressCard( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier =
-		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
-		ALL_TIERS.find( ( tier ) => tier.level === 0 );
+	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
 	if ( ! currentTier ) {
 		return null;

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -27,7 +27,9 @@ export default function AgencyTierProgressCard( {
 } ) {
 	const dispatch = useDispatch();
 
-	const currentTier = ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId );
+	const currentTier =
+		ALL_TIERS.find( ( tier ) => tier.id === currentAgencyTierId ) ??
+		ALL_TIERS.find( ( tier ) => tier.level === 0 );
 
 	if ( ! currentTier ) {
 		return null;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -40,11 +40,3 @@
 	vertical-align: bottom;
 	margin-left: 4px;
 }
-
-// TODO: remove when the list view declares a proper primary field.
-//
-// The issue here is that the email is not provided as a primary field,
-// hence it's displayed below the space reserved for the media+primary field in list view.
-.dataviews-view-list__media-wrapper {
-	display: none !important;
-}


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1786/testing-ui-feedback

## Proposed Changes

This PR makes some UI fixes & minor refactor to the Tiers, including:

- Issue with the gray background for the icons on the Benefits section. 
- Issue with clicking a benefit like `Make a client referral`, making the icons disappear when coming back to the same page.
- Showing the "Account activated" as the default tier if they don't have any tier set.
- Updated the Agency Tier IAR to $1200.

## Why are these changes being made?

* To fix some UI issues

## Testing Instructions

* Open the A4A live link
* Go to Agency Tiers > Verify the text color on the cards hasn't changed & Agency Tier IAR is updated to $1200.
* Verify the icons on the benefits section now have a light gray background color.
* Click the `Make a client referral` button  > Verify the rows on the table layout look good. Change to layout to list view >  Verify the rows on the table layout look good. You can compare it by comparing with: https://agencies.automattic.com/referrals/dashboard
* Use the MC tool > Set the tier as none (Set Tier option) > Refresh the UI > Verify the default UI (Account activated) is shown.

| Before | After |
|--------|--------|
| <img width="1912" height="800" alt="Screenshot 2025-11-06 at 9 24 07 AM" src="https://github.com/user-attachments/assets/87f8782c-d6f5-459d-bf64-14b50856a500" /> | <img width="1912" height="800" alt="Screenshot 2025-11-06 at 12 57 32 PM" src="https://github.com/user-attachments/assets/81c03b59-4bc8-4b61-bfdf-c968cc817d2e" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
