### PR TITLE
A4A: Configure A4A Help center.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -10,7 +10,11 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
+type Props = {
+	onClick?: () => void;
+};
+
+const SidebarHelpCenter = ( { onClick }: Props ) => {
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -27,7 +31,7 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 		} else {
 			setShowHelpCenter( ! show );
 		}
-		onClick();
+		onClick?.();
 	};
 
 	return (

--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -35,7 +35,7 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 	// Set Odie Bot to use A4A bot slug
 	useEffect( () => {
 		setOdieBotNameSlug( 'automattic-chat-support_a4a' );
-	}, [ setOdieBotNameSlug, show ] );
+	}, [ setOdieBotNameSlug ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -5,7 +5,6 @@ import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -20,8 +19,7 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 		};
 	}, [] );
 
-	const { setShowHelpCenter, setIsMinimized, setOdieBotNameSlug } =
-		useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
 		if ( isMinimized ) {
@@ -31,11 +29,6 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 		}
 		onClick();
 	};
-
-	// Set Odie Bot to use A4A bot slug
-	useEffect( () => {
-		setOdieBotNameSlug( 'automattic-chat-support_a4a' );
-	}, [ setOdieBotNameSlug ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -5,6 +5,7 @@ import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -19,7 +20,8 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 		};
 	}, [] );
 
-	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setIsMinimized, setOdieBotNameSlug } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
 		if ( isMinimized ) {
@@ -29,6 +31,11 @@ const SidebarHelpCenter = ( { onClick }: { onClick: () => void } ) => {
 		}
 		onClick();
 	};
+
+	// Set Odie Bot to use A4A bot slug
+	useEffect( () => {
+		setOdieBotNameSlug( 'automattic-chat-support_a4a' );
+	}, [ setOdieBotNameSlug, show ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/components/sidebar/header/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/index.tsx
@@ -1,7 +1,5 @@
-import config from '@automattic/calypso-config';
 import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
-import SidebarHelpCenter from './help-center';
 import ProfileDropdown from './profile-dropdown';
 
 type Props = {
@@ -20,8 +18,7 @@ const Header = ( { withProfileDropdown }: Props ) => {
 	return (
 		<SidebarHeader className="a4a-sidebar__header">
 			<AllSitesIcon />
-			{ config.isEnabled( 'a4a-help-center' ) && <SidebarHelpCenter onClick={ () => {} } /> }
-			{ withProfileDropdown && <ProfileDropdown compact /> }
+			{ withProfileDropdown && <ProfileDropdown /> }
 		</SidebarHeader>
 	);
 };

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -178,7 +178,7 @@ const ProfileDropdown = ( { dropdownPosition = 'down' }: ProfileDropdownProps ) 
 				) }
 			</Button>
 
-			{ withHelpCenter && <SidebarHelpCenter onClick={ () => {} } /> }
+			{ withHelpCenter && <SidebarHelpCenter /> }
 			<DropdownMenu isExpanded={ isMenuExpanded } setMenuExpanded={ setMenuExpanded } />
 		</nav>
 	);

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gravatar } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -16,6 +17,7 @@ import {
 	EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE,
 	EXTERNAL_WPCOM_ACCOUNT_URL,
 } from '../../sidebar-menu/lib/constants';
+import SidebarHelpCenter from './help-center';
 
 import './style.scss';
 
@@ -113,11 +115,10 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 };
 
 type ProfileDropdownProps = {
-	compact?: boolean;
 	dropdownPosition?: 'up' | 'down';
 };
 
