### PR TITLE
Add DNS propagation progress bar component

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
@@ -1,0 +1,10 @@
+@import '@wordpress/base-styles/variables';
+
+.dns-propagation-progress-bar {
+	width: 100%;
+
+	/* Change the progress bar color to the theme color */
+	& > div {
+		background-color: var( --wp-admin-theme-color );
+	}
+}

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
@@ -5,6 +5,6 @@
 
 	/* Change the progress bar color to the theme color */
 	& > div {
-		background-color: var( --wp-admin-theme-color );
+		--wp-components-color-foreground: var(--wp-admin-theme-color);
 	}
 }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -1,0 +1,37 @@
+import { domainPropagationStatusQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import './dns-propagation-progress-bar-style.scss';
+import {
+	ProgressBar,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+interface Props {
+	domainName: string;
+}
+
+export default function DnsPropagationProgressBar( { domainName }: Props ) {
+	const { data, isLoading, isError } = useQuery( domainPropagationStatusQuery( domainName ) );
+
+	if ( isError || isLoading || ! data ) {
+		return null;
+	}
+
+	const propagatedCount = data.propagation_status.filter( ( area ) => area.propagated ).length;
+	const totalCount = data.propagation_status.length;
+	const progressPercentage =
+		totalCount > 0 ? Math.round( ( propagatedCount / totalCount ) * 100 ) : 0;
+
+	return (
+		<VStack spacing={ 2 }>
+			<HStack justify="space-between">
+				<Text weight={ 500 }>{ __( 'Progress' ) }</Text>
+				<Text>{ progressPercentage }%</Text>
+			</HStack>
+			<ProgressBar className="dns-propagation-progress-bar" value={ progressPercentage } />
+		</VStack>
+	);
+}

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -13,6 +13,7 @@ import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import DnsPropagationProgressBar from './components/dns-propagation-progress-bar';
 import DnsRecordsTable from './components/dns-records-table';
 import DomainPropagationStatus from './components/domain-propagation-status';
 import { isMappingVerificationSuccess } from './utils';
@@ -61,6 +62,8 @@ export default function DomainConnectionVerification( {
 							{ status === 'connected' ? __( 'Active' ) : __( 'Verifying' ) }
 						</Badge>
 					</HStack>
+
+					<DnsPropagationProgressBar domainName={ domainName } />
 
 					{ status === 'verifying' && (
 						<Notice variant="info">

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainPropagationStatus } from '@automattic/api-core';
+import { useQuery } from '@tanstack/react-query';
+import { render } from '../../../test-utils';
+import DnsPropagationProgressBar from '../components/dns-propagation-progress-bar';
+
+jest.mock( '@tanstack/react-query', () => ( {
+	...jest.requireActual( '@tanstack/react-query' ),
+	useQuery: jest.fn(),
+} ) );
+
+const createMockPropagationStatus = (
+	overrides?: Partial< DomainPropagationStatus >
+): DomainPropagationStatus => ( {
+	propagation_status: [
+		{ area_code: 'NA', area_name: 'North America', propagated: true },
+		{ area_code: 'EU', area_name: 'Europe', propagated: false },
+	],
+	last_updated: '2025-11-12 13:15:48',
+	...overrides,
+} );
+
+describe( 'DnsPropagationProgressBar', () => {
+	const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders progress bar with correct percentage', () => {
+		const mockData = createMockPropagationStatus();
+
+		mockUseQuery.mockReturnValue( {
+			data: mockData,
+			isLoading: false,
+			isError: false,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar domainName="example.com" />
+		);
+
+		expect( getByText( 'Progress' ) ).toBeVisible();
+		expect( getByText( '50%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '50' );
+	} );
+
+	test( 'rounds the progress percentage to the nearest whole number', () => {
+		const mockData = createMockPropagationStatus( {
+			propagation_status: [
+				{ area_code: 'NA', area_name: 'North America', propagated: true },
+				{ area_code: 'EU', area_name: 'Europe', propagated: true },
+				{ area_code: 'AS', area_name: 'Asia', propagated: false },
+			],
+		} );
+
+		mockUseQuery.mockReturnValue( {
+			data: mockData,
+			isLoading: false,
+			isError: false,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar domainName="example.com" />
+		);
+
+		expect( getByText( '67%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
+	} );
+
+	test( 'renders 100% when every region is propagated', () => {
+		const mockData = createMockPropagationStatus( {
+			propagation_status: [
+				{ area_code: 'NA', area_name: 'North America', propagated: true },
+				{ area_code: 'EU', area_name: 'Europe', propagated: true },
+			],
+		} );
+
+		mockUseQuery.mockReturnValue( {
+			data: mockData,
+			isLoading: false,
+			isError: false,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar domainName="example.com" />
+		);
+
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+	} );
+
+	test( 'renders 0% when no propagation data is available', () => {
+		const mockData = createMockPropagationStatus( {
+			propagation_status: [],
+		} );
+
+		mockUseQuery.mockReturnValue( {
+			data: mockData,
+			isLoading: false,
+			isError: false,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar domainName="example.com" />
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+	} );
+
+	test.each( [
+		{
+			title: 'loading',
+			queryResult: {
+				data: undefined,
+				isLoading: true,
+				isError: false,
+			},
+		},
+		{
+			title: 'errored',
+			queryResult: {
+				data: undefined,
+				isLoading: false,
+				isError: true,
+			},
+		},
+		{
+			title: 'without data',
+			queryResult: {
+				data: undefined,
+				isLoading: false,
+				isError: false,
+			},
+		},
+	] )( 'returns null when query is $title', ( { queryResult } ) => {
+		mockUseQuery.mockReturnValue( {
+			...queryResult,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any );
+
+		const { container } = render( <DnsPropagationProgressBar domainName="example.com" /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
Part of [DOMAINS-1822](https://linear.app/a8c/issue/DOMAINS-1822)

Depends on 195854-ghe-Automattic/wpcom and #107043

## Proposed Changes

This PR creates the DNS propagation progress bar component that will be used in the domain connection verification page.

### Screenshots

<img width="1003" height="1075" alt="Screenshot 2025-11-12 at 18 51 29" src="https://github.com/user-attachments/assets/6ed1d031-eada-40b5-bdfb-99b87bf4a5de" />
<img width="1003" height="1075" alt="Screenshot 2025-11-12 at 19 12 00" src="https://github.com/user-attachments/assets/232ae810-30aa-41c8-8bbf-50682c8e00b6" />

## Why are these changes being made?

This component will help users understand how thoroughly their connected domain's DNS records are being propagated around the world.

## Testing Instructions

You can run the unit tests with:

```sh
yarn test-client client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
```

Manual testing:

- Apply 195854-ghe-Automattic/wpcom to your backend
- Open the live Calypso link or build this branch locally
- In the Multi-Site Dashboard, go to the domain connection verification page for a connected domain (`/v2/domains/<domain_name>/domain-connection-setup`)
- Ensure the progress bar is shown at the top of the page and it reflects the propagation status of the domain's DNS around the world (per the component introduced in #107043)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?