### PR TITLE
Notifications v2: Close panel on outside click after tab switch

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -20,6 +20,8 @@
 		"build:notifications": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/notifications",
 		"build": "NODE_ENV=production yarn dev",
+		"test:js": "yarn run -T test-apps apps/notifications",
+		"test:js:watch": "yarn test:js --watch",
 		"teamcity:build-app": "yarn build",
 		"translate": "rm -rf dist/strings && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './dist/strings' --output './dist/notifications.pot' && build-app-languages --stringsFilePath='./dist/notifications.pot' --outputPath='./dist/languages'"
 	},

--- a/apps/notifications/src/app/note-list/hooks.ts
+++ b/apps/notifications/src/app/note-list/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
-import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
+import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import getLastSelectedNoteId from '../../panel/state/selectors/get-last-selected-note-id';
 import type { Note } from '../types';
@@ -25,11 +25,8 @@ export function useNoteListFocusToLastSelectedNote( {
 	noteListRef: React.RefObject< HTMLObjectElement >;
 	notes: Note[];
 } ) {
-	const isNoteHidden = useSelector(
-		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
-	);
-
 	const lastSelectedNoteId = useSelector( getLastSelectedNoteId );
+	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
 
 	useEffect(
 		() => {
@@ -41,12 +38,12 @@ export function useNoteListFocusToLastSelectedNote( {
 					return;
 				}
 
-				if ( isNoteHidden( notes[ noteIndex ].id ) ) {
+				if ( hiddenNoteIds[ notes[ noteIndex ].id ] === true ) {
 					// The last selected note is no longer visible.
 
 					// Find the nearest visible note forwards.
 					for ( let i = noteIndex + 1; i < notes.length; i++ ) {
-						if ( ! isNoteHidden( notes[ i ].id ) ) {
+						if ( hiddenNoteIds[ notes[ i ].id ] !== true ) {
 							noteToFocus = notes[ i ];
 							break;
 						}
@@ -55,7 +52,7 @@ export function useNoteListFocusToLastSelectedNote( {
 					if ( ! noteToFocus ) {
 						// Find the nearest visible note backwards.
 						for ( let i = noteIndex - 1; i >= 0; i-- ) {
-							if ( ! isNoteHidden( notes[ i ].id ) ) {
+							if ( hiddenNoteIds[ notes[ i ].id ] !== true ) {
 								noteToFocus = notes[ i ];
 								break;
 							}

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -8,8 +8,8 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
+import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
-import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
 import { getFields, getActions } from './dataviews';
@@ -30,17 +30,11 @@ const DEFAULT_LAYOUTS = {
 const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
 	const { goTo } = useNavigator();
 	const filter = getFilters()[ filterName ];
-
-	const isNoteHidden = useSelector(
-		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
-	);
-
-	const notes = useSelector( ( state ) =>
-		( ( getAllNotes( state ) || [] ) as Note[] ).filter( ( note ) => filter.filter( note ) )
-	);
-
+	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
+	const notes = allNotes.filter( ( note ) => filter.filter( note ) );
 	// Filter out hidden notes, i.e. notes that have been just marked as spam or moved to the trash.
-	const visibleNotes = notes.filter( ( note ) => ! isNoteHidden( note.id ) );
+	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
+	const visibleNotes = notes.filter( ( note ) => hiddenNoteIds[ note.id ] !== true );
 
 	const isLoading = useSelector( ( state ) => getIsLoading( state ) );
 	const { client } = useAppContext();

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -27,7 +27,7 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { Tabs } = unlock( privateApis );
 
-const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
+export const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
 	name,
 	title: label,
 } ) );

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -4,13 +4,14 @@ import {
 	__experimentalHeading as Heading,
 	CardHeader,
 	Icon,
-	TabPanel,
 	useNavigator,
+	privateApis,
 } from '@wordpress/components';
 import '@wordpress/components/build-style/style.css';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
-import { useEffect } from 'react';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { useEffect, useCallback, useRef } from 'react';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
 import { getFilters } from '../../panel/templates/filters';
 import NoteList from '../note-list';
@@ -18,6 +19,13 @@ import CloseButton from '../templates/close-button';
 import NotePanelActions from './actions';
 
 type FilterName = keyof ReturnType< typeof getFilters >;
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
 
 const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } ) => ( {
 	name,
@@ -27,6 +35,14 @@ const NOTIFICATION_TABS = Object.values( getFilters() ).map( ( { name, label } )
 const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const { params, goTo } = useNavigator();
 	const { filterName = 'all' } = params;
+	const tabRefs = useRef< Record< string, HTMLButtonElement > >( {} );
+
+	const handleSelect = useCallback(
+		( tabId: string ) => {
+			goTo( `/${ tabId }`, { replace: true, skipFocus: true } );
+		},
+		[ goTo ]
+	);
 
 	useEffect( () => {
 		const stopEvent = ( event: KeyboardEvent ) => {
@@ -38,27 +54,23 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			if ( modifierKeyIsActive( event ) ) {
 				return;
 			}
-			switch ( event.key ) {
-				case 'a':
-					stopEvent( event );
-					goTo( '/all', { replace: true } );
-					break;
-				case 'u':
-					stopEvent( event );
-					goTo( '/unread', { replace: true } );
-					break;
-				case 'c':
-					stopEvent( event );
-					goTo( '/comments', { replace: true } );
-					break;
-				case 'f':
-					stopEvent( event );
-					goTo( '/follows', { replace: true } );
-					break;
-				case 'l':
-					stopEvent( event );
-					goTo( '/likes', { replace: true } );
-					break;
+
+			const shortcutToTabId: Record< string, string > = {
+				a: 'all',
+				u: 'unread',
+				c: 'comments',
+				f: 'follows',
+				s: 'follows', // It’s more intuitive to use s, since we display “Subscribes.”
+				l: 'likes',
+			};
+
+			const tabId = shortcutToTabId[ event.key ];
+			if ( tabId ) {
+				stopEvent( event );
+				handleSelect( tabId );
+
+				// Ensure that keyboard navigation focuses on the selected tab.
+				tabRefs.current[ tabId ]?.focus();
 			}
 		};
 
@@ -66,7 +78,7 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 		return () => {
 			window.removeEventListener( 'keydown', handleKeyDown, false );
 		};
-	}, [ goTo ] );
+	}, [ tabRefs, handleSelect ] );
 
 	return (
 		<>
@@ -87,17 +99,22 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 							{ isDismissible && <CloseButton /> }
 						</HStack>
 					</HStack>
-					<TabPanel
-						activeClass="is-active"
-						tabs={ NOTIFICATION_TABS }
-						initialTabName={ filterName as string }
-						key={ filterName as string }
-						onSelect={ ( tabName ) => {
-							goTo( `/${ tabName }`, { replace: true } );
-						} }
-					>
-						{ () => null /* Placeholder div since content is rendered elsewhere */ }
-					</TabPanel>
+					<Tabs selectedTabId={ filterName } onSelect={ handleSelect }>
+						<Tabs.TabList>
+							{ NOTIFICATION_TABS.map( ( { name, title } ) => (
+								<Tabs.Tab
+									key={ name }
+									tabId={ name }
+									style={ { fontFamily: 'inherit', fontWeight: 500, lineHeight: '16px' } }
+									ref={ ( element: HTMLButtonElement ) => {
+										tabRefs.current[ name ] = element;
+									} }
+								>
+									{ title }
+								</Tabs.Tab>
+							) ) }
+						</Tabs.TabList>
+					</Tabs>
 				</VStack>
 			</CardHeader>
 			<NoteList filterName={ filterName as FilterName } />

--- a/apps/notifications/src/app/note-panel/test/index.tsx
+++ b/apps/notifications/src/app/note-panel/test/index.tsx
@@ -1,4 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Navigator } from '@wordpress/components';
 import { renderWithProvider } from '../../../testing-library';
 import NodePanel, { NOTIFICATION_TABS } from '../index';
 
@@ -40,5 +42,28 @@ describe( 'NotePanel', () => {
 		NOTIFICATION_TABS.forEach( ( { title }: { title: string } ) => {
 			expect( getByText( title ) ).toBeInTheDocument();
 		} );
+	} );
+
+	it( 'should select tab on click', async () => {
+		renderWithProvider(
+			<Navigator initialPath="/all">
+				<Navigator.Screen path="/:filterName">
+					<NodePanel />
+				</Navigator.Screen>
+			</Navigator>
+		);
+
+		await waitForComponentToBeInitializedWithSelectedTab( NOTIFICATION_TABS[ 0 ].title );
+
+		const nextSelectedTab = NOTIFICATION_TABS[ 1 ];
+		await userEvent.click( screen.getByRole( 'tab', { name: nextSelectedTab.title } ) );
+		await waitFor( () =>
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: nextSelectedTab.title,
+				} )
+			).toBeVisible()
+		);
 	} );
 } );

--- a/apps/notifications/src/app/note-panel/test/index.tsx
+++ b/apps/notifications/src/app/note-panel/test/index.tsx
@@ -1,0 +1,16 @@
+import { waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../testing-library';
+import NodePanel, { NOTIFICATION_TABS } from '../index';
+
+describe( 'NotePanel', () => {
+	it( 'should render correctly', async () => {
+		const { getByText } = renderWithProvider( <NodePanel /> );
+
+		// Avoid the Tabs components that update state asynchronously to trigger warnings.
+		await waitFor( () => {
+			NOTIFICATION_TABS.forEach( ( { title }: { title: string } ) => {
+				expect( getByText( title ) ).toBeInTheDocument();
+			} );
+		} );
+	} );
+} );

--- a/apps/notifications/src/app/note-panel/test/index.tsx
+++ b/apps/notifications/src/app/note-panel/test/index.tsx
@@ -1,16 +1,44 @@
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../testing-library';
 import NodePanel, { NOTIFICATION_TABS } from '../index';
+
+// Copied from https://github.com/WordPress/gutenberg/blob/adf3ef6d41df4e70f283a35f552631668131dd95/packages/components/src/tabs/test/index.tsx#L181.
+async function waitForComponentToBeInitializedWithSelectedTab(
+	selectedTabName: string | undefined
+) {
+	if ( ! selectedTabName ) {
+		// Wait for the tablist to be tabbable as a mean to know
+		// that ariakit has finished initializing.
+		await waitFor( () =>
+			expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+				'tabindex',
+				expect.stringMatching( /^(0|-1)$/ )
+			)
+		);
+		// No initially selected tabs or tabpanels.
+		await waitFor( () =>
+			expect( screen.queryByRole( 'tab', { selected: true } ) ).not.toBeInTheDocument()
+		);
+	} else {
+		// Waiting for a tab to be selected is a sign that the component
+		// has fully initialized.
+		expect(
+			await screen.findByRole( 'tab', {
+				selected: true,
+				name: selectedTabName,
+			} )
+		).toBeVisible();
+	}
+}
 
 describe( 'NotePanel', () => {
 	it( 'should render correctly', async () => {
 		const { getByText } = renderWithProvider( <NodePanel /> );
 
-		// Avoid the Tabs components that update state asynchronously to trigger warnings.
-		await waitFor( () => {
-			NOTIFICATION_TABS.forEach( ( { title }: { title: string } ) => {
-				expect( getByText( title ) ).toBeInTheDocument();
-			} );
+		await waitForComponentToBeInitializedWithSelectedTab( NOTIFICATION_TABS[ 0 ].title );
+
+		NOTIFICATION_TABS.forEach( ( { title }: { title: string } ) => {
+			expect( getByText( title ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -16,8 +16,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getActions } from '../../panel/helpers/notes';
 import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
+import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
-import getIsNoteHidden from '../../panel/state/selectors/get-is-note-hidden';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
 import { getFilters } from '../../panel/templates/filters';
 import ActionDropdown from '../templates/action-dropdown';
@@ -76,16 +76,11 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const { filterName, noteId } = params;
 
 	const filter = getFilters()[ filterName as keyof ReturnType< typeof getFilters > ];
-
-	const isNoteHidden = useSelector(
-		( state ) => ( noteId: number ) => getIsNoteHidden( state, noteId )
-	);
-
 	const notes = useSelector( ( state ) => ( getAllNotes( state ) || [] ) as NoteObject[] );
 	const note = notes.find( ( note ) => String( note.id ) === noteId );
-
+	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
 	const visibleNotes = notes.filter(
-		( note ) => filter.filter( note ) && ! isNoteHidden( note.id )
+		( note ) => filter.filter( note ) && hiddenNoteIds[ note.id ] !== true
 	);
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );

--- a/apps/notifications/src/panel/state/selectors/get-hidden-note-ids.js
+++ b/apps/notifications/src/panel/state/selectors/get-hidden-note-ids.js
@@ -1,0 +1,5 @@
+import getNotes from './get-notes';
+
+export const getHiddenNoteIds = ( notesState ) => notesState.hiddenNoteIds;
+
+export default ( state ) => getHiddenNoteIds( getNotes( state ) );

--- a/apps/notifications/src/testing-library/index.tsx
+++ b/apps/notifications/src/testing-library/index.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { init as initStore } from '../panel/state';
+import type { RenderOptions } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+export const renderWithProvider = ( ui: ReactNode, options?: RenderOptions ) => {
+	return render( <Provider store={ initStore() }>{ ui }</Provider>, options );
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1209
Follow-up https://github.com/Automattic/wp-calypso/pull/107039

## Proposed Changes

* Remove the `key` from `TabPanel` to prevent losing focus in the `Dropdown`, as the key forces a remount when switching tabs.
* Since `TabPanel` doesn’t allow consumers to control the active tab, the previous changes broke keyboard navigation. To fix this, we replaced it with `Tabs`, which lets us control the active tab ourselves. With this change, keyboard navigation works correctly.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `key` on `TabPanel` forced a re-mount when switching tabs (e.g., Unread → All), resetting focus and preventing the built-in close logic from detecting focus transitions. Removing the key keeps focus stable and restores expected outside-click closing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Notifications from the header bell on `/v2/sites`.
* Switch to “Unread” (press `u`) or “Comments” (press `c`), then back to “All” (press `a`).
* Click outside the panel (e.g., page header or main content). The panel should close consistently.
* Validate keyboard navigation and screen-reader focus remain on the active tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
