### PR TITLE
MSD: Render left arrow instead of right arrow when RTL

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -8,8 +8,8 @@ import {
 	__experimentalHeading as Heading,
 	Icon,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { chevronRight } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
@@ -126,7 +126,10 @@ export default function OverviewCard( {
 						</Text>
 					</HStack>
 					{ relativeLink && ! progress && (
-						<Icon className="dashboard-overview-card__link-icon" icon={ chevronRight } />
+						<Icon
+							className="dashboard-overview-card__link-icon"
+							icon={ isRTL() ? chevronLeft : chevronRight }
+						/>
 					) }
 					{ externalLink && ! progress && (
 						<span

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -10,8 +10,8 @@ import {
 	FlexBlock,
 	SearchControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { chevronRight, Icon } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { chooseEmailSolutionRoute } from '../../app/router/emails';
@@ -87,7 +87,10 @@ export default function ChooseDomain() {
 									<Item key={ d.blog_id + '-' + d.domain } onClick={ () => handleDomainClick( d ) }>
 										<HStack justify="flex-start">
 											<FlexBlock>{ d.domain }</FlexBlock>
-											<Icon className="choose-domain__icon" icon={ chevronRight } />
+											<Icon
+												className="choose-domain__icon"
+												icon={ isRTL() ? chevronLeft : chevronRight }
+											/>
 										</HStack>
 									</Item>
 								) ) }
@@ -97,7 +100,10 @@ export default function ChooseDomain() {
 									<Item key={ d.blog_id + '-' + d.domain } onClick={ () => handleDomainClick( d ) }>
 										<HStack justify="flex-start">
 											<FlexBlock>{ d.domain }</FlexBlock>
-											<Icon className="choose-domain__icon" icon={ chevronRight } />
+											<Icon
+												className="choose-domain__icon"
+												icon={ isRTL() ? chevronLeft : chevronRight }
+											/>
 										</HStack>
 									</Item>
 								) ) }

--- a/client/dashboard/emails/choose-domain/styles.css
+++ b/client/dashboard/emails/choose-domain/styles.css
@@ -14,8 +14,6 @@
 /* Chevron icon color */
 .choose-domain__icon {
 	color: #757575;
-	fill: #757575; /* fallback for SVGs not using currentColor */
-	stroke: #757575; /* extra safety for stroke-based icons */
 }
 
 /* Ensure SearchControl input spans full width */

--- a/client/dashboard/emails/components/add-new-domain.css
+++ b/client/dashboard/emails/components/add-new-domain.css
@@ -12,6 +12,4 @@
 
 .add-new-domain__icon {
 	color: #757575;
-	fill: #757575;
-	stroke: #757575;
 }

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -6,7 +6,8 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
-import { chevronRight } from '@wordpress/icons';
+import { isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import { SummaryButtonProps } from './types';
@@ -76,7 +77,12 @@ function UnforwardedSummaryButton(
 					</VStack>
 					{ ! hasLowDensity && <BadgesList badges={ badges } /> }
 				</HStack>
-				{ showArrow && <Icon icon={ chevronRight } className="summary-button-navigation-icon" /> }
+				{ showArrow && (
+					<Icon
+						icon={ isRTL() ? chevronLeft : chevronRight }
+						className="summary-button-navigation-icon"
+					/>
+				) }
 			</HStack>
 		</Button>
 	);


### PR DESCRIPTION
Fixes DOTMSD-36

## Proposed Changes

Update so that these arrows point left when RTL.
<img width="753" height="924" alt="SCR-20251110-nghw" src="https://github.com/user-attachments/assets/4f919f6b-1191-457c-9001-3bfb35573d76" />

<img width="1275" height="543" alt="SCR-20251110-ngkq" src="https://github.com/user-attachments/assets/d02264b0-4ac9-4397-8132-2ec3ca210045" />

<img width="757" height="446" alt="SCR-20251110-ngma" src="https://github.com/user-attachments/assets/86069567-f5b9-48b3-82ea-628ab1e3d27c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

i18n

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to Site Overview, Site Settings, and /v2/emails/choose-domain, with RTL
* Ensure that the arrows point left

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
