### PR TITLE
MSD: Disable the scroll on body when the switcher opens

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -1,4 +1,9 @@
-import { __experimentalHStack as HStack, Dropdown, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Dropdown,
+	Button,
+	ScrollLock,
+} from '@wordpress/components';
 import { chevronDownSmall } from '@wordpress/icons';
 import SwitcherContent from './switcher-content';
 import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
@@ -60,17 +65,20 @@ export default function Switcher< T >( {
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<SwitcherContent
-					items={ items }
-					searchableFields={ searchableFields }
-					getItemUrl={ getItemUrl }
-					renderItemMedia={ renderItemMedia }
-					renderItemTitle={ renderItemTitle }
-					renderItemDescription={ renderItemDescription }
-					onClose={ onClose }
-				>
-					{ children?.( { onClose } ) }
-				</SwitcherContent>
+				<>
+					<ScrollLock />
+					<SwitcherContent
+						items={ items }
+						searchableFields={ searchableFields }
+						getItemUrl={ getItemUrl }
+						renderItemMedia={ renderItemMedia }
+						renderItemTitle={ renderItemTitle }
+						renderItemDescription={ renderItemDescription }
+						onClose={ onClose }
+					>
+						{ children?.( { onClose } ) }
+					</SwitcherContent>
+				</>
 			) }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-832

## Proposed Changes

* Disable the scroll on body when the switcher opens. We can also switch to `Menu` component to resolve it. However, it seems fine to use `ScrollLock`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the switcher is open, the user can navigate between options using the keyboard. If the page body is scrollable, keyboard navigation may cause the body to scroll as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site
* Open the site switcher
* Navigate by keyboard
* Ensure the body won't be scrolled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
