### PR TITLE
Revert "Help Center: Fix the crash by calling Smooch.render after init"

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -198,10 +198,6 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 						success: true,
 						error: '',
 					} );
-
-					if ( smoochRef.current ) {
-						Smooch.render( smoochRef.current );
-					}
 				} )
 				.catch( ( error ) => {
 					setIsChatLoaded( false );
@@ -214,6 +210,10 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		};
 
 		initializeSmooch();
+
+		if ( smoochRef.current ) {
+			Smooch.render( smoochRef.current );
+		}
 
 		return () => {
 			clearTimeout( retryTimeout );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#106981

It looks like this broke escalations: p1762780496973339-slack-C07D72S1135