### PR TITLE
MSD: Modal buttons consistency

### DIFF
--- a/client/dashboard/components/confirm-modal/index.tsx
+++ b/client/dashboard/components/confirm-modal/index.tsx
@@ -65,6 +65,7 @@ export default function ConfirmModal( {
 				<Text>{ children }</Text>
 				<ButtonStack justify="flex-end">
 					<Button
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ onCancel }
 						ref={ cancelButtonRef }
@@ -73,6 +74,7 @@ export default function ConfirmModal( {
 						{ closeButtonLabel }
 					</Button>
 					<Button
+						__next40pxDefaultSize
 						variant="primary"
 						onClick={ handleOnConfirm }
 						isBusy={ confirmButtonProps?.isBusy }

--- a/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
+++ b/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
@@ -161,16 +161,17 @@ export default function RemoveDomainDialog( {
 					</>
 				) }
 				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onCancel }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onCancel }>
 						{ __( 'Cancel' ) }
 					</Button>
 					{ step === 'intro' && (
-						<Button variant="primary" onClick={ onConfirmStep }>
+						<Button __next40pxDefaultSize variant="primary" onClick={ onConfirmStep }>
 							{ __( 'Continue' ) }
 						</Button>
 					) }
 					{ step === 'confirm' && (
 						<Button
+							__next40pxDefaultSize
 							isDestructive={ domainConfirmed }
 							variant="primary"
 							disabled={ ! domainConfirmed }

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -151,7 +151,7 @@ export default function DnsImportDialog( {
 	};
 
 	return (
-		<Modal title={ __( 'Import DNS Records' ) } onRequestClose={ onCancel }>
+		<Modal title={ __( 'Import DNS records' ) } onRequestClose={ onCancel }>
 			<VStack spacing={ 6 }>
 				<Text>
 					{ __(
@@ -172,6 +172,7 @@ export default function DnsImportDialog( {
 				<ButtonStack justify="flex-end">
 					<Button
 						__next40pxDefaultSize
+						variant="tertiary"
 						onClick={ onCancel }
 						disabled={ updateDnsMutation.isPending }
 					>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -308,7 +308,7 @@ export default function DomainDns() {
 									} }
 									__next40pxDefaultSize
 								>
-									{ __( 'Add Record' ) }
+									{ __( 'Add record' ) }
 								</Button>
 								<DnsActionsMenu
 									hasDefaultARecords={ hasDefaultARecordsValue }

--- a/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-a-records.tsx
@@ -33,7 +33,7 @@ export default function RestoreDefaultARecords( {
 			<VStack spacing={ 6 }>
 				<Text>{ targetPlatformMessage }</Text>
 				<ButtonStack justify="flex-end">
-					<Button __next40pxDefaultSize onClick={ onCancel } isBusy={ isBusy }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onCancel } isBusy={ isBusy }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>

--- a/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-cname-record.tsx
@@ -28,7 +28,7 @@ export default function RestoreDefaultCnameRecord( {
 			<VStack spacing={ 6 }>
 				<Text>{ __( 'In case a www CNAME record already exists, it will be deleted.' ) }</Text>
 				<ButtonStack justify="flex-end">
-					<Button __next40pxDefaultSize onClick={ onCancel }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onCancel }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>

--- a/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
+++ b/client/dashboard/domains/domain-dns/restore-default-email-records.tsx
@@ -30,7 +30,7 @@ export default function RestoreDefaultEmailRecords( {
 					{ __( 'This will restore SPF, DKIM and DMARC records to their default configurations.' ) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button __next40pxDefaultSize onClick={ onCancel }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onCancel }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button __next40pxDefaultSize variant="primary" isBusy={ isBusy } onClick={ onConfirm }>

--- a/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
+++ b/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
@@ -53,7 +53,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 		const registrar = ipsTagList.find( ( item ) => item.tag === ipsTag );
 		return (
 			<Modal
-				title={ __( 'Transfer Confirmation' ) }
+				title={ __( 'Transfer confirmation' ) }
 				onRequestClose={ () => setIsDialogOpen( false ) }
 			>
 				<VStack spacing={ 6 }>
@@ -78,12 +78,15 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 					</Text>
 					<ButtonStack justify="flex-end">
 						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
 							onClick={ () => setIsDialogOpen( false ) }
 							disabled={ saveIpsTagMutation.isPending }
 						>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							isBusy={ saveIpsTagMutation.isPending }
 							isDestructive

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -187,7 +187,7 @@ export default function TransferDomainToAnyUser() {
 	const renderConfirmationDialog = () => {
 		return (
 			<Modal
-				title={ __( 'Confirm Transfer' ) }
+				title={ __( 'Confirm transfer' ) }
 				onRequestClose={ () => setIsTransferDialogOpen( false ) }
 			>
 				<VStack spacing={ 6 }>
@@ -203,7 +203,7 @@ export default function TransferDomainToAnyUser() {
 					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
-							variant="secondary"
+							variant="tertiary"
 							onClick={ () => setIsTransferDialogOpen( false ) }
 							disabled={ isUpdatingDomainTransferRequest }
 						>
@@ -228,7 +228,7 @@ export default function TransferDomainToAnyUser() {
 	const renderCancelConfirmationDialog = () => {
 		return (
 			<Modal
-				title={ __( 'Confirm Cancel Transfer' ) }
+				title={ __( 'Confirm cancel transfer' ) }
 				onRequestClose={ () => setIsCancelDialogOpen( false ) }
 			>
 				<VStack spacing={ 6 }>
@@ -243,7 +243,7 @@ export default function TransferDomainToAnyUser() {
 					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
-							variant="secondary"
+							variant="tertiary"
 							onClick={ () => setIsCancelDialogOpen( false ) }
 							disabled={ isDeletingDomainTransferRequest }
 						>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
@@ -104,13 +104,15 @@ export default function DomainTransferToOtherSite() {
 						) }
 						<ButtonStack justify="flex-end">
 							<Button
-								variant="secondary"
+								__next40pxDefaultSize
+								variant="tertiary"
 								disabled={ isTransferringDomain }
 								onClick={ () => setIsConfirmDialogOpen( false ) }
 							>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
+								__next40pxDefaultSize
 								variant="primary"
 								isBusy={ isTransferringDomain }
 								disabled={ isTransferringDomain }

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -191,7 +191,7 @@ export default function TransferDomainToOtherUser() {
 		const selectedUser = availableUsers.find( ( user ) => user.id.toString() === formData.user );
 
 		return (
-			<Modal title={ __( 'Confirm Transfer' ) } onRequestClose={ () => setIsDialogOpen( false ) }>
+			<Modal title={ __( 'Confirm transfer' ) } onRequestClose={ () => setIsDialogOpen( false ) }>
 				<VStack spacing={ 6 }>
 					<Text>
 						{ createInterpolateElement(
@@ -211,7 +211,7 @@ export default function TransferDomainToOtherUser() {
 					<ButtonStack justify="flex-end">
 						<Button
 							__next40pxDefaultSize
-							variant="secondary"
+							variant="tertiary"
 							onClick={ () => setIsDialogOpen( false ) }
 							disabled={ isDomainTransferringToOtherUser }
 						>
@@ -225,7 +225,7 @@ export default function TransferDomainToOtherUser() {
 							onClick={ onConfirm }
 							disabled={ isDomainTransferringToOtherUser }
 						>
-							{ __( 'Confirm Transfer' ) }
+							{ __( 'Confirm transfer' ) }
 						</Button>
 					</ButtonStack>
 				</VStack>
@@ -254,7 +254,7 @@ export default function TransferDomainToOtherUser() {
 								type="submit"
 								disabled={ formData.user === '' }
 							>
-								{ isMapping ? __( 'Transfer Domain Connection' ) : __( 'Transfer Domain' ) }
+								{ isMapping ? __( 'Transfer domain connection' ) : __( 'Transfer domain' ) }
 							</Button>
 						</HStack>
 					</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
@@ -40,10 +40,11 @@ const RetentionConfirmationDialog: React.FC< RetentionConfirmationDialogProps > 
 						) }
 					</p>
 					<ButtonStack>
-						<Button key="cancel" onClick={ onClose }>
+						<Button __next40pxDefaultSize variant="tertiary" key="cancel" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							key="confirm"
 							onClick={ onConfirmation }
 							variant="primary"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/marketplace-subscriptions-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/marketplace-subscriptions-dialog.tsx
@@ -61,10 +61,16 @@ const MarketPlaceSubscriptionsWarning = ( {
 							) }
 					</p>
 					<ButtonStack justify="flex-end">
-						<Button onClick={ closeDialog } disabled={ false /*updateDnsMutation.isPending*/ }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ closeDialog }
+							disabled={ false /*updateDnsMutation.isPending*/ }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							isBusy={ /*updateDnsMutation.isPending*/ false }
 							onClick={ removePlan }

--- a/client/dashboard/me/profile-deletion/alternatives-modal.tsx
+++ b/client/dashboard/me/profile-deletion/alternatives-modal.tsx
@@ -117,10 +117,10 @@ export default function AlternativesModal( {
 					) ) }
 				</ActionList>
 				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary" onClick={ onContinue }>
+					<Button __next40pxDefaultSize variant="primary" onClick={ onContinue }>
 						{ __( 'Continue' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/me/profile-deletion/final-confirmation-modal.tsx
+++ b/client/dashboard/me/profile-deletion/final-confirmation-modal.tsx
@@ -83,10 +83,16 @@ export default function FinalConfirmationModal( {
 						} }
 					/>
 					<ButtonStack justify="flex-end">
-						<Button variant="tertiary" onClick={ onClose } disabled={ isDeleting }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onClose }
+							disabled={ isDeleting }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							isDestructive
 							type="submit"

--- a/client/dashboard/me/profile-deletion/purchases-modal.tsx
+++ b/client/dashboard/me/profile-deletion/purchases-modal.tsx
@@ -30,10 +30,10 @@ export default function PurchasesModal( { onClose }: PurchasesModalProps ) {
 					) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Back' ) }
 					</Button>
-					<RouterLinkButton variant="primary" to={ purchasesRoute.fullPath }>
+					<RouterLinkButton __next40pxDefaultSize variant="primary" to={ purchasesRoute.fullPath }>
 						{ __( 'Manage purchases' ) }
 					</RouterLinkButton>
 				</ButtonStack>

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/disable-two-step-dialog.tsx
@@ -198,10 +198,11 @@ export default function DisableTwoStepDialog( { onClose }: { onClose: () => void
 					) }
 
 					<ButtonStack justify="flex-end">
-						<Button variant="tertiary" onClick={ onClose }>
+						<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							isDestructive
 							variant="primary"
 							onClick={ handleSubmit }

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/register-application-password.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/register-application-password.tsx
@@ -135,6 +135,7 @@ export default function RegisterApplicationPassword( { onClose }: { onClose: () 
 						/>
 						<ButtonStack justify="flex-end">
 							<Button
+								__next40pxDefaultSize
 								variant="tertiary"
 								onClick={ onClose }
 								disabled={ isRegisteringApplicationPassword }
@@ -142,6 +143,7 @@ export default function RegisterApplicationPassword( { onClose }: { onClose: () 
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
+								__next40pxDefaultSize
 								variant="primary"
 								type="submit"
 								isBusy={ isRegisteringApplicationPassword }

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -136,10 +136,16 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 							} }
 						/>
 						<ButtonStack justify="flex-end">
-							<Button variant="tertiary" onClick={ onClose } disabled={ isRegisteringSecurityKey }>
+							<Button
+								__next40pxDefaultSize
+								variant="tertiary"
+								onClick={ onClose }
+								disabled={ isRegisteringSecurityKey }
+							>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
+								__next40pxDefaultSize
 								variant="primary"
 								type="submit"
 								isBusy={ isRegisteringSecurityKey }

--- a/client/dashboard/sites/deployments-list/trigger-deployment-modal-form.tsx
+++ b/client/dashboard/sites/deployments-list/trigger-deployment-modal-form.tsx
@@ -163,14 +163,14 @@ export function TriggerDeploymentModalForm( {
 				/>
 
 				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose } __next40pxDefaultSize>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
+						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
 						disabled={ ! selectedDeployment || isCreatingCodeDeploymentRun }
-						__next40pxDefaultSize
 					>
 						{ __( 'Deploy to production' ) }
 					</Button>

--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -77,6 +77,7 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 				</Text>
 				<ButtonStack justify="flex-end">
 					<Button
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ () => {
 							onClose();
@@ -87,7 +88,12 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 					>
 						{ __( 'Don’t cancel migration' ) }
 					</Button>
-					<Button variant="primary" isBusy={ mutation.isPending } onClick={ handleConfirmCancel }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ mutation.isPending }
+						onClick={ handleConfirmCancel }
+					>
 						{ __( 'Cancel migration' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/started-difm-content-info.tsx
@@ -89,6 +89,7 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 				<Text>{ modalProps.description }</Text>
 				<ButtonStack justify="flex-end">
 					<Button
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ () => {
 							onClose();
@@ -99,7 +100,12 @@ function CancellationModal( { site, onClose }: { site: Site; onClose: () => void
 					>
 						{ __( 'Don’t cancel migration' ) }
 					</Button>
-					<Button variant="primary" isBusy={ mutation.isPending } onClick={ handleConfirmCancel }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ mutation.isPending }
+						onClick={ handleConfirmCancel }
+					>
 						{ modalProps.buttonText }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -183,8 +183,14 @@ const PerformanceInsightFeedback = ( { chatId, hash }: { chatId: number; hash: s
 									} }
 								/>
 								<ButtonStack justify="flex-end">
-									<Button onClick={ handleCloseFeedbackModal }>{ __( 'Cancel' ) }</Button>
-									<Button variant="primary" type="submit">
+									<Button
+										__next40pxDefaultSize
+										variant="tertiary"
+										onClick={ handleCloseFeedbackModal }
+									>
+										{ __( 'Cancel' ) }
+									</Button>
+									<Button __next40pxDefaultSize variant="primary" type="submit">
 										{ __( 'Submit' ) }
 									</Button>
 								</ButtonStack>

--- a/client/dashboard/sites/scan/components/bulk-fix-threats-modal.tsx
+++ b/client/dashboard/sites/scan/components/bulk-fix-threats-modal.tsx
@@ -128,10 +128,11 @@ export function BulkFixThreatsModal( { items, closeModal, site }: BulkFixThreats
 			{ canBulkFix && bulkFixableSection }
 			{ remainingThreats.length > 0 && remainingThreatsSection }
 			<ButtonStack justify="flex-end">
-				<Button variant="tertiary" onClick={ closeModal }>
+				<Button __next40pxDefaultSize variant="tertiary" onClick={ closeModal }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
+					__next40pxDefaultSize
 					variant="primary"
 					onClick={ handleFixThreats }
 					isBusy={ isFixing }

--- a/client/dashboard/sites/settings-database/reset-password-modal.tsx
+++ b/client/dashboard/sites/settings-database/reset-password-modal.tsx
@@ -47,8 +47,15 @@ export default function ResetPasswordModal( {
 					{ __( 'Are you sure you want to restore the default password of your database?' ) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button onClick={ onClose }>{ __( 'Cancel' ) }</Button>
-					<Button variant="primary" isBusy={ isRestoring } onClick={ handleRestore }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ isRestoring }
+						onClick={ handleRestore }
+					>
 						{ __( 'Restore' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -82,7 +82,7 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 	const renderPrimaryButton = () => {
 		if ( isAtomicRemovalInProgress ) {
 			return (
-				<Button variant="primary" onClick={ onClose }>
+				<Button __next40pxDefaultSize variant="primary" onClick={ onClose }>
 					{ __( 'OK' ) }
 				</Button>
 			);
@@ -90,20 +90,28 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 
 		if ( p2HubP2Count ) {
 			return (
-				<Button variant="primary" href={ site.URL }>
+				<Button __next40pxDefaultSize variant="primary" href={ site.URL }>
 					{ __( 'Manage P2s' ) }
 				</Button>
 			);
 		}
 
 		if ( isTrialSite( site ) ) {
-			<Button variant="primary" href={ `/purchases/subscriptions/${ site.slug }` }>
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				href={ `/purchases/subscriptions/${ site.slug }` }
+			>
 				{ __( 'Cancel trial' ) }
 			</Button>;
 		}
 
 		return (
-			<Button variant="primary" href={ `/purchases/subscriptions/${ site.slug }` }>
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				href={ `/purchases/subscriptions/${ site.slug }` }
+			>
 				{ __( 'Manage purchases' ) }
 			</Button>
 		);
@@ -114,7 +122,7 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 			<Text as="p">{ renderWarningContent() }</Text>
 			<ButtonStack justify="flex-end">
 				{ ! isAtomicRemovalInProgress && (
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 				) }
@@ -208,10 +216,16 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 						} }
 					/>
 					<ButtonStack justify="flex-end">
-						<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							disabled={ mutation.isPending }
+							onClick={ onClose }
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							type="submit"
 							isDestructive

--- a/client/dashboard/sites/site-launch-button/agency-development-site-launch-modal.tsx
+++ b/client/dashboard/sites/site-launch-button/agency-development-site-launch-modal.tsx
@@ -25,10 +25,20 @@ export default function AgencyDevelopmentSiteLaunchModal( {
 					{ __( 'After launch, we’ll bill your agency in the next billing cycle.' ) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button disabled={ isLaunching } onClick={ onClose }>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						disabled={ isLaunching }
+						onClick={ onClose }
+					>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary" isBusy={ isLaunching } onClick={ onLaunch }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isBusy={ isLaunching }
+						onClick={ onLaunch }
+					>
 						{ __( 'Launch site' ) }
 					</Button>
 				</ButtonStack>

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -48,10 +48,11 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 				</Text>
 			</VStack>
 			<ButtonStack justify="flex-end" expanded={ false }>
-				<Button variant="tertiary" onClick={ onClose }>
+				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
+					__next40pxDefaultSize
 					variant="primary"
 					href={ `/purchases/subscriptions/${ site.slug }` }
 					onClick={ () =>
@@ -78,10 +79,11 @@ function ContentSiteOwner( { site, onClose }: ContentInfoProps ) {
 				</Text>
 			</VStack>
 			<ButtonStack justify="flex-end" expanded={ false }>
-				<Button variant="tertiary" onClick={ onClose }>
+				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<RouterLinkButton
+					__next40pxDefaultSize
 					variant="primary"
 					to={ `/sites/${ site.slug }/settings/transfer-site` }
 					onClick={ () =>
@@ -179,10 +181,11 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 					} }
 				/>
 				<ButtonStack justify="flex-end" expanded={ false }>
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
+						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
 						disabled={ ! isConfirmed }

--- a/client/dashboard/sites/site-reset-modal/index.tsx
+++ b/client/dashboard/sites/site-reset-modal/index.tsx
@@ -36,7 +36,7 @@ function ErrorContent( { message, onClose }: { message: string; onClose: () => v
 		<VStack spacing={ 6 }>
 			<Text>{ message }</Text>
 			<ButtonStack justify="flex-end">
-				<Button variant="primary" onClick={ onClose }>
+				<Button __next40pxDefaultSize variant="primary" onClick={ onClose }>
 					{ __( 'OK' ) }
 				</Button>
 			</ButtonStack>
@@ -132,10 +132,11 @@ function SiteResetContent( {
 						} }
 					/>
 					<HStack spacing={ 4 } justify="flex-end">
-						<Button variant="tertiary" onClick={ onClose }>
+						<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 							{ __( 'Cancel' ) }
 						</Button>
 						<Button
+							__next40pxDefaultSize
 							variant="primary"
 							type="submit"
 							isBusy={ isBusy }

--- a/client/dashboard/sites/staging-site-delete-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/index.tsx
@@ -76,10 +76,16 @@ export default function StagingSiteDeleteModal( {
 					) }
 				</Text>
 				<ButtonStack justify="flex-end">
-					<Button variant="tertiary" disabled={ mutation.isPending } onClick={ onClose }>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						disabled={ mutation.isPending }
+						onClick={ onClose }
+					>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
+						__next40pxDefaultSize
 						variant="primary"
 						isDestructive
 						isBusy={ mutation.isPending }

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -9,7 +9,6 @@ import {
 	ExternalLink,
 	Modal,
 	Icon,
-	CardDivider,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -32,6 +31,7 @@ import {
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
 import { ButtonStack } from '../../components/button-stack';
+import { CardDivider } from '../../components/card';
 import Environment, { EnvironmentType } from '../../components/environment';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
@@ -595,6 +595,7 @@ function StagingSiteSyncModalInner( {
 
 						<ButtonStack justify="flex-end">
 							<Button
+								__next40pxDefaultSize
 								variant="tertiary"
 								onClick={ handleClose }
 								disabled={ pullMutation.isPending || pushMutation.isPending }
@@ -602,6 +603,7 @@ function StagingSiteSyncModalInner( {
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
+								__next40pxDefaultSize
 								variant="primary"
 								onClick={ handleConfirm }
 								disabled={ isSubmitDisabled }

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -158,10 +158,15 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 				</VStack>
 
 				<VStack spacing={ 2 } direction="row" justify="flex-end">
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 						{ __( 'Cancel' ) }
 					</Button>
-					<Button variant="primary" onClick={ handleBuyStorage } disabled={ ! selectedTier }>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ handleBuyStorage }
+						disabled={ ! selectedTier }
+					>
 						{ __( 'Buy storage' ) }
 					</Button>
 				</VStack>


### PR DESCRIPTION
## Proposed Changes

This PR updates modal buttons as follow:

* Set __next40pxDefaultSize to enforce 40px height
* Set `variant: tertiary` for cancel buttons 

Bonus: Enforce sentence case for modal titles. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code check should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
