### PR TITLE
Help Center: Dont keep chat messages when switching between two chats

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -132,7 +132,7 @@ export const useGetCombinedChat = (
 						setMainChatState( ( mainChatState ) => {
 							const isSameConversation =
 								mainChatState.odieId?.toString() === odieId?.toString() &&
-								mainChatState.conversationId === conversationId;
+								mainChatState.conversationId === conversation.id;
 
 							return {
 								...( odieChat ? odieChat : {} ),

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -129,23 +129,33 @@ export const useGetCombinedChat = (
 					if ( conversation ) {
 						// We need to load the conversation to get typing events. Load simply means "focus on".
 						Smooch.loadConversation( conversation.id );
-						setMainChatState( {
-							...( odieChat ? odieChat : {} ),
-							supportInteractionId: currentSupportInteraction.uuid,
-							conversationId: conversation.id,
-							messages: [
-								...( odieChat ? filteredOdieMessages : [] ),
-								...( odieChat
-									? getOdieTransferMessage( currentSupportInteraction.bot_slug as OdieAllBotSlugs )
-									: [] ),
-								...( deduplicateZDMessages( [
-									// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
-									...mainChatState.messages.filter( ( message ) => message.role === 'user' ),
-									...conversation.messages,
-								] ) as Message[] ),
-							],
-							provider: 'zendesk',
-							status: currentSupportInteraction.status === 'closed' ? 'closed' : 'loaded',
+						setMainChatState( ( mainChatState ) => {
+							const isSameConversation =
+								mainChatState.odieId?.toString() === odieId?.toString() &&
+								mainChatState.conversationId === conversationId;
+
+							return {
+								...( odieChat ? odieChat : {} ),
+								supportInteractionId: currentSupportInteraction.uuid,
+								conversationId: conversation.id,
+								messages: [
+									...( odieChat ? filteredOdieMessages : [] ),
+									...( odieChat
+										? getOdieTransferMessage(
+												currentSupportInteraction.bot_slug as OdieAllBotSlugs
+										  )
+										: [] ),
+									...( deduplicateZDMessages( [
+										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
+										...( isSameConversation
+											? mainChatState.messages.filter( ( message ) => message.role === 'user' )
+											: [] ),
+										...conversation.messages,
+									] ) as Message[] ),
+								],
+								provider: 'zendesk',
+								status: currentSupportInteraction.status === 'closed' ? 'closed' : 'loaded',
+							};
 						} );
 					}
 				} );


### PR DESCRIPTION
Fixes DOTSUP-340

## Proposed Changes

When recovering from a broken chat connection, we redownload the conversation again and consolidate it with the existing one. There was a bug in this logic when switching from one conversation to another, as the messages of the old conversation were merged into the new one. This only merges the conversation messages if they belong to the same chat.

## Why are these changes being made?
Bugfix.

## Testing Instructions
I recommend testing locally to get staging.

### Switching between conversations
1. Start a chat.
2. Ask Odie for a human with a distinct message (like human please, one).
3. Refresh the page.
4. Start a new chat.
5. Ask for a human in another distinct message (like human please, two).
6. Click "yes, take me there".
7. You should see the messages of the first conversation only.

### Connection recovery
1. While in a conversation, go to DevTools > Network and set yourself offline.
2. Toggle back online. Messages should remain unchanged and unduplicated.
