### PR TITLE
MSD Purchases: Reword relative time to use "in" instead of "from now"

### DIFF
--- a/client/dashboard/utils/datetime.ts
+++ b/client/dashboard/utils/datetime.ts
@@ -51,7 +51,7 @@ export function isWithinNext( date: Date, count: number, unit: 'hours' | 'days' 
 }
 
 /**
- * Return a string like "2 days from now" or "1 month ago" for a given date.
+ * Return a string like "in 2 days" or "1 month ago" for a given date.
  *
  * Note that given the imprecision of date math and time zones, this may not be
  * totally accurate. Use it only in places where precision is not required.
@@ -146,27 +146,27 @@ export function getRelativeTimeString( date: Date ): string {
 	switch ( unit ) {
 		case 'year':
 			// translators: value is a number
-			return sprintf( _n( '%(value)s year from now', '%(value)s years from now', value ), {
+			return sprintf( _n( 'in %(value)s year', 'in %(value)s years', value ), {
 				value,
 			} );
 		case 'month':
 			// translators: value is a number
-			return sprintf( _n( '%(value)s month from now', '%(value)s months from now', value ), {
+			return sprintf( _n( 'in %(value)s month', 'in %(value)s months', value ), {
 				value,
 			} );
 		case 'day':
 			// translators: value is a number
-			return sprintf( _n( '%(value)s day from now', '%(value)s days from now', value ), {
+			return sprintf( _n( 'in %(value)s day', 'in %(value)s days', value ), {
 				value,
 			} );
 		case 'hour':
 			// translators: value is a number
-			return sprintf( _n( '%(value)s hour from now', '%(value)s hours from now', value ), {
+			return sprintf( _n( 'in %(value)s hour', 'in %(value)s hours', value ), {
 				value,
 			} );
 		case 'minute':
 			// translators: value is a number
-			return sprintf( _n( '%(value)s minute from now', '%(value)s minutes from now', value ), {
+			return sprintf( _n( 'in %(value)s minute', 'in %(value)s minutes', value ), {
 				value,
 			} );
 		default:


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-275/msd-expiry-text-on-purchase-list-could-be-shorter

## Proposed Changes

This PR refactors `getRelativeTimeString()` in the Multi Site Dashboard to return string like "in 5 days" instead of "5 days from now" because the latter is too long.

Before             |  After
:-------------------------:|:-------------------------:
<img width="988" height="93" alt="Screenshot 2025-11-07 at 4 45 00 PM" src="https://github.com/user-attachments/assets/f0f4e96d-6de8-4521-a103-db10b1edd595" /> | <img width="995" height="94" alt="Screenshot 2025-11-07 at 4 44 42 PM" src="https://github.com/user-attachments/assets/943baedd-f0d5-4f08-b722-509ae501031d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This more closely matches how calypso's purchase management renders relative text strings (using `moment` which we cannot use in the Multi Site Dashboard).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit https://wpcalypso.wordpress.com/v2/me/billing/purchases when you have a purchase that is going to expire soon (a non-monthly purchase that expires in 30 days that has auto-renew disabled or no payment method attached) and verify that the "Expires/Renews on" column shows strings like "Expires in 2 weeks" instead of "Expires 2 weeks from now".

Note that if the purchase does not expire soon, it will just render something like "Expires on November 18". That should be unchanged by this PR.
