### PR TITLE
Help Center: Do not get persisted history if on direct url escalation

### DIFF
--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -165,12 +165,10 @@ export const usePersistedHistory = () => {
 			const history = new MemoryHistory( persistedHistory.entries, persistedHistory.index );
 			setHistory( history );
 
-			if ( helpCenterParam !== 'happiness-engineer' ) {
-				setState( {
-					action: history.action,
-					location: history.location,
-				} );
-			}
+			setState( {
+				action: history.action,
+				location: history.location,
+			} );
 		}
 	}, [ persistedHistory ] );
 

--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -159,6 +159,7 @@ export const usePersistedHistory = () => {
 
 	useEffect( () => {
 		const urlParams = new URLSearchParams( window.location.search );
+		// Skip persisted history if help-center=happiness-engineer to allow escalation to live chat, otherwise the location is overwritten.
 		const helpCenterParam = urlParams.get( 'help-center' );
 
 		if ( persistedHistory && helpCenterParam !== 'happiness-engineer' ) {

--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -161,7 +161,7 @@ export const usePersistedHistory = () => {
 		const urlParams = new URLSearchParams( window.location.search );
 		const helpCenterParam = urlParams.get( 'help-center' );
 
-		if ( persistedHistory ) {
+		if ( persistedHistory && helpCenterParam !== 'happiness-engineer' ) {
 			const history = new MemoryHistory( persistedHistory.entries, persistedHistory.index );
 			setHistory( history );
 

--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -158,13 +158,19 @@ export const usePersistedHistory = () => {
 	}, [ history ] );
 
 	useEffect( () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const helpCenterParam = urlParams.get( 'help-center' );
+
 		if ( persistedHistory ) {
 			const history = new MemoryHistory( persistedHistory.entries, persistedHistory.index );
 			setHistory( history );
-			setState( {
-				action: history.action,
-				location: history.location,
-			} );
+
+			if ( helpCenterParam !== 'happiness-engineer' ) {
+				setState( {
+					action: history.action,
+					location: history.location,
+				} );
+			}
 		}
 	}, [ persistedHistory ] );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-343/help-center-url-escalation-not-working-if-persisted-history

## Testing steps

1. Open the Help Center
2. Visit an article
3. add ?help-center=happiness-engineer to the URL and refresh
4. It should open a live chat (or open the last one open, if you have one)

Verify first that on prod it does not open the live chat but it reopens the article