### PR TITLE
MSD: Update hasCancelablePurchases logic

### DIFF
--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -19,8 +19,11 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { purchasesRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import type { Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
@@ -80,9 +83,14 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 	};
 
 	const renderPrimaryButton = () => {
+		const buttonProps = {
+			__next40pxDefaultSize: true,
+			variant: 'primary' as const,
+		};
+
 		if ( isAtomicRemovalInProgress ) {
 			return (
-				<Button __next40pxDefaultSize variant="primary" onClick={ onClose }>
+				<Button { ...buttonProps } onClick={ onClose }>
 					{ __( 'OK' ) }
 				</Button>
 			);
@@ -90,30 +98,28 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 
 		if ( p2HubP2Count ) {
 			return (
-				<Button __next40pxDefaultSize variant="primary" href={ site.URL }>
+				<Button { ...buttonProps } href={ site.URL }>
 					{ __( 'Manage P2s' ) }
 				</Button>
 			);
 		}
 
-		if ( isTrialSite( site ) ) {
-			<Button
-				__next40pxDefaultSize
-				variant="primary"
-				href={ `/purchases/subscriptions/${ site.slug }` }
-			>
-				{ __( 'Cancel trial' ) }
-			</Button>;
+		if ( isDashboardBackport() ) {
+			return (
+				<Button { ...buttonProps } href={ `/purchases/subscriptions/${ site.slug }` }>
+					{ isTrialSite( site ) ? __( 'Cancel trial' ) : __( 'Manage purchases' ) }
+				</Button>
+			);
 		}
 
 		return (
-			<Button
-				__next40pxDefaultSize
-				variant="primary"
-				href={ `/purchases/subscriptions/${ site.slug }` }
+			<RouterLinkButton
+				{ ...buttonProps }
+				to={ purchasesRoute.fullPath }
+				search={ { site: site.slug } }
 			>
-				{ __( 'Manage purchases' ) }
-			</Button>
+				{ isTrialSite( site ) ? __( 'Cancel trial' ) : __( 'Manage purchases' ) }
+			</RouterLinkButton>
 		);
 	};
 

--- a/packages/api-queries/src/site-purchases.ts
+++ b/packages/api-queries/src/site-purchases.ts
@@ -8,12 +8,12 @@ export const siteHasCancelablePurchasesQuery = ( siteId: number, userId: number 
 		select: ( purchases ) => {
 			const cancelables = purchases
 				.filter( ( purchase ) => {
-					// Exclude inactive purchases and legacy premium theme purchases.
-					if ( purchase.expiry_status === 'expired' || purchase.product_slug === 'premium_theme' ) {
-						return false;
+					if ( purchase.is_refundable ) {
+						return true;
 					}
 
-					return purchase.is_cancelable;
+					// Exclude legacy premium theme purchases.
+					return purchase.product_slug !== 'premium_theme';
 				} )
 				.filter( ( purchase ) => purchase.user_id === userId );
 


### PR DESCRIPTION
Fixes DOTMSD-641

## Proposed Changes

This PR updates the hasCancelablePurchasesQuery logic to follow the original implementation in https://github.com/Automattic/wp-calypso/blob/c8186d5cbdd4162f8e136977f8848140696f38d8/client/state/selectors/has-cancelable-site-purchases.js#L19-L25

This fixes an issue where on the site delete action, client-side doesn't indicate that the site has active upgrades but the API blocks the site deletion by saying it has active upgrades. Although it's odd that expired upgrades counts as "active".

This PR also updates routing so that in v2, we are navigating users to v2 screens instead of Calypso admin.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a site with expired plan
* Go to the Settings tab and click on Delete Site's "Delete"
* Ensure you see the "Unable to delete" modal with the "Manage purchase" button
* Ensure that clicking the "Manage purchase" button takes you to:
  * Active upgrades DataViews if v2
  * Site's Calypso admin if v1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
