### PR TITLE
Calypso Products: add free CIAB products

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -76,6 +76,8 @@ export const PLAN_WOOEXPRESS_SMALL_MONTHLY = 'wooexpress-small-bundle-monthly';
 export const PLAN_WOOEXPRESS_MEDIUM = 'wooexpress-medium-bundle-yearly';
 export const PLAN_WOOEXPRESS_MEDIUM_MONTHLY = 'wooexpress-medium-bundle-monthly';
 export const PLAN_WOOEXPRESS_PLUS = 'wooexpress-plus'; // Not a real plan;
+export const PLAN_WOO_HOSTED_FREE = 'woo_hosted_free_plan';
+export const PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY = 'woo_hosted_free_trial_plan_monthly';
 export const PLAN_WOO_HOSTED_BASIC = 'woo_hosted_basic_plan_yearly';
 export const PLAN_WOO_HOSTED_BASIC_MONTHLY = 'woo_hosted_basic_plan_monthly';
 export const PLAN_WOO_HOSTED_PRO = 'woo_hosted_pro_plan_yearly';
@@ -137,6 +139,8 @@ export const WPCOM_PLANS = < const >[
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,
+	PLAN_WOO_HOSTED_FREE,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC,
 	PLAN_WOO_HOSTED_BASIC_MONTHLY,
 	PLAN_WOO_HOSTED_PRO,
@@ -154,6 +158,7 @@ export const WPCOM_MONTHLY_PLANS = < const >[
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC_MONTHLY,
 	PLAN_WOO_HOSTED_PRO_MONTHLY,
 	PLAN_WPCOM_PRO_MONTHLY,
@@ -170,6 +175,8 @@ export const WOO_EXPRESS_PLANS = < const >[
 ];
 
 export const WOO_HOSTED_PLANS = < const >[
+	PLAN_WOO_HOSTED_FREE,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC,
 	PLAN_WOO_HOSTED_BASIC_MONTHLY,
 	PLAN_WOO_HOSTED_PRO,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -321,6 +321,8 @@ import {
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_SMALL,
+	PLAN_WOO_HOSTED_FREE,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC,
 	PLAN_WOO_HOSTED_PRO_MONTHLY,
@@ -3107,12 +3109,40 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getStoreSlug: () => PLAN_WOOEXPRESS_PLUS,
 	},
 
-	// CIAB Plans. Features are a placeholder.
+	// CIAB Plans. Features and translation strings are a placeholder.
+	[ PLAN_WOO_HOSTED_FREE ]: {
+		...getPlanFreeDetails(),
+		...getAnnualTimeframe(),
+		getTitle: () => i18n.translate( 'Free subscription' ),
+		getTagline: () => 'Learn more about everything included with Woo Free Trial.',
+		getProductId: () => 4005,
+		getStoreSlug: () => PLAN_WOO_HOSTED_FREE,
+		getPathSlug: () => 'woo-hosted-free',
+	},
+
+	[ PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ]: {
+		...getPlanFreeDetails(),
+		...getMonthlyTimeframe(),
+		getTitle: () => 'Free Trial',
+		getPlanTagline: () => "Get a taste of the world's most popular eCommerce software.",
+		getDescription: () =>
+			i18n.translate(
+				'Try Woo Hosted for free and explore all the features before committing to a plan.'
+			),
+		getTagline: () => 'Learn more about everything included with Woo Free Trial.',
+		availableFor: ( plan ) =>
+			[ PLAN_WOO_HOSTED_FREE, PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ].includes( plan ),
+		getProductId: () => 4006,
+		getStoreSlug: () => PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+		getPathSlug: () => 'woo-hosted-free-trial-monthly',
+	},
+
 	[ PLAN_WOO_HOSTED_BASIC_MONTHLY ]: {
 		...getPlanWooHostedBasicDetails(),
 		...getMonthlyTimeframe(),
 		type: TYPE_WOO_HOSTED_BASIC,
-		getBillingTimeFrame: () => translate( 'per month' ),
+		availableFor: ( plan ) =>
+			[ PLAN_WOO_HOSTED_FREE, PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ].includes( plan ),
 		getProductId: () => 4001,
 		getStoreSlug: () => PLAN_WOO_HOSTED_BASIC_MONTHLY,
 		getPathSlug: () => 'woo-hosted-basic-monthly',
@@ -3120,10 +3150,14 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 
 	[ PLAN_WOO_HOSTED_BASIC ]: {
 		...getPlanWooHostedBasicDetails(),
+		...getAnnualTimeframe(),
 		type: TYPE_WOO_HOSTED_BASIC,
-		term: TERM_ANNUALLY,
-		getBillingTimeFrame: WPComGetBillingTimeframe,
-		availableFor: ( plan ) => [ PLAN_WOO_HOSTED_BASIC_MONTHLY ].includes( plan ),
+		availableFor: ( plan ) =>
+			[
+				PLAN_WOO_HOSTED_FREE,
+				PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+				PLAN_WOO_HOSTED_BASIC_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 4002,
 		getStoreSlug: () => PLAN_WOO_HOSTED_BASIC,
 		getPathSlug: () => 'woo-hosted-basic',
@@ -3133,7 +3167,13 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		...getPlanWooHostedProDetails(),
 		...getMonthlyTimeframe(),
 		type: TYPE_WOO_HOSTED_PRO,
-		getBillingTimeFrame: () => translate( 'per month' ),
+		availableFor: ( plan ) =>
+			[
+				PLAN_WOO_HOSTED_FREE,
+				PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+				PLAN_WOO_HOSTED_BASIC_MONTHLY,
+				PLAN_WOO_HOSTED_BASIC,
+			].includes( plan ),
 		getProductId: () => 4003,
 		getStoreSlug: () => PLAN_WOO_HOSTED_PRO_MONTHLY,
 		getPathSlug: () => 'woo-hosted-pro-monthly',
@@ -3141,11 +3181,12 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 
 	[ PLAN_WOO_HOSTED_PRO ]: {
 		...getPlanWooHostedProDetails(),
-		term: TERM_ANNUALLY,
-		getBillingTimeFrame: WPComGetBillingTimeframe,
+		...getAnnualTimeframe(),
 		type: TYPE_WOO_HOSTED_PRO,
 		availableFor: ( plan ) =>
 			[
+				PLAN_WOO_HOSTED_FREE,
+				PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 				PLAN_WOO_HOSTED_BASIC_MONTHLY,
 				PLAN_WOO_HOSTED_BASIC,
 				PLAN_WOO_HOSTED_PRO_MONTHLY,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -64,6 +64,8 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_WOO_HOSTED_BASIC,
 	PLAN_WOO_HOSTED_BASIC_MONTHLY,
+	PLAN_WOO_HOSTED_FREE,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	PLAN_WOO_HOSTED_PRO,
 	PLAN_WOO_HOSTED_PRO_MONTHLY,
 	PLAN_WOOEXPRESS_MEDIUM,
@@ -140,6 +142,7 @@ describe( 'isFreePlan', () => {
 	test( 'should return true for free plans', () => {
 		expect( isFreePlan( PLAN_FREE ) ).toEqual( true );
 		expect( isFreePlan( PLAN_JETPACK_FREE ) ).toEqual( true );
+		expect( isFreePlan( PLAN_WOO_HOSTED_FREE ) ).toEqual( true );
 	} );
 	test( 'should return false for non-free plans', () => {
 		expect( isFreePlan( PLAN_PERSONAL ) ).toEqual( false );
@@ -1107,6 +1110,7 @@ describe( 'findPlansKeys', () => {
 				PLAN_P2_FREE,
 				PLAN_PERSONAL,
 				PLAN_PREMIUM,
+				PLAN_WOO_HOSTED_FREE,
 				PLAN_WOO_HOSTED_BASIC,
 				PLAN_WOO_HOSTED_PRO,
 				PLAN_WOOEXPRESS_MEDIUM,
@@ -1138,6 +1142,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_PERSONAL_MONTHLY,
 			PLAN_PREMIUM_MONTHLY,
 			PLAN_WOO_HOSTED_BASIC_MONTHLY,
+			PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 			PLAN_WOO_HOSTED_PRO_MONTHLY,
 			PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
@@ -1150,11 +1155,15 @@ describe( 'findPlansKeys', () => {
 	} );
 
 	test( 'all matching plans keys - by type', () => {
-		expect( findPlansKeys( { type: TYPE_FREE } ) ).toEqual( [
-			PLAN_FREE,
-			PLAN_JETPACK_FREE,
-			PLAN_P2_FREE,
-		] );
+		expect( findPlansKeys( { type: TYPE_FREE } ).sort() ).toEqual(
+			[
+				PLAN_FREE,
+				PLAN_JETPACK_FREE,
+				PLAN_P2_FREE,
+				PLAN_WOO_HOSTED_FREE,
+				PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+			].sort()
+		);
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).toEqual( [
 			PLAN_BLOGGER,
 			PLAN_BLOGGER_2_YEARS,
@@ -1218,6 +1227,8 @@ describe( 'findPlansKeys', () => {
 				PLAN_PREMIUM_MONTHLY,
 				PLAN_WOO_HOSTED_BASIC,
 				PLAN_WOO_HOSTED_BASIC_MONTHLY,
+				PLAN_WOO_HOSTED_FREE,
+				PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 				PLAN_WOO_HOSTED_PRO,
 				PLAN_WOO_HOSTED_PRO_MONTHLY,
 				PLAN_WOOEXPRESS_MEDIUM,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

See: https://linear.app/a8c/issue/SHILL-929/ciab-create-checkout-flow-for-ciab
See: https://linear.app/a8c/issue/SHILL-925/ciab-add-store-and-billing-product-and-plans-for-test-purchases

## Proposed Changes

This adds the product constants and definitions for the free Woo Hosted plans to the `calypso-products` package.

## Why are these changes being made?

Similar to https://github.com/Automattic/wp-calypso/pull/106517, this adds the free Woo Hosted plan configuration before returning them from the relevant endpoints.

The `usePlans` and `useSitePlans` hooks loop through the products returned from either the `/plans` or `/site/{site}/plans` endpoints, and merge the response with data from the `calypso-products` package to render the plans grid. There is no fallback plan structure in the package's `getPlans()`, thus if new plans are added to the REST endpoints, the hooks will throw errors and the grid will fail to load.

## Testing Instructions

- With `public-api.wordpress.com` sandboxed and your sandbox running `trunk`
- View the plans grid in either the dashboard (http://calypso.localhost:3000/{site}/plans/) or stepper (http://calypso.localhost:3000/setup/onboarding/)
- Verify that the plans grid is correctly rendered and no errors are shown in your console
