### PR TITLE
MSD: Make support links more consistent

### DIFF
--- a/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
+++ b/client/dashboard/domains/domain-contact-details/contact-form-privacy.tsx
@@ -84,13 +84,15 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 						{ createInterpolateElement(
 							domain.private_domain
 								? __(
-										'Privacy protection must be enabled due to the registry’s policies. <link>Learn more</link>'
+										'Privacy protection must be enabled due to the registry’s policies. <learnMoreLink />'
 								  )
 								: __(
-										'Privacy protection is not available due to the registry’s policies. <link>Learn more</link>'
+										'Privacy protection is not available due to the registry’s policies. <learnMoreLink />'
 								  ),
 							{
-								link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+								learnMoreLink: (
+									<InlineSupportLink supportContext="domain-registrations-and-privacy" />
+								),
 							}
 						) }
 					</Text>
@@ -170,9 +172,11 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 			{ domain.privacy_available && (
 				<Text as="p" variant="muted">
 					{ createInterpolateElement(
-						__( 'We recommend keeping privacy protection on. <link>Learn more</link>' ),
+						__( 'We recommend keeping privacy protection on. <learnMoreLink />' ),
 						{
-							link: <InlineSupportLink supportContext="domain-registrations-and-privacy" />,
+							learnMoreLink: (
+								<InlineSupportLink supportContext="domain-registrations-and-privacy" />
+							),
 						}
 					) }
 				</Text>

--- a/client/dashboard/domains/domain-dns/dns-description.tsx
+++ b/client/dashboard/domains/domain-dns/dns-description.tsx
@@ -4,9 +4,9 @@ import InlineSupportLink from '../../components/inline-support-link';
 
 export default function DnsDescription() {
 	return createInterpolateElement(
-		__( 'DNS records change how your domain works. <link>Learn more</link>' ),
+		__( 'DNS records change how your domain works. <learnMoreLink />' ),
 		{
-			link: <InlineSupportLink supportContext="manage-your-dns-records" />,
+			learnMoreLink: <InlineSupportLink supportContext="manage-your-dns-records" />,
 		}
 	);
 }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -203,7 +203,7 @@ export default function DomainDns() {
 				<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 					{ createInterpolateElement(
 						__(
-							'This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
+							'This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink />'
 						),
 						{
 							defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -216,7 +216,7 @@ export default function DomainDns() {
 			<Notice variant="warning" title={ __( 'Your domain is not using default A records' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
+						'This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select “Restore default A records”. <defaultRecordsLink />'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -238,7 +238,7 @@ export default function DomainDns() {
 			>
 				{ createInterpolateElement(
 					__(
-						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink>Learn more</defaultRecordsLink>'
+						'This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select “Restore default CNAME record”. <defaultRecordsLink />'
 					),
 					{
 						defaultRecordsLink: <InlineSupportLink supportContext="dns_default_records" />,
@@ -253,10 +253,10 @@ export default function DomainDns() {
 			<Notice title={ __( 'What are DNS records used for?' ) }>
 				{ createInterpolateElement(
 					__(
-						'Custom DNS records allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider. <link>Learn more</link>'
+						'Custom DNS records allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider. <learnMoreLink />'
 					),
 					{
-						link: <InlineSupportLink supportContext="manage-your-dns-records" />,
+						learnMoreLink: <InlineSupportLink supportContext="manage-your-dns-records" />,
 					}
 				) }
 			</Notice>

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -44,10 +44,10 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 			return createInterpolateElement(
 				__(
 					/* translators: <link> will be replaced with an a support link */
-					'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. <link>Learn more</link>'
+					'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. <learnMoreLink />'
 				),
 				{
-					link: <InlineSupportLink supportContext="https-ssl" />,
+					learnMoreLink: <InlineSupportLink supportContext="https-ssl" />,
 				}
 			);
 		}

--- a/client/dashboard/domains/name-servers/upsell-nudge.tsx
+++ b/client/dashboard/domains/name-servers/upsell-nudge.tsx
@@ -26,12 +26,12 @@ export default function UpsellNudge( { domainName, domainSiteSlug }: Props ) {
 				<Text as="p">
 					{ createInterpolateElement(
 						__(
-							'Upgrade to a paid plan to make <domain /> the primary address that your visitors see when they visit your site.<br /><learnMore />'
+							'Upgrade to a paid plan to make <domain /> the primary address that your visitors see when they visit your site.<br /><learnMoreLink />'
 						),
 						{
 							br: <br />,
 							domain: <strong>{ domainName }</strong>,
-							learnMore: <InlineSupportLink supportLink={ SETTING_PRIMARY_DOMAIN } />,
+							learnMoreLink: <InlineSupportLink supportLink={ SETTING_PRIMARY_DOMAIN } />,
 						}
 					) }
 				</Text>

--- a/client/dashboard/me/blocked-sites/index.tsx
+++ b/client/dashboard/me/blocked-sites/index.tsx
@@ -1,4 +1,5 @@
 import { blockedSitesInfiniteQuery, unblockSiteMutation } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useMutation, useInfiniteQuery } from '@tanstack/react-query';
 import { ExternalLink, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -130,14 +131,15 @@ export default function BlockedSites() {
 					title={ __( 'Blocked sites' ) }
 					description={ createInterpolateElement(
 						__(
-							'Blocked sites will not appear in your Reader and will not be recommended to you. <link>Learn more</link>'
+							'Blocked sites will not appear in your Reader and will not be recommended to you. <learnMoreLink />'
 						),
 						{
-							link: (
+							learnMoreLink: (
 								<InlineSupportLink
 									supportPostId={ 32011 }
-									// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-									supportLink="https://wordpress.com/support/reader/#interact-with-posts"
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/reader/#interact-with-posts'
+									) }
 								/>
 							),
 						}

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -144,10 +144,10 @@ export default function SecurityConnectedApps() {
 					title={ __( 'Connected applications' ) }
 					description={ createInterpolateElement(
 						__(
-							'Connect with third-party applications that extend your site in new and cool ways. <link>Learn more</link>'
+							'Connect with third-party applications that extend your site in new and cool ways. <learnMoreLink />'
 						),
 						{
-							link: (
+							learnMoreLink: (
 								<InlineSupportLink
 									supportPostId={ 17288 }
 									supportLink={ localizeUrl(

--- a/client/dashboard/me/security-ssh-key/index.tsx
+++ b/client/dashboard/me/security-ssh-key/index.tsx
@@ -26,7 +26,7 @@ export default function SecuritySshKey() {
 				sprintf(
 					/* translators: %(businessPlan)s is the name of the Business plan, %(commercePlan)s is the name of the Commerce plan */
 					__(
-						'Attach the SSH key to a site with a %(businessPlan)s or %(commercePlan)s plan to enable SSH key authentication for that site. If the SSH key is removed, it will also be removed from all attached sites. <learnMoreLink>Learn more</learnMoreLink>'
+						'Attach the SSH key to a site with a %(businessPlan)s or %(commercePlan)s plan to enable SSH key authentication for that site. If the SSH key is removed, it will also be removed from all attached sites. <learnMoreLink />'
 					),
 					{
 						businessPlan: getPlanNames()[ DotcomPlans.BUSINESS ],

--- a/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key-form.tsx
@@ -140,7 +140,7 @@ export default function SshKeyForm( {
 								level={ 3 }
 								description={ createInterpolateElement(
 									__(
-										'Once added, attach the SSH key to a site with a Business or Commerce plan to enable SSH key authentication for that site. <learnMoreLink>Learn more</learnMoreLink>'
+										'Once added, attach the SSH key to a site with a Business or Commerce plan to enable SSH key authentication for that site. <learnMoreLink />'
 									),
 									{
 										learnMoreLink: (

--- a/client/dashboard/me/security-two-step-auth-app/index.tsx
+++ b/client/dashboard/me/security-two-step-auth-app/index.tsx
@@ -26,7 +26,7 @@ export default function SecurityTwoStepAuthApp() {
 					<Notice variant="info" title={ __( 'Before you continue' ) }>
 						{ createInterpolateElement(
 							__(
-								'You‘ll need an authenticator app like Google Authenticator or Authy installed on your device to enable two-step authentication. <learnMoreLink>Learn more</learnMoreLink>'
+								'You‘ll need an authenticator app like Google Authenticator or Authy installed on your device to enable two-step authentication. <learnMoreLink />'
 							),
 							{
 								learnMoreLink: (

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -165,7 +165,7 @@ export default function ApplicationPasswords() {
 				title={ __( 'Application passwords' ) }
 				description={ createInterpolateElement(
 					__(
-						'Generate a custom password for each third-party application you authorize to use your WordPress.com account. You can revoke access for an individual application here if you ever need to. <learnMoreLink>Learn more</learnMoreLink>'
+						'Generate a custom password for each third-party application you authorize to use your WordPress.com account. You can revoke access for an individual application here if you ever need to. <learnMoreLink />'
 					),
 					{
 						learnMoreLink: (

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -136,13 +136,11 @@ export default function SecurityKeys() {
 					isBrowserSupported
 						? createInterpolateElement(
 								__(
-									'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser. <learnMoreLink>Learn more</learnMoreLink>'
+									'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser. <learnMoreLink />'
 								),
 								{
 									learnMoreLink: (
-										<InlineSupportLink supportContext="two-step-authentication-security-key">
-											{ __( 'Learn more' ) }
-										</InlineSupportLink>
+										<InlineSupportLink supportContext="two-step-authentication-security-key" />
 									),
 								}
 						  )

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -170,9 +170,7 @@ function DeploymentsList() {
 				<PageHeader
 					title={ __( 'Deployments' ) }
 					description={ createInterpolateElement(
-						__(
-							'Automate updates from GitHub to streamline workflows. <learnMoreLink>Learn more</learnMoreLink>'
-						),
+						__( 'Automate updates from GitHub to streamline workflows. <learnMoreLink />' ),
 						{
 							learnMoreLink: <InlineSupportLink supportContext="github-deployments" />,
 						}

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -91,7 +91,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 	const renderMessage = () => {
 		if ( ! canUserSetPrimaryDomainOnThisSite ) {
 			return createInterpolateElement(
-				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink>Learn more</learnMoreLink>.',
+				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink />',
 				{
 					upgradeLink: <a href={ `/plans/${ site.slug }` } />,
 					br: <br />,
@@ -101,7 +101,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		}
 		if ( domainsList.length === 0 ) {
 			return createInterpolateElement(
-				'Before changing your primary site address you must register or connect a new custom domain. <learnMoreLink>Learn more</learnMoreLink>.',
+				'Before changing your primary site address you must register or connect a new custom domain. <learnMoreLink />',
 				{
 					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
 				}
@@ -109,7 +109,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		}
 
 		return createInterpolateElement(
-			'The current primary site address for this site is: <currentPrimaryDomain />. This is the site address your visitors will see while browsing your site. <learnMoreLink>Learn more</learnMoreLink>.',
+			'The current primary site address for this site is: <currentPrimaryDomain />. This is the site address your visitors will see while browsing your site. <learnMoreLink />',
 			{
 				currentPrimaryDomain: <strong>{ currentPrimaryDomain }</strong>,
 				learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,

--- a/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/data-center-form.tsx
@@ -1,4 +1,5 @@
 import { getDataCenterOptions } from '@automattic/api-core';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -62,14 +63,16 @@ export function DataCenterForm( { value, onChange }: DataCenterFormProps ) {
 					label={ __( 'Pick your primary data center' ) }
 					help={ createInterpolateElement(
 						__(
-							'For redundancy, your site will be replicated in real-time to another region. <link>Learn more</link>'
+							'Your site is automatically backed up in real-time to another region.<br /><learnMoreLink />'
 						),
 						{
-							link: (
+							br: <br />,
+							learnMoreLink: (
 								<InlineSupportLink
 									supportPostId={ 227309 }
-									// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-									supportLink="https://wordpress.com/support/choose-your-sites-primary-data-center/"
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/choose-your-sites-primary-data-center/'
+									) }
 								/>
 							),
 						}

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -132,9 +132,7 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 				<PageHeader
 					title={ __( 'Logs' ) }
 					description={ createInterpolateElement(
-						__(
-							'View and download various server logs. <learnMoreLink>Learn more</learnMoreLink>'
-						),
+						__( 'View and download various server logs. <learnMoreLink />' ),
 						{
 							learnMoreLink: <InlineSupportLink supportContext="site-monitoring-logs" />,
 						}

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -184,9 +184,7 @@ function SitePerformance() {
 					header={
 						<PageHeader
 							description={ createInterpolateElement(
-								__(
-									'Optimize your site for lightning-fast performance. <learnMoreLink>Learn more</learnMoreLink>'
-								),
+								__( 'Optimize your site for lightning-fast performance. <learnMoreLink />' ),
 								{
 									learnMoreLink: <InlineSupportLink supportContext="site-performance" />,
 								}

--- a/client/dashboard/sites/performance/report-footer.tsx
+++ b/client/dashboard/sites/performance/report-footer.tsx
@@ -1,4 +1,4 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Text } from '../../components/text';
 
@@ -16,13 +16,9 @@ export default function ReportFooter() {
 				) }
 			</Text>
 			<Text as="p">
-				<a
-					href="https://developer.wordpress.com/docs/site-performance/speed-test/#accessing-the-speed-test-tool"
-					target="_blank"
-					rel="noreferrer"
-				>
-					{ __( 'Learn more about the Chrome UX Report ↗' ) }
-				</a>
+				<ExternalLink href="https://developer.wordpress.com/docs/site-performance/speed-test/#accessing-the-speed-test-tool">
+					{ __( 'Learn more about the Chrome UX Report' ) }
+				</ExternalLink>
 			</Text>
 		</VStack>
 	);

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -294,22 +294,19 @@ export default function CachingSettings( { siteSlug }: { siteSlug: string } ) {
 	};
 
 	const description = hasPlanFeature( site, HostingFeatures.CACHING )
-		? createInterpolateElement(
-				__( 'Manage your site’s server-side caching. <link>Learn more</link>' ),
-				{
-					link: <InlineSupportLink supportContext="hosting-edge-cache" />,
-				}
-		  )
+		? createInterpolateElement( __( 'Manage your site’s server-side caching. <learnMoreLink />' ), {
+				learnMoreLink: <InlineSupportLink supportContext="hosting-edge-cache" />,
+		  } )
 		: createInterpolateElement(
 				sprintf(
 					/* translators: %s: plan name. Eg. 'Personal' */
 					__(
-						'Caching is managed for you on the %s plan. The cache is cleared automatically as you make changes to your site. <link>Learn more</link>'
+						'Caching is managed for you on the %s plan. The cache is cleared automatically as you make changes to your site. <learnMoreLink />'
 					),
 					getSitePlanDisplayName( site )
 				),
 				{
-					link: <InlineSupportLink supportContext="hosting-edge-cache" />,
+					learnMoreLink: <InlineSupportLink supportContext="hosting-edge-cache" />,
 				}
 		  );
 

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -74,10 +74,10 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 	const description = hasPlanFeature( site, HostingFeatures.DATABASE )
 		? createInterpolateElement(
 				__(
-					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL. <link>Learn more</link>'
+					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL. <learnMoreLink />'
 				),
 				{
-					link: <InlineSupportLink supportContext="hosting-mysql" />,
+					learnMoreLink: <InlineSupportLink supportContext="hosting-mysql" />,
 				}
 		  )
 		: undefined;

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -219,10 +219,10 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 					title={ __( 'Defensive mode' ) }
 					description={ createInterpolateElement(
 						__(
-							'Extra protection against spam bots and attacks. Visitors will see a quick loading page while we run additional security checks. <link>Learn more</link>'
+							'Extra protection against spam bots and attacks. Visitors will see a quick loading page while we run additional security checks. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="hosting-defensive-mode" />,
+							learnMoreLink: <InlineSupportLink supportContext="hosting-defensive-mode" />,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -156,10 +156,10 @@ export default function SftpCard( {
 						title={ __( 'SFTP' ) }
 						description={ createInterpolateElement(
 							__(
-								'Use the credentials below to access and edit your website files using an SFTP client. <link>Learn more</link>'
+								'Use the credentials below to access and edit your website files using an SFTP client. <learnMoreLink />'
 							),
 							{
-								link: <InlineSupportLink supportContext="hosting-sftp" />,
+								learnMoreLink: <InlineSupportLink supportContext="hosting-sftp" />,
 							}
 						) }
 						level={ 3 }

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -294,7 +294,7 @@ export default function SshCard( {
 						title={ __( 'SSH' ) }
 						description={ createInterpolateElement(
 							__(
-								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink>Learn more</learnMoreLink>'
+								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink />'
 							),
 							{
 								wpCliLink: <ExternalLink href="https://wp-cli.org/" children={ null } />,

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -43,9 +43,9 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Site visibility' ) }
 					description={ createInterpolateElement(
-						__( 'Control who can view your site. <link>Learn more</link>' ),
+						__( 'Control who can view your site. <learnMoreLink />' ),
 						{
-							link: <InlineSupportLink supportContext="privacy" />,
+							learnMoreLink: <InlineSupportLink supportContext="privacy" />,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -93,10 +93,12 @@ const robotFields: Field< PrivacyFormData & { isPrimaryDomainStaging: boolean } 
 				} }
 				help={ createInterpolateElement(
 					__(
-						'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <a>Learn more</a>'
+						'This will prevent this site’s content from being shared with our licensed network of content and research partners, including those that train AI models. <learnMoreLink />'
 					),
 					{
-						a: <InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />,
+						learnMoreLink: (
+							<InlineSupportLink supportContext="privacy-prevent-third-party-sharing" />
+						),
 					}
 				) }
 			/>

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -99,10 +99,10 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 					title={ __( 'Accept a gift subscription' ) }
 					description={ createInterpolateElement(
 						__(
-							'Allow a site visitor to cover the full cost of your site’s WordPress.com plan. <link>Learn more</link>'
+							'Allow a site visitor to cover the full cost of your site’s WordPress.com plan. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="gift-a-subscription" />,
+							learnMoreLink: <InlineSupportLink supportContext="gift-a-subscription" />,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -32,10 +32,10 @@ const SettingsTransferSitePageLayout = ( { children }: { children: React.ReactNo
 					title={ __( 'Transfer site' ) }
 					description={ createInterpolateElement(
 						__(
-							'Transfer this site to a new or existing site member with just a few clicks. <link>Learn more</link>'
+							'Transfer this site to a new or existing site member with just a few clicks. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="site-transfer" />,
+							learnMoreLink: <InlineSupportLink supportContext="site-transfer" />,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-web-application-firewall/index.tsx
+++ b/client/dashboard/sites/settings-web-application-firewall/index.tsx
@@ -45,10 +45,12 @@ export default function WebApplicationFirewallSettings( { siteSlug }: { siteSlug
 					title={ __( 'Web Application Firewall (WAF)' ) }
 					description={ createInterpolateElement(
 						__(
-							'Our web application firewall (WAF) examines incoming traffic to your website and decides to allow or block it based on various rules. <link>Learn more</link>'
+							'Our web application firewall (WAF) examines incoming traffic to your website and decides to allow or block it based on various rules. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="security-web-application-firewall" />,
+							learnMoreLink: (
+								<InlineSupportLink supportContext="security-web-application-firewall" />
+							),
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -117,7 +117,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 						<Text as="p">
 							{ createInterpolateElement(
 								__(
-									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink>Learn more</learnMoreLink>'
+									'Switch to a staging site to test a beta version of the next WordPress release. <learnMoreLink />'
 								),
 								{
 									learnMoreLink: <InlineSupportLink supportContext="switch-to-staging-site" />,

--- a/client/dashboard/sites/settings-wpcom-login/index.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/index.tsx
@@ -44,10 +44,10 @@ export default function WpcomLoginSettings( { siteSlug }: { siteSlug: string } )
 					title={ __( 'WordPress.com login' ) }
 					description={ createInterpolateElement(
 						__(
-							'Allow registered users to log in to your site with their WordPress.com accounts. <link>Learn more</link>'
+							'Allow registered users to log in to your site with their WordPress.com accounts. <learnMoreLink />'
 						),
 						{
-							link: <InlineSupportLink supportContext="security-wpcom-login" />,
+							learnMoreLink: <InlineSupportLink supportContext="security-wpcom-login" />,
 						}
 					) }
 				/>
@@ -66,8 +66,12 @@ export default function WpcomLoginSettings( { siteSlug }: { siteSlug: string } )
 									'The WordPress.com login feature is disabled because your site is in offline mode. <link>Learn more</link>'
 								),
 								{
-									// @ts-ignore - ExternalLink's children is not missing but is provided by the createInterpolateElement above.
-									link: <ExternalLink href="https://jetpack.com/support/offline-mode/" />,
+									link: (
+										<ExternalLink
+											href="https://jetpack.com/support/offline-mode/"
+											children={ null }
+										/>
+									),
 								}
 							) }
 						</Text>


### PR DESCRIPTION
Fixes DOTMSD-790
Fixes DOTMSD-788

## Proposed Changes

The component `<InlineSupportLink>` already uses "Learn more" as its default text value, so there's no need to explicitly define it. Doing so will reduce complexity for translators.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test the "Learn more" links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
