### PR TITLE
Use the correct `botSlug` in new messages before interaction is created

### DIFF
--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -11,6 +11,7 @@ import {
 	getExistingConversationMessage,
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,
 	getErrorMessageUnknownError,
+	ODIE_NEW_INTERACTIONS_BOT_SLUG,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useCreateZendeskConversation } from '../hooks';
@@ -18,6 +19,17 @@ import { generateUUID, getOdieIdFromInteraction, getIsRequestingHumanSupport } f
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import { useManageSupportInteraction, broadcastOdieMessage } from '.';
 import type { Chat, Message, ReturnedChat, SupportInteraction } from '../types';
+
+function getBotSlug( supportInteraction?: SupportInteraction ): string {
+	if ( supportInteraction ) {
+		// Legacy support interactions have their botSlug set to `''`. We need to use the default bot slug for them.
+		return supportInteraction.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
+	}
+
+	// When the interaction is undefined, it means we're sending the first message to Odie, which is done before the interaction is created.
+	// In this case, we use the new interactions bot slug.
+	return ODIE_NEW_INTERACTIONS_BOT_SLUG;
+}
 
 const getErrorMessageForSiteIdAndInternalMessageId = (
 	selectedSiteId: number | null | undefined,
@@ -164,7 +176,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 
 	return useMutation< ReturnedChat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
-			const botSlug = currentSupportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
+			const botSlug = getBotSlug( currentSupportInteraction );
 			const chatIdSegment = odieId ? `/${ odieId }` : '';
 			const path = window.location.pathname + window.location.search;
 			return canAccessWpcomApis()

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -22,7 +22,7 @@ import type { Chat, Message, ReturnedChat, SupportInteraction } from '../types';
 
 function getBotSlug( supportInteraction?: SupportInteraction ): string {
 	if ( supportInteraction ) {
-		// Legacy support interactions have their botSlug set to `''`. We need to use the default bot slug for them.
+		// Legacy support interactions have their botSlug set to `''`. We need to use the legacy bot slug for them.
 		return supportInteraction.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
 	}
 


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/106892 broke non-default bots (nothing in prod yet).

Because we now depend on the interaction to provide us with the `botSlug`, and we stopped creating interactions until after the first Odie message, the first message was targeting the wrong bot.

This uses the `ODIE_NEW_INTERACTIONS_BOT_SLUG` when the interaction is not yet created. As opposed to the `ODIE_DEFAULT_BOT_SLUG_LEGACY`.

## Why are these changes being made?
Support new bots

## Testing Instructions
1. Go to My Home and start a chat.
2. Send a message to Odie, it should target `wpcom-support-chat`.
3. Go to /?flags=help-center/workflow&version=0.0.1.
4. Start a new interaction and send a message to Odie.
5. It should target `?flags=help-center/workflow&version=0.0.1`.
