### PR TITLE
MSD: Fix DataViews persistence default data for sites and domains

### DIFF
--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -3,11 +3,15 @@ import type { View } from '@wordpress/dataviews';
 // Base properties that are common to all view types
 const BASE_VIEW_PROPS: View = {
 	type: 'table',
+	layout: {
+		density: 'balanced',
+	},
 	sort: {
 		field: 'domain',
 		direction: 'asc',
 	},
 	perPage: 10,
+	showLevels: false,
 	showMedia: false,
 	titleField: 'domain',
 	fields: [

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -4,6 +4,9 @@ import type { Operator, SortDirection, SupportedLayouts, View } from '@wordpress
 
 export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	table: {
+		layout: {
+			density: 'balanced',
+		},
 		showLevels: false,
 		showMedia: true,
 		mediaField: 'icon.ico',
@@ -11,6 +14,9 @@ export const DEFAULT_LAYOUTS: SupportedLayouts = {
 		descriptionField: 'URL',
 	},
 	grid: {
+		layout: {
+			previewSize: 230,
+		},
 		showLevels: false,
 		showMedia: true,
 		mediaField: 'preview',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/107032#discussion_r2520855199

## Proposed Changes

This PR fixes the default views for sites and domains DataViews.

It adds some missing properties that are the default ones when we actually update the view via the UI.

## Testing Instructions

1. Go to /v2/sites.
2. Click Reset view button if it appears.
3. Click the gear button, change Density to Compact.
5. Verify the Reset view button appears.
4. Change it back to Balanced.
5. Verify the Reset view button is gone.
6. Repeat the same for /v2/domains.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
