### PR TITLE
SSH Migration: Prevent duplicate ticket creation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/support-nudge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/support-nudge/index.tsx
@@ -6,9 +6,10 @@ import './style.scss';
 
 type SupportNudgeProps = {
 	onAskForHelp: () => void;
+	isLoading?: boolean;
 };
 
-export const SupportNudge: FC< SupportNudgeProps > = ( { onAskForHelp } ) => {
+export const SupportNudge: FC< SupportNudgeProps > = ( { onAskForHelp, isLoading = false } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -24,6 +25,7 @@ export const SupportNudge: FC< SupportNudgeProps > = ( { onAskForHelp } ) => {
 							} }
 							type="button"
 							className="site-migration-instructions-support-nudge__button"
+							disabled={ isLoading }
 						/>
 					),
 				},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -47,7 +47,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const [ shouldStartMigration, setShouldStartMigration ] = useState( false );
 	const locale = useLocale();
 	const siteSlug = useSiteSlugParam() ?? '';
-	const { sendTicketAsync } = useSubmitMigrationTicket();
+	const { sendTicketAsync, isPending: isSubmittingTicket } = useSubmitMigrationTicket();
 
 	// Redirect back to verification step if transferId is missing
 	useEffect( () => {
@@ -208,7 +208,11 @@ const SiteMigrationSshShareAccess: StepType< {
 				}
 		  );
 	const topBar = (
-		<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
+		<Step.TopBar
+			rightElement={
+				<SupportNudge onAskForHelp={ navigateToDoItForMe } isLoading={ isSubmittingTicket } />
+			}
+		/>
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15175

## Proposed Changes

* Prevent duplicate support ticket submissions
* Disables the "Let us migrate your site" link in SupportNudge while a ticket is being submitted

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users can click "Let us migrate your site" multiple times, creating duplicate support tickets before the first submission completes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Go through the flow until you reach the `Securely share your access` step
* Click on "Let us migrate your site" in the top-right corner
* Immediately try to click it again before the request completes
* Expected: The link should be disabled after the first click, preventing duplicate submissions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
