### PR TITLE
Domain Search: Improve domain search tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -206,14 +206,23 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 			onSkip: ( suggestion?: FreeDomainSuggestion ) => {
+				let signupDomainOrigin = suggestion
+					? SIGNUP_DOMAIN_ORIGIN.FREE
+					: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER;
+
+				if (
+					! isLoadingExperiment &&
+					experimentVariation === 'treatment_paid_domain_area_skip_emphasis'
+				) {
+					signupDomainOrigin = SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER;
+				}
+
 				submit( {
 					siteUrl: suggestion?.domain_name.replace( '.wordpress.com', '' ),
 					domainItem: undefined,
 					domainCart: [],
 					suggestion,
-					signupDomainOrigin: suggestion
-						? SIGNUP_DOMAIN_ORIGIN.FREE
-						: SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER,
+					signupDomainOrigin,
 				} );
 			},
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -188,7 +188,6 @@ const DomainSearchStep: StepType< {
 				submit( {
 					navigateToUseMyDomain: true,
 					lastQuery: domainName,
-					shouldSkipSubmitTracking: true,
 				} );
 			},
 			onContinue: ( domainCart: MinimalRequestCartProduct[] ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -54,6 +54,7 @@ type UseMyDomain = {
 	siteUrl?: string;
 	domainItem?: MinimalRequestCartProduct;
 	lastQuery?: string;
+	signupDomainOrigin?: string;
 };
 
 type StepSubmission = {
@@ -188,6 +189,7 @@ const DomainSearchStep: StepType< {
 				submit( {
 					navigateToUseMyDomain: true,
 					lastQuery: domainName,
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
 				} );
 			},
 			onContinue: ( domainCart: MinimalRequestCartProduct[] ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -227,7 +227,7 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 		};
-	}, [ submit, setQuery, clearQuery, flow, siteSlug ] );
+	}, [ submit, setQuery, clearQuery, flow, siteSlug, isLoadingExperiment, experimentVariation ] );
 
 	const slots = useMemo( () => {
 		return {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Addressed pbxNRc-5td-p2#comment-7176

## Proposed Changes

* Changes the tracked data for `calypso_signup_actions_submit_step` to use `signup_domain_origin: choose-later` when the experiment is active.
* Fixes the `calypso_signup_actions_submit_step` event not being recorded when `Use a domain I own` is clicked on the domain search flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the following experiment: pbxNRc-5td-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions in pbxNRc-5td-p2#comment-7176

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?