### PR TITLE
Add Domain Connect flow

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -317,8 +317,6 @@ function ConnectDomainStep( {
 						{ __( 'Back' ) }
 					</BackButton>
 				) }
-
-				<div>cucucucuc</div>
 				<ConnectDomainSteps
 					baseClassName={ baseClassName }
 					domain={ domain }

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -317,6 +317,8 @@ function ConnectDomainStep( {
 						{ __( 'Back' ) }
 					</BackButton>
 				) }
+
+				<div>cucucucuc</div>
 				<ConnectDomainSteps
 					baseClassName={ baseClassName }
 					domain={ domain }

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -25,7 +25,6 @@ import {
 	lazyRouteComponent,
 } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { StepName } from '../../domains/domain-connection-setup/types';
 import {
 	checkDomainNameServersPermissions,
 	checkDomainTransferPermissions,
@@ -101,6 +100,14 @@ export const domainRoute = createRoute( {
 		}
 
 		return domain;
+	},
+	validateSearch: ( search ): { error?: string; error_description?: string } => {
+		// Validate query parameters for Domain Connect flow
+		return {
+			error: typeof search.error === 'string' ? search.error : undefined,
+			error_description:
+				typeof search.error_description === 'string' ? search.error_description : undefined,
+		};
 	},
 } ).lazy( () =>
 	import( '../../domains/domain' ).then( ( d ) =>
@@ -549,7 +556,7 @@ export const domainConnectionSetupRoute = createRoute( {
 			domainConnectionSetupInfoQuery(
 				domainName,
 				domain.blog_id,
-				`${ window.location.href }?step=${ StepName.DC_RETURN }`
+				`${ location.origin + location.pathname }`
 			)
 		);
 	},

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -101,14 +101,6 @@ export const domainRoute = createRoute( {
 
 		return domain;
 	},
-	validateSearch: ( search ): { error?: string; error_description?: string } => {
-		// Validate query parameters for Domain Connect flow
-		return {
-			error: typeof search.error === 'string' ? search.error : undefined,
-			error_description:
-				typeof search.error_description === 'string' ? search.error_description : undefined,
-		};
-	},
 } ).lazy( () =>
 	import( '../../domains/domain' ).then( ( d ) =>
 		createLazyRoute( 'domain' )( {
@@ -556,9 +548,18 @@ export const domainConnectionSetupRoute = createRoute( {
 			domainConnectionSetupInfoQuery(
 				domainName,
 				domain.blog_id,
-				`${ location.origin + location.pathname }`
+				`${ location.origin + location.pathname }?step=dc_return`
 			)
 		);
+	},
+	validateSearch: ( search ): { error?: string; error_description?: string; step?: string } => {
+		// Validate query parameters for Domain Connect flow
+		return {
+			error: typeof search.error === 'string' ? search.error : undefined,
+			error_description:
+				typeof search.error_description === 'string' ? search.error_description : undefined,
+			step: typeof search.step === 'string' ? search.step : undefined,
+		};
 	},
 } ).lazy( () =>
 	config.isEnabled( 'domain-connection-redesign' )

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -55,8 +55,10 @@ export default function ConnectionModeCard( {
 }: ConnectionModeCardProps ) {
 	const isSelected = selectedMode === mode;
 
-	// Track which steps are expanded
-	const [ stepsExpanded, setStepsExpanded ] = useState< boolean[] >( steps.map( () => false ) );
+	// Track which steps are expanded (first step expanded by default)
+	const [ stepsExpanded, setStepsExpanded ] = useState< boolean[] >(
+		steps.map( ( _, index ) => index === 0 )
+	);
 
 	const handleStepChange = ( index: number, checked: boolean ) => {
 		onStepChange( index, checked );

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -1,8 +1,4 @@
 import {
-	DomainConnectionSetupMode,
-	type DomainConnectionSetupModeValue,
-} from '@automattic/api-core';
-import {
 	Button,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -18,9 +14,8 @@ interface DomainConnectCardProps {
 	onChangeSetupMode: () => void;
 	error?: string | null;
 	errorDescription?: string | null;
-	onVerifyConnection: ( mode: DomainConnectionSetupModeValue ) => void;
+	onVerifyConnection: () => void;
 	isUpdatingConnectionMode: boolean;
-	domainConnectUrl: string;
 }
 
 export default function DomainConnectCard( {
@@ -29,7 +24,6 @@ export default function DomainConnectCard( {
 	isUpdatingConnectionMode,
 	error,
 	errorDescription,
-	domainConnectUrl,
 }: DomainConnectCardProps ) {
 	const renderErrorMessage = () => {
 		const noticeText =
@@ -82,11 +76,6 @@ export default function DomainConnectCard( {
 		);
 	};
 
-	const startSetup = () => {
-		onVerifyConnection( DomainConnectionSetupMode.DC );
-		window.location.href = domainConnectUrl;
-	};
-
 	return (
 		<Card>
 			<CardBody>
@@ -98,7 +87,7 @@ export default function DomainConnectCard( {
 							variant="primary"
 							isBusy={ isUpdatingConnectionMode }
 							disabled={ isUpdatingConnectionMode }
-							onClick={ startSetup }
+							onClick={ onVerifyConnection }
 						>
 							{ __( 'Start setup' ) }
 						</Button>

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -65,7 +65,7 @@ export default function DomainConnectCard( {
 				<Text>
 					{ createInterpolateElement(
 						__(
-							"Your domain name provider supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to you registrar platform when prompted, and we'll handle the rest."
+							'Your domain name provider supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to your registrar platform when prompted, and we’ll handle the rest.'
 						),
 						{
 							b: <b />,

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -1,0 +1,124 @@
+import {
+	DomainConnectionSetupMode,
+	type DomainConnectionSetupModeValue,
+} from '@automattic/api-core';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
+
+interface DomainConnectCardProps {
+	onChangeSetupMode: () => void;
+	error?: string | null;
+	errorDescription?: string | null;
+	onVerifyConnection: ( mode: DomainConnectionSetupModeValue ) => void;
+	isUpdatingConnectionMode: boolean;
+	domainConnectUrl: string;
+}
+
+export default function DomainConnectCard( {
+	onChangeSetupMode,
+	onVerifyConnection,
+	isUpdatingConnectionMode,
+	error,
+	errorDescription,
+	domainConnectUrl,
+}: DomainConnectCardProps ) {
+	const renderErrorMessage = () => {
+		const noticeText =
+			error === 'access_denied' && errorDescription?.startsWith( 'user_cancel' )
+				? __( 'Connecting your domain to WordPress.com was cancelled' )
+				: __( 'There was a problem connecting your domain' );
+
+		return (
+			<>
+				<Notice variant="error">{ noticeText }</Notice>
+				<Text size="medium" weight={ 500 }>
+					{ __( 'Something went wrong' ) }
+				</Text>
+				<Text>
+					{ createInterpolateElement(
+						__(
+							'There was a problem completing your Domain Connect setup. You can retry the setup process, or use our <link>manual setup</link> option instead.'
+						),
+						{
+							link: <Button variant="link" onClick={ onChangeSetupMode } />,
+						}
+					) }
+				</Text>
+			</>
+		);
+	};
+
+	const renderDefaultContent = () => {
+		return (
+			<>
+				<Notice variant="info">
+					{ __(
+						'Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
+					) }
+				</Notice>
+				<Text size="medium" weight={ 500 }>
+					{ __( 'Domain Connect available' ) }
+				</Text>
+				<Text>
+					{ createInterpolateElement(
+						__(
+							"Your domain name provider supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to you registrar platform when prompted, and we'll handle the rest."
+						),
+						{
+							b: <b />,
+						}
+					) }
+				</Text>
+			</>
+		);
+	};
+
+	const startSetup = () => {
+		onVerifyConnection( DomainConnectionSetupMode.DC );
+		window.location.href = domainConnectUrl;
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 6 }>
+					{ error && renderErrorMessage() }
+					{ ! error && renderDefaultContent() }
+					<ButtonStack justify="flex-start">
+						<Button
+							variant="primary"
+							isBusy={ isUpdatingConnectionMode }
+							disabled={ isUpdatingConnectionMode }
+							onClick={ startSetup }
+						>
+							{ __( 'Start setup' ) }
+						</Button>
+					</ButtonStack>
+					<Text size="medium" weight={ 500 }>
+						{ __( 'Need help?' ) }
+					</Text>
+					<VStack spacing={ 2 }>
+						<InlineSupportLink supportContext="map-domain-setup-instructions">
+							{ __( 'Domain connection guide' ) }
+						</InlineSupportLink>
+						<InlineSupportLink supportContext="general-support-options">
+							{ __( 'Contact support' ) }
+						</InlineSupportLink>
+						<Button variant="link" onClick={ onChangeSetupMode } style={ { lineHeight: '20px' } }>
+							{ __( 'Use manual setup' ) }
+						</Button>
+					</VStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -163,7 +163,6 @@ export default function DomainConnectionSetup( {
 
 	if (
 		connectionMode === DomainConnectionSetupMode.DC &&
-		domainMappingStatus.mode === null &&
 		domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null
 	) {
 		return (

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -201,11 +201,11 @@ export default function DomainConnectionSetup( {
 				<ConnectionModeCard
 					mode={ DomainConnectionSetupMode.SUGGESTED }
 					title={ __( 'I only use this domain name for my website' ) }
-					description={ __( "You'll update your name servers to point to WordPress.com" ) }
+					description={ __( 'You’ll update your name servers to point to WordPress.com' ) }
 					infoText={ sprintf(
 						// translators: %s is the domain name
 						__(
-							"Name servers connect your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We'll email you when it's done."
+							'Name servers connect your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
 						),
 						domainName
 					) }
@@ -227,7 +227,7 @@ export default function DomainConnectionSetup( {
 					infoText={ sprintf(
 						// translators: %s is the domain name
 						__(
-							"DNS records point your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We'll email you when it's done."
+							'DNS records point your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
 						),
 						domainName
 					) }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -29,7 +29,6 @@ interface DomainConnectionSetupProps {
 	domainMappingStatus: DomainMappingStatus;
 	queryError?: string | null;
 	queryErrorDescription?: string | null;
-	domainConnectUrl?: string;
 }
 
 export default function DomainConnectionSetup( {
@@ -171,11 +170,10 @@ export default function DomainConnectionSetup( {
 			<div className="domain-connection-setup">
 				<DomainConnectCard
 					onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
-					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.SUGGESTED ) }
+					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.DC ) }
 					isUpdatingConnectionMode={ isUpdatingConnectionMode }
 					error={ queryError }
 					errorDescription={ queryErrorDescription }
-					domainConnectUrl={ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting }
 				/>
 			</div>
 		);

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -4,11 +4,20 @@ import {
 	type DomainConnectionSetupModeValue,
 	DomainMappingStatus,
 } from '@automattic/api-core';
-import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	Button,
+	Icon,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
 import { useState } from 'react';
+import { Card, CardBody } from '../../components/card';
 import ConnectionModeCard from './connection-mode-card';
 import DNSRecordsDataView from './dns-records-dataview';
+import DomainConnectCard from './domain-connect-card';
 import NameserversDataView from './nameservers-dataview';
 
 interface DomainConnectionSetupProps {
@@ -18,6 +27,9 @@ interface DomainConnectionSetupProps {
 	onVerifyConnection: ( mode: DomainConnectionSetupModeValue ) => void;
 	isUpdatingConnectionMode: boolean;
 	domainMappingStatus: DomainMappingStatus;
+	queryError?: string | null;
+	queryErrorDescription?: string | null;
+	domainConnectUrl?: string;
 }
 
 export default function DomainConnectionSetup( {
@@ -26,11 +38,17 @@ export default function DomainConnectionSetup( {
 	domainMappingStatus,
 	domainName,
 	domainConnectionSetupInfo,
+	queryError,
+	queryErrorDescription,
 }: DomainConnectionSetupProps ) {
+	const domainConnectAvailable =
+		domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null;
+	const recommendedMode = domainMappingStatus.has_mx_records
+		? DomainConnectionSetupMode.ADVANCED
+		: DomainConnectionSetupMode.SUGGESTED;
+
 	const [ connectionMode, setConnectionMode ] = useState< DomainConnectionSetupModeValue >(
-		domainMappingStatus.has_mx_records
-			? DomainConnectionSetupMode.ADVANCED
-			: DomainConnectionSetupMode.SUGGESTED
+		domainConnectAvailable ? DomainConnectionSetupMode.DC : recommendedMode
 	);
 	const [ suggestedStepsCompleted, setSuggestedStepsCompleted ] = useState< boolean[] >( [
 		false,
@@ -144,9 +162,44 @@ export default function DomainConnectionSetup( {
 		} );
 	};
 
+	if (
+		connectionMode === DomainConnectionSetupMode.DC &&
+		domainMappingStatus.mode === null &&
+		domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null
+	) {
+		return (
+			<div className="domain-connection-setup">
+				<DomainConnectCard
+					onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
+					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.SUGGESTED ) }
+					isUpdatingConnectionMode={ isUpdatingConnectionMode }
+					error={ queryError }
+					errorDescription={ queryErrorDescription }
+					domainConnectUrl={ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting }
+				/>
+			</div>
+		);
+	}
+
 	return (
 		<div className="domain-connection-setup">
 			<VStack spacing={ 4 }>
+				{ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null && (
+					<Card>
+						<CardBody>
+							<HStack spacing={ 2 } justify="flex-start">
+								<Icon icon={ globe } />
+								<Text>{ __( 'This domain name can be automatically connected.' ) }</Text>
+								<Button
+									variant="link"
+									onClick={ () => setConnectionMode( DomainConnectionSetupMode.DC ) }
+								>
+									{ __( 'Use domain connect' ) }
+								</Button>
+							</HStack>
+						</CardBody>
+					</Card>
+				) }
 				<ConnectionModeCard
 					mode={ DomainConnectionSetupMode.SUGGESTED }
 					title={ __( 'I only use this domain name for my website' ) }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -24,8 +24,6 @@ interface DomainConnectionVerificationProps {
 	siteSlug: string;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
 	domainMappingStatus: DomainMappingStatus;
-	queryError: string | null;
-	queryErrorDescription: string | null;
 }
 
 export default function DomainConnectionVerification( {

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -57,7 +57,6 @@ export default function DomainConnection() {
 	const onVerifyConnection = ( mode: DomainConnectionSetupModeValue ) => {
 		updateConnectionMode( mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
-				setConnectionMode( data.mode );
 				recordTracksEvent( 'calypso_dashboard_domain_connection_setup', {
 					domain: domainName,
 					mode,
@@ -67,12 +66,19 @@ export default function DomainConnection() {
 						!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting,
 					domain_connect_provider_id: domainConnectionSetupInfo.domain_connect_provider_id,
 				} );
+
+				// Check if we need to redirect for Domain Connect
 				if (
 					mode === DomainConnectionSetupMode.DC &&
 					domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
 				) {
+					// Redirect immediately without updating local state to avoid flash of verification step
 					window.location.href = domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting;
+					return;
 				}
+
+				// Only set connection mode if we're not redirecting
+				setConnectionMode( data.mode );
 			},
 			onError: () => {
 				createErrorNotice(

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -67,6 +67,16 @@ export default function DomainConnection() {
 					domain_connect_provider_id: domainConnectionSetupInfo.domain_connect_provider_id,
 				} );
 
+				// Clear error query params from URL after successful mutation
+				if ( queryError || queryErrorDescription ) {
+					router.navigate( {
+						to: domainConnectionSetupRoute.fullPath,
+						params: { domainName },
+						search: {},
+						replace: true,
+					} );
+				}
+
 				// Check if we need to redirect for Domain Connect
 				if (
 					mode === DomainConnectionSetupMode.DC &&

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -21,12 +22,9 @@ import './style.scss';
 
 export default function DomainConnection() {
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 	const { domainName } = domainRoute.useParams();
-	const {
-		error: queryError,
-		error_description: queryErrorDescription,
-		// domain_connect: domainConnect,
-	} = domainRoute.useSearch();
+	const { error: queryError, error_description: queryErrorDescription } = domainRoute.useSearch();
 	// Load domain data
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const siteSlug = domain.site_slug;
@@ -38,7 +36,6 @@ export default function DomainConnection() {
 		params: { domainName },
 	} ).href;
 	const returnUrl = new URL( relativePath, window.location.origin ).href;
-	// const returnUrl = new URL( relativePath, window.location.origin ).href + '?domain-connect';
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
 		domainConnectionSetupInfoQuery( domainName, domain.blog_id, returnUrl )
 	);
@@ -57,6 +54,15 @@ export default function DomainConnection() {
 		updateConnectionMode( mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
 				setConnectionMode( data.mode );
+				recordTracksEvent( 'calypso_dashboard_domain_glue_records_update_record', {
+					domain: domainName,
+					mode,
+					query_error: queryError,
+					query_error_description: queryErrorDescription,
+					supports_our_domain_connect_template:
+						!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting,
+					domain_connect_provider_id: domainConnectionSetupInfo.domain_connect_provider_id,
+				} );
 			},
 			onError: () => {
 				createErrorNotice(

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -1,4 +1,8 @@
-import { DomainMappingStatus, type DomainConnectionSetupModeValue } from '@automattic/api-core';
+import {
+	DomainMappingStatus,
+	type DomainConnectionSetupModeValue,
+	DomainConnectionSetupMode,
+} from '@automattic/api-core';
 import {
 	domainConnectionSetupInfoQuery,
 	domainMappingStatusQuery,
@@ -63,6 +67,12 @@ export default function DomainConnection() {
 						!! domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting,
 					domain_connect_provider_id: domainConnectionSetupInfo.domain_connect_provider_id,
 				} );
+				if (
+					mode === DomainConnectionSetupMode.DC &&
+					domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
+				) {
+					window.location.href = domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting;
+				}
 			},
 			onError: () => {
 				createErrorNotice(

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -22,8 +22,11 @@ import './style.scss';
 export default function DomainConnection() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
-	const { error: queryError, error_description: queryErrorDescription } = domainRoute.useSearch();
-
+	const {
+		error: queryError,
+		error_description: queryErrorDescription,
+		// domain_connect: domainConnect,
+	} = domainRoute.useSearch();
 	// Load domain data
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const siteSlug = domain.site_slug;
@@ -34,7 +37,8 @@ export default function DomainConnection() {
 		to: domainConnectionSetupRoute.fullPath,
 		params: { domainName },
 	} ).href;
-	const returnUrl = new URL( relativePath, window.location.origin ).href + '?step=dc_return';
+	const returnUrl = new URL( relativePath, window.location.origin ).href;
+	// const returnUrl = new URL( relativePath, window.location.origin ).href + '?domain-connect';
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
 		domainConnectionSetupInfoQuery( domainName, domain.blog_id, returnUrl )
 	);
@@ -86,15 +90,13 @@ export default function DomainConnection() {
 				/>
 			}
 		>
-			{ isVerificationStep ? (
+			{ isVerificationStep && ! queryError ? (
 				<DomainConnectionVerification
 					domainData={ domain }
 					domainName={ domainName }
 					siteSlug={ siteSlug }
 					domainConnectionSetupInfo={ domainConnectionSetupInfo }
 					domainMappingStatus={ domainMappingStatus }
-					queryError={ queryError }
-					queryErrorDescription={ queryErrorDescription }
 				/>
 			) : (
 				<DomainConnectionSetup
@@ -104,6 +106,8 @@ export default function DomainConnection() {
 					domainMappingStatus={ domainMappingStatus }
 					onVerifyConnection={ onVerifyConnection }
 					isUpdatingConnectionMode={ isUpdatingConnectionMode }
+					queryError={ queryError }
+					queryErrorDescription={ queryErrorDescription }
 				/>
 			) }
 		</PageLayout>

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -14,7 +14,7 @@ import { useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { domainRoute, domainConnectionSetupRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -28,7 +28,11 @@ export default function DomainConnection() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 	const { domainName } = domainRoute.useParams();
-	const { error: queryError, error_description: queryErrorDescription } = domainRoute.useSearch();
+	const {
+		error: queryError,
+		error_description: queryErrorDescription,
+		step,
+	} = domainConnectionSetupRoute.useSearch();
 	// Load domain data
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const siteSlug = domain.site_slug;
@@ -39,7 +43,8 @@ export default function DomainConnection() {
 		to: domainConnectionSetupRoute.fullPath,
 		params: { domainName },
 	} ).href;
-	const returnUrl = new URL( relativePath, window.location.origin ).href;
+	// Add domain_connect parameter to return URL so we know when user comes back from DC
+	const returnUrl = new URL( relativePath, window.location.origin ).href + '?step=dc_return';
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
 		domainConnectionSetupInfoQuery( domainName, domain.blog_id, returnUrl )
 	);
@@ -54,7 +59,22 @@ export default function DomainConnection() {
 		updateConnectionModeMutation( domainName, domain.blog_id )
 	);
 
+	// Sync local state with server state when it changes (e.g., on page reload)
+	useEffect( () => {
+		setConnectionMode( domainMappingStatus.mode );
+	}, [ domainMappingStatus.mode ] );
+
 	const onVerifyConnection = ( mode: DomainConnectionSetupModeValue ) => {
+		// For Domain Connect, just redirect - don't update server yet
+		if (
+			mode === DomainConnectionSetupMode.DC &&
+			domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
+		) {
+			window.location.href = domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting;
+			return;
+		}
+
+		// For manual modes (SUGGESTED/ADVANCED), update the server
 		updateConnectionMode( mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
 				recordTracksEvent( 'calypso_dashboard_domain_connection_setup', {
@@ -77,29 +97,54 @@ export default function DomainConnection() {
 					} );
 				}
 
-				// Check if we need to redirect for Domain Connect
-				if (
-					mode === DomainConnectionSetupMode.DC &&
-					domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting
-				) {
-					// Redirect immediately without updating local state to avoid flash of verification step
-					window.location.href = domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting;
-					return;
-				}
-
-				// Only set connection mode if we're not redirecting
+				// Set connection mode to show verification step
 				setConnectionMode( data.mode );
 			},
 			onError: () => {
-				createErrorNotice(
-					__( 'We couldn’t verify the connection for your domain, please try again.' ),
-					{
-						type: 'snackbar',
-					}
-				);
+				createErrorNotice( __( 'We could not verify your domain connection. Please try again.' ), {
+					type: 'snackbar',
+				} );
 			},
 		} );
 	};
+
+	// If returning from successful Domain Connect, update the server
+	useEffect( () => {
+		if ( step === 'dc_return' && ! queryError && ! isUpdatingConnectionMode ) {
+			// Call mutation to set mode to DC
+			updateConnectionMode( DomainConnectionSetupMode.DC, {
+				onSuccess: ( data: DomainMappingStatus ) => {
+					recordTracksEvent( 'calypso_dashboard_domain_connection_setup', {
+						domain: domainName,
+						mode: DomainConnectionSetupMode.DC,
+						query_error: null,
+						query_error_description: null,
+						supports_our_domain_connect_template: true,
+						domain_connect_provider_id: domainConnectionSetupInfo.domain_connect_provider_id,
+					} );
+
+					// Clear the domain_connect param from URL
+					router.navigate( {
+						to: domainConnectionSetupRoute.fullPath,
+						params: { domainName },
+						search: {},
+						replace: true,
+					} );
+
+					setConnectionMode( data.mode );
+				},
+			} );
+		}
+	}, [
+		step,
+		queryError,
+		isUpdatingConnectionMode,
+		updateConnectionMode,
+		recordTracksEvent,
+		domainName,
+		domainConnectionSetupInfo.domain_connect_provider_id,
+		router,
+	] );
 
 	// If the connection mode is not null, it means we are on the verification step
 	const isVerificationStep = !! connectionMode;

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -54,7 +54,7 @@ export default function DomainConnection() {
 		updateConnectionMode( mode, {
 			onSuccess: ( data: DomainMappingStatus ) => {
 				setConnectionMode( data.mode );
-				recordTracksEvent( 'calypso_dashboard_domain_glue_records_update_record', {
+				recordTracksEvent( 'calypso_dashboard_domain_connection_setup', {
 					domain: domainName,
 					mode,
 					query_error: queryError,

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	DomainConnectionSetupMode,
+	DomainMappingSetupInfo,
+	DomainMappingStatus,
+} from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import DomainConnectionSetup from '../domain-connection-setup';
+
+// Mock InlineSupportLink to avoid async state update warnings
+jest.mock( '../../../components/inline-support-link', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <button>{ children }</button>,
+} ) );
+
+const createMockDomainMappingStatus = (
+	overrides?: Partial< DomainMappingStatus >
+): DomainMappingStatus => ( {
+	has_mapping_records: false,
+	has_wpcom_nameservers: false,
+	has_wpcom_ip_addresses: false,
+	has_cloudflare_ip_addresses: false,
+	has_mx_records: false,
+	www_cname_record_target: null,
+	resolves_to_wpcom: false,
+	host_ip_addresses: [],
+	name_servers: [],
+	mode: null,
+	...overrides,
+} );
+
+const createMockDomainConnectionSetupInfo = (
+	overrides?: Partial< DomainMappingSetupInfo >
+): DomainMappingSetupInfo => ( {
+	connection_mode: null,
+	domain_connect_apply_wpcom_hosting: null,
+	domain_connect_provider_id: null,
+	default_ip_addresses: [ '192.0.2.1' ],
+	wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+	is_subdomain: false,
+	root_domain: 'example.com',
+	...overrides,
+} );
+
+describe( 'DomainConnectionSetup', () => {
+	const defaultProps = {
+		domainName: 'example.com',
+		siteSlug: 'example.wordpress.com',
+		onVerifyConnection: jest.fn(),
+		isUpdatingConnectionMode: false,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Domain Connect Available', () => {
+		test( 'renders Domain Connect card by default when DC is available and mode is null', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+				domain_connect_provider_id: 'godaddy',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show Domain Connect card
+			expect( screen.getByText( 'Domain Connect available' ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Start setup' } ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Use manual setup' } ) ).toBeVisible();
+		} );
+
+		test( 'renders error message when error query params are present', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					queryError="access_denied"
+					queryErrorDescription="user_cancel"
+				/>
+			);
+
+			// Should show error message
+			expect(
+				screen.getByText( 'Connecting your domain to WordPress.com was cancelled' )
+			).toBeVisible();
+			expect( screen.getByText( 'Something went wrong' ) ).toBeVisible();
+			expect(
+				screen.getByText( /There was a problem completing your Domain Connect setup/ )
+			).toBeVisible();
+		} );
+
+		test( 'renders generic error message for non-cancellation errors', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					queryError="server_error"
+					queryErrorDescription="internal_error"
+				/>
+			);
+
+			// Should show generic error message
+			expect( screen.getByText( 'There was a problem connecting your domain' ) ).toBeVisible();
+		} );
+
+		test( 'switches to manual setup when "Use manual setup" is clicked', async () => {
+			const user = userEvent.setup();
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Click "Use manual setup" button
+			const manualSetupButton = screen.getByRole( 'button', { name: 'Use manual setup' } );
+			await user.click( manualSetupButton );
+
+			// Should now show manual setup cards
+			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+			expect(
+				screen.getByText( 'I use this domain name for email or other services' )
+			).toBeVisible();
+
+			// Should show banner to switch back to DC
+			expect(
+				screen.getByText( 'This domain name can be automatically connected.' )
+			).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Use domain connect' } ) ).toBeVisible();
+		} );
+
+		test( 'calls onVerifyConnection with DC mode when "Start setup" is clicked', async () => {
+			const user = userEvent.setup();
+			const onVerifyConnection = jest.fn();
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					onVerifyConnection={ onVerifyConnection }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			const startSetupButton = screen.getByRole( 'button', { name: 'Start setup' } );
+			await user.click( startSetupButton );
+
+			expect( onVerifyConnection ).toHaveBeenCalledWith( DomainConnectionSetupMode.DC );
+		} );
+	} );
+
+	describe( 'Domain Connect Not Available', () => {
+		test( 'renders manual setup cards when DC is not available', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show manual setup cards
+			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+			expect(
+				screen.getByText( 'I use this domain name for email or other services' )
+			).toBeVisible();
+
+			// Should NOT show Domain Connect card or banner
+			expect( screen.queryByText( 'Domain Connect available' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'This domain name can be automatically connected.' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'defaults to suggested mode when no MX records detected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Suggested mode card should be expanded (shows steps)
+			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
+			expect( screen.getByText( '2. Back up DNS records' ) ).toBeVisible();
+			expect( screen.getByText( '3. Update name servers' ) ).toBeVisible();
+		} );
+
+		test( 'defaults to advanced mode when MX records detected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: true,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Advanced mode card should be expanded (shows steps)
+			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
+			expect( screen.getByText( '2. Back up DNS records' ) ).toBeVisible();
+			expect( screen.getByText( '3. Update DNS records' ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Mode Switching', () => {
+		test( 'switches from manual to Domain Connect when "Use domain connect" is clicked', async () => {
+			const user = userEvent.setup();
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Start at DC card, switch to manual
+			const manualSetupButton = screen.getByRole( 'button', { name: 'Use manual setup' } );
+			await user.click( manualSetupButton );
+
+			// Verify we're at manual setup
+			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+
+			// Switch back to DC
+			const useDomainConnectButton = screen.getByRole( 'button', {
+				name: 'Use domain connect',
+			} );
+			await user.click( useDomainConnectButton );
+
+			// Should be back at Domain Connect card
+			expect( screen.getByText( 'Domain Connect available' ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Mode Already Set', () => {
+		test( 'does not show Domain Connect card when mode is already set', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.SUGGESTED,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show manual cards, not DC card, even though DC is available
+			expect( screen.queryByText( 'Domain Connect available' ) ).not.toBeInTheDocument();
+			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
+
+			// Should still show the banner to switch to DC
+			expect(
+				screen.getByText( 'This domain name can be automatically connected.' )
+			).toBeVisible();
+		} );
+	} );
+
+	describe( 'Help Links', () => {
+		test( 'renders help section in Domain Connect card', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			expect( screen.getByText( 'Need help?' ) ).toBeVisible();
+			// InlineSupportLink components are present
+			expect( screen.getByRole( 'button', { name: 'Use manual setup' } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Loading States', () => {
+		test( 'disables Start setup button when updating connection mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					isUpdatingConnectionMode
+				/>
+			);
+
+			const startSetupButton = screen.getByRole( 'button', { name: 'Start setup' } );
+			expect( startSetupButton ).toBeDisabled();
+		} );
+	} );
+} );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -295,7 +295,7 @@ describe( 'DomainConnectionSetup', () => {
 	} );
 
 	describe( 'Mode Already Set', () => {
-		test( 'does not show Domain Connect card when mode is already set', () => {
+		test( 'shows Domain Connect card when DC is available, even if server mode is set', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( {
 				mode: DomainConnectionSetupMode.SUGGESTED,
 			} );
@@ -311,14 +311,9 @@ describe( 'DomainConnectionSetup', () => {
 				/>
 			);
 
-			// Should show manual cards, not DC card, even though DC is available
-			expect( screen.queryByText( 'Domain Connect available' ) ).not.toBeInTheDocument();
-			expect( screen.getByText( 'I only use this domain name for my website' ) ).toBeVisible();
-
-			// Should still show the banner to switch to DC
-			expect(
-				screen.getByText( 'This domain name can be automatically connected.' )
-			).toBeVisible();
+			// Should show DC card because local state initializes to DC when available
+			expect( screen.getByText( 'Domain Connect available' ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Start setup' } ) ).toBeVisible();
 		} );
 	} );
 

--- a/client/dashboard/domains/domain-connection-setup/utils.ts
+++ b/client/dashboard/domains/domain-connection-setup/utils.ts
@@ -59,10 +59,10 @@ export const getProgressStepList = (
 };
 
 export function isMappingVerificationSuccess(
-	mode: DomainConnectionSetupModeValue,
+	mode: DomainConnectionSetupModeValue | null,
 	verificationStatus: DomainMappingStatus | undefined
 ) {
-	if ( ! verificationStatus ) {
+	if ( ! verificationStatus || ! mode ) {
 		return false;
 	}
 

--- a/packages/api-core/src/domain-connection-setup/types.ts
+++ b/packages/api-core/src/domain-connection-setup/types.ts
@@ -20,7 +20,7 @@ export type DomainMappingStatus = {
 	resolves_to_wpcom: boolean;
 	host_ip_addresses: string[];
 	name_servers: string[];
-	mode: DomainConnectionSetupModeValue;
+	mode: DomainConnectionSetupModeValue | null;
 };
 
 export type DomainMappingSetupInfo = {


### PR DESCRIPTION
Closes [DOMAINS-1798](https://linear.app/a8c/issue/DOMAINS-1798/implement-domain-connect-subflow)

## Proposed Changes
* Introduces **Domain Connect** as an automated connection method in the redesigned domain connection flow
* Adds a new `DomainConnectCard` component to guide users through the automated setup
* Updates the domain connection setup to prioritize Domain Connect when available from the domain provider
* Implements error handling and fallback to manual setup when Domain Connect fails or is cancelled
* Adds analytics tracking for Domain Connect usage and errors
* Improves type safety by adding `validateSearch` validation for query parameters
* Fixes cache key consistency between route loader and component

>[!NOTE]
>The registrar detection feature hasn't been implemented yet, so the messages in the UI refer to a generic registrar.

|![Screenshot 2025-11-06 alle 11 29 15](https://github.com/user-attachments/assets/0fa59385-5a05-4ecd-a5ed-9b4f06fc6f60)|![Screenshot 2025-11-06 alle 11 29 08](https://github.com/user-attachments/assets/fa4bf16e-41e5-4422-9482-137bf0e42976)|![Screenshot 2025-11-06 alle 11 30 14](https://github.com/user-attachments/assets/980ee921-b1bf-48c5-a68b-f7d76a5d6bd2)|![Screenshot 2025-11-06 alle 11 30 26](https://github.com/user-attachments/assets/91108dd4-5358-4836-b40d-83b56f9fe450)|
|:---:|:---:|:---:|:---:|
|**Setup with Domain Connect**|**Manual setup**|**Domain Connect: cancelled**|**Domain Connect: generic error**|


## Why are these changes being made?
Domain Connect is an industry-standard protocol that enables automated domain configuration. Many domain registrars support this protocol, allowing users to connect their domains to WordPress.com with just a few clicks instead of manually updating DNS records or nameservers.

This PR enhances the user experience by:
1. **Reducing friction**: Users with supported domain providers can complete the connection in seconds without needing to understand DNS or nameserver concepts
2. **Preventing errors**: Automated setup eliminates manual configuration mistakes
3. **Improving discoverability**: The UI proactively detects and offers Domain Connect when available, but still allows users to fall back to manual setup if needed or preferred
4. **Better error handling**: Clear messaging when Domain Connect fails, with easy fallback to manual methods

## Testing Instructions
### Prerequisites
* A domain that supports Domain Connect (examples: GoDaddy, 1&1 IONOS, etc.)
* The domain should be mapped to a WordPress.com site

### Test Case 1: Successful Domain Connect Flow
1. Navigate to the domain connection setup page for a domain that supports Domain Connect
2. Verify that the **"Domain Connect available"** card is displayed by default
3. Verify the informational notice about propagation time is shown
4. Click **"Start setup"**
5. Verify you're redirected to your domain registrar's authorization page
6. Approve the connection at your registrar
7. Verify you're redirected back to WordPress.com
8. Verify you see the verification page showing the connection status

### Test Case 2: Cancelled Domain Connect Flow
1. Navigate to the domain connection setup page for a domain that supports Domain Connect
2. Click **"Start setup"**
3. At the registrar page, **cancel or deny** the authorization
4. Verify you're redirected back with an error message: **"Connecting your domain to WordPress.com was cancelled"**
5. Verify the error card displays options to retry or use manual setup
6. Click **"Use manual setup"** and verify you see the suggested/advanced mode options
>[!TIP]
>As an alternative, you can manually append this query string to the setup url `error_description=user_cancel%20shopper%20canceled%20the%20request`

### Test Case 3: Domain Connect Unavailable
1. Navigate to the domain connection setup page for a domain that does **not** support Domain Connect
2. Verify the suggested/advanced mode cards are shown by default
3. Verify there's no Domain Connect option visible

### Test Case 4: Switching Between Modes
1. Navigate to a domain that supports Domain Connect
2. Verify you can click **"Use manual setup"** at the bottom and see the manual setup cards
3. Verify you see a banner: **"This domain name can be automatically connected"** with a **"Use domain connect"** link
4. Click **"Use domain connect"** and verify you return to the Domain Connect card

### Test Case 5: Verification Page Behavior
1. Complete any connection method (Domain Connect, suggested, or advanced)
2. When there are **no query error parameters**, verify the verification/connected page is shown
3. When there **are** error query parameters (e.g., `?error=access_denied`), verify the setup page is shown instead of verification

### Test Case 6: Analytics Tracking
1. Open browser console and monitor network requests
2. Complete a Domain Connect setup attempt
3. Verify a `calypso_dashboard_domain_connection_setup` Tracks event is fired with:
   - `domain`: the domain name
   - `mode`: "dc"
   - `supports_our_domain_connect_template`: true/false
   - `domain_connect_provider_id`: provider identifier
   - Error params (if applicable)

### Test Case 7: Automated Tests
1. Run the test suite: `yarn test-client client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx`
2. Verify all 12 tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
