### PR TITLE
Add registrar details in domain connection setup

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -634,6 +634,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/transfer-domain-registration/#before-you-get-started',
 		post_id: 41298,
 	},
+	'transfer-domain-registrar-login': {
+		link: 'https://wordpress.com/support/domains/incoming-domain-transfer/#step-3-log-into-your-domain-provider-s-account',
+		post_id: 137759,
+	},
 	'domain-registrations-and-privacy': {
 		link: 'https://wordpress.com/support/domains/private-domain-registration/#what-is-privacy-protection',
 		post_id: 365563,

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -69,6 +69,7 @@ export default function DomainConnectCard( {
 				</Text>
 				<Text>
 					{ createInterpolateElement(
+						// translators: <registrar/> is the domain name provider
 						__(
 							'<registrar/> supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to your registrar platform when prompted, and we’ll handle the rest.'
 						),

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -112,7 +112,12 @@ export default function DomainConnectCard( {
 						<InlineSupportLink supportContext="general-support-options">
 							{ __( 'Contact support' ) }
 						</InlineSupportLink>
-						<Button variant="link" onClick={ onChangeSetupMode } style={ { lineHeight: '20px' } }>
+						<Button
+							variant="link"
+							onClick={ onChangeSetupMode }
+							disabled={ isUpdatingConnectionMode }
+							style={ { lineHeight: '20px' } }
+						>
 							{ __( 'Use manual setup' ) }
 						</Button>
 					</VStack>

--- a/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connect-card.tsx
@@ -1,5 +1,6 @@
 import {
 	Button,
+	ExternalLink,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -16,9 +17,13 @@ interface DomainConnectCardProps {
 	errorDescription?: string | null;
 	onVerifyConnection: () => void;
 	isUpdatingConnectionMode: boolean;
+	registrar: string | null;
+	registrar_url: string | null;
 }
 
 export default function DomainConnectCard( {
+	registrar,
+	registrar_url,
 	onChangeSetupMode,
 	onVerifyConnection,
 	isUpdatingConnectionMode,
@@ -65,10 +70,15 @@ export default function DomainConnectCard( {
 				<Text>
 					{ createInterpolateElement(
 						__(
-							'Your domain name provider supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to your registrar platform when prompted, and we’ll handle the rest.'
+							'<registrar/> supports a quick and easy connection to WordPress.com. Select <b>Start setup</b> below, sign in to your registrar platform when prompted, and we’ll handle the rest.'
 						),
 						{
 							b: <b />,
+							registrar: registrar_url ? (
+								<ExternalLink href={ registrar_url }> { registrar } </ExternalLink>
+							) : (
+								<>{ registrar || __( 'Your domain name provider' ) }</>
+							),
 						}
 					) }
 				</Text>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -12,6 +12,7 @@ import {
 	Icon,
 	ExternalLink,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import { useState } from 'react';
@@ -60,16 +61,33 @@ export default function DomainConnectionSetup( {
 		false,
 	] );
 
-	const suggestedModeSteps = [
+	const registrar = domainConnectionSetupInfo.registrar || domainConnectionSetupInfo.reseller;
+	const registrar_url = domainConnectionSetupInfo.registrar_url;
+
+	const commonSteps = [
 		{
-			title: __( '1. Login to your domain name provider' ),
+			title: registrar
+				? sprintf(
+						// translators: %s is the registrar name
+						__( '1. Login to %s' ),
+						registrar
+				  )
+				: __( '1. Login to your domain name provider' ),
 			label: __( 'I have opened the DNS settings' ),
 			content: (
 				<Text>
-					{ sprintf(
+					{ createInterpolateElement(
 						// translators: %s is the domain name
-						__( 'Log in to your domain name provider and open DNS management for %s.' ),
-						domainName
+						__( 'Log in to <registrar/> and open DNS management for <domain/>.' ),
+
+						{
+							registrar: registrar_url ? (
+								<ExternalLink href={ registrar_url }> { registrar } </ExternalLink>
+							) : (
+								<>{ registrar || __( 'your domain name provider' ) }</>
+							),
+							domain: <>{ domainName }</>,
+						}
 					) }
 				</Text>
 			),
@@ -85,6 +103,10 @@ export default function DomainConnectionSetup( {
 				</Text>
 			),
 		},
+	];
+
+	const suggestedModeSteps = [
+		...commonSteps,
 		{
 			title: __( '3. Update name servers' ),
 			label: __( 'I have updated the name servers' ),
@@ -103,30 +125,7 @@ export default function DomainConnectionSetup( {
 	];
 
 	const advancedModeSteps = [
-		{
-			title: __( '1. Login to your domain name provider' ),
-			label: __( 'I have opened the DNS settings' ),
-			content: (
-				<Text>
-					{ sprintf(
-						// translators: %s is the domain name
-						__( 'Log in to your domain name provider and open DNS management for %s.' ),
-						domainName
-					) }
-				</Text>
-			),
-		},
-		{
-			title: __( '2. Back up DNS records' ),
-			label: __( 'I have downloaded the DNS records' ),
-			content: (
-				<Text>
-					{ __(
-						'It’s rare, but things can go sideways. Download your DNS records as a fallback, just in case.'
-					) }
-				</Text>
-			),
-		},
+		...commonSteps,
 		{
 			title: __( '3. Update DNS records' ),
 			label: __( 'I have updated the DNS settings' ),
@@ -165,7 +164,6 @@ export default function DomainConnectionSetup( {
 	};
 
 	const renderDomainBanner = () => {
-		const registrar = domainConnectionSetupInfo.registrar || domainConnectionSetupInfo.reseller;
 		return (
 			<Card>
 				<CardBody>
@@ -176,10 +174,8 @@ export default function DomainConnectionSetup( {
 								<Text variant="muted" size="small">
 									{ __( 'Registered by' ) }
 								</Text>
-								{ domainConnectionSetupInfo.registrar_url ? (
-									<ExternalLink href={ domainConnectionSetupInfo.registrar_url }>
-										{ registrar }
-									</ExternalLink>
+								{ registrar_url ? (
+									<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>
 								) : (
 									<Text size="small">{ registrar }</Text>
 								) }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -259,7 +259,7 @@ export default function DomainConnectionSetup( {
 					<ConnectionModeCard
 						mode={ DomainConnectionSetupMode.ADVANCED }
 						title={ __( 'I use this domain name for email or other services' ) }
-						description={ __( "You'll update DNS records (CNAME and A)" ) }
+						description={ __( 'You’ll update DNS records (CNAME and A)' ) }
 						infoText={ sprintf(
 							// translators: %s is the domain name
 							__(

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -10,6 +10,7 @@ import {
 	__experimentalHStack as HStack,
 	Button,
 	Icon,
+	ExternalLink,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
@@ -163,85 +164,118 @@ export default function DomainConnectionSetup( {
 		} );
 	};
 
+	const renderDomainBanner = () => {
+		const registrar = domainConnectionSetupInfo.registrar || domainConnectionSetupInfo.reseller;
+		return (
+			<Card>
+				<CardBody>
+					<HStack spacing={ 2 } justify="space-between">
+						<Text size="medium">{ domainName }</Text>
+						{ registrar && (
+							<HStack spacing={ 1 } justify="flex-end">
+								<Text variant="muted" size="small">
+									{ __( 'Registered by' ) }
+								</Text>
+								{ domainConnectionSetupInfo.registrar_url ? (
+									<ExternalLink href={ domainConnectionSetupInfo.registrar_url }>
+										{ registrar }
+									</ExternalLink>
+								) : (
+									<Text size="small">{ registrar }</Text>
+								) }
+							</HStack>
+						) }
+					</HStack>
+				</CardBody>
+			</Card>
+		);
+	};
+
 	if (
 		connectionMode === DomainConnectionSetupMode.DC &&
 		domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null
 	) {
 		return (
 			<div className="domain-connection-setup">
-				<DomainConnectCard
-					onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
-					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.DC ) }
-					isUpdatingConnectionMode={ isUpdatingConnectionMode }
-					error={ queryError }
-					errorDescription={ queryErrorDescription }
-				/>
+				<VStack spacing={ 6 }>
+					{ renderDomainBanner() }
+					<DomainConnectCard
+						onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
+						onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.DC ) }
+						isUpdatingConnectionMode={ isUpdatingConnectionMode }
+						error={ queryError }
+						errorDescription={ queryErrorDescription }
+					/>
+				</VStack>
 			</div>
 		);
 	}
 
 	return (
 		<div className="domain-connection-setup">
-			<VStack spacing={ 4 }>
-				{ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null && (
-					<Card>
-						<CardBody>
-							<HStack spacing={ 2 } justify="flex-start">
-								<Icon icon={ globe } />
-								<Text>{ __( 'This domain name can be automatically connected.' ) }</Text>
-								<Button
-									variant="link"
-									onClick={ () => setConnectionMode( DomainConnectionSetupMode.DC ) }
-								>
-									{ __( 'Use domain connect' ) }
-								</Button>
-							</HStack>
-						</CardBody>
-					</Card>
-				) }
-				<ConnectionModeCard
-					mode={ DomainConnectionSetupMode.SUGGESTED }
-					title={ __( 'I only use this domain name for my website' ) }
-					description={ __( 'You’ll update your name servers to point to WordPress.com' ) }
-					infoText={ sprintf(
-						// translators: %s is the domain name
-						__(
-							'Name servers connect your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
-						),
-						domainName
+			<VStack spacing={ 6 }>
+				{ renderDomainBanner() }
+				<VStack spacing={ 4 }>
+					{ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null && (
+						<Card>
+							<CardBody>
+								<HStack spacing={ 2 } justify="flex-start">
+									<Icon icon={ globe } />
+									<Text>{ __( 'This domain name can be automatically connected.' ) }</Text>
+									<Button
+										variant="link"
+										onClick={ () => setConnectionMode( DomainConnectionSetupMode.DC ) }
+									>
+										{ __( 'Use domain connect' ) }
+									</Button>
+								</HStack>
+							</CardBody>
+						</Card>
 					) }
-					steps={ suggestedModeSteps }
-					stepsCompleted={ suggestedStepsCompleted }
-					selectedMode={ connectionMode }
-					onModeChange={ setConnectionMode }
-					onStepChange={ handleSuggestedStepChange }
-					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.SUGGESTED ) }
-					isUpdatingConnectionMode={ isUpdatingConnectionMode }
-					verificationDisabled={ ! suggestedStepsCompleted.every( ( completed ) => completed ) }
-					hasEmailOrOtherServices={ domainMappingStatus.has_mx_records }
-				/>
+					<ConnectionModeCard
+						mode={ DomainConnectionSetupMode.SUGGESTED }
+						title={ __( 'I only use this domain name for my website' ) }
+						description={ __( 'You’ll update your name servers to point to WordPress.com' ) }
+						infoText={ sprintf(
+							// translators: %s is the domain name
+							__(
+								'Name servers connect your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
+							),
+							domainName
+						) }
+						steps={ suggestedModeSteps }
+						stepsCompleted={ suggestedStepsCompleted }
+						selectedMode={ connectionMode }
+						onModeChange={ setConnectionMode }
+						onStepChange={ handleSuggestedStepChange }
+						onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.SUGGESTED ) }
+						isUpdatingConnectionMode={ isUpdatingConnectionMode }
+						verificationDisabled={ ! suggestedStepsCompleted.every( ( completed ) => completed ) }
+						hasEmailOrOtherServices={ domainMappingStatus.has_mx_records }
+					/>
 
-				<ConnectionModeCard
-					mode={ DomainConnectionSetupMode.ADVANCED }
-					title={ __( 'I use this domain name for email or other services' ) }
-					description={ __( "You'll update DNS records (CNAME and A)" ) }
-					infoText={ sprintf(
-						// translators: %s is the domain name
-						__(
-							'DNS records point your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
-						),
-						domainName
-					) }
-					steps={ advancedModeSteps }
-					stepsCompleted={ advancedStepsCompleted }
-					selectedMode={ connectionMode }
-					onModeChange={ setConnectionMode }
-					onStepChange={ handleAdvancedStepChange }
-					onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.ADVANCED ) }
-					isUpdatingConnectionMode={ isUpdatingConnectionMode }
-					verificationDisabled={ ! advancedStepsCompleted.every( ( completed ) => completed ) }
-					hasEmailOrOtherServices={ domainMappingStatus.has_mx_records }
-				/>
+					<ConnectionModeCard
+						mode={ DomainConnectionSetupMode.ADVANCED }
+						title={ __( 'I use this domain name for email or other services' ) }
+						description={ __( "You'll update DNS records (CNAME and A)" ) }
+						infoText={ sprintf(
+							// translators: %s is the domain name
+							__(
+								'DNS records point your domain name to your site. It may take up to 72 hours for %s to become visible across the internet. We’ll email you when it’s done.'
+							),
+							domainName
+						) }
+						steps={ advancedModeSteps }
+						stepsCompleted={ advancedStepsCompleted }
+						selectedMode={ connectionMode }
+						onModeChange={ setConnectionMode }
+						onStepChange={ handleAdvancedStepChange }
+						onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.ADVANCED ) }
+						isUpdatingConnectionMode={ isUpdatingConnectionMode }
+						verificationDisabled={ ! advancedStepsCompleted.every( ( completed ) => completed ) }
+						hasEmailOrOtherServices={ domainMappingStatus.has_mx_records }
+					/>
+				</VStack>
 			</VStack>
 		</div>
 	);

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -78,7 +78,7 @@ export default function DomainConnectionSetup( {
 			content: (
 				<Text>
 					{ createInterpolateElement(
-						// translators: %s is the domain name
+						// translators: <registrar/> is the domain name provider, <domain/> is the domain name
 						__( 'Log in to <registrar/> and open DNS management for <domain/>.' ),
 
 						{

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -61,7 +61,8 @@ export default function DomainConnectionSetup( {
 		false,
 	] );
 
-	const registrar = domainConnectionSetupInfo.registrar || domainConnectionSetupInfo.reseller;
+	const isReseller = !! domainConnectionSetupInfo.reseller;
+	const registrar = domainConnectionSetupInfo.reseller || domainConnectionSetupInfo.registrar;
 	const registrar_url = domainConnectionSetupInfo.registrar_url;
 
 	const commonSteps = [
@@ -81,11 +82,12 @@ export default function DomainConnectionSetup( {
 						__( 'Log in to <registrar/> and open DNS management for <domain/>.' ),
 
 						{
-							registrar: registrar_url ? (
-								<ExternalLink href={ registrar_url }> { registrar } </ExternalLink>
-							) : (
-								<>{ registrar || __( 'your domain name provider' ) }</>
-							),
+							registrar:
+								! isReseller && registrar_url ? (
+									<ExternalLink href={ registrar_url }> { registrar } </ExternalLink>
+								) : (
+									<>{ registrar || __( 'your domain name provider' ) }</>
+								),
 							domain: <>{ domainName }</>,
 						}
 					) }
@@ -168,13 +170,15 @@ export default function DomainConnectionSetup( {
 			<Card>
 				<CardBody>
 					<HStack spacing={ 2 } justify="space-between">
-						<Text size="medium">{ domainName }</Text>
+						<Text size="medium" style={ { whiteSpace: 'nowrap' } }>
+							{ domainName }
+						</Text>
 						{ registrar && (
 							<HStack spacing={ 1 } justify="flex-end">
 								<Text variant="muted" size="small">
 									{ __( 'Registered by' ) }
 								</Text>
-								{ registrar_url ? (
+								{ ! isReseller && registrar_url ? (
 									<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>
 								) : (
 									<Text size="small">{ registrar }</Text>
@@ -199,6 +203,8 @@ export default function DomainConnectionSetup( {
 						onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
 						onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.DC ) }
 						isUpdatingConnectionMode={ isUpdatingConnectionMode }
+						registrar={ registrar }
+						registrar_url={ isReseller ? null : registrar_url }
 						error={ queryError }
 						errorDescription={ queryErrorDescription }
 					/>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -125,8 +125,9 @@ export default function DomainConnectionVerification( {
 						<InlineSupportLink supportContext="general-support-options">
 							{ __( 'Contact support' ) }
 						</InlineSupportLink>
-						{ /* TODO: Add additional help resources or links here in the future */ }
-						{ /* <ExternalLink href="#" children={ __( 'Registrar instructions' ) } /> */ }
+						<InlineSupportLink supportContext="transfer-domain-registrar-login">
+							{ __( 'Registrar instructions' ) }
+						</InlineSupportLink>
 					</VStack>
 				</VStack>
 			</CardBody>

--- a/client/dashboard/domains/domain-connection-setup/setup-step.tsx
+++ b/client/dashboard/domains/domain-connection-setup/setup-step.tsx
@@ -54,7 +54,12 @@ export default function SetupStep( {
 		>
 			<VStack spacing={ 4 } style={ { paddingLeft: '32px' } }>
 				{ children }
-				<CheckboxControl checked={ completed } onChange={ onCheckboxChange } label={ label } />
+				<CheckboxControl
+					checked={ completed }
+					onChange={ onCheckboxChange }
+					label={ label }
+					__nextHasNoMarginBottom
+				/>
 			</VStack>
 		</CollapsibleCard>
 	);

--- a/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
@@ -314,15 +314,21 @@ describe( 'DNSRecordsDataView - Advanced Mode (A and CNAME Records)', () => {
 		mode: 'advanced',
 	} );
 
-	const createMockDomainConnectionSetupInfo = (): DomainMappingSetupInfo => ( {
-		connection_mode: null,
-		domain_connect_apply_wpcom_hosting: null,
-		domain_connect_provider_id: null,
-		default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
-		wpcom_name_servers: [],
-		is_subdomain: false,
-		root_domain: 'example.com',
-	} );
+	const createMockDomainConnectionSetupInfo = (): DomainMappingSetupInfo => {
+		return {
+			connection_mode: null,
+			domain_connect_apply_wpcom_hosting: null,
+			domain_connect_provider_id: null,
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
+			wpcom_name_servers: [],
+			is_subdomain: false,
+			root_domain: 'example.com',
+			registrar_url: null,
+			registrar: '',
+			registrar_iana_id: null,
+			reseller: null,
+		} as DomainMappingSetupInfo;
+	};
 
 	test( 'renders A records when current IPs match target IPs exactly', async () => {
 		const domainMappingStatus = createMockDomainMappingStatus( [ '192.0.78.24', '192.0.78.25' ] );

--- a/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx
@@ -32,6 +32,10 @@ describe( 'DNSRecordsDataView - Suggested Mode (Nameservers)', () => {
 		wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		is_subdomain: false,
 		root_domain: 'example.com',
+		registrar_url: null,
+		registrar: '',
+		registrar_iana_id: null,
+		reseller: null,
 	} );
 
 	test( 'renders 3 rows when current nameservers match target nameservers exactly', async () => {

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connect-card.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connect-card.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import DomainConnectCard from '../domain-connect-card';
+
+// Mock InlineSupportLink to avoid async state updates warnings
+jest.mock( '../../../components/inline-support-link', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <button>{ children }</button>,
+} ) );
+
+describe( 'DomainConnectCard', () => {
+	const defaultProps = {
+		onChangeSetupMode: jest.fn(),
+		onVerifyConnection: jest.fn(),
+		isUpdatingConnectionMode: false,
+		registrar: null,
+		registrar_url: null,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Basic Rendering', () => {
+		test( 'renders the card with basic elements', () => {
+			render( <DomainConnectCard { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Domain Connect available' ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Start setup' } ) ).toBeVisible();
+			expect( screen.getByRole( 'button', { name: 'Use manual setup' } ) ).toBeVisible();
+		} );
+
+		test( 'calls onVerifyConnection when Start setup is clicked', async () => {
+			const user = userEvent.setup();
+			const onVerifyConnection = jest.fn();
+
+			render( <DomainConnectCard { ...defaultProps } onVerifyConnection={ onVerifyConnection } /> );
+
+			const startButton = screen.getByRole( 'button', { name: 'Start setup' } );
+			await user.click( startButton );
+
+			expect( onVerifyConnection ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'calls onChangeSetupMode when Use manual setup is clicked', async () => {
+			const user = userEvent.setup();
+			const onChangeSetupMode = jest.fn();
+
+			render( <DomainConnectCard { ...defaultProps } onChangeSetupMode={ onChangeSetupMode } /> );
+
+			const manualButton = screen.getByRole( 'button', { name: 'Use manual setup' } );
+			await user.click( manualButton );
+
+			expect( onChangeSetupMode ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'disables buttons when isUpdatingConnectionMode is true', () => {
+			render( <DomainConnectCard { ...defaultProps } isUpdatingConnectionMode /> );
+
+			const startButton = screen.getByRole( 'button', { name: 'Start setup' } );
+			const manualButton = screen.getByRole( 'button', { name: 'Use manual setup' } );
+
+			expect( startButton ).toBeDisabled();
+			expect( manualButton ).toBeDisabled();
+		} );
+	} );
+
+	describe( 'Registrar Information Display', () => {
+		test( 'displays registrar name as a clickable link when registrar and URL are provided', () => {
+			render(
+				<DomainConnectCard
+					{ ...defaultProps }
+					registrar="GoDaddy"
+					registrar_url="https://www.godaddy.com"
+				/>
+			);
+
+			// Check that registrar link is present in the description
+			const registrarLink = screen.getByRole( 'link', { name: /GoDaddy/i } );
+			expect( registrarLink ).toBeVisible();
+			expect( registrarLink ).toHaveAttribute( 'href', 'https://www.godaddy.com' );
+
+			// Check that the text is correctly formatted
+			expect(
+				screen.getByText( /supports a quick and easy connection to WordPress.com/, {
+					exact: false,
+				} )
+			).toBeVisible();
+		} );
+
+		test( 'displays registrar name without link when URL is not provided', () => {
+			render(
+				<DomainConnectCard { ...defaultProps } registrar="GoDaddy" registrar_url={ null } />
+			);
+
+			// Check that registrar name is displayed but not as a link
+			expect( screen.getByText( /GoDaddy/ ) ).toBeVisible();
+			const registrarLink = screen.queryByRole( 'link', { name: /GoDaddy/i } );
+			expect( registrarLink ).not.toBeInTheDocument();
+		} );
+
+		test( 'displays registrar name without link when registrar_url is null (reseller)', () => {
+			render(
+				<DomainConnectCard { ...defaultProps } registrar="Reseller Name" registrar_url={ null } />
+			);
+
+			// Check that reseller name is displayed but not as a link
+			expect( screen.getByText( /Reseller Name/ ) ).toBeVisible();
+			const registrarLink = screen.queryByRole( 'link', { name: /Reseller Name/i } );
+			expect( registrarLink ).not.toBeInTheDocument();
+		} );
+
+		test( 'displays fallback text when registrar info is not available', () => {
+			render( <DomainConnectCard { ...defaultProps } registrar={ null } registrar_url={ null } /> );
+
+			// Check that fallback text is displayed
+			expect( screen.getByText( /Your domain name provider/ ) ).toBeVisible();
+
+			// Ensure no registrar links are present
+			const links = screen.queryAllByRole( 'link' );
+			const registrarLinks = links.filter( ( link ) => {
+				const text = link.textContent || '';
+				return (
+					text.includes( 'GoDaddy' ) || text.includes( 'Namecheap' ) || text.includes( 'Bluehost' )
+				);
+			} );
+			expect( registrarLinks ).toHaveLength( 0 );
+		} );
+
+		test( 'displays fallback text when registrar is empty string', () => {
+			render( <DomainConnectCard { ...defaultProps } registrar="" registrar_url={ null } /> );
+
+			// Check that fallback text is displayed
+			expect( screen.getByText( /Your domain name provider/ ) ).toBeVisible();
+		} );
+
+		test( 'correctly formats description with different registrar names', () => {
+			const registrars = [
+				{ name: 'Namecheap', url: 'https://www.namecheap.com' },
+				{ name: 'Bluehost', url: 'https://www.bluehost.com' },
+				{ name: 'Google Domains', url: 'https://domains.google' },
+			];
+
+			registrars.forEach( ( { name, url } ) => {
+				const { unmount } = render(
+					<DomainConnectCard { ...defaultProps } registrar={ name } registrar_url={ url } />
+				);
+
+				const registrarLink = screen.getByRole( 'link', { name: new RegExp( name, 'i' ) } );
+				expect( registrarLink ).toBeVisible();
+				expect( registrarLink ).toHaveAttribute( 'href', url );
+
+				unmount();
+			} );
+		} );
+	} );
+
+	describe( 'Error States', () => {
+		test( 'displays error message when error is provided', () => {
+			render(
+				<DomainConnectCard
+					{ ...defaultProps }
+					error="access_denied"
+					errorDescription="user_cancel"
+				/>
+			);
+
+			// Check that error message is displayed
+			expect(
+				screen.getByText( 'Connecting your domain to WordPress.com was cancelled' )
+			).toBeVisible();
+			expect( screen.getByText( 'Something went wrong' ) ).toBeVisible();
+		} );
+
+		test( 'displays generic error message for non-cancellation errors', () => {
+			render(
+				<DomainConnectCard { ...defaultProps } error="server_error" errorDescription={ null } />
+			);
+
+			// Check that generic error message is displayed
+			expect( screen.getByText( 'There was a problem connecting your domain' ) ).toBeVisible();
+		} );
+
+		test( 'displays registrar info even when error is present', () => {
+			render(
+				<DomainConnectCard
+					{ ...defaultProps }
+					registrar="GoDaddy"
+					registrar_url="https://www.godaddy.com"
+					error="access_denied"
+					errorDescription="user_cancel"
+				/>
+			);
+
+			// Check that error is displayed
+			expect( screen.getByText( 'Something went wrong' ) ).toBeVisible();
+
+			// When error is present, registrar info is not displayed (only shown in default content)
+			const registrarLink = screen.queryByRole( 'link', { name: /GoDaddy/i } );
+			expect( registrarLink ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Help Section', () => {
+		test( 'renders help section with support links', () => {
+			render( <DomainConnectCard { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Need help?' ) ).toBeVisible();
+		} );
+	} );
+} );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -364,4 +364,220 @@ describe( 'DomainConnectionSetup', () => {
 			expect( startSetupButton ).toBeDisabled();
 		} );
 	} );
+
+	describe( 'Registrar Information Display', () => {
+		test( 'displays registrar banner with clickable link when registrar info is available', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: 'GoDaddy',
+				registrar_url: 'https://www.godaddy.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that "Registered by" text is displayed (unique to banner)
+			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+
+			// Check that registrar links are present with correct href
+			const registrarLinks = screen.getAllByRole( 'link', { name: /GoDaddy/i } );
+			expect( registrarLinks.length ).toBeGreaterThan( 0 );
+			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.godaddy.com' );
+		} );
+
+		test( 'displays registrar banner without link when registrar is a reseller', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: 'GoDaddy',
+				reseller: 'Reseller Name',
+				registrar_url: 'https://example.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that reseller name is displayed
+			expect( screen.getByText( 'Reseller Name' ) ).toBeVisible();
+			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+
+			// Check that there's no clickable link for reseller
+			const registrarLink = screen.queryByRole( 'link', { name: 'Reseller Name' } );
+			expect( registrarLink ).not.toBeInTheDocument();
+		} );
+
+		test( 'does not display registrar banner when registrar info is not available', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: null,
+				registrar_url: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that "Registered by" text is not displayed
+			expect( screen.queryByText( 'Registered by' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'displays registrar name in setup instructions when available', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: 'Namecheap',
+				registrar_url: 'https://www.namecheap.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that step 1 includes registrar name
+			expect( screen.getByText( '1. Login to Namecheap' ) ).toBeVisible();
+
+			// Check that registrar links exist (they appear in multiple places)
+			const registrarLinks = screen.getAllByRole( 'link', { name: /Namecheap/i } );
+			expect( registrarLinks.length ).toBeGreaterThan( 0 );
+			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.namecheap.com' );
+		} );
+
+		test( 'displays fallback text in setup instructions when registrar is not available', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: null,
+				registrar_url: null,
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that step 1 uses fallback text
+			expect( screen.getByText( '1. Login to your domain name provider' ) ).toBeVisible();
+		} );
+
+		test( 'does not display clickable registrar link for resellers in setup instructions', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				reseller: 'Reseller Company',
+				registrar: 'GoDaddy',
+				registrar_url: 'https://www.godaddy.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// When reseller is present, it takes precedence over registrar
+			expect( screen.getByText( '1. Login to Reseller Company' ) ).toBeVisible();
+
+			// Reseller name should not be a clickable link in instructions
+			const resellerLinks = screen.queryAllByRole( 'link', { name: 'Reseller Company' } );
+			expect( resellerLinks ).toHaveLength( 0 );
+		} );
+
+		test( 'displays registrar info in Domain Connect mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: 'https://example.com/domain-connect',
+				registrar: 'GoDaddy',
+				registrar_url: 'https://www.godaddy.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check that registrar banner is displayed in DC mode
+			expect( screen.getByText( 'Registered by' ) ).toBeVisible();
+
+			// Check that registrar links are present (appears in banner and DC card)
+			const registrarLinks = screen.getAllByRole( 'link', { name: /GoDaddy/i } );
+			expect( registrarLinks.length ).toBeGreaterThan( 0 );
+			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.godaddy.com' );
+		} );
+
+		test( 'displays registrar info in both Suggested and Advanced modes', async () => {
+			const user = userEvent.setup();
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_mx_records: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				domain_connect_apply_wpcom_hosting: null,
+				registrar: 'Bluehost',
+				registrar_url: 'https://www.bluehost.com',
+			} );
+
+			render(
+				<DomainConnectionSetup
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Check in Suggested mode (default)
+			expect( screen.getByText( '1. Login to Bluehost' ) ).toBeVisible();
+			let registrarLinks = screen.getAllByRole( 'link', { name: /Bluehost/i } );
+			expect( registrarLinks.length ).toBeGreaterThan( 0 );
+			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.bluehost.com' );
+
+			// Switch to Advanced mode
+			const advancedModeTitle = screen.getByText(
+				'I use this domain name for email or other services'
+			);
+			await user.click( advancedModeTitle );
+
+			// Check in Advanced mode
+			expect( screen.getByText( '1. Login to Bluehost' ) ).toBeVisible();
+			registrarLinks = screen.getAllByRole( 'link', { name: /Bluehost/i } );
+			expect( registrarLinks.length ).toBeGreaterThan( 0 );
+			expect( registrarLinks[ 0 ] ).toHaveAttribute( 'href', 'https://www.bluehost.com' );
+		} );
+	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -35,16 +35,22 @@ const createMockDomainMappingStatus = (
 
 const createMockDomainConnectionSetupInfo = (
 	overrides?: Partial< DomainMappingSetupInfo >
-): DomainMappingSetupInfo => ( {
-	connection_mode: null,
-	domain_connect_apply_wpcom_hosting: null,
-	domain_connect_provider_id: null,
-	default_ip_addresses: [ '192.0.2.1' ],
-	wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
-	is_subdomain: false,
-	root_domain: 'example.com',
-	...overrides,
-} );
+): DomainMappingSetupInfo => {
+	return {
+		connection_mode: null,
+		domain_connect_apply_wpcom_hosting: null,
+		domain_connect_provider_id: null,
+		default_ip_addresses: [ '192.0.2.1' ],
+		wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		is_subdomain: false,
+		root_domain: 'example.com',
+		registrar_url: null,
+		registrar: '',
+		registrar_iana_id: null,
+		reseller: null,
+		...overrides,
+	} as DomainMappingSetupInfo;
+};
 
 describe( 'DomainConnectionSetup', () => {
 	const defaultProps = {

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	Domain,
+	DomainConnectionSetupMode,
+	DomainMappingSetupInfo,
+	DomainMappingStatus,
+	DomainStatus,
+	DomainSubtype,
+} from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import DomainConnectionVerification from '../domain-connection-verification';
+
+// Mock InlineSupportLink to render a button with the support context as data attribute
+jest.mock( '../../../components/inline-support-link', () => ( {
+	__esModule: true,
+	default: ( {
+		children,
+		supportContext,
+	}: {
+		children: React.ReactNode;
+		supportContext: string;
+	} ) => <button data-support-context={ supportContext }>{ children }</button>,
+} ) );
+
+// Mock RouterLinkSummaryButton to avoid routing issues
+jest.mock( '../../../components/router-link-summary-button', () => ( {
+	__esModule: true,
+	default: ( { title }: { title: string } ) => <div>{ title }</div>,
+} ) );
+
+// Mock DomainPropagationStatus to avoid useAuth dependency
+jest.mock( '../components/domain-propagation-status', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const createMockDomain = (): Domain => ( {
+	// DomainSummary properties
+	blog_id: 123,
+	domain: 'example.com',
+	subtype: {
+		id: DomainSubtype.DOMAIN_CONNECTION,
+		label: 'Domain Connection',
+	},
+	blog_name: 'Example Blog',
+	site_slug: 'example.wordpress.com',
+	auto_renewing: false,
+	current_user_is_owner: true,
+	is_domain_only_site: false,
+	expiry: null,
+	expired: false,
+	primary_domain: false,
+	can_set_as_primary: true,
+	domain_status: {
+		id: DomainStatus.ACTIVE,
+		label: 'Active',
+		type: 'success',
+	},
+	subscription_id: null,
+	tags: [],
+
+	// Domain-specific properties
+	auth_code_required: false,
+	aftermarket_auction: false,
+	auto_renewal_date: '',
+	can_manage_name_servers: true,
+	can_manage_dns_records: true,
+	can_update_contact_info: true,
+	can_transfer_to_any_user: true,
+	can_transfer_to_other_site: true,
+	cannot_manage_name_servers_reason: null,
+	cannot_manage_dns_records_reason: null,
+	cannot_update_contact_info_reason: null,
+	current_user_can_manage: true,
+	contact_info_disclosure_available: false,
+	contact_info_disclosed: false,
+	current_user_cannot_add_email_reason: null,
+	domain_locking_available: false,
+	has_wpcom_nameservers: false,
+	is_dnssec_enabled: false,
+	is_dnssec_supported: false,
+	is_eligible_for_inbound_transfer: false,
+	is_gravatar_domain: false,
+	is_gravatar_restricted_domain: false,
+	is_locked: false,
+	is_pending_whois_update: false,
+	is_root_domain_registered_with_automattic: false,
+	is_redeemable: false,
+	is_hundred_year_domain: false,
+	is_subdomain: false,
+	is_pending_icann_verification: false,
+	is_wpcom_staging_domain: false,
+	move_to_new_site_pending: false,
+	nominet_pending_contact_verification_request: false,
+	nominet_domain_suspended: false,
+	owner: 'user',
+	is_pending_registration: false,
+	is_pending_registration_at_registry: false,
+	private_domain: false,
+	privacy_available: false,
+	points_to_wpcom: false,
+	pending_registration: false,
+	pending_registration_at_registry: false,
+	pending_transfer: false,
+	renewable_until: '',
+	ssl_status: 'inactive',
+	subdomain_part: '',
+	transfer_status: null,
+	transfer_away_eligible_at: '',
+	type: 'mapping',
+	wpcom_domain: false,
+	registration_date: '',
+	last_transfer_error: '',
+	current_user_can_add_email: true,
+} );
+
+const createMockDomainMappingStatus = (
+	overrides?: Partial< DomainMappingStatus >
+): DomainMappingStatus => ( {
+	has_mapping_records: true,
+	has_wpcom_nameservers: false,
+	has_wpcom_ip_addresses: true,
+	has_cloudflare_ip_addresses: false,
+	has_mx_records: false,
+	www_cname_record_target: 'example.com',
+	resolves_to_wpcom: true,
+	host_ip_addresses: [ '192.0.2.1' ],
+	name_servers: [],
+	mode: DomainConnectionSetupMode.ADVANCED,
+	...overrides,
+} );
+
+const createMockDomainConnectionSetupInfo = (
+	overrides?: Partial< DomainMappingSetupInfo >
+): DomainMappingSetupInfo => ( {
+	connection_mode: null,
+	domain_connect_apply_wpcom_hosting: null,
+	domain_connect_provider_id: null,
+	default_ip_addresses: [ '192.0.2.1' ],
+	wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+	is_subdomain: false,
+	root_domain: 'example.com',
+	registrar_url: null,
+	registrar: null,
+	registrar_iana_id: null,
+	reseller: null,
+	...overrides,
+} );
+
+describe( 'DomainConnectionVerification', () => {
+	const defaultProps = {
+		domainData: createMockDomain(),
+		domainName: 'example.com',
+		siteSlug: 'example.wordpress.com',
+		domainMappingStatus: createMockDomainMappingStatus(),
+		domainConnectionSetupInfo: createMockDomainConnectionSetupInfo(),
+	};
+
+	describe( 'Basic Rendering', () => {
+		test( 'renders the verification component with domain name', () => {
+			const { container } = render( <DomainConnectionVerification { ...defaultProps } /> );
+
+			const titleElement = container.querySelector(
+				'.dashboard-domain-connection-verification__title'
+			);
+			expect( titleElement ).toHaveTextContent( 'example.com' );
+		} );
+
+		test( 'shows Active badge when domain is connected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect( screen.getByText( 'Active' ) ).toBeVisible();
+		} );
+
+		test( 'shows Verifying badge when domain is not fully connected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: false,
+				resolves_to_wpcom: false,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			const badgeElements = screen.getAllByText( 'Verifying' );
+			expect( badgeElements.length ).toBeGreaterThan( 0 );
+			expect( badgeElements[ 0 ] ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Help Section', () => {
+		test( 'renders help section with all support links', () => {
+			render( <DomainConnectionVerification { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Need help?' ) ).toBeVisible();
+
+			// Check all three support links are present
+			expect( screen.getByText( 'Domain connection guide' ) ).toBeVisible();
+			expect( screen.getByText( 'Contact support' ) ).toBeVisible();
+			expect( screen.getByText( 'Registrar instructions' ) ).toBeVisible();
+		} );
+
+		test( 'renders registrar instructions support link with correct support context', () => {
+			render( <DomainConnectionVerification { ...defaultProps } /> );
+
+			const registrarInstructionsLink = screen.getByText( 'Registrar instructions' );
+			expect( registrarInstructionsLink ).toBeVisible();
+
+			// Verify it has the correct support context
+			expect( registrarInstructionsLink ).toHaveAttribute(
+				'data-support-context',
+				'transfer-domain-registrar-login'
+			);
+		} );
+
+		test( 'renders domain connection guide link with correct support context', () => {
+			render( <DomainConnectionVerification { ...defaultProps } /> );
+
+			const domainConnectionGuideLink = screen.getByText( 'Domain connection guide' );
+			expect( domainConnectionGuideLink ).toBeVisible();
+			expect( domainConnectionGuideLink ).toHaveAttribute(
+				'data-support-context',
+				'map-domain-setup-instructions'
+			);
+		} );
+
+		test( 'renders contact support link with correct support context', () => {
+			render( <DomainConnectionVerification { ...defaultProps } /> );
+
+			const contactSupportLink = screen.getByText( 'Contact support' );
+			expect( contactSupportLink ).toBeVisible();
+			expect( contactSupportLink ).toHaveAttribute(
+				'data-support-context',
+				'general-support-options'
+			);
+		} );
+	} );
+
+	describe( 'Verification Status', () => {
+		test( 'displays info notice when domain is verifying', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: false,
+				resolves_to_wpcom: false,
+			} );
+
+			const { container } = render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			const noticeElement = container.querySelector( '.dashboard-notice.is-info' );
+			expect( noticeElement ).toBeInTheDocument();
+			expect( noticeElement?.textContent ).toContain( 'checking your DNS records' );
+		} );
+
+		test( 'does not display info notice when domain is connected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect(
+				screen.queryByText(
+					/We're checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours./
+				)
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'displays correct verification section title for Advanced mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.ADVANCED,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect( screen.getByText( 'DNS record verification' ) ).toBeVisible();
+		} );
+
+		test( 'displays correct verification section title for Suggested mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.SUGGESTED,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect( screen.getByText( 'Name server verification' ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'While You Wait Section', () => {
+		test( 'displays "While you wait" section when domain is verifying', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: false,
+				resolves_to_wpcom: false,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect( screen.getByText( 'While you wait' ) ).toBeVisible();
+			expect( screen.getByText( 'Customize your site' ) ).toBeVisible();
+		} );
+
+		test( 'does not display "While you wait" heading when domain is connected', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			expect( screen.queryByText( 'While you wait' ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/packages/api-core/src/domain-connection-setup/types.ts
+++ b/packages/api-core/src/domain-connection-setup/types.ts
@@ -32,7 +32,7 @@ export type DomainMappingSetupInfo = {
 	is_subdomain: boolean;
 	root_domain: string;
 	registrar_url: string | null;
-	registrar: string;
+	registrar: string | null;
 	registrar_iana_id: string | null;
 	reseller: string | null;
 };

--- a/packages/api-core/src/domain-connection-setup/types.ts
+++ b/packages/api-core/src/domain-connection-setup/types.ts
@@ -31,4 +31,8 @@ export type DomainMappingSetupInfo = {
 	wpcom_name_servers: string[];
 	is_subdomain: boolean;
 	root_domain: string;
+	registrar_url: string | null;
+	registrar: string;
+	registrar_iana_id: string | null;
+	reseller: string | null;
 };


### PR DESCRIPTION
Closes [DOMAINS-1820](https://linear.app/a8c/issue/DOMAINS-1820/add-current-registrar-detail-front-end)

## Proposed Changes
Enhances the domain connection setup flow by displaying registrar information throughout the setup and verification process, making it easier for users to identify where their domain is registered and access the correct login portal.

### Registrar Banner
Added a registrar information banner to the domain connection setup page showing:
- Domain name
- Registrar name (with external link when available)
**Reseller handling**: When the API returns a reseller value, only the reseller name is displayed without a link (the API does not provide reseller URLs, only registrar URLs)

###  Enhanced Setup Instructions
Updated manual setup instructions (both Suggested and Advanced modes) to include registrar-specific information:
- Step 1 title now shows "Login to [Registrar Name]" instead of generic "Login to your domain name provider"
- Step 1 content includes clickable registrar link (when URL is available)
- Instructions explicitly reference the registrar name for clarity
**Reseller domains**: For domains with a reseller, the reseller name is shown as plain text without a link since the API does not provide reseller URLs
- Handles cases where registrar information is unavailable with fallback text

### Domain Connect Card
Enhanced the Domain Connect automatic setup card to:
- Display registrar name with clickable link in the description
- Show which registrar supports the automatic connection
- Fixed "Use manual setup" button disabled state during connection process
**Reseller domains**: When a reseller is present, only the reseller name is displayed without a clickable link (reseller URLs are not provided by the API)


|<img width="1508" height="1882" alt="registrar detected" src="https://github.com/user-attachments/assets/717e9a0f-b58b-40c2-bff8-3938b023d5ae" />|<img width="1562" height="1808" alt="registrar+reseller" src="https://github.com/user-attachments/assets/545c0086-e82a-4b73-b8d2-70ef6660149c" />|<img width="1522" height="1396" alt="domain-connect-with-registrar" src="https://github.com/user-attachments/assets/1363fb91-0ae8-4f9d-b771-06f0cf341ca8" />|<img width="1500" height="1348" alt="domain-connect-reseller" src="https://github.com/user-attachments/assets/54587a25-7cdd-47dd-a8c7-e52b5520667c" />|
|:---:|:---:|:---:|:---:|
|**Registrar only**|**Reseller**|**Domain connect registrar only**|**Domain connect with reseller**|

## Why are these changes being made?
This is part of the new Domain Connect redesign flow

## Testing Instructions
Test the setup in the described scenario. It’s probably easier to temporarily modify (hack) the endpoint to return the required values.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
