### PR TITLE
Forms: add form responses notification setting

### DIFF
--- a/client/dashboard/me/notifications-sites/helpers/translations.ts
+++ b/client/dashboard/me/notifications-sites/helpers/translations.ts
@@ -13,6 +13,7 @@ const translations = {
 	draft_post_prompt: __( 'Draft post reminders' ),
 	store_order: __( 'New order' ),
 	comment_reply: __( 'Replies to my comments' ),
+	form_response: __( 'Form responses' ),
 } as const;
 
 type TranslationKey = keyof typeof translations;

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/index.tsx
@@ -131,6 +131,11 @@ export const DevicesSettings = ( { siteId }: { siteId: number } ) => {
 				label: getFieldLabel( 'scheduled_publicize' ),
 				value: settings?.scheduled_publicize ?? false,
 			},
+			{
+				id: 'form_response',
+				label: getFieldLabel( 'form_response' ),
+				value: settings?.form_response ?? false,
+			},
 		],
 		[ settings ]
 	);

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
@@ -74,6 +74,7 @@ const buildNotificationSettings = ( blogId: number, devices: DeviceNotificationS
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 				},
 				devices: devices,
 				email: {
@@ -89,6 +90,7 @@ const buildNotificationSettings = ( blogId: number, devices: DeviceNotificationS
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 				},
 			},
 		],
@@ -123,6 +125,7 @@ const buildDeviceSettings = (
 		draft_post_prompt: false,
 		recommended_blog: false,
 		comment_reply: false,
+		form_response: false,
 		device_id: 0,
 		...settings,
 	} as DeviceNotificationSettings;
@@ -206,6 +209,10 @@ describe( 'DevicesSettings', () => {
 
 		expect(
 			await screen.findByRole( 'checkbox', { name: getFieldLabel( 'new_comment' ) } )
+		).not.toBeChecked();
+
+		expect(
+			await screen.findByRole( 'checkbox', { name: getFieldLabel( 'form_response' ) } )
 		).not.toBeChecked();
 	} );
 

--- a/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
@@ -76,6 +76,7 @@ const buildEmailNotificationSettings = (
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 				},
 				devices: [],
 				email: {
@@ -91,6 +92,7 @@ const buildEmailNotificationSettings = (
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 					...settings,
 				},
 			},

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/index.tsx
@@ -138,6 +138,11 @@ export const WebSettings = ( { siteId }: { siteId: number } ) => {
 				label: getFieldLabel( 'blogging_prompt' ),
 				value: timelineSettings?.blogging_prompt ?? false,
 			},
+			{
+				id: 'form_response',
+				label: getFieldLabel( 'form_response' ),
+				value: timelineSettings?.form_response ?? false,
+			},
 		],
 		[ timelineSettings ]
 	);

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
@@ -76,6 +76,7 @@ const buildWebNotificationSettings = (
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 					...settings,
 				},
 				devices: [],
@@ -92,6 +93,7 @@ const buildWebNotificationSettings = (
 					draft_post_prompt: false,
 					store_order: false,
 					recommended_blog: false,
+					form_response: false,
 				},
 			},
 		],
@@ -125,6 +127,10 @@ describe( 'WebSettings', () => {
 
 		expect(
 			await screen.findByRole( 'checkbox', { name: getFieldLabel( 'new_comment' ) } )
+		).not.toBeChecked();
+
+		expect(
+			await screen.findByRole( 'checkbox', { name: getFieldLabel( 'form_response' ) } )
 		).not.toBeChecked();
 	} );
 

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -69,6 +69,7 @@ class BlogSettings extends Component {
 			'scheduled_publicize',
 			'blogging_prompt',
 			'draft_post_prompt',
+			'form_response',
 		];
 
 		if ( site.options?.woocommerce_is_active ) {

--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,4 +1,4 @@
 export const NOTIFICATIONS_EXCEPTIONS = {
 	timeline: [ 'draft_post_prompt', 'recommended_blog' ],
-	email: [ 'achievement', 'scheduled_publicize', 'store_order' ],
+	email: [ 'achievement', 'scheduled_publicize', 'store_order', 'form_response' ],
 };

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -21,6 +21,7 @@ export const settingLabels = {
 	blogging_prompt: () => i18n.translate( 'Daily writing prompts' ),
 	draft_post_prompt: () => i18n.translate( 'Draft post reminders' ),
 	store_order: () => i18n.translate( 'New order' ),
+	form_response: () => i18n.translate( 'Form responses' ),
 };
 
 export const getLabelForStream = ( stream ) =>

--- a/packages/api-core/src/me-notification-settings/types.ts
+++ b/packages/api-core/src/me-notification-settings/types.ts
@@ -37,6 +37,7 @@ export interface NotificationSettings {
 	draft_post_prompt: boolean;
 	recommended_blog: boolean;
 	comment_reply: boolean;
+	form_response: boolean;
 }
 
 export interface DeviceNotificationSettings extends NotificationSettings {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of FORMS-350

## Proposed Changes

* Added Form responses notification setting.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We've added form response notifications and we want to allow users to mute those notifications per site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
<img width="1053" height="964" alt="Screenshot 2025-11-14 at 13 45 21" src="https://github.com/user-attachments/assets/f1f60352-928d-40f0-8544-de0d1f65bc98" />

After:
<img width="1056" height="922" alt="Screenshot 2025-11-14 at 13 47 15" src="https://github.com/user-attachments/assets/c546a8eb-133a-4dc9-a6a2-ffa9dd809863" />

* You can use the Calypso Link below.
* Go to /me/notifications
* Check that there is a new row for `Form responses` on each of the blog cards under Notifications.
* Confirm that the checkboxes are checked by default.
* Uncheck the mobile notification checkbox and try to submit a form response on a form that has notifications set up.
<img width="291" height="629" alt="Screenshot 2025-10-28 at 17 48 46" src="https://github.com/user-attachments/assets/de07a8df-f75f-4259-a5b1-b3bde9da5100" />

* Confirm that you don't receive a push notification in this case.
* Check the mobile push notification back again and try to submit a form response to confirm that you now receive the notification.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
