### PR TITLE
A4A: Bypass payment method check when assigning licenses after BD checkout

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
@@ -139,7 +140,7 @@ export default function LicensePreview( {
 		const redirectUrl = isWPCOMLicense
 			? A4A_SITES_LINK_NEEDS_SETUP
 			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
-		if ( paymentMethodRequired && ! referral ) {
+		if ( paymentMethodRequired && ! referral && ! isEnabled( 'a4a-bd-checkout' ) ) {
 			const noticeLinkHref = addQueryArgs(
 				{
 					return: redirectUrl,


### PR DESCRIPTION
When the 'a4a-bd-checkout' feature flag is enabled, users should be able to assign licenses without requiring a primary payment method. This change adds a check for the feature flag before showing the "A primary payment method is required" error message.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1801/allow-bd-agencies-to-assign-licenses-without-a-payment-method

## Proposed Changes

- Add condition to bypass payment method check when a4a-bd-checkout is enabled
- Allow license assignment to proceed without payment method when flag is active

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow agencies using the BD flow to assign a license

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the BD flow, Purchase a Jetpack or Woo product
* On the backend set the `agency_billing_system` blog option for the agency to `billingdragon`
* From `/purchases/licenses` click "Assign" next to that product
* You should be taken to the `marketplace/assign-license` page and you shouldn't see an error saying "A primary payment method is required."

**BEFORE**
<img width="1685" height="784" alt="Screenshot 2025-11-11 at 4 26 23 PM" src="https://github.com/user-attachments/assets/146d5372-49db-446d-97c4-78c0ba117614" />

**AFTER**
<img width="1716" height="593" alt="Screenshot 2025-11-11 at 4 31 34 PM" src="https://github.com/user-attachments/assets/5764fc41-0a35-4b3b-a3c9-552b0c81bb7a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
