### PR TITLE
A4A: Add way to skip URL validation in the signup form.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
@@ -26,9 +26,7 @@ const useContactFormValidation = ( { withEmail }: Props ) => {
 	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
 	const [ isValidating, setIsValidating ] = useState( false );
 
-	const skipURLValidation = new URLSearchParams( window.location.search ).has(
-		'skip-url-validation'
-	);
+	const skipURLValidation = new URLSearchParams( window.location.search ).has( '_nvc' );
 
 	const updateValidationError = ( newState: ValidationState ) => {
 		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
@@ -26,6 +26,10 @@ const useContactFormValidation = ( { withEmail }: Props ) => {
 	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
 	const [ isValidating, setIsValidating ] = useState( false );
 
+	const skipURLValidation = new URLSearchParams( window.location.search ).has(
+		'skip-url-validation'
+	);
+
 	const updateValidationError = ( newState: ValidationState ) => {
 		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
 	};
@@ -59,7 +63,7 @@ const useContactFormValidation = ( { withEmail }: Props ) => {
 				newValidationError.agencyUrl = translate( 'Please enter a valid URL' );
 			} else if (
 				CAPTURE_SOCIAL_URL_RGX.test( payload.agencyUrl ) ||
-				! ( await isSiteActive( payload.agencyUrl ) )
+				! ( skipURLValidation || ( await isSiteActive( payload.agencyUrl ) ) )
 			) {
 				newValidationError.agencyUrl = preventWidows(
 					translate(
@@ -77,7 +81,7 @@ const useContactFormValidation = ( { withEmail }: Props ) => {
 
 			return null;
 		},
-		[ translate, withEmail ]
+		[ skipURLValidation, translate, withEmail ]
 	);
 
 	return { validate, validationError, updateValidationError, isValidating };


### PR DESCRIPTION
This PR introduces an option for users to bypass URL validation in the signup form.

Context: p1762509414724749/1762382630.781769-slack-C091P0A65U5


## Proposed Changes

* We added a `_nvc` query string parameter to allow users to skip the url validation in the signup form.

## Why are these changes being made?

* Sometimes, the URL provided by the user cannot be pinged by our servers due to hosting restrictions. This prevents users from signing up, so the option allows them to skip validation quickly.
## Testing Instructions


* Use the A4A live link and navigate to `/signup?_nvc`
* In the form, input a URL (valid format) that do not exists.
* Confirm that the user is able to signup.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?is PR 