### PR TITLE
SSH Migration: Update allowed hosts

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch } from '@wordpress/data';
@@ -112,6 +113,7 @@ const siteMigration: FlowV2< typeof initialize > = {
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
 		const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+		const locale = useLocale();
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 		const actionQueryParam = urlQueryParams.get( 'action' );
@@ -163,11 +165,13 @@ const siteMigration: FlowV2< typeof initialize > = {
 						hosting_provider: host || 'unknown',
 						is_ssh_supported: isHostingSupported,
 						ssh_feature_enabled: isSSHMigrationAvailable,
-						redirected_to_ssh: isSSHMigrationAvailable && isHostingSupported,
+						is_english_locale: locale === 'en',
+						redirected_to_ssh: isSSHMigrationAvailable && isHostingSupported && locale === 'en',
 					} );
 
-					// SSH migration is ONLY available if feature flag is enabled AND hosting is supported
-					const canUseSSHMigration = isSSHMigrationAvailable && isHostingSupported;
+					// SSH migration is ONLY available if feature flag is enabled AND hosting is supported AND locale is English
+					const canUseSSHMigration =
+						isSSHMigrationAvailable && isHostingSupported && locale === 'en';
 
 					if ( canUseSSHMigration ) {
 						if ( hasDestinationSite && canInstallPlugins ) {
@@ -245,12 +249,15 @@ const siteMigration: FlowV2< typeof initialize > = {
 							const host = detectedHost || hostQueryParam;
 
 							// Check if this is an SSH migration flow
-							// Either from ssh=true param OR from move-lp with supported hosting
+							// Either from ssh=true param OR from move-lp with supported hosting and English locale
 							const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 							const isHostingSupported = isHostingSupportedForSSHMigration( host );
 							const shouldUseSSH =
 								urlQueryParams.get( 'ssh' ) === 'true' ||
-								( entryPoint === 'move-lp' && isSSHMigrationAvailable && isHostingSupported );
+								( entryPoint === 'move-lp' &&
+									isSSHMigrationAvailable &&
+									isHostingSupported &&
+									locale === 'en' );
 
 							if ( shouldUseSSH ) {
 								if ( selectedSiteCanInstallPlugins ) {
@@ -313,7 +320,10 @@ const siteMigration: FlowV2< typeof initialize > = {
 							const isHostingSupported = isHostingSupportedForSSHMigration( host );
 							const shouldUseSSH =
 								urlQueryParams.get( 'ssh' ) === 'true' ||
-								( entryPoint === 'move-lp' && isSSHMigrationAvailable && isHostingSupported );
+								( entryPoint === 'move-lp' &&
+									isSSHMigrationAvailable &&
+									isHostingSupported &&
+									locale === 'en' );
 
 							const queryParams: {
 								from: string | null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -219,11 +219,17 @@ export const useCredentialsForm = (
 			hostingProviderSlug = await getHostingProvider( domain );
 		}
 
-		// Check if SSH migration is available and hosting is supported
+		// Check if SSH migration is available and hosting is supported and locale is English
 		const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 		const isHostingSupported = isHostingSupportedForSSHMigration( hostingProviderSlug );
 
-		if ( isSSHMigrationAvailable && isHostingSupported && hostingProviderSlug && siteInfoResult ) {
+		if (
+			isSSHMigrationAvailable &&
+			isHostingSupported &&
+			locale === 'en' &&
+			hostingProviderSlug &&
+			siteInfoResult
+		) {
 			return submitToSSHMigrationFlow( siteInfoResult, hostingProviderSlug );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -106,8 +106,8 @@ const SiteMigrationCredentials: StepType< {
 		const isSSHMigrationAvailable = config.isEnabled( 'migration/ssh-migration' );
 		const isHostingSupported = isHostingSupportedForSSHMigration( hostingProviderSlug );
 
-		// If SSH migration is available and hosting is supported, redirect to SSH flow
-		if ( isSSHMigrationAvailable && isHostingSupported ) {
+		// If SSH migration is available and hosting is supported and locale is English, redirect to SSH flow
+		if ( isSSHMigrationAvailable && isHostingSupported && locale === 'en' ) {
 			siteId && dispatch( resetSite( siteId ) );
 			return navigation.submit?.( {
 				action: 'redirect-to-ssh',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts
@@ -3,13 +3,7 @@ import { SSH_HOST_DISPLAY_NAMES } from '../steps/ssh-host-support-urls';
 /**
  * List of hosting providers currently enabled for SSH migration
  */
-const ENABLED_SSH_HOSTS: string[] = [
-	'hostinger-international-limited',
-	'ionos',
-	'ovh-sas',
-	'bluehost',
-	'namecheap',
-];
+const ENABLED_SSH_HOSTS: string[] = [ 'ionos', 'ovh-sas', 'bluehost', 'digitalocean', 'hostgator' ];
 
 /**
  * Checks if a hosting provider is supported for SSH migration


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15108

## Proposed Changes

 - Update the allowed hosts: Added DigitalOcean and Hostgator.
 - Added locale checks (`locale === 'en'`) to all SSH migration eligibility conditions
 - Updated 3 locations in `site-migration-flow.ts` where SSH migration routing decisions are made
 - Updated `use-credentials-form.ts` to prevent SSH flow redirect for non-English users
 - Updated `site-migration-credentials/index.tsx` to prevent SSH flow redirect for non-English users
 - Added `is_english_locale` tracking property to analytics event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The SSH migration flow includes technical instructions and documentation that are currently only available in English.
* We encountered a few issues with the other hosts, which we'll address in the future.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Execute the following code on the Console to enable the flag
```js
sessionStorage.setItem('flags', '+migration/ssh-migration')
```
* Navigate to `/setup/site-migration` and input a site that supports the SSH Migration
* Ensure you land on the `Securely share you access` step if your locale is English

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
