### PR TITLE
MSD Purchase Management: Simplify when to display "Add payment method" link

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -31,13 +31,15 @@ export function PurchasePaymentMethod( {
 	}
 
 	if (
-		purchase.is_auto_renew_enabled &&
-		! isExpired( purchase ) &&
-		( ! purchase.payment_type || purchase.payment_type === 'credits' ) &&
-		! purchase.partner_name &&
-		! isAkismetFreeProduct( purchase ) &&
-		! isDisconnectedSite
+		isExpired( purchase ) ||
+		purchase.partner_name ||
+		isAkismetFreeProduct( purchase ) ||
+		isDisconnectedSite
 	) {
+		return null;
+	}
+
+	if ( ! purchase.is_rechargable && purchase.is_auto_renew_enabled ) {
 		return (
 			<div>
 				<Link to={ changePaymentMethodRoute.fullPath } params={ { purchaseId: purchase.ID } }>
@@ -47,87 +49,77 @@ export function PurchasePaymentMethod( {
 		);
 	}
 
-	if (
-		! isAkismetFreeProduct( purchase ) &&
-		! purchase.is_rechargable &&
-		purchase.is_auto_renew_enabled
-	) {
+	if ( ! isRenewing( purchase ) ) {
+		return null;
+	}
+
+	if ( purchase.payment_type === 'credit_card' && purchase.payment_card_id ) {
+		const paymentMethodType = purchase.payment_card_display_brand
+			? purchase.payment_card_display_brand
+			: purchase.payment_card_type || purchase.payment_card_processor || '';
+
+		const maskedCardNumber = sprintf(
+			/** Translators: %s is last four digits of card number */
+			_x( '**** **** **** %s', 'Long-form masked credit card number.' ),
+			purchase.payment_details
+		);
+
 		return (
-			<div>
-				<span>{ __( 'You don’t have a payment method to renew this subscription' ) }</span>
-			</div>
+			<HStack className="purchase-payment-method__wrapper">
+				<HStack justify="flex-start">
+					<PaymentMethodImage paymentMethodType={ paymentMethodType } />
+					<span>{ maskedCardNumber }</span>
+				</HStack>
+				{ showUpdateButton && (
+					<Button
+						className="purchase-payment-method__update"
+						aria-label={ __( 'Update payment method' ) }
+						variant="secondary"
+						size="compact"
+						onClick={ () => {
+							navigate( {
+								to: changePaymentMethodRoute.fullPath,
+								params: { purchaseId: purchase.ID },
+							} );
+						} }
+					>
+						{ __( 'Update' ) }
+					</Button>
+				) }
+			</HStack>
 		);
 	}
 
-	if ( isRenewing( purchase ) ) {
-		if ( purchase.payment_type === 'credit_card' && purchase.payment_card_id ) {
-			const paymentMethodType = purchase.payment_card_display_brand
-				? purchase.payment_card_display_brand
-				: purchase.payment_card_type || purchase.payment_card_processor || '';
-
-			const maskedCardNumber = sprintf(
-				/** Translators: %s is last four digits of card number */
-				_x( '**** **** **** %s', 'Long-form masked credit card number.' ),
-				purchase.payment_details
-			);
-
-			return (
-				<HStack className="purchase-payment-method__wrapper">
-					<HStack justify="flex-start">
-						<PaymentMethodImage paymentMethodType={ paymentMethodType } />
-						<span>{ maskedCardNumber }</span>
-					</HStack>
-					{ showUpdateButton && (
-						<Button
-							className="purchase-payment-method__update"
-							aria-label={ __( 'Update payment method' ) }
-							variant="secondary"
-							size="compact"
-							onClick={ () => {
-								navigate( {
-									to: changePaymentMethodRoute.fullPath,
-									params: { purchaseId: purchase.ID },
-								} );
-							} }
-						>
-							{ __( 'Update' ) }
-						</Button>
-					) }
+	if ( purchase.payment_type === 'paypal' ) {
+		return (
+			<HStack>
+				<HStack justify="flex-start">
+					<PaymentMethodImage paymentMethodType={ purchase.payment_type } />
+					<span>PayPal { purchase.payment_name }</span>
 				</HStack>
-			);
-		}
-
-		if ( purchase.payment_type === 'paypal' ) {
-			return (
-				<HStack>
-					<HStack justify="flex-start">
-						<PaymentMethodImage paymentMethodType={ purchase.payment_type } />
-						<span>PayPal { purchase.payment_name }</span>
-					</HStack>
-					{ showUpdateButton && (
-						<Button
-							className="purchase-payment-method__update"
-							aria-label={ __( 'Update payment method' ) }
-							variant="secondary"
-							size="compact"
-							onClick={ () => {
-								navigate( {
-									to: changePaymentMethodRoute.fullPath,
-									params: { purchaseId: purchase.ID },
-								} );
-							} }
-						>
-							{ __( 'Update' ) }
-						</Button>
-					) }
-				</HStack>
-			);
-		}
-
-		if ( purchase.payment_type === 'upi' ) {
-			return <PaymentMethodImage paymentMethodType={ purchase.payment_type } />;
-		}
-
-		return null;
+				{ showUpdateButton && (
+					<Button
+						className="purchase-payment-method__update"
+						aria-label={ __( 'Update payment method' ) }
+						variant="secondary"
+						size="compact"
+						onClick={ () => {
+							navigate( {
+								to: changePaymentMethodRoute.fullPath,
+								params: { purchaseId: purchase.ID },
+							} );
+						} }
+					>
+						{ __( 'Update' ) }
+					</Button>
+				) }
+			</HStack>
+		);
 	}
+
+	if ( purchase.payment_type === 'upi' ) {
+		return <PaymentMethodImage paymentMethodType={ purchase.payment_type } />;
+	}
+
+	return null;
 }

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -39,7 +39,7 @@ export function PurchasePaymentMethod( {
 		return null;
 	}
 
-	if ( ! purchase.is_rechargable && purchase.is_auto_renew_enabled ) {
+	if ( ! purchase.is_rechargable ) {
 		return (
 			<div>
 				<Link to={ changePaymentMethodRoute.fullPath } params={ { purchaseId: purchase.ID } }>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-274/msd-show-add-payment-method-when-there-is-none-set

## Proposed Changes

This PR refactors `PurchasePaymentMethod` to clarify the logic and to show the "Add payment method" link in more situations. This component is used by the Multi Site Dashboard in the purchases list and the purchase settings page to show the attached payment method.

Primarily, the component used to display "You don't have a payment method to renew this subscription" in certain situations instead of "Add payment method" link if there was no payment method attached and if the purchase had auto-renew enabled. There's really not much reason for this, I think. If there is no rechargable payment method attached, we should display the "Add payment method" button. So this PR removes that text entirely.

<img width="689" height="167" alt="Screenshot 2025-11-07 at 4 27 39 PM" src="https://github.com/user-attachments/assets/c88fc6fc-cb03-47f5-8c39-1ab69e2897ae" />

<img width="1365" height="218" alt="Screenshot 2025-11-07 at 4 27 32 PM" src="https://github.com/user-attachments/assets/954a3cea-f590-4c93-8ca8-d66271759f3e" />

After this PR, the only times that the text will not be shown are the following.

In this case, the payment method will be displayed:

-   If the purchase has a rechargable payment method attached that's a card, PayPal, or Razorpay.

In these cases, a special notice will be displayed:

-   If the purchase is included with a plan.
-   If the purchase is attached to an in-app-payment.

In these cases, nothing will be displayed:

-   If the purchase is expired.
-   If the purchase is a partner purchase.
-   If the purchase is an Akismet free plan.
-   If the purchase is a disconnected Jetpack site.
-   If the purchase has a rechargable payment method but the purchase has auto-renew disabled.
-   If the purchase has a rechargable payment method attached that's not a card, PayPal, or Razorpay.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://calypso.localhost:3000/v2/me/billing/purchases
- Verify that you see "Add payment method" displayed for any purchase that does not fall into any of the above categories and not if it does not.
- Click through to various purchases and verify you see the same thing on that page.
