### PR TITLE
Add Multi-site Dashboard Learn more links to domain screens

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -591,6 +591,34 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/custom-dns/edit-or-delete-dns-records/',
 		post_id: 386584,
 	},
+	'domain-forwarding': {
+		link: 'https://wordpress.com/support/domains/domain-forwarding/',
+		post_id: 258498,
+	},
+	'domain-dnssec': {
+		link: 'https://wordpress.com/support/domains/dnssec-on-wordpress-com/',
+		post_id: 369656,
+	},
+	'domain-glue-records': {
+		link: 'https://wordpress.com/support/domains/manage-your-domains-glue-records/',
+		post_id: 318606,
+	},
+	'domain-detach-from-site': {
+		link: 'https://wordpress.com/support/domains/disconnect-a-domain-from-a-site/',
+		post_id: 318512,
+	},
+	'domain-email-google': {
+		link: 'https://wordpress.com/support/add-email/add-email-through-google-workspace/',
+		post_id: 49342,
+	},
+	'domain-email-zoho': {
+		link: 'https://wordpress.com/support/add-email/add-email-through-zoho-mail/',
+		post_id: 50985,
+	},
+	'domain-email-o365': {
+		link: 'https://wordpress.com/support/add-email/add-email-through-office-365/',
+		post_id: 78065,
+	},
 	'domain-designated-agent': {
 		link: 'https://wordpress.com/support/domains/update-contact-information/#designated-agent',
 		post_id: 3441,

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -1,7 +1,11 @@
 import { type DnsTemplateVariables } from '@automattic/api-core';
 import { domainDnsApplyTemplateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { DataForm, Field, useFormValidity } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -22,7 +26,7 @@ const defaultFormData: EmailSetupFormData = {
 };
 
 interface EmailSetupFormProps {
-	description: string;
+	description: React.ReactNode;
 	label: string;
 	transformVariables?: ( variables: DnsTemplateVariables ) => DnsTemplateVariables;
 	pattern: RegExp;
@@ -88,7 +92,6 @@ export default function EmailSetupForm( {
 			id: 'record',
 			type: 'text',
 			label: __( 'Verification token' ),
-			description,
 			placeholder,
 			isValid: {
 				custom: ( item ) => {
@@ -106,7 +109,7 @@ export default function EmailSetupForm( {
 	const canSubmit = formData.record && isValid;
 
 	return (
-		<div style={ { marginTop: '28px' } }>
+		<div>
 			<form onSubmit={ handleSubmit }>
 				<VStack spacing={ 5 }>
 					<DataForm< EmailSetupFormData >
@@ -117,6 +120,7 @@ export default function EmailSetupForm( {
 							setFormData( ( data ) => ( { ...data, ...edits } ) );
 						} }
 					/>
+					<Text variant="muted">{ description }</Text>
 					<ButtonStack justify="flex-start">
 						<Button
 							type="submit"

--- a/client/dashboard/domains/domain-dns/email-setup.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup.tsx
@@ -1,8 +1,10 @@
 import { DnsTemplates } from '@automattic/api-core';
 import { __experimentalVStack as VStack, TabPanel } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
 import EmailSetupForm from './email-setup-form';
 
@@ -16,8 +18,13 @@ export default function EmailSetup() {
 				<EmailSetupForm
 					label="Google Workspace"
 					key="google-workspace"
-					description={ __(
-						'Paste the verification token provided by Google Workspace for the TXT record.'
+					description={ createInterpolateElement(
+						__(
+							'Paste the verification token provided by Google Workspace for the TXT record. <link />'
+						),
+						{
+							link: <InlineSupportLink supportContext="domain-email-google" />,
+						}
 					) }
 					pattern={ /^google-site-verification=[A-Za-z0-9_-]{43}$/ }
 					placeholder="google-site-verification=…"
@@ -49,8 +56,13 @@ export default function EmailSetup() {
 			content: (
 				<EmailSetupForm
 					key="office-365"
-					description={ __(
-						'Paste the verification token provided by Office 365 for the TXT record.'
+					description={ createInterpolateElement(
+						__(
+							'Paste the verification token provided by Office 365 for the TXT record. <link />'
+						),
+						{
+							link: <InlineSupportLink supportContext="domain-email-o365" />,
+						}
 					) }
 					label="Office 365"
 					transformVariables={ ( variables ) =>
@@ -71,8 +83,11 @@ export default function EmailSetup() {
 			content: (
 				<EmailSetupForm
 					key="zoho-mail"
-					description={ __(
-						'Paste the verification token provided by Zoho Mail for the TXT record.'
+					description={ createInterpolateElement(
+						__( 'Paste the verification token provided by Zoho Mail for the TXT record. <link />' ),
+						{
+							link: <InlineSupportLink supportContext="domain-email-zoho" />,
+						}
 					) }
 					label="Zoho Mail"
 					pattern={ /^zb\w{1,100}$/ }
@@ -94,7 +109,7 @@ export default function EmailSetup() {
 						level={ 3 }
 					/>
 					<TabPanel tabs={ tabs } orientation={ isMobile ? 'horizontal' : 'vertical' }>
-						{ ( tab ) => tab.content }
+						{ ( tab ) => <p>{ tab.content }</p> }
 					</TabPanel>
 				</VStack>
 			</CardBody>

--- a/client/dashboard/domains/domain-dns/email-setup.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup.tsx
@@ -20,10 +20,10 @@ export default function EmailSetup() {
 					key="google-workspace"
 					description={ createInterpolateElement(
 						__(
-							'Paste the verification token provided by Google Workspace for the TXT record. <link />'
+							'Paste the verification token provided by Google Workspace for the TXT record. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="domain-email-google" />,
+							learnMoreLink: <InlineSupportLink supportContext="domain-email-google" />,
 						}
 					) }
 					pattern={ /^google-site-verification=[A-Za-z0-9_-]{43}$/ }
@@ -58,10 +58,10 @@ export default function EmailSetup() {
 					key="office-365"
 					description={ createInterpolateElement(
 						__(
-							'Paste the verification token provided by Office 365 for the TXT record. <link />'
+							'Paste the verification token provided by Office 365 for the TXT record. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="domain-email-o365" />,
+							learnMoreLink: <InlineSupportLink supportContext="domain-email-o365" />,
 						}
 					) }
 					label="Office 365"
@@ -84,9 +84,11 @@ export default function EmailSetup() {
 				<EmailSetupForm
 					key="zoho-mail"
 					description={ createInterpolateElement(
-						__( 'Paste the verification token provided by Zoho Mail for the TXT record. <link />' ),
+						__(
+							'Paste the verification token provided by Zoho Mail for the TXT record. <learnMoreLink />'
+						),
 						{
-							link: <InlineSupportLink supportContext="domain-email-zoho" />,
+							learnMoreLink: <InlineSupportLink supportContext="domain-email-zoho" />,
 						}
 					) }
 					label="Zoho Mail"

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -7,7 +7,11 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Button,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -286,7 +290,7 @@ export default function DomainDns() {
 					<PageHeader
 						prefix={ <Breadcrumbs length={ 2 } /> }
 						actions={
-							<>
+							<HStack>
 								<ImportBindFileButton
 									domainName={ domainName }
 									onRecordsImported={ ( data ) => {
@@ -304,7 +308,7 @@ export default function DomainDns() {
 									} }
 									__next40pxDefaultSize
 								>
-									{ __( 'Add DNS Record' ) }
+									{ __( 'Add Record' ) }
 								</Button>
 								<DnsActionsMenu
 									hasDefaultARecords={ hasDefaultARecordsValue }
@@ -318,7 +322,7 @@ export default function DomainDns() {
 										setIsRestoreDefaultEmailRecordsDialogOpen( true )
 									}
 								/>
-							</>
+							</HStack>
 						}
 						description={ <DnsDescription /> }
 					/>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -207,10 +207,10 @@ export default function DomainDns() {
 				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 					{ createInterpolateElement(
 						__(
-							'This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink />'
+							'This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <learnMoreLink />'
 						),
 						{
-							defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+							learnMoreLink: <InlineSupportLink supportContext="dns_default_records" />,
 						}
 					) }
 				</Notice>
@@ -220,10 +220,10 @@ export default function DomainDns() {
 			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink />'
+						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <learnMoreLink />'
 					),
 					{
-						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+						learnMoreLink: <InlineSupportLink supportContext="dns_default_records" />,
 					}
 				) }
 			</Notice>
@@ -242,10 +242,10 @@ export default function DomainDns() {
 			>
 				{ createInterpolateElement(
 					__(
-						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink />'
+						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <learnMoreLink />'
 					),
 					{
-						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
+						learnMoreLink: <InlineSupportLink supportContext="dns_default_records" />,
 					}
 				) }
 			</Notice>

--- a/client/dashboard/domains/domain-forwarding/index.tsx
+++ b/client/dashboard/domains/domain-forwarding/index.tsx
@@ -153,9 +153,9 @@ function DomainForwarding() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					description={ createInterpolateElement(
-						__( 'Forward your domain or subdomain to another address. <link />' ),
+						__( 'Forward your domain or subdomain to another address. <learnMoreLink />' ),
 						{
-							link: <InlineSupportLink supportContext="domain-forwarding" />,
+							learnMoreLink: <InlineSupportLink supportContext="domain-forwarding" />,
 						}
 					) }
 					actions={

--- a/client/dashboard/domains/domain-forwarding/index.tsx
+++ b/client/dashboard/domains/domain-forwarding/index.tsx
@@ -2,6 +2,7 @@ import { domainForwardingQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useRouter } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -11,6 +12,7 @@ import {
 	domainForwardingEditRoute,
 } from '../../app/router/domains';
 import { DataViewsCard } from '../../components/dataviews-card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -150,6 +152,12 @@ function DomainForwarding() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
+					description={ createInterpolateElement(
+						__( 'Forward your domain or subdomain to another address. <link />' ),
+						{
+							link: <InlineSupportLink supportContext="domain-forwarding" />,
+						}
+					) }
 					actions={
 						<RouterLinkButton
 							to={ domainForwardingAddRoute.fullPath }

--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -126,9 +126,9 @@ function DomainGlueRecords() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					description={ createInterpolateElement(
-						__( 'Edit your private name server records. <link />' ),
+						__( 'Edit your private name server records. <learnMoreLink />' ),
 						{
-							link: <InlineSupportLink supportContext="domain-glue-records" />,
+							learnMoreLink: <InlineSupportLink supportContext="domain-glue-records" />,
 						}
 					) }
 					actions={

--- a/client/dashboard/domains/domain-glue-records/index.tsx
+++ b/client/dashboard/domains/domain-glue-records/index.tsx
@@ -3,6 +3,7 @@ import { isMobile } from '@automattic/viewport';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -12,6 +13,7 @@ import {
 	domainGlueRecordsEditRoute,
 } from '../../app/router/domains';
 import { DataViewsCard } from '../../components/dataviews-card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -123,6 +125,12 @@ function DomainGlueRecords() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
+					description={ createInterpolateElement(
+						__( 'Edit your private name server records. <link />' ),
+						{
+							link: <InlineSupportLink supportContext="domain-glue-records" />,
+						}
+					) }
 					actions={
 						<RouterLinkButton
 							to={ domainGlueRecordsAddRoute.fullPath }

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -223,9 +223,9 @@ export default function Actions() {
 						domainName
 					) }
 					description={ createInterpolateElement(
-						__( 'Are you sure you want to detach this domain? <link />' ),
+						__( 'Are you sure you want to detach this domain? <learnMoreLink />' ),
 						{
-							link: (
+							learnMoreLink: (
 								<InlineSupportLink
 									onClick={ () => setIsDisconnectDialogOpen( false ) }
 									supportContext="domain-detach-from-site"

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -222,9 +222,7 @@ export default function Actions() {
 						__( 'Detach domain %s' ),
 						domainName
 					) }
-				/>
-				<p>
-					{ createInterpolateElement(
+					description={ createInterpolateElement(
 						__( 'Are you sure you want to detach this domain? <link />' ),
 						{
 							link: (
@@ -235,7 +233,7 @@ export default function Actions() {
 							),
 						}
 					) }
-				</p>
+				/>
 			</ConfirmDialog>
 
 			<RemoveDomainDialog

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -13,12 +13,14 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { domainRoute, domainsRoute, domainTransferRoute } from '../../app/router/domains';
 import { ActionList } from '../../components/action-list';
+import InlineSupportLink from '../../components/inline-support-link';
 import RemoveDomainDialog from '../../components/purchase-dialogs/remove-domain-dialog';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
@@ -214,7 +216,26 @@ export default function Actions() {
 				onCancel={ () => setIsDisconnectDialogOpen( false ) }
 				onConfirm={ onDisconnectConfirm }
 			>
-				{ __( 'Are you sure you want to detach this domain?' ) }
+				<SectionHeader
+					title={ sprintf(
+						/* translators: %s is the domain name */
+						__( 'Detach domain %s' ),
+						domainName
+					) }
+				/>
+				<p>
+					{ createInterpolateElement(
+						__( 'Are you sure you want to detach this domain? <link />' ),
+						{
+							link: (
+								<InlineSupportLink
+									onClick={ () => setIsDisconnectDialogOpen( false ) }
+									supportContext="domain-detach-from-site"
+								/>
+							),
+						}
+					) }
+				</p>
 			</ConfirmDialog>
 
 			<RemoveDomainDialog

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -39,46 +39,51 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 	return (
 		<Card>
 			<CardBody>
-				<SectionHeader title={ __( 'DNSSEC' ) } level={ 3 } />
-				<p>
-					{ createInterpolateElement(
+				<SectionHeader
+					title={ __( 'DNSSEC' ) }
+					description={ createInterpolateElement(
 						__( 'A security feature that helps protect your domain from DNS hijacking. <link />' ),
 						{ link: <InlineSupportLink supportContext="domain-dnssec" /> }
 					) }
+					level={ 3 }
+				/>
+				<p>
+					{ ! domain.is_dnssec_supported ? (
+						<Text>{ __( 'DNSSEC is not supported for this domain.' ) }</Text>
+					) : (
+						<VStack spacing={ 4 }>
+							<HStack alignment="left">
+								<ToggleControl
+									__nextHasNoMarginBottom
+									checked={ domain.is_dnssec_enabled ?? false }
+									onChange={ ( checked ) => handleToggleChange( checked ) }
+									disabled={ isPending }
+									label={
+										domain.is_dnssec_enabled ? __( 'Disable DNSSEC' ) : __( 'Enable DNSSEC' )
+									}
+								/>
+							</HStack>
+							{ domain.is_dnssec_enabled && (
+								<VStack spacing={ 3 }>
+									{ domain.dnssec_records?.dnskey?.map( ( dnskey, index ) => (
+										<DnsSecRecordTextarea
+											key={ `dnskey-${ index }` }
+											value={ dnskey }
+											label="DNSKEY Record"
+										/>
+									) ) }
+									{ domain.dnssec_records?.ds_data?.map( ( dsRecord, index ) => (
+										<DnsSecRecordTextarea
+											key={ `ds-${ index }` }
+											value={ dsRecord }
+											label="Delegation Signer (DS) record"
+										/>
+									) ) }
+								</VStack>
+							) }
+						</VStack>
+					) }
 				</p>
-				{ ! domain.is_dnssec_supported ? (
-					<Text>{ __( 'DNSSEC is not supported for this domain.' ) }</Text>
-				) : (
-					<VStack spacing={ 4 }>
-						<HStack alignment="left">
-							<ToggleControl
-								__nextHasNoMarginBottom
-								checked={ domain.is_dnssec_enabled ?? false }
-								onChange={ ( checked ) => handleToggleChange( checked ) }
-								disabled={ isPending }
-								label={ domain.is_dnssec_enabled ? __( 'Disable DNSSEC' ) : __( 'Enable DNSSEC' ) }
-							/>
-						</HStack>
-						{ domain.is_dnssec_enabled && (
-							<VStack spacing={ 3 }>
-								{ domain.dnssec_records?.dnskey?.map( ( dnskey, index ) => (
-									<DnsSecRecordTextarea
-										key={ `dnskey-${ index }` }
-										value={ dnskey }
-										label="DNSKEY Record"
-									/>
-								) ) }
-								{ domain.dnssec_records?.ds_data?.map( ( dsRecord, index ) => (
-									<DnsSecRecordTextarea
-										key={ `ds-${ index }` }
-										value={ dsRecord }
-										label="Delegation Signer (DS) record"
-									/>
-								) ) }
-							</VStack>
-						) }
-					</VStack>
-				) }
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -42,8 +42,10 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 				<SectionHeader
 					title={ __( 'DNSSEC' ) }
 					description={ createInterpolateElement(
-						__( 'A security feature that helps protect your domain from DNS hijacking. <link />' ),
-						{ link: <InlineSupportLink supportContext="domain-dnssec" /> }
+						__(
+							'A security feature that helps protect your domain from DNS hijacking. <learnMoreLink />'
+						),
+						{ learnMoreLink: <InlineSupportLink supportContext="domain-dnssec" /> }
 					) }
 					level={ 3 }
 				/>

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -6,8 +6,11 @@ import {
 	__experimentalVStack as VStack,
 	ToggleControl,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
+import { SectionHeader } from '../../components/section-header';
 import { DnsSecRecordTextarea } from './dnssec-record-textarea';
 import type { Domain } from '@automattic/api-core';
 
@@ -36,6 +39,13 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 	return (
 		<Card>
 			<CardBody>
+				<SectionHeader title={ __( 'DNSSEC' ) } level={ 3 } />
+				<p>
+					{ createInterpolateElement(
+						__( 'A security feature that helps protect your domain from DNS hijacking. <link />' ),
+						{ link: <InlineSupportLink supportContext="domain-dnssec" /> }
+					) }
+				</p>
 				{ ! domain.is_dnssec_supported ? (
 					<Text>{ __( 'DNSSEC is not supported for this domain.' ) }</Text>
 				) : (

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -70,9 +70,9 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 
 		// If we get here, there is an issue with the certificate that can be fixed by the user.
 		return createInterpolateElement(
-			__( 'There is an issue with your certificate. Contact us to <link>learn more</link>.' ),
+			__( 'There is an issue with your certificate. Contact us to <learnMoreLink />.' ),
 			{
-				link: <InlineSupportLink supportLink={ CONTACT } />,
+				learnMoreLink: <InlineSupportLink supportLink={ CONTACT } />,
 			}
 		);
 	};

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -43,7 +43,7 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 		if ( sslDetails.certificate_provisioned ) {
 			return createInterpolateElement(
 				__(
-					/* translators: <link> will be replaced with an a support link */
+					/* translators: <learnMoreLink> will be replaced with an a support link */
 					'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. <learnMoreLink />'
 				),
 				{

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useCallback } from 'react';
@@ -13,6 +14,7 @@ import { useAuth } from '../../app/auth';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { getDomainSiteSlug } from '../../utils/domain';
@@ -54,7 +56,20 @@ export default function NameServers() {
 	);
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					description={ createInterpolateElement(
+						__( 'Change the name servers for your domain. <link />' ),
+						{
+							link: <InlineSupportLink supportContext="nameservers" />,
+						}
+					) }
+					prefix={ <Breadcrumbs length={ 2 } /> }
+				/>
+			}
+		>
 			<Card>
 				<CardBody>
 					<NameServersForm

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -61,9 +61,9 @@ export default function NameServers() {
 			header={
 				<PageHeader
 					description={ createInterpolateElement(
-						__( 'Change the name servers for your domain. <link />' ),
+						__( 'Change the name servers for your domain. <learnMoreLink />' ),
 						{
-							link: <InlineSupportLink supportContext="nameservers" />,
+							learnMoreLink: <InlineSupportLink supportContext="nameservers" />,
 						}
 					) }
 					prefix={ <Breadcrumbs length={ 2 } /> }


### PR DESCRIPTION
Adds Learn more links to all domain screens

Part of [DOMAINS-1764: Add support links to domain settings](https://linear.app/a8c/issue/DOMAINS-1764/add-support-links-to-domain-settings)

I found out some bugs with how the `InlineSupportLink` component works that I'll report:
* Clicking on the close button of the inline support pop-up sometimes shows "500 Error" in Firefox
* In some cases clicking on Learn more opens the wrong support page in the inline pop-up

## Proposed Changes

* Add page description and Learn more links to:
  * Domain forwarding
  * Name servers
  * Email setup form
  * DNSSEC toggle
  * Glue records
  * Detach domain action pop-up
* Fix the button label for the DNS section so that the actions are now rendered correctly next to the header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Give customers more information on how to use the different features

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit any of the above sections and click on the Learn more links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
