### PR TITLE
MSD: Update monitoring subtitle to use description.

### DIFF
--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
@@ -129,9 +128,7 @@ function SiteMonitoring() {
 						wrap
 						spacing={ isSmallViewport ? 5 : 10 }
 					>
-						<PageHeader
-							description={ <Text variant="muted">{ getDateRange( timeRange, locale ) }</Text> }
-						/>
+						<PageHeader description={ getDateRange( timeRange, locale ) } />
 
 						<div>
 							<ToggleGroupControl

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -129,11 +129,9 @@ function SiteMonitoring() {
 						wrap
 						spacing={ isSmallViewport ? 5 : 10 }
 					>
-						<VStack spacing={ 2 }>
-							<PageHeader
-								description={ <Text variant="muted">{ getDateRange( timeRange, locale ) }</Text> }
-							/>
-						</VStack>
+						<PageHeader
+							description={ <Text variant="muted">{ getDateRange( timeRange, locale ) }</Text> }
+						/>
 
 						<div>
 							<ToggleGroupControl

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -130,8 +130,9 @@ function SiteMonitoring() {
 						spacing={ isSmallViewport ? 5 : 10 }
 					>
 						<VStack spacing={ 2 }>
-							<PageHeader />
-							<Text variant="muted">{ getDateRange( timeRange, locale ) }</Text>
+							<PageHeader
+								description={ <Text variant="muted">{ getDateRange( timeRange, locale ) }</Text> }
+							/>
 						</VStack>
 
 						<div>


### PR DESCRIPTION
Part of DOTCOM-15116

## Proposed Changes

Move the date range into the description to it matches the other pages and allow for consistent spacing control.





## Why are these changes being made?

-

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
