### PR TITLE
Replace the siteDomainsQuery with alternative

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -14,6 +14,7 @@ import {
 	siteDefensiveModeSettingsQuery,
 	siteDifmWebsiteContentQuery,
 	siteDomainsQuery,
+	domainsQuery,
 	siteJetpackModulesQuery,
 	siteJetpackSettingsQuery,
 	siteMediaStorageQuery,
@@ -567,7 +568,7 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 
 		await Promise.all( [
 			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
-			queryClient.ensureQueryData( siteDomainsQuery( site.ID ) ),
+			queryClient.ensureQueryData( domainsQuery() ),
 			site.is_coming_soon &&
 				hasPlanFeature( site, DotcomFeatures.SITE_PREVIEW_LINKS ) &&
 				queryClient.ensureQueryData( sitePreviewLinksQuery( site.ID ) ),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -1,8 +1,7 @@
-import { siteDomainsQuery } from '@automattic/api-queries';
+import { domainQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
-import { getSelectedDomain } from '../../../utils/domain';
 import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -15,9 +14,7 @@ const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isJetpackPurchase,
 }: CancelPurchaseRefundInformationProps ) => {
-	const { data: domains } = useSuspenseQuery( siteDomainsQuery( purchase.blog_id ) );
-	const selectedDomainName = purchase.product_name;
-	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+	const { data: selectedDomain } = useSuspenseQuery( domainQuery( purchase.product_name ) );
 
 	const isGravatarRestrictedDomain = selectedDomain?.is_gravatar_restricted_domain;
 	const { refund_period_in_days: refundPeriodInDays } = purchase;

--- a/client/dashboard/sites/settings-site-visibility/test/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.tsx
@@ -1,6 +1,8 @@
 /**
  * @jest-environment jsdom
  */
+
+import { DomainSubtype } from '@automattic/api-core';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -35,8 +37,14 @@ function mockTestSite( options: TestSiteOptions ) {
 		return {
 			domain,
 			blog_id: siteId,
-			wpcom_domain: domain.endsWith( '.wordpress.com' ) || domain.endsWith( '.wpcomstaging.com' ),
-			is_wpcom_staging_domain: domain.endsWith( '.wpcomstaging.com' ),
+			subtype: {
+				id:
+					domain.endsWith( '.wordpress.com' ) || domain.endsWith( '.wpcomstaging.com' )
+						? DomainSubtype.DEFAULT_ADDRESS
+						: DomainSubtype.DOMAIN_REGISTRATION,
+				label: 'Does not matter',
+			},
+			tags: domain.endsWith( '.wpcomstaging.com' ) ? [ 'wpcom_staging' ] : [],
 			primary_domain: domain === primary_domain,
 		};
 	} );
@@ -63,7 +71,7 @@ function mockTestSite( options: TestSiteOptions ) {
 		.get( `/rest/v1.4/sites/${ site.ID }/settings` )
 		.query( true )
 		.reply( 200, settings )
-		.get( `/rest/v1.2/sites/${ site.ID }/domains` )
+		.get( '/rest/v1.2/all-domains' )
 		.query( true )
 		.reply( 200, { domains: domainObjects } );
 

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -1,5 +1,5 @@
 import { DotcomPlans } from '@automattic/api-core';
-import { siteDomainsQuery, siteLaunchMutation } from '@automattic/api-queries';
+import { domainsQuery, siteLaunchMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -16,7 +16,10 @@ import type { Site } from '@automattic/api-core';
 
 export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksContext: string } ) {
 	const { recordTracksEvent } = useAnalytics();
-	const { data: domains = [], isLoading } = useQuery( siteDomainsQuery( site.ID ) );
+	const { data: domains = [], isLoading } = useQuery( {
+		...domainsQuery(),
+		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
+	} );
 	const launchMutation = useMutation( {
 		...siteLaunchMutation( site.ID ),
 		meta: {

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -386,36 +386,3 @@ export function isGoogleWorkspaceSupportedDomain( domain: Domain ) {
 
 	return ! domain.domain.endsWith( '.wpcomstaging.com' );
 }
-
-export function getSelectedDomain<
-	T extends {
-		type?: string;
-		name?: string;
-	},
->( {
-	domains,
-	selectedDomainName,
-	isSiteRedirect = false,
-}: {
-	domains: T[] | Record< string, T > | null;
-	selectedDomainName: string;
-	isSiteRedirect?: boolean;
-} ): T | undefined {
-	if ( ! domains ) {
-		return undefined;
-	}
-	const domainList = Array.isArray( domains ) ? domains : Object.values( domains );
-	return domainList.find( ( domain ) => {
-		const isType = ( type: string ) => domain.type === type;
-
-		if ( domain.name !== selectedDomainName ) {
-			return false;
-		}
-
-		if ( isSiteRedirect && isType( DomainTypes.SITE_REDIRECT ) ) {
-			return true;
-		}
-
-		return ! isType( DomainTypes.SITE_REDIRECT );
-	} );
-}

--- a/packages/api-queries/src/site-address-change.ts
+++ b/packages/api-queries/src/site-address-change.ts
@@ -5,9 +5,9 @@ import {
 	type ChangeSiteAddressData,
 } from '@automattic/api-core';
 import { mutationOptions } from '@tanstack/react-query';
+import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import { siteDomainsQuery } from './site-domains';
 
 export const validateSiteAddressChangeMutation = () =>
 	mutationOptions( {
@@ -19,6 +19,6 @@ export const changeSiteAddressChangeMutation = () =>
 		mutationFn: ( data: ChangeSiteAddressData ) => changeSiteAddress( data ),
 		onSuccess: ( data, { siteId } ) => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( siteDomainsQuery( siteId ) );
+			queryClient.invalidateQueries( domainsQuery() );
 		},
 	} );

--- a/packages/api-queries/src/site-domains.ts
+++ b/packages/api-queries/src/site-domains.ts
@@ -1,5 +1,6 @@
 import { fetchSiteDomains, setPrimaryDomain } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 
@@ -15,6 +16,6 @@ export const siteSetPrimaryDomainMutation = () =>
 			setPrimaryDomain( siteId, domain ),
 		onSuccess: ( data, { siteId } ) => {
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
-			queryClient.invalidateQueries( siteDomainsQuery( siteId ) );
+			queryClient.invalidateQueries( domainsQuery() );
 		},
 	} );

--- a/packages/api-queries/src/site-domains.ts
+++ b/packages/api-queries/src/site-domains.ts
@@ -4,6 +4,9 @@ import { domainsQuery } from './domains';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 
+/**
+ * @deprecated use either domainQuery or domainsQuery or something else (we'll need separate endpoint to get emails)
+ */
 export const siteDomainsQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'domains' ],


### PR DESCRIPTION
We have to stop using the siteDomainsQuery

Part of [DOMAINS-1828: Replace the usage of siteDomainsQuery with domainsQuery or domainQuery](https://linear.app/a8c/issue/DOMAINS-1828/replace-the-usage-of-sitedomainsquery-with-domainsquery-or-domainquery)

## Proposed Changes

* Replace the use of siteDomainsQuery with domainsQuery or domainQuery

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The siteDomainsQuery is very slow endpoint that we're trying to get rid of and makes the cache management really complicated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change the primary domain for a site and make sure that it'll get updated in the screen below + the primary domain switcher panel
* Cancel purchase should work fine with domainQuery instead of siteDomainsQuery - test it
* I'm not sure where the site launch button is but it should also work fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
