### PR TITLE
MSD: Bulk add descriptions to page headers without descriptions.

### DIFF
--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -92,7 +92,7 @@ export default function DomainContactInfo() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
-					description={ __( "Update your domain's contact information for registration." ) }
+					description={ __( 'Update your domain’s contact information for registration.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -87,7 +87,15 @@ export default function DomainContactInfo() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					description={ __( "Update your domain's contact information for registration." ) }
+				/>
+			}
+		>
 			<ContactForm
 				isSubmitting={ isSubmitting }
 				onSubmit={ handleSubmit }

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -185,7 +185,7 @@ export default function DomainContactVerification() {
 			size="small"
 			header={
 				<PageHeader
-					title={ __( 'Contact Verification' ) }
+					title={ __( 'Contact verification' ) }
 					description={ __(
 						'Verify your domain contact information to comply with ICANN requirements.'
 					) }

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -181,7 +181,17 @@ export default function DomainContactVerification() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Contact Verification' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Contact Verification' ) }
+					description={ __(
+						'Verify your domain contact information to comply with ICANN requirements.'
+					) }
+				/>
+			}
+		>
 			{ submitted && renderSubmittedMessage() }
 			{ error && renderErrorMessage() }
 			<Card>

--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -41,7 +41,15 @@ export default function AddDomainForwarding() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ __( 'Set up domain forwarding to redirect visitors to another URL.' ) }
+				/>
+			}
+		>
 			<DomainForwardingNotice domainName={ domainName } domainData={ domainData } />
 			<DomainForwardingForm
 				domainName={ domainName }

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -68,7 +68,15 @@ export default function EditDomainForwarding() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ __( 'Edit your domain forwarding configuration.' ) }
+				/>
+			}
+		>
 			<DomainForwardingNotice domainName={ domainName } domainData={ domainData } />
 			<DomainForwardingForm
 				domainName={ domainName }

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -73,7 +73,7 @@ export default function EditDomainForwarding() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
-					description={ __( 'Edit your domain forwarding configuration.' ) }
+					description={ __( 'Update where your domain redirects visitors.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -55,7 +55,7 @@ export default function AddDomainGlueRecords() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
-					description={ __( "Add a glue record for your domain's name servers." ) }
+					description={ __( 'Add a glue record for your domain’s name servers.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -50,7 +50,15 @@ export default function AddDomainGlueRecords() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ __( "Add a glue record for your domain's name servers." ) }
+				/>
+			}
+		>
 			<DomainGlueRecordsForm
 				domainName={ domainName }
 				onSubmit={ handleSubmit }

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -59,7 +59,7 @@ export default function EditDomainGlueRecords() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
-					description={ __( "Edit a glue record for your domain's name servers." ) }
+					description={ __( 'Edit a glue record for your domain’s name servers.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -54,7 +54,15 @@ export default function EditDomainGlueRecords() {
 	};
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 3 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ __( "Edit a glue record for your domain's name servers." ) }
+				/>
+			}
+		>
 			<DomainGlueRecordsForm
 				domainName={ domainName }
 				initialData={ glueRecord }

--- a/client/dashboard/domains/domain-security/index.tsx
+++ b/client/dashboard/domains/domain-security/index.tsx
@@ -1,5 +1,6 @@
 import { domainQuery, sslDetailsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';

--- a/client/dashboard/domains/domain-security/index.tsx
+++ b/client/dashboard/domains/domain-security/index.tsx
@@ -13,7 +13,17 @@ export default function DomainSecurity() {
 	const { data: sslDetails } = useSuspenseQuery( sslDetailsQuery( domainName ) );
 
 	return (
-		<PageLayout size="small" header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					description={ __(
+						'Manage security settings for your domain, including SSL certificates.'
+					) }
+				/>
+			}
+		>
 			<SslCertificate domainName={ domainName } domain={ domain } sslDetails={ sslDetails } />
 			<DnsSec domainName={ domainName } domain={ domain } />
 		</PageLayout>

--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -216,7 +216,7 @@ export default function DomainTransfer() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Transfer' ) }
-					description={ __( 'Transfer your domain to another owner or registrar.' ) }
+					description={ __( 'Transfer this domain to another site or WordPress.com user.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -212,7 +212,13 @@ export default function DomainTransfer() {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Transfer' ) } /> }
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Transfer' ) }
+					description={ __( 'Transfer your domain to another owner or registrar.' ) }
+				/>
+			}
 		>
 			{ renderTransferInfo() }
 			{ isDomainTransferable && <InternalTransferOptions domain={ domain } /> }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -316,6 +316,7 @@ export default function TransferDomainToAnyUser() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Transfer to another user' ) }
+					description={ __( 'Transfer your domain to any WordPress.com user.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -270,6 +270,7 @@ export default function TransferDomainToOtherUser() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Transfer to another user' ) }
+					description={ __( 'Transfer your domain to another WordPress.com user.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -270,7 +270,7 @@ export default function TransferDomainToOtherUser() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ __( 'Transfer to another user' ) }
-					description={ __( 'Transfer your domain to another WordPress.com user.' ) }
+					description={ __( 'Transfer this domain to any administrator on this site.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -63,7 +63,7 @@ function Domains() {
 				<PageHeader
 					title={ __( 'Domains' ) }
 					description={ __(
-						'Configure DNS, forwarding, and domain settings across all your domains.'
+						'Manage settings and configuration for all your domains.'
 					) }
 					actions={ <AddDomainButton /> }
 				/>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -62,9 +62,7 @@ function Domains() {
 			header={
 				<PageHeader
 					title={ __( 'Domains' ) }
-					description={ __(
-						'Manage settings and configuration for all your domains.'
-					) }
+					description={ __( 'Manage settings and configuration for your domains.' ) }
 					actions={ <AddDomainButton /> }
 				/>
 			}

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -59,7 +59,13 @@ function Domains() {
 
 	return (
 		<PageLayout
-			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
+			header={
+				<PageHeader
+					title={ __( 'Domains' ) }
+					description={ __( 'Manage all your domains in one place.' ) }
+					actions={ <AddDomainButton /> }
+				/>
+			}
 			notices={ <OptInWelcome tracksContext="domains" /> }
 		>
 			<DataViewsCard>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -62,7 +62,9 @@ function Domains() {
 			header={
 				<PageHeader
 					title={ __( 'Domains' ) }
-					description={ __( 'Manage all your domains in one place.' ) }
+					description={ __(
+						'Configure DNS, forwarding, and domain settings across all your domains.'
+					) }
 					actions={ <AddDomainButton /> }
 				/>
 			}

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -59,13 +59,7 @@ function Domains() {
 
 	return (
 		<PageLayout
-			header={
-				<PageHeader
-					title={ __( 'Domains' ) }
-					description={ __( 'Manage settings and configuration for your domains.' ) }
-					actions={ <AddDomainButton /> }
-				/>
-			}
+			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
 			notices={ <OptInWelcome tracksContext="domains" /> }
 		>
 			<DataViewsCard>

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -247,7 +247,7 @@ function AddEmailForwarder() {
 			header={
 				<PageHeader
 					prefix={ <BackToEmailsPrefix /> }
-					description={ __( 'Create an email forwarder to redirect emails to another address.' ) }
+					description={ __( 'Set where your emails should be forwarded.' ) }
 				/>
 			}
 			size="small"
@@ -260,122 +260,119 @@ function AddEmailForwarder() {
 					<AddNewDomain origin="add-forwarder" />
 				</>
 			) : (
-				<>
-					<Text size={ 16 }>{ __( 'Set where your emails should be forwarded.' ) }</Text>
-					<Card>
-						<CardBody>
-							<form onSubmit={ handleSubmit }>
-								<VStack spacing={ 6 }>
-									<DataForm
-										data={ formData }
-										fields={ fields }
-										form={ form }
-										onChange={ ( edits: Partial< FormData > ) => {
-											setFormData( ( data ) => ( { ...data, ...edits } ) );
-										} }
-									/>
+				<Card>
+					<CardBody>
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 6 }>
+								<DataForm
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: Partial< FormData > ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
 
-									<FormTokenField
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										label={ __( 'Forward to' ) }
-										onInputChange={ ( val ) => {
-											setUntokenizedInput( val );
-										} }
-										value={ formData.forwardingAddresses }
-										onChange={ ( newTokens ) => {
-											// Clear the untokenized input if a new token was added (the value added is what was in the untokenized input)
-											// A token is removed by clicking on Token component's X, so in that case we keep the untokenized input as-is
-											const shouldClearUntokenizedInput =
-												newTokens.length > formData.forwardingAddresses.length;
+								<FormTokenField
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Forward to' ) }
+									onInputChange={ ( val ) => {
+										setUntokenizedInput( val );
+									} }
+									value={ formData.forwardingAddresses }
+									onChange={ ( newTokens ) => {
+										// Clear the untokenized input if a new token was added (the value added is what was in the untokenized input)
+										// A token is removed by clicking on Token component's X, so in that case we keep the untokenized input as-is
+										const shouldClearUntokenizedInput =
+											newTokens.length > formData.forwardingAddresses.length;
 
-											if ( shouldClearUntokenizedInput ) {
-												setUntokenizedInput( '' );
+										if ( shouldClearUntokenizedInput ) {
+											setUntokenizedInput( '' );
+										}
+
+										setFormData( ( data ) => ( {
+											...data,
+											forwardingAddresses: newTokens as string[],
+										} ) );
+									} }
+								/>
+
+								{ newForwardingAddresses.length > 0 && (
+									<Notice>
+										{ sprintf(
+											/* Translators: %s: emailAddress is the email address the user was attempting to add a forwarder for */
+											_n(
+												"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to that email after saving.",
+												"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to those emails after saving.",
+												newForwardingAddresses.length
+											),
+											{
+												emailAddresses: newForwardingAddresses.join( ', ' ),
 											}
+										) }
+									</Notice>
+								) }
 
-											setFormData( ( data ) => ( {
-												...data,
-												forwardingAddresses: newTokens as string[],
-											} ) );
-										} }
-									/>
+								{ isDomainMaxForwardsReached && (
+									<Notice variant="warning">
+										{ sprintf(
+											// translators: %(maxForwards) is the maximum number of email forwards allowed for a domain.
+											__(
+												"You can't add another email forwarder for this domain because you've reached the maximum number %(maxForwards)d of Email Forwards allowed on it. Please delete an existing forwarder in order to add a new one."
+											),
+											{
+												maxForwards,
+											}
+										) }
+									</Notice>
+								) }
 
-									{ newForwardingAddresses.length > 0 && (
-										<Notice>
-											{ sprintf(
-												/* Translators: %s: emailAddress is the email address the user was attempting to add a forwarder for */
-												_n(
-													"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to that email after saving.",
-													"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to those emails after saving.",
-													newForwardingAddresses.length
-												),
-												{
-													emailAddresses: newForwardingAddresses.join( ', ' ),
-												}
-											) }
-										</Notice>
-									) }
+								{ ! isDomainMaxForwardsReached && willDomainMaxForwardsBeReached && (
+									<Notice variant="warning">
+										{ sprintf(
+											// translators: %(forwardingAddressesCount)d is the number of new email forwards the user is attempting to add, %(maxForwards)d is the maximum number of email forwards allowed for a domain, %(existingForwardersCount)d is the number of existing email forwards already set up for the domain.
+											__(
+												'You are adding too many new email forwarders for this domain (%(forwardingAddressesCount)d); the maximum number is %(maxForwards)d and there are already %(existingForwardersCount)d before this change. Please edit your changes or delete any of the existing forwarders.'
+											),
+											{
+												forwardingAddressesCount: formData.forwardingAddresses.length,
+												maxForwards,
+												existingForwardersCount: forwards?.length ?? 0,
+											}
+										) }
+									</Notice>
+								) }
 
-									{ isDomainMaxForwardsReached && (
-										<Notice variant="warning">
-											{ sprintf(
-												// translators: %(maxForwards) is the maximum number of email forwards allowed for a domain.
-												__(
-													"You can't add another email forwarder for this domain because you've reached the maximum number %(maxForwards)d of Email Forwards allowed on it. Please delete an existing forwarder in order to add a new one."
-												),
-												{
-													maxForwards,
-												}
-											) }
-										</Notice>
-									) }
+								{ duplicateForwardAddress && (
+									<Notice variant="error">
+										{ sprintf(
+											// translators: %(mailbox)s is the email address the user is attempting to add a forwarder for, %(forwardingAddress)s is the duplicate forwarding email address.
+											__(
+												'There is already a forwarding set from %(mailbox)s to %(forwardingAddress)s. Please remove the duplicate and try again.'
+											),
+											{
+												mailbox: `${ formData.localPart }@${ formData.domain }`,
+												forwardingAddress: duplicateForwardAddress,
+											}
+										) }
+									</Notice>
+								) }
 
-									{ ! isDomainMaxForwardsReached && willDomainMaxForwardsBeReached && (
-										<Notice variant="warning">
-											{ sprintf(
-												// translators: %(forwardingAddressesCount)d is the number of new email forwards the user is attempting to add, %(maxForwards)d is the maximum number of email forwards allowed for a domain, %(existingForwardersCount)d is the number of existing email forwards already set up for the domain.
-												__(
-													'You are adding too many new email forwarders for this domain (%(forwardingAddressesCount)d); the maximum number is %(maxForwards)d and there are already %(existingForwardersCount)d before this change. Please edit your changes or delete any of the existing forwarders.'
-												),
-												{
-													forwardingAddressesCount: formData.forwardingAddresses.length,
-													maxForwards,
-													existingForwardersCount: forwards?.length ?? 0,
-												}
-											) }
-										</Notice>
-									) }
-
-									{ duplicateForwardAddress && (
-										<Notice variant="error">
-											{ sprintf(
-												// translators: %(mailbox)s is the email address the user is attempting to add a forwarder for, %(forwardingAddress)s is the duplicate forwarding email address.
-												__(
-													'There is already a forwarding set from %(mailbox)s to %(forwardingAddress)s. Please remove the duplicate and try again.'
-												),
-												{
-													mailbox: `${ formData.localPart }@${ formData.domain }`,
-													forwardingAddress: duplicateForwardAddress,
-												}
-											) }
-										</Notice>
-									) }
-
-									<ButtonStack justify="flex-start">
-										<Button
-											variant="primary"
-											type="submit"
-											isBusy={ isBusy }
-											disabled={ isBusy || ! allFieldsSet || ! isValid }
-										>
-											{ __( 'Save' ) }
-										</Button>
-									</ButtonStack>
-								</VStack>
-							</form>
-						</CardBody>
-					</Card>
-				</>
+								<ButtonStack justify="flex-start">
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={ isBusy }
+										disabled={ isBusy || ! allFieldsSet || ! isValid }
+									>
+										{ __( 'Save' ) }
+									</Button>
+								</ButtonStack>
+							</VStack>
+						</form>
+					</CardBody>
+				</Card>
 			) }
 		</PageLayout>
 	);

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -243,7 +243,15 @@ function AddEmailForwarder() {
 	}
 
 	return (
-		<PageLayout header={ <PageHeader prefix={ <BackToEmailsPrefix /> } /> } size="small">
+		<PageLayout
+			header={
+				<PageHeader
+					prefix={ <BackToEmailsPrefix /> }
+					description={ __( 'Create an email forwarder to redirect emails to another address.' ) }
+				/>
+			}
+			size="small"
+		>
 			{ eligibleDomains.length === 0 ? (
 				<>
 					<Text size={ 16 }>

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -177,6 +177,7 @@ const AddProfessionalEmail = () => {
 							} }
 						/>
 					}
+					description={ __( 'Add a new email mailbox to your domain.' ) }
 				/>
 			}
 			size="small"

--- a/client/dashboard/emails/choose-domain/index.tsx
+++ b/client/dashboard/emails/choose-domain/index.tsx
@@ -62,7 +62,15 @@ export default function ChooseDomain() {
 	};
 
 	return (
-		<PageLayout header={ <PageHeader prefix={ <BackToEmailsPrefix /> } /> } size="small">
+		<PageLayout
+			header={
+				<PageHeader
+					prefix={ <BackToEmailsPrefix /> }
+					description={ __( 'Select a domain to set up email for.' ) }
+				/>
+			}
+			size="small"
+		>
 			<Text size={ 16 }>{ __( 'Which domain name would you like to add a mailbox for?' ) }</Text>
 			<VStack spacing={ 6 }>
 				{ isLoading ? (

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -159,7 +159,14 @@ export default function ChooseEmailSolution() {
 
 	return (
 		<PageLayout
-			header={ <PageHeader prefix={ <BackToEmailsPrefix /> } /> }
+			header={
+				<PageHeader
+					prefix={ <BackToEmailsPrefix /> }
+					description={ __(
+						'Choose between Professional Email and Google Workspace for your domain.'
+					) }
+				/>
+			}
 			size="small"
 			notices={
 				<>

--- a/client/dashboard/emails/layout.tsx
+++ b/client/dashboard/emails/layout.tsx
@@ -16,7 +16,6 @@ export const Layout = ( { children }: PropsWithChildren ) => {
 		<PageLayout
 			header={
 				<PageHeader
-					description={ __( 'Manage emails for your domains.' ) }
 					actions={
 						<>
 							<Button

--- a/client/dashboard/emails/layout.tsx
+++ b/client/dashboard/emails/layout.tsx
@@ -16,6 +16,7 @@ export const Layout = ( { children }: PropsWithChildren ) => {
 		<PageLayout
 			header={
 				<PageHeader
+					description={ __( 'Manage email accounts and mailboxes for your domains.' ) }
 					actions={
 						<>
 							<Button

--- a/client/dashboard/emails/layout.tsx
+++ b/client/dashboard/emails/layout.tsx
@@ -16,7 +16,7 @@ export const Layout = ( { children }: PropsWithChildren ) => {
 		<PageLayout
 			header={
 				<PageHeader
-					description={ __( 'Manage email accounts and mailboxes for your domains.' ) }
+					description={ __( 'Manage emails for your domains.' ) }
 					actions={
 						<>
 							<Button

--- a/client/dashboard/emails/mailboxes-ready/index.tsx
+++ b/client/dashboard/emails/mailboxes-ready/index.tsx
@@ -89,7 +89,11 @@ export default function MailboxesReady() {
 	);
 
 	return (
-		<PageLayout header={ <PageHeader /> } notices={ <MailboxesReadyNotice /> } size="small">
+		<PageLayout
+			header={ <PageHeader description={ __( 'Your email mailboxes are ready to use.' ) } /> }
+			notices={ <MailboxesReadyNotice /> }
+			size="small"
+		>
 			{ status === 'ready' && (
 				<Text size={ 16 }>
 					{ _n(

--- a/client/dashboard/me/apps/index.tsx
+++ b/client/dashboard/me/apps/index.tsx
@@ -7,7 +7,15 @@ import AppsMobileCard from './apps-mobile-card';
 
 export default function Apps() {
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Apps' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Apps' ) }
+					description={ __( 'Download WordPress.com mobile and desktop apps.' ) }
+				/>
+			}
+		>
 			<VStack spacing={ 8 }>
 				<AppsMobileCard />
 				<AppsDesktopCard appSlug="wordpress" />

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -64,7 +64,11 @@ export default function BillingHistory() {
 		<PageLayout
 			size="large"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Billing history' ) } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Billing history' ) }
+					description={ __( 'View receipts and billing history for your purchases.' ) }
+				/>
 			}
 		>
 			<div ref={ ref }>

--- a/client/dashboard/me/billing-monetize-subscriptions/index.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/index.tsx
@@ -97,7 +97,7 @@ function MonetizeSubscriptions() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ getMonetizeSubscriptionsPageTitle() }
-					description={ __( 'Manage your Monetize subscriptions and revenue.' ) }
+					description={ __( 'Manage your Monetize subscriptions.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-monetize-subscriptions/index.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/index.tsx
@@ -97,6 +97,7 @@ function MonetizeSubscriptions() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ getMonetizeSubscriptionsPageTitle() }
+					description={ __( 'Manage your Monetize subscriptions and revenue.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -246,7 +246,7 @@ export default function MonetizeSubscriptionDetails() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ isProduct ? __( 'Product details' ) : __( 'Subscription details' ) }
-					description={ __( 'View and manage details for this Monetize subscription.' ) }
+					description={ __( 'View and manage details for this subscription.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -246,6 +246,7 @@ export default function MonetizeSubscriptionDetails() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 3 } /> }
 					title={ isProduct ? __( 'Product details' ) : __( 'Subscription details' ) }
+					description={ __( 'View and manage details for this Monetize subscription.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -174,6 +174,7 @@ export default function PaymentMethods() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Payment methods' ) }
+					description={ __( 'Manage your saved payment methods and billing information.' ) }
 					actions={
 						<Button
 							__next40pxDefaultSize

--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -71,6 +71,7 @@ function ChangePaymentMethod() {
 							? __( 'Add payment method' )
 							: __( 'Update payment method' )
 					}
+					description={ __( 'Select or update the payment method for this purchase.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -109,7 +109,11 @@ export default function PurchasesList() {
 		<PageLayout
 			size="large"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Active upgrades' ) } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Active upgrades' ) }
+					description={ __( 'View and manage your active plans and purchases.' ) }
+				/>
 			}
 		>
 			<div ref={ ref }>

--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -15,7 +15,15 @@ import { getMonetizeSubscriptionsPageTitle } from '../billing-monetize-subscript
 
 function Billing() {
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Billing' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Billing' ) }
+					description={ __( 'View your billing information and payment methods.' ) }
+				/>
+			}
+		>
 			<VStack spacing={ 4 }>
 				<RouterLinkSummaryButton
 					title={ __( 'Active upgrades' ) }

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -10,7 +10,15 @@ export default function Preferences() {
 	const { optIn } = useAppContext();
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Preferences' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Preferences' ) }
+					description={ __( 'Customize your account preferences and settings.' ) }
+				/>
+			}
+		>
 			{ optIn && <PreferencesNewHostingDashboard /> }
 			<PreferencesLanguageForm />
 			<PreferencesLogin />

--- a/client/dashboard/me/privacy/index.tsx
+++ b/client/dashboard/me/privacy/index.tsx
@@ -9,7 +9,15 @@ import UsageInformationCard from './usage-information-card';
 
 export default function Privacy() {
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Privacy' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Privacy' ) }
+					description={ __( 'Manage your privacy settings and data usage preferences.' ) }
+				/>
+			}
+		>
 			<VStack spacing={ 8 }>
 				<UsageInformationCard />
 				<DpaCard />

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -11,7 +11,15 @@ import SecurityTwoStepAuthSummary from '../security-two-step-auth/summary';
 
 function Security() {
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Security' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Security' ) }
+					description={ __( 'Manage your account security settings and authentication methods.' ) }
+				/>
+			}
+		>
 			<VStack spacing={ 6 }>
 				<SecurityPasswordSummary />
 				<SecurityAccountRecoverySummary />

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -89,7 +89,12 @@ export default function PluginsList() {
 	return (
 		<PageLayout
 			size="large"
-			header={ <PageHeader title={ __( 'Manage plugins' ) } /> }
+			header={
+				<PageHeader
+					title={ __( 'Manage plugins' ) }
+					description={ __( 'Install, activate, and manage plugins across your sites.' ) }
+				/>
+			}
 			notices={ <OptInWelcome tracksContext="plugins" /> }
 		>
 			<DataViewsCard>

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -53,6 +53,7 @@ export default function Plugin() {
 								<TextBlur>{ pluginSlug }</TextBlur>
 							)
 						}
+						description={ __( 'View plugin details and manage installation across your sites.' ) }
 					/>
 				</VStack>
 			}

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -48,7 +48,12 @@ export default function PluginsScheduledUpdatesEdit() {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } /> }
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					description={ __( 'Edit your scheduled plugin update configuration.' ) }
+				/>
+			}
 			notices={
 				error && (
 					<Notice status="error" isDismissible={ false }>

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -228,6 +228,7 @@ export default function PluginsScheduledUpdates() {
 				header={
 					<PageHeader
 						title={ __( 'Scheduled updates' ) }
+						description={ __( 'Schedule automatic plugin updates for your sites.' ) }
 						actions={
 							<RouterLinkButton
 								variant="primary"

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -137,7 +137,11 @@ function SiteBackupDownload() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Download backup' ) }
+					description={ __( 'Download a backup of your site from a specific point in time.' ) }
+				/>
 			}
 		>
 			{ currentStep !== 'success' ? (

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -113,7 +113,11 @@ function SiteBackupRestore() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Site restore' ) } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'Site restore' ) }
+					description={ __( 'Restore your site to a previous point in time.' ) }
+				/>
 			}
 		>
 			{ currentStep !== 'success' ? (

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -193,7 +193,7 @@ export function BackupsListPage() {
 				<PageHeader
 					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
 					description={ __(
-						'Access and restore your site backups — powered by Jetpack VaultPress Backup.'
+						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
 					) }
 					prefix={ isMobileDetailsView && rewindId ? <Breadcrumbs length={ 2 } /> : undefined }
 					actions={ shouldShowActions ? actions : undefined }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -192,6 +192,9 @@ export function BackupsListPage() {
 			header={
 				<PageHeader
 					title={ isMobileDetailsView ? __( 'Backup details' ) : __( 'Backups' ) }
+					description={ __(
+						'Access and restore your site backups — powered by Jetpack VaultPress Backup.'
+					) }
 					prefix={ isMobileDetailsView && rewindId ? <Breadcrumbs length={ 2 } /> : undefined }
 					actions={ shouldShowActions ? actions : undefined }
 				/>

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -61,6 +61,7 @@ function SiteDomains() {
 			header={
 				<PageHeader
 					title={ __( 'Domains' ) }
+					description={ __( 'Manage domains associated with this site.' ) }
 					actions={ <AddDomainButton siteSlug={ site.slug } redirectTo={ redirectTo } /> }
 				/>
 			}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -273,7 +273,7 @@ export default function Sites() {
 				header={
 					<PageHeader
 						title={ __( 'Sites' ) }
-						description={ __( 'View and manage all your WordPress sites in one place.' ) }
+						description={ __( 'View and manage your WordPress sites.' ) }
 						actions={
 							<Button
 								variant="primary"

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -273,7 +273,6 @@ export default function Sites() {
 				header={
 					<PageHeader
 						title={ __( 'Sites' ) }
-						description={ __( 'View and manage your WordPress sites.' ) }
 						actions={
 							<Button
 								variant="primary"

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -273,6 +273,7 @@ export default function Sites() {
 				header={
 					<PageHeader
 						title={ __( 'Sites' ) }
+						description={ __( 'View and manage all your WordPress sites in one place.' ) }
 						actions={
 							<Button
 								variant="primary"

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -71,7 +71,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 	};
 
 	const description = hasPlanFeature( site, HostingFeatures.PHP )
-		? undefined
+		? __( 'Configure the PHP version for your site.' )
 		: sprintf(
 				/* translators: %s: plan name. Eg. 'Personal' */
 				__( 'Sites on the %s plan run on our recommended PHP version.' ),

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -38,7 +38,15 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'SFTP/SSH' ) } /> }
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'SFTP/SSH' ) }
+					description={ __(
+						'Securely access and manage your website files using SFTP, or use SSH for advanced command-line operations and troubleshooting.'
+					) }
+				/>
+			}
 		>
 			<HostingFeatureGatedWithCallout
 				site={ site }

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -137,7 +137,7 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title="WordPress"
-					description={ __( 'Manage your WordPress version and update settings.' ) }
+					description={ __( 'Manage your WordPress version.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -133,7 +133,13 @@ export default function WordPressSettings( { siteSlug }: { siteSlug: string } ) 
 	return (
 		<PageLayout
 			size="small"
-			header={ <PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title="WordPress" /> }
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title="WordPress"
+					description={ __( 'Manage your WordPress version and update settings.' ) }
+				/>
+			}
 		>
 			{ canView ? renderForm() : renderNotice() }
 		</PageLayout>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -40,7 +40,15 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	}
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'Settings' ) }
+					description={ __( "Configure your site's general, server, and security settings." ) }
+				/>
+			}
+		>
 			{ supportsSettings.general && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -45,7 +45,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 			header={
 				<PageHeader
 					title={ __( 'Settings' ) }
-					description={ __( "Configure your site's general, server, and security settings." ) }
+					description={ __( 'Configure your site’s general, server, and security settings.' ) }
 				/>
 			}
 		>


### PR DESCRIPTION
See pgz0xU-mh-p2
Related: DES-290

@michaelpick @lucasmendes-design Here's the super PR with headings added to PageHeaders that don't have a title.

## Proposed Changes

This PR leverages AI to generate descriptions for all `<PageHeader>` components that do not have them.

The goal of this PR is to determine if a description is necessary for a specific view and improve the copy.

## Why are these changes being made?

For most pages, the page header clearly communicates the main purpose of the page. A concise description helps me understand what I can do much faster than scanning the entire page visually.


## Testing Instructions

There are a lot of pages here, I'm not sure what the best testing strategy is for testing. It's a pretty low risk.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
