### PR TITLE
Increase clarity around retired themes

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -26,6 +26,8 @@ export default function ThemeTierBadge( {
 	themeId,
 	showPartnerPrice = false,
 	isThemeList = false,
+	isThemeRetired,
+	isThemeActiveForSite,
 } ) {
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const { slug: themeTierSlug } = useThemeTierForTheme( themeId );
@@ -34,6 +36,12 @@ export default function ThemeTierBadge( {
 	const badge = useMemo( () => {
 		// We're still loading the theme tier, so don't render anything.
 		if ( ! themeTierSlug ) {
+			return null;
+		}
+
+		if ( isThemeRetired && ! isThemeActiveForSite ) {
+			// Don't make it seem like the theme is available via upgrade when it isn't.
+			// Do be clear whether use of the active and retired theme is contingent on the current plan.
 			return null;
 		}
 
@@ -100,6 +108,8 @@ export default function ThemeTierBadge( {
 		showPartnerPrice,
 		isThemeList,
 		showUpgradeBadge,
+		isThemeRetired,
+		isThemeActiveForSite,
 	] );
 
 	if ( ! badge ) {

--- a/client/components/theme-tier/theme-tier-badge/test/index.tsx
+++ b/client/components/theme-tier/theme-tier-badge/test/index.tsx
@@ -96,6 +96,20 @@ describe( 'ThemeTierBadge', () => {
 		expect( screen.getByText( 'Partner' ) ).toBeInTheDocument();
 	} );
 
+	it( 'should render nothing for inactive & retired themes', () => {
+		const { container } = render(
+			<ThemeTierBadge
+				themeId="drinkify"
+				siteId={ 123 }
+				siteSlug="test-site"
+				isLockedStyleVariation={ false }
+				isThemeRetired
+				isThemeActiveForSite={ false }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	it( 'should render upgrade badge for non-allowed themes', async () => {
 		jest.mocked( wpcomProxyRequest ).mockResolvedValue( [ PERSONAL_PLAN ] );
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -43,6 +43,7 @@ export class Theme extends Component {
 			update: PropTypes.object,
 			soft_launched: PropTypes.bool,
 			isCustomGeneratedTheme: PropTypes.bool,
+			retired: PropTypes.bool,
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
@@ -318,7 +319,8 @@ export class Theme extends Component {
 	};
 
 	renderBadge = () => {
-		const { selectedStyleVariation, shouldLimitGlobalStyles, theme, siteId, siteSlug } = this.props;
+		const { selectedStyleVariation, shouldLimitGlobalStyles, theme, siteId, siteSlug, active } =
+			this.props;
 
 		const isPremiumTheme = theme.theme_tier?.slug === PREMIUM_THEME;
 
@@ -335,6 +337,8 @@ export class Theme extends Component {
 				themeId={ theme.id }
 				isLockedStyleVariation={ isLocked }
 				isThemeList
+				isThemeRetired={ theme.retired }
+				isThemeActiveForSite={ active }
 			/>
 		);
 	};

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -390,7 +390,9 @@ const ConnectedTheme = connect(
 	{ recordTracksEvent, setThemesBookmark, updateThemes }
 )( localize( Theme ) );
 
-export default ( props ) => {
+const ThemeWithGlobalStyles = ( props ) => {
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( props.siteId );
 	return <ConnectedTheme { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
 };
+
+export default ThemeWithGlobalStyles;

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -40,6 +40,7 @@ exports[`Theme rendering should match snapshot 1`] = `
       >
         <components--theme-tier-badge
           islockedstylevariation="false"
+          isthemeactiveforsite="false"
           isthemelist="true"
           themeid="twentyseventeen"
         />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,5 +1,6 @@
 import { type Design } from '@automattic/design-picker';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import type { FC } from 'react';
 
 import './design-picker-design-title.scss';
@@ -16,18 +17,28 @@ const DesignPickerDesignTitle: FC< Props > = ( {
 	selectedDesign,
 	siteId,
 	siteSlug,
-} ) => (
-	<div className="design-picker-design-title__container">
-		<span className="design-picker-design-title__design-title">{ designTitle }</span>
-		<ThemeTierBadge
-			className="design-picker-design-title__theme-tier-badge"
-			isLockedStyleVariation={ false }
-			themeId={ selectedDesign.slug }
-			showPartnerPrice
-			siteId={ siteId }
-			siteSlug={ siteSlug }
-		/>
-	</div>
-);
+} ) => {
+	const { data: siteActiveTheme } = useActiveThemeQuery( siteId ?? 0, !! siteId );
+
+	const isActive =
+		selectedDesign.slug === siteActiveTheme?.[ 0 ]?.stylesheet?.replace( /pub\/|premium\//, '' );
+
+	return (
+		<div className="design-picker-design-title__container">
+			<span className="design-picker-design-title__design-title">{ designTitle }</span>
+			<ThemeTierBadge
+				className="design-picker-design-title__theme-tier-badge"
+				isLockedStyleVariation={ false }
+				themeId={ selectedDesign.slug }
+				showPartnerPrice
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				// Design picker shouldn't include retired themes.
+				isThemeRetired={ false }
+				isThemeActiveForSite={ isActive }
+			/>
+		</div>
+	);
+};
 
 export default DesignPickerDesignTitle;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -226,6 +226,10 @@ const UnifiedDesignPickerStep: StepType< {
 			siteId={ siteId }
 			siteSlug={ siteSlug }
 			themeId={ themeId }
+			isThemeActiveForSite={
+				themeId === siteActiveTheme?.[ 0 ]?.stylesheet?.replace( /pub\/|premium\//, '' )
+			}
+			isThemeRetired={ false } // assuming starter designs are not retired - they're filtered out on backend.
 		/>
 	);
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -597,6 +597,7 @@ class ThemeSheet extends Component {
 			themeId,
 			siteId,
 			siteSlug,
+			isActive,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -615,6 +616,8 @@ class ThemeSheet extends Component {
 								themeId={ themeId }
 								siteId={ siteId }
 								siteSlug={ siteSlug }
+								isThemeRetired={ retired }
+								isThemeActiveForSite={ isActive }
 							/>
 
 							{ title }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -754,9 +754,11 @@ class ThemeSheet extends Component {
 			  );
 
 		return (
-			<Notice status="warning" isDismissible={ false }>
-				{ description }
-			</Notice>
+			<div className="theme__sheet-retired-notice">
+				<Notice status="warning" isDismissible={ false }>
+					{ description }
+				</Notice>
+			</div>
 		);
 	};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -730,7 +730,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderRetiredNotice = () => {
-		const { retired, isActive } = this.props;
+		const { retired, isActive, isLoggedIn } = this.props;
 		if ( ! retired ) {
 			return null;
 		}
@@ -748,7 +748,12 @@ class ThemeSheet extends Component {
 					'This theme has been retired and will only receive security updates. It is no longer available to sites that are not already using it. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 					{
 						components: {
-							learnMoreLink: <InlineSupportLink supportContext="themes-retired" />,
+							learnMoreLink: (
+								<InlineSupportLink
+									supportContext="themes-retired"
+									showSupportModal={ isLoggedIn }
+								/>
+							),
 						},
 					}
 			  );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -609,7 +609,7 @@ class ThemeSheet extends Component {
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
-		const shouldRenderButton = ! retired && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
+		const shouldRenderButton = ! isWPForTeamsSite && ! this.shouldRenderForStaging();
 
 		return (
 			<div className="theme__sheet-header">
@@ -871,7 +871,14 @@ class ThemeSheet extends Component {
 			siteCount,
 			siteId,
 			themeTier,
+			retired,
 		} = this.props;
+
+		// For retired themes, don't allow any action except if the theme is active, when customising it is allowed.
+		const shouldHideButton = retired && ( ! isActive || key !== 'customize' );
+		if ( shouldHideButton ) {
+			return null;
+		}
 
 		return (
 			<Button

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -388,8 +388,13 @@ class ThemeSheet extends Component {
 	}
 
 	shouldRenderPreviewButton() {
-		const { isWPForTeamsSite } = this.props;
-		return this.isThemeAvailable() && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
+		const { isWPForTeamsSite, demoUrl, isActive, retired } = this.props;
+
+		if ( retired && ! isActive ) {
+			return false;
+		}
+
+		return demoUrl && ! isWPForTeamsSite && ! this.shouldRenderForStaging();
 	}
 
 	shouldRenderUnlockStyleButton() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -17,6 +17,7 @@ import {
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Notice } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import { hasQueryArg } from '@wordpress/url';
@@ -37,6 +38,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
@@ -722,6 +724,37 @@ class ThemeSheet extends Component {
 		return <div>{ this.props.description }</div>;
 	};
 
+	renderRetiredNotice = () => {
+		const { retired, isActive } = this.props;
+		if ( ! retired ) {
+			return null;
+		}
+
+		const description = isActive
+			? this.props.translate(
+					'This theme has been retired and will only receive security updates. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="themes-retired" />,
+						},
+					}
+			  )
+			: this.props.translate(
+					'This theme has been retired and will only receive security updates. It is no longer available to sites that are not already using it. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="themes-retired" />,
+						},
+					}
+			  );
+
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ description }
+			</Notice>
+		);
+	};
+
 	renderNotice = () => {
 		const { activeThemeId, themeId, name, siteIntent, translate } = this.props;
 		const isAIAssembler = siteIntent === SiteIntent.AIAssembler && activeThemeId === 'assembler';
@@ -1090,6 +1123,7 @@ class ThemeSheet extends Component {
 					navigationItems={ navigationItems }
 					compactBreadcrumb={ ! this.state.isWide }
 				/>
+				{ this.renderRetiredNotice() }
 				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-header">
 						{ this.renderStagingPaidThemeNotice() }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -69,6 +69,11 @@ $button-border: 4px;
 				border: 1px solid $gray-200;
 			}
 		}
+
+		.theme__sheet > .components-notice {
+			margin-left: 20px;
+			margin-right: 20px;
+		}
 	}
 
 	.theme__sheet .navigation-header {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -69,11 +69,11 @@ $button-border: 4px;
 				border: 1px solid $gray-200;
 			}
 		}
+	}
 
-		.theme__sheet > .components-notice {
-			margin-left: 20px;
-			margin-right: 20px;
-		}
+	.theme__sheet > .components-notice {
+		margin-left: 20px;
+		margin-right: 20px;
 	}
 
 	.theme__sheet .navigation-header {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -71,12 +71,8 @@ $button-border: 4px;
 		}
 	}
 
-	.theme__sheet > .components-notice {
-		margin-left: 20px;
-		margin-right: 20px;
-	}
-
-	.theme__sheet .navigation-header {
+	.theme__sheet .navigation-header,
+	.theme__sheet .theme__sheet-retired-notice {
 		margin: 0 auto;
 		max-width: $theme-sheet-content-max-width;
 		padding: 24px 44px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTTHEM-118 (#102498)

## Proposed Changes

* On the theme details screen don't show a theme badge for retired themes unless it is the users active theme. This reduces confusion where users may think that upgrading plan will give them access to the retired theme, while continuing to be clear that where it is the active theme, that it's use may be contingent on their current plan.
* On the theme details screen, do show preview + customize buttons for the active theme regardless of whether the theme is retired or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve clarity around what theme retirement means
* Reduce scope for confusion around plan upgrades and retired themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are three test scenarios for the theme showcase:
 1. The global themes view at /theme/:retired-theme-slug
 2. The site-specific calypso themes view for a site with a retired theme active (you can enable a retired theme via the cli/brc) /theme/:retired-theme-slug/:site-with-that-theme-active
 3. The site-specific calypso themes view for a site without a retired theme active: /theme/:retired-theme-slug/:site-without-that-theme-active

For each scenario, it should be clear that the theme is retired and what this means. Specifically, you should see a notice with a link and should not see anything that looks like an upsell for the theme.

If the theme is active you should now be able to see the preview and customise buttons. You should never be able to see other buttons.

You should also check the onboarding design picker (/setup/site-setup/designSetup?siteSlug=:site-slug) ( and the theme showcase grid (/themes) to check nothing has changed there.









Context | Before | After
-------|------|------
Global | <img width="1326" height="969" alt="Screenshot 2025-11-13 at 20 23 20" src="https://github.com/user-attachments/assets/6667060d-1983-47c6-b8dc-f46a2c5ec9b2" /> | <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 31 57" src="https://github.com/user-attachments/assets/b0f7b21f-4270-4aed-9aa0-9839477fc723" /> 
Site w/o theme | <img width="1326" height="969" alt="Screenshot 2025-11-13 at 20 23 37" src="https://github.com/user-attachments/assets/aa682edc-0b43-4ee7-9c4c-cc14ca3cdbd5" /> | <img width="1326" height="966" alt="Screenshot 2025-11-13 at 22 26 11" src="https://github.com/user-attachments/assets/dfd00755-3bf1-497a-a1ec-af14bdff03e8" /> | <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 36 32" src="https://github.com/user-attachments/assets/e7b2745a-ba7f-4929-8fcb-e3521f155587" />
Site with theme | <img width="1326" height="969" alt="Screenshot 2025-11-13 at 20 23 51" src="https://github.com/user-attachments/assets/201511b9-b686-4469-99d5-abb467dbf907" />|  <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 37 43" src="https://github.com/user-attachments/assets/00167ee8-bef4-4ed7-a13b-15ca586e629f" />
LOTS | <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 26 25" src="https://github.com/user-attachments/assets/d5bc1729-ae8b-4405-8cff-7418ea1ac9d8" /> | <img width="1323" height="969" alt="Screenshot 2025-11-17 at 14 34 37" src="https://github.com/user-attachments/assets/03d41fdb-34dc-44bd-beba-86a47aa1d5e5" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
