### PR TITLE
Stats: update docs link

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -463,8 +463,8 @@ const contextLinks = {
 		link: 'https://jetpack.com/support/jetpack-stats/traffic-dashboard/#harnessing-utm-stats-for-precision-tracking',
 	},
 	'stats-videos': {
-		link: 'https://wordpress.com/support/stats/analyze-content-performance/#see-video-traffic',
-		post_id: 404034,
+		link: 'https://wordpress.com/support/stats/video-stats/',
+		post_id: 418571,
 	},
 	'stats-videos-jetpack': {
 		link: 'https://jetpack.com/support/jetpack-videopress/add-video-block-editor/video-stats/',


### PR DESCRIPTION
Closes DOTCOM-14942

## Proposed Changes

* Change help doc link for Video Stats to https://wordpress.com/support/stats/video-stats/
