### PR TITLE
Login i18n: Fix formatting issue with KO and JA

### DIFF
--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -68,6 +68,8 @@ $breakpoint-mobile: 660px;
 		font-size: 0.75rem;
 		z-index: 1;
 		color: var(--studio-gray-50);
+		white-space: nowrap;
+		word-break: keep-all;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/I18N-260/login-formatting-issue-in-ko-and-ja

## Proposed Changes

The PR fixes the "or" separator on the Login page being broken by each vertical in  [Japanese](https://wordpress.com/log-in/ja) and [Korean](https://wordpress.com/log-in/ko) log-in page. 

### Media

| Before | After |
|--------|--------|
| <img width="997" height="820" alt="Screenshot 2025-11-10 at 6 12 23 PM" src="https://github.com/user-attachments/assets/03a80c2b-4c48-4576-9bc9-363fe70b441f" /> | <img width="997" height="819" alt="Screenshot 2025-11-10 at 6 12 47 PM" src="https://github.com/user-attachments/assets/92356bd8-6a6a-480b-ace8-e4d90ba0d780" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/I18N-260/login-formatting-issue-in-ko-and-ja

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/ko` and confirm

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
