### PR TITLE
Update domain forwarding form source field design

### DIFF
--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -109,16 +109,16 @@ export default function DomainForwardingForm( {
 		() => [
 			{
 				id: 'sourceType',
-				label: __( 'Source URL' ),
+				label: __( 'Type' ),
 				type: 'text' as const,
 				Edit: 'select',
 				elements: [
 					{
-						label: `${ domainName } subdomain`,
+						label: 'Subdomain',
 						value: '',
 					},
 					{
-						label: `${ domainName } root domain`,
+						label: 'Domain',
 						value: 'root',
 					},
 				],
@@ -128,12 +128,13 @@ export default function DomainForwardingForm( {
 			},
 			{
 				id: 'subdomain',
-				label: __( 'Subdomain' ),
+				label: __( 'Source URL' ),
 				help: __( 'Enter the subdomain (e.g., "blog")' ),
 				type: 'text' as const,
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;
-					const suffix = `.${ domainName }`;
+					const isDisabled = field.isDisabled( data );
+					const suffix = isDisabled ? '' : `.${ domainName }`;
 					const value = getValue( { item: data } );
 					const validationMessage = field.isValid?.custom?.( data, field );
 
@@ -142,7 +143,8 @@ export default function DomainForwardingForm( {
 							required={ !! field.isValid?.required }
 							label={ field.label }
 							placeholder={ field.placeholder }
-							value={ value }
+							disabled={ isDisabled }
+							value={ isDisabled ? domainName : value }
 							onChange={ ( value: string ) => {
 								return onChange( { [ id ]: value } );
 							} }
@@ -164,8 +166,8 @@ export default function DomainForwardingForm( {
 						return null;
 					},
 				},
-				isVisible: ( item: FormData ) => {
-					return item.sourceType === '';
+				isDisabled: ( item: FormData ) => {
+					return item.sourceType !== '';
 				},
 			},
 			{
@@ -189,7 +191,21 @@ export default function DomainForwardingForm( {
 
 	const form = {
 		layout: { type: 'regular' as const },
-		fields: [ 'sourceType', 'subdomain', 'targetUrl' ],
+		fields: [
+			{
+				id: 'source',
+				children: [ 'sourceType', 'subdomain' ],
+				layout: {
+					type: 'row',
+					alignment: 'top',
+					styles: {
+						sourceType: { flex: 1 },
+						subdomain: { flex: 3 },
+					},
+				},
+			},
+			'targetUrl',
+		],
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -193,8 +193,8 @@ export default function DomainForwardingForm( {
 				id: 'source',
 				children: [ 'sourceType', 'subdomain' ],
 				layout: {
-					type: 'row',
-					alignment: 'top',
+					type: 'row' as const,
+					alignment: 'start' as const,
 					styles: {
 						sourceType: { flex: 1 },
 						subdomain: { flex: 3 },

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -213,13 +213,14 @@ export default function DomainForwardingForm( {
 
 	const [ currentForm, setForm ] = useState( form );
 
+	// Reflow the form based on the width of the container for mobile/desktop
 	const ref = useResizeObserver( ( entries ) => {
 		const firstEntry = entries[ 0 ];
 		if ( firstEntry ) {
-			if ( firstEntry.contentRect.width <= 535 ) {
-				setForm( mobileForm );
-			} else {
+			if ( firstEntry.contentRect.width > 535 ) {
 				setForm( form );
+			} else {
+				setForm( mobileForm );
 			}
 		}
 	} );

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -133,7 +133,7 @@ export default function DomainForwardingForm( {
 				type: 'text' as const,
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;
-					const isDisabled = field.isDisabled( data );
+					const isDisabled = data.sourceType !== '';
 					const suffix = isDisabled ? '' : `.${ domainName }`;
 					const value = getValue( { item: data } );
 					const validationMessage = field.isValid?.custom?.( data, field );
@@ -165,9 +165,6 @@ export default function DomainForwardingForm( {
 						}
 						return null;
 					},
-				},
-				isDisabled: ( item: FormData ) => {
-					return item.sourceType !== '';
 				},
 			},
 			{

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -254,7 +254,7 @@ export default function DomainForwardingForm( {
 									initialOpen={ hasNonDefaultAdvancedValues }
 								>
 									<PanelRow>
-										<VStack spacing={ 6 }>
+										<VStack spacing={ 6 } style={ { marginTop: '12px' } }>
 											<RadioControl
 												label={ isPermanentField.label }
 												selected={ formData.isPermanent ? 'true' : 'false' }

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -6,6 +6,7 @@ import {
 	PanelRow,
 	RadioControl,
 } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -205,6 +206,24 @@ export default function DomainForwardingForm( {
 		],
 	};
 
+	const mobileForm = {
+		layout: { type: 'regular' as const },
+		fields: [ 'sourceType', 'subdomain', 'targetUrl' ],
+	};
+
+	const [ currentForm, setForm ] = useState( form );
+
+	const ref = useResizeObserver( ( entries ) => {
+		const firstEntry = entries[ 0 ];
+		if ( firstEntry ) {
+			if ( firstEntry.contentRect.width <= 535 ) {
+				setForm( mobileForm );
+			} else {
+				setForm( form );
+			}
+		}
+	} );
+
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
 		onSubmit( formData );
@@ -215,63 +234,65 @@ export default function DomainForwardingForm( {
 	return (
 		<Card>
 			<CardBody>
-				<form onSubmit={ handleSubmit }>
-					<VStack spacing={ 4 }>
-						<DataForm< FormData >
-							data={ formData }
-							fields={ fields }
-							validity={ validity }
-							form={ form }
-							onChange={ ( edits: Partial< FormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
+				<div ref={ ref }>
+					<form onSubmit={ handleSubmit }>
+						<VStack spacing={ 4 }>
+							<DataForm< FormData >
+								data={ formData }
+								fields={ fields }
+								validity={ validity }
+								form={ currentForm }
+								onChange={ ( edits: Partial< FormData > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
 
-						<Panel>
-							<PanelBody
-								title={ __( 'Advanced settings' ) }
-								initialOpen={ hasNonDefaultAdvancedValues }
-							>
-								<PanelRow>
-									<VStack spacing={ 6 }>
-										<RadioControl
-											label={ isPermanentField.label }
-											selected={ formData.isPermanent ? 'true' : 'false' }
-											options={ isPermanentField.elements }
-											onChange={ ( value: string ) => {
-												setFormData( ( data ) => ( {
-													...data,
-													isPermanent: value === 'true',
-												} ) );
-											} }
-										/>
-										<RadioControl
-											label={ forwardPathsField.label }
-											selected={ formData.forwardPaths ? 'true' : 'false' }
-											options={ forwardPathsField.elements }
-											onChange={ ( value: string ) => {
-												setFormData( ( data ) => ( {
-													...data,
-													forwardPaths: value === 'true',
-												} ) );
-											} }
-										/>
-									</VStack>
-								</PanelRow>
-							</PanelBody>
-						</Panel>
-						<ButtonStack justify="start">
-							<Button
-								variant="primary"
-								type="submit"
-								isBusy={ isSubmitting }
-								disabled={ isSubmitting }
-							>
-								{ submitButtonText }
-							</Button>
-						</ButtonStack>
-					</VStack>
-				</form>
+							<Panel>
+								<PanelBody
+									title={ __( 'Advanced settings' ) }
+									initialOpen={ hasNonDefaultAdvancedValues }
+								>
+									<PanelRow>
+										<VStack spacing={ 6 }>
+											<RadioControl
+												label={ isPermanentField.label }
+												selected={ formData.isPermanent ? 'true' : 'false' }
+												options={ isPermanentField.elements }
+												onChange={ ( value: string ) => {
+													setFormData( ( data ) => ( {
+														...data,
+														isPermanent: value === 'true',
+													} ) );
+												} }
+											/>
+											<RadioControl
+												label={ forwardPathsField.label }
+												selected={ formData.forwardPaths ? 'true' : 'false' }
+												options={ forwardPathsField.elements }
+												onChange={ ( value: string ) => {
+													setFormData( ( data ) => ( {
+														...data,
+														forwardPaths: value === 'true',
+													} ) );
+												} }
+											/>
+										</VStack>
+									</PanelRow>
+								</PanelBody>
+							</Panel>
+							<ButtonStack justify="start">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isSubmitting }
+									disabled={ isSubmitting }
+								>
+									{ submitButtonText }
+								</Button>
+							</ButtonStack>
+						</VStack>
+					</form>
+				</div>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -40,8 +40,8 @@ test( 'renders domain forwarding form with correct fields', async () => {
 		expect( screen.getByText( /Target URL/ ) ).toBeInTheDocument();
 	} );
 
-	expect( screen.getByText( 'Source URL' ) ).toBeInTheDocument();
-	expect( screen.getByText( /Subdomain/ ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Type' ) ).toBeInTheDocument();
+	expect( screen.getByText( /Source URL/ ) ).toBeInTheDocument();
 	expect( screen.getByRole( 'button', { name: 'Add' } ) ).toBeInTheDocument();
 } );
 
@@ -53,8 +53,8 @@ test( 'hides source URL selector when forceSubdomain is true', async () => {
 	} );
 
 	// Should not show the source type selector when forceSubdomain is true
-	expect( screen.queryByText( 'Source URL' ) ).not.toBeInTheDocument();
-	expect( screen.getByText( /Subdomain/ ) ).toBeInTheDocument();
+	expect( screen.queryByText( 'Type' ) ).not.toBeInTheDocument();
+	expect( screen.getByText( /Source URL/ ) ).toBeInTheDocument();
 } );
 
 test( 'shows both root domain and subdomain options when forceSubdomain is false', async () => {
@@ -65,7 +65,7 @@ test( 'shows both root domain and subdomain options when forceSubdomain is false
 	} );
 
 	// Should show the source type selector when forceSubdomain is false
-	expect( screen.getByText( 'Source URL' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Type' ) ).toBeInTheDocument();
 } );
 
 test( 'calls onSubmit with correct data when form is submitted', async () => {
@@ -79,7 +79,7 @@ test( 'calls onSubmit with correct data when form is submitted', async () => {
 	} );
 
 	// Fill in the subdomain field (default sourceType is empty '' meaning subdomain)
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Fill in the target URL
@@ -142,7 +142,7 @@ test( 'shows validation error when subdomain starts with dash and is blurred', a
 	} );
 
 	// Fill in an invalid subdomain starting with dash and blur
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, '-invalid' );
 	await user.tab(); // This will blur the field
 
@@ -162,7 +162,7 @@ test( 'shows validation error when target URL is empty and blurred', async () =>
 	} );
 
 	// Fill in a valid subdomain
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Focus on target URL field but leave it empty, then blur
@@ -187,7 +187,7 @@ test( 'shows validation error when target URL is invalid and blurred', async () 
 	} );
 
 	// Fill in a valid subdomain
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Fill in an invalid target URL and blur
@@ -211,7 +211,7 @@ test( 'shows validation error when target URL redirects to same domain without p
 	} );
 
 	// Fill in a valid subdomain
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Fill in target URL that points to same domain (which is not allowed) and blur
@@ -236,7 +236,7 @@ test( 'allows target URL that redirects to same domain with path', async () => {
 	} );
 
 	// Fill in a valid subdomain
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Fill in target URL that points to same domain with path (which is allowed)
@@ -270,7 +270,7 @@ test( 'allows target URL without protocol (normalizes input)', async () => {
 	} );
 
 	// Fill in a valid subdomain
-	const subdomainInput = screen.getByRole( 'textbox', { name: /subdomain/i } );
+	const subdomainInput = screen.getByRole( 'textbox', { name: /source url/i } );
 	await user.type( subdomainInput, 'blog' );
 
 	// Fill in target URL without protocol

--- a/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
@@ -69,7 +69,7 @@ test( 'renders edit form with pre-filled root domain forwarding data', async () 
 	} );
 
 	// For root domain forwarding, source type should be 'root'
-	expect( screen.getByText( 'Source URL' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Type' ) ).toBeInTheDocument();
 } );
 
 test( 'forces subdomain mode when forceSubdomain is true for existing subdomain forwarding', async () => {
@@ -92,8 +92,8 @@ test( 'forces subdomain mode when forceSubdomain is true for existing subdomain 
 	} );
 
 	// Should not show the source type selector when forceSubdomain is true
-	expect( screen.queryByText( 'Source URL' ) ).not.toBeInTheDocument();
-	expect( screen.getByText( /Subdomain/ ) ).toBeInTheDocument();
+	expect( screen.queryByText( 'Type' ) ).not.toBeInTheDocument();
+	expect( screen.getByText( /Source URL/ ) ).toBeInTheDocument();
 } );
 
 test( 'calls onSubmit with updated data when form is submitted', async () => {


### PR DESCRIPTION
This is an effort to make the interface of the domain forwarding form better match the original one

| before | after |
| --- | --- |
| <img width="701" height="515" alt="Screenshot 2025-11-06 at 15 25 50" src="https://github.com/user-attachments/assets/541c525c-eb09-4876-bb2a-724f7b70fab8" /> | <img width="709" height="440" alt="Screenshot 2025-11-06 at 15 24 29" src="https://github.com/user-attachments/assets/dab5007a-5eab-4ba9-877c-e3a2b1c83127" /> |
| <img width="698" height="438" alt="Screenshot 2025-11-06 at 15 25 56" src="https://github.com/user-attachments/assets/1f85706d-adae-46ed-a7ea-049c75003f71" /> | <img width="694" height="438" alt="Screenshot 2025-11-06 at 15 24 36" src="https://github.com/user-attachments/assets/78f9c165-1fd9-4303-9a36-208f4c3a1c0f" /> |
| <img width="699" height="568" alt="Screenshot 2025-11-06 at 15 26 08" src="https://github.com/user-attachments/assets/676e2f4d-c554-4938-9335-e8816b7a06f2" /> | <img width="701" height="478" alt="Screenshot 2025-11-06 at 15 25 04" src="https://github.com/user-attachments/assets/36066866-5773-42e6-a026-a0a7da23d512" /> |



Part of [DOMAINS-1753: Intuitive subdomain/root domain forwarding](https://linear.app/a8c/issue/DOMAINS-1753/intuitive-subdomainroot-domain-forwarding)

## Proposed Changes

* Use row layout for the type and the subdomain fields
* Change the subdomain field to disabled instead of hiding it if the `Domain` type is selected
* Update the tests to work with the new logic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve how the interface for adding domain forwarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There are tests that should work
* Go to /v2/domains, click on a domain > Domain forwarding > Add and make sure that you can add new domain forwarding for the root domain and/or a subdomain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
