### PR TITLE
MSD Site Settings: Update hundred year plan setting layout

### DIFF
--- a/client/dashboard/sites/settings-hundred-year-plan/contact-form.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/contact-form.tsx
@@ -1,0 +1,93 @@
+import { siteSettingsMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button, ExternalLink } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { SectionHeader } from '../../components/section-header';
+import type { Site, SiteSettings } from '@automattic/api-core';
+import type { Field, SimpleFormField } from '@wordpress/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_legacy_contact',
+		label: __( 'Contact name' ),
+		Edit: 'text',
+	},
+];
+
+const form = {
+	layout: { type: 'regular' as const },
+	fields: [ { id: 'wpcom_legacy_contact' } ] as SimpleFormField[],
+};
+
+export default function ContactForm( { site, settings }: { site: Site; settings: SiteSettings } ) {
+	const mutation = useMutation( {
+		...siteSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Legacy contact saved.' ),
+				error: __( 'Failed to save legacy contact.' ),
+			},
+		},
+	} );
+
+	const [ formData, setFormData ] = useState( {
+		wpcom_legacy_contact: settings?.wpcom_legacy_contact,
+	} );
+
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
+	);
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( { ...formData } );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							title={ __( 'Legacy contact' ) }
+							description={ createInterpolateElement(
+								__(
+									'Choose someone to look after your site when you pass away. To take ownership of the site, we ask that the person you designate contacts us at <link>wordpress.com/help</link> with a copy of the death certificate.'
+								),
+								{
+									link: <ExternalLink href="/help" children={ null } />,
+								}
+							) }
+							level={ 3 }
+						/>
+						<DataForm< SiteSettings >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< SiteSettings > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<ButtonStack justify="flex-start">
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -1,62 +1,17 @@
-import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button, ExternalLink } from '@wordpress/components';
-import { DataForm } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { SectionHeader } from '../../components/section-header';
 import { canViewHundredYearPlanSettings } from '../features';
-import type { SiteSettings } from '@automattic/api-core';
-import type { Field, SimpleFormField } from '@wordpress/dataviews';
-
-const fields: Field< SiteSettings >[] = [
-	{
-		id: 'wpcom_legacy_contact',
-		label: __( 'Contact name' ),
-		Edit: 'text',
-
-		// Workaround to create additional vertical space between the two fields.
-		description: ' ',
-	},
-	{
-		id: 'wpcom_locked_mode',
-		label: __( 'Enable locked mode' ),
-		Edit: 'checkbox',
-		description: __(
-			'Prevents new posts and pages from being created as well as existing posts and pages from being edited, and closes comments site wide.'
-		),
-	},
-];
-
-const form = {
-	layout: { type: 'regular' as const },
-	fields: [ { id: 'wpcom_legacy_contact' }, { id: 'wpcom_locked_mode' } ] as SimpleFormField[],
-};
+import ContactForm from './contact-form';
+import LockedModeForm from './locked-mode-form';
 
 export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
-	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'Legacy settings saved.' ),
-				error: __( 'Failed to save legacy settings.' ),
-			},
-		},
-	} );
-
-	const [ formData, setFormData ] = useState( {
-		wpcom_legacy_contact: settings?.wpcom_legacy_contact,
-		wpcom_locked_mode: settings?.wpcom_locked_mode,
-	} );
 
 	if ( ! site || ! settings ) {
 		return null;
@@ -66,17 +21,6 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 		throw notFound();
 	}
 
-	const isDirty = Object.entries( formData ).some(
-		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
-	);
-
-	const { isPending } = mutation;
-
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
-		mutation.mutate( { ...formData } );
-	};
-
 	return (
 		<PageLayout
 			size="small"
@@ -84,44 +28,8 @@ export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: strin
 				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Control your legacy' ) } />
 			}
 		>
-			<Card>
-				<CardBody>
-					<form onSubmit={ handleSubmit } className="dashboard-site-settings-form">
-						<VStack spacing={ 4 }>
-							<SectionHeader
-								title={ __( 'Legacy contact' ) }
-								description={ createInterpolateElement(
-									__(
-										'Choose someone to look after your site when you pass away. To take ownership of the site, we ask that the person you designate contacts us at <link>wordpress.com/help</link> with a copy of the death certificate.'
-									),
-									{
-										link: <ExternalLink href="/help" children={ null } />,
-									}
-								) }
-								level={ 3 }
-							/>
-							<DataForm< SiteSettings >
-								data={ formData }
-								fields={ fields }
-								form={ form }
-								onChange={ ( edits: Partial< SiteSettings > ) => {
-									setFormData( ( data ) => ( { ...data, ...edits } ) );
-								} }
-							/>
-							<ButtonStack justify="flex-start">
-								<Button
-									variant="primary"
-									type="submit"
-									isBusy={ isPending }
-									disabled={ isPending || ! isDirty }
-								>
-									{ __( 'Save' ) }
-								</Button>
-							</ButtonStack>
-						</VStack>
-					</form>
-				</CardBody>
-			</Card>
+			<ContactForm site={ site } settings={ settings } />
+			<LockedModeForm site={ site } settings={ settings } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-hundred-year-plan/locked-mode-form.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/locked-mode-form.tsx
@@ -1,0 +1,93 @@
+import { siteSettingsMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { ButtonStack } from '../../components/button-stack';
+import { Card, CardBody } from '../../components/card';
+import { SectionHeader } from '../../components/section-header';
+import type { Site, SiteSettings } from '@automattic/api-core';
+import type { Field, SimpleFormField } from '@wordpress/dataviews';
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_locked_mode',
+		label: __( 'Enable locked mode' ),
+		Edit: 'checkbox',
+	},
+];
+
+const form = {
+	layout: { type: 'regular' as const },
+	fields: [ { id: 'wpcom_locked_mode' } ] as SimpleFormField[],
+};
+
+export default function LockedModeForm( {
+	site,
+	settings,
+}: {
+	site: Site;
+	settings: SiteSettings;
+} ) {
+	const mutation = useMutation( {
+		...siteSettingsMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Locked mode saved.' ),
+				error: __( 'Failed to save locked mode.' ),
+			},
+		},
+	} );
+
+	const [ formData, setFormData ] = useState( {
+		wpcom_locked_mode: !! settings?.wpcom_locked_mode,
+	} );
+
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => !! settings[ key as keyof SiteSettings ] !== value
+	);
+
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( { ...formData } );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							title={ __( 'Locked mode' ) }
+							description={ __(
+								'Prevents new posts and pages from being created as well as existing posts and pages from being edited, and closes comments site wide.'
+							) }
+							level={ 3 }
+						/>
+						<DataForm< SiteSettings >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< SiteSettings > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<ButtonStack justify="flex-start">
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}


### PR DESCRIPTION
Fixes DOTMSD-1

## Proposed Changes

Updates the setting layout to be closer with v1.

v1:
<img width="1444" height="804" alt="image" src="https://github.com/user-attachments/assets/6f3f32cd-4bfc-4bb4-a7ea-b02fb6bade12" />

v2:
| Before | After |
| --- | --- |
| <img width="705" height="520" alt="SCR-20251110-lpbl" src="https://github.com/user-attachments/assets/76d5da88-c4f5-48ae-a9c5-3047ceeaf4a7" /> | <img width="705" height="664" alt="SCR-20251110-lpla" src="https://github.com/user-attachments/assets/a618af48-fa57-42bc-aac8-6d9566f7540f" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Head to /v2 or /sites
* Select a site with the hundred year plan
* Go to Settings > Control your legacy
* Ensure that the layout is updated as shown above and works as intended

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
