### PR TITLE
Black Friday 2025: Hide checkout coupon

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -24,6 +24,7 @@ import {
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import useEquivalentMonthlyTotals from 'calypso/my-sites/checkout/utils/use-equivalent-monthly-totals';
 import { useSelector } from 'calypso/state';
@@ -447,6 +448,9 @@ export function CouponCostOverride( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 	const isOnboardingUnifiedFlow = useSelector( getIsOnboardingUnifiedFlow );
+	const isBFref =
+		typeof window !== 'undefined' &&
+		getQueryArg( window.location.href, 'ref' ) === 'black-friday-2025-lp';
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;
@@ -458,7 +462,9 @@ export function CouponCostOverride( {
 	} );
 
 	const label =
-		isOnboardingAffiliateFlow || isOnboardingUnifiedFlow ? getAffiliateCouponLabel() : couponLabel;
+		isBFref || isOnboardingAffiliateFlow || isOnboardingUnifiedFlow
+			? getAffiliateCouponLabel()
+			: couponLabel;
 	return (
 		<CostOverridesListStyle>
 			<WPCheckoutCheckIcon />

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -16,6 +16,7 @@ import {
 	RemovedFromCartItem,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
+import { getQueryArg } from '@wordpress/url';
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan, getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -98,11 +99,14 @@ export function WPOrderReviewLineItems( {
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 	const isOnboardingUnifiedFlow = useSelector( getIsOnboardingUnifiedFlow );
+	const isBFref =
+		typeof window !== 'undefined' &&
+		getQueryArg( window.location.href, 'ref' ) === 'black-friday-2025-lp';
 	const [ restorableProducts ] = useRestorableProducts();
 
 	if ( couponLineItem ) {
 		couponLineItem.label =
-			isOnboardingAffiliateFlow || isOnboardingUnifiedFlow
+			isBFref || isOnboardingAffiliateFlow || isOnboardingUnifiedFlow
 				? getAffiliateCouponLabel()
 				: couponLineItem.label;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTCOM-14779](https://linear.app/a8c/issue/DOTCOM-14779/bf-landing-page-build-qa-live#comment-c7880375)

## Proposed Changes

* hides the coupon field if there's a `ref=black-friday-2025-lp` param in the URL

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* similar to the affiliate and unified onboarding flows, this helps limit coupon leaks during the promotion. Changes will be reverted after promo has completed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to /start/business/?coupon={COUPON}&ref=black-friday-2025-lp with a valid and active COUPON
* the coupon should not be visible in the checkout page

| Before | After |
|--------|--------|
|<img width="1580" height="753" alt="Screenshot 2025-11-12 at 15 47 41" src="https://github.com/user-attachments/assets/7dc0764f-b239-42f7-a139-50f34c433f59" /> |  <img width="1638" height="765" alt="Screenshot 2025-11-12 at 16 11 00" src="https://github.com/user-attachments/assets/a0a365bc-2863-428c-bea9-607628932daa" />| 





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
