### PR TITLE
MSD: remove list layout from domains DataViews

### DIFF
--- a/client/dashboard/app/dataviews/dataviews.tsx
+++ b/client/dashboard/app/dataviews/dataviews.tsx
@@ -28,3 +28,6 @@ export function DataViews< Item >( { view, onResetView, ...props }: DataViewsPro
 		/>
 	);
 }
+
+DataViews.Layout = WPDataViews.Layout;
+DataViews.Pagination = WPDataViews.Pagination;

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -1,13 +1,11 @@
-import type { ViewTable, ViewList, ViewPickerGrid } from '@wordpress/dataviews';
-
-export type DomainsView = ViewTable | ViewList | ViewPickerGrid;
+import type { View } from '@wordpress/dataviews';
 
 // Base properties that are common to all view types
-const BASE_VIEW_PROPS = {
-	type: 'table' as const,
+const BASE_VIEW_PROPS: View = {
+	type: 'table',
 	sort: {
 		field: 'domain',
-		direction: 'asc' as const,
+		direction: 'asc',
 	},
 	perPage: 10,
 	showMedia: false,
@@ -31,5 +29,4 @@ export const SITE_CONTEXT_VIEW = {
 // Default layouts
 export const DEFAULT_LAYOUTS = {
 	table: {},
-	list: {},
 };

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -151,7 +151,7 @@ function SiteOverviewSecondaryCards( {
 					{ ! isSelfHostedJetpackConnectedSite && ! site.is_wpcom_staging_site && (
 						<>
 							<DIFMUpsellCard site={ site } />
-							<DomainsCard site={ site } isCompact={ isSmallViewport } />
+							<DomainsCard site={ site } />
 						</>
 					) }
 				</VStack>


### PR DESCRIPTION
Context: https://github.com/Automattic/wp-calypso/pull/106849#issuecomment-3484175682

## Proposed Changes

Remove `list` layout from Domains DataViews across Multi-site dashboard, even on small viewport.

### `/v2/domains`

|Before|After|
|-|-|
|<img width="590" height="312" alt="image" src="https://github.com/user-attachments/assets/25e5ead4-35e6-405f-bcd1-4295b91c562c" />|<img width="589" height="308" alt="image" src="https://github.com/user-attachments/assets/e1308d91-56de-4c24-819c-e35d252a9e2c" />|


### `/v2/sites/:siteSlug/`

|Before|After|
|-|-|
|<img width="545" height="341" alt="image" src="https://github.com/user-attachments/assets/23d7610b-a1f3-44df-82be-60f0df2fbfd4" />|<img width="533" height="299" alt="image" src="https://github.com/user-attachments/assets/62a6e0c2-092a-4188-916e-11bcbf66e20b" />|

### `/v2/sites/:siteSlug/domains`

|Before|After|
|-|-|
|<img width="636" height="494" alt="image" src="https://github.com/user-attachments/assets/8eeedadc-cdbc-4dea-aa81-aac8d1a61d70" />|<img width="644" height="498" alt="image" src="https://github.com/user-attachments/assets/dfb0c2bf-ac4f-4d7f-8764-b9584ebda3a3" />|


## Why are these changes being made?

The `list` layout is supposed to be used when the item has preview which is shown when a row is clicked. It's not for the use case where we want to click on a row and it takes us somewhere.

For example, currently, when we choose `list` layout in any of the above DataViews, the rows do nothing when clicked.

## Testing Instructions

Test the pages as shown in the above screenshots.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
