### PR TITLE
SSH Migration: Gate the flow for specified hosts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
@@ -7,7 +7,7 @@ export const SSH_HOST_DISPLAY_NAMES: Record< string, string > = {
 	godaddy: 'GoDaddy',
 	bluehost: 'Bluehost',
 	ionos: 'IONOS',
-	hostinger: 'Hostinger',
+	'hostinger-international-limited': 'Hostinger',
 	inmotion: 'InMotion Hosting',
 	aruba: 'Aruba',
 	hostgator: 'HostGator',
@@ -39,7 +39,7 @@ const SSH_HOST_SUPPORT_DOCS: Record< string, SSHSupportDoc > = {
 		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ionos-using-ssh/' ),
 		postId: 445543,
 	},
-	hostinger: {
+	'hostinger-international-limited': {
 		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-hostinger-using-ssh/' ),
 		postId: 445542,
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/ssh-host-support-urls.ts
@@ -14,7 +14,7 @@ export const SSH_HOST_DISPLAY_NAMES: Record< string, string > = {
 	digitalocean: 'DigitalOcean',
 	hetzner: 'Hetzner',
 	namecheap: 'Namecheap',
-	ovh: 'OVHcloud',
+	'ovh-sas': 'OVHcloud',
 	dreamhost: 'DreamHost',
 };
 
@@ -71,7 +71,7 @@ const SSH_HOST_SUPPORT_DOCS: Record< string, SSHSupportDoc > = {
 		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-namecheap-using-ssh/' ),
 		postId: 445547,
 	},
-	ovh: {
+	'ovh-sas': {
 		url: localizeUrl( 'https://wordpress.com/support/migrate-a-site-from-ovhcloud-using-ssh/' ),
 		postId: 445548,
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -6,7 +6,7 @@ import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
 const ENABLED_SSH_HOSTS: string[] = [
 	'hostinger-international-limited',
 	'ionos',
-	'ovh',
+	'ovh-sas',
 	'bluehost',
 	'namecheap',
 ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -3,7 +3,13 @@ import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
 /**
  * List of hosting providers currently enabled for SSH migration
  */
-const ENABLED_SSH_HOSTS: string[] = [ 'hostinger', 'ionos', 'ovh', 'bluehost', 'namecheap' ];
+const ENABLED_SSH_HOSTS: string[] = [
+	'hostinger-international-limited',
+	'ionos',
+	'ovh',
+	'bluehost',
+	'namecheap',
+];
 
 /**
  * Checks if a hosting provider is supported for SSH migration

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -1,9 +1,14 @@
 import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
 
 /**
+ * List of hosting providers currently enabled for SSH migration
+ */
+const ENABLED_SSH_HOSTS = [ 'hostinger', 'ionos', 'ovh', 'bluehost', 'namecheap' ] as const;
+
+/**
  * Checks if a hosting provider is supported for SSH migration
  * @param hostingSlug - The hosting provider slug (e.g., 'digitalocean', 'bluehost')
- * @returns true if the hosting provider is in the supported list
+ * @returns true if the hosting provider is in the enabled list
  */
 export const isHostingSupportedForSSHMigration = ( hostingSlug?: string ): boolean => {
 	if ( ! hostingSlug ) {
@@ -11,5 +16,12 @@ export const isHostingSupportedForSSHMigration = ( hostingSlug?: string ): boole
 	}
 
 	const normalizedSlug = hostingSlug.toLowerCase().trim();
-	return normalizedSlug in SSH_HOST_DISPLAY_NAMES;
+
+	// Check if host exists in display names (validates it's a known host)
+	if ( ! ( normalizedSlug in SSH_HOST_DISPLAY_NAMES ) ) {
+		return false;
+	}
+
+	// Check if host is in the enabled list
+	return ENABLED_SSH_HOSTS.includes( normalizedSlug as ( typeof ENABLED_SSH_HOSTS )[ number ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -3,7 +3,7 @@ import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
 /**
  * List of hosting providers currently enabled for SSH migration
  */
-const ENABLED_SSH_HOSTS = [ 'hostinger', 'ionos', 'ovh', 'bluehost', 'namecheap' ] as const;
+const ENABLED_SSH_HOSTS: string[] = [ 'hostinger', 'ionos', 'ovh', 'bluehost', 'namecheap' ];
 
 /**
  * Checks if a hosting provider is supported for SSH migration
@@ -23,5 +23,5 @@ export const isHostingSupportedForSSHMigration = ( hostingSlug?: string ): boole
 	}
 
 	// Check if host is in the enabled list
-	return ENABLED_SSH_HOSTS.includes( normalizedSlug as ( typeof ENABLED_SSH_HOSTS )[ number ] );
+	return ENABLED_SSH_HOSTS.includes( normalizedSlug );
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15108

Depends on 195626-ghe-Automattic/wpcom

## Proposed Changes

* Gate the SSH Migration for the following hosts:
    * Hostinger
    * Ionos
    * Ovh
    * Bluehost
    * Namecheap

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to start with only a few hosts so we can properly test the SSH Migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration`
* Input a site in one of the hosts mentioned in the description
* Go through the flow until you reach the `Securely share your access` step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?