### PR TITLE
Setup Domain: Redirect to domain connection setup if adding a connection to an existing site on a paid plan

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -1,3 +1,4 @@
+import { isDomainMapping } from '@automattic/calypso-products';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import {
 	DOMAIN_FLOW,
@@ -160,21 +161,33 @@ const domain: FlowV2< typeof initialize > = {
 						return navigate( destination as typeof currentStepSlug );
 					}
 
-					if ( siteSlug && providedDependencies && 'domainCartItem' in providedDependencies ) {
-						// For garden sites with domain mapping, skip plans and map directly
-						if (
-							site &&
-							( site as { is_garden?: boolean } ).is_garden &&
-							providedDependencies.domainCartItem &&
-							providedDependencies.domainCartItem?.product_slug === 'domain_map'
-						) {
-							const domain = providedDependencies.domainCartItem.meta as string;
+					if ( ! providedDependencies || ! ( 'domainCartItem' in providedDependencies ) ) {
+						throw new Error( 'No domain cart item found' );
+					}
 
-							try {
-								await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
-								return window.location.assign( `/ciab/sites/${ domain }/domains` );
-							} catch ( error ) {
-								// If mapping fails, fall through to original flow
+					if ( site ) {
+						if ( isDomainMapping( providedDependencies.domainCartItem ) ) {
+							const isGardenSite = ( site as { is_garden?: boolean } ).is_garden;
+							const hasPaidPlan = siteHasPaidPlan( site );
+
+							if ( isGardenSite || hasPaidPlan ) {
+								setPendingAction( async () => {
+									const domain = providedDependencies.domainCartItem.meta;
+
+									if ( ! domain ) {
+										throw new Error( 'No domain found' );
+									}
+
+									await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
+
+									return {
+										redirectTo: isGardenSite
+											? `/ciab/sites/${ domain }/domains`
+											: `/v2/domains/${ domain }/domain-connection-setup`,
+									};
+								} );
+
+								return navigate( STEPS.PROCESSING.slug );
 							}
 						}
 
@@ -204,12 +217,10 @@ const domain: FlowV2< typeof initialize > = {
 						return navigate( STEPS.PROCESSING.slug );
 					}
 
-					if ( providedDependencies && 'domainCartItem' in providedDependencies ) {
-						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
-						setHideFreePlan( true );
-						setDomainCartItem( providedDependencies.domainCartItem );
-						setDomainCartItems( [ providedDependencies.domainCartItem ] );
-					}
+					setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
+					setHideFreePlan( true );
+					setDomainCartItem( providedDependencies.domainCartItem );
+					setDomainCartItems( [ providedDependencies.domainCartItem ] );
 
 					return navigate( STEPS.NEW_OR_EXISTING_SITE.slug );
 
@@ -315,6 +326,10 @@ const domain: FlowV2< typeof initialize > = {
 					return navigate( STEPS.PROCESSING.slug, undefined, true );
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
+						if ( providedDependencies.redirectTo ) {
+							return window.location.replace( providedDependencies.redirectTo );
+						}
+
 						const destination = `/v2/sites/${ providedDependencies.siteSlug }/domains`;
 
 						persistSignupDestination( destination );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -174,10 +174,6 @@ const domain: FlowV2< typeof initialize > = {
 								setPendingAction( async () => {
 									const domain = providedDependencies.domainCartItem.meta;
 
-									if ( ! domain ) {
-										throw new Error( 'No domain found' );
-									}
-
 									await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 
 									return {
@@ -258,6 +254,24 @@ const domain: FlowV2< typeof initialize > = {
 
 					setPendingAction( async () => {
 						if ( domainCartItems ) {
+							const hasOnlyDomainMappingInCart =
+								domainCartItems.length === 1 && isDomainMapping( domainCartItems[ 0 ] );
+
+							if ( hasOnlyDomainMappingInCart ) {
+								const domain = domainCartItems[ 0 ].meta;
+
+								await wpcom.req.post(
+									`/sites/${ providedDependencies.site.ID }/add-domain-mapping`,
+									{
+										domain,
+									}
+								);
+
+								return {
+									redirectTo: `/v2/domains/${ domain }/domain-connection-setup`,
+								};
+							}
+
 							await addProductsToCart( providedDependencies.siteSlug, this.name, domainCartItems );
 						}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -52,6 +52,7 @@ const ProcessingStep: StepType< {
 				intent?: SiteIntent;
 				previousStep?: string;
 				nextStep?: string;
+				redirectTo?: string;
 				// The processing step is impossible to type precisely because it submits whatever the pendingAction resolves to.
 		  } & Record< string, unknown > );
 	accepts: {


### PR DESCRIPTION
Closes DOMAINS-1833.

## Proposed Changes

Send the user to `/v2/domains/%s/domain-connection-setup` where `%s` is the domain to be mapped if browsing `/setup/domain` on a site with a paid plan.

## Testing Instructions

Enter `/setup/domain` and add a mapping product by clicking the "Already own a domain?" card. Pick an existing site in the site picker (down the road) with a paid plan and verify you end up in `/v2/domains/${ domain }/domain-connection-setup`.

Enter `/setup/domain?siteSlug=%s` where `%s` is a site on a paid plan and add a mapping product by clicking the "Already own a domain?" card. Verify you end up in `/v2/domains/${ domain }/domain-connection-setup` instead of checkout.