### PR TITLE
MSD: Remove width restriction on SectionHeader description.

### DIFF
--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -63,7 +63,3 @@
 	flex-shrink: 0;
 	align-self: stretch;
 }
-
-.dashboard-section-header__description {
-	max-width: 75ch; /* stylelint-disable-line unit-allowed-list */
-}


### PR DESCRIPTION
## Proposed Changes

Remove the `75ch` width restriction on the SectionHeader description container, expect the consumer to constrain text width when needed.

## Why are these changes being made?

The constraint was added when the component was initially created by @ntsekouras in #103555. For most cases, this is a good idea. 

When page widths get long, we can end up with very wide text. Very wide text can feel unnatural in some contexts. If the text is long enough, it will also force the actions onto a new line since they are set to `wrap` and nothing is stopping the left container to grow. 

However, there are cases, like on the Site Overview, where we build context for the description that can be of variable length and it doesn't fit into the `75ch` box. See #106005.

The _easiest_ solution to that is to not use the `description` and do it locally for those exceptional cases (which it was before #106898).

That runs into a new problem. We want the action buttons to fold under the description. How do we do that if the action buttons are in the `SectionHeader`, but the description comes after the `SectionHeader`?

If we look at the Design System specs, we're already a bit misaligned in trunk by having the heading and description in a container on the left and the actions on the right. 

We are violating this guideline:

> Typically the Header width should match the widest section of subsequent content within the page.

<img width="505" height="285" alt="Screenshot 2025-11-07 at 10 16 08 AM" src="https://github.com/user-attachments/assets/45f8f2c0-53fe-4410-9eff-6276669431f6" />

Source: rykv85Ii9RkvP504dtqqaW0-fi

**So what choices do we have?**

## Don't stretch full width, consumer constrains text width

We say, it's okay to not stretch full width of the content container, and if the view uses long text in the description, they should handle its width.

Implemented in this PR.

## Restructure the layout...

We could move the action to the right of the title. 

```js
<VStack>
    <HStack>
      <Title />
      <Actions />
    </HStack>
    <Description />
</VStack>
```

### ... and not wrap

That would be tricky for views that have a calendar picker or multiple buttons. Maybe we could move calendar pickers into the body and out of the header actions?

###  .. and wrap actions between Heading and Description

The oddity here is a view that has a calendar picker or inputs that separate the heading from the description.

<img width="406" height="297" alt="Screenshot 2025-11-07 at 10 30 44 AM" src="https://github.com/user-attachments/assets/65b90a5a-b85a-47c2-a38c-af21f9399f0e" />

We could move the calendar picker out of the PageHeader actions, but on desktop we'd have a hard time getting it to align top right with the Heading.

## JavaScript magic 🪄 

We can use `ResizeObserver` to figure out when to change the order of the elements and fix the 

My least favorite.

## Testing Instructions
-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
