### PR TITLE
Update the domain forwarding function that checks the target path

### DIFF
--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -159,6 +159,10 @@ export default function DomainForwardingForm( {
 				isValid: {
 					required: true,
 					custom: ( item ) => {
+						// Only validate subdomain when in subdomain mode
+						if ( item.sourceType === 'root' ) {
+							return null;
+						}
 						if ( ! isSubdomainValid( item.subdomain ) ) {
 							return __(
 								'Subdomain should be a valid domain label - up to 63 characters, starting with a letter or number, and containing only letters, numbers, and hyphens.'
@@ -176,10 +180,11 @@ export default function DomainForwardingForm( {
 				isValid: {
 					required: true,
 					custom: ( item ) => {
-						const validationError = isTargetUrlValid(
-							item.targetUrl,
-							item.subdomain ? `${ item.subdomain }.${ domainName }` : domainName
-						);
+						const sourceWithSubdomain = item.subdomain
+							? `${ item.subdomain }.${ domainName }`
+							: domainName;
+						const sourceDomain = item.sourceType === 'root' ? domainName : sourceWithSubdomain;
+						const validationError = isTargetUrlValid( item.targetUrl, sourceDomain );
 						if ( validationError !== null ) {
 							return validationError;
 						}

--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -176,8 +176,12 @@ export default function DomainForwardingForm( {
 				isValid: {
 					required: true,
 					custom: ( item ) => {
-						if ( ! isTargetUrlValid( item.targetUrl, domainName ) ) {
-							return __( 'Please enter a valid URL.' );
+						const validationError = isTargetUrlValid(
+							item.targetUrl,
+							item.subdomain ? `${ item.subdomain }.${ domainName }` : domainName
+						);
+						if ( validationError !== null ) {
+							return validationError;
 						}
 						return null;
 					},

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -216,12 +216,14 @@ test( 'shows validation error when target URL redirects to same domain without p
 
 	// Fill in target URL that points to same domain (which is not allowed) and blur
 	const targetUrlInput = screen.getByRole( 'textbox', { name: /target url/i } );
-	await user.type( targetUrlInput, 'https://example.com' );
+	await user.type( targetUrlInput, 'https://blog.example.com' );
 	await user.tab(); // This will blur the field
 
 	// Validation error should appear after blur
 	await waitFor( () => {
-		expect( screen.getByText( /please enter a valid url/i ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /Forwarding to the same domain is not allowed/i )
+		).toBeInTheDocument();
 	} );
 } );
 

--- a/client/dashboard/domains/domain-forwarding/test/utils.test.ts
+++ b/client/dashboard/domains/domain-forwarding/test/utils.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+import { isTargetUrlValid } from '../utils';
+
+describe( 'domain forwarding utils', () => {
+	describe( 'isTargetUrlValid', () => {
+		const sourceDomain = 'example.com';
+
+		it( 'returns error when target URL is empty', () => {
+			const error = isTargetUrlValid( '', sourceDomain );
+
+			expect( error ).toBe( 'Please enter target URL.' );
+		} );
+
+		it( 'returns error when target URL equals the source domain root', () => {
+			const error = isTargetUrlValid( 'https://example.com', sourceDomain );
+
+			expect( error ).toBe( 'Forwarding to the same domain is not allowed.' );
+		} );
+
+		it( 'allows forwarding to the same domain when a path is provided', () => {
+			const error = isTargetUrlValid( 'https://example.com/blog', sourceDomain );
+
+			expect( error ).toBeNull();
+		} );
+
+		it( 'returns error when forwarding to a deeper subdomain', () => {
+			const error = isTargetUrlValid( 'https://blog.example.com', sourceDomain );
+
+			expect( error ).toBe( 'Forwarding to a further nested domain is not allowed.' );
+		} );
+
+		it( 'allows forwarding to a different domain', () => {
+			const error = isTargetUrlValid( 'https://wordpress.com', sourceDomain );
+
+			expect( error ).toBeNull();
+		} );
+	} );
+	describe( 'isTargetUrlValid with subdomain', () => {
+		const sourceDomain = 'blog.example.com';
+
+		it( 'allows forwarding to the same domain when a path is provided', () => {
+			const error = isTargetUrlValid( 'https://blog.example.com/blog', sourceDomain );
+
+			expect( error ).toBeNull();
+		} );
+
+		it( 'returns error when forwarding to the same subdomain without a path', () => {
+			const error = isTargetUrlValid( 'https://blog.example.com', sourceDomain );
+
+			expect( error ).toBe( 'Forwarding to the same domain is not allowed.' );
+		} );
+
+		it( 'returns error when forwarding to a deeper subdomain', () => {
+			const error = isTargetUrlValid( 'https://something.blog.example.com/', sourceDomain );
+
+			expect( error ).toBe( 'Forwarding to a further nested domain is not allowed.' );
+		} );
+
+		it( 'allows forwarding to the same subdomain when a path is provided', () => {
+			const error = isTargetUrlValid( 'https://blog.example.com/blog', sourceDomain );
+
+			expect( error ).toBeNull();
+		} );
+
+		it( 'allows forwarding to a different domain', () => {
+			const error = isTargetUrlValid( 'https://wordpress.com/blog', sourceDomain );
+
+			expect( error ).toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION
There's a bug in the way we validate the target path when adding domain forwarding.

I also took the opportunity to add tests and improve how it works so it'll show better errrors

Part of [DOMAINS-1817: Domains: Confusion about the expected value on the Target URL field](https://linear.app/a8c/issue/DOMAINS-1817/domains-confusion-about-the-expected-value-on-the-target-url-field)

## Proposed Changes

* Fix the bug with the target URL validation
* Add unit tests for the `isTargetUrlValid` function
* Update the code to get more sensible errors instead of just "Please enter valid URL"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Decrease customer confusion

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to add domain forwarding record for a domain or a subdomain using the same domain or subdomain - it should not allow you that and it should show "Forwarding to the same domain is not allowed"
* Try to add forwarding to a nested subdomain - from blog.example.com > something.blog.example.com - it should show "Forwarding to a further nested domain is not allowed"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
