### PR TITLE
MSD: Update page headers for better mobile layout.

### DIFF
--- a/client/dashboard/app-ciab/style.scss
+++ b/client/dashboard/app-ciab/style.scss
@@ -41,7 +41,7 @@
 	// Headings
 	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: 54px;
+	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/app-dotcom/style.scss
+++ b/client/dashboard/app-dotcom/style.scss
@@ -41,7 +41,7 @@
 	// Headings
 	--dashboard-h1__font-size: 40px;
 	--dashboard-h1__font-weight: 400;
-	--dashboard-h1__line-height: 54px;
+	--dashboard-h1__line-height: normal;
 	--dashboard-h1__font-family: Recoleta, sans-serif;
 
 	// Overview

--- a/client/dashboard/components/date-range-picker/index.tsx
+++ b/client/dashboard/components/date-range-picker/index.tsx
@@ -45,52 +45,50 @@ export function DateRangePicker( {
 	].join( '|' );
 
 	return (
-		<div className="daterange-container">
-			<Dropdown
-				popoverProps={ { className: 'daterange-popover' } }
-				renderToggle={ ( { onToggle, isOpen } ) => (
-					<Tooltip text={ __( 'Select a date range' ) } placement="top">
-						<div className="daterange-input__toggle">
-							<Button
-								type="button"
-								variant="tertiary"
-								onClick={ onToggle }
-								aria-haspopup="dialog"
-								aria-expanded={ isOpen }
-								aria-label={ sprintf(
-									/* Translators: %s: date range label */
-									__( 'Date range: %s. Activate to open calendar.' ),
-									label
-								) }
-								className="daterange-input__field"
-								icon={ calendar }
-								iconPosition="right"
-							>
-								<span aria-hidden="true" className="daterange-input__text">
-									{ label }
-								</span>
-							</Button>
-						</div>
-					</Tooltip>
-				) }
-				renderContent={ ( { onClose } ) => (
-					<DateRangePickerInner
-						key={ resetKey }
-						isSmall={ isSmall }
-						showTwoMonths={ showTwoMonths }
-						start={ start }
-						end={ end }
-						timezoneString={ timezoneString }
-						gmtOffset={ gmtOffset }
-						onChange={ onChange }
-						onClose={ onClose }
-						mobileLabelId={ mobileLabelId }
-						desktopLabelId={ desktopLabelId }
-						disableFuture={ disableFuture }
-					/>
-				) }
-			/>
-		</div>
+		<Dropdown
+			popoverProps={ { className: 'daterange-popover' } }
+			renderToggle={ ( { onToggle, isOpen } ) => (
+				<Tooltip text={ __( 'Select a date range' ) } placement="top">
+					<div className="daterange-input__toggle">
+						<Button
+							type="button"
+							variant="tertiary"
+							onClick={ onToggle }
+							aria-haspopup="dialog"
+							aria-expanded={ isOpen }
+							aria-label={ sprintf(
+								/* Translators: %s: date range label */
+								__( 'Date range: %s. Activate to open calendar.' ),
+								label
+							) }
+							className="daterange-input__field"
+							icon={ calendar }
+							iconPosition="right"
+						>
+							<span aria-hidden="true" className="daterange-input__text">
+								{ label }
+							</span>
+						</Button>
+					</div>
+				</Tooltip>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<DateRangePickerInner
+					key={ resetKey }
+					isSmall={ isSmall }
+					showTwoMonths={ showTwoMonths }
+					start={ start }
+					end={ end }
+					timezoneString={ timezoneString }
+					gmtOffset={ gmtOffset }
+					onChange={ onChange }
+					onClose={ onClose }
+					mobileLabelId={ mobileLabelId }
+					desktopLabelId={ desktopLabelId }
+					disableFuture={ disableFuture }
+				/>
+			) }
+		/>
 	);
 }
 

--- a/client/dashboard/components/date-range-picker/style.scss
+++ b/client/dashboard/components/date-range-picker/style.scss
@@ -1,15 +1,3 @@
-/* Container */
-.daterange-container {
-	display: flex;
-	justify-content: flex-end;
-	align-items: center;
-	width: 100%;
-
-	> * {
-		flex: 0 0 auto;
-	}
-}
-
 /* Popover sizing */
 .daterange-popover .components-popover__content {
 	overflow: visible;

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -36,7 +36,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 4 } wrap>
+				<HStack justify="space-between" alignment="center" spacing={ 7 } wrap>
 					<VStack>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
