### PR TITLE
v2 HD: Fix chart margins on monitoring page

### DIFF
--- a/client/dashboard/sites/monitoring-card/style.scss
+++ b/client/dashboard/sites/monitoring-card/style.scss
@@ -39,10 +39,6 @@
 }
 
 .dashboard-monitoring-card__line-chart {
-	flex-direction: column-reverse !important;
-	gap: 20px;
-	justify-content: start;
-
 	svg {
 		/* Ensure the chart numbers are not clipped. */
 		overflow: visible;

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -207,6 +207,7 @@ export default function MonitoringHttpResponsesCard( {
 				maxWidth={ 1400 }
 				showLegend
 				withLegendGlyph
+				margin={ { bottom: 30 } }
 				glyphStyle={ {
 					radius: 8,
 				} }

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -207,7 +207,6 @@ export default function MonitoringHttpResponsesCard( {
 				maxWidth={ 1400 }
 				showLegend
 				withLegendGlyph
-				margin={ { bottom: 30 } }
 				glyphStyle={ {
 					radius: 8,
 				} }
@@ -264,6 +263,7 @@ export default function MonitoringHttpResponsesCard( {
 						x: xAxisOptions,
 					},
 				} }
+				legendPosition="top"
 			/>
 		</MonitoringCard>
 	);

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -207,6 +207,7 @@ export default function MonitoringHttpResponsesCard( {
 				maxWidth={ 1400 }
 				showLegend
 				withLegendGlyph
+				curveType="monotone"
 				glyphStyle={ {
 					radius: 8,
 				} }

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -155,7 +155,6 @@ export default function MonitoringPerformanceCard( {
 					maxWidth={ 1400 }
 					showLegend
 					withLegendGlyph
-					margin={ { bottom: 30 } }
 					renderGlyph={ ( glyphProps ) => getLegendIcon( glyphProps.key ) }
 					renderTooltip={ ( tooltipProps ) => {
 						if ( ! tooltipProps?.tooltipData?.nearestDatum?.datum?.date ) {
@@ -209,6 +208,7 @@ export default function MonitoringPerformanceCard( {
 							x: xAxisOptions,
 						},
 					} }
+					legendPosition="top"
 				/>
 			) : (
 				<VStack alignment="center">

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -155,6 +155,7 @@ export default function MonitoringPerformanceCard( {
 					maxWidth={ 1400 }
 					showLegend
 					withLegendGlyph
+					margin={ { bottom: 30 } }
 					renderGlyph={ ( glyphProps ) => getLegendIcon( glyphProps.key ) }
 					renderTooltip={ ( tooltipProps ) => {
 						if ( ! tooltipProps?.tooltipData?.nearestDatum?.datum?.date ) {

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -155,6 +155,7 @@ export default function MonitoringPerformanceCard( {
 					maxWidth={ 1400 }
 					showLegend
 					withLegendGlyph
+					curveType="monotone"
 					renderGlyph={ ( glyphProps ) => getLegendIcon( glyphProps.key ) }
 					renderTooltip={ ( tooltipProps ) => {
 						if ( ! tooltipProps?.tooltipData?.nearestDatum?.datum?.date ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes https://linear.app/a8c/issue/M4R73CH-1201/v2-hd-charts-on-monitoring-page-touch-the-card-border

## Proposed Changes

The charts on the monitoring page contain x‑axis numbers/ticks that touch the bottom (card) border. This PR addresses the issue by passing a slightly increased `margin` to the chart component.

### Alternative

The change here is obviously a local fix, not a holistic one. If we render these charts alone in other cards, elsewhere, we'd likely need to do the same (pass `margin`). An alternative may be to slightly increase the default margin in the charts library, which would remove the need to hand-tune bottom margins when charts sit inside tight cards.

I am exploring the above in https://github.com/Automattic/jetpack/pull/45815. Other alternatives are also possible.

### Media 

| Before | After |
|--------|--------|
| <img width="919" height="776" alt="Screenshot 2025-11-07 at 4 12 04 PM" src="https://github.com/user-attachments/assets/ace5bb4f-34fc-49c5-89f2-4d9a0e5c5e0d" /> | <img width="922" height="774" alt="Screenshot 2025-11-07 at 4 11 30 PM" src="https://github.com/user-attachments/assets/7d6951b1-158b-49b4-b13e-8661893cf8ed" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Closes https://linear.app/a8c/issue/M4R73CH-1201/v2-hd-charts-on-monitoring-page-touch-the-card-border

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/sites/{site}/monitoring` and confirm

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
