### PR TITLE
MSD Billing: Fix redirect after cancel load for non-cancelable subs

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -975,16 +975,15 @@ export default function CancelPurchase() {
 			return false;
 		}
 
-		const isValidForDisablingAutoRenew = purchase.can_disable_auto_renew;
-		const isValidForCancellation = purchase.is_cancelable;
-		// const isValidForRemoval = ! purchase.is_cancelable && purchase.is_removable;
-		const isValidForRemoval = purchase.is_removable;
-
-		if ( ! isValidForCancellation && state.surveyShown ) {
+		if ( ! purchase.is_cancelable && state.surveyShown ) {
 			return true;
 		}
 
-		if ( ! isValidForDisablingAutoRenew && isValidForCancellation && isValidForRemoval ) {
+		if (
+			! purchase.can_disable_auto_renew &&
+			! purchase.is_cancelable &&
+			! purchase.is_removable
+		) {
 			if ( ! createdErrorNoticeForRedirect.current ) {
 				createErrorNotice(
 					__(


### PR DESCRIPTION
Fixes SHILL-1295

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This fixes a bug in the Multi Site Dashboard purchase cancel flow. If the purchase cannot be cancelled, removed, or have auto-renew disabled, we redirect back to the purchase page with an error message. However, the logic is flawed and needed to be corrected.

(I'm not certain if the message is correct. It mentions that the purchase has been removed, which is not necessarily the case, but that's a separate issue.)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit a purchase page in the Multi Site Dashboard billing section.
- To visit the cancel page you have to add `/cancel` to the purchase page (the buttons are not yet wired up to the flow).
- Visit the cancel page for an active plan where `can_disable_auto_renew` is false.
- Verify that you see the cancel page.
