### PR TITLE
e2e tests: Fix default value for waitUntilStable in authenticate method

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -50,7 +50,7 @@ export class TestAccount {
 	 */
 	async authenticate(
 		page: Page,
-		{ url, waitUntilStable }: { url?: string | RegExp; waitUntilStable?: boolean } = {}
+		{ url, waitUntilStable = true }: { url?: string | RegExp; waitUntilStable?: boolean } = {}
 	): Promise< void > {
 		const browserContext = page.context();
 		await browserContext.clearCookies();


### PR DESCRIPTION
Fixes QAO-151

## Proposed Changes

Changed the default value of `waitUntilStable` from `undefined` to `true` in the authenticate method, to ensure that by default the method will now wait for the sidebar to initialize, confirming successful authentication.

In some cases, a following explicit navigation that happens too quickly can result in the login page being displayed.


## Testing Instructions

```
cd test/e2e
yarn build
yarn test
```

