### PR TITLE
A4A: On BD context, skip the Add Payment Method screen for agencies without payment methods

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
@@ -1,7 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import useStoredCards from './use-stored-cards';
 
 export default function usePaymentMethod( refetchInterval?: number ) {
+	const isBillingDragonCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
+
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
@@ -10,15 +13,18 @@ export default function usePaymentMethod( refetchInterval?: number ) {
 
 	const hasValidPaymentMethod = allStoredCards?.length > 0;
 
+	// Determine if a payment method is required based on the Billing Dragon feature flag and stored cards.
+	const paymentMethodRequired = isBillingDragonCheckoutEnabled ? false : ! hasValidPaymentMethod;
+
 	// Refetch the stored cards every `refetchInterval` milliseconds until a valid payment method is found.
 	useEffect( () => {
-		if ( ! hasValidPaymentMethod && refetchInterval ) {
+		if ( ! isBillingDragonCheckoutEnabled && paymentMethodRequired && refetchInterval ) {
 			const intervalId = setInterval( refetch, refetchInterval );
 			return () => clearInterval( intervalId );
 		}
-	}, [ hasValidPaymentMethod, refetch, refetchInterval ] );
+	}, [ isBillingDragonCheckoutEnabled, paymentMethodRequired, refetch, refetchInterval ] );
 
 	return {
-		paymentMethodRequired: ! hasValidPaymentMethod,
+		paymentMethodRequired,
 	};
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/3071

## Proposed Changes

This PR fixes the issue for agencies without payment methods. In the Jetpack Start context, the checkout flows redirect to the Payment Method page, but in the BD context, the checkout flows skip the Payment Method page.

Given an agency that has set the Billing Dragon, if you add products to the cart and then click on the checkout button, if the agency does not have a payment method, the checkout flow redirects to the Payment Method page:

<img width="1220" height="571" alt="image" src="https://github.com/user-attachments/assets/adaf961a-f4e6-4767-9518-a9a9202c6f2e" />

After this PR, that page is skipped. It checks if the agency works with BD, In that case, it skips the Payment Method page: 

<img width="1249" height="814" alt="image" src="https://github.com/user-attachments/assets/acf71ec5-bded-41ee-9aed-db996f1373ef" />

## Why are these changes being made?

- This is part of the Billing Dragon Phase 2 project.
- Linear `A4A-1798/ui-skip-the-payment-method-screen-in-a4a-bd-context`

## Testing Instructions

- Launch an A4A app using the live link below.
- With a new agency (no credit cards added), activate the Billing Dragon context by activating the `a4a-bd-checkout` feature.
- Set the agency as billing dragon via `update_blog_option` for the `agency_billing_system`.
- Go to the marketplace, add a product to the cart and checkout it.
- In trunk, it will try to redirect you to the Payment Method page
- In this branch, it will skip the Payment Method page and send you directly to the Checkout page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
