### PR TITLE
MSD Scheduled Updates: Improve DataViews

### DIFF
--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -2,7 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useNavigate } from '@tanstack/react-router';
 import { FormToggle, Icon, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataViews, type Field, filterSortAndPaginate, View } from '@wordpress/dataviews';
+import { DataViews, type Field, filterSortAndPaginate, Operator, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -47,13 +47,14 @@ const getFields = (
 	return [
 		{
 			id: 'site',
-			type: 'text',
 			label: __( 'Site' ),
 			getValue: ( { item } ) => item.site.name,
+			enableSorting: false,
+			enableGlobalSearch: true,
 		},
 		{
 			id: 'lastUpdate',
-			type: 'integer',
+			type: 'datetime',
 			label: __( 'Last update' ),
 			render: ( { item } ) =>
 				item.lastUpdate
@@ -62,27 +63,37 @@ const getFields = (
 							timeStyle: 'short',
 					  } )
 					: '-',
+			filterBy: { operators: [] },
 		},
 		{
 			id: 'nextUpdate',
-			type: 'integer',
+			type: 'datetime',
 			label: __( 'Next update' ),
 			render: ( { item } ) =>
 				formatDate( new Date( item.nextUpdate * 1000 ), locale, {
 					dateStyle: 'medium',
 					timeStyle: 'short',
 				} ),
+			filterBy: { operators: [] },
 		},
 		{
 			id: 'schedule',
 			type: 'text',
 			label: __( 'Frequency' ),
+			elements: [
+				{ value: 'daily', label: __( 'Daily' ) },
+				{ value: 'weekly', label: __( 'Weekly' ) },
+			],
+			filterBy: {
+				operators: [ 'isAny' as Operator ],
+			},
 			render: ( { item } ) => ( item.schedule === 'daily' ? __( 'Daily' ) : __( 'Weekly' ) ),
 		},
 		{
 			id: 'plugins',
-			type: 'text',
+			type: 'integer',
 			label: __( 'Plugins' ),
+			getValue: ( { item } ) => item.plugins.length,
 			render: ( { item } ) => (
 				<span
 					style={ {
@@ -103,11 +114,19 @@ const getFields = (
 					</Tooltip>
 				</span>
 			),
+			filterBy: { operators: [] },
 		},
 		{
 			id: 'active',
-			type: 'text',
+			type: 'boolean',
 			label: __( 'Active' ),
+			elements: [
+				{ value: true, label: __( 'Yes' ) },
+				{ value: false, label: __( 'No' ) },
+			],
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
 			render: ( { item } ) => (
 				<FormToggle
 					checked={ item.active }
@@ -118,15 +137,10 @@ const getFields = (
 			),
 		},
 		{
-			id: 'actions',
-			type: 'text',
-			label: __( 'Actions' ),
-		},
-		{
 			id: 'scheduleId',
-			type: 'text',
 			label: __( 'Schedule' ),
 			getValue: ( { item } ) => getUniqueScheduleName( locale, item ),
+			filterBy: { operators: [] },
 		},
 		{
 			id: 'icon.ico',


### PR DESCRIPTION
Fixes DOTMSD-838

## Proposed Changes

This PR updates the DataView fields definition to more appropriate types, and disable filter for fields that doesn't feel as intuitive to set. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/plugins/scheduled-updates
* Ensure that the site title is searchable
* Ensure that the Active and Frequency fields are filterable and working as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
