### PR TITLE
MSD: Create the wrapper for the summary button to add mobile styles.

### DIFF
--- a/client/dashboard/components/router-link-summary-button/index.tsx
+++ b/client/dashboard/components/router-link-summary-button/index.tsx
@@ -1,11 +1,11 @@
-import SummaryButton from '@automattic/components/src/summary-button';
 import { createLink } from '@tanstack/react-router';
+import DashboardSummaryButton from '../summary-button';
 
 /**
- * This component is a wrapper of `SummaryButton` component and acts as a
- * navigational element. It uses `createLink` from `@tanstack/react-router` to create a
- * link that can be used to navigate to a different route when the button is clicked.
- * It's separate from `SummaryButton` to allow for better separation of concerns, as
- * `SummaryButton` is a pure UI component.
+ * This component wraps `DashboardSummaryButton` (which itself wraps `SummaryButton`)
+ * and transforms it into a navigational element using `createLink` from `@tanstack/react-router`.
+ * When the button is clicked, it navigates to a different route instead of performing
+ * a standard action. This separation allows `SummaryButton` to remain a pure UI component
+ * while providing routing functionality when needed.
  */
-export default createLink( SummaryButton );
+export default createLink( DashboardSummaryButton );

--- a/client/dashboard/components/summary-button/index.tsx
+++ b/client/dashboard/components/summary-button/index.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 /**
  * This component is a wrapper of the `SummaryButton` component and adds a
  * `dashboard-summary-button` class to the component to handle responsive padding temporarily.
- * See https://github.com/Automattic/wp-dashboard/pull/106797 for more details.
+ * See https://github.com/Automattic/wp-dashboard/pull/107025 for more details.
  * @param props - The props for the SummaryButton component.
  * @returns The SummaryButton component.
  */

--- a/client/dashboard/components/summary-button/index.tsx
+++ b/client/dashboard/components/summary-button/index.tsx
@@ -1,0 +1,14 @@
+import SummaryButton from '@automattic/components/src/summary-button';
+import type { SummaryButtonProps } from '@automattic/components/src/summary-button/types';
+import './style.scss';
+
+/**
+ * This component is a wrapper of the `SummaryButton` component and adds a
+ * `dashboard-summary-button` class to the component to handle responsive padding temporarily.
+ * See https://github.com/Automattic/wp-dashboard/pull/106797 for more details.
+ * @param props - The props for the SummaryButton component.
+ * @returns The SummaryButton component.
+ */
+export default function DashboardSummaryButton( props: SummaryButtonProps ) {
+	return <SummaryButton className="dashboard-summary-button" { ...props } />;
+}

--- a/client/dashboard/components/summary-button/style.scss
+++ b/client/dashboard/components/summary-button/style.scss
@@ -1,0 +1,8 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.dashboard-summary-button {
+    @media (max-width: #{$break-medium - 1px}) {
+        padding-inline: $grid-unit-20 !important;
+    }
+}


### PR DESCRIPTION
Alternative to #106797, #106795, #106825
Suggested in https://github.com/Automattic/wp-calypso/pull/106825#discussion_r2476638356

## Proposed Changes

We don't yet have a preferred format for handling mobile styles. I've tried a few other approaches to handle this, but without a clear strategy for responsive layouts in Automattic components. The design team is moving towards an agreed approach. 

I think for now, this is the best approach. While it does add a line of CSS, it isolates it to a wrapper component and makes it clear that this isn't a pattern to be followed.

| Before | After |
|--------|--------|
| <img width="894" height="1856" alt="wpcalypso wordpress com_v2_sites_abstracting blog_settings" src="https://github.com/user-attachments/assets/c131c24e-e01d-49c3-a84b-a2442188645c" /> | <img width="894" height="1856" alt="calypso localhost_3000_v2_sites_abstracting blog_settings (2)" src="https://github.com/user-attachments/assets/47568916-ae6f-4994-a4b4-ed5f381339c8" /> | 





## Testing Instructions

Load your `/v2` settings page on mobile, expect the padding to be smaller than on desktop.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
