### PR TITLE
A4A: Add A4A Jetpack Stats product for the Stats app

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,4 +1,6 @@
 import {
+	A4A_PRODUCT_JETPACK_STATS_MONTHLY,
+	A4A_PRODUCT_JETPACK_STATS_YEARLY,
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_GROWTH_PLANS,
 	JETPACK_SECURITY_PLANS,
@@ -80,6 +82,8 @@ const isCommercialPurchaseOwned = ( ownedPurchases: Purchase[] ) => {
 		PRODUCT_JETPACK_STATS_MONTHLY,
 		PRODUCT_JETPACK_STATS_YEARLY,
 		PRODUCT_JETPACK_STATS_BI_YEARLY,
+		A4A_PRODUCT_JETPACK_STATS_MONTHLY,
+		A4A_PRODUCT_JETPACK_STATS_YEARLY,
 	] );
 };
 
@@ -194,8 +198,13 @@ export default function useStatsPurchases( siteId: number | null ) {
 	};
 }
 
-export const withStatsPurchases =
-	( WrappedComponent: ComponentClass ) => ( props: { siteId: number | null } ) => {
+export const withStatsPurchases = ( WrappedComponent: ComponentClass ) => {
+	const WithStatsPurchases = ( props: { siteId: number | null } ) => {
 		const statsPurchases = useStatsPurchases( props.siteId );
 		return <WrappedComponent { ...props } { ...statsPurchases } />;
 	};
+	const wrappedComponentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+	WithStatsPurchases.displayName = `withStatsPurchases(${ wrappedComponentName })`;
+
+	return WithStatsPurchases;
+};

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -86,6 +86,9 @@ export const PRODUCT_JETPACK_MONITOR = PRODUCT_JETPACK_MONITOR_YEARLY;
 export const PRODUCT_JETPACK_CREATOR_BI_YEARLY = 'jetpack_creator_bi_yearly';
 export const PRODUCT_JETPACK_CREATOR_YEARLY = 'jetpack_creator_yearly';
 export const PRODUCT_JETPACK_CREATOR_MONTHLY = 'jetpack_creator_monthly';
+// A4A Jetpack Products
+export const A4A_PRODUCT_JETPACK_STATS_YEARLY = 'a4a_jetpack_stats_yearly';
+export const A4A_PRODUCT_JETPACK_STATS_MONTHLY = 'a4a_jetpack_stats_monthly';
 
 //add-on products
 export const PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY =


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/2969

## Proposed Changes


**Context:** p1761914272463199-slack-C047ACYM8UQ

- **Before**

<img width="635" height="815" alt="image" src="https://github.com/user-attachments/assets/bbdfd8a9-5017-48fd-9d40-7cf786db8fbe" />

- **After**

<img width="1388" height="796" alt="image" src="https://github.com/user-attachments/assets/90f1d275-52ae-479e-b47c-5b1bff1bd69b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?