### PR TITLE
Add dns propagation status in Domain Connection Verification

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
@@ -19,20 +19,44 @@ function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 				backgroundColor: propagated ? '#048015' : '#dcdcde',
 			} }
 			aria-label={ propagated ? __( 'Propagated' ) : __( 'Not propagated' ) }
+			role="status"
 		/>
 	);
 }
 
 function formatLastUpdated( lastUpdated: string ): string {
+	// Handle empty or null-like values
+	if ( ! lastUpdated || typeof lastUpdated !== 'string' ) {
+		return '';
+	}
+
 	try {
 		const date = new Date( lastUpdated );
-		return date.toLocaleTimeString( undefined, {
+
+		// Check if date is valid (new Date() can return Invalid Date without throwing)
+		if ( isNaN( date.getTime() ) ) {
+			return '';
+		}
+
+		const formattedTime = date.toLocaleTimeString( undefined, {
 			hour: 'numeric',
 			minute: '2-digit',
 			hour12: true,
 		} );
-	} catch {
-		return lastUpdated;
+
+		// Additional check in case toLocaleTimeString returns unexpected result
+		if ( ! formattedTime || formattedTime === 'Invalid Date' ) {
+			return '';
+		}
+
+		return formattedTime;
+	} catch ( error ) {
+		// Log error in development for debugging
+		if ( process.env.NODE_ENV === 'development' ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Failed to format date:', lastUpdated, error );
+		}
+		return '';
 	}
 }
 

--- a/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
@@ -1,0 +1,69 @@
+import { domainPropagationStatusQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalGrid as Grid,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '../../../components/card';
+
+function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
+	return (
+		<span
+			style={ {
+				width: '8px',
+				height: '8px',
+				borderRadius: '50%',
+				backgroundColor: propagated ? '#048015' : '#dcdcde',
+			} }
+			aria-label={ propagated ? __( 'Propagated' ) : __( 'Not propagated' ) }
+		/>
+	);
+}
+
+function formatLastUpdated( lastUpdated: string ): string {
+	try {
+		const date = new Date( lastUpdated );
+		return date.toLocaleTimeString( undefined, {
+			hour: 'numeric',
+			minute: '2-digit',
+			hour12: true,
+		} );
+	} catch {
+		return lastUpdated;
+	}
+}
+
+export default function DomainPropagationStatus( { domainName }: { domainName: string } ) {
+	const { data, isLoading, isError } = useQuery( domainPropagationStatusQuery( domainName ) );
+
+	if ( isError || isLoading || ! data ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 4 }>
+			<Text size="medium" weight={ 500 }>
+				{ __( 'Global propagation status' ) }
+			</Text>
+			<Card className="domain-propagation-status">
+				<CardBody>
+					<Grid columns={ 3 } gap={ 4 }>
+						{ data.propagation_status.map( ( area ) => (
+							<HStack key={ area.area_code } spacing={ 2 } justify="flex-start">
+								<PropagationStatusIndicator propagated={ area.propagated } />
+								<Text>{ area.area_name }</Text>
+							</HStack>
+						) ) }
+					</Grid>
+				</CardBody>
+			</Card>
+			<Text variant="muted" size={ 12 }>
+				{ /* translators: %s is the time the status was last checked */ }
+				{ __( 'Last checked at' ) } { formatLastUpdated( data.last_updated ) }
+			</Text>
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '../../../components/card';
+import { useTimeSince } from '../../../components/time-since';
 
 function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 	return (
@@ -16,7 +17,7 @@ function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 				width: '8px',
 				height: '8px',
 				borderRadius: '50%',
-				backgroundColor: propagated ? '#048015' : '#dcdcde',
+				backgroundColor: propagated ? 'var(--dashboard__foreground-color-success)' : '#dcdcde',
 			} }
 			aria-label={ propagated ? __( 'Propagated' ) : __( 'Not propagated' ) }
 			role="status"
@@ -24,44 +25,9 @@ function PropagationStatusIndicator( { propagated }: { propagated: boolean } ) {
 	);
 }
 
-function formatLastUpdated( lastUpdated: string ): string {
-	// Handle empty or null-like values
-	if ( ! lastUpdated || typeof lastUpdated !== 'string' ) {
-		return '';
-	}
-
-	try {
-		const date = new Date( lastUpdated );
-
-		// Check if date is valid (new Date() can return Invalid Date without throwing)
-		if ( isNaN( date.getTime() ) ) {
-			return '';
-		}
-
-		const formattedTime = date.toLocaleTimeString( undefined, {
-			hour: 'numeric',
-			minute: '2-digit',
-			hour12: true,
-		} );
-
-		// Additional check in case toLocaleTimeString returns unexpected result
-		if ( ! formattedTime || formattedTime === 'Invalid Date' ) {
-			return '';
-		}
-
-		return formattedTime;
-	} catch ( error ) {
-		// Log error in development for debugging
-		if ( process.env.NODE_ENV === 'development' ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'Failed to format date:', lastUpdated, error );
-		}
-		return '';
-	}
-}
-
 export default function DomainPropagationStatus( { domainName }: { domainName: string } ) {
 	const { data, isLoading, isError } = useQuery( domainPropagationStatusQuery( domainName ) );
+	const lastChecked = useTimeSince( data?.last_updated ?? '' );
 
 	if ( isError || isLoading || ! data ) {
 		return null;
@@ -72,7 +38,7 @@ export default function DomainPropagationStatus( { domainName }: { domainName: s
 			<Text size="medium" weight={ 500 }>
 				{ __( 'Global propagation status' ) }
 			</Text>
-			<Card className="domain-propagation-status">
+			<Card>
 				<CardBody>
 					<Grid columns={ 3 } gap={ 4 }>
 						{ data.propagation_status.map( ( area ) => (
@@ -86,7 +52,7 @@ export default function DomainPropagationStatus( { domainName }: { domainName: s
 			</Card>
 			<Text variant="muted" size={ 12 }>
 				{ /* translators: %s is the time the status was last checked */ }
-				{ __( 'Last checked at' ) } { formatLastUpdated( data.last_updated ) }
+				{ __( 'Last checked' ) } { lastChecked }
 			</Text>
 		</VStack>
 	);

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -14,6 +14,7 @@ import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import DnsRecordsTable from './components/dns-records-table';
+import DomainPropagationStatus from './components/domain-propagation-status';
 import { isMappingVerificationSuccess } from './utils';
 import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
 import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
@@ -42,7 +43,7 @@ export default function DomainConnectionVerification( {
 			className={ `dashboard-domain-connection-verification dashboard-domain-connection-verification--${ status }` }
 		>
 			<CardBody>
-				<VStack spacing={ 4 }>
+				<VStack spacing={ 7 }>
 					<HStack justify="flex-start">
 						<Icon
 							className="dashboard-domain-connection-verification__icon"
@@ -64,44 +65,51 @@ export default function DomainConnectionVerification( {
 						</Notice>
 					) }
 
-					<Text size="medium" weight={ 500 }>
-						{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
-							? __( 'Name server verification' )
-							: __( 'DNS record verification' ) }
-					</Text>
-
-					<DnsRecordsTable
-						domainData={ domainData }
-						domainConnectionStatus={ domainMappingStatus }
-						domainConnectionSetupInfo={ domainConnectionSetupInfo }
-					/>
-
-					{ status === 'verifying' && (
+					<VStack spacing={ 4 }>
 						<Text size="medium" weight={ 500 }>
-							{ __( 'While you wait' ) }
+							{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
+								? __( 'Name server verification' )
+								: __( 'DNS record verification' ) }
 						</Text>
-					) }
 
-					{ status === 'connected' && (
-						<RouterLinkSummaryButton
-							to={ siteDomainsRoute.fullPath }
-							params={ { siteSlug } }
-							/* Translators: %s is the domain name. */
-							title={ sprintf( __( 'Set %s as your primary site address' ), domainName ) }
-							description={ __( 'It’s the URL visitors see in their browser’s address bar.' ) }
-							decoration={ <Icon icon={ atSymbol } /> }
+						<DnsRecordsTable
+							domainData={ domainData }
+							domainConnectionStatus={ domainMappingStatus }
+							domainConnectionSetupInfo={ domainConnectionSetupInfo }
 						/>
-					) }
-					<RouterLinkSummaryButton
-						to={ siteOverviewRoute.fullPath }
-						params={ { siteSlug } }
-						title={ __( 'Customize your site' ) }
-						description={ __(
-							'While your domain name is connecting, you can still work on your site.'
+					</VStack>
+
+					<DomainPropagationStatus domainName={ domainName } />
+
+					<VStack spacing={ 4 }>
+						{ status === 'verifying' && (
+							<Text size="medium" weight={ 500 }>
+								{ __( 'While you wait' ) }
+							</Text>
 						) }
-						decoration={ <Icon icon={ layout } /> }
-					/>
+
+						{ status === 'connected' && (
+							<RouterLinkSummaryButton
+								to={ siteDomainsRoute.fullPath }
+								params={ { siteSlug } }
+								/* Translators: %s is the domain name. */
+								title={ sprintf( __( 'Set %s as your primary site address' ), domainName ) }
+								description={ __( 'It’s the URL visitors see in their browser’s address bar.' ) }
+								decoration={ <Icon icon={ atSymbol } /> }
+							/>
+						) }
+						<RouterLinkSummaryButton
+							to={ siteOverviewRoute.fullPath }
+							params={ { siteSlug } }
+							title={ __( 'Customize your site' ) }
+							description={ __(
+								'While your domain name is connecting, you can still work on your site.'
+							) }
+							decoration={ <Icon icon={ layout } /> }
+						/>
+					</VStack>
 					{ status === 'verifying' && <VerificationInProgressNextSteps /> }
+
 					<Text size="medium" weight={ 500 }>
 						{ __( 'Need help?' ) }
 					</Text>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -19,6 +19,8 @@ import { isMappingVerificationSuccess } from './utils';
 import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
 import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
 
+type DomainConnectionStatus = 'connected' | 'verifying';
+
 interface DomainConnectionVerificationProps {
 	domainData: Domain;
 	domainName: string;
@@ -34,7 +36,10 @@ export default function DomainConnectionVerification( {
 	domainMappingStatus,
 	domainConnectionSetupInfo,
 }: DomainConnectionVerificationProps ) {
-	const status = isMappingVerificationSuccess( domainMappingStatus.mode, domainMappingStatus )
+	const status: DomainConnectionStatus = isMappingVerificationSuccess(
+		domainMappingStatus.mode,
+		domainMappingStatus
+	)
 		? 'connected'
 		: 'verifying';
 

--- a/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
@@ -13,6 +13,11 @@ jest.mock( '@tanstack/react-query', () => ( {
 	useQuery: jest.fn(),
 } ) );
 
+// Mock the useTimeSince hook
+jest.mock( '../../../components/time-since', () => ( {
+	useTimeSince: jest.fn( () => '2m ago' ),
+} ) );
+
 const createMockPropagationStatus = (
 	overrides?: Partial< DomainPropagationStatus >
 ): DomainPropagationStatus => ( {
@@ -105,8 +110,9 @@ describe( 'DomainPropagationStatus', () => {
 
 			render( <DomainPropagationStatusComponent domainName="example.com" /> );
 
-			// Should show "Last checked at" text
-			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+			// Should show "Last checked" text with relative time
+			expect( screen.getByText( /Last checked/i ) ).toBeVisible();
+			expect( screen.getByText( /2m ago/i ) ).toBeVisible();
 		} );
 
 		test( 'renders with all areas propagated', () => {
@@ -248,7 +254,7 @@ describe( 'DomainPropagationStatus', () => {
 
 			// Should still render the component structure
 			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
-			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+			expect( screen.getByText( /Last checked/i ) ).toBeVisible();
 		} );
 
 		test( 'renders with single propagation area', () => {
@@ -283,8 +289,8 @@ describe( 'DomainPropagationStatus', () => {
 
 			// Should still render without crashing
 			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
-			// Should show "Last checked at" text but no timestamp
-			expect( screen.getByText( 'Last checked at' ) ).toBeVisible();
+			// Should show "Last checked" text with mocked relative time
+			expect( screen.getByText( /Last checked/i ) ).toBeVisible();
 		} );
 
 		test( 'handles empty string in last_updated', () => {
@@ -302,8 +308,8 @@ describe( 'DomainPropagationStatus', () => {
 
 			// Should still render without crashing
 			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
-			// Should show "Last checked at" text but no timestamp
-			expect( screen.getByText( 'Last checked at' ) ).toBeVisible();
+			// Should show "Last checked" text with mocked relative time
+			expect( screen.getByText( /Last checked/i ) ).toBeVisible();
 		} );
 
 		test( 'handles various invalid date formats', () => {
@@ -331,7 +337,7 @@ describe( 'DomainPropagationStatus', () => {
 	} );
 
 	describe( 'Component structure', () => {
-		test( 'renders Card component', () => {
+		test( 'renders Card component with propagation status grid', () => {
 			const mockData = createMockPropagationStatus();
 			mockUseQuery.mockReturnValue( {
 				data: mockData,
@@ -340,10 +346,11 @@ describe( 'DomainPropagationStatus', () => {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} as any );
 
-			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
 
-			const cardElement = container.querySelector( '.domain-propagation-status' );
-			expect( cardElement ).toBeInTheDocument();
+			// Verify Card component structure exists with title and content
+			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+			expect( screen.getByText( 'North America' ) ).toBeVisible();
 		} );
 
 		test( 'renders indicators with correct styling attributes', () => {

--- a/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainPropagationStatus } from '@automattic/api-core';
+import { useQuery } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import DomainPropagationStatusComponent from '../components/domain-propagation-status';
+
+// Mock the useQuery hook from React Query
+jest.mock( '@tanstack/react-query', () => ( {
+	...jest.requireActual( '@tanstack/react-query' ),
+	useQuery: jest.fn(),
+} ) );
+
+const createMockPropagationStatus = (
+	overrides?: Partial< DomainPropagationStatus >
+): DomainPropagationStatus => ( {
+	propagation_status: [
+		{ area_code: 'NA', area_name: 'North America', propagated: true },
+		{ area_code: 'AS', area_name: 'Asia', propagated: true },
+		{ area_code: 'OC', area_name: 'Australia', propagated: true },
+		{ area_code: 'AF', area_name: 'Africa', propagated: true },
+		{ area_code: 'SA', area_name: 'South America', propagated: false },
+		{ area_code: 'EU', area_name: 'Europe', propagated: false },
+	],
+	last_updated: '2025-11-11 13:15:48',
+	...overrides,
+} );
+
+describe( 'DomainPropagationStatus', () => {
+	const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Successful data loading', () => {
+		test( 'renders component with title when data is loaded', () => {
+			const mockData = createMockPropagationStatus();
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+		} );
+
+		test( 'renders all propagation areas with correct names', () => {
+			const mockData = createMockPropagationStatus();
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( screen.getByText( 'North America' ) ).toBeVisible();
+			expect( screen.getByText( 'Asia' ) ).toBeVisible();
+			expect( screen.getByText( 'Australia' ) ).toBeVisible();
+			expect( screen.getByText( 'Africa' ) ).toBeVisible();
+			expect( screen.getByText( 'South America' ) ).toBeVisible();
+			expect( screen.getByText( 'Europe' ) ).toBeVisible();
+		} );
+
+		test( 'renders propagated indicators with correct ARIA labels', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [
+					{ area_code: 'NA', area_name: 'North America', propagated: true },
+					{ area_code: 'EU', area_name: 'Europe', propagated: false },
+				],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			const propagatedIndicator = screen.getByLabelText( 'Propagated' );
+			expect( propagatedIndicator ).toBeInTheDocument();
+
+			const notPropagatedIndicator = screen.getByLabelText( 'Not propagated' );
+			expect( notPropagatedIndicator ).toBeInTheDocument();
+		} );
+
+		test( 'renders last updated timestamp in formatted time', () => {
+			const mockData = createMockPropagationStatus( {
+				last_updated: '2025-11-11 13:15:48',
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// Should show "Last checked at" text
+			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+		} );
+
+		test( 'renders with all areas propagated', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [
+					{ area_code: 'NA', area_name: 'North America', propagated: true },
+					{ area_code: 'AS', area_name: 'Asia', propagated: true },
+					{ area_code: 'EU', area_name: 'Europe', propagated: true },
+				],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// All indicators should have "Propagated" ARIA label
+			const propagatedIndicators = screen.getAllByLabelText( 'Propagated' );
+			expect( propagatedIndicators ).toHaveLength( 3 );
+		} );
+
+		test( 'renders with all areas not propagated', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [
+					{ area_code: 'NA', area_name: 'North America', propagated: false },
+					{ area_code: 'AS', area_name: 'Asia', propagated: false },
+					{ area_code: 'EU', area_name: 'Europe', propagated: false },
+				],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// All indicators should have "Not propagated" ARIA label
+			const notPropagatedIndicators = screen.getAllByLabelText( 'Not propagated' );
+			expect( notPropagatedIndicators ).toHaveLength( 3 );
+		} );
+
+		test( 'renders with mixed propagation status', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [
+					{ area_code: 'NA', area_name: 'North America', propagated: true },
+					{ area_code: 'AS', area_name: 'Asia', propagated: false },
+					{ area_code: 'EU', area_name: 'Europe', propagated: true },
+				],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			const propagatedIndicators = screen.getAllByLabelText( 'Propagated' );
+			expect( propagatedIndicators ).toHaveLength( 2 );
+
+			const notPropagatedIndicators = screen.getAllByLabelText( 'Not propagated' );
+			expect( notPropagatedIndicators ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'Loading and error states', () => {
+		test( 'does not render when loading', () => {
+			mockUseQuery.mockReturnValue( {
+				data: undefined,
+				isLoading: true,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		test( 'does not render when there is an error', () => {
+			mockUseQuery.mockReturnValue( {
+				data: undefined,
+				isLoading: false,
+				isError: true,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		test( 'does not render when data is undefined', () => {
+			mockUseQuery.mockReturnValue( {
+				data: undefined,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		test( 'does not render when data is null', () => {
+			mockUseQuery.mockReturnValue( {
+				data: null,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		test( 'renders with empty propagation status array', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// Should still render the component structure
+			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+		} );
+
+		test( 'renders with single propagation area', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [ { area_code: 'NA', area_name: 'North America', propagated: true } ],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			expect( screen.getByText( 'North America' ) ).toBeVisible();
+			expect( screen.getByLabelText( 'Propagated' ) ).toBeInTheDocument();
+		} );
+
+		test( 'handles invalid date format in last_updated', () => {
+			const mockData = createMockPropagationStatus( {
+				last_updated: 'invalid-date',
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// Should still render without crashing
+			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+			// Should show the raw date string when parsing fails
+			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Component structure', () => {
+		test( 'renders Card component', () => {
+			const mockData = createMockPropagationStatus();
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			const { container } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			const cardElement = container.querySelector( '.domain-propagation-status' );
+			expect( cardElement ).toBeInTheDocument();
+		} );
+
+		test( 'renders indicators with correct styling attributes', () => {
+			const mockData = createMockPropagationStatus( {
+				propagation_status: [ { area_code: 'NA', area_name: 'North America', propagated: true } ],
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			const indicator = screen.getByLabelText( 'Propagated' );
+			expect( indicator ).toHaveStyle( {
+				width: '8px',
+				height: '8px',
+				borderRadius: '50%',
+			} );
+		} );
+	} );
+} );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
@@ -283,8 +283,50 @@ describe( 'DomainPropagationStatus', () => {
 
 			// Should still render without crashing
 			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
-			// Should show the raw date string when parsing fails
-			expect( screen.getByText( /Last checked at/i ) ).toBeVisible();
+			// Should show "Last checked at" text but no timestamp
+			expect( screen.getByText( 'Last checked at' ) ).toBeVisible();
+		} );
+
+		test( 'handles empty string in last_updated', () => {
+			const mockData = createMockPropagationStatus( {
+				last_updated: '',
+			} );
+			mockUseQuery.mockReturnValue( {
+				data: mockData,
+				isLoading: false,
+				isError: false,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any );
+
+			render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+			// Should still render without crashing
+			expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+			// Should show "Last checked at" text but no timestamp
+			expect( screen.getByText( 'Last checked at' ) ).toBeVisible();
+		} );
+
+		test( 'handles various invalid date formats', () => {
+			const invalidDates = [ 'not-a-date', '0000-00-00', '99/99/9999', 'null', 'undefined' ];
+
+			invalidDates.forEach( ( invalidDate ) => {
+				const mockData = createMockPropagationStatus( {
+					last_updated: invalidDate,
+				} );
+				mockUseQuery.mockReturnValue( {
+					data: mockData,
+					isLoading: false,
+					isError: false,
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} as any );
+
+				const { unmount } = render( <DomainPropagationStatusComponent domainName="example.com" /> );
+
+				// Should render without crashing for any invalid date
+				expect( screen.getByText( 'Global propagation status' ) ).toBeVisible();
+
+				unmount();
+			} );
 		} );
 	} );
 

--- a/packages/api-core/src/domain-propagation-status/fetchers.ts
+++ b/packages/api-core/src/domain-propagation-status/fetchers.ts
@@ -1,0 +1,11 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { DomainPropagationStatus } from './types';
+
+export async function fetchDomainPropagationStatus(
+	domainName: string
+): Promise< DomainPropagationStatus > {
+	return wpcom.req.get( {
+		path: `/domains/propagation-status/${ domainName }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/packages/api-core/src/domain-propagation-status/index.ts
+++ b/packages/api-core/src/domain-propagation-status/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/domain-propagation-status/types.ts
+++ b/packages/api-core/src/domain-propagation-status/types.ts
@@ -1,0 +1,10 @@
+export type PropagationStatusArea = {
+	area_code: string;
+	area_name: string;
+	propagated: boolean;
+};
+
+export type DomainPropagationStatus = {
+	propagation_status: PropagationStatusArea[];
+	last_updated: string;
+};

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -17,6 +17,7 @@ export * from './domain-forwarding';
 export * from './domain-glue-records';
 export * from './domain-name-servers';
 export * from './domain-privacy';
+export * from './domain-propagation-status';
 export * from './domain-ssl';
 export * from './domain-suggestions';
 export * from './domain-supported-countries';

--- a/packages/api-queries/src/domain-propagation-status.ts
+++ b/packages/api-queries/src/domain-propagation-status.ts
@@ -1,0 +1,9 @@
+import { fetchDomainPropagationStatus } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const domainPropagationStatusQuery = ( domainName: string ) =>
+	queryOptions( {
+		queryKey: [ 'domain-propagation-status', domainName ],
+		queryFn: () => fetchDomainPropagationStatus( domainName ),
+		staleTime: 60 * 60 * 1000, // Consider data stale after 1 hour
+	} );

--- a/packages/api-queries/src/domain-propagation-status.ts
+++ b/packages/api-queries/src/domain-propagation-status.ts
@@ -5,5 +5,4 @@ export const domainPropagationStatusQuery = ( domainName: string ) =>
 	queryOptions( {
 		queryKey: [ 'domain-propagation-status', domainName ],
 		queryFn: () => fetchDomainPropagationStatus( domainName ),
-		staleTime: 60 * 60 * 1000, // Consider data stale after 1 hour
 	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -13,6 +13,7 @@ export * from './domain-forwarding';
 export * from './domain-glue-records';
 export * from './domain-name-servers';
 export * from './domain-privacy';
+export * from './domain-propagation-status';
 export * from './domain-ssl';
 export * from './domain-supported-contries';
 export * from './domain-transfer';


### PR DESCRIPTION
Closes [DOMAINS-1824](https://linear.app/a8c/issue/DOMAINS-1824/show-global-propagation-status-in-the-verification-page)

Depends on 195854-ghe-Automattic/wpcom

## Proposed Changes
Adds a new Global Propagation Status feature to the the Domain Connection flow. This component displays real-time DNS propagation status across major geographical regions (North America, Asia, Australia, Africa, South America, Europe), providing users with visibility into their domain's propagation progress worldwide.

## Why are these changes being made?
When users connect a custom domain to WordPress.com, DNS changes can take anywhere from minutes to hours (up to 72 hours) to propagate globally. Currently, users have no visibility into this process and cannot tell if their domain changes have propagated in different regions. This leads to:
- Confusion about whether setup was successful
- Support requests asking "why isn't my domain working yet?"
- Uncertainty about when to verify their domain connection

<img width="1688" height="1672" alt="propagation" src="https://github.com/user-attachments/assets/02945ad1-6f0f-4f90-8414-a7ff02b6e2fe" />

The component show the propagation status next to each geographical area:
- 🟢 Green dot for propagated regions
- ⚪ Gray dot for non-propagated regions

## Testing Instructions
1. **Setup**: Navigate to domain connection verification page
   ```
   /domains/{domain}/connection-setup
   ```

2. **Verify Component Renders**:
   - Should see "Global propagation status" title
   - Should see grid of regions with status indicators
   - Should see "Last checked at [time]"

3. **Test Different States**:
   - **All Propagated**: All dots should be green
   - **None Propagated**: All dots should be gray
   - **Mixed**: Some green, some gray


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?