### PR TITLE
Refactor `canUseTheme` so it relies on theme tier instead of theme type

### DIFF
--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -32,7 +32,6 @@ const getThemeTierFeatureChecks = ( state, siteId, themeId ) => {
 			return [ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ];
 		}
 
-		// is this exactly the same as type DOT_ORG?
 		case 'community': {
 			return [ FEATURE_INSTALL_THEMES, WPCOM_FEATURES_COMMUNITY_THEMES ];
 		}

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -7,7 +7,7 @@ import {
 	WPCOM_FEATURES_COMMUNITY_THEMES,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
-import { BUNDLED_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
+import { MARKETPLACE_THEME } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getThemeType,
@@ -73,19 +73,6 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	// debugger;
-
-	if ( type === BUNDLED_THEME ) {
-		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
-		const themeSoftware = themeSoftwareSet[ 0 ];
-
-		const featureChecks = [
-			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-			WPCOM_FEATURES_ATOMIC,
-			...( extraFeatureChecks[ themeSoftware ] || [] ),
-		];
-
-		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
-	}
 
 	if ( type === MARKETPLACE_THEME ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -8,7 +8,6 @@ import {
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
 import {
-	FREE_THEME,
 	PREMIUM_THEME,
 	BUNDLED_THEME,
 	MARKETPLACE_THEME,
@@ -40,6 +39,10 @@ export function canUseTheme( state, siteId, themeId ) {
 	// console.debug( 'type', type );
 	// console.debug( 'themeTier', themeTier );
 
+	if ( themeTier.slug === 'free' ) {
+		return true;
+	}
+
 	// is this exactly the same as type DOT_ORG?
 	if ( themeTier.slug === 'community' ) {
 		return (
@@ -67,10 +70,6 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	// debugger;
-
-	if ( type === FREE_THEME ) {
-		return true;
-	}
 
 	if ( type === PERSONAL_THEME ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -16,6 +16,52 @@ const extraFeatureChecks = {
 	'woo-on-plans': [ FEATURE_WOOP ],
 };
 
+const getThemeTierFeatureChecks = ( state, siteId, themeId ) => {
+	const themeTier = getThemeTierForTheme( state, themeId );
+
+	switch ( themeTier.slug ) {
+		case 'free': {
+			return [];
+		}
+
+		case 'personal': {
+			return [ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ];
+		}
+
+		case 'premium': {
+			return [ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ];
+		}
+
+		// is this exactly the same as type DOT_ORG?
+		case 'community': {
+			return [ FEATURE_INSTALL_THEMES, WPCOM_FEATURES_COMMUNITY_THEMES ];
+		}
+
+		case 'sensei': {
+			return [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
+		}
+
+		case 'woocommerce': {
+			const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
+			const themeSoftware = themeSoftwareSet[ 0 ];
+
+			return [
+				WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+				WPCOM_FEATURES_ATOMIC,
+				...( extraFeatureChecks[ themeSoftware ] || [] ),
+			];
+		}
+
+		case 'partner': {
+			return [ WPCOM_FEATURES_ATOMIC ];
+		}
+
+		default: {
+			return null;
+		}
+	}
+};
+
 /**
  * Checks whether the given theme is included in the current plan of the site.
  * @param  {Object}  state   Global state tree
@@ -24,49 +70,11 @@ const extraFeatureChecks = {
  * @returns {boolean}         Whether the theme is included in the site plan.
  */
 export function canUseTheme( state, siteId, themeId ) {
-	const themeTier = getThemeTierForTheme( state, themeId );
+	const featureChecks = getThemeTierFeatureChecks( state, siteId, themeId );
 
-	if ( themeTier.slug === 'free' ) {
-		return true;
+	if ( featureChecks === null ) {
+		return false;
 	}
 
-	if ( themeTier.slug === 'personal' ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
-	}
-
-	if ( themeTier.slug === 'premium' ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
-	}
-
-	// is this exactly the same as type DOT_ORG?
-	if ( themeTier.slug === 'community' ) {
-		return (
-			siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) &&
-			siteHasFeature( state, siteId, WPCOM_FEATURES_COMMUNITY_THEMES )
-		);
-	}
-
-	if ( themeTier.slug === 'sensei' ) {
-		const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
-		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
-	}
-
-	if ( themeTier.slug === 'woocommerce' ) {
-		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
-		const themeSoftware = themeSoftwareSet[ 0 ];
-
-		const featureChecks = [
-			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-			WPCOM_FEATURES_ATOMIC,
-			...( extraFeatureChecks[ themeSoftware ] || [] ),
-		];
-
-		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
-	}
-
-	if ( themeTier.slug === 'partner' ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
-	}
-
-	return false;
+	return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
 }

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -40,18 +40,7 @@ export function canUseTheme( state, siteId, themeId ) {
 	// console.debug( 'type', type );
 	// console.debug( 'themeTier', themeTier );
 
-	if ( type === FREE_THEME ) {
-		return true;
-	}
-
-	if ( type === PERSONAL_THEME ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
-	}
-
-	if ( type === PREMIUM_THEME ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
-	}
-
+	// is this exactly the same as type DOT_ORG?
 	if ( themeTier.slug === 'community' ) {
 		return (
 			siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) &&
@@ -62,6 +51,33 @@ export function canUseTheme( state, siteId, themeId ) {
 	if ( themeTier.slug === 'sensei' ) {
 		const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
 		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
+	}
+
+	if ( themeTier.slug === 'woocommerce' ) {
+		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
+		const themeSoftware = themeSoftwareSet[ 0 ];
+
+		const featureChecks = [
+			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+			WPCOM_FEATURES_ATOMIC,
+			...( extraFeatureChecks[ themeSoftware ] || [] ),
+		];
+
+		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
+	}
+
+	// debugger;
+
+	if ( type === FREE_THEME ) {
+		return true;
+	}
+
+	if ( type === PERSONAL_THEME ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
+	}
+
+	if ( type === PREMIUM_THEME ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
 	}
 
 	if ( type === BUNDLED_THEME ) {

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -16,7 +16,11 @@ import {
 	PERSONAL_THEME,
 } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getThemeType, getThemeSoftwareSet } from 'calypso/state/themes/selectors';
+import {
+	getThemeType,
+	getThemeSoftwareSet,
+	getThemeTierForTheme,
+} from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
 
@@ -33,7 +37,9 @@ const extraFeatureChecks = {
  */
 export function canUseTheme( state, siteId, themeId ) {
 	const type = getThemeType( state, themeId );
-
+	const themeTier = getThemeTierForTheme( state, themeId );
+	// console.debug( 'type', type );
+	// console.debug( 'themeTier', themeTier );
 	if ( type === FREE_THEME ) {
 		return true;
 	}
@@ -53,16 +59,16 @@ export function canUseTheme( state, siteId, themeId ) {
 		);
 	}
 
+	// e.g. Course theme
+	const features = themeTier?.featureList ?? [ themeTier?.feature ];
+	if ( features.includes( WPCOM_FEATURES_SENSEI_THEMES ) ) {
+		const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
+		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
+	}
+
 	if ( type === BUNDLED_THEME ) {
 		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );
 		const themeSoftware = themeSoftwareSet[ 0 ];
-
-		// Add a special case for Sensei themes to ensure they are limited to the Business plan.
-		// @todo refactor this whole file using theme tiers.
-		if ( themeSoftware === 'sensei' ) {
-			const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
-			return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
-		}
 
 		const featureChecks = [
 			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -10,7 +10,6 @@ import {
 import {
 	FREE_THEME,
 	PREMIUM_THEME,
-	DOT_ORG_THEME,
 	BUNDLED_THEME,
 	MARKETPLACE_THEME,
 	PERSONAL_THEME,
@@ -40,6 +39,7 @@ export function canUseTheme( state, siteId, themeId ) {
 	const themeTier = getThemeTierForTheme( state, themeId );
 	// console.debug( 'type', type );
 	// console.debug( 'themeTier', themeTier );
+
 	if ( type === FREE_THEME ) {
 		return true;
 	}
@@ -52,7 +52,7 @@ export function canUseTheme( state, siteId, themeId ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
 	}
 
-	if ( type === DOT_ORG_THEME ) {
+	if ( themeTier.slug === 'community' ) {
 		return (
 			siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ) &&
 			siteHasFeature( state, siteId, WPCOM_FEATURES_COMMUNITY_THEMES )

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -7,13 +7,8 @@ import {
 	WPCOM_FEATURES_COMMUNITY_THEMES,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
-import { MARKETPLACE_THEME } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import {
-	getThemeType,
-	getThemeSoftwareSet,
-	getThemeTierForTheme,
-} from 'calypso/state/themes/selectors';
+import { getThemeSoftwareSet, getThemeTierForTheme } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
 
@@ -29,10 +24,7 @@ const extraFeatureChecks = {
  * @returns {boolean}         Whether the theme is included in the site plan.
  */
 export function canUseTheme( state, siteId, themeId ) {
-	const type = getThemeType( state, themeId );
 	const themeTier = getThemeTierForTheme( state, themeId );
-	// console.debug( 'type', type );
-	// console.debug( 'themeTier', themeTier );
 
 	if ( themeTier.slug === 'free' ) {
 		return true;
@@ -72,9 +64,7 @@ export function canUseTheme( state, siteId, themeId ) {
 		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
 	}
 
-	// debugger;
-
-	if ( type === MARKETPLACE_THEME ) {
+	if ( themeTier.slug === 'partner' ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 	}
 

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -59,9 +59,7 @@ export function canUseTheme( state, siteId, themeId ) {
 		);
 	}
 
-	// e.g. Course theme
-	const features = themeTier?.featureList ?? [ themeTier?.feature ];
-	if ( features.includes( WPCOM_FEATURES_SENSEI_THEMES ) ) {
+	if ( themeTier.slug === 'sensei' ) {
 		const featureChecks = [ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ];
 		return featureChecks.every( ( feature ) => siteHasFeature( state, siteId, feature ) );
 	}

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -7,7 +7,7 @@ import {
 	WPCOM_FEATURES_COMMUNITY_THEMES,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
-import { PREMIUM_THEME, BUNDLED_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
+import { BUNDLED_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getThemeType,
@@ -42,6 +42,10 @@ export function canUseTheme( state, siteId, themeId ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
 	}
 
+	if ( themeTier.slug === 'premium' ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
+	}
+
 	// is this exactly the same as type DOT_ORG?
 	if ( themeTier.slug === 'community' ) {
 		return (
@@ -69,10 +73,6 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	// debugger;
-
-	if ( type === PREMIUM_THEME ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );
-	}
 
 	if ( type === BUNDLED_THEME ) {
 		const themeSoftwareSet = getThemeSoftwareSet( state, themeId );

--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -7,12 +7,7 @@ import {
 	WPCOM_FEATURES_COMMUNITY_THEMES,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
-import {
-	PREMIUM_THEME,
-	BUNDLED_THEME,
-	MARKETPLACE_THEME,
-	PERSONAL_THEME,
-} from '@automattic/design-picker';
+import { PREMIUM_THEME, BUNDLED_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getThemeType,
@@ -43,6 +38,10 @@ export function canUseTheme( state, siteId, themeId ) {
 		return true;
 	}
 
+	if ( themeTier.slug === 'personal' ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
+	}
+
 	// is this exactly the same as type DOT_ORG?
 	if ( themeTier.slug === 'community' ) {
 		return (
@@ -70,10 +69,6 @@ export function canUseTheme( state, siteId, themeId ) {
 	}
 
 	// debugger;
-
-	if ( type === PERSONAL_THEME ) {
-		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
-	}
 
 	if ( type === PREMIUM_THEME ) {
 		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED );

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -61,6 +61,32 @@ describe( 'canUseTheme', () => {
 		} );
 	} );
 
+	describe( 'premium', () => {
+		const themeTier = {
+			slug: 'premium',
+			feature: 'premium-themes',
+			platform: 'simple',
+		};
+
+		it( 'returns true if the site has the Premium Themes feature', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'sensei', () => {
 		const themeTier = {
 			slug: 'sensei',

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -1,0 +1,40 @@
+import { WPCOM_FEATURES_ATOMIC, WPCOM_FEATURES_SENSEI_THEMES } from '@automattic/calypso-products';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import * as themeSelectors from 'calypso/state/themes/selectors';
+import { canUseTheme } from '../can-use-theme';
+
+jest.mock( 'calypso/state/selectors/site-has-feature' );
+jest.mock( 'calypso/state/themes/selectors' );
+
+const mockedSiteHasFeature = jest.mocked( siteHasFeature );
+const mockedThemeSelectors = jest.mocked( themeSelectors );
+
+describe( 'canUseTheme', () => {
+	describe( 'sensei', () => {
+		const state = {};
+		const siteId = 1;
+		const themeTier = {
+			slug: 'sensei',
+			feature: 'sensei-themes',
+			platform: 'atomic',
+		};
+
+		it( 'returns true if the site has Sensei and Atomic features', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -1,7 +1,9 @@
 import {
 	FEATURE_INSTALL_THEMES,
+	FEATURE_WOOP,
 	WPCOM_FEATURES_ATOMIC,
 	WPCOM_FEATURES_COMMUNITY_THEMES,
+	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -25,7 +27,7 @@ describe( 'canUseTheme', () => {
 			platform: 'atomic',
 		};
 
-		it( 'returns true if the site has Sensei and Atomic features', () => {
+		it( 'returns true if the site has the Sensei and Atomic features', () => {
 			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
 				[ WPCOM_FEATURES_SENSEI_THEMES, WPCOM_FEATURES_ATOMIC ].includes( feature )
 			);
@@ -65,6 +67,48 @@ describe( 'canUseTheme', () => {
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
 			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'woo', () => {
+		const themeTier = {
+			slug: 'woocommerce',
+			platform: 'simple',
+			feature: null,
+			featureList: [ 'woocommerce-themes', 'ecommerce-managed-plugins' ],
+		};
+
+		it( 'returns true if the site has the Premium Themes and Atomic features, as well as any extra feature checks depending on the theme software set', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED, WPCOM_FEATURES_ATOMIC, FEATURE_WOOP ].includes(
+					feature
+				)
+			);
+
+			mockedThemeSelectors.getThemeSoftwareSet.mockReturnValue( [ 'woo-on-plans' ] );
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kiosko' ) ).toBe( true );
+		} );
+
+		it( 'returns false if the site has the Premium Themes and Atomic features, but not the extra feature checks depending on the theme software set', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED, WPCOM_FEATURES_ATOMIC ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeSoftwareSet.mockReturnValue( [ 'woo-on-plans' ] );
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kiosko' ) ).toBe( false );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeSoftwareSet.mockReturnValue( [ 'woo-on-plans' ] );
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kiosko' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -87,6 +87,30 @@ describe( 'canUseTheme', () => {
 		} );
 	} );
 
+	describe( 'community', () => {
+		const themeTier = {
+			slug: 'community',
+		};
+
+		it( 'returns true if the site has the Install Themes and Community Themes features', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ FEATURE_INSTALL_THEMES, WPCOM_FEATURES_COMMUNITY_THEMES ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'sensei', () => {
 		const themeTier = {
 			slug: 'sensei',
@@ -110,30 +134,6 @@ describe( 'canUseTheme', () => {
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
 			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'community', () => {
-		const themeTier = {
-			slug: 'community',
-		};
-
-		it( 'returns true if the site has the Install Themes and Community Themes features', () => {
-			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
-				[ FEATURE_INSTALL_THEMES, WPCOM_FEATURES_COMMUNITY_THEMES ].includes( feature )
-			);
-
-			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
-
-			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( true );
-		} );
-
-		it( 'returns false otherwise', () => {
-			mockedSiteHasFeature.mockReturnValue( false );
-
-			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
-
-			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( false );
 		} );
 	} );
 
@@ -176,6 +176,32 @@ describe( 'canUseTheme', () => {
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
 			expect( canUseTheme( state, siteId, 'kiosko' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'partner', () => {
+		const themeTier = {
+			slug: 'partner',
+			feature: 'partner-themes',
+			platform: 'atomic',
+		};
+
+		it( 'returns true if the site has the Atomic feature', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_ATOMIC ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'organic-stax' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'organic-stax' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -3,6 +3,7 @@ import {
 	FEATURE_WOOP,
 	WPCOM_FEATURES_ATOMIC,
 	WPCOM_FEATURES_COMMUNITY_THEMES,
+	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	WPCOM_FEATURES_SENSEI_THEMES,
 } from '@automattic/calypso-products';
@@ -31,6 +32,32 @@ describe( 'canUseTheme', () => {
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
 			expect( canUseTheme( state, siteId, 'strand' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'personal', () => {
+		const themeTier = {
+			slug: 'personal',
+			feature: 'personal-themes',
+			platform: 'simple',
+		};
+
+		it( 'returns true if the site has the Personal Themes feature', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
 		} );
 	} );
 

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -49,7 +49,7 @@ describe( 'canUseTheme', () => {
 
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
-			expect( canUseTheme( state, siteId, 'course' ) ).toBe( true );
+			expect( canUseTheme( state, siteId, 'crafted' ) ).toBe( true );
 		} );
 
 		it( 'returns false otherwise', () => {
@@ -57,7 +57,7 @@ describe( 'canUseTheme', () => {
 
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
-			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
+			expect( canUseTheme( state, siteId, 'crafted' ) ).toBe( false );
 		} );
 	} );
 
@@ -75,7 +75,7 @@ describe( 'canUseTheme', () => {
 
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
-			expect( canUseTheme( state, siteId, 'course' ) ).toBe( true );
+			expect( canUseTheme( state, siteId, 'launchit' ) ).toBe( true );
 		} );
 
 		it( 'returns false otherwise', () => {
@@ -83,7 +83,7 @@ describe( 'canUseTheme', () => {
 
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
-			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
+			expect( canUseTheme( state, siteId, 'launchit' ) ).toBe( false );
 		} );
 	} );
 

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -20,6 +20,20 @@ describe( 'canUseTheme', () => {
 	const state = {};
 	const siteId = 1;
 
+	describe( 'free', () => {
+		const themeTier = {
+			slug: 'free',
+			feature: null,
+			platform: 'simple',
+		};
+
+		it( 'returns true', () => {
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'strand' ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'sensei', () => {
 		const themeTier = {
 			slug: 'sensei',

--- a/client/state/themes/selectors/test/can-use-theme.test.ts
+++ b/client/state/themes/selectors/test/can-use-theme.test.ts
@@ -1,4 +1,9 @@
-import { WPCOM_FEATURES_ATOMIC, WPCOM_FEATURES_SENSEI_THEMES } from '@automattic/calypso-products';
+import {
+	FEATURE_INSTALL_THEMES,
+	WPCOM_FEATURES_ATOMIC,
+	WPCOM_FEATURES_COMMUNITY_THEMES,
+	WPCOM_FEATURES_SENSEI_THEMES,
+} from '@automattic/calypso-products';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import * as themeSelectors from 'calypso/state/themes/selectors';
 import { canUseTheme } from '../can-use-theme';
@@ -10,9 +15,10 @@ const mockedSiteHasFeature = jest.mocked( siteHasFeature );
 const mockedThemeSelectors = jest.mocked( themeSelectors );
 
 describe( 'canUseTheme', () => {
+	const state = {};
+	const siteId = 1;
+
 	describe( 'sensei', () => {
-		const state = {};
-		const siteId = 1;
 		const themeTier = {
 			slug: 'sensei',
 			feature: 'sensei-themes',
@@ -35,6 +41,30 @@ describe( 'canUseTheme', () => {
 			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
 
 			expect( canUseTheme( state, siteId, 'course' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'community', () => {
+		const themeTier = {
+			slug: 'community',
+		};
+
+		it( 'returns true if the site has the Install Themes and Community Themes features', () => {
+			mockedSiteHasFeature.mockImplementation( ( _state, _siteId, feature ) =>
+				[ FEATURE_INSTALL_THEMES, WPCOM_FEATURES_COMMUNITY_THEMES ].includes( feature )
+			);
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( true );
+		} );
+
+		it( 'returns false otherwise', () => {
+			mockedSiteHasFeature.mockReturnValue( false );
+
+			mockedThemeSelectors.getThemeTierForTheme.mockReturnValue( themeTier );
+
+			expect( canUseTheme( state, siteId, 'kadence' ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-111

## Proposed Changes

* Refactor `canUseTheme` so it relies on theme tier instead of theme type.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview.

### Free site

* Go to a `community` theme (e.g. `/theme/kadence/{siteSlug}`.
* Check that you see the `Available on Business` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/2ae0eb05-ed45-4b74-b902-60d7473ef54f" />

* Go to a `sensei` theme (e.g. `/theme/course/{siteSlug}`.
* Check that you see the `Available on Business` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/b28a907c-294e-4953-add4-ad14f2f89c1e" />

* Click on `Preview`, check that you don't see `Try and customize` on the top right side of the preview:

<img width="3804" height="338" alt="image" src="https://github.com/user-attachments/assets/3e8c10a0-3c04-4410-b64a-910ffc9980ca" />

* Go to a `woocommerce` theme (e.g. `/theme/kiosko/{siteSlug}`.
* Check that you see the `Available on Business` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/1ed1faaf-55bb-4271-9bfc-6ed5f0c23274" />

### Business site

* Go to a `community` theme (e.g. `/theme/kadence/{siteSlug}`.
* Check that you see the `Included with plan` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/b036d910-64c1-4ed0-8338-9c0719cecd37" />

* Go to a `sensei` theme (e.g. `/theme/course/{siteSlug}`.
* Check that you see the `Included with plan` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/a0a703fb-c9f1-437e-ae07-3caa6b8b4a60" />

* Click on `Preview`, check that you don't see `Try and customize` on the top right side of the preview:

<img width="3804" height="338" alt="image" src="https://github.com/user-attachments/assets/7c89584f-5e9e-4991-8ee1-d21155ff79b0" />

* Go to a `woocommerce` theme (e.g. `/theme/kiosko/{siteSlug}`.
* Check that you see the `Included with plan` badge:

<img width="656" height="286" alt="image" src="https://github.com/user-attachments/assets/ccaf11ae-5b3c-40d3-8b00-d1cb38fe4abd" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
