### PR TITLE
[Billing] Allow domains and plans to be cancelled together

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -15,6 +15,7 @@ import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { CancelPurchaseState } from './index';
 import type { Purchases } from '@automattic/data-stores';
+import type { FormEvent } from 'react';
 
 // Helper function to determine if radio buttons will be shown
 export const willShowDomainOptionsRadioButtons = (
@@ -173,8 +174,8 @@ const CancelPurchaseDomainOptions = ( {
 	const dispatch = useDispatch();
 
 	const onCancelBundledDomainChange = useCallback(
-		( event: { target: { value: string } } ) => {
-			const newCancelBundledDomainValue = event.target.value === 'cancel';
+		( event: FormEvent< HTMLInputElement > ) => {
+			const newCancelBundledDomainValue = event.currentTarget.value === 'cancel';
 			onCancelConfirmationStateChange( {
 				cancelBundledDomain: newCancelBundledDomainValue,
 				confirmCancelBundledDomain: newCancelBundledDomainValue && confirmCancel,

--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -173,8 +173,8 @@ const CancelPurchaseDomainOptions = ( {
 	const dispatch = useDispatch();
 
 	const onCancelBundledDomainChange = useCallback(
-		( event: { currentTarget: { value: string } } ) => {
-			const newCancelBundledDomainValue = event.currentTarget.value === 'cancel';
+		( event: { target: { value: string } } ) => {
+			const newCancelBundledDomainValue = event.target.value === 'cancel';
 			onCancelConfirmationStateChange( {
 				cancelBundledDomain: newCancelBundledDomainValue,
 				confirmCancelBundledDomain: newCancelBundledDomainValue && confirmCancel,

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -207,7 +207,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
 		this.setState( ( state ) => ( {
 			...state,
-			newState,
+			...newState,
 		} ) );
 	};
 
@@ -773,7 +773,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
 			this.setState( ( state ) => ( {
 				...state,
-				newState,
+				...newState,
 			} ) );
 		};
 
@@ -799,7 +799,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						includedDomainPurchase={ includedDomainPurchase }
 						disabled={ ! canContinue() }
 						siteSlug={ this.props.siteSlug }
-						cancelBundledDomain={ cancelBundledDomain }
+						cancelBundledDomain={ this.state.cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -799,7 +799,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						includedDomainPurchase={ includedDomainPurchase }
 						disabled={ ! canContinue() }
 						siteSlug={ this.props.siteSlug }
-						cancelBundledDomain={ this.state.cancelBundledDomain }
+						cancelBundledDomain={ cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }

--- a/client/state/purchases/selectors/get-included-domain-purchase.ts
+++ b/client/state/purchases/selectors/get-included-domain-purchase.ts
@@ -26,11 +26,7 @@ export const getIncludedDomainPurchase = (
 	state: AppState,
 	subscriptionPurchase: Purchase | null | undefined
 ): Purchase | null | undefined => {
-	if (
-		! subscriptionPurchase ||
-		! isSubscription( subscriptionPurchase ) ||
-		subscriptionPurchase.includedDomainPurchaseAmount
-	) {
+	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
 		return null;
 	}
 
@@ -41,6 +37,7 @@ export const getIncludedDomainPurchase = (
 			( isDomainMapping( purchase ) ||
 				isDomainRegistration( purchase ) ||
 				isDomainTransfer( purchase ) ) &&
-			includedDomain === purchase.meta
+			includedDomain === purchase.meta &&
+			purchase.costToUnbundleText
 	);
 };

--- a/client/state/purchases/selectors/get-included-domain-purchase.ts
+++ b/client/state/purchases/selectors/get-included-domain-purchase.ts
@@ -38,6 +38,6 @@ export const getIncludedDomainPurchase = (
 				isDomainRegistration( purchase ) ||
 				isDomainTransfer( purchase ) ) &&
 			includedDomain === purchase.meta &&
-			parseFloat( purchase.costToUnbundleText ) > 0
+			purchase.costToUnbundleText
 	);
 };

--- a/client/state/purchases/selectors/get-included-domain-purchase.ts
+++ b/client/state/purchases/selectors/get-included-domain-purchase.ts
@@ -38,6 +38,6 @@ export const getIncludedDomainPurchase = (
 				isDomainRegistration( purchase ) ||
 				isDomainTransfer( purchase ) ) &&
 			includedDomain === purchase.meta &&
-			purchase.costToUnbundleText
+			parseFloat( purchase.costToUnbundleText ) > 0
 	);
 };

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -231,6 +231,8 @@ describe( 'selectors', () => {
 							is_domain_registration: 'true',
 							product_slug: 'dotlive_domain',
 							subsciption_status: 'active',
+							cost_to_unbundle_display: '$500.00',
+							price_text: '$500.00',
 						},
 						{
 							ID: '82867',
@@ -315,6 +317,7 @@ describe( 'selectors', () => {
 							blog_id: '123',
 							product_slug: 'domain_transfer',
 							subsciption_status: 'active',
+							cost_to_unbundle_display: '$15',
 						},
 						{
 							ID: '82867',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [SHILL-941](https://linear.app/a8c/issue/SHILL-941/cancelling-a-plan-and-domain-together-is-no-longer-possible)

## Proposed Changes

* Allow domains and plans to be cancelled together

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug where the user was not given a choice to cancel the domain at the same time as the plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For a new site, purchase a plan and a domain, and make sure that the domain is registered for at least 2 years - this page will not show if you allow the default of "1 year" to be shown because there will be no opportunity to refund a free domain which comes with the plan. Instead, when the length of the domain registration _at checkout_ is 2 years or more, the user is given a choice because the domain will now have had an additional refundable cost.
* Cancel the plan and domain by managing it at `/me/purchases`, and make sure you see the option which asks you to choose if you want to keep the domain.
* Choose to cancel the plan and domain and make sure the checkbox appears and that the "Cancel Subscription" button isn't enabled unless the checkbox is checked.
* Continue with cancellation and make sure the correct products are removed from the `/me/purchases` page and that the refund amount is correct (depending on your choice made when cancelling)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
