### PR TITLE
SSH Migration: Add tracks events to the form step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -135,6 +135,11 @@ const SiteMigrationSshShareAccess: StepType< {
 	};
 
 	const handleContinue = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share_access',
+			action: 'click_button',
+			button: 'continue',
+		} );
 		setMigrationError( null );
 
 		if ( isTransferring ) {
@@ -154,6 +159,10 @@ const SiteMigrationSshShareAccess: StepType< {
 	}, [ transferStatus, shouldStartMigration ] );
 
 	const handleSkip = useCallback( async () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share_access',
+			action: 'click_assisted_migration',
+		} );
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 			automated_migration: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/help-link.tsx
@@ -1,14 +1,24 @@
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 interface HelpLinkProps {
 	supportLink: string;
 	supportPostId?: number;
+	stepKey: string;
 }
 
-export const HelpLink: FC< HelpLinkProps > = ( { supportLink, supportPostId } ) => {
+export const HelpLink: FC< HelpLinkProps > = ( { supportLink, supportPostId, stepKey } ) => {
 	const translate = useTranslate();
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: stepKey,
+			action: 'click_guide',
+			support_link: supportLink,
+		} );
+	};
 
 	return (
 		<p className="migration-site-ssh__help-link">
@@ -17,6 +27,7 @@ export const HelpLink: FC< HelpLinkProps > = ( { supportLink, supportPostId } ) 
 				supportLink={ supportLink }
 				supportPostId={ supportPostId }
 				showIcon={ false }
+				onClick={ handleClick }
 			>
 				{ translate( 'Follow our guide' ) }
 			</InlineSupportLink>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 interface StepFindSSHDetailsProps {
 	onSuccess: () => void;
@@ -19,6 +20,24 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const handleFoundDetails = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'find-ssh-details',
+			action: 'click_button',
+			button: 'found_details',
+		} );
+		onSuccess();
+	};
+
+	const handleNoSSH = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'find-ssh-details',
+			action: 'click_button',
+			button: 'no_ssh',
+		} );
+		onNoSSHAccess?.();
+	};
+
 	const instructionText = hostDisplayName
 		? translate(
 				"Go to your %(currentHost)s WordPress site's settings, enable SSH, and take note of your details.",
@@ -35,12 +54,12 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 			<p>{ instructionText }</p>
 			{ helpLink }
 			<div className="migration-site-ssh__find-ssh-details-buttons">
-				<Button variant="primary" onClick={ onSuccess }>
+				<Button variant="primary" onClick={ handleFoundDetails }>
 					{ translate( 'I found my SSH details' ) }
 				</Button>
 				<Button
 					variant="link"
-					onClick={ onNoSSHAccess }
+					onClick={ handleNoSSH }
 					className="migration-site-ssh__no-ssh-link"
 					disabled={ isInputDisabled }
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -6,6 +6,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { AccordionNotice } from '../components/accordion-notice';
 
 interface StepShareSSHAccessProps {
@@ -52,6 +53,42 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	const translate = useTranslate();
 	const [ copied, setCopied ] = useState( false );
 
+	const handleAuthMethodChange = ( method: 'password' | 'key' ) => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share-ssh-access',
+			action: 'change_auth_method',
+			auth_method: method,
+		} );
+		onAuthMethodChange( method );
+	};
+
+	const handleGenerateSSHKey = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share-ssh-access',
+			action: 'click_button',
+			button: 'generate_ssh_key',
+		} );
+		onGenerateSSHKey();
+	};
+
+	const handleEditUsername = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share-ssh-access',
+			action: 'click_button',
+			button: 'edit_username',
+		} );
+		onEditUsername();
+	};
+
+	const handleCopyKey = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share-ssh-access',
+			action: 'copy_ssh_key',
+		} );
+		setCopied( true );
+		setTimeout( () => setCopied( false ), 2000 );
+	};
+
 	return (
 		<div className="site-migration-ssh__step-share-ssh">
 			<p className="site-migration-ssh__step-share-ssh-description">
@@ -81,7 +118,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 							value="password"
 							disabled={ isInputDisabled }
 							checked={ authMethod === 'password' }
-							onChange={ () => onAuthMethodChange( 'password' ) }
+							onChange={ () => handleAuthMethodChange( 'password' ) }
 							label={ translate( 'Username and password' ) }
 						/>
 					</div>
@@ -92,7 +129,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 							value="key"
 							disabled={ isInputDisabled }
 							checked={ authMethod === 'key' }
-							onChange={ () => onAuthMethodChange( 'key' ) }
+							onChange={ () => handleAuthMethodChange( 'key' ) }
 							label={ translate( 'SSH key' ) }
 						/>
 					</div>
@@ -159,7 +196,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 									icon={ edit }
 									label={ translate( 'Edit username' ) }
 									className="site-migration-ssh__step-share-ssh-edit-button"
-									onClick={ onEditUsername }
+									onClick={ handleEditUsername }
 								/>
 							) }
 						</div>
