### PR TITLE
Dashboard: Fix sticky header on very long pages

### DIFF
--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,7 +1,3 @@
-.dashboard-root__layout {
-	height: 100%;
-}
-
 // For pages without sub menus, the first header is the sticky header
 // For pages with sub menus, the second header is the sticky header
 .dashboard-root__layout:not(:has(main > .dashboard-header-bar)) > .dashboard-header-bar,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-806

## Proposed Changes

* Remove explicit height from <Root> element

We don't need an explicit height, by default parent elements already encompass their children—no CSS required.

Another option would have been to use a `min-height: 100vh;`. But afaict there just isn't a need for the <Root> element to take up the whole screen. The snackbars are already `position:fixed` so they don't depend on it.


https://github.com/user-attachments/assets/07f44ac6-4395-493a-b9c5-064ef79bfae0


https://github.com/user-attachments/assets/c84d3a5c-8223-4d6d-814f-65dac05571c2



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The sticky header currently on sticks to the top of the screen for a screen-heights-worth of scrolling. Then it just disappears. This fixes that issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On pages like `/sites`, the primary menu is sticky. Scroll up and down a long `/sites` page to confirm the sticky header works.
* On pages like `/sites/$siteSlug/settings`, the secondary menu is sticky. Test to confirm.
* Make some snackbars appear. Confirm they're still pinned to the bottom left.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
