### PR TITLE
MSD: add view persistence to domains DataViews

### DIFF
--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -4,17 +4,14 @@ export type DomainsView = ViewTable | ViewList | ViewPickerGrid;
 
 // Base properties that are common to all view types
 const BASE_VIEW_PROPS = {
-	filters: [] as any[],
+	type: 'table' as const,
 	sort: {
 		field: 'domain',
 		direction: 'asc' as const,
 	},
-	page: 1,
 	perPage: 10,
-	search: '',
 	showMedia: false,
 	titleField: 'domain',
-	// descriptionField: 'domain_type',
 	fields: [
 		// 'owner',
 		'blog_name',

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,23 +1,34 @@
 import { DomainSubtype } from '@automattic/api-core';
 import { domainsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
+import { usePersistentView, DataViews } from '../app/dataviews';
+import { domainsRoute } from '../app/router/domains';
 import { DataViewsCard } from '../components/dataviews-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { AddDomainButton } from './add-domain-button';
 import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
-import type { DomainsView } from './dataviews';
 import type { DomainSummary } from '@automattic/api-core';
 
 export function getDomainId( domain: DomainSummary ): string {
 	return `${ domain.domain }-${ domain.blog_id }`;
 }
+
+const defaultView = {
+	...DEFAULT_VIEW,
+	filters: [
+		{
+			field: 'owner',
+			operator: 'isAny' as const,
+			value: [ 'owned-by-me' ],
+		},
+	],
+};
 
 function Domains() {
 	const { user } = useAuth();
@@ -25,17 +36,13 @@ function Domains() {
 	const fields = useFields();
 	const { data: sites } = useQuery( queries.sitesQuery() );
 	const actions = useActions( { user, sites } );
-	const [ view, setView ] = useState< DomainsView >( () => ( {
-		...DEFAULT_VIEW,
-		type: 'table',
-		filters: [
-			{
-				field: 'owner',
-				operator: 'isAny',
-				value: [ 'owned-by-me' ],
-			},
-		],
-	} ) );
+	const searchParams = domainsRoute.useSearch();
+
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'domains',
+		defaultView,
+		queryParams: searchParams,
+	} );
 
 	const { data: domains, isLoading } = useQuery( {
 		...domainsQuery(),
@@ -59,7 +66,8 @@ function Domains() {
 				<DataViews< DomainSummary >
 					data={ filteredData || [] }
 					fields={ fields }
-					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
+					onChangeView={ updateView }
+					onResetView={ resetView }
 					view={ view }
 					actions={ actions }
 					search

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,12 +1,12 @@
 import { domainsQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import { useAuth } from '../../app/auth';
-import { siteRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
+import { usePersistentView, DataViews } from '../../app/dataviews';
+import { siteRoute, siteDomainsRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -14,7 +14,6 @@ import PageLayout from '../../components/page-layout';
 import { AddDomainButton } from '../../domains/add-domain-button';
 import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
 import PrimaryDomainSelector from './primary-domain-selector';
-import type { DomainsView } from '../../domains/dataviews';
 import type { DomainSummary } from '@automattic/api-core';
 
 function getDomainId( domain: DomainSummary ) {
@@ -40,10 +39,13 @@ function SiteDomains() {
 
 	const actions = useActions( { user, sites: [ site ] } );
 
-	const [ view, setView ] = useState< DomainsView >( () => ( {
-		...SITE_CONTEXT_VIEW,
-		type: 'table',
-	} ) );
+	const searchParams = siteDomainsRoute.useSearch();
+
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'site-domains',
+		defaultView: SITE_CONTEXT_VIEW,
+		queryParams: searchParams,
+	} );
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
 		siteDomains ?? [],
@@ -86,7 +88,8 @@ function SiteDomains() {
 				<DataViews< DomainSummary >
 					data={ filteredData || [] }
 					fields={ fields }
-					onChangeView={ ( nextView ) => setView( () => nextView as DomainsView ) }
+					onChangeView={ updateView }
+					onResetView={ resetView }
 					view={ view }
 					actions={ actions }
 					search


### PR DESCRIPTION
Fixes DOTMSD-888

## Proposed Changes

Persist `/v2/domains` and `/v2/sites/:siteSlug/domains` DataViews appearance options to Calypso preferences.

## Why are these changes being made?

We want to persist DataViews configuration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/v2/domains`
2. Click the gear button at top-right corner; play around with appearance options
3. Refresh the page; verify the options persist
4. Click `Reset view`; verify the options went back to default
5. Repeat the same in `/v2/sites/:siteSlug/domains`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
