### PR TITLE
Fix Help Center e2e test

### DIFF
--- a/test/e2e/specs/help-center/help-center__calypso.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.ts
@@ -91,11 +91,12 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Help Center in Calyp
 		} );
 
 		it( 'search returns proper results', async () => {
-			await helpCenterComponent.search( 'Change a Domain Name Address' );
+			await helpCenterComponent.search( 'Change a domain name address' );
 			const resultTitles = await helpCenterComponent.getArticles().allTextContents();
+
 			expect(
 				resultTitles.some(
-					( title ) => normalizeString( title )?.includes( 'Change a Domain Name Address' )
+					( title ) => normalizeString( title )?.includes( 'Change a domain name address' )
 				)
 			).toBeTruthy();
 		} );


### PR DESCRIPTION
## Proposed Changes
Fix failing Help Center E2E test:
```
test/e2e/specs/help-center/help-center__calypso.ts
```

## Why are these changes being made?
The test was failing due to a title casing change introduced on November 13th.

## Testing Instructions
Verify that the test now passes:
```
yarn workspace wp-e2e-tests test -- test/e2e/specs/help-center/help-center__calypso.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
