### PR TITLE
MSD: Add plan filter to the sites dataviews

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -115,7 +115,7 @@ module.exports = {
 					},
 					{
 						name: '@automattic/api-queries',
-						importNames: [ 'sitesQuery', 'dashboardSiteListQuery' ],
+						importNames: [ 'sitesQuery', 'dashboardSiteListQuery', 'dashboardSiteFiltersQuery' ],
 						message: 'Use local queries exported from either context or useAppContext instead.',
 					},
 				],

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -1,8 +1,18 @@
-import { sitesQuery, dashboardSiteListQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
+/* eslint-disable no-restricted-imports */
+import {
+	sitesQuery,
+	dashboardSiteListQuery,
+	dashboardSiteFiltersQuery,
+} from '@automattic/api-queries';
+/* eslint-enable no-restricted-imports */
 import boot from '../app/boot';
 import Logo from './logo';
 import './translations';
-import type { FetchSitesOptions, FetchDashboardSiteListParams } from '@automattic/api-core';
+import type {
+	FetchSitesOptions,
+	FetchDashboardSiteListParams,
+	FetchDashboardSiteFiltersParams,
+} from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -51,5 +61,7 @@ boot( {
 			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
 		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
 			dashboardSiteListQuery( [ 'commerce-garden' ], fetchDashboardSiteListParams ),
+		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
+			dashboardSiteFiltersQuery( [ 'commerce-garden' ], fields ),
 	},
 } );

--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -49,9 +49,7 @@ boot( {
 	queries: {
 		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>
 			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
-		dashboardSiteListQuery: ( params?: FetchDashboardSiteListParams ) => {
-			// TODO: Add a filter for commerce garden types to the params.
-			return dashboardSiteListQuery( params );
-		},
+		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
+			dashboardSiteListQuery( [ 'commerce-garden' ], fetchDashboardSiteListParams ),
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,7 +1,7 @@
 import { sitesQuery, dashboardSiteListQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
 import boot from '../app/boot';
 import Logo from './logo';
-import type { FetchSitesOptions } from '@automattic/api-core';
+import type { FetchSitesOptions, FetchDashboardSiteListParams } from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -47,6 +47,7 @@ boot( {
 	},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
-		dashboardSiteListQuery,
+		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
+			dashboardSiteListQuery( 'all', fetchDashboardSiteListParams ),
 	},
 } );

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,7 +1,17 @@
-import { sitesQuery, dashboardSiteListQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
+/* eslint-disable no-restricted-imports */
+import {
+	sitesQuery,
+	dashboardSiteListQuery,
+	dashboardSiteFiltersQuery,
+} from '@automattic/api-queries';
+/* eslint-enable no-restricted-imports */
 import boot from '../app/boot';
 import Logo from './logo';
-import type { FetchSitesOptions, FetchDashboardSiteListParams } from '@automattic/api-core';
+import type {
+	FetchSitesOptions,
+	FetchDashboardSiteListParams,
+	FetchDashboardSiteFiltersParams,
+} from '@automattic/api-core';
 import './style.scss';
 
 boot( {
@@ -49,5 +59,7 @@ boot( {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
 			dashboardSiteListQuery( 'all', fetchDashboardSiteListParams ),
+		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
+			dashboardSiteFiltersQuery( 'all', fields ),
 	},
 } );

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -65,7 +65,7 @@ export type AppConfig = {
 			params?: FetchDashboardSiteListParams
 		) => ReturnType< typeof dashboardSiteListQuery >;
 		dashboardSiteFiltersQuery: (
-			field: FetchDashboardSiteFiltersParams[ 'field' ]
+			field: FetchDashboardSiteFiltersParams[ 'fields' ]
 		) => ReturnType< typeof dashboardSiteFiltersQuery >;
 	};
 };

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,6 +1,16 @@
-import { sitesQuery, dashboardSiteListQuery } from '@automattic/api-queries'; // eslint-disable-line no-restricted-imports
+/* eslint-disable no-restricted-imports */
+import {
+	sitesQuery,
+	dashboardSiteListQuery,
+	dashboardSiteFiltersQuery,
+} from '@automattic/api-queries';
+/* eslint-enable no-restricted-imports */
 import { createContext, useContext } from 'react';
-import type { FetchSitesOptions, FetchDashboardSiteListParams } from '@automattic/api-core';
+import type {
+	FetchSitesOptions,
+	FetchDashboardSiteListParams,
+	FetchDashboardSiteFiltersParams,
+} from '@automattic/api-core';
 
 export type SiteSettingsGeneralSupports = {
 	redirect: boolean;
@@ -54,6 +64,9 @@ export type AppConfig = {
 		dashboardSiteListQuery: (
 			params?: FetchDashboardSiteListParams
 		) => ReturnType< typeof dashboardSiteListQuery >;
+		dashboardSiteFiltersQuery: (
+			field: FetchDashboardSiteFiltersParams[ 'field' ]
+		) => ReturnType< typeof dashboardSiteFiltersQuery >;
 	};
 };
 
@@ -79,7 +92,10 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	components: {},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
-		dashboardSiteListQuery,
+		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
+			dashboardSiteListQuery( 'all', fetchDashboardSiteListParams ),
+		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
+			dashboardSiteFiltersQuery( 'all', fields ),
 	},
 };
 

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -1,10 +1,6 @@
 import { isAutomatticianQuery, siteBySlugQuery, siteByIdQuery } from '@automattic/api-queries';
