### PR TITLE
Fix setup/domain/use-my-domain flow ownership verification

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -16,6 +16,7 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 	pageSlug,
 	connectDomainActionHandler,
 	progressStepList,
+	onConnect,
 } ) => {
 	const { __ } = useI18n();
 	const recordMappingButtonClickInUseYourDomain = useCallback(
@@ -71,7 +72,7 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 			className={ className }
 			domain={ domain }
 			onBeforeValidate={ recordMappingButtonClickInUseYourDomain }
-			validateHandler={ connectDomainActionHandler }
+			validateHandler={ onConnect ?? connectDomainActionHandler }
 			pageSlug={ pageSlug }
 			progressStepList={ progressStepList }
 		/>

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -126,6 +127,7 @@ function DomainTransferOrConnect( {
 	return (
 		<>
 			<QueryProductsList />
+			{ selectedSite?.ID && <QuerySitePlans siteId={ selectedSite.ID } /> }
 			<Card className={ baseClassName + '__content' }>
 				{ content.map( ( optionProps, index ) => (
 					<OptionContent

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -165,6 +165,13 @@ const domain: FlowV2< typeof initialize > = {
 						return navigate( destination as typeof currentStepSlug );
 					}
 
+					// Handle skip to plan when user needs paid plan for ownership verification
+					if ( providedDependencies && 'skipToPlan' in providedDependencies ) {
+						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+						setHideFreePlan( true );
+						return navigate( STEPS.UNIFIED_PLANS.slug );
+					}
+
 					if ( ! providedDependencies || ! ( 'domainCartItem' in providedDependencies ) ) {
 						throw new Error( 'No domain cart item found' );
 					}
@@ -407,6 +414,17 @@ const domain: FlowV2< typeof initialize > = {
 		const reduxDispatch = useReduxDispatch();
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const { siteId } = useSiteData();
+
+		/**
+		 * Sync site ID from stepper context to Redux store
+		 * This ensures components using Redux connect() can access the selected site
+		 */
+		useEffect( () => {
+			if ( siteId ) {
+				reduxDispatch( setSelectedSiteId( siteId ) );
+			}
+		}, [ siteId, reduxDispatch ] );
+
 		/**
 		 * Clears every state we're persisting during the flow
 		 * when entering it. This is to ensure that the user
@@ -415,7 +433,6 @@ const domain: FlowV2< typeof initialize > = {
 		useEffect( () => {
 			if ( ! currentStepSlug ) {
 				resetOnboardStore();
-				reduxDispatch( setSelectedSiteId( siteId ) );
 				clearStepPersistedState( this.name );
 				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -175,9 +175,39 @@ const domain: FlowV2< typeof initialize > = {
 							const hasPaidPlan = siteHasPaidPlan( site );
 
 							if ( isGardenSite || hasPaidPlan ) {
-								setPendingAction( async () => {
-									const domain = providedDependencies.domainCartItem.meta;
+								const domain = providedDependencies.domainCartItem.meta;
 
+								// If there's verification data (auth code), handle it synchronously to show errors on the current step
+								if ( providedDependencies.verificationData ) {
+									try {
+										await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, {
+											domain,
+											...providedDependencies.verificationData,
+										} );
+
+										// Success - navigate to setup page
+										const redirectTo = isGardenSite
+											? `/ciab/sites/${ domain }/domains`
+											: `/v2/domains/${ domain }/domain-connection-setup`;
+
+										return window.location.replace( redirectTo );
+									} catch ( error ) {
+										// Call onDone callback to display error in the UI
+										if ( providedDependencies.onDone ) {
+											// Convert unknown error to Error type for the callback
+											const errorObj =
+												error instanceof Error
+													? error
+													: new Error( typeof error === 'string' ? error : 'An error occurred' );
+											providedDependencies.onDone( errorObj );
+										}
+										// Return early to stay on current step
+										return;
+									}
+								}
+
+								// No verification data - use the pending action flow
+								setPendingAction( async () => {
 									await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 
 									return {

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -184,36 +184,8 @@ const domain: FlowV2< typeof initialize > = {
 							if ( isGardenSite || hasPaidPlan ) {
 								const domain = providedDependencies.domainCartItem.meta;
 
-								// If there's verification data (auth code), handle it synchronously to show errors on the current step
-								if ( providedDependencies.verificationData ) {
-									try {
-										await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, {
-											domain,
-											...providedDependencies.verificationData,
-										} );
-
-										// Success - navigate to setup page
-										const redirectTo = isGardenSite
-											? `/ciab/sites/${ domain }/domains`
-											: `/v2/domains/${ domain }/domain-connection-setup`;
-
-										return window.location.replace( redirectTo );
-									} catch ( error ) {
-										// Call onDone callback to display error in the UI
-										if ( providedDependencies.onDone ) {
-											// Convert unknown error to Error type for the callback
-											const errorObj =
-												error instanceof Error
-													? error
-													: new Error( typeof error === 'string' ? error : 'An error occurred' );
-											providedDependencies.onDone( errorObj );
-										}
-										// Return early to stay on current step
-										return;
-									}
-								}
-
-								// No verification data - use the pending action flow
+								// Use pending action for domain mapping
+								// Note: Verification (if required) is handled in the step before submission
 								setPendingAction( async () => {
 									await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -102,15 +102,21 @@ const PlansStepAdaptor: StepType< {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
-	const { siteTitle, domainItem, domainItems, selectedDesign } = useSelect(
+	const { siteTitle, domainItem, domainItems, selectedDesign, hideFreePlan } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
-			const { getSelectedSiteTitle, getDomainCartItem, getDomainCartItems, getSelectedDesign } =
-				select( ONBOARD_STORE );
+			const {
+				getSelectedSiteTitle,
+				getDomainCartItem,
+				getDomainCartItems,
+				getSelectedDesign,
+				getHideFreePlan,
+			} = select( ONBOARD_STORE );
 			return {
 				siteTitle: getSelectedSiteTitle(),
 				domainItem: getDomainCartItem(),
 				domainItems: getDomainCartItems(),
 				selectedDesign: getSelectedDesign(),
+				hideFreePlan: getHideFreePlan(),
 			};
 		},
 		[]
@@ -194,6 +200,7 @@ const PlansStepAdaptor: StepType< {
 	return (
 		<UnifiedPlansStep
 			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
+			hideFreePlan={ hideFreePlan }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } as ProvidedDependencies ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useLocation } from 'react-router';
@@ -11,9 +11,12 @@ import {
 	UseMyDomainInputMode,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import { useDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 
@@ -32,10 +35,20 @@ const UseMyDomain: StepType< {
 	const { goNext, goBack, submit } = navigation;
 	const location = useLocation();
 	const isDomainConnectionRedesign = config.isEnabled( 'domain-connection-redesign' );
+	const reduxDispatch = useDispatch();
+	const { siteId } = useSiteData();
 
 	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
 		inputMode.domainInput
 	);
+
+	// Sync site ID from stepper context to Redux store
+	// This ensures components using Redux connect() can access the selected site
+	useEffect( () => {
+		if ( siteId ) {
+			reduxDispatch( setSelectedSiteId( siteId ) );
+		}
+	}, [ siteId, reduxDispatch ] );
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -37,7 +37,6 @@ const UseMyDomain: StepType< {
 		  }
 		| {
 				domainCartItem: MinimalRequestCartProduct;
-				verificationData?: OwnershipVerificationData;
 		  }
 		| {
 				skipToPlan: true;
@@ -122,7 +121,7 @@ const UseMyDomain: StepType< {
 		}
 
 		clearQueryParams();
-		submit?.( { domainCartItem, verificationData } );
+		submit?.( { domainCartItem } );
 	};
 
 	const getInitialQuery = function () {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -22,13 +22,24 @@ import type { Step as StepType } from '../../types';
 
 import './style.scss';
 
+type OwnershipVerificationData = {
+	ownership_verification_data: {
+		verification_type: 'auth_code';
+		verification_data: string;
+	};
+};
+
 const UseMyDomain: StepType< {
 	submits:
 		| {
 				mode: 'transfer' | 'connect';
 				domain: string;
 		  }
-		| { domainCartItem: MinimalRequestCartProduct }
+		| {
+				domainCartItem: MinimalRequestCartProduct;
+				verificationData?: OwnershipVerificationData;
+				onDone?: ( error?: Error ) => void;
+		  }
 		| undefined;
 } > = function UseMyDomain( { navigation, flow } ) {
 	const { __ } = useI18n();
@@ -77,11 +88,14 @@ const UseMyDomain: StepType< {
 		submit?.( { domainCartItem } );
 	};
 
-	const handleOnConnect = async ( domain: string ) => {
+	const handleOnConnect = async (
+		{ domain, verificationData }: { domain: string; verificationData?: OwnershipVerificationData },
+		onDone?: ( error?: Error ) => void
+	) => {
 		const domainCartItem = domainMapping( { domain } );
 
 		clearQueryParams();
-		submit?.( { domainCartItem } );
+		submit?.( { domainCartItem, verificationData, onDone } );
 	};
 
 	const getInitialQuery = function () {
@@ -111,7 +125,7 @@ const UseMyDomain: StepType< {
 					initialMode={ getInitialMode() }
 					isSignupStep
 					onTransfer={ handleOnTransfer }
-					onConnect={ ( { domain } ) => handleOnConnect( domain ) }
+					onConnect={ handleOnConnect }
 					useMyDomainMode={ useMyDomainMode }
 					setUseMyDomainMode={ setUseMyDomainMode }
 					onNextStep={ handleOnNext }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { StepContainer, isStartWritingFlow, Step } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useLocation } from 'react-router';
@@ -11,12 +11,9 @@ import {
 	UseMyDomainInputMode,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
-import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import { useDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 
@@ -40,26 +37,19 @@ const UseMyDomain: StepType< {
 				verificationData?: OwnershipVerificationData;
 				onDone?: ( error?: Error ) => void;
 		  }
+		| {
+				skipToPlan: true;
+		  }
 		| undefined;
 } > = function UseMyDomain( { navigation, flow } ) {
 	const { __ } = useI18n();
 	const { goNext, goBack, submit } = navigation;
 	const location = useLocation();
 	const isDomainConnectionRedesign = config.isEnabled( 'domain-connection-redesign' );
-	const reduxDispatch = useDispatch();
-	const { siteId } = useSiteData();
 
 	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
 		inputMode.domainInput
 	);
-
-	// Sync site ID from stepper context to Redux store
-	// This ensures components using Redux connect() can access the selected site
-	useEffect( () => {
-		if ( siteId ) {
-			reduxDispatch( setSelectedSiteId( siteId ) );
-		}
-	}, [ siteId, reduxDispatch ] );
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {
@@ -116,6 +106,11 @@ const UseMyDomain: StepType< {
 		submit?.( { mode, domain, shouldSkipSubmitTracking: true } );
 	};
 
+	const handleOnSkip = () => {
+		// When user needs to purchase a plan to connect domain with ownership verification
+		submit?.( { skipToPlan: true } );
+	};
+
 	const getBlogOnboardingFlowStepContent = () => {
 		return (
 			<CalypsoShoppingCartProvider>
@@ -126,6 +121,7 @@ const UseMyDomain: StepType< {
 					isSignupStep
 					onTransfer={ handleOnTransfer }
 					onConnect={ handleOnConnect }
+					onSkip={ handleOnSkip }
 					useMyDomainMode={ useMyDomainMode }
 					setUseMyDomainMode={ setUseMyDomainMode }
 					onNextStep={ handleOnNext }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -11,9 +11,12 @@ import {
 	UseMyDomainInputMode,
 } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
+import wpcom from 'calypso/lib/wp';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 
@@ -35,7 +38,6 @@ const UseMyDomain: StepType< {
 		| {
 				domainCartItem: MinimalRequestCartProduct;
 				verificationData?: OwnershipVerificationData;
-				onDone?: ( error?: Error ) => void;
 		  }
 		| {
 				skipToPlan: true;
@@ -46,6 +48,7 @@ const UseMyDomain: StepType< {
 	const { goNext, goBack, submit } = navigation;
 	const location = useLocation();
 	const isDomainConnectionRedesign = config.isEnabled( 'domain-connection-redesign' );
+	const { site } = useSiteData();
 
 	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
 		inputMode.domainInput
@@ -84,8 +87,42 @@ const UseMyDomain: StepType< {
 	) => {
 		const domainCartItem = domainMapping( { domain } );
 
+		// If there's verification data and the site has a paid plan, validate it before submitting
+		if ( verificationData && site ) {
+			const isGardenSite = ( site as { is_garden?: boolean } ).is_garden;
+			const hasPaidPlan = siteHasPaidPlan( site );
+
+			if ( isGardenSite || hasPaidPlan ) {
+				try {
+					// Validate the auth code by making the API call
+					await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, {
+						domain,
+						...verificationData,
+					} );
+
+					// Success - redirect to setup page
+					const redirectTo = isGardenSite
+						? `/ciab/sites/${ domain }/domains`
+						: `/v2/domains/${ domain }/domain-connection-setup`;
+
+					return window.location.replace( redirectTo );
+				} catch ( error ) {
+					// Validation failed - call onDone to display error and stay on current step
+					if ( onDone ) {
+						const errorObj =
+							error instanceof Error
+								? error
+								: new Error( typeof error === 'string' ? error : 'An error occurred' );
+						onDone( errorObj );
+					}
+					// Don't submit the step - stay on current step to allow retry
+					return;
+				}
+			}
+		}
+
 		clearQueryParams();
-		submit?.( { domainCartItem, verificationData, onDone } );
+		submit?.( { domainCartItem, verificationData } );
 	};
 
 	const getInitialQuery = function () {


### PR DESCRIPTION
Closes [DOMAINS-1826](https://linear.app/a8c/issue/DOMAINS-1826/fix-broken-setupdomainuse-my-domain-flow)

## Proposed Changes
Resolve three critical issues in the domain ownership verification process within the stepper, for the `setup/domain` flow:

1. ### Missing selectedSite Data
  - **Problem**: selectedSite was null because stepper uses `useSiteData()` but components use Redux `getSelectedSite()`
  - **Solution**: Added `useEffect` to sync site ID from stepper context to Redux store
2. ### isSiteOnPaidPlan Returning False
  - **Problem**: Site plans data wasn't being fetched, so `state.sites.plans[siteId].data` was null
  - **Solution**: Added `QuerySitePlans` component to fetch site plans data
3. ### Authorization Code Error Handling
  - **Problem:** When users entered an incorrect authorization code for domain ownership verification, the API error was not displayed in the UI and the submit button remained disabled, leaving users stuck with no feedback.
  - **Root Cause:** The `onDone` error callback from the auth code component wasn't being properly passed through the stepper's submit flow to the domain flow handler.
  - **Solution:**
    - Updated the `use-my-domain` step to pass the `onDone` callback as part of `providedDependencies`
    - Modified the domain flow handler to catch API errors when verification data is present
    - Properly convert caught errors and invoke the `onDone` callback to display error messages in the UI
    - This ensures users receive immediate feedback when verification fails and can retry with the correct code
### 4. Missing onSkip Handler
  - **Problem:** When clicking "Purchase a plan" for domain connection requiring ownership verification (without a paid plan), nothing happened and console showed `onSkip is not a function`.
  - **Root Cause:** The `UseMyDomainComponent` was rendered with `isSignupStep={true}` but the `onSkip` prop was missing.
  - **Solution:**
    - Added `handleOnSkip` handler in the use-my-domain step that submits `{ skipToPlan: true }`
    - Passed `onSkip` prop to the `UseMyDomainComponent`
    - Updated type definition to include the new `skipToPlan` submission type
    - Added flow logic in the domain flow to handle the skip case and navigate to the plans step

## Why are these changes being made?
The ownership verification process was broken in this flow.

## Testing Instructions
Prerequisite: hack the get_verification_type function in wpcom to return `auth_code`. fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sqbznvaf%2Sbjarefuvc%2Qirevsvpngvba%2Sqbznva%2Qbjarefuvc%2Qirevsvpngvba.cuc%3Se%3Q93on7r82%2373-og

### Site with paid plan
- Visit `v2/site/[SITE]/domains`
- Start the flow, selection "Use a domain name I own"
- Enter the domain name, the select "Connect"
- Ensure the Ownership Verification step is shown and it works

### Site without paid plan
- Visit `v2/site/[SITE]/domains`
- Start the flow, selection "Use a domain name I own"
- Enter the domain name, the select "Connect"
- Ensure the plan selection step is rendered
- After selecting a plan, ensure you are redirected to the checkout without the mapping (this matches the current Calypso behavior)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?