### PR TITLE
Domains: Lowercase the initial search query parameter

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
@@ -20,6 +20,11 @@ describe( 'useQueryHandler', () => {
 		expect( result.current.query ).toBe( 'test-domain' );
 	} );
 
+	it( 'should initialize with provided initialQuery in lowercase', () => {
+		const { result } = renderHook( () => useQueryHandler( { initialQuery: 'TEST-DOMAIN' } ) );
+		expect( result.current.query ).toBe( 'test-domain' );
+	} );
+
 	it( 'should initialize with domain from currentSiteUrl when provided', () => {
 		const { result } = renderHook( () =>
 			useQueryHandler( { currentSiteUrl: 'https://test-site.wordpress.com' } )

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -27,7 +27,7 @@ export const useQueryHandler = ( {
 } ) => {
 	const [ localQuery, setLocalQuery ] = useState< string | undefined >( () => {
 		if ( externalInitialQuery ) {
-			return externalInitialQuery;
+			return externalInitialQuery.toLowerCase();
 		}
 
 		if ( currentSiteUrl ) {

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -27,7 +27,7 @@ export const useQueryHandler = ( {
 } ) => {
 	const [ localQuery, setLocalQuery ] = useState< string | undefined >( () => {
 		if ( externalInitialQuery ) {
-			return externalInitialQuery.toLowerCase();
+			return externalInitialQuery;
 		}
 
 		if ( currentSiteUrl ) {
@@ -43,7 +43,7 @@ export const useQueryHandler = ( {
 	}, [] );
 
 	return {
-		query: localQuery,
+		query: localQuery?.trim().toLowerCase(),
 		setQuery,
 		clearQuery: clearSessionStorageQuery,
 	};


### PR DESCRIPTION
Part of [DOMENG-228](https://linear.app/a8c/issue/DOMENG-228)

## Proposed Changes

This PR normalizes the initial domain search query parameter to lowercase.

## Why are these changes being made?

This prevents weird situations where the same domain suggestion might appear in the results twice, one time non-lowercased and another time lowercased. See the screenshots below:

## Screenshots

| Before | After |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot 2025-11-07 at 19 00 19" src="https://github.com/user-attachments/assets/a8bb3716-713d-41d0-a4ac-df72b861453b" /> | <img width="1920" height="1080" alt="Screenshot 2025-11-07 at 19 26 23" src="https://github.com/user-attachments/assets/36ccf3cd-8efa-47a6-a101-5f4af51a745a" /> |

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Visit the `/setup/onboarding/domains?new=LeotabaCamelCaseTest.com` URL. You can change the `new` parameter by any other FQDN with uppercase characters
- Ensure the searched domain appears only once in the suggestions, lowercased
- Go to the `/domains/add` flow for one of your sites and do the same, but with the `suggestion` parameter: `/domains/add/<site_slug>?suggestion=LeotabaCamelCaseTest.com`
- Ensure the searched domain appears only once
- Try the same in any `/start` flow, e.g. `/start/domain/domain-only?new=LeoTabaCamelCase.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
