### PR TITLE
Enable Survicate only for logged in users

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -151,8 +151,10 @@ class Layout extends Component {
 
 		refreshColorScheme( undefined, this.props.colorScheme );
 
-		// Load Survicate survey on all pages
-		this.props.dispatch( loadTrackingTool( 'Survicate' ) );
+		// Load Survicate survey on all pages when the user is logged in
+		if ( this.props.isLoggedIn ) {
+			this.props.dispatch( loadTrackingTool( 'Survicate' ) );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-277

## Proposed Changes

* Make sure we only initialize Survicate for logged in users in the Layout component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to prevent instances of Survicate for logged out users, since we  want to hear feedback from actual users trying the platform
* We were receiving a fiew `calypso_survicate_user_not_available_error` errors and with this we should not see that anymore

