### PR TITLE
Enable Survicate only for logged in users during onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -19,7 +19,8 @@ import {
 	clearSignupDestinationCookie,
 	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
@@ -269,6 +270,7 @@ const onboarding: FlowV2< typeof initialize > = {
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+		const isLoggedIn = useSelector( isUserLoggedIn );
 
 		/**
 		 * Clears every state we're persisting during the flow
@@ -296,8 +298,10 @@ const onboarding: FlowV2< typeof initialize > = {
 		 * - Analytics tracking works correctly throughout the onboarding flow
 		 */
 		useEffect( () => {
-			addSurvicate();
-		}, [ currentStepSlug ] );
+			if ( isLoggedIn ) {
+				addSurvicate();
+			}
+		}, [ isLoggedIn, currentStepSlug ] );
 
 		// Preload the visual split experiment
 		useEffect( () => {

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -105,8 +105,9 @@ describe( 'Onboarding Flow', () => {
 		} );
 
 		describe( 'Survicate side effect', () => {
-			it( 'calls addSurvicate on step changes', () => {
+			it( 'calls addSurvicate when logged in on step changes', () => {
 				const { addSurvicate } = require( 'calypso/lib/analytics/survicate' );
+				const loggedInState = { currentUser: { id: 123 } };
 
 				const TestSideEffect = ( { step }: { step: string } ) => {
 					onboarding.useSideEffect( step );
@@ -116,7 +117,8 @@ describe( 'Onboarding Flow', () => {
 				const { rerender } = renderWithProvider(
 					<MemoryRouter initialEntries={ [ '/setup/onboarding/domains' ] }>
 						<TestSideEffect step={ STEPS.DOMAIN_SEARCH.slug } />
-					</MemoryRouter>
+					</MemoryRouter>,
+					{ initialState: loggedInState }
 				);
 
 				expect( addSurvicate ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTOBRD-277

## Proposed Changes

* Make sure we only initialize Survicate for logged in users in the Onboarding
* The goal is to validate if we're having a special race condition on prod when loading Survicate x User data

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to prevent instances of Survicate for logged out users, since we  want to hear feedback from actual users trying the platform
* We were receiving a fiew `calypso_survicate_user_not_available_error` errors and with this we should not see that anymore

