### PR TITLE
HC: fixup dev console warnings

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -137,7 +137,7 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 				<div className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }>
 					{ group.messages.map( ( message, index ) => (
 						<ChatMessage
-							key={ getMessageUniqueIdentifier( message ) }
+							key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
 							message={ message }
 							currentUser={ currentUser }
 							header={ index === 0 ? messageHeader() : undefined }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -147,8 +147,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				aria-atomic="false"
 				aria-relevant="additions"
 			>
-				{ chat.messages.map( ( message ) => (
-					<div key={ getMessageUniqueIdentifier( message ) }>
+				{ chat.messages.map( ( message, index ) => (
+					<div key={ getMessageUniqueIdentifier( message, `chat-message-${ index }` ) }>
 						{ [ 'bot', 'business' ].includes( message.role ) && message.content }
 					</div>
 				) ) }

--- a/packages/odie-client/src/components/message/test/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/test/get-message-unique-identifier.tsx
@@ -1,0 +1,76 @@
+import { Message } from '../../../types';
+import { getMessageUniqueIdentifier } from '../utils/get-message-unique-identifier';
+
+describe( 'getMessageUniqueIdentifier', () => {
+	it( 'returns message.metadata.temporary_id when present', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			metadata: {
+				temporary_id: 'temp-123',
+			},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 'temp-123' );
+	} );
+
+	it( 'returns message.message_id when temporary_id is not present', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			message_id: 456,
+			metadata: {},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 456 );
+	} );
+
+	it( 'returns message.internal_message_id when temporary_id and message_id are not present', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			internal_message_id: 'internal-789',
+			metadata: {},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 'internal-789' );
+	} );
+
+	it( 'returns message.metadata.local_timestamp when no other identifier is present but local_timestamp is', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			metadata: {
+				local_timestamp: 1234567890,
+			},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBe( 1234567890 );
+	} );
+
+	it( 'returns the fallback string when no other identifier is present', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			metadata: {},
+		};
+
+		expect( getMessageUniqueIdentifier( message, 'fallback-value' ) ).toBe( 'fallback-value' );
+	} );
+
+	it( 'returns undefined when no identifier is present and no fallback is provided', () => {
+		const message: Message = {
+			content: 'test',
+			role: 'user',
+			type: 'message',
+			metadata: {},
+		};
+
+		expect( getMessageUniqueIdentifier( message ) ).toBeUndefined();
+	} );
+} );

--- a/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
+++ b/packages/odie-client/src/components/message/utils/get-message-unique-identifier.tsx
@@ -1,5 +1,11 @@
 import { Message } from '../../../types';
 
-export const getMessageUniqueIdentifier = ( message: Message ) => {
-	return message.metadata?.temporary_id || message.message_id || message.internal_message_id;
+export const getMessageUniqueIdentifier = ( message: Message, fallback?: string ) => {
+	return (
+		message.metadata?.temporary_id ??
+		message.message_id ??
+		message.internal_message_id ??
+		message.metadata?.local_timestamp ??
+		fallback
+	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTSUP-351

## Proposed Changes

* Ensure `key` is generated

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Warning and error message clog the console and make debugging difficult

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Open the HC and open the console
* Send messages to odie and support and you should not see the `key` react messages in the console


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
