### PR TITLE
MSD Billing: Fix checked state of 'my site will change' in cancel flow

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1252,6 +1252,7 @@ export default function CancelPurchase() {
 				<div>
 					<CheckboxControl
 						label={ __( 'I understand my site will change when my plan expires.' ) }
+						checked={ state.customerConfirmedUnderstanding }
 						onChange={ ( checked ) => {
 							if ( atomicTransfer?.created_at ) {
 								setState( ( state ) => ( {


### PR DESCRIPTION
Fixes SHILL-1296

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR fixes a bug where the checkbox that reads "I understand my site will change when my plan expires." on the cancel page in the Multi Site Dashboard did not have a value set which means it was an uncontrolled checkbox.

Before             |  After
:-------------------------:|:-------------------------:
<img width="692" height="225" alt="Screenshot 2025-11-06 at 12 35 44 PM" src="https://github.com/user-attachments/assets/c6092904-c11f-401a-9e22-1eed0f5b784f" /> | <img width="695" height="235" alt="Screenshot 2025-11-06 at 12 34 48 PM" src="https://github.com/user-attachments/assets/aa866e73-742d-4229-b72f-83f7489f9ae9" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit a purchase page in the Multi Site Dashboard billing section.
- To visit the cancel page you have to add `/cancel` to the purchase page (the buttons are not yet wired up to the flow).
- Visit the cancel page for a domain registration.
- Verify that checking both checkboxes at the bottom of the page work as expected.