-import {
-	useQuery,
-	useQueryClient,
-	useSuspenseQuery,
-	keepPreviousData,
-} from '@tanstack/react-query';
+import { isEnabled } from '@automattic/calypso-config';
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -13,13 +9,13 @@ import deepmerge from 'deepmerge';
 import { useEffect } from 'react';
 import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
-import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/dataviews';
 import { useHelpCenter } from '../app/help-center';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
+import { useSiteListQuery } from '../sites';
 import {
 	SitesDataViews,
 	useActions,
@@ -29,23 +25,8 @@ import {
 } from '../sites/dataviews';
 import noSitesIllustration from '../sites/no-sites-illustration.svg';
 import { SitesNotices } from '../sites/notices';
-import type { FetchSitesOptions, Site } from '@automattic/api-core';
-import type { View, Filter } from '@wordpress/dataviews';
-
-const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchSitesOptions => {
-	const filters = view.filters ?? [];
-
-	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {
-		return { site_visibility: 'deleted', include_a8c_owned: false };
-	}
-
-	return {
-		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
-		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility: view.search || isRestoringAccount ? 'all' : 'visible',
-		include_a8c_owned: false,
-	};
-};
+import type { Site } from '@automattic/api-core';
+import type { View } from '@wordpress/dataviews';
 
 export default function CIABSites() {
 	const { recordTracksEvent } = useAnalytics();
@@ -55,7 +36,6 @@ export default function CIABSites() {
 	const isRestoringAccount = !! currentSearchParams.restored;
 
 	const { user } = useAuth();
-	const { queries } = useAppContext();
 	const { setShowHelpCenter } = useHelpCenter();
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 
@@ -71,14 +51,10 @@ export default function CIABSites() {
 		queryParams: currentSearchParams,
 	} );
 
-	const {
-		data: sites,
-		isLoading: isLoadingSites,
-		isPlaceholderData,
-	} = useQuery( {
-		...queries.sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
-		placeholderData: keepPreviousData,
-	} );
+	const { sites, isLoadingSites, isPlaceholderData, totalItems } = useSiteListQuery(
+		view,
+		isRestoringAccount
+	);
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );
 	const actions = useActions();
@@ -118,7 +94,7 @@ export default function CIABSites() {
 	}
 
 	useEffect( () => {
-		if ( sites ) {
+		if ( sites && ! isEnabled( 'dashboard/v2/es-site-list' ) ) {
 			sites.forEach( ( site ) => {
 				const updater = ( oldData?: Site ) => ( oldData ? deepmerge( oldData, site ) : site );
 				queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, updater );
@@ -154,10 +130,10 @@ export default function CIABSites() {
 				<SitesDataViews
 					view={ view }
 					sites={ sites ?? [] }
-					totalItems={ sites?.length ?? 0 }
+					totalItems={ totalItems ?? 0 }
 					fields={ fields }
 					actions={ actions }
-					isLoading={ isLoadingSites || ( isPlaceholderData && sites.length === 0 ) }
+					isLoading={ isLoadingSites || ( isPlaceholderData && sites?.length === 0 ) }
 					empty={
 						<DataViewsEmptyState
 							title={ emptyTitle }

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -23,7 +23,7 @@ import PageLayout from '../components/page-layout';
 import {
 	SitesDataViews,
 	useActions,
-	getFields,
+	useFields,
 	getDefaultView,
 	recordViewChanges,
 } from '../sites/dataviews';
@@ -80,7 +80,7 @@ export default function CIABSites() {
 		placeholderData: keepPreviousData,
 	} );
 
-	const fields = getFields( { isAutomattician, viewType: view.type } );
+	const fields = useFields( { isAutomattician, viewType: view.type } );
 	const actions = useActions();
 
 	const handleAddNewStore = () => {

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,7 +1,8 @@
-import { queryClient, dashboardSiteFiltersQuery } from '@automattic/api-queries';
+import { queryClient } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useAppContext } from '../../app/context';
 import SiteIcon from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
@@ -22,10 +23,11 @@ import {
 	URL,
 	Uptime,
 } from '../site-fields';
+import type { AppConfig } from '../../app/context';
 import type { Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
-function getDefaultFields(): Field< Site >[] {
+function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 	return [
 		{
 			id: 'name',
@@ -66,8 +68,8 @@ function getDefaultFields(): Field< Site >[] {
 			render: ( { item } ) => <Plan site={ item } />,
 			getElements: async () => {
 				const { plan = [] } = await queryClient.fetchQuery( {
-					...dashboardSiteFiltersQuery( { field: 'plan', site_type_filters: 'all' } ),
-					staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
+					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
+					staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
 				} );
 
 				// A plan may have different product_slugs due to the period.
@@ -83,6 +85,12 @@ function getDefaultFields(): Field< Site >[] {
 			},
 			filterBy: {
 				operators: [ 'isAny' ],
+			},
+			sort: ( a, b, direction ) => {
+				const planA = getSitePlanDisplayName( a ) ?? '';
+				const planB = getSitePlanDisplayName( b ) ?? '';
+
+				return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
 			},
 		},
 		{
@@ -182,8 +190,10 @@ export function useFields( {
 	isAutomattician?: boolean;
 	viewType?: string;
 } ) {
+	const { queries } = useAppContext();
+
 	return useMemo( () => {
-		const defaultFields = getDefaultFields();
+		const defaultFields = getDefaultFields( queries );
 		return defaultFields.filter( ( field ) => {
 			if ( field.id === 'is_a8c' && ! isAutomattician ) {
 				return false;
@@ -199,5 +209,5 @@ export function useFields( {
 
 			return true;
 		} );
-	}, [ isAutomattician, viewType ] );
+	}, [ isAutomattician, viewType, queries ] );
 }

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -66,7 +66,7 @@ function getDefaultFields(): Field< Site >[] {
 			render: ( { item } ) => <Plan site={ item } />,
 			getElements: async () => {
 				const { plan = [] } = await queryClient.fetchQuery( {
-					...dashboardSiteFiltersQuery( 'plan' ),
+					...dashboardSiteFiltersQuery( { field: 'plan', site_type_filters: 'all' } ),
 					staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
 				} );
 
@@ -75,9 +75,7 @@ function getDefaultFields(): Field< Site >[] {
 				// As a result, it seems better to use the name as value for filters.
 				return [
 					...Array.from( new Set( plan.map( ( plan ) => plan.product_name_short ) ) ),
-					// Not sure how to deal with these values...
 					__( 'Staging site' ),
-					__( 'Woo Free' ),
 				].map( ( name ) => ( {
 					label: name,
 					value: name,

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -75,12 +75,10 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				// A plan may have different product_slugs due to the period.
 				// However, a filter can only represent one value.
 				// As a result, it seems better to use the name as value for filters.
-				return Array.from( new Set( plan.map( ( plan ) => plan.product_name_short ) ) ).map(
-					( name ) => ( {
-						label: name,
-						value: name,
-					} )
-				);
+				return Array.from( new Set( plan.map( ( plan ) => plan.name ) ) ).map( ( name ) => ( {
+					label: name,
+					value: name,
+				} ) );
 			},
 			filterBy: {
 				operators: [ 'isAny' ],

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,5 +1,7 @@
+import { queryClient, dashboardSiteFiltersQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import SiteIcon from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
@@ -62,6 +64,28 @@ function getDefaultFields(): Field< Site >[] {
 			label: __( 'Plan' ),
 			getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
 			render: ( { item } ) => <Plan site={ item } />,
+			getElements: async () => {
+				const { plan = [] } = await queryClient.fetchQuery( {
+					...dashboardSiteFiltersQuery( 'plan' ),
+					staleTime: 30 * 60 * 1000, // Consider auth valid for 30 minutes
+				} );
+
+				// A plan may have different product_slugs due to the period.
+				// However, a filter can only represent one value.
+				// As a result, it seems better to use the name as value for filters.
+				return [
+					...Array.from( new Set( plan.map( ( plan ) => plan.product_name_short ) ) ),
+					// Not sure how to deal with these values...
+					__( 'Staging site' ),
+					__( 'Woo Free' ),
+				].map( ( name ) => ( {
+					label: name,
+					value: name,
+				} ) );
+			},
+			filterBy: {
+				operators: [ 'isAny' ],
+			},
 		},
 		{
 			id: 'status',
@@ -153,27 +177,29 @@ function getDefaultFields(): Field< Site >[] {
 	];
 }
 
-export function getFields( {
+export function useFields( {
 	isAutomattician,
 	viewType,
 }: {
 	isAutomattician?: boolean;
 	viewType?: string;
 } ) {
-	const defaultFields = getDefaultFields();
-	return defaultFields.filter( ( field ) => {
-		if ( field.id === 'is_a8c' && ! isAutomattician ) {
-			return false;
-		}
+	return useMemo( () => {
+		const defaultFields = getDefaultFields();
+		return defaultFields.filter( ( field ) => {
+			if ( field.id === 'is_a8c' && ! isAutomattician ) {
+				return false;
+			}
 
-		if ( field.id === 'icon.ico' && viewType === 'grid' ) {
-			return false;
-		}
+			if ( field.id === 'icon.ico' && viewType === 'grid' ) {
+				return false;
+			}
 
-		if ( field.id === 'preview' && viewType === 'table' ) {
-			return false;
-		}
+			if ( field.id === 'preview' && viewType === 'table' ) {
+				return false;
+			}
 
-		return true;
-	} );
+			return true;
+		} );
+	}, [ isAutomattician, viewType ] );
 }

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -75,13 +75,12 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				// A plan may have different product_slugs due to the period.
 				// However, a filter can only represent one value.
 				// As a result, it seems better to use the name as value for filters.
-				return [
-					...Array.from( new Set( plan.map( ( plan ) => plan.product_name_short ) ) ),
-					__( 'Staging site' ),
-				].map( ( name ) => ( {
-					label: name,
-					value: name,
-				} ) );
+				return Array.from( new Set( plan.map( ( plan ) => plan.product_name_short ) ) ).map(
+					( name ) => ( {
+						label: name,
+						value: name,
+					} )
+				);
 			},
 			filterBy: {
 				operators: [ 'isAny' ],

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -26,7 +26,7 @@ import AddNewSite from './add-new-site';
 import {
 	SitesDataViews,
 	useActions,
-	getFields,
+	useFields,
 	getDefaultView,
 	recordViewChanges,
 } from './dataviews';
@@ -220,7 +220,7 @@ export default function Sites() {
 		isRestoringAccount
 	);
 
-	const fields = getFields( { isAutomattician, viewType: view.type } );
+	const fields = useFields( { isAutomattician, viewType: view.type } );
 	const actions = useActions();
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -158,7 +158,7 @@ function siteProfileSiteToSite( site: SiteProfileSite ): Site {
 /**
  * Enables the correct site query based on the dataviews/v2/es-site-list feature flag.
  */
-function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
+export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 	const { queries } = useAppContext();
 
 	const siteProfilesQueryResult = useQuery( {

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -19,12 +19,12 @@ function render( ui: React.ReactElement ) {
 }
 
 describe( '<Plan>', () => {
-	test( 'for staging sites, it renders "Staging site"', () => {
+	test( 'for staging sites, it renders "Staging Site"', () => {
 		const site = {
 			is_wpcom_staging_site: true,
 		} as Site;
 		const { container } = render( <Plan site={ site } /> );
-		expect( container.textContent ).toBe( 'Staging site' );
+		expect( container.textContent ).toBe( 'Staging Site' );
 	} );
 
 	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', () => {

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -85,7 +85,7 @@ export function getJetpackProductsForSite( site: Site ) {
 
 export function getSitePlanDisplayName( site: Site ) {
 	if ( site.is_wpcom_staging_site ) {
-		return __( 'Staging site' );
+		return __( 'Staging Site' );
 	}
 
 	const plan = site.plan;

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { FetchSitesFilters } from '../me-sites';
+import type { FetchSiteTypes } from '../me-sites';
 import type {
 	FetchDashboardSiteListParams,
 	DashboardSiteListResponse,
@@ -8,7 +8,7 @@ import type {
 } from './types';
 
 export async function fetchDashboardSiteList(
-	siteTypeFilters: FetchSitesFilters,
+	siteTypes: FetchSiteTypes,
 	{ fields, ...params }: FetchDashboardSiteListParams = {}
 ): Promise< DashboardSiteListResponse > {
 	return wpcom.req.get(
@@ -17,21 +17,21 @@ export async function fetchDashboardSiteList(
 			...params,
 			fields: fields?.join( ',' ),
 			filters: {
-				site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters : undefined,
+				site_types: siteTypes !== 'all' ? siteTypes : undefined,
 			},
 		}
 	);
 }
 
 export async function fetchDashboardSiteFilters(
-	siteTypeFilters: FetchSitesFilters,
+	siteTypes: FetchSiteTypes,
 	fields: FetchDashboardSiteFiltersParams[ 'fields' ]
 ): Promise< DashboardFilters > {
 	return wpcom.req.get(
 		{ path: '/dashboard/site-filters', apiNamespace: 'wpcom/v2' },
 		{
 			fields,
-			site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters : undefined,
+			site_types: siteTypes !== 'all' ? siteTypes : undefined,
 		}
 	);
 }

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -1,24 +1,35 @@
 import { wpcom } from '../wpcom-fetcher';
+import type { FetchSitesFilters } from '../me-sites';
 import type {
 	FetchDashboardSiteListParams,
 	DashboardSiteListResponse,
+	FetchDashboardSiteFiltersParams,
 	DashboardFilters,
 } from './types';
 
 export async function fetchDashboardSiteList(
-	params: FetchDashboardSiteListParams = {}
+	siteTypeFilters: FetchSitesFilters,
+	{ fields, ...params }: FetchDashboardSiteListParams = {}
 ): Promise< DashboardSiteListResponse > {
 	return wpcom.req.get(
 		{ path: '/dashboard/site-list', apiNamespace: 'wpcom/v2' },
-		{ ...params, fields: params.fields?.join( ',' ) }
+		{
+			...params,
+			fields: fields?.join( ',' ),
+			site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters.join( ',' ) : undefined,
+		}
 	);
 }
 
 export async function fetchDashboardSiteFilters(
-	field: keyof DashboardFilters
+	siteTypeFilters: FetchSitesFilters,
+	field: FetchDashboardSiteFiltersParams[ 'field' ]
 ): Promise< DashboardFilters > {
 	return wpcom.req.get(
 		{ path: '/dashboard/site-filters', apiNamespace: 'wpcom/v2' },
-		{ fields: field }
+		{
+			fields: field,
+			site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters : undefined,
+		}
 	);
 }

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -1,5 +1,9 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { FetchDashboardSiteListParams, DashboardSiteListResponse } from './types';
+import type {
+	FetchDashboardSiteListParams,
+	DashboardSiteListResponse,
+	DashboardFilters,
+} from './types';
 
 export async function fetchDashboardSiteList(
 	params: FetchDashboardSiteListParams = {}
@@ -7,5 +11,14 @@ export async function fetchDashboardSiteList(
 	return wpcom.req.get(
 		{ path: '/dashboard/site-list', apiNamespace: 'wpcom/v2' },
 		{ ...params, fields: params.fields?.join( ',' ) }
+	);
+}
+
+export async function fetchDashboardSiteFilters(
+	field: keyof DashboardFilters
+): Promise< DashboardFilters > {
+	return wpcom.req.get(
+		{ path: '/dashboard/site-filters', apiNamespace: 'wpcom/v2' },
+		{ fields: field }
 	);
 }

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -8,7 +8,7 @@ import type {
 } from './types';
 
 export async function fetchDashboardSiteList(
-	siteTypes: FetchSiteTypes,
+	site_types: FetchSiteTypes,
 	{ fields, ...params }: FetchDashboardSiteListParams = {}
 ): Promise< DashboardSiteListResponse > {
 	return wpcom.req.get(
@@ -17,21 +17,21 @@ export async function fetchDashboardSiteList(
 			...params,
 			fields: fields?.join( ',' ),
 			filters: {
-				site_types: siteTypes !== 'all' ? siteTypes : undefined,
+				site_types: site_types !== 'all' ? site_types : undefined,
 			},
 		}
 	);
 }
 
 export async function fetchDashboardSiteFilters(
-	siteTypes: FetchSiteTypes,
+	site_types: FetchSiteTypes,
 	fields: FetchDashboardSiteFiltersParams[ 'fields' ]
 ): Promise< DashboardFilters > {
 	return wpcom.req.get(
 		{ path: '/dashboard/site-filters', apiNamespace: 'wpcom/v2' },
 		{
 			fields,
-			site_types: siteTypes !== 'all' ? siteTypes : undefined,
+			site_types: site_types !== 'all' ? site_types : undefined,
 		}
 	);
 }

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -16,19 +16,21 @@ export async function fetchDashboardSiteList(
 		{
 			...params,
 			fields: fields?.join( ',' ),
-			site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters.join( ',' ) : undefined,
+			filters: {
+				site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters : undefined,
+			},
 		}
 	);
 }
 
 export async function fetchDashboardSiteFilters(
 	siteTypeFilters: FetchSitesFilters,
-	field: FetchDashboardSiteFiltersParams[ 'field' ]
+	fields: FetchDashboardSiteFiltersParams[ 'fields' ]
 ): Promise< DashboardFilters > {
 	return wpcom.req.get(
 		{ path: '/dashboard/site-filters', apiNamespace: 'wpcom/v2' },
 		{
-			fields: field,
+			fields,
 			site_type_filters: siteTypeFilters !== 'all' ? siteTypeFilters : undefined,
 		}
 	);

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -35,6 +35,10 @@ export interface FetchDashboardSiteListParams {
 	per_page?: number;
 }
 
+export interface FetchDashboardSiteFiltersParams {
+	field: keyof DashboardFilters;
+}
+
 export interface DashboardFilters {
 	plan?: Array< { product_id: number; product_slug: string; product_name_short: string } >;
 }

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -34,3 +34,7 @@ export interface FetchDashboardSiteListParams {
 	page?: number;
 	per_page?: number;
 }
+
+export interface DashboardFilters {
+	plan?: Array< { product_id: number; product_slug: string; product_name_short: string } >;
+}

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -36,7 +36,7 @@ export interface FetchDashboardSiteListParams {
 }
 
 export interface FetchDashboardSiteFiltersParams {
-	field: keyof DashboardFilters;
+	fields: ( keyof DashboardFilters )[];
 }
 
 export interface DashboardFilters {

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -40,5 +40,5 @@ export interface FetchDashboardSiteFiltersParams {
 }
 
 export interface DashboardFilters {
-	plan?: Array< { product_id: number; product_slug: string; product_name_short: string } >;
+	plan?: Array< { name: string; value: string } >;
 }

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -16,7 +16,7 @@ export interface FetchSitesOptions {
 }
 
 export async function fetchSites(
-	siteTypes: FetchSiteTypes,
+	site_types: FetchSiteTypes,
 	{ include_a8c_owned, site_visibility }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
@@ -31,7 +31,7 @@ export async function fetchSites(
 			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
-			filters: siteTypes !== 'all' ? siteTypes.join( ',' ) : undefined,
+			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 		}
 	);
 	return sites;

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -2,7 +2,7 @@ import { JOINED_SITE_FIELDS, JOINED_SITE_OPTIONS } from '../site';
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from '../site';
 
-type FetchSitesFilter = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden';
+export type FetchSitesFilter = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden';
 
 /**
  * This option is required to ensure consumers explicitly specify which types of sites they want.

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -2,13 +2,13 @@ import { JOINED_SITE_FIELDS, JOINED_SITE_OPTIONS } from '../site';
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from '../site';
 
-export type FetchSitesFilter = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden';
+export type FetchSiteType = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'commerce-garden';
 
 /**
  * This option is required to ensure consumers explicitly specify which types of sites they want.
  * The `all` option means fetching all types of sites.
  */
-export type FetchSitesFilters = 'all' | FetchSitesFilter[];
+export type FetchSiteTypes = 'all' | FetchSiteType[];
 
 export interface FetchSitesOptions {
 	include_a8c_owned: boolean;
@@ -16,7 +16,7 @@ export interface FetchSitesOptions {
 }
 
 export async function fetchSites(
-	site_filters: FetchSitesFilters,
+	siteTypes: FetchSiteTypes,
 	{ include_a8c_owned, site_visibility }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
@@ -31,7 +31,7 @@ export async function fetchSites(
 			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
-			filters: site_filters !== 'all' ? site_filters.join( ',' ) : undefined,
+			filters: siteTypes !== 'all' ? siteTypes.join( ',' ) : undefined,
 		}
 	);
 	return sites;

--- a/packages/api-queries/src/dashboard-site-list.ts
+++ b/packages/api-queries/src/dashboard-site-list.ts
@@ -1,15 +1,25 @@
 import { fetchDashboardSiteList, fetchDashboardSiteFilters } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
-import type { FetchDashboardSiteListParams, DashboardFilters } from '@automattic/api-core';
+import type {
+	FetchSitesFilters,
+	FetchDashboardSiteListParams,
+	FetchDashboardSiteFiltersParams,
+} from '@automattic/api-core';
 
-export const dashboardSiteListQuery = ( params?: FetchDashboardSiteListParams ) =>
+export const dashboardSiteListQuery = (
+	siteTypeFilters: FetchSitesFilters,
+	params?: FetchDashboardSiteListParams
+) =>
 	queryOptions( {
-		queryKey: [ 'dashboard-site-list', params ],
-		queryFn: () => fetchDashboardSiteList( params ),
+		queryKey: [ 'dashboard-site-list', siteTypeFilters, params ],
+		queryFn: () => fetchDashboardSiteList( siteTypeFilters, params ),
 	} );
 
-export const dashboardSiteFiltersQuery = ( field: keyof DashboardFilters ) =>
+export const dashboardSiteFiltersQuery = (
+	siteTypeFilters: FetchSitesFilters,
+	field: FetchDashboardSiteFiltersParams[ 'field' ]
+) =>
 	queryOptions( {
-		queryKey: [ 'dashboard-site-filters', field ],
-		queryFn: () => fetchDashboardSiteFilters( field ),
+		queryKey: [ 'dashboard-site-filters', siteTypeFilters, field ],
+		queryFn: () => fetchDashboardSiteFilters( siteTypeFilters, field ),
 	} );

--- a/packages/api-queries/src/dashboard-site-list.ts
+++ b/packages/api-queries/src/dashboard-site-list.ts
@@ -17,9 +17,9 @@ export const dashboardSiteListQuery = (
 
 export const dashboardSiteFiltersQuery = (
 	siteTypeFilters: FetchSitesFilters,
-	field: FetchDashboardSiteFiltersParams[ 'field' ]
+	fields: FetchDashboardSiteFiltersParams[ 'fields' ]
 ) =>
 	queryOptions( {
-		queryKey: [ 'dashboard-site-filters', siteTypeFilters, field ],
-		queryFn: () => fetchDashboardSiteFilters( siteTypeFilters, field ),
+		queryKey: [ 'dashboard-site-filters', siteTypeFilters, fields ],
+		queryFn: () => fetchDashboardSiteFilters( siteTypeFilters, fields ),
 	} );

--- a/packages/api-queries/src/dashboard-site-list.ts
+++ b/packages/api-queries/src/dashboard-site-list.ts
@@ -1,9 +1,15 @@
-import { fetchDashboardSiteList } from '@automattic/api-core';
+import { fetchDashboardSiteList, fetchDashboardSiteFilters } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
-import type { FetchDashboardSiteListParams } from '@automattic/api-core';
+import type { FetchDashboardSiteListParams, DashboardFilters } from '@automattic/api-core';
 
 export const dashboardSiteListQuery = ( params?: FetchDashboardSiteListParams ) =>
 	queryOptions( {
 		queryKey: [ 'dashboard-site-list', params ],
 		queryFn: () => fetchDashboardSiteList( params ),
+	} );
+
+export const dashboardSiteFiltersQuery = ( field: keyof DashboardFilters ) =>
+	queryOptions( {
+		queryKey: [ 'dashboard-site-filters', field ],
+		queryFn: () => fetchDashboardSiteFilters( field ),
 	} );

--- a/packages/api-queries/src/dashboard-site-list.ts
+++ b/packages/api-queries/src/dashboard-site-list.ts
@@ -1,25 +1,25 @@
 import { fetchDashboardSiteList, fetchDashboardSiteFilters } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 import type {
-	FetchSitesFilters,
+	FetchSiteTypes,
 	FetchDashboardSiteListParams,
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
 
 export const dashboardSiteListQuery = (
-	siteTypeFilters: FetchSitesFilters,
+	siteTypes: FetchSiteTypes,
 	params?: FetchDashboardSiteListParams
 ) =>
 	queryOptions( {
-		queryKey: [ 'dashboard-site-list', siteTypeFilters, params ],
-		queryFn: () => fetchDashboardSiteList( siteTypeFilters, params ),
+		queryKey: [ 'dashboard-site-list', siteTypes, params ],
+		queryFn: () => fetchDashboardSiteList( siteTypes, params ),
 	} );
 
 export const dashboardSiteFiltersQuery = (
-	siteTypeFilters: FetchSitesFilters,
+	siteTypes: FetchSiteTypes,
 	fields: FetchDashboardSiteFiltersParams[ 'fields' ]
 ) =>
 	queryOptions( {
-		queryKey: [ 'dashboard-site-filters', siteTypeFilters, fields ],
-		queryFn: () => fetchDashboardSiteFilters( siteTypeFilters, fields ),
+		queryKey: [ 'dashboard-site-filters', siteTypes, fields ],
+		queryFn: () => fetchDashboardSiteFilters( siteTypes, fields ),
 	} );

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -1,11 +1,11 @@
 import { fetchSites, SITE_FIELDS, SITE_OPTIONS } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
-import type { FetchSitesFilters, FetchSitesOptions } from '@automattic/api-core';
+import type { FetchSiteTypes, FetchSitesOptions } from '@automattic/api-core';
 
 export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
-	siteFilters: FetchSitesFilters,
+	siteFilters: FetchSiteTypes,
 	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) =>
 	queryOptions( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-729

## Proposed Changes

* Retrieve the available plans from the `/dashboard/site-filters` endpoint using the plan field, so that the sites data views can filter sites based on the selected plan.

<img width="243" height="354" alt="image" src="https://github.com/user-attachments/assets/01902196-4c78-411d-bc05-b5162e85cbf1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's important for users to filter their sites by the specific plans

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 196035-ghe-Automattic/wpcom to your sandbox and sandbox your endpoint
* Go to /v2/sites
* Add plan filter
* Ensure the result is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?