-const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdownProps ) => {
+const ProfileDropdown = ( { dropdownPosition = 'down' }: ProfileDropdownProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const user = useSelector( getCurrentUser );
@@ -139,10 +140,14 @@ const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdow
 	const dropdownRef = useRef( null );
 	useOutsideClickCallback( dropdownRef, onCloseMenu );
 
+	const withHelpCenter = isEnabled( 'a4a-help-center' );
+
 	return (
 		<nav
 			ref={ dropdownRef }
-			className={ clsx( 'a4a-sidebar__profile-dropdown', `is-align-menu-${ dropdownPosition }` ) }
+			className={ clsx( 'a4a-sidebar__profile-dropdown', `is-align-menu-${ dropdownPosition }`, {
+				'with-help-center': withHelpCenter,
+			} ) }
 			aria-label={
 				translate( 'User menu', {
 					comment: 'Label used to differentiate navigation landmarks in screen readers',
@@ -163,7 +168,7 @@ const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdow
 					alt={ translate( 'My Profile', { textOnly: true } ) }
 				/>
 
-				{ ! compact && (
+				{ ! withHelpCenter && (
 					<div className="a4a-sidebar__profile-dropdown-button-label">
 						<span className="a4a-sidebar__profile-dropdown-button-label-text">
 							{ user?.display_name }
@@ -172,6 +177,8 @@ const ProfileDropdown = ( { compact, dropdownPosition = 'down' }: ProfileDropdow
 					</div>
 				) }
 			</Button>
+
+			{ withHelpCenter && <SidebarHelpCenter onClick={ () => {} } /> }
 			<DropdownMenu isExpanded={ isMenuExpanded } setMenuExpanded={ setMenuExpanded } />
 		</nav>
 	);

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -21,6 +21,17 @@ $profile-dropdown-menu-height: 250px;
 	position: relative;
 }
 
+.a4a-sidebar__profile-dropdown.with-help-center {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px;
+
+	border-block-start: 1px solid var(--color-neutral-70);
+	margin: 0 -16px -16px;
+}
+
 .a4a-sidebar__profile-dropdown-button {
 	position: relative;
 	z-index: 1;

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, starEmpty } from '@wordpress/icons';
@@ -133,13 +134,15 @@ const A4ASidebar = ( {
 						/>
 					) }
 
-					<SidebarNavigatorMenuItem
-						title={ contactUsText }
-						link={ CONTACT_URL_HASH_FRAGMENT }
-						path=""
-						icon={ <Icon icon={ starEmpty } /> }
-						onClickMenuItem={ onShowUserSupportForm }
-					/>
+					{ ! isEnabled( 'a4a-help-center' ) && (
+						<SidebarNavigatorMenuItem
+							title={ contactUsText }
+							link={ CONTACT_URL_HASH_FRAGMENT }
+							path=""
+							icon={ <Icon icon={ starEmpty } /> }
+							onClickMenuItem={ onShowUserSupportForm }
+						/>
+					) }
 
 					{ withUserProfileFooter && <ProfileDropdown dropdownPosition="up" /> }
 				</ul>

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -46,6 +46,12 @@ export default function HelpCenterLoader( {
 		return null;
 	}
 
+	const additionalHelpCenterProps = isA8CForAgencies()
+		? {
+				newInteractionsBotSlug: 'automattic-chat-support_a4a',
+		  }
+		: {};
+
 	return (
 		<AsyncLoad
 			require="@automattic/help-center"
@@ -62,7 +68,7 @@ export default function HelpCenterLoader( {
 			onboardingUrl={ onboardingUrl() }
 			googleMailServiceFamily={ getGoogleMailServiceFamily() }
 			source={ source }
-			newInteractionsBotSlug={ isA8CForAgencies() ? 'automattic-chat-support_a4a' : undefined }
+			{ ...additionalHelpCenterProps }
 		/>
 	);
 }

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -61,6 +62,7 @@ export default function HelpCenterLoader( {
 			onboardingUrl={ onboardingUrl() }
 			googleMailServiceFamily={ getGoogleMailServiceFamily() }
 			source={ source }
+			newInteractionsBotSlug={ isA8CForAgencies() ? 'automattic-chat-support_a4a' : undefined }
 		/>
 	);
 }

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -304,6 +304,7 @@ export const ODIE_ALLOWED_BOTS = [
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,
 	'wpcom-plan-support',
 	'wpcom-workflow-support_chat',
+	'automattic-chat-support_a4a',
 ];
 
 export const ODIE_ALL_BOT_SLUGS = [ ...ODIE_ALLOWED_BOTS, 'ciab-workflow-support_chat' ];


### PR DESCRIPTION
This PR updates the A4A Help Center to use the `automattic-chat-support_a4a` chat bot and moves the button to the Sidebar's footer next to the profile button.

<img width="311" height="456" alt="Screenshot 2025-11-14 at 7 42 27 PM" src="https://github.com/user-attachments/assets/a742eba6-e835-4f54-807d-5302946ad08e" />

Closes https://linear.app/a8c/issue/A4A-1805/a4a-move-helpcenter-icon-at-the-sidebar-footer

## Proposed Changes

* Reposition the Help center button at the sidebar's footer based on the design. MYGhJfDKwa8VdLu6WfFd7b-fi-12469_2263
* Set Help Center Odie bot to `automattic-chat-support_a4a` in the loader when in A4A environment.

## Why are these changes being made?

* This is part of the Cohesive support in the A4A project.

## Testing Instructions


* Use the A4A live link and navigate to `/overview` page.
* Confirm that the Help center button is located at the Sidebar's footer next to the profile menu button.
* Click the Help Center button to reveal the Help center.
* Click the `Get in touch` button.
* Asked for any A4A related questions.
* Confirm that the Bot is able to respond to the question.
    <img width="445" height="845" alt="Screenshot 2025-11-14 at 7 42 55 PM" src="https://github.com/user-attachments/assets/07da9969-7fe7-4799-a70e-ad17acb8e8ac" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?