### PR TITLE
Limit the length of the Site field in the domains datagrid

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-site.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-site.tsx
@@ -7,6 +7,7 @@ import { domainTransferToOtherSiteRoute } from '../../app/router/domains';
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
+import { Truncate } from '../../components/truncate';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
@@ -28,7 +29,11 @@ export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; val
 				params={ { siteSlug: domain?.site_slug } }
 				style={ { textDecoration: 'none' } }
 			>
-				<Text>{ value }</Text>
+				<Text>
+					<Truncate tooltip={ value } ellipsizeMode="tail" limit={ 32 }>
+						{ value }
+					</Truncate>
+				</Text>
 			</Link>
 		</HStack>
 	);


### PR DESCRIPTION
The Site field in the domains datagrid is not limited so if a site has a longer title it would enlarge that column visually taking over the entire view.

| what | image |
| --- | --- |
| before | <img width="1441" height="114" alt="Screenshot 2025-11-12 at 21 17 55" src="https://github.com/user-attachments/assets/111cfa79-8845-4062-b9e2-6073874499c6" /> |
| after | <img width="1435" height="96" alt="Screenshot 2025-11-12 at 21 18 02" src="https://github.com/user-attachments/assets/c0054001-cf8a-40d1-b587-25940f7f90d3" /> |
| tooltip | <img width="1410" height="94" alt="Screenshot 2025-11-12 at 21 18 08" src="https://github.com/user-attachments/assets/f416b3ba-5631-44cb-9412-794ccf9d2e41" /> |


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1746: Limit the site title to certain length in the domains datagrids](https://linear.app/a8c/issue/DOMAINS-1746/limit-the-site-title-to-certain-length-in-the-domains-datagrids)

## Proposed Changes

* Use the `Truncate` component with `limit` to limit the number of characters we show 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the experience better

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the title of a site to something long and make sure you have a domain attached to that site
* Then visit /v2/domains/ and verify that the title is truncated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
