### PR TITLE
Show the 100-year domain thank-you post purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -9,7 +9,7 @@ import { useUpdateZendeskUserFields } from '@automattic/zendesk-client';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HundredYearLoaderView from 'calypso/components/hundred-year-loader-view';
 import { getRegisteredDomains, getTransferredInDomains } from 'calypso/lib/domains';
@@ -158,16 +158,28 @@ export default function HundredYearThankYou( {
 	const receipt = useSelector( ( state ) => getReceiptById( state, receiptId ) );
 	const isReceiptLoading = ! receipt.hasLoadedFromServer || receipt.isRequesting;
 
+	// Infer whether this is a 100-year domain registration/transfer or the 100-year plan
+	const resolvedProductSlug = useMemo( () => {
+		const purchases = receipt?.data?.purchases || [];
+		const hundredYearDomainPurchase = purchases.find( ( p ) => p.isHundredYearDomain );
+		if ( hundredYearDomainPurchase ) {
+			return hundredYearDomainPurchase.isDomainRegistration
+				? domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
+				: domainProductSlugs.TRANSFER_IN;
+		}
+		return productSlug;
+	}, [ receipt, productSlug ] );
+
 	const siteDomains = useSelector( ( state ) =>
 		siteId ? getDomainsBySiteId( state, siteId ) : []
 	);
 	const isLoadingDomains = useSelector( ( state ) =>
-		siteId && productSlug !== PLAN_100_YEARS
+		siteId && resolvedProductSlug !== PLAN_100_YEARS
 			? isRequestingSite( state, siteId ) || isRequestingSiteDomains( state, siteId )
 			: false
 	);
 	let targetDomain: ResponseDomain | null = null;
-	switch ( productSlug ) {
+	switch ( resolvedProductSlug ) {
 		case domainProductSlugs.TRANSFER_IN:
 			targetDomain = getTransferredInDomains( siteDomains )[ 0 ] ?? null;
 			break;
@@ -188,24 +200,26 @@ export default function HundredYearThankYou( {
 	}, [ dispatch, isReceiptLoading, receiptId ] );
 
 	useEffect( () => {
-		if ( productSlug && submitUserFields && siteId ) {
+		if ( resolvedProductSlug && submitUserFields && siteId ) {
 			submitUserFields( {
 				messaging_flow:
 					FLOWS_ZENDESK_FLOWNAME[
-						productSlug === PLAN_100_YEARS ? HUNDRED_YEAR_PLAN_FLOW : HUNDRED_YEAR_DOMAIN_FLOW
+						resolvedProductSlug === PLAN_100_YEARS
+							? HUNDRED_YEAR_PLAN_FLOW
+							: HUNDRED_YEAR_DOMAIN_FLOW
 					],
 				messaging_site_id: siteId,
 				messaging_url: window.location.href,
 			} );
 		}
-	}, [ siteId, submitUserFields, productSlug ] );
+	}, [ siteId, submitUserFields, resolvedProductSlug ] );
 
 	if (
 		! isReceiptLoading &&
 		( ! receipt.data?.purchases?.length || receipt.data?.purchases[ 0 ].blogId !== siteId ) &&
 		// For transfers, the current siteId might be different - purchase performed with no site (siteId = null)
 		// and blog created after the purchase (siteId != null).
-		productSlug !== domainProductSlugs.TRANSFER_IN
+		resolvedProductSlug !== domainProductSlugs.TRANSFER_IN
 	) {
 		page( '/' );
 	}
@@ -215,7 +229,7 @@ export default function HundredYearThankYou( {
 	const isPageLoading =
 		isReceiptLoading ||
 		isLoadingDomains ||
-		( productSlug !== PLAN_100_YEARS && ! isDomainDataLoaded );
+		( resolvedProductSlug !== PLAN_100_YEARS && ! isDomainDataLoaded );
 	const hundredYearPlanCta = (
 		<StyledLightButton onClick={ () => page( ` /home/${ siteSlug }` ) }>
 			{ translate( 'Manage your site' ) }
@@ -230,9 +244,9 @@ export default function HundredYearThankYou( {
 			{ translate( 'Manage your domain' ) }
 		</StyledLightButton>
 	);
-	const cta = productSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
+	const cta = resolvedProductSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
 	const domainSpecificDescription =
-		productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
+		resolvedProductSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
 			? translate( 'Your 100-Year Domain %(domain)s has been registered.', {
 					args: {
 						domain: targetDomain?.domain || siteSlug, // though targetDomain?.domain should be defined here, right?
@@ -268,7 +282,7 @@ export default function HundredYearThankYou( {
 	);
 
 	const description =
-		productSlug === PLAN_100_YEARS ? (
+		resolvedProductSlug === PLAN_100_YEARS ? (
 			`${ hundredYearPlanDescription } ${ helpAndSupportDescription }`
 		) : (
 			<>

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -236,11 +236,7 @@ export default function HundredYearThankYou( {
 		</StyledLightButton>
 	);
 	const hundredYearDomainCta = (
-		<StyledLightButton
-			onClick={ () =>
-				page( ` /domains/manage/all/overview/${ targetDomain?.name }/${ targetDomain?.name }` )
-			}
-		>
+		<StyledLightButton onClick={ () => page( ` /domains/manage/${ siteSlug }` ) }>
 			{ translate( 'Manage your domain' ) }
 		</StyledLightButton>
 	);

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -40,6 +40,7 @@ import {
 	hasTitanMail,
 	hasProPlan,
 	hasStarterPlan,
+	has100YearDomain,
 } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getEligibleTitanDomain } from 'calypso/lib/titan';
@@ -619,7 +620,8 @@ function getFallbackDestination( {
 	}
 
 	const is100YearPlanProduct = cart?.products?.some( is100Year );
-	if ( is100YearPlanProduct ) {
+	const is100YearDomainProduct = cart ? has100YearDomain( cart ) : false;
+	if ( is100YearPlanProduct || is100YearDomainProduct ) {
 		debug( 'site with 100 year plan' );
 		return `/checkout/100-year/thank-you/${ siteSlug }/${ receiptIdOrPlaceholder }`;
 	}

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1706,6 +1706,28 @@ describe( 'getThankYouPageUrl', () => {
 			expect( url ).toBe( '/checkout/100-year/thank-you/yourgroovydomain.com/999999' );
 		} );
 
+		it( 'Redirects to the 100 year thank-you page when a 100-year domain was purchased (volume 100)', () => {
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: 'domain_reg',
+						is_domain_registration: true,
+						meta: 'example-100-year.com',
+						volume: 100,
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: 'yourgroovydomain.com',
+				receiptId: 999999,
+				cart,
+			} );
+			expect( url ).toBe( '/checkout/100-year/thank-you/yourgroovydomain.com/999999' );
+		} );
+
 		it( 'redirects with jetpackTemporarySiteId query param when available', () => {
 			const cart = {
 				...getMockCart(),


### PR DESCRIPTION
of a 100-year plan

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOMENG-205

## Proposed Changes

* Update the code related to 100-year thank-you to display the 100-year domain even if out of the 100-year domain flow
* This change is ready but is missing half the test plan, will add it on Monday. I need to figure out how to test the regular 100-year domain flow and ensure it's not broken

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Follow the instructions in 195525-ghe-Automattic/wpcom
2. Sandbox the Store
3. Log in
4. Buy a 100-year domain from domains

<img width="1389" height="652" alt="Screenshot 2025-11-07 at 16 31 22" src="https://github.com/user-attachments/assets/33f0e8d8-bb43-4584-9d77-14c54a5e260f" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
