### PR TITLE
MSD: Update Leave Site → Manage Purchases button link

### DIFF
--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -18,8 +18,10 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
+import { purchasesRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import type { Site, User } from '@automattic/api-core';
 
 interface ContentInfoProps {
@@ -38,6 +40,15 @@ function isSiteOwner( user: User, site: Site ) {
 function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 	const { recordTracksEvent } = useAnalytics();
 
+	const managePurchasesButtonProps = {
+		__next40pxDefaultSize: true,
+		text: __( 'Manage purchases' ),
+		variant: 'primary' as const,
+		onClick: () => {
+			recordTracksEvent( 'calypso_dashboard_site_leave_modal_manage_purchases_click' );
+		},
+	};
+
 	return (
 		<>
 			<VStack spacing={ 0 }>
@@ -51,16 +62,18 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					href={ `/purchases/subscriptions/${ site.slug }` }
-					onClick={ () =>
-						recordTracksEvent( 'calypso_sites_dashboard_site_leave_modal_manage_purchases_click' )
-					}
-				>
-					{ __( 'Manage purchases' ) }
-				</Button>
+				{ isDashboardBackport() ? (
+					<Button
+						{ ...managePurchasesButtonProps }
+						href={ `/purchases/subscriptions/${ site.slug }` }
+					/>
+				) : (
+					<RouterLinkButton
+						{ ...managePurchasesButtonProps }
+						to={ purchasesRoute.fullPath }
+						search={ { site: site.slug } }
+					/>
+				) }
 			</ButtonStack>
 		</>
 	);


### PR DESCRIPTION
## Proposed Changes

For MSD, update the Manage Purchases button link to the v2 Active Upgrades screen.

<img width="596" height="281" alt="SCR-20251113-nbmj" src="https://github.com/user-attachments/assets/71739290-138c-4b3e-bda8-36f601b2b27c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
