### PR TITLE
Sites: Fix domains link for the backport

### DIFF
--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -5,6 +5,7 @@ import { backup, wordpress } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { isP2, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canManageSite } from '../features';
 import type { Site } from '@automattic/api-core';
@@ -46,12 +47,17 @@ export function useActions(): Action< Site >[] {
 		},
 		{
 			id: 'domains',
-			label: __( 'Domains' ),
+			label: isDashboardBackport() ? __( 'Domains ↗' ) : __( 'Domains' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				if ( isDashboardBackport() ) {
+					window.open( `/domains/manage/${ site.slug }`, '_blank' );
+					return;
+				}
+
 				router.navigate( { to: siteDomainsRoute.fullPath, params: { siteSlug: site.slug } } );
 			},
-			isEligible: ( item: Site ) => canManageSite( item ),
+			isEligible: ( item: Site ) => ! isSelfHostedJetpackConnected( item ) && canManageSite( item ),
 		},
 		{
 			id: 'jetpack-cloud',
@@ -86,7 +92,7 @@ export function useActions(): Action< Site >[] {
 				const site = sites[ 0 ];
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
-			isEligible: ( item: Site ) => canManageSite( item ),
+			isEligible: ( item: Site ) => ! isSelfHostedJetpackConnected( item ) && canManageSite( item ),
 		},
 		{
 			id: 'restore',


### PR DESCRIPTION
## Proposed Changes

#106705 updated the domains link to the site-level domains tab, and did not account that the sites list backport does not have the site-level domains tab. This PR makes it so that the backport goes to /domains/manage/:siteSlug instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
