### PR TITLE
MSD: Fix the view transition between sites and site overview

### DIFF
--- a/client/dashboard/app/dataviews/use-view.ts
+++ b/client/dashboard/app/dataviews/use-view.ts
@@ -1,11 +1,11 @@
 import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { useLocation, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import fastDeepEqual from 'fast-deep-equal/es6';
 import { useCallback, useMemo } from 'react';
 import type { Field, View } from '@wordpress/dataviews';
 
-interface UseViewOptions {
+interface UseViewOptions< T > {
 	/**
 	 * Unique slug to identify the view.
 	 * Used as the suffix for the Calypso preference name.
@@ -21,7 +21,12 @@ interface UseViewOptions {
 	 * Possible fields that could be displayed in the view.
 	 * Used to sanitize the persisted view.
 	 */
-	defaultFields: Field< any >[];
+	defaultFields: Field< T >[];
+
+	/**
+	 * The transient properties (e.g.: `page` and `search`) from the URL query params.
+	 */
+	queryParams: any;
 }
 
 /**
@@ -29,7 +34,12 @@ interface UseViewOptions {
  * Transient properties (`page` and `search`) are synced to the URL query params,
  * while the rest of the properties is persisted to Calypso preferences.
  */
-export function useView( { slug, defaultView, defaultFields }: UseViewOptions ): {
+export function useView< T >( {
+	slug,
+	defaultView,
+	defaultFields,
+	queryParams,
+}: UseViewOptions< T > ): {
 	view: View;
 	updateView: ( newView: View ) => void;
 	isViewModified: boolean;
@@ -39,8 +49,6 @@ export function useView( { slug, defaultView, defaultFields }: UseViewOptions ):
 
 	const { data: persistedView } = useSuspenseQuery( userPreferenceQuery( preferenceName ) );
 	const { mutate: persistView } = useMutation( userPreferenceOptimisticMutation( preferenceName ) );
-
-	const { search: queryParams } = useLocation();
 	const navigate = useNavigate();
 
 	const baseView: View = sanitizeView( persistedView ?? defaultView, defaultFields );

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -70,6 +70,7 @@ export default function CIABSites() {
 		slug: 'sites-ciab',
 		defaultView,
 		defaultFields: getDefaultFields(),
+		queryParams: currentSearchParams,
 	} );
 
 	const {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -75,6 +75,7 @@ export default function Sites() {
 		slug: 'sites',
 		defaultView,
 		defaultFields: getDefaultFields(),
+		queryParams: currentSearchParams,
 	} );
 
 	const {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1762415093849379-slack-CRWCHQGUB

## Proposed Changes

* Fix the view transition between the Site and Site Overview pages. The old view was stuck on the first page because the query parameters were not coming from the current route.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The old view was stuck in the first page 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Navigate to next page
* Select any site
* Ensure the transition to the Site Overview is smooth and does not briefly display the first page during navigation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?