### PR TITLE
Fix the condition we use to render the external name servers notice in the dns records page

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -225,6 +225,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/connect-existing-domain/#step-2-change-your-domains-name-servers',
 		post_id: 2789,
 	},
+	'map-domain-update-name-servers': {
+		link: 'https://wordpress.com/support/domains/connect-existing-domain/#option-2-manual-setup',
+		post_id: 2789,
+	},
 	'map-domain-update-a-records': {
 		link: 'https://wordpress.com/support/domains/connect-a-domain-alternative-method/',
 		post_id: 219751,

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -1,5 +1,5 @@
-import { domainDnsMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { domainDnsMutation, domainQuery } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -9,6 +9,7 @@ import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DnsDescription from '../domain-dns/dns-description';
+import { DomainDnsNameserversNotice } from '../domain-dns/notice';
 import DNSRecordForm from './form';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import type { DnsRecordTypeFormData, DnsRecordFormData } from './records/dns-record-configs';
@@ -18,6 +19,7 @@ export default function DomainAddDNS() {
 	const navigate = useNavigate();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const mutation = useMutation( domainDnsMutation( domainName ) );
 
 	const navigateToDNSOverviewPage = () => {
@@ -57,6 +59,7 @@ export default function DomainAddDNS() {
 				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
 			}
 		>
+			<DomainDnsNameserversNotice domainName={ domainName } domain={ domain } />
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -1,4 +1,4 @@
-import { domainDnsMutation, domainDnsQuery } from '@automattic/api-queries';
+import { domainDnsMutation, domainDnsQuery, domainQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
@@ -9,6 +9,7 @@ import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import DnsDescription from '../domain-dns/dns-description';
+import { DomainDnsNameserversNotice } from '../domain-dns/notice';
 import DNSRecordForm from './form';
 import { DNS_RECORD_CONFIGS } from './records/dns-record-configs';
 import { getProcessedRecord } from './utils';
@@ -19,6 +20,7 @@ export default function DomainEditDNS() {
 	const navigate = useNavigate();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { recordId } = domainRoute.useSearch();
 	const mutation = useMutation( domainDnsMutation( domainName ) );
 
@@ -66,6 +68,7 @@ export default function DomainEditDNS() {
 				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
 			}
 		>
+			<DomainDnsNameserversNotice domainName={ domainName } domain={ domain } />
 			<DNSRecordForm
 				domainName={ domainName }
 				isBusy={ mutation.isPending }

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -31,6 +31,7 @@ import DnsImportDialog from './dns-import-dialog';
 import EmailSetup from './email-setup';
 import { useDnsFields } from './fields';
 import ImportBindFileButton from './import-bind-file-button';
+import { DomainDnsNameserversNotice } from './notice';
 import RestoreDefaultARecords from './restore-default-a-records';
 import RestoreDefaultCnameRecord from './restore-default-cname-record';
 import RestoreDefaultEmailRecords from './restore-default-email-records';
@@ -263,21 +264,6 @@ export default function DomainDns() {
 		);
 	};
 
-	const renderExternalNameserversNotice = () => {
-		if ( domain.has_wpcom_nameservers ) {
-			return null;
-		}
-
-		// TODO: Add a link to the name servers page or connection setup, once we have the pages
-		return (
-			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
-				{ __(
-					'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers.'
-				) }
-			</Notice>
-		);
-	};
-
 	return (
 		<PageLayout
 			size="small"
@@ -326,7 +312,7 @@ export default function DomainDns() {
 			}
 		>
 			{ renderDnsRecordsExplanationNotice() }
-			{ renderExternalNameserversNotice() }
+			<DomainDnsNameserversNotice domainName={ domainName } domain={ domain } />
 			{ renderDefaultARecordsNotice() }
 			{ renderDefaultCnameRecordNotice() }
 			<DataViewsCard>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -3,7 +3,6 @@ import {
 	domainDnsMutation,
 	domainDnsQuery,
 	domainDnsEmailMutation,
-	domainNameServersQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -79,9 +78,6 @@ export default function DomainDns() {
 	} );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const {
-		data: { nameServers, isUsingDefaultNameServers },
-	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
 	const { data: dnsData, isLoading } = useQuery( domainDnsQuery( domainName ) );
 	const [ isRestoreDefaultARecordsDialogOpen, setIsRestoreDefaultARecordsDialogOpen ] =
 		useState( false );
@@ -198,7 +194,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultARecordsNotice = () => {
-		if ( ! isUsingDefaultNameServers || hasDefaultARecordsValue ) {
+		if ( ! domain.has_wpcom_nameservers || hasDefaultARecordsValue ) {
 			return null;
 		}
 
@@ -231,7 +227,7 @@ export default function DomainDns() {
 	};
 
 	const renderDefaultCnameRecordNotice = () => {
-		if ( ! isUsingDefaultNameServers || hasDefaultCnameRecordValue ) {
+		if ( ! domain.has_wpcom_nameservers || hasDefaultCnameRecordValue ) {
 			return null;
 		}
 
@@ -268,7 +264,7 @@ export default function DomainDns() {
 	};
 
 	const renderExternalNameserversNotice = () => {
-		if ( isUsingDefaultNameServers || ! nameServers || ! nameServers.length ) {
+		if ( domain.has_wpcom_nameservers ) {
 			return null;
 		}
 

--- a/client/dashboard/domains/domain-dns/notice.tsx
+++ b/client/dashboard/domains/domain-dns/notice.tsx
@@ -24,7 +24,7 @@ export const DomainDnsNameserversNotice = ( {
 			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means the DNS records you are editing you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
+						'This means that the DNS records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
 					),
 					{
 						learnMoreLink: <InlineSupportLink supportContext="map-domain-update-name-servers" />,
@@ -38,7 +38,7 @@ export const DomainDnsNameserversNotice = ( {
 		<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 			{ createInterpolateElement(
 				__(
-					'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
+					'This means that the DNS records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
 				),
 				{
 					updateNameServersLink: (

--- a/client/dashboard/domains/domain-dns/notice.tsx
+++ b/client/dashboard/domains/domain-dns/notice.tsx
@@ -24,7 +24,7 @@ export const DomainDnsNameserversNotice = ( {
 			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
+						'This means the DNS records you are editing you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
 					),
 					{
 						learnMoreLink: <InlineSupportLink supportContext="map-domain-update-name-servers" />,

--- a/client/dashboard/domains/domain-dns/notice.tsx
+++ b/client/dashboard/domains/domain-dns/notice.tsx
@@ -1,0 +1,51 @@
+import { DomainSubtype, Domain } from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { domainNameServersRoute } from '../../app/router/domains';
+import InlineSupportLink from '../../components/inline-support-link';
+import { Notice } from '../../components/notice';
+
+interface DomainDnsNameserversNoticeProps {
+	domainName: string;
+	domain: Domain;
+}
+
+export const DomainDnsNameserversNotice = ( {
+	domainName,
+	domain,
+}: DomainDnsNameserversNoticeProps ) => {
+	if ( domain.has_wpcom_nameservers ) {
+		return null;
+	}
+
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+		return (
+			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
+				{ createInterpolateElement(
+					__(
+						'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
+					),
+					{
+						learnMoreLink: <InlineSupportLink supportContext="map-domain-update-name-servers" />,
+					}
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
+			{ createInterpolateElement(
+				__(
+					'This means the DNS records you are editing will not be in effect until you switch to use WordPress.com name servers. <updateNameServersLink>You can update your name servers here</updateNameServersLink>'
+				),
+				{
+					updateNameServersLink: (
+						<Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />
+					),
+				}
+			) }
+		</Notice>
+	);
+};

--- a/client/dashboard/domains/domain-forwarding/index.tsx
+++ b/client/dashboard/domains/domain-forwarding/index.tsx
@@ -1,4 +1,4 @@
-import { domainForwardingQuery } from '@automattic/api-queries';
+import { domainForwardingQuery, domainQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useRouter } from '@tanstack/react-router';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -17,6 +17,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import DomainForwardingDeleteModal from './delete-modal';
+import { DomainForwardingNotice } from './notice';
 import type { DomainForwarding as DomainForwardingType } from '@automattic/api-core';
 import type { Action, Field, ViewTable, ViewList, View } from '@wordpress/dataviews';
 
@@ -49,6 +50,7 @@ function DomainForwarding() {
 	const router = useRouter();
 
 	const { domainName } = domainRoute.useParams();
+	const { data: domainData } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: forwardingData } = useSuspenseQuery( domainForwardingQuery( domainName ) );
 
 	const actions: Action< DomainForwardingType >[] = useMemo(
@@ -171,6 +173,7 @@ function DomainForwarding() {
 				/>
 			}
 		>
+			<DomainForwardingNotice domainName={ domainName } domainData={ domainData } />
 			<DataViewsCard>
 				<DataViews< DomainForwardingType >
 					data={ filteredData || [] }

--- a/client/dashboard/domains/domain-forwarding/notice.tsx
+++ b/client/dashboard/domains/domain-forwarding/notice.tsx
@@ -35,7 +35,7 @@ export const DomainForwardingNotice = ( {
 			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>You can update your name servers here</link>.'
+						'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>You can update your name servers here</link>'
 					),
 					{
 						link: <Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />,

--- a/client/dashboard/domains/domain-forwarding/notice.tsx
+++ b/client/dashboard/domains/domain-forwarding/notice.tsx
@@ -35,7 +35,7 @@ export const DomainForwardingNotice = ( {
 			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ createInterpolateElement(
 					__(
-						'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>Update your name servers now</link>.'
+						'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>You can update your name servers here</link>.'
 					),
 					{
 						link: <Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />,

--- a/client/dashboard/domains/domain-forwarding/notice.tsx
+++ b/client/dashboard/domains/domain-forwarding/notice.tsx
@@ -22,7 +22,7 @@ export const DomainForwardingNotice = ( {
 				<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 					{ createInterpolateElement(
 						__(
-							'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />.'
+							'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />'
 						),
 						{
 							learnMoreLink: <InlineSupportLink supportContext="map-domain-update-name-servers" />,

--- a/client/dashboard/domains/domain-forwarding/notice.tsx
+++ b/client/dashboard/domains/domain-forwarding/notice.tsx
@@ -1,9 +1,10 @@
-import { Domain } from '@automattic/api-core';
+import { DomainSubtype, Domain } from '@automattic/api-core';
 import { Link } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { domainNameServersRoute } from '../../app/router/domains';
 import { siteDomainsRoute } from '../../app/router/sites';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 
 interface DomainForwardingNoticeProps {
@@ -15,22 +16,26 @@ export const DomainForwardingNotice = ( {
 	domainName,
 	domainData,
 }: DomainForwardingNoticeProps ) => {
-	const usesDefaultNameservers = domainData?.has_wpcom_nameservers;
-	const isPrimaryDomain = domainData?.primary_domain;
-	const isDomainOnly = domainData?.is_domain_only_site;
-	const siteSlug = domainData?.site_slug;
-
-	// TODO: Should the first notice link to the domain mapping setup page???
-	// That's how it works in client/my-sites/domains/domain-management/settings/index.tsx
-	// but I'm not sure how useful that is if at all???
-
-	// TODO: The second link is to set a primary domain for a site, but I'm not sure if that'll be the correct link - check it once it's clear what the correct link is
-	if ( ! usesDefaultNameservers ) {
+	if ( ! domainData?.has_wpcom_nameservers ) {
+		if ( domainData.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+			return (
+				<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
+					{ createInterpolateElement(
+						__(
+							'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <learnMoreLink />.'
+						),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="map-domain-update-name-servers" />,
+						}
+					) }
+				</Notice>
+			);
+		}
 		return (
-			<Notice variant="warning">
+			<Notice variant="warning" title={ __( 'Your domain is using external name servers' ) }>
 				{ createInterpolateElement(
 					__(
-						'Your domain is using external name servers so the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>Update your name servers now</link>.'
+						'This means that the Domain Forwarding records you’re editing won’t be in effect until you switch to use WordPress.com name servers. <link>Update your name servers now</link>.'
 					),
 					{
 						link: <Link to={ domainNameServersRoute.fullPath } params={ { domainName } } />,
@@ -38,7 +43,7 @@ export const DomainForwardingNotice = ( {
 				) }
 			</Notice>
 		);
-	} else if ( isPrimaryDomain && ! isDomainOnly ) {
+	} else if ( domainData?.primary_domain && ! domainData?.is_domain_only_site ) {
 		return (
 			<Notice variant="info">
 				{ createInterpolateElement(
@@ -46,7 +51,12 @@ export const DomainForwardingNotice = ( {
 						'This domain is your site’s main address. You can forward subdomains or <link>set a new primary site address</link> to forward the root domain.'
 					),
 					{
-						link: <Link to={ siteDomainsRoute.fullPath } params={ { siteSlug } } />,
+						link: (
+							<Link
+								to={ siteDomainsRoute.fullPath }
+								params={ { siteSlug: domainData?.site_slug } }
+							/>
+						),
 					}
 				) }
 			</Notice>

--- a/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
@@ -54,7 +54,7 @@ test( 'shows warning notice when domain registration uses external name servers'
 		has_wpcom_nameservers: false, // External name servers
 		primary_domain: false,
 		is_domain_only_site: true,
-		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION },
+		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
 	} );
 
 	const TestWrapper = () => {
@@ -80,7 +80,7 @@ test( 'shows warning notice when domain connection uses external name servers', 
 		has_wpcom_nameservers: false, // External name servers
 		primary_domain: false,
 		is_domain_only_site: true,
-		subtype: { id: DomainSubtype.DOMAIN_CONNECTION },
+		subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
 	} );
 
 	const TestWrapper = () => {

--- a/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { Domain } from '@automattic/api-core';
+import { Domain, DomainSubtype } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import { render } from '../../../test-utils';
 
@@ -49,11 +49,12 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ) => {
 	};
 };
 
-test( 'shows warning notice when domain uses external name servers', () => {
+test( 'shows warning notice when domain registration uses external name servers', () => {
 	const domainData = getMockedDomainData( {
 		has_wpcom_nameservers: false, // External name servers
 		primary_domain: false,
 		is_domain_only_site: true,
+		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION },
 	} );
 
 	const TestWrapper = () => {
@@ -66,7 +67,32 @@ test( 'shows warning notice when domain uses external name servers', () => {
 	expect(
 		screen.getAllByText( /your domain is using external name servers/i ).length
 	).toBeGreaterThan( 0 );
-	expect( screen.getAllByText( /update your name servers now/i ).length ).toBeGreaterThan( 0 );
+	expect( screen.getAllByText( /you can update your name servers here/i ).length ).toBeGreaterThan(
+		0
+	);
+
+	// Should be a warning notice
+	expect( document.querySelector( '.dashboard-notice' ) ).toHaveClass( 'is-warning' );
+} );
+
+test( 'shows warning notice when domain connection uses external name servers', () => {
+	const domainData = getMockedDomainData( {
+		has_wpcom_nameservers: false, // External name servers
+		primary_domain: false,
+		is_domain_only_site: true,
+		subtype: { id: DomainSubtype.DOMAIN_CONNECTION },
+	} );
+
+	const TestWrapper = () => {
+		const { DomainForwardingNotice } = require( '../notice' );
+		return <DomainForwardingNotice domainName={ domainName } domainData={ domainData } />;
+	};
+
+	render( <TestWrapper /> );
+
+	expect(
+		screen.getAllByText( /your domain is using external name servers/i ).length
+	).toBeGreaterThan( 0 );
 
 	// Should be a warning notice
 	expect( document.querySelector( '.dashboard-notice' ) ).toHaveClass( 'is-warning' );

--- a/client/dashboard/domains/domain/index.tsx
+++ b/client/dashboard/domains/domain/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { domainQuery, domainsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
@@ -13,8 +14,14 @@ import './style.scss';
 
 function Domain() {
 	const { domainName } = domainRoute.useParams();
-	const domains = useQuery( domainsQuery() ).data;
+	const domains = useQuery( {
+		...domainsQuery(),
+		select: ( data ) => {
+			return data.filter( ( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS );
+		},
+	} ).data;
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
+
 	const searchableFields = [
 		{
 			id: 'name',


### PR DESCRIPTION
The condition we use to show the notice that your domain is currently using external name servers was not always working - we should use the `has_wpcom_nameservers` property of the Domain object

This is the notice we need to show:

<img width="693" height="130" alt="Screenshot 2025-11-11 at 20 33 52" src="https://github.com/user-attachments/assets/25f3d06d-5d79-4c55-8280-65789d29f84d" />

Part of [DOMAINS-1829: Render notice if name servers are not ours in the DNS editor](https://linear.app/a8c/issue/DOMAINS-1829/render-notice-if-name-servers-are-not-ours-in-the-dns-editor)

## Proposed Changes

* Update the condition to render the external name servers notice to use the Domain object `has_wpcom_nameservers`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The original condition didn't work for connected domains

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try with domain that's registered with us or a domain that's connected to us and verify that you can see the "Your domain is using external name servers" notice is visible if you're using external name servers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
