### PR TITLE
Help Center: Wrap destroying Smooch with try-catch

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -20,7 +20,12 @@ import { getClientId, getZendeskConversations } from './utils';
 import type { ZendeskMessage } from '@automattic/odie-client';
 
 const destroy = () => {
-	Smooch.destroy();
+	try {
+		Smooch.destroy();
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error destroying Smooch', error );
+	}
 };
 
 const initSmooch = (


### PR DESCRIPTION
Fixes DOTSUP-349

## Proposed Changes

Destroying Smooch on component unmount throws an error in Firefox. I think because Firefox's garbage collector is more eager than the other browsers, and it destroys the instance before we explicitly destroy it.

## Why are these changes being made?
Fix DOTSUP-349

## Testing Instructions

1. Run `yarn dev --sync` in `apps/help-center`.
2. Sandbox widgets.wp.com.
3. In FF, In a post, add a pattern.
4. Edit that pattern by clicking "Edit original" option on the pattern context menu.
5. The editor shouldn't crash.