### PR TITLE
A4A: Add warning modal for BD tier based discounts

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-message/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-message/index.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+type Props = {
+	onLearnMoreClick: () => void;
+};
+
+export default function DiscountsComingSoonMessage( { onLearnMoreClick }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="discounts-coming-soon-message">
+			<span className="discounts-coming-soon-message__text">
+				{ translate( 'Tier-based discounts are coming soon.' ) }{ ' ' }
+				<button
+					className="discounts-coming-soon-message__link"
+					onClick={ onLearnMoreClick }
+					type="button"
+				>
+					{ translate( 'Learn more' ) }
+				</button>
+			</span>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-message/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-message/style.scss
@@ -1,0 +1,18 @@
+.discounts-coming-soon-message {
+	display: flex;
+	align-items: center;
+
+	&__text {
+		font-size: 14px;
+	}
+
+	&__link {
+		color: var(--color-primary);
+		text-decoration: underline;
+		cursor: pointer;
+
+		&:hover {
+			color: var(--color-primary-70);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/index.tsx
@@ -1,0 +1,25 @@
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+type Props = {
+	onClose: () => void;
+};
+
+export default function DiscountsComingSoonModal( { onClose }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<Modal
+			className="discounts-coming-soon-modal"
+			title={ translate( 'Discounts coming soon' ) }
+			onRequestClose={ onClose }
+		>
+			<p>
+				{ translate(
+					"We're working on a new tier-based discount model that rewards you as you grow with Automattic for Agencies. We'll notify you when it's ready."
+				) }
+			</p>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/style.scss
@@ -1,0 +1,13 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.discounts-coming-soon-modal {
+	@include break-large {
+		max-width: 420px;
+	}
+
+	p {
+		@include body-large;
+		margin: 0;
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1804/disable-discount-bundle-for-agencies-with-billing-dragon-after-phase-2

## Proposed Changes

* For agencies with Billing Dragon enabled, show a message & modal about Tier-based discounts coming soon.

<img width="1264" height="73" alt="Screenshot 2025-11-12 at 19 03 30" src="https://github.com/user-attachments/assets/b18af56e-b8e8-4a0a-9c12-da39c18ef893" />

<img width="442" height="201" alt="Screenshot 2025-11-12 at 19 03 23" src="https://github.com/user-attachments/assets/331872d5-19d8-49e8-951c-7888de5eac3e" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using an agency with Billing Dragon enabled
* Open the live link
* Go to /marketplace/products
* Confirm you see the "Tier-based discounts are coming soon. Learn more" message where the Tier based dropdown usually shows.
* Click "learn more" and confirm the modal works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
