### PR TITLE
MSD: Add the URL of the site to the site switcher

### DIFF
--- a/client/dashboard/components/site-icon/site-migration-icon.tsx
+++ b/client/dashboard/components/site-icon/site-migration-icon.tsx
@@ -6,7 +6,13 @@ export default function SiteMigrationIcon( {
 	size?: number;
 } ) {
 	return (
-		<svg className={ className } height={ size } width={ size } viewBox="0 0 56 56">
+		<svg
+			className={ className }
+			style={ { color: '#3858E9' } }
+			height={ size }
+			width={ size }
+			viewBox="0 0 56 56"
+		>
 			<g clipPath="url(#clip0_3923_15349)">
 				<path
 					d="M0 4C0 1.79086 1.79086 0 4 0H52C54.2091 0 56 1.79086 56 4V52C56 54.2091 54.2091 56 52 56H4C1.79086 56 0 54.2091 0 52V4Z"

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -9,7 +9,7 @@ interface RenderCallbackProps {
 	onClose: () => void;
 }
 
-type SwitcherProps< T > = {
+export type SwitcherProps< T > = {
 	items?: T[];
 	value: T;
 	searchableFields: Field< T >[];

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,6 +1,7 @@
-import { Dropdown, Button } from '@wordpress/components';
+import { __experimentalHStack as HStack, Dropdown, Button } from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
-import SwitcherContent, { type RenderItemIcon } from './switcher-content';
+import SwitcherContent from './switcher-content';
+import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
 import type { Field } from '@wordpress/dataviews';
 import type { ComponentProps } from 'react';
 
@@ -11,11 +12,12 @@ interface RenderCallbackProps {
 type SwitcherProps< T > = {
 	items?: T[];
 	value: T;
-	searchableFields?: Field< T >[];
+	searchableFields: Field< T >[];
 	children?: ( props: RenderCallbackProps ) => React.ReactNode;
-	getItemName: ( item: T ) => string;
 	getItemUrl: ( item: T ) => string;
-	renderItemIcon: RenderItemIcon< T >;
+	renderItemMedia: RenderItemMedia< T >;
+	renderItemTitle: RenderItemTitle< T >;
+	renderItemDescription?: RenderItemDescription< T >;
 } & Pick< ComponentProps< typeof Dropdown >, 'open' | 'onToggle' | 'defaultOpen' >; // For controlled usage of the switcher
 
 export default function Switcher< T >( {
@@ -23,9 +25,10 @@ export default function Switcher< T >( {
 	value,
 	searchableFields,
 	children,
-	getItemName,
 	getItemUrl,
-	renderItemIcon,
+	renderItemMedia,
+	renderItemTitle,
+	renderItemDescription,
 	open,
 	onToggle,
 	defaultOpen,
@@ -50,19 +53,20 @@ export default function Switcher< T >( {
 					aria-haspopup="true"
 					aria-expanded={ isOpen }
 				>
-					<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
-						{ renderItemIcon( { item: value, context: 'dropdown', size: 16 } ) }
-						{ getItemName( value ) }
-					</div>
+					<HStack alignment="center">
+						{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
+						{ renderItemTitle( { item: value, context: 'dropdown' } ) }
+					</HStack>
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<SwitcherContent
 					items={ items }
 					searchableFields={ searchableFields }
-					getItemName={ getItemName }
 					getItemUrl={ getItemUrl }
-					renderItemIcon={ renderItemIcon }
+					renderItemMedia={ renderItemMedia }
+					renderItemTitle={ renderItemTitle }
+					renderItemDescription={ renderItemDescription }
 					onClose={ onClose }
 				>
 					{ children?.( { onClose } ) }

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -1,9 +1,17 @@
-import { MenuGroup, NavigableMenu, SearchControl } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	MenuGroup,
+	NavigableMenu,
+	SearchControl,
+} from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { type PropsWithChildren, type ReactNode, useMemo, useState } from 'react';
+import { useState, useMemo } from 'react';
 import RouterLinkMenuItem from '../router-link-menu-item';
+import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
 import type { View, Field } from '@wordpress/dataviews';
+import type { PropsWithChildren } from 'react';
 
 const DEFAULT_VIEW: View = {
 	type: 'list',
@@ -12,43 +20,32 @@ const DEFAULT_VIEW: View = {
 	sort: { field: 'name', direction: 'asc' },
 };
 
-export type RenderItemIcon< T > = ( props: {
-	item: T;
-	context: 'dropdown' | 'list';
-	size: number;
-} ) => ReactNode;
-
 export default function SwitcherContent< T >( {
 	items,
-	searchableFields = [],
-	getItemName,
+	searchableFields,
 	getItemUrl,
-	renderItemIcon,
+	renderItemMedia,
+	renderItemTitle,
+	renderItemDescription,
 	children,
 	onClose,
 }: PropsWithChildren< {
 	items?: T[];
-	searchableFields?: Field< T >[];
-	getItemName: ( item: T ) => string;
+	searchableFields: Field< T >[];
 	getItemUrl: ( item: T ) => string;
-	renderItemIcon: RenderItemIcon< T >;
+	renderItemMedia: RenderItemMedia< T >;
+	renderItemTitle: RenderItemTitle< T >;
+	renderItemDescription?: RenderItemDescription< T >;
 	onClose: () => void;
 } > ) {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
 	const fields = useMemo( () => {
-		return [
-			{
-				id: 'name',
-				getValue: ( { item }: { item: T } ) => getItemName( item ),
-				enableGlobalSearch: true,
-			},
-			...searchableFields.map( ( searchableField ) => ( {
-				...searchableField,
-				enableGlobalSearch: true,
-			} ) ),
-		];
-	}, [ searchableFields, getItemName ] );
+		return searchableFields.map( ( searchableField ) => ( {
+			...searchableField,
+			enableGlobalSearch: true,
+		} ) );
+	}, [ searchableFields ] );
 
 	if ( ! items ) {
 		return __( 'Loading…' );
@@ -71,15 +68,19 @@ export default function SwitcherContent< T >( {
 				{ filteredData.map( ( item ) => {
 					const itemUrl = getItemUrl( item );
 					return (
-						<RouterLinkMenuItem key={ itemUrl } to={ itemUrl } onClick={ onClose }>
-							<div style={ { display: 'flex', gap: '8px', alignItems: 'center', width: '100%' } }>
-								{ renderItemIcon( { item, context: 'list', size: 24 } ) }
-								<span
-									style={ { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }
-								>
-									{ getItemName( item ) }
-								</span>
-							</div>
+						<RouterLinkMenuItem
+							key={ itemUrl }
+							to={ itemUrl }
+							style={ { height: 'fit-content', minHeight: '40px' } }
+							onClick={ onClose }
+						>
+							<HStack justify="flex-start" alignment="center" expanded>
+								{ renderItemMedia( { item, context: 'list', size: 32 } ) }
+								<VStack spacing={ 0 }>
+									{ renderItemTitle( { item, context: 'list' } ) }
+									{ renderItemDescription?.( { item, context: 'list' } ) }
+								</VStack>
+							</HStack>
 						</RouterLinkMenuItem>
 					);
 				} ) }

--- a/client/dashboard/components/switcher/types.ts
+++ b/client/dashboard/components/switcher/types.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+type RenderItemProps< T > = {
+	item: T;
+	context: 'dropdown' | 'list';
+};
+
+export type RenderItemMedia< T > = ( props: RenderItemProps< T > & { size?: number } ) => ReactNode;
+
+export type RenderItemTitle< T > = ( props: RenderItemProps< T > ) => ReactNode;
+
+export type RenderItemDescription< T > = ( props: RenderItemProps< T > ) => ReactNode;

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -8,13 +8,21 @@ import { domainRoute } from '../../app/router/domains';
 import HeaderBar from '../../components/header-bar';
 import Switcher from '../../components/switcher';
 import DomainMenu from '../domain-menu';
-
+import type { DomainSummary } from '@automattic/api-core';
 import './style.scss';
 
 function Domain() {
 	const { domainName } = domainRoute.useParams();
 	const domains = useQuery( domainsQuery() ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+	const searchableFields = [
+		{
+			id: 'name',
+			getValue: ( { item }: { item: DomainSummary } ) => item.domain,
+			enableGlobalSearch: true,
+		},
+	];
+
 	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	return (
@@ -25,15 +33,26 @@ function Domain() {
 						<Switcher
 							items={ domains }
 							value={ domain }
-							getItemName={ ( domain ) => domain.domain }
+							searchableFields={ searchableFields }
 							getItemUrl={ ( domain ) =>
 								buildCurrentRouteLink( { params: { domainName: domain.domain } } )
 							}
-							renderItemIcon={ ( { context } ) =>
+							renderItemMedia={ ( { context } ) =>
 								context === 'list' ? null : (
 									<Icon className="domain-icon" icon={ globe } size={ 24 } />
 								)
 							}
+							renderItemTitle={ ( { item } ) => (
+								<span
+									style={ {
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+									} }
+								>
+									{ item.domain }
+								</span>
+							) }
 						/>
 					</HeaderBar.Title>
 					<DomainMenu domainName={ domain.domain } />

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -1,46 +1,12 @@
-import { siteBySlugQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack, MenuGroup, MenuItem, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { useAppContext } from '../../app/context';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
-import { siteRoute } from '../../app/router/sites';
-import SiteIcon from '../../components/site-icon';
-import Switcher from '../../components/switcher';
-import { Text } from '../../components/text';
-import { getSiteDisplayName } from '../../utils/site-name';
-import { getSiteDisplayUrl } from '../../utils/site-url';
-import type { Site } from '@automattic/api-core';
-
-const searchableFields = [
-	{
-		id: 'name',
-		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
-	},
-	{
-		id: 'URL',
-		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
-	},
-];
+import { SiteSwitcherBase } from '../../sites/site-switcher/base';
 
 const CIABSiteSwitcher = () => {
 	const { recordTracksEvent } = useAnalytics();
-	const { queries } = useAppContext();
-	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
-	const { data: sites } = useQuery( {
-		...queries.sitesQuery( {
-			site_visibility: 'visible',
-			include_a8c_owned: false,
-		} ),
-		enabled: isSwitcherOpen,
-	} );
-	const { siteSlug } = siteRoute.useParams();
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 	const handleAddNewStore = () => {
 		recordTracksEvent( 'calypso_dashboard_site_switcher_new_site_button_click', {
 			action: 'big-sky',
@@ -56,31 +22,7 @@ const CIABSiteSwitcher = () => {
 	};
 
 	return (
-		<Switcher< Site >
-			items={ sites }
-			value={ site }
-			searchableFields={ searchableFields }
-			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
-			renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
-			renderItemTitle={ ( { item } ) => (
-				<span
-					style={ {
-						overflow: 'hidden',
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-					} }
-				>
-					{ getSiteDisplayName( item ) }
-				</span>
-			) }
-			renderItemDescription={ ( { item } ) => (
-				<Text variant="muted" truncate numberOfLines={ 1 }>
-					{ getSiteDisplayUrl( item ) }
-				</Text>
-			) }
-			open={ isSwitcherOpen }
-			onToggle={ setIsSwitcherOpen }
-		>
+		<SiteSwitcherBase>
 			{ () => (
 				<MenuGroup>
 					<MenuItem onClick={ handleAddNewStore }>
@@ -91,7 +33,7 @@ const CIABSiteSwitcher = () => {
 					</MenuItem>
 				</MenuGroup>
 			) }
-		</Switcher>
+		</SiteSwitcherBase>
 	);
 };
 

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -11,11 +11,16 @@ import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-li
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
 const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
+	},
 	{
 		id: 'URL',
 		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
@@ -51,13 +56,28 @@ const CIABSiteSwitcher = () => {
 	};
 
 	return (
-		<Switcher
+		<Switcher< Site >
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
-			getItemName={ getSiteDisplayName }
 			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
-			renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+			renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+			renderItemTitle={ ( { item } ) => (
+				<span
+					style={ {
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					} }
+				>
+					{ getSiteDisplayName( item ) }
+				</span>
+			) }
+			renderItemDescription={ ( { item } ) => (
+				<Text variant="muted" truncate numberOfLines={ 1 }>
+					{ getSiteDisplayUrl( item ) }
+				</Text>
+			) }
 			open={ isSwitcherOpen }
 			onToggle={ setIsSwitcherOpen }
 		>

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -42,6 +42,7 @@ export const SiteSwitcherBase = ( props: Pick< SwitcherProps< Site >, 'children'
 			renderItemTitle={ ( { item } ) => (
 				<span
 					style={ {
+						fontWeight: 500,
 						overflow: 'hidden',
 						textOverflow: 'ellipsis',
 						whiteSpace: 'nowrap',

--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -1,0 +1,62 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useAppContext } from '../../app/context';
+import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
+import { siteRoute } from '../../app/router/sites';
+import SiteIcon from '../../components/site-icon';
+import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
+import { getSiteDisplayName } from '../../utils/site-name';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import type { SwitcherProps } from '../../components/switcher';
+import type { Site } from '@automattic/api-core';
+
+const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
+	},
+	{
+		id: 'URL',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
+	},
+];
+
+export const SiteSwitcherBase = ( props: Pick< SwitcherProps< Site >, 'children' > ) => {
+	const { queries } = useAppContext();
+	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
+	const { data: sites } = useQuery( { ...queries.sitesQuery(), enabled: isSwitcherOpen } );
+	const { siteSlug } = siteRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const buildCurrentRouteLink = useBuildCurrentRouteLink();
+
+	return (
+		<Switcher< Site >
+			{ ...props }
+			items={ sites }
+			value={ site }
+			searchableFields={ searchableFields }
+			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
+			renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+			renderItemTitle={ ( { item } ) => (
+				<span
+					style={ {
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					} }
+				>
+					{ getSiteDisplayName( item ) }
+				</span>
+			) }
+			renderItemDescription={ ( { item } ) => (
+				<Text variant="muted" truncate numberOfLines={ 1 }>
+					{ getSiteDisplayUrl( item ) }
+				</Text>
+			) }
+			open={ isSwitcherOpen }
+			onToggle={ setIsSwitcherOpen }
+		/>
+	);
+};

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -1,5 +1,3 @@
-import { siteBySlugQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	MenuGroup,
@@ -10,64 +8,15 @@ import {
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
-import { useAppContext } from '../../app/context';
-import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-link';
-import { siteRoute } from '../../app/router/sites';
-import SiteIcon from '../../components/site-icon';
-import Switcher from '../../components/switcher';
-import { Text } from '../../components/text';
-import { getSiteDisplayName } from '../../utils/site-name';
-import { getSiteDisplayUrl } from '../../utils/site-url';
 import AddNewSite from '../add-new-site';
-import type { Site } from '@automattic/api-core';
-
-const searchableFields = [
-	{
-		id: 'name',
-		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
-	},
-	{
-		id: 'URL',
-		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
-	},
-];
+import { SiteSwitcherBase } from './base';
 
 const SiteSwitcher = () => {
-	const { queries } = useAppContext();
-	const [ isSwitcherOpen, setIsSwitcherOpen ] = useState( false );
-	const { data: sites } = useQuery( { ...queries.sitesQuery(), enabled: isSwitcherOpen } );
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
-	const { siteSlug } = siteRoute.useParams();
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const buildCurrentRouteLink = useBuildCurrentRouteLink();
 
 	return (
 		<>
-			<Switcher< Site >
-				items={ sites }
-				value={ site }
-				searchableFields={ searchableFields }
-				getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
-				renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
-				renderItemTitle={ ( { item } ) => (
-					<span
-						style={ {
-							overflow: 'hidden',
-							textOverflow: 'ellipsis',
-							whiteSpace: 'nowrap',
-						} }
-					>
-						{ getSiteDisplayName( item ) }
-					</span>
-				) }
-				renderItemDescription={ ( { item } ) => (
-					<Text variant="muted" truncate numberOfLines={ 1 }>
-						{ getSiteDisplayUrl( item ) }
-					</Text>
-				) }
-				open={ isSwitcherOpen }
-				onToggle={ setIsSwitcherOpen }
-			>
+			<SiteSwitcherBase>
 				{ ( { onClose } ) => (
 					<MenuGroup>
 						<MenuItem
@@ -83,7 +32,7 @@ const SiteSwitcher = () => {
 						</MenuItem>
 					</MenuGroup>
 				) }
-			</Switcher>
+			</SiteSwitcherBase>
 			{ isAddSiteModalOpen && (
 				<Modal
 					title={ __( 'Add new site' ) }

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -15,12 +15,17 @@ import useBuildCurrentRouteLink from '../../app/hooks/use-build-current-route-li
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import Switcher from '../../components/switcher';
+import { Text } from '../../components/text';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import AddNewSite from '../add-new-site';
 import type { Site } from '@automattic/api-core';
 
 const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
+	},
 	{
 		id: 'URL',
 		getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
@@ -38,13 +43,28 @@ const SiteSwitcher = () => {
 
 	return (
 		<>
-			<Switcher
+			<Switcher< Site >
 				items={ sites }
 				value={ site }
 				searchableFields={ searchableFields }
-				getItemName={ getSiteDisplayName }
 				getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
-				renderItemIcon={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+				renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
+				renderItemTitle={ ( { item } ) => (
+					<span
+						style={ {
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						} }
+					>
+						{ getSiteDisplayName( item ) }
+					</span>
+				) }
+				renderItemDescription={ ( { item } ) => (
+					<Text variant="muted" truncate numberOfLines={ 1 }>
+						{ getSiteDisplayUrl( item ) }
+					</Text>
+				) }
 				open={ isSwitcherOpen }
 				onToggle={ setIsSwitcherOpen }
 			>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-718

## Proposed Changes

* Update `Switcher` components as follows:
  * Support `renderItemMedia`, `renderItemTitle`, and `renderItemDescription` props to render media, title, and description
  * Update `searchableFields` props. Consumer now needs to pass all searchable fields
* Add `SiteSwitcherBase` component to share between wpcom and CIAB
* Add the URL of the site to the site switcher

| Before | After |
| - | - |
|<img width="289" height="535" alt="image" src="https://github.com/user-attachments/assets/dafa11a3-90e8-47d0-a112-777a9fe4a9ba" />|<img width="288" height="651" alt="image" src="https://github.com/user-attachments/assets/eb088304-3149-473d-9da0-070157f6a109" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It can be confusing to see the same site title in the switcher. Adding the URL helps users distinguish between their sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Select any site
* Open the site switcher
* Ensure you can see the URL
* Go to /v2/domains
* Select any domain
* Open the domain switcher
* Ensure it works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
