### PR TITLE
Help Center: Do not auto escalate failed Odie messages

### DIFF
--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -10,6 +10,9 @@ export const getOdieErrorMessage = (): string =>
 		__i18n_text_domain__
 	);
 
+export const getOdieErrorMessageUnknownError = (): string =>
+	__( 'Sorry, an unknown error occurred. Please try again later.', __i18n_text_domain__ );
+
 export const getOdieErrorMessageNonEligible = (): string =>
 	__(
 		'Sorry, I am offline right now. Come back later or ask for help in our forums:',

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -260,6 +260,21 @@ export const getOdieInitialMessage = (
 	};
 };
 
+export const getErrorMessageUnknownError = (): Message => {
+	return {
+		content: getOdieErrorMessageUnknownError(),
+		role: 'bot',
+		type: 'message',
+		context: {
+			site_id: null,
+			flags: {
+				show_ai_avatar: true,
+				is_error_message: true,
+			},
+		},
+	};
+};
+
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;
 

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -10,7 +10,7 @@ import {
 	getOdieErrorMessageNonEligible,
 	getExistingConversationMessage,
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,
-	getOdieErrorMessageUnknownError,
+	getErrorMessageUnknownError,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -34,21 +34,6 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 				forward_to_human_support: true,
 				hide_disclaimer_content: false,
 				show_contact_support_msg: true,
-				show_ai_avatar: true,
-				is_error_message: true,
-			},
-		},
-	};
-};
-
-const getErrorMessageUnknownError = (): Message => {
-	return {
-		content: getOdieErrorMessageUnknownError(),
-		role: 'bot',
-		type: 'message',
-		context: {
-			site_id: null,
-			flags: {
 				show_ai_avatar: true,
 				is_error_message: true,
 			},

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -10,6 +10,7 @@ import {
 	getOdieErrorMessageNonEligible,
 	getExistingConversationMessage,
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,
+	getOdieErrorMessageUnknownError,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -33,6 +34,21 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 				forward_to_human_support: true,
 				hide_disclaimer_content: false,
 				show_contact_support_msg: true,
+				show_ai_avatar: true,
+				is_error_message: true,
+			},
+		},
+	};
+};
+
+const getErrorMessageUnknownError = (): Message => {
+	return {
+		content: getOdieErrorMessageUnknownError(),
+		role: 'bot',
+		type: 'message',
+		context: {
+			site_id: null,
+			flags: {
 				show_ai_avatar: true,
 				is_error_message: true,
 			},
@@ -286,11 +302,11 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 				const message: Message = { ...getOdieRateLimitMessage(), internal_message_id };
 				addMessage( { message, props: {}, isFromError: true } );
 			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
-				// User is eligible for premium support - transfer to Zendesk
-				createZendeskConversation( {
-					createdFrom: 'api_error',
-					errorReason: error.message || error.toString?.(),
-					isFromError: true,
+				const errorMessage = getErrorMessageUnknownError();
+				addMessage( { message: errorMessage, props: {}, isFromError: true } );
+
+				trackEvent( 'error_sending_odie_message', {
+					error_message: error instanceof Error ? error.toString() : 'unknown_error',
 				} );
 			} else {
 				// User is not eligible for premium support - show error message with support buttons


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Currently, when ANY error occuers, Odie instantly escalates the chat to Happiness. This can happen on network errors, parsing errors, and without user desire to escalate. This removes this behaviour and stops at showing the user a nice message in case of these failures.

## Why are these changes being made?
Stop extraneous tickets.

## Testing Instructions

1. Send a message to Odie.
2. DevTools > Network and filter by `wpcom/v2/odie/chat/`
3. Send a message to Odie. 
4. Find the request with `wpcom/v2/odie/chat/NUMBER`.
5. Block it. 
6. Send another message.
7. It should fail with generic error message and not try to escalate.
