### PR TITLE
Plugins rededsign: Add more customizable option to the Dot Pager component

### DIFF
--- a/packages/components/src/dot-pager/style.scss
+++ b/packages/components/src/dot-pager/style.scss
@@ -33,8 +33,30 @@
 		}
 	}
 
-	.dot-pager__control-gap {
-		margin-left: auto;
+	.dot-pager__controls-spacer {
+		flex: 1;
+		justify-content: flex-end;
+		text-align: right;
+	}
+}
+
+.dot-pager__control-button {
+	background-color: var(--studio-white, #fff);
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 50%;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	justify-content: center;
+	align-items: center;
+	margin-inline-start: 9px;
+
+	&:hover {
+		background-color: var(--studio-white, #fff);
+	}
+
+	&[disabled] {
+		border-color: var(--studio-gray-0);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-258](https://linear.app/a8c/issue/DOTDEV-258/implement-carousel-for-the-discovery-plugins-lists)

## Proposed Changes

* adds the `showDots` prop to not render the page dots
* adds the `controlsAction` prop that allows extra content/actions to be added next to the arrows (such as a `Browse all` link)
* adds the `navigationVariant` which restyles to arrows with chevrons in rounded buttons 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed to implement the Plugins redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Go to a page that uses the DotPager component, such as /home/{SITE_ID}
* Ensure the secondary (learn-grow) slider is unchanged
<img width="340" alt="Screenshot 2025-11-07 at 15 24 11" src="https://github.com/user-attachments/assets/7730fbd2-c197-421e-800e-c2e4b7ddfaf0" />

* Edit [this DotPager component](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx#L64) with the newly added props:
```
<DotPager
			className="learn-grow__content customer-home__card"
			hasDynamicHeight
			onPageSelected={ handlePageSelected }
			navigationVariant="button"
			controlsAction={ <button>Browse all</button> }
			showDots={ false }
		>
```
* The slider should work as expected

<img width="340" alt="Screenshot 2025-11-07 at 15 18 16" src="https://github.com/user-attachments/assets/c5973053-8327-4f96-bf67-67b491359e22" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
