### PR TITLE
A4A > Tiers: Add an early access badge on the agency tier card on the Overview page

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/ui';
 import {
 	Card,
 	CardBody,
@@ -50,9 +51,15 @@ export default function AgencyTierProgressCard( {
 							{ __( 'Your agency tier and benefits' ) }
 						</Heading>
 						<VStack spacing={ 3 }>
+							{ isEarlyAccess && (
+								<Badge
+									style={ { width: 'fit-content' } }
+									intent="default"
+									children={ __( 'Early access' ) }
+								/>
+							) }
 							<Heading level={ 3 } weight={ 500 }>
 								{ currentTier.name }
-								{ isEarlyAccess && ` (${ __( 'Early access' ) })` }
 							</Heading>
 							<Text color="#757575">
 								{ isEarlyAccess


### PR DESCRIPTION
## Proposed Changes

This PR adds an early access badge on the agency tier card on the Overview page.

## Why are these changes being made?

* UI enhancement

## Testing Instructions

* Set the "Premier Partner" tier to your agency using the MC tool
* Open the A4A live link > Verify the "Early access" badge is shown 
* Set the "Emerging Partner" tier to your agency using the MC tool
* Verify the "Early access" badge is now shown 

<img width="506" height="308" alt="Screenshot 2025-11-12 at 4 42 14 PM" src="https://github.com/user-attachments/assets/160ea594-4c8e-4782-93f6-0d9126c54778" />

<img width="506" height="278" alt="Screenshot 2025-11-12 at 4 42 42 PM" src="https://github.com/user-attachments/assets/e0819060-3e36-4372-91bb-a16ee9f37204" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
