### PR TITLE
MSD: Implement transient filters in emails DataViews

### DIFF
--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -2,7 +2,7 @@ import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automatt
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Filter, View } from '@wordpress/dataviews';
 
 interface UseViewOptions {
@@ -65,17 +65,11 @@ export function usePersistentView( {
 
 	const [ transientFilters, setTransientFilters ] = useState< Filter[] | undefined >( undefined );
 
-	const didAddTransientFilters = useRef( false );
 	useEffect( () => {
-		if ( didAddTransientFilters.current ) {
-			return;
-		}
 		if ( transientFilterFields.length === 0 ) {
 			return;
 		}
-		didAddTransientFilters.current = true;
 
-		// This is done only on the initial page load.
 		setTransientFilters(
 			transientFilterFields.map(
 				( field ) =>
@@ -86,7 +80,10 @@ export function usePersistentView( {
 					} ) as Filter
 			)
 		);
-	}, [ transientFilterFields, queryParams ] );
+
+		// Set transient filters once on initial page load.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ JSON.stringify( transientFilterFields ) ] );
 
 	// Merge transient properties and filters from query params into the view.
 	const view: View = useMemo(

--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -2,8 +2,8 @@ import { userPreferenceQuery, userPreferenceOptimisticMutation } from '@automatt
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { useCallback, useMemo } from 'react';
-import type { View } from '@wordpress/dataviews';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Filter, View } from '@wordpress/dataviews';
 
 interface UseViewOptions {
 	/**
@@ -22,6 +22,12 @@ interface UseViewOptions {
 	 * If passed, transient properties (`page` and `search`) are synced to the URL query params.
 	 */
 	queryParams?: any;
+
+	/**
+	 * Fields that should become transient filters when present in the URL query params.
+	 * The returned view's `filters` will be merged with the transient filters.
+	 */
+	queryParamFilterFields?: string[];
 }
 
 /**
@@ -29,7 +35,12 @@ interface UseViewOptions {
  * Transient properties (`page` and `search`) are synced to the URL query params,
  * while the rest of the properties is persisted to Calypso preferences.
  */
-export function usePersistentView( { slug, defaultView, queryParams }: UseViewOptions ): {
+export function usePersistentView( {
+	slug,
+	defaultView,
+	queryParams,
+	queryParamFilterFields = [],
+}: UseViewOptions ): {
 	view: View;
 	updateView: ( newView: View ) => void;
 	resetView?: () => void;
@@ -46,33 +57,88 @@ export function usePersistentView( { slug, defaultView, queryParams }: UseViewOp
 	const page = parseInt( queryParams?.page ) || baseView.page || 1;
 	const search = queryParams?.search || baseView.search || '';
 
-	// Merge transient properties from query params into the view.
+	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
+
+	const transientFilterFields = queryParamFilterFields.filter(
+		( field ) => queryParams && queryParams[ field ] !== undefined
+	);
+
+	const [ transientFilters, setTransientFilters ] = useState< Filter[] | undefined >( undefined );
+
+	const didAddTransientFilters = useRef( false );
+	useEffect( () => {
+		if ( didAddTransientFilters.current ) {
+			return;
+		}
+		if ( transientFilterFields.length === 0 ) {
+			return;
+		}
+		didAddTransientFilters.current = true;
+
+		// This is done only on the initial page load.
+		setTransientFilters(
+			transientFilterFields.map(
+				( field ) =>
+					( {
+						field,
+						operator: 'is',
+						value: queryParams[ field ],
+					} ) as Filter
+			)
+		);
+	}, [ transientFilterFields, queryParams ] );
+
+	// Merge transient properties and filters from query params into the view.
 	const view: View = useMemo(
 		() => ( {
 			...baseView,
-			page,
-			search,
+			...transientProperties,
+			...( transientFilters && {
+				filters: [
+					...( baseView.filters || [] ).filter(
+						( filter ) => ! transientFilterFields.includes( filter.field )
+					),
+					...transientFilters,
+				],
+			} ),
 		} ),
-		[ baseView, page, search ]
+		[ baseView, transientProperties, transientFilterFields, transientFilters ]
 	);
 
 	const updateView = useCallback(
 		( newView: View ) => {
 			if ( queryParams ) {
-				// Sync transient properties to the URL query params.
-				const newQueryParams = {
+				const newTransientFilterFields = transientFilterFields.filter(
+					( field ) =>
+						newView.filters?.some(
+							( filter ) => filter.field === field && filter.value === queryParams[ field ]
+						)
+				);
+
+				const newTransientProperties = {
 					page: newView.page,
 					search: newView.search,
 				};
-				if ( ! fastDeepEqual( newQueryParams, { page, search } ) ) {
+
+				if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
+					setTransientFilters( undefined );
 					navigate( {
-						search: mergeQueryParams( queryParams, newQueryParams ),
+						search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
+						replace: true,
+					} );
+				} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
+					navigate( {
+						search: mergeQueryParamsWithTransientProperties( queryParams, newTransientProperties ),
 					} );
 				}
 			}
 
+			let viewToPersist = newView;
+			viewToPersist = removeTransientPropertiesFromView( viewToPersist );
+			viewToPersist = removeTransientFiltersFromView( viewToPersist, transientFilterFields );
+			viewToPersist = removeEmptyFiltersFromView( viewToPersist );
+
 			// Persist view if different from baseView.
-			const viewToPersist = removeQueryParamsFromView( newView );
 			if ( ! fastDeepEqual( viewToPersist, baseView ) ) {
 				if ( fastDeepEqual( viewToPersist, defaultView ) ) {
 					persistView( undefined );
@@ -81,7 +147,15 @@ export function usePersistentView( { slug, defaultView, queryParams }: UseViewOp
 				}
 			}
 		},
-		[ page, search, queryParams, navigate, baseView, defaultView, persistView ]
+		[
+			queryParams,
+			transientProperties,
+			transientFilterFields,
+			navigate,
+			baseView,
+			defaultView,
+			persistView,
+		]
 	);
 
 	const isViewModified = !! persistedView;
@@ -93,7 +167,7 @@ export function usePersistentView( { slug, defaultView, queryParams }: UseViewOp
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
 }
 
-function removeQueryParamsFromView( view: View ): Omit< View, 'page' | 'search' > {
+function removeTransientPropertiesFromView( view: View ): Omit< View, 'page' | 'search' > {
 	const viewToPersist = { ...view };
 
 	delete viewToPersist.page;
@@ -102,7 +176,31 @@ function removeQueryParamsFromView( view: View ): Omit< View, 'page' | 'search' 
 	return viewToPersist;
 }
 
-function mergeQueryParams(
+function removeTransientFiltersFromView( view: View, transientFilterFields: string[] ): View {
+	return {
+		...view,
+		filters: view.filters?.filter( ( filter ) => ! transientFilterFields.includes( filter.field ) ),
+	};
+}
+
+function removeEmptyFiltersFromView( view: View ): View {
+	if ( ( view.filters || [] ).length === 0 ) {
+		delete view.filters;
+	}
+	return view;
+}
+
+function clearQueryParamsFromTransientFilters( queryParams: any, transientFilterFields: string[] ) {
+	const newQueryParams = { ...queryParams };
+
+	transientFilterFields.forEach( ( field ) => {
+		delete newQueryParams[ field ];
+	} );
+
+	return newQueryParams;
+}
+
+function mergeQueryParamsWithTransientProperties(
 	queryParams: any,
 	{ page, search }: { page?: number; search?: string }
 ): any {

--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -63,13 +63,9 @@ export function usePersistentView( {
 		( field ) => queryParams && queryParams[ field ] !== undefined
 	);
 
-	const [ transientFilters, setTransientFilters ] = useState< Filter[] | undefined >( undefined );
+	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( [] );
 
 	useEffect( () => {
-		if ( transientFilterFields.length === 0 ) {
-			return;
-		}
-
 		setTransientFilters(
 			transientFilterFields.map(
 				( field ) =>
@@ -90,7 +86,7 @@ export function usePersistentView( {
 		() => ( {
 			...baseView,
 			...transientProperties,
-			...( transientFilters && {
+			...( transientFilters.length > 0 && {
 				filters: [
 					...( baseView.filters || [] ).filter(
 						( filter ) => ! transientFilterFields.includes( filter.field )
@@ -104,21 +100,21 @@ export function usePersistentView( {
 
 	const updateView = useCallback(
 		( newView: View ) => {
-			if ( queryParams ) {
-				const newTransientFilterFields = transientFilterFields.filter(
-					( field ) =>
-						newView.filters?.some(
-							( filter ) => filter.field === field && filter.value === queryParams[ field ]
-						)
-				);
+			const newTransientFilterFields = transientFilterFields.filter(
+				( field ) =>
+					newView.filters?.some(
+						( filter ) => filter.field === field && filter.value === queryParams[ field ]
+					)
+			);
 
+			if ( queryParams ) {
 				const newTransientProperties = {
 					page: newView.page,
 					search: newView.search,
 				};
 
 				if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
-					setTransientFilters( undefined );
+					setTransientFilters( [] );
 					navigate( {
 						search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
 						replace: true,
@@ -132,7 +128,7 @@ export function usePersistentView( {
 
 			let viewToPersist = newView;
 			viewToPersist = removeTransientPropertiesFromView( viewToPersist );
-			viewToPersist = removeTransientFiltersFromView( viewToPersist, transientFilterFields );
+			viewToPersist = removeTransientFiltersFromView( viewToPersist, newTransientFilterFields );
 			viewToPersist = removeEmptyFiltersFromView( viewToPersist );
 
 			// Persist view if different from baseView.

--- a/client/dashboard/emails/dataviews/fields/domain-name.ts
+++ b/client/dashboard/emails/dataviews/fields/domain-name.ts
@@ -3,9 +3,13 @@ import { __ } from '@wordpress/i18n';
 import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const getDomainNameField = ( domains: DomainSummary[] ): Field< Email > => ( {
+export const getDomainNameField = (
+	domains: DomainSummary[],
+	domainNameFilter?: string
+): Field< Email > => ( {
 	id: 'domainName',
 	label: __( 'Domain' ),
 	getValue: ( { item }: { item: Email } ) => item.domainName,
 	elements: domains.map( ( { domain } ) => ( { value: domain, label: domain } ) ),
+	...( domainNameFilter && { filterBy: { isPrimary: true } } ),
 } );

--- a/client/dashboard/emails/dataviews/fields/index.ts
+++ b/client/dashboard/emails/dataviews/fields/index.ts
@@ -6,9 +6,12 @@ import { typeField } from './type';
 import type { Email } from '../../types';
 import type { Field } from '@wordpress/dataviews';
 
-export const getFields = ( domains: DomainSummary[] ): Field< Email >[] => [
+export const getFields = (
+	domains: DomainSummary[],
+	domainNameFilter?: string
+): Field< Email >[] => [
 	emailAddressField,
-	getDomainNameField( domains ),
+	getDomainNameField( domains, domainNameFilter ),
 	typeField,
 	statusField,
 ];

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -18,6 +18,7 @@ import type { Email } from './types';
 import './style.scss';
 
 function Emails() {
+	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
 	const { data: allDomains, isLoading: isLoadingDomains } = useQuery( domainsQuery() );
 	const domains = ( allDomains ?? [] ).filter(
 		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
@@ -81,11 +82,12 @@ function Emails() {
 		slug: 'emails',
 		defaultView: DEFAULT_VIEW,
 		queryParams: searchParams,
+		queryParamFilterFields: [ 'domainName' ],
 	} );
 
 	const actions = useActions();
 
-	const emailFields = getFields( domainsWithEmails );
+	const emailFields = getFields( domainsWithEmails, domainNameFilter );
 
 	const { data: filteredData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( emails, view, emailFields );


### PR DESCRIPTION
Implements https://github.com/Automattic/wp-calypso/pull/107032#discussion_r2513756890
Part of CHE-257

## Proposed Changes

This PR implements filtering the `/v2/emails` DataViews by domain, on top of the persisted view (see: https://github.com/Automattic/wp-calypso/pull/107032). Currently, this is done when we click the Emails card in the `/v2/domains/:domainName` screen:

<img width="579" height="364" alt="image" src="https://github.com/user-attachments/assets/faf30b60-38f8-4897-86b0-48d7fdbe0492" />

This PR also makes an improvement by marking the transient filter as primary filter, so that it's clear that we're looking at a filtered list:

|Before|After|
|-|-|
|<img width="825" height="287" alt="image" src="https://github.com/user-attachments/assets/b3fc44c4-424a-43a7-8c79-86bb99a6c5c2" />|<img width="835" height="333" alt="image" src="https://github.com/user-attachments/assets/97d107c2-9646-4b67-8a9b-acc4360f34ad" />|


## Why are these changes being made?

We want to persist view except the filter from query params.

## Testing Instructions

1. Go to `/v2/domains/:domainName` of a domain that you have purchased emails.
2. Click the emails card.
3. Verify you only see emails from that domain.
4. Click the top-nav Emails.
5. Verify the filter is no longer set.
6. Repeat steps 1-3.
7. Try search and/or changing appearance options.
8. Refresh the page; verify all things are retained.
9. Try clearing the Domain filter.
10. Verify it's cleared and the `domainName` query param is no longer set.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
