### PR TITLE
MSD Plugins Management: Make sites count field clickable

### DIFF
--- a/client/dashboard/plugins/manage/fields/sites-count.tsx
+++ b/client/dashboard/plugins/manage/fields/sites-count.tsx
@@ -1,4 +1,6 @@
+import { Link } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { pluginRoute } from '../../../app/router/plugins';
 import type { PluginListRow } from '../types';
 import type { Field } from '@wordpress/dataviews';
 
@@ -8,5 +10,9 @@ export const sitesCountField: Field< PluginListRow > = {
 	getValue: ( { item } ) => item.sitesCount,
 	enableHiding: false,
 	enableSorting: true,
-	render: ( { item } ) => String( item.sitesCount ),
+	render: ( { item } ) => (
+		<Link to={ pluginRoute.to } params={ { pluginId: item.slug } }>
+			{ String( item.sitesCount ) }
+		</Link>
+	),
 };


### PR DESCRIPTION
## Proposed Changes

This PR makes the sites count field clickable to help with action discoverability.

<img width="1390" height="382" alt="SCR-20251107-mvtv" src="https://github.com/user-attachments/assets/c4220852-e7c7-4151-a908-d3e0a78095e4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
