### PR TITLE
A4A > Tiers: Enable revamped tiers UI on production & minor UI fix

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -8,13 +8,13 @@ import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
-import { SectionHeader } from 'calypso/dashboard/components/section-header';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentAgencyTier from '../lib/get-current-agency-tier';
@@ -81,7 +81,9 @@ export default function TierCards( {
 						<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
 							<VStack spacing={ 2 } style={ { flex: 1, justifyContent: 'flex-start' } }>
 								<HStack>
-									<SectionHeader title={ tier.name } />
+									<Heading level={ 3 } weight={ 500 }>
+										{ tier.name }
+									</Heading>
 									{ isCurrentTier && ! isEarlyAccess && (
 										<Badge
 											style={ { minWidth: 'fit-content' } }

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,7 +42,8 @@
 		"a4a-bd-checkout": false,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"tiers-revamp": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1671/janitorial-enable-feature-flag-on-production

This PR also does a minor UI fix

Reverts Automattic/wp-calypso#106962