### PR TITLE
MSD: Align actions to the left on mobile

### DIFF
--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -54,7 +54,6 @@ export const SectionHeader = ( {
 							expanded={ false }
 							alignment="flex-start"
 							className="dashboard-section-header__actions"
-							style={ { flex: '1 1 auto' } }
 						>
 							{ actions }
 						</ButtonStack>


### PR DESCRIPTION
Closes DOMAINS-1814. Related to #107003.

## Proposed Changes

| Before | After |
| --- | --- |
| <img width="541" height="228" alt="image" src="https://github.com/user-attachments/assets/d98a0816-7e1f-4416-9ccb-8bda22cd5575" /> | <img width="536" height="202" alt="image" src="https://github.com/user-attachments/assets/54425954-667b-4db8-8dfa-feec4cbbeaf8" /> |

## Testing Instructions

Enter `/v2/domains/%s/dns` where `%s` is a domain, and verify, on small screens, that the buttons align on the left instead of being spaced throughout the available real estate.