### PR TITLE
SSH Migration: Block the verify button while the preflight is running

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { AccordionNotice } from '../components/accordion-notice';
 import { useVerifySSHConnection } from '../hooks/use-verify-ssh-connection';
 import { validatePort } from '../utils/validation';
@@ -15,6 +16,7 @@ interface StepAddServerAddressProps {
 	onServerAddressChange: ( address: string ) => void;
 	onPortChange: ( port: number ) => void;
 	onVerify: () => void;
+	isInputDisabled: boolean;
 }
 
 export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
@@ -26,12 +28,18 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 	onServerAddressChange,
 	onPortChange,
 	onVerify,
+	isInputDisabled,
 } ) => {
 	const translate = useTranslate();
 
 	const { mutate: verifyConnection, isPending, error } = useVerifySSHConnection();
 
 	const handleVerify = () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'add-server-address',
+			action: 'click_button',
+			button: 'verify_server',
+		} );
 		verifyConnection(
 			{
 				siteId,
@@ -46,7 +54,8 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 		);
 	};
 
-	const canVerify = serverAddress.length > 0 && validatePort( port ) && ! isPending;
+	const canVerify =
+		serverAddress.length > 0 && validatePort( port ) && ! isPending && ! isInputDisabled;
 
 	const instructionText = hostDisplayName
 		? translate(
@@ -88,6 +97,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 							onServerAddressChange( e.target.value )
 						}
 						placeholder="ssh.wp.example-host.net"
+						disabled={ isInputDisabled }
 					/>
 				</div>
 
@@ -104,6 +114,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 							const newPort = Number.isNaN( parsedPort ) ? 22 : parsedPort;
 							onPortChange( newPort );
 						} }
+						disabled={ isInputDisabled }
 					/>
 				</div>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -7,6 +7,7 @@ interface StepFindSSHDetailsProps {
 	onNoSSHAccess?: () => void;
 	hostDisplayName?: string;
 	helpLink: ReactNode;
+	isInputDisabled: boolean;
 }
 
 export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
@@ -14,6 +15,7 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 	onNoSSHAccess,
 	hostDisplayName,
 	helpLink,
+	isInputDisabled,
 } ) => {
 	const translate = useTranslate();
 
@@ -40,6 +42,7 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 					variant="link"
 					onClick={ onNoSSHAccess }
 					className="migration-site-ssh__no-ssh-link"
+					disabled={ isInputDisabled }
 				>
 					{ translate( "I don't have SSH" ) }
 				</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -125,6 +125,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					onServerAddressChange={ options.onServerAddressChange }
 					onPortChange={ options.onPortChange }
 					onVerify={ options.onServerVerify }
+					isInputDisabled={ options.isInputDisabled }
 				/>
 			),
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -109,6 +109,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					onNoSSHAccess={ options.onNoSSHAccess }
 					hostDisplayName={ hostDisplayName }
 					helpLink={ helpLink }
+					isInputDisabled={ options.isInputDisabled }
 				/>
 			),
 		},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15172

## Proposed Changes

* Blocks the `Verify server address` button while the preflight is running.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After submitting my details at the end, there are parts of the interface that are still active. I can open the second step and edit the server address and port. We should disable this field to prevent people from breaking something (as I did in my case).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Go through the flow until you reach the `Securely share your access` step
* Now input all the information and click on `Continue`
* While the preflight is running, click on the step number 2, and confirm that the `Verify server address` is disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
