### PR TITLE
Fix/msd cancel purchase domain

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1432,7 +1432,11 @@ export default function CancelPurchase() {
 					cancellationChanges={ cancellationChanges }
 				/>
 
-				<CancelPurchaseRefundInformation purchase={ purchase } isJetpackPurchase={ isJetpack } />
+				<CancelPurchaseRefundInformation
+					purchase={ purchase }
+					isJetpackPurchase={ isJetpack }
+					selectedDomain={ selectedDomain }
+				/>
 
 				{ ! cancellationFeatures.length ? renderProductRevertContent() : renderPlanRevertContent() }
 			</>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -1,21 +1,19 @@
-import { domainQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
-import type { Purchase } from '@automattic/api-core';
+import type { Purchase, Domain } from '@automattic/api-core';
 
 interface CancelPurchaseRefundInformationProps {
 	purchase: Purchase;
 	isJetpackPurchase: boolean;
+	selectedDomain: Domain | null;
 }
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isJetpackPurchase,
+	selectedDomain,
 }: CancelPurchaseRefundInformationProps ) => {
-	const { data: selectedDomain } = useSuspenseQuery( domainQuery( purchase.meta ?? '' ) );
-
 	const isGravatarRestrictedDomain = selectedDomain?.is_gravatar_restricted_domain;
 	const { refund_period_in_days: refundPeriodInDays } = purchase;
 	let text;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -14,7 +14,7 @@ const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isJetpackPurchase,
 }: CancelPurchaseRefundInformationProps ) => {
-	const { data: selectedDomain } = useSuspenseQuery( domainQuery( purchase.product_name ) );
+	const { data: selectedDomain } = useSuspenseQuery( domainQuery( purchase.meta ?? '' ) );
 
 	const isGravatarRestrictedDomain = selectedDomain?.is_gravatar_restricted_domain;
 	const { refund_period_in_days: refundPeriodInDays } = purchase;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -6,7 +6,7 @@ import type { Purchase, Domain } from '@automattic/api-core';
 interface CancelPurchaseRefundInformationProps {
 	purchase: Purchase;
 	isJetpackPurchase: boolean;
-	selectedDomain: Domain | null;
+	selectedDomain: Domain | null | undefined;
 }
 
 const CancelPurchaseRefundInformation = ( {


### PR DESCRIPTION
I've recently refactored to code to move away from siteDomainsQuery and replaced all instances with `domainsQuery` or `domainQuery` - in this case I missed that the original code is using `product_name` instead of `meta` (see https://github.com/Automattic/wp-calypso/blob/442456b14e9a7259af7a21643be17b6f183ab5ac/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx#L19 ) and I just mechanically replaced the code to use domainQuery. I suppose it's good that it started failing because otherwise we wouldn't know why it's not behaving as expected for a while

Part of p1762831890802979-slack-C0117V2PCAE

## Proposed Changes

* Don't use query to fetch the domain information as it's already available in the parent component - so just pass it as property

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The cancellation flow was failing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a purchases page for a single purchase for a domain and add `/cancel` to the end of the URL - it should show you the cancel form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?