### PR TITLE
MSD: Change to use a prop to control the last element in PageHeader to control dropdown menu alignment.

### DIFF
--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -23,6 +23,7 @@ export const SectionHeader = ( {
 	prefix,
 	className,
 	level = 2,
+	hasActionDropdown = false,
 }: SectionHeaderProps ) => {
 	const HeadingTag = `h${ level }` as keyof JSX.IntrinsicElements;
 	return (
@@ -53,7 +54,9 @@ export const SectionHeader = ( {
 							justify="flex-start"
 							expanded={ false }
 							alignment="flex-start"
-							className="dashboard-section-header__actions"
+							className={ clsx( 'dashboard-section-header__actions', {
+								'has-action-dropdown': !! hasActionDropdown,
+							} ) }
 							style={ { flex: '1 1 auto' } }
 						>
 							{ actions }

--- a/client/dashboard/components/section-header/style.scss
+++ b/client/dashboard/components/section-header/style.scss
@@ -68,3 +68,10 @@
 	flex-shrink: 0;
 	align-self: stretch;
 }
+
+.dashboard-section-header__actions.has-action-dropdown {
+	:last-child {
+		margin-inline-start: auto;
+		min-width: fit-content;
+	}
+}

--- a/client/dashboard/components/section-header/types.ts
+++ b/client/dashboard/components/section-header/types.ts
@@ -16,6 +16,10 @@ export interface SectionHeaderProps {
 	 */
 	actions?: React.ReactNode;
 	/**
+	 * Whether the section header has an action dropdown.
+	 */
+	hasActionDropdown?: boolean;
+	/**
 	 * An optional visual element like an icon or small illustration
 	 * to enhance recognition or provide visual interest.
 	 */

--- a/client/dashboard/components/section-header/types.ts
+++ b/client/dashboard/components/section-header/types.ts
@@ -16,7 +16,7 @@ export interface SectionHeaderProps {
 	 */
 	actions?: React.ReactNode;
 	/**
-	 * Whether the section header has an action dropdown.
+	 * Whether the section header has a dropdown in the actions section.
 	 */
 	hasActionDropdown?: boolean;
 	/**

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -54,7 +54,11 @@ export default function DomainAddDNS() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ <DnsDescription /> }
+					hasActionDropdown
+				/>
 			}
 		>
 			<DNSRecordForm

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -63,7 +63,11 @@ export default function DomainEditDNS() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader prefix={ <Breadcrumbs length={ 3 } /> } description={ <DnsDescription /> } />
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 3 } /> }
+					description={ <DnsDescription /> }
+					hasActionDropdown
+				/>
 			}
 		>
 			<DNSRecordForm

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -325,6 +325,7 @@ export default function DomainDns() {
 							</HStack>
 						}
 						description={ <DnsDescription /> }
+						hasActionDropdown
 					/>
 				</VStack>
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -25,7 +25,6 @@ import { Link } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	DropdownMenu,
 	MenuGroup,
@@ -1084,16 +1083,17 @@ export default function PurchaseSettings() {
 						title={ getTitleForDisplay( purchase ) }
 						actions={
 							site?.options?.admin_url && (
-								<HStack justify="space-between">
+								<>
 									{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
 											{ __( 'Upgrade' ) }
 										</Button>
 									) }
 									<PurchaseActionMenu purchase={ purchase } />
-								</HStack>
+								</>
 							)
 						}
+						hasActionDropdown
 						description={
 							<MetadataList>
 								<PurchaseSubtitle purchase={ purchase } />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,21 +197,19 @@ function SiteOverview( {
 		}
 
 		return (
-			<HStack justify="space-between">
-				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' } style={ { width: 'auto' } }>
-					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
-					<Button
-						ref={ wpAdminButtonRef }
-						__next40pxDefaultSize
-						variant="primary"
-						href={ site.options.admin_url }
-						icon={ wordpress }
-					>
-						{ __( 'WP Admin' ) }
-					</Button>
-				</HStack>
+			<>
+				<StagingSiteSyncDropdown siteSlug={ siteSlug } />
+				<Button
+					ref={ wpAdminButtonRef }
+					__next40pxDefaultSize
+					variant="primary"
+					href={ site.options.admin_url }
+					icon={ wordpress }
+				>
+					{ __( 'WP Admin' ) }
+				</Button>
 				<SiteActionMenu site={ site } />
-			</HStack>
+			</>
 		);
 	};
 
@@ -223,6 +221,7 @@ function SiteOverview( {
 					title={ getSiteDisplayName( site ) }
 					description={ <SiteOverviewFields site={ site } /> }
 					actions={ renderActions() }
+					hasActionDropdown
 				/>
 			}
 		>


### PR DESCRIPTION
Alternative: #107072
Related to: #107003

## Proposed Changes

This PR attempts to improve devEx for PageHeader consumers, who have drop-downs in their `action`. Our preferred small screen layout is to right-align the menu. 

The problem right now, is that the consumer is responsible for handling that layout. See [this comment](https://github.com/Automattic/wp-calypso/pull/107072#issuecomment-3524069800) for context.

Here I've added a prop, `hasActionDropdown`, that tells the section header that it has a dropdown in the actions list, and it adds a custom style , `has-action-dropdown` which sets up CSS to right align the last item when the actions wrap.

I'm not sure I'm in love with the prop name, but I can't think of one that's short and descriptive.

### Screenshots
| Use Cases |
|--------|
| <img width="400" height="1856" alt="calypso localhost_3000_v2_me_billing_purchases_27468300 (2)" src="https://github.com/user-attachments/assets/fe729881-d594-4c20-a261-49028d8bac6b" /> |
| <img width="400" height="1856" alt="calypso localhost_3000_v2_me_billing_purchases_27468300 (1)" src="https://github.com/user-attachments/assets/7ca262d3-b12e-43b4-b864-f37a09e6411b" /> |
| <img width="400" height="1856" alt="calypso localhost_3000_v2_me_billing_purchases_27468300" src="https://github.com/user-attachments/assets/9bcbf96c-13cc-4af8-992e-27e4addb714d" /> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit the following pages on mobile/desktop:
- `/v2/sites/:site`
- `/v2/domains/:domain/dns`
- `/v2/me/billing/purchases/:purchaseId`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
