### PR TITLE
Plugins redesign: Implement carousel for the discovery plugins lists

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -162,6 +162,100 @@ export const getCategories: () => Record< string, Category > = () => ( {
 				icon: 'https://ps.w.org/woocommerce-paypal-payments/assets/icon-256x256.png?rev=3234615',
 				short_description: __( 'Accept PayPal payments' ),
 			},
+			{
+				slug: 'woocommerce',
+				name: __( 'WooCommerce' ),
+				icon: 'https://ps.w.org/woocommerce/assets/icon-256x256.png?rev=3234504',
+				short_description: __(
+					'Everything you need to launch an online store in days and keep it growing for years. From your first sale to millions in revenue, Woo is with you.'
+				),
+			},
+			{
+				slug: 'woocommerce-analytics',
+				name: __( 'WooCommerce Analytics' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2024/12/Storefront_Parallax_Hero_icon-order-attribution-160x160-1.png',
+				short_description: __(
+					"WooCommerce Analytics has advanced order attribution reporting that provides powerful insights into each order's last-touch data, whether you're just launching or have thousands of products in your catalog."
+				),
+			},
+			{
+				slug: 'woocommerce-bookings',
+				name: __( 'WooCommerce Bookings' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2014/05/Bookings_icon-marketplace-160x160-2.png',
+				short_description: __(
+					'Allow customers to book appointments, make reservations or rent equipment without leaving your site.'
+				),
+			},
+			{
+				slug: 'woocommerce-payments',
+				name: __( 'WooPayments: Integrated WooCommerce Payments' ),
+				icon: 'https://ps.w.org/woocommerce-payments/assets/icon-256x256.png?rev=3234740',
+				short_description: __(
+					'Securely accept credit and debit cards on your WooCommerce store. Manage payments without leaving your WordPress dashboard. Only with WooPayments.'
+				),
+			},
+			{
+				slug: 'woocommerce-gateway-stripe',
+				name: __( 'WooCommerce Stripe Payment Gateway' ),
+				icon: 'https://ps.w.org/woocommerce-gateway-stripe/assets/icon-256x256.png?rev=3177277',
+				short_description: __(
+					'Accept debit and credit cards in 135+ currencies, many local methods like Alipay, ACH, and SEPA, and express checkout with Apple Pay and Google Pay.'
+				),
+			},
+			{
+				slug: 'woocommerce-services',
+				name: __( 'WooCommerce Tax (formerly WooCommerce Shipping & Tax)' ),
+				icon: 'https://ps.w.org/woocommerce-services/assets/icon-256x256.png?rev=3234419',
+				short_description: __(
+					"We're here to help with tax rates: collect accurate sales tax, automatically."
+				),
+			},
+			{
+				slug: 'woocommerce-one-page-checkout',
+				name: __( 'WooCommerce One Page Checkout' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2014/10/One_Page_Checkout_icon-marketplace-80x80-1.png',
+				short_description: __(
+					'Create special pages where customers can choose products, checkout & pay all on the one page.'
+				),
+			},
+			{
+				slug: 'woocommerce-product-filters',
+				name: __( 'Product Filters for WooCommerce' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2018/10/Product_Filters_icon-marketplace-80x80-1.png',
+				short_description: __(
+					'This is a tool to create ajax product filters that make the process of finding products in your store simple and fast'
+				),
+			},
+			{
+				slug: 'woocommerce-additional-variation-images',
+				name: __( 'WooCommerce Additional Variation Images' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2014/08/Additional_Variation_Images_icon-marketplace-160x160-2.png',
+				short_description: __( 'Unlimited images for your product variations.' ),
+			},
+			{
+				slug: 'woocommerce-shipping-per-product',
+				name: __( 'Per Product Shipping' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2013/04/Per_product_shipping_icon-marketplace-160x160-1.png',
+				short_description: __(
+					'Define separate shipping costs per product which are combined at checkout to provide a total shipping cost.'
+				),
+			},
+			{
+				slug: 'automatewoo-referrals',
+				name: __( 'AutomateWoo - Refer A Friend add-on' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2019/10/woo-AutomateWoo-m4jpva.png ',
+				short_description: __(
+					'Boost your organic sales by adding a customer referral program to your WooCommerce store.'
+				),
+			},
+			{
+				slug: 'warranty-requests',
+				name: __( 'Returns and Warranty Requests' ),
+				icon: 'https://woocommerce.com/wp-content/uploads/2013/07/Returns_and_Warranty_Woo.png',
+				short_description: __(
+					'Manage the RMA process, add warranties to products, and let customers request and manage returns/exchanges from their account.'
+				),
+			},
 		],
 	},
 	booking: {
@@ -375,6 +469,98 @@ export const getCategories: () => Record< string, Category > = () => ( {
 				icon: 'https://ps.w.org/elementor/assets/icon-256x256.gif?rev=3111597',
 				short_description: __( 'Drag and drop page builder' ),
 			},
+			{
+				slug: 'ads-txt',
+				name: __( 'Ads.txt Manager' ),
+				icon: 'https://ps.w.org/ads-txt/assets/icon-256x256.png?rev=2834081',
+				short_description: __(
+					'Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, like any other content asset.'
+				),
+			},
+			{
+				slug: 'advanced-popups',
+				name: __( 'Advanced Popups' ),
+				icon: 'https://ps.w.org/advanced-popups/assets/icon-256x256.png?rev=2690535',
+				short_description: __(
+					'Display high-converting newsletter popups, a cookie notice, or a notification with the light-weight yet feature-rich plugin.'
+				),
+			},
+			{
+				slug: 'kliken-marketing-for-google',
+				name: __( 'AI Powered Marketing' ),
+				icon: 'https://ps.w.org/kliken-marketing-for-google/assets/icon-256x256.png?rev=2832456',
+				short_description: __(
+					"Kliken's all-in-one marketing helps businesses reach high-intent customers, beat the competition and see sales growth while lowering conversion costs"
+				),
+			},
+			{
+				slug: 'website-monetization-by-magenet',
+				name: __( 'Website Monetization by MageNet' ),
+				icon: 'https://ps.w.org/website-monetization-by-magenet/assets/icon-256x256.jpg?rev=1630832',
+				short_description: __(
+					'Get additional income from your website or blog by placing text ads automatically.'
+				),
+			},
+			{
+				slug: 'website-article-monetization-by-magenet',
+				name: __( 'Website Article Monetization By MageNet' ),
+				icon: 'https://ps.w.org/website-article-monetization-by-magenet/assets/icon-256x256.jpg?rev=2300741',
+				short_description: __(
+					'Get additional income from your website or blog by placing text ads automatically.'
+				),
+			},
+			{
+				slug: 'affiliatex',
+				name: __( 'AffiliateX – Affiliate Block Plugin' ),
+				icon: 'https://ps.w.org/affiliatex/assets/icon-256x256.jpg?rev=2636351',
+				short_description: __(
+					'AffiliateX is the best WordPress Affiliate Block Plugin. Create professional affiliate websites with customizable WordPress Affiliate Blocks.'
+				),
+			},
+			{
+				slug: 'mediavine-control-panel',
+				name: __( 'Mediavine Control Panel' ),
+				icon: 'https://ps.w.org/mediavine-control-panel/assets/icon-128x128.png?rev=1605431',
+				short_description: __( 'Manage your ads, analytics and more with our lightweight plugin!' ),
+			},
+			{
+				slug: 'content-egg',
+				name: __( 'Content Egg – Affiliate Product Importer & Price Comparison' ),
+				icon: 'https://ps.w.org/content-egg/assets/icon-128x128.png?rev=1236433',
+				short_description: __(
+					'Import affiliate products, compare prices, sync to WooCommerce, and auto-generate SEO content with AI — all in one toolkit.'
+				),
+			},
+			{
+				slug: 'affiliates-manager',
+				name: __( 'Affiliates Manager' ),
+				icon: 'https://ps.w.org/affiliates-manager/assets/icon-128x128.png?rev=981249',
+				short_description: __(
+					'Affiliates Manager plugin can help you manage an affiliate marketing program to drive more traffic and more sales to your site.'
+				),
+			},
+			{
+				slug: 'meks-easy-ads-widget',
+				name: __( 'Meks Easy Ads Widget' ),
+				icon: 'https://ps.w.org/meks-easy-ads-widget/assets/icon-256x256.png?rev=1522332',
+				short_description: __( 'Display unlimited number of ads inside your WordPress widget.' ),
+			},
+			{
+				slug: 'callrail-phone-call-tracking',
+				name: __( 'CallRail Phone Call Tracking' ),
+				icon: 'https://ps.w.org/callrail-phone-call-tracking/assets/icon-256x256.png?rev=2227520',
+				short_description: __(
+					"Dynamically swap CallRail tracking phone numbers based on the visitor's referring source."
+				),
+			},
+			{
+				slug: 'yith-woocommerce-affiliates',
+				name: __( 'YITH WooCommerce Affiliates' ),
+				icon: 'https://ps.w.org/yith-woocommerce-affiliates/assets/icon-256x256.jpg?rev=3089234',
+				short_description: __(
+					'YITH WooCommerce Affiliates allows you to create affiliate profiles and grant your affiliates earnings each time someone purchases from their link.'
+				),
+			},
 		],
 	},
 	business: {
@@ -419,6 +605,106 @@ export const getCategories: () => Record< string, Category > = () => ( {
 				name: __( 'All-in-One WP Migration' ),
 				icon: 'https://ps.w.org/all-in-one-wp-migration/assets/icon-256x256.png',
 				short_description: __( 'Move websites between hosts with ease' ),
+			},
+			{
+				slug: 'google-site-kit',
+				name: __( 'Site Kit by Google - Analytics, Search Console, AdSense, Speed' ),
+				icon: 'https://ps.w.org/google-site-kit/assets/icon-256x256.png?rev=3141863',
+				short_description: __(
+					'Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.'
+				),
+			},
+			{
+				slug: 'google-listings-and-ads',
+				name: __( 'Google for WooCommerce' ),
+				icon: 'https://ps.w.org/google-listings-and-ads/assets/icon-256x256.png?rev=2775988',
+				short_description: __(
+					"Native integration with Google that allows merchants to easily display their products across Google's network."
+				),
+			},
+			{
+				slug: 'wp-reviews-plugin-for-google',
+				name: __( 'Widgets for Google Reviews' ),
+				icon: 'https://ps.w.org/wp-reviews-plugin-for-google/assets/icon-256x256.png?rev=2721569',
+				short_description: __(
+					'Embed Google reviews fast and easily into your WordPress site. Increase SEO, trust and sales using Google reviews.'
+				),
+			},
+			{
+				slug: 'flamingo',
+				name: __( 'Flamingo' ),
+				icon: 'https://ps.w.org/flamingo/assets/icon-128x128.png?rev=1540977',
+				short_description: __( 'A trustworthy message storage plugin for Contact Form 7.' ),
+			},
+			{
+				slug: 'ga-google-analytics',
+				name: __( 'GA Google Analytics – Connect Google Analytics to WordPress' ),
+				icon: 'https://ps.w.org/ga-google-analytics/assets/icon-256x256.png?rev=2053004',
+				short_description: __(
+					'Adds Google Analytics 4 tracking code to your WordPress site. Supports many tracking features.'
+				),
+			},
+			{
+				slug: 'leadin',
+				name: __( 'HubSpot - CRM, Email Marketing, Live Chat, Forms & Analytics' ),
+				icon: 'https://ps.w.org/leadin/assets/icon-256x256.png?rev=3041936',
+				short_description: __(
+					'The CRM, Sales, and Marketing WordPress plugin to grow your business better. Capture, organize, and engage web visitors with free live chat, forms, CR …'
+				),
+			},
+			{
+				slug: 'reviews-feed',
+				name: __(
+					'Reviews Feed – Add Testimonials and Customer Reviews From Google Reviews, Yelp, TripAdvisor, and More'
+				),
+				icon: 'https://ps.w.org/reviews-feed/assets/icon-256x256.png?rev=2885733',
+				short_description: __(
+					'No API key required. Display Yelp and Google reviews for any business in a clean, customizable feed on your site.'
+				),
+			},
+			{
+				slug: 'event-tickets',
+				name: __( 'Event Tickets and Registration' ),
+				icon: 'https://ps.w.org/event-tickets/assets/icon-256x256.png?rev=2259359',
+				short_description: __(
+					'Event Tickets allows your visitors to RSVP and buy tickets to events on your site. Also works seamlessly with The Events Calendar.'
+				),
+			},
+			{
+				slug: 'wp-job-manager',
+				name: __( 'WP Job Manager' ),
+				icon: 'https://ps.w.org/wp-job-manager/assets/icon-256x256.gif?rev=2975257',
+				short_description: __(
+					'Create a careers page for your company website, or build a public job board for your community.'
+				),
+			},
+			{
+				slug: 'auto-terms-of-service-and-privacy-policy',
+				name: __(
+					'TermsFeed AutoTerms: Privacy Policy Generator, Cookie Consent, GDPR, CCPA, Terms & Conditions, Disclaimers, Cookies Policy, EULA'
+				),
+				icon: 'https://ps.w.org/auto-terms-of-service-and-privacy-policy/assets/icon-256x256.png?rev=3300987',
+				short_description: __(
+					'All-in-One compliance solution from TermsFeed: Generator of Privacy Policy, T&Cs, Affiliate Disclaimers and Cookie Consent Notice Banner.'
+				),
+			},
+			{
+				slug: 'fluent-crm',
+				name: __(
+					'FluentCRM - Email Newsletter, Automation, Email Marketing, Email Campaigns, Optins, Leads, and CRM Solution'
+				),
+				icon: 'https://ps.w.org/fluent-crm/assets/icon-256x256.png?rev=2390407',
+				short_description: __(
+					'The easiest and fastest Email Marketing, Newsletter, Marketing Automation Plugin & CRM Solution for WordPress'
+				),
+			},
+			{
+				slug: 'site-reviews',
+				name: __( 'Site Reviews' ),
+				icon: 'https://ps.w.org/site-reviews/assets/icon-256x256.gif?rev=3307009',
+				short_description: __(
+					'Site Reviews is a complete review management solution for your website that is designed to work in a similar way to Amazon, Tripadvisor, and Yelp.'
+				),
 			},
 		],
 	},

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,7 +1,5 @@
 import { Card, DotPager } from '@automattic/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { chevronRight } from '@wordpress/icons';
-import clsx from 'clsx';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
@@ -54,9 +52,7 @@ const PluginsBrowserList = ( {
 	const extendedVariant = extended
 		? PluginsBrowserElementVariant.Extended
 		: PluginsBrowserElementVariant.Compact;
-	const isBelowCarouselBreakpoint = useViewportMatch( 'medium', '<' );
-	const shouldUseCarousel = useCarousel && ! isBelowCarouselBreakpoint;
-	const shouldUseHorizontalScroll = useCarousel && ! shouldUseCarousel;
+	const shouldUseCarousel = useCarousel;
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -140,7 +136,7 @@ const PluginsBrowserList = ( {
 						{ slides.map( ( slideItems, index ) => (
 							<Card
 								tagName="ul"
-								className="plugins-browser-list__elements plugins-browser-list__elements--carousel"
+								className="plugins-browser-list__elements"
 								key={ `plugins-carousel-slide-${ index }` }
 							>
 								{ slideItems }
@@ -151,12 +147,8 @@ const PluginsBrowserList = ( {
 			);
 		}
 
-		const listClassName = clsx( 'plugins-browser-list__elements', {
-			'plugins-browser-list__elements--horizontal-scroll': shouldUseHorizontalScroll,
-		} );
-
 		return (
-			<Card tagName="ul" className={ listClassName }>
+			<Card tagName="ul" className="plugins-browser-list__elements">
 				{ items }
 			</Card>
 		);

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,6 @@
 import { Card, DotPager } from '@automattic/components';
+import { useViewportMatch } from '@wordpress/compose';
+import clsx from 'clsx';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
@@ -51,6 +53,9 @@ const PluginsBrowserList = ( {
 	const extendedVariant = extended
 		? PluginsBrowserElementVariant.Extended
 		: PluginsBrowserElementVariant.Compact;
+	const isBelowCarouselBreakpoint = useViewportMatch( 'medium', '<' );
+	const shouldUseCarousel = useCarousel && ! isBelowCarouselBreakpoint;
+	const shouldUseHorizontalScroll = useCarousel && ! shouldUseCarousel;
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -116,7 +121,7 @@ const PluginsBrowserList = ( {
 	const pageSize = Math.max( 1, carouselPageSize );
 
 	const renderViews = () => {
-		if ( useCarousel ) {
+		if ( shouldUseCarousel ) {
 			const slides = chunkItems( items, pageSize );
 
 			if ( ! slides.length ) {
@@ -144,8 +149,12 @@ const PluginsBrowserList = ( {
 			);
 		}
 
+		const listClassName = clsx( 'plugins-browser-list__elements', {
+			'plugins-browser-list__elements--horizontal-scroll': shouldUseHorizontalScroll,
+		} );
+
 		return (
-			<Card tagName="ul" className="plugins-browser-list__elements">
+			<Card tagName="ul" className={ listClassName }>
 				{ items }
 			</Card>
 		);

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,5 +1,6 @@
 import { Card, DotPager } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -134,6 +135,7 @@ const PluginsBrowserList = ( {
 						className="plugins-browser-list__carousel-pager"
 						hasDynamicHeight
 						navArrowSize={ 20 }
+						navArrowIcon={ chevronRight }
 					>
 						{ slides.map( ( slideItems, index ) => (
 							<Card

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, DotPager } from '@automattic/components';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
@@ -13,6 +13,21 @@ import { PluginsBrowserListVariant } from './types';
 import './style.scss';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
+const DEFAULT_CAROUSEL_PAGE_SIZE = 3;
+
+function chunkItems( items, chunkSize ) {
+	if ( ! chunkSize || chunkSize <= 0 ) {
+		return [];
+	}
+
+	const chunks = [];
+
+	for ( let index = 0; index < items.length; index += chunkSize ) {
+		chunks.push( items.slice( index, index + chunkSize ) );
+	}
+
+	return chunks;
+}
 
 const PluginsBrowserList = ( {
 	plugins,
@@ -30,6 +45,8 @@ const PluginsBrowserList = ( {
 	size,
 	search,
 	noHeader = false,
+	useCarousel = false,
+	carouselPageSize = DEFAULT_CAROUSEL_PAGE_SIZE,
 } ) => {
 	const extendedVariant = extended
 		? PluginsBrowserElementVariant.Extended
@@ -73,7 +90,7 @@ const PluginsBrowserList = ( {
 		) );
 	};
 
-	const renderViews = () => {
+	const getRenderableItems = () => {
 		if ( ! plugins.length ) {
 			return renderPlaceholdersViews();
 		}
@@ -93,6 +110,45 @@ const PluginsBrowserList = ( {
 			default:
 				return renderPluginsViewList();
 		}
+	};
+
+	const items = ( getRenderableItems() || [] ).filter( Boolean );
+	const pageSize = Math.max( 1, carouselPageSize );
+
+	const renderViews = () => {
+		if ( useCarousel ) {
+			const slides = chunkItems( items, pageSize );
+
+			if ( ! slides.length ) {
+				return null;
+			}
+
+			return (
+				<div className="plugins-browser-list__carousel">
+					<DotPager
+						className="plugins-browser-list__carousel-pager"
+						hasDynamicHeight
+						navArrowSize={ 20 }
+					>
+						{ slides.map( ( slideItems, index ) => (
+							<Card
+								tagName="ul"
+								className="plugins-browser-list__elements plugins-browser-list__elements--carousel"
+								key={ `plugins-carousel-slide-${ index }` }
+							>
+								{ slideItems }
+							</Card>
+						) ) }
+					</DotPager>
+				</div>
+			);
+		}
+
+		return (
+			<Card tagName="ul" className="plugins-browser-list__elements">
+				{ items }
+			</Card>
+		);
 	};
 
 	const SpotlightPlaceholder = (
@@ -147,9 +203,7 @@ const PluginsBrowserList = ( {
 					messagePath={ `calypso:${ sectionJitmPath }:spotlight` }
 				/>
 			) }
-			<Card tagName="ul" className="plugins-browser-list__elements">
-				{ renderViews() }
-			</Card>
+			{ renderViews() }
 		</div>
 	);
 };
@@ -158,6 +212,8 @@ PluginsBrowserList.propTypes = {
 	plugins: PropTypes.array.isRequired,
 	variant: PropTypes.oneOf( Object.values( PluginsBrowserListVariant ) ).isRequired,
 	extended: PropTypes.bool,
+	useCarousel: PropTypes.bool,
+	carouselPageSize: PropTypes.number,
 };
 
 export default PluginsBrowserList;

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,5 +1,4 @@
 import { Card, DotPager } from '@automattic/components';
-import { chevronRight } from '@wordpress/icons';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
@@ -127,12 +126,7 @@ const PluginsBrowserList = ( {
 
 			return (
 				<div className="plugins-browser-list__carousel">
-					<DotPager
-						className="plugins-browser-list__carousel-pager"
-						hasDynamicHeight
-						navArrowSize={ 20 }
-						navArrowIcon={ chevronRight }
-					>
+					<DotPager className="plugins-browser-list__carousel-pager" hasDynamicHeight>
 						{ slides.map( ( slideItems, index ) => (
 							<Card
 								tagName="ul"

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -51,6 +51,16 @@
 	.dot-pager__control-choose-page {
 		display: none;
 	}
+	.dot-pager__control-prev,
+	.dot-pager__control-next {
+		width: 32px;
+		height: 32px;
+		border-radius: 100%;
+		border: 1px solid var(--studio-gray-5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 .card.plugins-browser-list__elements--carousel {

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -46,6 +46,7 @@
 .plugins-browser-list__carousel .dot-pager__controls {
 	justify-content: flex-end;
 	margin-block-end: 24px;
+	margin-block-start: -20px;
 
 	.dot-pager__control-choose-page {
 		display: none;
@@ -58,7 +59,41 @@
 	gap: 24px;
 }
 
+.card.plugins-browser-list__elements--horizontal-scroll {
+	flex-wrap: nowrap;
+	overflow-x: auto;
+	gap: 0 18px;
+	padding-block-end: 12px;
+	scroll-snap-type: x proximity;
+	-webkit-overflow-scrolling: touch;
+	margin-inline: 0;
+	padding-inline: 0;
+	scroll-padding-inline: 0;
+
+	@media ( max-width: $break-medium ) {
+		margin-inline: -56px;
+		padding-inline: 56px;
+		scroll-padding-inline: 56px;
+	}
+
+	@media ( max-width: $break-small ) {
+		margin-inline: -16px;
+		padding-inline: 56px;
+		scroll-padding-inline: 16px;
+	}
+
+	.plugins-browser-item {
+		flex: 0 0 clamp( 260px, 75vw, 480px );
+		width: clamp( 260px, 75vw, 480px );
+		scroll-snap-align: start;
+	}
+}
+
 .card.plugins-browser-list__elements--carousel .plugins-browser-item {
 	margin: 0;
 	width: 100%;
+}
+
+.plugins-results-header:has(+ .plugins-browser-list__carousel .plugins-browser-list__carousel-pager) .plugins-results-header__actions{
+	margin-inline-end: 90px;
 }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -42,3 +42,23 @@
 		display: none;
 	}
 }
+
+.plugins-browser-list__carousel .dot-pager__controls {
+	justify-content: flex-end;
+	margin-block-end: 24px;
+
+	.dot-pager__control-choose-page {
+		display: none;
+	}
+}
+
+.card.plugins-browser-list__elements--carousel {
+	display: grid;
+	grid-template-columns: repeat( 3, 1fr );
+	gap: 24px;
+}
+
+.card.plugins-browser-list__elements--carousel .plugins-browser-item {
+	margin: 0;
+	width: 100%;
+}

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -44,66 +44,6 @@
 }
 
 .plugins-browser-list__carousel .dot-pager__controls {
-	justify-content: flex-end;
-	margin-block-end: 24px;
-	margin-block-start: -20px;
-
-	.dot-pager__control-choose-page {
-		display: none;
-	}
-	.dot-pager__control-prev,
-	.dot-pager__control-next {
-		width: 32px;
-		height: 32px;
-		border-radius: 100%;
-		border: 1px solid var(--studio-gray-5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-}
-
-.card.plugins-browser-list__elements--carousel {
-	display: grid;
-	grid-template-columns: repeat( 3, 1fr );
-	gap: 24px;
-}
-
-.card.plugins-browser-list__elements--horizontal-scroll {
-	flex-wrap: nowrap;
-	overflow-x: auto;
-	gap: 0 18px;
-	padding-block-end: 12px;
-	scroll-snap-type: x proximity;
-	-webkit-overflow-scrolling: touch;
-	margin-inline: 0;
-	padding-inline: 0;
-	scroll-padding-inline: 0;
-
-	@media ( max-width: $break-medium ) {
-		margin-inline: -56px;
-		padding-inline: 56px;
-		scroll-padding-inline: 56px;
-	}
-
-	@media ( max-width: $break-small ) {
-		margin-inline: -16px;
-		padding-inline: 56px;
-		scroll-padding-inline: 16px;
-	}
-
-	.plugins-browser-item {
-		flex: 0 0 clamp( 260px, 75vw, 480px );
-		width: clamp( 260px, 75vw, 480px );
-		scroll-snap-align: start;
-	}
-}
-
-.card.plugins-browser-list__elements--carousel .plugins-browser-item {
-	margin: 0;
-	width: 100%;
-}
-
-.plugins-results-header:has(+ .plugins-browser-list__carousel .plugins-browser-list__carousel-pager) .plugins-results-header__actions{
-	margin-inline-end: 90px;
+	margin-top: 16px;
+	margin-bottom: 0;
 }

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { ReactElement } from 'react';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { useGetCategoryUrl } from 'calypso/my-sites/plugins/categories/use-get-category-url';
@@ -7,6 +8,8 @@ import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const COLLECTION_LIST_LENGTH = isEnabled( 'marketplace-redesign' ) ? 18 : 6;
 
 export default function CollectionListView( {
 	category,
@@ -25,7 +28,7 @@ export default function CollectionListView( {
 	const getCategoryUrl = useGetCategoryUrl();
 	const categories = useCategories( [ category ] );
 
-	const plugins = categories[ category ].preview.slice( 0, 6 );
+	const plugins = categories[ category ].preview.slice( 0, COLLECTION_LIST_LENGTH );
 
 	if ( isJetpackSelfHosted ) {
 		return null;
@@ -47,6 +50,8 @@ export default function CollectionListView( {
 			resultCount={ false }
 			search=""
 			extended={ false }
+			useCarousel={ isEnabled( 'marketplace-redesign' ) }
+			carouselPageSize={ 6 }
 		/>
 	);
 }

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useViewportMatch } from '@wordpress/compose';
 import { ReactElement } from 'react';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { useGetCategoryUrl } from 'calypso/my-sites/plugins/categories/use-get-category-url';
@@ -28,6 +29,17 @@ export default function CollectionListView( {
 	const getCategoryUrl = useGetCategoryUrl();
 	const categories = useCategories( [ category ] );
 
+	const isUseCarousel = isEnabled( 'marketplace-redesign' );
+	const isLessThanLargeViewport = useViewportMatch( 'large', '<' );
+	const isLessThanWideViewport = useViewportMatch( 'wide', '<' );
+
+	let carouselPageSize = 6;
+	if ( isLessThanLargeViewport ) {
+		carouselPageSize = 1;
+	} else if ( isLessThanWideViewport ) {
+		carouselPageSize = 4;
+	}
+
 	const plugins = categories[ category ].preview.slice( 0, COLLECTION_LIST_LENGTH );
 
 	if ( isJetpackSelfHosted ) {
@@ -50,8 +62,8 @@ export default function CollectionListView( {
 			resultCount={ false }
 			search=""
 			extended={ false }
-			useCarousel={ isEnabled( 'marketplace-redesign' ) }
-			carouselPageSize={ 6 }
+			useCarousel={ isUseCarousel }
+			carouselPageSize={ carouselPageSize }
 		/>
 	);
 }

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -11,7 +12,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Module variables
  */
-export const SHORT_LIST_LENGTH = 6;
+export const SHORT_LIST_LENGTH = isEnabled( 'marketplace-redesign' ) ? 9 : 6;
 
 const PLUGIN_SLUGS_BLOCKLIST = [];
 
@@ -75,6 +76,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 			variant={ PluginsBrowserListVariant.Fixed }
 			extended
 			noHeader={ noHeader }
+			useCarousel={ isEnabled( 'marketplace-redesign' ) }
 		/>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -42,6 +43,10 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 	const categoryName = categories[ category ]?.title || translate( 'Plugins' );
 	const categoryDescription = categories[ category ]?.description || null;
 
+	const isUseCarousel = isEnabled( 'marketplace-redesign' );
+	const isLessThanLargeViewport = useViewportMatch( 'large', '<' );
+	const isLessThanWideViewport = useViewportMatch( 'wide', '<' );
+
 	const { localizePath } = useLocalizedPlugins();
 
 	const installedPlugins = useSelector( ( state ) =>
@@ -61,6 +66,13 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 		return null;
 	}
 
+	let carouselPageSize = 3;
+	if ( isLessThanLargeViewport ) {
+		carouselPageSize = 1;
+	} else if ( isLessThanWideViewport ) {
+		carouselPageSize = 2;
+	}
+
 	return (
 		<PluginsBrowserList
 			plugins={ plugins.slice( 0, SHORT_LIST_LENGTH ) }
@@ -76,7 +88,8 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 			variant={ PluginsBrowserListVariant.Fixed }
 			extended
 			noHeader={ noHeader }
-			useCarousel={ isEnabled( 'marketplace-redesign' ) }
+			useCarousel={ isUseCarousel }
+			carouselPageSize={ carouselPageSize }
 		/>
 	);
 };

--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,6 +76,7 @@
 		"mailchimp": false,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,6 +93,7 @@
 		"mcp-settings": true,
 		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,6 +91,7 @@
 		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -71,6 +71,7 @@
 		"mcp-settings": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"me/account-close": true,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -99,6 +99,7 @@
 		"marketing-force-facebook-display": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-redesign": false,
 		"marketplace-reviews-notification": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/packages/components/src/dot-pager/index.tsx
+++ b/packages/components/src/dot-pager/index.tsx
@@ -3,7 +3,7 @@ import { Icon, arrowRight, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
-import { Children, useState, useEffect, ReactNode, ReactElement } from 'react';
+import { Children, useState, useEffect, ReactNode } from 'react';
 import { Swipeable } from '../swipeable';
 
 import './style.scss';

--- a/packages/components/src/dot-pager/index.tsx
+++ b/packages/components/src/dot-pager/index.tsx
@@ -3,7 +3,7 @@ import { Icon, arrowRight, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
-import { Children, useState, useEffect, ReactNode } from 'react';
+import { Children, useState, useEffect, ReactNode, ReactElement } from 'react';
 import { Swipeable } from '../swipeable';
 
 import './style.scss';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-258](https://linear.app/a8c/issue/DOTDEV-258/implement-carousel-for-the-discovery-plugins-lists)

## Proposed Changes

* use the dotPager component to render the plugins inside a carousel on larger screens
* show plugins in a horizontal scrolling contain on smaller screens
* style carousel control to match the design [BwSzqN2tZikisxcHhpuj3W-fi-2775_4224]
* adds more plugins for the collection previous list so there're 3 pane to swipe in the carousels
* use feature flag to hide the implementation for now

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed for implementing the Plugins redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins?flags=marketplace-redesign`
* The plugins should be rendered as carousels
* Go to `/plugins`
* The plugins should render as before

| Before (without flag) | After (with flag) |
|--------|--------|
| <img width="1115" height="1003" alt="Screenshot 2025-11-06 at 15 17 05" src="https://github.com/user-attachments/assets/b42aab4c-38cc-4c3e-8fbf-4233bc73e0cb" /> | <img width="1223" height="800" alt="Screenshot 2025-11-07 at 12 52 32" src="https://github.com/user-attachments/assets/397aeac3-ea25-4f8e-97d6-df07ffbc8372" />
| 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?