@@ -25,6 +26,8 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
+	const isSmallViewport = useViewportMatch( 'medium', '<' );
+
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }
@@ -50,8 +53,8 @@ export const SectionHeader = ( {
 
 					{ /* The wrapper is always needed for view transitions. */ }
 					<ButtonStack
-						justify="flex-end"
-						expanded={ false }
+						justify={ isSmallViewport ? 'flex-start' : 'flex-end' }
+						expanded={ isSmallViewport }
 						alignment="flex-start"
 						className="dashboard-section-header__actions"
 					>

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -39,7 +39,7 @@ export const SectionHeader = ( {
 				{ decoration && (
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
-				<HStack justify="space-between" alignment="center" spacing={ 7 } wrap>
+				<HStack justify="space-between" alignment="center" spacing={ 6 } wrap>
 					<VStack>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -26,7 +26,7 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
-	const isSmallViewport = useViewportMatch( 'medium', '<' );
+	const isSmallViewport = useViewportMatch( 'small', '<' );
 
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -3,7 +3,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
@@ -26,7 +25,6 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
-	const isSmallViewport = useViewportMatch( 'small', '<' );
 
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
@@ -40,7 +38,7 @@ export const SectionHeader = ( {
 					<span className="dashboard-section-header__decoration">{ decoration }</span>
 				) }
 				<HStack justify="space-between" alignment="center" spacing={ 6 } wrap>
-					<VStack>
+					<VStack style={ { flex: '1000 1 auto' } }>
 						<HeadingTag className="dashboard-section-header__heading" id={ headingId }>
 							{ title }
 						</HeadingTag>
@@ -53,10 +51,11 @@ export const SectionHeader = ( {
 
 					{ /* The wrapper is always needed for view transitions. */ }
 					<ButtonStack
-						justify={ isSmallViewport ? 'flex-start' : 'flex-end' }
-						expanded={ isSmallViewport }
+						justify="flex-start"
+						expanded={ false }
 						alignment="flex-start"
 						className="dashboard-section-header__actions"
+						style={ { flex: '1 1 auto' } }
 					>
 						{ actions }
 					</ButtonStack>

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -25,7 +25,6 @@ export const SectionHeader = ( {
 	level = 2,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
-
 	return (
 		<VStack className={ clsx( 'dashboard-section-header', `is-level-${ level }`, className ) }>
 			{ prefix && <div className="dashboard-section-header__prefix">{ prefix }</div> }

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -49,16 +49,17 @@ export const SectionHeader = ( {
 						) }
 					</VStack>
 
-					{ /* The wrapper is always needed for view transitions. */ }
-					<ButtonStack
-						justify="flex-start"
-						expanded={ false }
-						alignment="flex-start"
-						className="dashboard-section-header__actions"
-						style={ { flex: '1 1 auto' } }
-					>
-						{ actions }
-					</ButtonStack>
+					{ !! actions && (
+						<ButtonStack
+							justify="flex-start"
+							expanded={ false }
+							alignment="flex-start"
+							className="dashboard-section-header__actions"
+							style={ { flex: '1 1 auto' } }
+						>
+							{ actions }
+						</ButtonStack>
+					) }
 				</HStack>
 			</HStack>
 		</VStack>

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
 
 .dashboard-section-header {
 	position: relative;
@@ -16,9 +17,13 @@
 
 	.dashboard-section-header.is-level-1 & {
 		font-family: var( --dashboard-h1__font-family );
-		font-size: var( --dashboard-h1__font-size, $font-size-2x-large );
+		font-size: $font-size-2x-large;
 		font-weight: var( --dashboard-h1__font-weight ) !important;
 		line-height: var( --dashboard-h1__line-height, $font-line-height-2x-large );
+
+		@include break-medium {
+			font-size: var( --dashboard-h1__font-size );
+		}
 	}
 
 	.dashboard-section-header.is-level-2 & {

--- a/client/dashboard/emails/layout.tsx
+++ b/client/dashboard/emails/layout.tsx
@@ -20,7 +20,7 @@ export const Layout = ( { children }: PropsWithChildren ) => {
 						<>
 							<Button
 								className="emails__add-email-forwarder"
-								variant="link"
+								variant="secondary"
 								__next40pxDefaultSize
 								onClick={ () => navigate( { to: addEmailForwarderRoute.to } ) }
 							>

--- a/client/dashboard/emails/style.scss
+++ b/client/dashboard/emails/style.scss
@@ -29,11 +29,6 @@
 	width: 16px;
 }
 
-
-.dashboard-section-header__actions {
-	align-items: center;
-}
-
 .emails__add-email-forwarder {
 	text-decoration: none !important;
 	font-size: $font-size-medium;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -25,6 +25,7 @@ import { Link } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	DropdownMenu,
 	MenuGroup,
@@ -1083,14 +1084,14 @@ export default function PurchaseSettings() {
 						title={ getTitleForDisplay( purchase ) }
 						actions={
 							site?.options?.admin_url && (
-								<>
+								<HStack justify="space-between">
 									{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
 											{ __( 'Upgrade' ) }
 										</Button>
 									) }
 									<PurchaseActionMenu purchase={ purchase } />
-								</>
+								</HStack>
 							)
 						}
 						description={

--- a/client/dashboard/sites/monitoring/index.tsx
+++ b/client/dashboard/sites/monitoring/index.tsx
@@ -99,7 +99,6 @@ function SiteMonitoring() {
 	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
 	const locale = useLocale();
 
-	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const [ timeRange, setTimeRange ] = useState( '24-hours' );
 
 	if ( ! site ) {
@@ -122,15 +121,9 @@ function SiteMonitoring() {
 		>
 			<PageLayout
 				header={
-					<HStack
-						justify="space-between"
-						alignment="stretch"
-						wrap
-						spacing={ isSmallViewport ? 5 : 10 }
-					>
-						<PageHeader description={ getDateRange( timeRange, locale ) } />
-
-						<div>
+					<PageHeader
+						description={ getDateRange( timeRange, locale ) }
+						actions={
 							<ToggleGroupControl
 								value={ timeRange }
 								isBlock
@@ -146,8 +139,8 @@ function SiteMonitoring() {
 								<ToggleGroupControlOption value="3-days" label={ __( '3 days' ) } />
 								<ToggleGroupControlOption value="7-days" label={ __( '7 days' ) } />
 							</ToggleGroupControl>
-						</div>
-					</HStack>
+						}
+					/>
 				}
 			>
 				<SiteMonitoringBody timeRange={ timeRange } site={ site } locale={ locale } />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -198,7 +198,7 @@ function SiteOverview( {
 
 		return (
 			<HStack justify="space-between">
-				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' }>
+				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' } style={ { width: 'auto' } }>
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button
 						ref={ wpAdminButtonRef }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,7 +197,7 @@ function SiteOverview( {
 		}
 
 		return (
-			<HStack justify="space-between" className="site-overview-actions">
+			<HStack justify="space-between">
 				<HStack justify="flex-start">
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -198,7 +198,7 @@ function SiteOverview( {
 
 		return (
 			<HStack justify="space-between">
-				<HStack justify="flex-start">
+				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' }>
 					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
 					<Button
 						ref={ wpAdminButtonRef }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,19 +197,21 @@ function SiteOverview( {
 		}
 
 		return (
-			<>
-				<StagingSiteSyncDropdown siteSlug={ siteSlug } />
-				<Button
-					ref={ wpAdminButtonRef }
-					__next40pxDefaultSize
-					variant="primary"
-					href={ site.options.admin_url }
-					icon={ wordpress }
-				>
-					{ __( 'WP Admin' ) }
-				</Button>
+			<HStack justify="space-between" className="site-overview-actions">
+				<HStack justify="flex-start">
+					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
+					<Button
+						ref={ wpAdminButtonRef }
+						__next40pxDefaultSize
+						variant="primary"
+						href={ site.options.admin_url }
+						icon={ wordpress }
+					>
+						{ __( 'WP Admin' ) }
+					</Button>
+				</HStack>
 				<SiteActionMenu site={ site } />
-			</>
+			</HStack>
 		);
 	};
 

--- a/client/dashboard/sites/performance/device-toggle.tsx
+++ b/client/dashboard/sites/performance/device-toggle.tsx
@@ -16,7 +16,7 @@ type DeviceToggleProps = {
 };
 
 export default function DeviceToggle( { value, onChange, disabled }: DeviceToggleProps ) {
-	const isDesktop = useViewportMatch( 'medium' );
+	const isMobileViewPort = useViewportMatch( 'mobile', '<' );
 	const options: { value: DeviceToggleType; label: string; icon: React.ReactElement }[] = [
 		{
 			value: 'mobile',
@@ -42,18 +42,18 @@ export default function DeviceToggle( { value, onChange, disabled }: DeviceToggl
 			onChange={ ( value ) => onChange( value as DeviceToggleType ) }
 		>
 			{ options.map( ( option ) => {
-				return isDesktop ? (
-					<ToggleGroupControlOption
-						key={ option.value }
-						value={ option.value }
-						label={ option.label }
-					/>
-				) : (
+				return isMobileViewPort ? (
 					<ToggleGroupControlOptionIcon
 						key={ option.value }
 						value={ option.value }
 						label={ option.label }
 						icon={ option.icon }
+					/>
+				) : (
+					<ToggleGroupControlOption
+						key={ option.value }
+						value={ option.value }
+						label={ option.label }
 					/>
 				);
 			} ) }


### PR DESCRIPTION
Related to: #106954
Part of DOTCOM-15116

## Proposed Changes

This PR updates PageHeader to fold better on small screens and modifies subsequent views to improve layout.

| Small (@430px)| Medium (@768px) |
|--------|--------|
| <img width="1290" height="2796" alt="calypso localhost_3000_v2_me_profile(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/056ce58f-9b5f-4040-99e9-a16bfe98af13" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini)" src="https://github.com/user-attachments/assets/4cd60f0a-d3ad-4dd8-b58a-7664696826fe" /> |
| <img width="1290" height="2796" alt="calypso localhost_3000_v2_me_profile(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/d7de4513-6764-4dd3-95c2-72ab090dea50" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini) (5)" src="https://github.com/user-attachments/assets/8aa40852-4588-4d28-ada2-6a2481f5bcb1" /> |
| <img width="1290" height="2796" alt="calypso localhost_3000_v2_me_profile(iPhone 14 Pro Max) (2)" src="https://github.com/user-attachments/assets/2f210055-14ec-4ac0-939a-b95d34ba9dcd" /> | <img width="1536" height="2048" alt="wpcalypso wordpress com_v2_sites_abstracting blog_logs_activity(iPad Mini)" src="https://github.com/user-attachments/assets/7000906e-af55-41c8-9cd4-66b2f2b60de0" /> |
| <img width="1290" height="2796" alt="calypso localhost_3000_v2_me_profile(iPhone 14 Pro Max) (3)" src="https://github.com/user-attachments/assets/4ec8c4c0-553a-42ff-b852-b1e3e5db587a" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini) (3)" src="https://github.com/user-attachments/assets/706262ad-8eae-472a-8d41-05b33d754789" /> |
| <img width="1290" height="2796" alt="calypso localhost_3000_v2_me_profile(iPhone 14 Pro Max) (4)" src="https://github.com/user-attachments/assets/5756284e-919f-4e25-91dc-c73ef2ce7ff3" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini) (2)" src="https://github.com/user-attachments/assets/95af8b39-7ba3-4b25-8d4c-2e80c5a96d7e" /> | 
| <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog_logs_activity(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/796aaa60-3571-4f8a-8a0e-65591ffd4552" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini) (1)" src="https://github.com/user-attachments/assets/55e0a4bd-c896-4a83-a1ef-68f5ddecf897" />  |
|  <img width="1290" height="2796" alt="wpcalypso wordpress com_v2_sites_abstracting blog_logs_activity(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/3278311d-922b-479a-ba93-d8edd2136710" /> | <img width="1536" height="2048" alt="calypso localhost_3000_v2_me_profile(iPad Mini) (4)" src="https://github.com/user-attachments/assets/cedbfb83-b4d0-4de3-8444-ac51171776ee" /> |


## Testing Instructions

- Visit `/v2/`.
- Click around the desktop using a Mobile screen size preset and a tablet preset. 
- Pay close attention to how the PageHeader actions are presented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
