### PR TITLE
e2e tests: Fix e2e test locator for site address field

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/import-lets-find-your-site-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/import-lets-find-your-site-page.ts
@@ -45,7 +45,7 @@ export class ImportLetsFindYourSitePage {
 	 * @param url The site URL to enter.
 	 */
 	async enterSiteURLAndCheck( url: string ): Promise< void > {
-		await this.page.getByRole( 'textbox', { name: 'Enter your site address:' } ).fill( url );
+		await this.page.getByRole( 'textbox', { name: 'Site address' } ).fill( url );
 		await this.page.getByRole( 'button', { name: 'Check my site' } ).click();
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes the e2e tests in `specs/tools/import__*.spec.ts` that were broken by PR #106938.

PR #106938 changed the site address field label from "Enter your site address:" to "Site address", which broke the locator in the `ImportLetsFindYourSitePage` page object.


## Testing Instructions

Run the import e2e tests:

```bash
cd tests/e2e
yarn build
yarn playwright test:pw specs/tools/import
```
