### PR TITLE
MSD: add view persistence to /v2/emails DataViews

### DIFF
--- a/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
@@ -9,9 +9,9 @@ import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useAnalytics } from '../../app/analytics';
-import { Text } from '../../components/text';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { Text } from '../../../components/text';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useDeleteEmailForwardAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/delete-titan-mailbox.tsx
+++ b/client/dashboard/emails/dataviews/actions/delete-titan-mailbox.tsx
@@ -9,9 +9,9 @@ import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useAnalytics } from '../../app/analytics';
-import { Text } from '../../components/text';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { Text } from '../../../components/text';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useDeleteTitanMailboxAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/finish-setup.tsx
+++ b/client/dashboard/emails/dataviews/actions/finish-setup.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import { useAnalytics } from '../../app/analytics';
-import { buildGoogleFinishSetupLink } from '../../utils/email-utils';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { buildGoogleFinishSetupLink } from '../../../utils/email-utils';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useFinishSetupAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/index.ts
+++ b/client/dashboard/emails/dataviews/actions/index.ts
@@ -5,10 +5,10 @@ import { useManageGoogleWorkspaceAction } from './manage-google-workspace';
 import { usePaymentDetailsAction } from './payment-details';
 import { useResendVerificationAction } from './resend-verification';
 import { useViewMailboxAction } from './view-mailbox';
-import type { Email } from '../types';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
-export function useEmailActions(): Action< Email >[] {
+export function useActions(): Action< Email >[] {
 	return [
 		useViewMailboxAction(),
 		useFinishSetupAction(),

--- a/client/dashboard/emails/dataviews/actions/manage-google-workspace.ts
+++ b/client/dashboard/emails/dataviews/actions/manage-google-workspace.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import { useAnalytics } from '../../app/analytics';
-import { buildGoogleManageWorkspaceLink } from '../../utils/email-utils';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { buildGoogleManageWorkspaceLink } from '../../../utils/email-utils';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useManageGoogleWorkspaceAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/payment-details.ts
+++ b/client/dashboard/emails/dataviews/actions/payment-details.ts
@@ -1,8 +1,8 @@
 import { useNavigate } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { useAnalytics } from '../../app/analytics';
-import { purchasesRoute } from '../../app/router/me';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { purchasesRoute } from '../../../app/router/me';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const usePaymentDetailsAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/resend-verification.ts
+++ b/client/dashboard/emails/dataviews/actions/resend-verification.ts
@@ -3,8 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useAnalytics } from '../../app/analytics';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useResendVerificationAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/actions/view-mailbox.tsx
+++ b/client/dashboard/emails/dataviews/actions/view-mailbox.tsx
@@ -1,8 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { useAnalytics } from '../../app/analytics';
-import { buildTitanMailboxLink, buildGoogleMailboxLink } from '../../utils/email-utils';
-import MailboxIcon from '../resources/mailbox-icon';
-import type { Email } from '../types';
+import { useAnalytics } from '../../../app/analytics';
+import { buildTitanMailboxLink, buildGoogleMailboxLink } from '../../../utils/email-utils';
+import MailboxIcon from '../../resources/mailbox-icon';
+import type { Email } from '../../types';
 import type { Action } from '@wordpress/dataviews';
 
 export const useViewMailboxAction = (): Action< Email > => {

--- a/client/dashboard/emails/dataviews/fields/domain-name.ts
+++ b/client/dashboard/emails/dataviews/fields/domain-name.ts
@@ -1,6 +1,6 @@
 import { DomainSummary } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
-import type { Email } from '../types';
+import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
 export const getDomainNameField = ( domains: DomainSummary[] ): Field< Email > => ( {

--- a/client/dashboard/emails/dataviews/fields/email-address.tsx
+++ b/client/dashboard/emails/dataviews/fields/email-address.tsx
@@ -5,9 +5,9 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { next, wordpress } from '@wordpress/icons';
-import { Text } from '../../components/text';
-import GoogleLogo from '../resources/google-logo';
-import type { Email } from '../types';
+import { Text } from '../../../components/text';
+import GoogleLogo from '../../resources/google-logo';
+import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
 export const emailAddressField: Field< Email > = {

--- a/client/dashboard/emails/dataviews/fields/index.ts
+++ b/client/dashboard/emails/dataviews/fields/index.ts
@@ -3,10 +3,10 @@ import { getDomainNameField } from './domain-name';
 import { emailAddressField } from './email-address';
 import { statusField } from './status';
 import { typeField } from './type';
-import type { Email } from '../types';
+import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const getEmailFields = ( domains: DomainSummary[] ): Field< Email >[] => [
+export const getFields = ( domains: DomainSummary[] ): Field< Email >[] => [
 	emailAddressField,
 	getDomainNameField( domains ),
 	typeField,

--- a/client/dashboard/emails/dataviews/fields/status.tsx
+++ b/client/dashboard/emails/dataviews/fields/status.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { Text } from '../../components/text';
-import type { Email } from '../types';
+import { Text } from '../../../components/text';
+import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
 export const statusField: Field< Email > = {

--- a/client/dashboard/emails/dataviews/fields/type.tsx
+++ b/client/dashboard/emails/dataviews/fields/type.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import type { Email } from '../types';
+import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
 export const typeField: Field< Email > = {

--- a/client/dashboard/emails/dataviews/index.tsx
+++ b/client/dashboard/emails/dataviews/index.tsx
@@ -1,0 +1,3 @@
+export * from './actions';
+export * from './fields';
+export * from './views';

--- a/client/dashboard/emails/dataviews/views.tsx
+++ b/client/dashboard/emails/dataviews/views.tsx
@@ -1,15 +1,13 @@
 import type { View } from '@wordpress/dataviews';
 
-export { getEmailFields } from './fields';
-
-export const DEFAULT_EMAILS_VIEW: View = {
+export const DEFAULT_VIEW: View = {
 	type: 'table',
-	page: 1,
+	layout: {
+		density: 'balanced',
+	},
 	perPage: 10,
 	sort: { field: 'emailAddress', direction: 'asc' },
 	fields: [ 'domainName', 'type', 'status' ],
 	titleField: 'emailAddress',
-	search: '',
+	showLevels: false,
 };
-
-export { useEmailActions } from './actions';


### PR DESCRIPTION
Fixes DOTMSD-889

## Proposed Changes

This PR adds persistence in `/v2/emails` DataViews. With this, the current filters and appearance options will be saved to Calypso preferences.

While doing that, this PR also takes the opportunity to move all DataViews-related files under `client/dashboard/emails/dataviews/` directory. This is to make DataViews pattern in the codebase consistent.

## Why are these changes being made?

We want DataViews to not lose view configuration when we move away from the page.

## Testing Instructions

1. Go to `/v2/emails`.
2. Try to modify the view (sorting, fields, filters, appearance options....)
3. Refresh the page; verify the view is retained.
4. Click the Reset view button at the top-right; verify the default view comes back.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
