### PR TITLE
MSD: Update PageHeader for better mobile layout.

### DIFF
--- a/client/dashboard/app-ciab/style.scss
+++ b/client/dashboard/app-ciab/style.scss
@@ -41,7 +41,7 @@
 	// Headings
 	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: 54px;
+	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -41,7 +41,7 @@
 	// Headings
 	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: 54px;
+	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -36,7 +36,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 4 } wrap>
+				<HStack justify="space-between" alignment="center" spacing={ 7 } wrap>
 					<VStack>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
@@ -25,6 +26,8 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }
@@ -50,8 +53,8 @@ export const SectionHeader = ( {
 
 					{ /* The wrapper is always needed for view transitions. */ }
 					<ButtonStack
-						justify="flex-end"
-						expanded={ false }
+						justify={ isSmallViewport ? 'flex-start' : 'flex-end' }
+						expanded={ isSmallViewport }
 						alignment="flex-start"
 						className="dashboard-section-header__actions"
 					>

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -39,7 +39,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 7 } wrap>
+				<HStack justify="space-between" alignment="center" spacing={ 6 } wrap>
 					<VStack>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
 
 .dashboard-section-header {
 	position: relative;
@@ -16,9 +17,13 @@
 
 	.dashboard-section-header.is-level-1 & {
 		font-family: var( --dashboard-h1__font-family );
-		font-size: var( --dashboard-h1__font-size, $font-size-2x-large );
+		font-size: $font-size-2x-large;
 		font-weight: var( --dashboard-h1__font-weight ) !important;
 		line-height: var( --dashboard-h1__line-height, $font-line-height-2x-large );
+
+		@include break-medium {
+			font-size: var( --dashboard-h1__font-size );
+		}
 	}
 
 	.dashboard-section-header.is-level-2 & {

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -198,7 +198,7 @@ function SiteOverview( {
 
 		return (
 			<HStack justify="space-between">
-				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' }>
+				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' } style={ { width: 'auto' } }>
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button
 						ref={ wpAdminButtonRef }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,7 +197,7 @@ function SiteOverview( {
 		}
 
 		return (
-			<HStack justify="space-between" className="site-overview-actions">
+			<HStack justify="space-between">
 				<HStack justify="flex-start">
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -198,7 +198,7 @@ function SiteOverview( {
 
 		return (
 			<HStack justify="space-between">
-				<HStack justify="flex-start">
+				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' }>
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button
 						ref={ wpAdminButtonRef }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,19 +197,21 @@ function SiteOverview( {
 		}
 
 		return (
-			<>
-				<StagingSiteSyncDropdown siteSlug={ siteSlug } />
-				<Button
-					ref={ wpAdminButtonRef }
-					__next40pxDefaultSize
-					variant="primary"
-					href={ site.options.admin_url }
-					icon={ wordpress }
-				>
-					{ __( 'WP Admin' ) }
-				</Button>
+			<HStack justify="space-between" className="site-overview-actions">
+				<HStack justify="flex-start">
+					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
+					<Button
+						ref={ wpAdminButtonRef }
+						__next40pxDefaultSize
+						variant="primary"
+						href={ site.options.admin_url }
+						icon={ wordpress }
+					>
+						{ __( 'WP Admin' ) }
+					</Button>
+				</HStack>
 				<SiteActionMenu site={ site } />
-			</>
+			</HStack>
 		);
 	};
 


### PR DESCRIPTION
Part of DOTCOM-15116

## Proposed Changes

This PR makes two important updates to PageHeader:
- Reduced font size to `32px` on small screens.
- Expand the actions container 100% on mobile so consumers can utilize that space as they please.

Additionally, this PR uses those changes to implement the PageHeader described in DOTCOM-15116.

### Screenshot
| Design | Before | After | 
|--------|--------| --------|
| <img width="1210" height="1126" alt="image (1)" src="https://github.com/user-attachments/assets/d26fbf07-8aae-4c92-a145-42a8709540d5" />  | <img width="1290" height="2796" alt="wpcalypso wordpress com_v2(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/830f0984-2b29-4c68-9e56-317fc72f3e91" /> | <img width="1290" height="2796" alt="calypso localhost_3000_v2_sites_abstracting blog(iPhone 14 Pro Max) (6)" src="https://github.com/user-attachments/assets/161a65a9-1064-481b-b263-fa8fac25b061" /> | 


| iPad Mini |
|--------|
| <img width="1536" height="2048" alt="calypso localhost_3000_v2_sites_abstracting blog(iPad Mini)" src="https://github.com/user-attachments/assets/cfd1fca7-b31f-4fbf-958b-ce98fa55612c" /> | 

## Considerations

@lucasmendes-design Your guidance was to make the font size `24px` on small screens, however, I chose to use `32px` because `24px` seems small and is not part of [WordPress's typography presets](https://github.com/WordPress/gutenberg/blob/8be05648748c7e3c9b8d1034664339a0e1be2fe3/packages/base-styles/_variables.scss#L28).

Here's `24px`:

<img width="399" height="434" alt="Screenshot 2025-11-06 at 2 30 14 PM" src="https://github.com/user-attachments/assets/4e926b59-1efc-4e19-ad27-c2fc7d7ea319" />

## Testing Instructions

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
