### PR TITLE
Domains: Improve Domain Name Servers view

### DIFF
--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -26,12 +26,12 @@ const createNameServerField = ( index: number, formData: FormData, isBusy?: bool
 		type: 'text' as const,
 		label: sprintf(
 			// translators: %s is the name server number (1-4)
-			__( 'Custom name server %s' ),
+			__( 'Name server %s' ),
 			index
 		),
 		placeholder: sprintf(
 			// translators: %s is the name server number (1-4)
-			__( 'ns%s.domain.com' ),
+			__( 'ns%s.example.com' ),
 			index
 		),
 		isValid: {


### PR DESCRIPTION
## Summary

Improves the Domain Name Servers view based on feedback in [DOMAINS-1805](https://linear.app/a8c/issue/DOMAINS-1805/improve-domain-name-servers-view).
Context of its creation: pbe7d3-4rM-p2#comment-4445

## Changes

1. **Removed "Custom" from label**: Changed from "Custom name server 1" to "Name server 1" for cleaner, more standard terminology
2. **Improved placeholder text**: Changed from "ns1.domain.com" to "ns1.example.com" to better distinguish placeholders from actual values

## Before

- Label: "Custom name server 1", "Custom name server 2", etc.
- Placeholder: "ns1.domain.com", "ns2.domain.com", etc.
- The placeholder text resembled the previous read-only state, causing confusion

## After

- Label: "Name server 1", "Name server 2", etc.
- Placeholder: "ns1.example.com", "ns2.example.com", etc.
- Placeholder is now clearly distinct from WordPress.com default values ("ns1.wordpress.com")

## Implementation Notes

Based on team discussion in Linear:
- Kept the "Look up the name servers for popular hosts" link in its original position (not moved) as the layout jump is not a significant issue for this rare action
- Used "example.com" without "Example:" prefix as it's distinctive enough from the WordPress.com nameservers

## Test Plan

1. Navigate to Domain Management > Name Servers for any domain
2. Verify labels now say "Name server 1", "Name server 2", etc. (without "Custom")
3. Toggle to custom name servers and verify placeholders show "ns1.example.com", "ns2.example.com", etc.
4. Verify the "Look up" link appears when toggled to custom name servers
5. Verify form validation and submission still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>