@@ -176,7 +213,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 							<div>
 								<Button
 									variant="secondary"
-									onClick={ onGenerateSSHKey }
+									onClick={ handleGenerateSSHKey }
 									disabled={
 										! username || isGeneratingKey || ( isTransferring && shouldGenerateKey )
 									}
@@ -207,10 +244,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 										text={ sshPublicKey }
 										transparent
 										className="site-migration-ssh__step-share-ssh-copy-button"
-										onCopy={ () => {
-											setCopied( true );
-											setTimeout( () => setCopied( false ), 2000 );
-										} }
+										onCopy={ handleCopyKey }
 									>
 										<Icon icon={ copied ? check : copy } />
 									</ClipboardButton>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useGenerateSSHKey } from '../hooks/use-generate-ssh-key';
 import { HelpLink } from './help-link';
 import { getSSHHostDisplayName, getSSHSupportDoc } from './ssh-host-support-urls';
@@ -97,7 +98,6 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 	const translate = useTranslate();
 	const hostDisplayName = getSSHHostDisplayName( options.host );
 	const supportDoc = getSSHSupportDoc( options.host );
-	const helpLink = <HelpLink supportLink={ supportDoc.url } supportPostId={ supportDoc.postId } />;
 
 	const stepsData: StepsData = [
 		{
@@ -108,7 +108,13 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					onSuccess={ options.onFindSSHDetailsSuccess }
 					onNoSSHAccess={ options.onNoSSHAccess }
 					hostDisplayName={ hostDisplayName }
-					helpLink={ helpLink }
+					helpLink={
+						<HelpLink
+							supportLink={ supportDoc.url }
+							supportPostId={ supportDoc.postId }
+							stepKey={ FIND_SSH_DETAILS }
+						/>
+					}
 					isInputDisabled={ options.isInputDisabled }
 				/>
 			),
@@ -122,7 +128,13 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					serverAddress={ options.serverAddress }
 					port={ options.port }
 					hostDisplayName={ hostDisplayName }
-					helpLink={ helpLink }
+					helpLink={
+						<HelpLink
+							supportLink={ supportDoc.url }
+							supportPostId={ supportDoc.postId }
+							stepKey={ ADD_SERVER_ADDRESS }
+						/>
+					}
 					onServerAddressChange={ options.onServerAddressChange }
 					onPortChange={ options.onPortChange }
 					onVerify={ options.onServerVerify }
@@ -149,7 +161,13 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					onPasswordChange={ options.onPasswordChange }
 					onGenerateSSHKey={ options.onGenerateSSHKey }
 					onEditUsername={ options.onEditUsername }
-					helpLink={ helpLink }
+					helpLink={
+						<HelpLink
+							supportLink={ supportDoc.url }
+							supportPostId={ supportDoc.postId }
+							stepKey={ SHARE_SSH_ACCESS }
+						/>
+					}
 					isTransferring={ options.isTransferring }
 					shouldGenerateKey={ options.shouldGenerateKey }
 					isInputDisabled={ options.isInputDisabled }
@@ -347,7 +365,13 @@ export const useSteps = ( {
 		const canClick = index === 0 || index <= lastCompleteStep + 1;
 		const onItemClick = canClick
 			? () => {
-					setCurrentStep( ( prev ) => ( prev === index ? -1 : index ) );
+					const newStepState = currentStep === index ? -1 : index;
+					const isOpening = newStepState !== -1;
+					recordTracksEvent( 'calypso_site_migration_ssh_action', {
+						step: step.key,
+						action: isOpening ? 'expand_accordion' : 'collapse_accordion',
+					} );
+					setCurrentStep( newStepState );
 			  }
 			: undefined;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15170

## Proposed Changes

* Add the `calypso_site_migration_ssh_action` tracks events to track the user iteration on the `Securely share your access`.

1. Continue Button
  ```yml
  {
    step: 'share_access',
    action: 'click_button',
    button: 'continue'
  }
  ```
  - Fires when user clicks the main "Continue" button to start migration
2. Assisted Migration Request
  ```yml
  {
    step: 'share_access',
    action: 'click_assisted_migration'
  }
  ```
  - Fires when user clicks "Let us take over" in the support nudge
  ---
  Step 1: find-ssh-details
3. Accordion Expand
  ```yml
  {
    step: 'find-ssh-details',
    action: 'expand_accordion'
  }
  ```
  - Fires when user expands the "Find your SSH details" accordion
4. Accordion Collapse
  ```yml
  {
    step: 'find-ssh-details',
    action: 'collapse_accordion'
  }
  ```
  - Fires when user collapses the "Find your SSH details" accordion
5. Help Guide Click
  ```yml
  {
    step: 'find-ssh-details',
    action: 'click_guide',
    support_link: string
  }
  ```
  - Fires when user clicks "Follow our guide" link
6. Found SSH Details
  ```yml
  {
    step: 'find-ssh-details',
    action: 'click_button',
    button: 'found_details'
  }
  ```
  - Fires when user clicks "I found my SSH details"
7. No SSH Access
  ```yml
  {
    step: 'find-ssh-details',
    action: 'click_button',
    button: 'no_ssh'
  }
  ```
  - Fires when user clicks "I don't have SSH"
  ---
  Step 2: add-server-address
8. Accordion Expand
  ```yml
  {
    step: 'add-server-address',
    action: 'expand_accordion'
  }
  ```
  - Fires when user expands the "Add SSH server address" accordion
9. Accordion Collapse
  ```yml
  {
    step: 'add-server-address',
    action: 'collapse_accordion'
  }
  ```
  - Fires when user collapses the "Add SSH server address" accordion
10. Help Guide Click
  ```yml
  {
    step: 'add-server-address',
    action: 'click_guide',
    support_link: string
  }
  ```
  - Fires when user clicks "Follow our guide" link
11. Verify Server Address
  ```yml
  {
    step: 'add-server-address',
    action: 'click_button',
    button: 'verify_server'
  }
  ```
  - Fires when user clicks "Verify server address"
  ---
  Step 3: share-ssh-access
12. Accordion Expand
  ```yml
  {
    step: 'share-ssh-access',
    action: 'expand_accordion'
  }
  ```
  - Fires when user expands the "Share SSH access" accordion
13. Accordion Collapse
  ```yml
  {
    step: 'share-ssh-access',
    action: 'collapse_accordion'
  }
  ```
  - Fires when user collapses the "Share SSH access" accordion
14. Help Guide Click
  ```yml
  {
    step: 'share-ssh-access',
    action: 'click_guide',
    support_link: string
  }
  ```
  - Fires when user clicks "Follow our guide" link
15. Change Auth Method
  ```yml
  {
    step: 'share-ssh-access',
    action: 'change_auth_method',
    auth_method: 'password' | 'key'
  }
  ```
  - Fires when user switches between "Username and password" and "SSH key" authentication methods
16. Generate SSH Key
  ```yml
  {
    step: 'share-ssh-access',
    action: 'click_button',
    button: 'generate_ssh_key'
  }
  ```
  - Fires when user clicks "Generate SSH key" (only visible when SSH key method is selected)
17. Copy SSH Key
  ```yml
  {
    step: 'share-ssh-access',
    action: 'copy_ssh_key'
  }
  ```
  - Fires when user clicks the copy button to copy the SSH public key to clipboard
18. Edit Username
  ```yml
  {
    step: 'share-ssh-access',
    action: 'click_button',
    button: 'edit_username'
  }
  ```
  - Fires when user clicks the edit button to modify username after SSH key generation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More context: p1762361899821389/1762361834.660169-slack-C09C6B8QDV1

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Go through the flow until you reach the `Securely share your access` step
* Click around and validate that the events are fired as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?