### PR TITLE
Show the error returned from the API when setting primary domain

### DIFF
--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -138,9 +138,10 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 					setShowForm( false );
 					setFormData( { primaryDomain: '' } );
 				},
-				onError: () => {
+				onError: ( error ) => {
 					createErrorNotice(
-						__( 'Something went wrong and we couldn’t change your primary site address.' ),
+						error.message ||
+							__( 'Something went wrong and we couldn’t change your primary site address.' ),
 						{
 							type: 'snackbar',
 						}

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -7,11 +7,9 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
@@ -29,7 +27,6 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		primaryDomain: '',
 	} );
 	const [ showForm, setShowForm ] = useState( false );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const primaryWithPlanOnly = userHasFlag( user, 'calypso_allow_nonprimary_domains_without_plan' );
 	const isOnFreePlan = site?.plan?.is_free ?? false;
 	const isFlexSite = site?.is_wpcom_flex ?? false;
@@ -37,7 +34,19 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 		( ! ( primaryWithPlanOnly && isOnFreePlan ) &&
 			( site?.plan?.features?.active.includes( 'set-primary-custom-domain' ) ?? false ) ) ||
 		isFlexSite;
-	const setPrimaryDomainMutation = useMutation( siteSetPrimaryDomainMutation() );
+	const setPrimaryDomainMutation = useMutation( {
+		...siteSetPrimaryDomainMutation(),
+		meta: {
+			snackbar: {
+				success: sprintf(
+					/* translators: %s is domain */
+					__( 'Primary site address changed: all domains will redirect to %s.' ),
+					formData.primaryDomain
+				),
+				error: { source: 'server' },
+			},
+		},
+	} );
 	const currentPrimaryDomain = domains.find( ( domain ) => domain.primary_domain )?.domain;
 	const domainsList = useMemo( () => {
 		if ( ! domains || ! site ) {
@@ -125,27 +134,8 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 			{ siteId: site.ID, domain: formData.primaryDomain },
 			{
 				onSuccess: () => {
-					createSuccessNotice(
-						sprintf(
-							/* translators: %s is domain */
-							__( 'Primary site address changed: all domains will redirect to %s.' ),
-							formData.primaryDomain
-						),
-						{
-							type: 'snackbar',
-						}
-					);
 					setShowForm( false );
 					setFormData( { primaryDomain: '' } );
-				},
-				onError: ( error ) => {
-					createErrorNotice(
-						error.message ||
-							__( 'Something went wrong and we couldn’t change your primary site address.' ),
-						{
-							type: 'snackbar',
-						}
-					);
 				},
 			}
 		);


### PR DESCRIPTION
We can show the actual error that you get when you try to set a domain as primary as the default error message is not really useful

It might look like this:
<img width="514" height="59" alt="Screenshot 2025-11-11 at 14 44 20" src="https://github.com/user-attachments/assets/281348c3-16f7-434d-8eae-c0da7ce88b7c" />


Part of [DOMAINS-1758: Show better error message when changing the primary domain fails](https://linear.app/a8c/issue/DOMAINS-1758/show-better-error-message-when-changing-the-primary-domain-fails)

## Proposed Changes

* Show the error returned from the API when setting primary domain

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently we show a default error message that's not really giving any information to the customer

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can change the `/sites/%s/domains/primary` POST REST API endpoint on the backend to return `WP_Error`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
