### PR TITLE
v2 Notifications: close panel on outside click after tab switch

### DIFF
--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -91,7 +91,6 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 						activeClass="is-active"
 						tabs={ NOTIFICATION_TABS }
 						initialTabName={ filterName as string }
-						key={ filterName as string }
 						onSelect={ ( tabName ) => {
 							goTo( `/${ tabName }`, { replace: true } );
 						} }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -4,7 +4,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
-import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
 import { useLocale } from '../locale';
@@ -19,8 +19,6 @@ export default function Notifications( { className }: { className: string } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
-	const toggleRef = useRef< HTMLButtonElement | null >( null );
-	const contentRef = useRef< HTMLDivElement | null >( null );
 
 	const handleToggle = useCallback( ( willOpen: boolean ) => {
 		setIsOpen( willOpen );
@@ -76,36 +74,6 @@ export default function Notifications( { className }: { className: string } ) {
 		};
 	}, [ handleToggle ] );
 
-	// Capture-phase outside click fallback to ensure the popover closes even if focus remains inside.
-	useEffect( () => {
-		if ( ! isOpen ) {
-			return;
-		}
-
-		const handlePointerDownCapture = ( event: Event ) => {
-			const target = event.target as Node | null;
-			if ( ! target ) {
-				return;
-			}
-
-			// Ignore interactions within the dropdown content or the toggle button
-			if (
-				( contentRef.current && contentRef.current.contains( target ) ) ||
-				( toggleRef.current && toggleRef.current.contains( target ) )
-			) {
-				return;
-			}
-
-			handleClose();
-		};
-
-		// Prefer pointerdown to catch interactions before focus/blur changes; use capture to avoid bubbles blocked by stopPropagation.
-		document.addEventListener( 'pointerdown', handlePointerDownCapture, true );
-		return () => {
-			document.removeEventListener( 'pointerdown', handlePointerDownCapture, true );
-		};
-	}, [ isOpen, handleClose ] );
-
 	return (
 		<Dropdown
 			popoverProps={ {
@@ -119,7 +87,6 @@ export default function Notifications( { className }: { className: string } ) {
 			onToggle={ handleToggle }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
-					ref={ toggleRef }
 					className={ clsx( className, 'dashboard-notifications__icon' ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
@@ -130,7 +97,6 @@ export default function Notifications( { className }: { className: string } ) {
 			) }
 			renderContent={ () => (
 				<div
-					ref={ contentRef }
 					style={ {
 						width: '100vw',
 						height: '100vh',

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -4,7 +4,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
-import { Suspense, lazy, useEffect, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { useAuth } from '../auth';
 import { useLocale } from '../locale';
@@ -19,14 +19,16 @@ export default function Notifications( { className }: { className: string } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ hasUnseenNotifications, setHasUnseenNotifications ] = useState( user.has_unseen_notes );
+	const toggleRef = useRef< HTMLButtonElement | null >( null );
+	const contentRef = useRef< HTMLDivElement | null >( null );
 
-	const handleToggle = ( willOpen: boolean ) => {
+	const handleToggle = useCallback( ( willOpen: boolean ) => {
 		setIsOpen( willOpen );
-	};
+	}, [] );
 
-	const handleClose = () => {
+	const handleClose = useCallback( () => {
 		handleToggle( false );
-	};
+	}, [ handleToggle ] );
 
 	const actionHandlers = {
 		APP_RENDER_NOTES: [
@@ -72,7 +74,37 @@ export default function Notifications( { className }: { className: string } ) {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [] );
+	}, [ handleToggle ] );
+
+	// Capture-phase outside click fallback to ensure the popover closes even if focus remains inside.
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		const handlePointerDownCapture = ( event: Event ) => {
+			const target = event.target as Node | null;
+			if ( ! target ) {
+				return;
+			}
+
+			// Ignore interactions within the dropdown content or the toggle button
+			if (
+				( contentRef.current && contentRef.current.contains( target ) ) ||
+				( toggleRef.current && toggleRef.current.contains( target ) )
+			) {
+				return;
+			}
+
+			handleClose();
+		};
+
+		// Prefer pointerdown to catch interactions before focus/blur changes; use capture to avoid bubbles blocked by stopPropagation.
+		document.addEventListener( 'pointerdown', handlePointerDownCapture, true );
+		return () => {
+			document.removeEventListener( 'pointerdown', handlePointerDownCapture, true );
+		};
+	}, [ isOpen, handleClose ] );
 
 	return (
 		<Dropdown
@@ -87,6 +119,7 @@ export default function Notifications( { className }: { className: string } ) {
 			onToggle={ handleToggle }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
+					ref={ toggleRef }
 					className={ clsx( className, 'dashboard-notifications__icon' ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
@@ -97,6 +130,7 @@ export default function Notifications( { className }: { className: string } ) {
 			) }
 			renderContent={ () => (
 				<div
+					ref={ contentRef }
 					style={ {
 						width: '100vw',
 						height: '100vh',


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/M4R73CH-1209/v2-notifications-outside-click-stops-closing-the-panel-after-clicking

## Proposed Changes

* Remove `key={ filterName }` from `apps/notifications/src/app/note-panel/index.tsx` to avoid remounting the `TabPanel` on tab change, which preserved focus and restored reliable outside-close behavior.
* Drop the previously added capture-phase pointerdown outside-click fallback in the dashboard dropdown since it’s no longer necessary.

## Why are these changes being made?

* The `key` on `TabPanel` forced a re-mount when switching tabs (e.g., Unread → All), resetting focus and preventing the built-in close logic from detecting focus transitions. Removing the key keeps focus stable and restores expected outside-click closing.
* This aligns with the suggestion in the PR discussion.

Reference: https://github.com/Automattic/wp-calypso/pull/107039#issuecomment-3517980501

## Testing Instructions

* Open Notifications from the header bell on `/v2/sites`.
* Switch to “Unread” (press `u`) or “Comments” (press `c`), then back to “All” (press `a`).
* Click outside the panel (e.g., page header or main content). The panel should close consistently.
* Validate keyboard navigation and screen-reader focus remain on the active tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if applicable?
