### PR TITLE
Add domains overview cards intent in the Multi-site Dashboard

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -77,6 +77,7 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 			}
 			icon={ <Icon icon={ envelope } /> }
 			description={ getDescription( mailboxes ) }
+			intent={ mailboxes.length > 0 ? 'success' : 'upsell' }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
@@ -2,7 +2,7 @@ import { Domain } from '@automattic/api-core';
 import { PRIVACY_PROTECTION } from '@automattic/urls';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { unseen } from '@wordpress/icons';
+import { seen, unseen } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 
 interface Props {
@@ -19,9 +19,10 @@ export default function FeaturedCardPrivacy( { domain }: Props ) {
 		<OverviewCard
 			title={ __( 'Privacy' ) }
 			heading={ __( 'WHOIS Privacy' ) }
-			icon={ <Icon icon={ unseen } /> }
+			icon={ <Icon icon={ domain.private_domain ? unseen : seen } /> }
 			externalLink={ ! domain.privacy_available ? PRIVACY_PROTECTION : undefined }
-			description={ ! domain.private_domain ? privacyWarning : privacyProtectionNote }
+			description={ ! domain.privacy_available ? privacyWarning : privacyProtectionNote }
+			intent={ domain.private_domain ? 'success' : 'warning' }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -21,7 +21,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 		return null;
 	}
 
-	let intent = 'warning';
+	let intent: 'error' | 'success' | 'warning' | 'upsell' = 'warning';
 
 	if ( domain.expired ) {
 		intent = 'error';

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -21,6 +21,14 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 		return null;
 	}
 
+	let intent = 'warning';
+
+	if ( domain.expired ) {
+		intent = 'error';
+	} else if ( domain.auto_renewing ) {
+		intent = 'success';
+	}
+
 	const formattedDate = formatDate( new Date( date ), locale, {
 		day: 'numeric',
 		month: 'long',
@@ -41,6 +49,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 			description={
 				domain.auto_renewing ? __( 'Auto-renew is enabled.' ) : __( 'Auto-renew is disabled.' )
 			}
+			intent={ intent }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -51,6 +51,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 					</Truncate>
 				)
 			}
+			intent={ shouldShowAddAttachSite ? 'upsell' : 'success' }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

We want to add color to the overview cards based on some basic rules.

Here's what I've done so far:

| where | how it looks |
| --- | --- |
| expires card if auto-renew is on | <img width="342" height="164" alt="Screenshot 2025-11-12 at 14 50 30" src="https://github.com/user-attachments/assets/3c2f5876-0c43-4191-a5e2-6f55cc5a0eb8" /> |
| expires card if auto-renew is off | <img width="346" height="163" alt="Screenshot 2025-11-12 at 14 49 05" src="https://github.com/user-attachments/assets/0e867a51-8961-4cee-ac41-de40153fd485" /> |
| privacy is enabled | <img width="343" height="157" alt="Screenshot 2025-11-12 at 14 49 09" src="https://github.com/user-attachments/assets/3862959b-2a1b-4b2c-a2a6-41228e30d3e9" /> |
| privacy is disabled | <img width="347" height="158" alt="Screenshot 2025-11-12 at 14 49 14" src="https://github.com/user-attachments/assets/9ea915e3-379b-4002-93c3-4be2d7e9d708" /> |
| privacy can not be disabled | <img width="343" height="183" alt="Screenshot 2025-11-12 at 14 51 09" src="https://github.com/user-attachments/assets/9569c512-7ff7-474d-8139-61b5719e845a" /> |
| no email service is attached to the domain | <img width="340" height="165" alt="Screenshot 2025-11-12 at 15 01 17" src="https://github.com/user-attachments/assets/8be380df-222e-4f71-b389-89f4ad76ca66" /> |
| an email service is attached to the domain | <img width="344" height="164" alt="Screenshot 2025-11-12 at 15 01 11" src="https://github.com/user-attachments/assets/5a066aaf-b253-4ff9-8e81-0770b3e2bbb3" /> |

> the site card looks the same as now since the site icon doesn't change no matter what the intent is


Part of [DOMAINS-1748: Add colors to the domain overview cards](https://linear.app/a8c/issue/DOMAINS-1748/add-colors-to-the-domain-overview-cards)

## Proposed Changes

* Add `intent` property to all domain overview cards based on some basic rules

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
