### PR TITLE
MSD: Fix DashboardSummaryButton ref forwarding

### DIFF
--- a/client/dashboard/components/summary-button/index.tsx
+++ b/client/dashboard/components/summary-button/index.tsx
@@ -1,4 +1,5 @@
 import SummaryButton from '@automattic/components/src/summary-button';
+import { forwardRef } from 'react';
 import type { SummaryButtonProps } from '@automattic/components/src/summary-button/types';
 import './style.scss';
 
@@ -7,8 +8,16 @@ import './style.scss';
  * `dashboard-summary-button` class to the component to handle responsive padding temporarily.
  * See https://github.com/Automattic/wp-dashboard/pull/107025 for more details.
  * @param props - The props for the SummaryButton component.
+ * @param ref - The ref for the SummaryButton component.
  * @returns The SummaryButton component.
  */
-export default function DashboardSummaryButton( props: SummaryButtonProps ) {
-	return <SummaryButton className="dashboard-summary-button" { ...props } />;
-}
+const DashboardSummaryButton = forwardRef<
+	HTMLAnchorElement | HTMLButtonElement,
+	SummaryButtonProps
+>( ( props, ref ) => (
+	<SummaryButton ref={ ref } className="dashboard-summary-button" { ...props } />
+) );
+
+DashboardSummaryButton.displayName = 'DashboardSummaryButton';
+
+export default DashboardSummaryButton;


### PR DESCRIPTION
## Proposed Changes

Follow-up of #107025. Fixes

<img width="720" height="278" alt="image" src="https://github.com/user-attachments/assets/0c875d53-de6d-4357-8747-bae513e68435" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
