### PR TITLE
Update reader full-post view design

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -21,7 +21,7 @@ function CommentButton( {
 	const translate = useTranslate();
 	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
-	// Show a tooltip only when we are showing the number of existing comments.
+	// Show a tooltip when there are existing comments, or when explicitly requested.
 	const showTooltip = commentCount > 0 || alwaysShowTooltip;
 
 	return (

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -19,7 +19,7 @@ function CommentButton( {
 	alwaysShowTooltip = false,
 } ) {
 	const translate = useTranslate();
-	const showLabel = commentCount > 0 || defaultLabel;
+	const showLabel = commentCount > 0;
 	const label = commentCount || defaultLabel;
 	// Show a tooltip only when we are showing the number of existing comments.
 	const showTooltip = commentCount > 0 || alwaysShowTooltip;
@@ -35,9 +35,11 @@ function CommentButton( {
 			target={ 'a' === TagName ? target : undefined }
 		>
 			{ icon || <Gridicon icon="comment" size={ size } className="comment-button__icon" /> }
-			<span className="comment-button__label">
-				{ showLabel && <span className="comment-button__label-count">{ label }</span> }
-			</span>
+			{ showLabel && (
+				<span className="comment-button__label">
+					<span className="comment-button__label-count">{ label }</span>
+				</span>
+			) }
 		</TagName>
 	);
 }

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -16,12 +16,13 @@ function CommentButton( {
 	target,
 	icon,
 	defaultLabel,
+	alwaysShowTooltip = false,
 } ) {
 	const translate = useTranslate();
 	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
 	// Show a tooltip only when we are showing the number of existing comments.
-	const showTooltip = commentCount > 0;
+	const showTooltip = commentCount > 0 || alwaysShowTooltip;
 
 	return (
 		<TagName
@@ -50,6 +51,7 @@ CommentButton.propTypes = {
 	target: PropTypes.string,
 	icon: PropTypes.object,
 	defaultLabel: PropTypes.string,
+	alwaysShowTooltip: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, ownProps ) => {

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -29,6 +29,7 @@ function CommentButton( {
 			className={ clsx( 'comment-button', {
 				tooltip: showTooltip,
 			} ) }
+			aria-label={ translate( 'Comment' ) }
 			data-tooltip={ showTooltip ? translate( 'Comment' ) : undefined }
 			onClick={ onClick }
 			href={ 'a' === TagName ? href : undefined }

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -19,7 +19,7 @@ function CommentButton( {
 	alwaysShowTooltip = false,
 } ) {
 	const translate = useTranslate();
-	const showLabel = commentCount > 0;
+	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
 	// Show a tooltip only when we are showing the number of existing comments.
 	const showTooltip = commentCount > 0 || alwaysShowTooltip;

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -83,7 +83,6 @@ class FollowButton extends Component {
 		const attributes = {
 			onClick: this.toggleFollow,
 			className: menuClasses.join( ' ' ),
-			title: label,
 		};
 
 		if ( this.props.following ) {

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -54,6 +54,7 @@ class FollowButton extends Component {
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
+			menuClasses.push( 'tooltip' );
 			label = this.props.followingLabel
 				? this.props.followingLabel
 				: this.props.translate( 'Subscribed' );
@@ -79,15 +80,21 @@ class FollowButton extends Component {
 			</span>
 		);
 
-		return createElement(
-			this.props.tagName,
-			{
-				onClick: this.toggleFollow,
-				className: menuClasses.join( ' ' ),
-				title: label,
-			},
-			[ followingIcon, followIcon, followLabelElement ]
-		);
+		const attributes = {
+			onClick: this.toggleFollow,
+			className: menuClasses.join( ' ' ),
+			title: label,
+		};
+
+		if ( this.props.following ) {
+			attributes[ 'data-tooltip' ] = this.props.translate( 'Unsubscribe' );
+		}
+
+		return createElement( this.props.tagName, attributes, [
+			followingIcon,
+			followIcon,
+			followLabelElement,
+		] );
 	}
 }
 

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -83,6 +83,9 @@ class FollowButton extends Component {
 		const attributes = {
 			onClick: this.toggleFollow,
 			className: menuClasses.join( ' ' ),
+			'aria-label': this.props.following
+				? this.props.translate( 'Unsubscribe' )
+				: this.props.translate( 'Subscribe' ),
 		};
 
 		if ( this.props.following ) {

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -22,8 +22,6 @@ class LikeButton extends PureComponent {
 		icon: PropTypes.object,
 		defaultLabel: PropTypes.string,
 		showTooltip: PropTypes.bool,
-		onLabelMouseEnter: PropTypes.func,
-		onLabelMouseLeave: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -67,8 +65,6 @@ class LikeButton extends PureComponent {
 			icon,
 			defaultLabel,
 			showTooltip,
-			onLabelMouseEnter,
-			onLabelMouseLeave,
 		} = this.props;
 		const showLikeCount = likeCount > 0 || showZeroCount;
 		const isLink = containerTag === 'a';
@@ -87,11 +83,7 @@ class LikeButton extends PureComponent {
 		}
 
 		const labelElement = (
-			<span
-				className="like-button__label"
-				onMouseEnter={ onLabelMouseEnter }
-				onMouseLeave={ onLabelMouseLeave }
-			>
+			<span className="like-button__label">
 				<span className="like-button__label-count">
 					{ showLikeCount ? likeCount : defaultLabel }
 				</span>

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -21,6 +21,9 @@ class LikeButton extends PureComponent {
 		slug: PropTypes.string,
 		icon: PropTypes.object,
 		defaultLabel: PropTypes.string,
+		showTooltip: PropTypes.bool,
+		onLabelMouseEnter: PropTypes.func,
+		onLabelMouseLeave: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -34,6 +37,7 @@ class LikeButton extends PureComponent {
 		slug: null,
 		icon: null,
 		defaultLabel: '',
+		showTooltip: false,
 	};
 
 	constructor( props ) {
@@ -62,6 +66,9 @@ class LikeButton extends PureComponent {
 			onMouseLeave,
 			icon,
 			defaultLabel,
+			showTooltip,
+			onLabelMouseEnter,
+			onLabelMouseLeave,
 		} = this.props;
 		const showLikeCount = likeCount > 0 || showZeroCount;
 		const isLink = containerTag === 'a';
@@ -72,6 +79,7 @@ class LikeButton extends PureComponent {
 			'is-animated': this.props.animateLike,
 			'has-count': showLikeCount,
 			'has-label': this.props.showLabel,
+			tooltip: showTooltip,
 		};
 
 		if ( this.props.liked ) {
@@ -79,7 +87,11 @@ class LikeButton extends PureComponent {
 		}
 
 		const labelElement = (
-			<span className="like-button__label">
+			<span
+				className="like-button__label"
+				onMouseEnter={ onLabelMouseEnter }
+				onMouseLeave={ onLabelMouseLeave }
+			>
 				<span className="like-button__label-count">
 					{ showLikeCount ? likeCount : defaultLabel }
 				</span>
@@ -98,6 +110,7 @@ class LikeButton extends PureComponent {
 					onMouseEnter,
 					onMouseLeave,
 					'aria-label': this.props.liked ? translate( 'Liked' ) : translate( 'Like' ),
+					'data-tooltip': showTooltip ? translate( 'Like' ) : undefined,
 				},
 				( prop ) => prop === null
 			),

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -7,6 +7,11 @@
 	box-sizing: border-box;
 	height: 20px;
 	gap: 4px;
+
+	&.tooltip {
+		@include tooltip-base;
+		@include tooltip-top;
+	}
 }
 
 .like-button:hover {

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Icon, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { getEditURL } from 'calypso/state/posts/utils';
@@ -16,7 +16,7 @@ const PostEditButton = ( { post, site, iconSize = 24, onClick } ) => {
 			onClick={ onClick }
 			data-tooltip={ translate( 'Edit post' ) }
 		>
-			<Gridicon icon="pencil" size={ iconSize } className="post-edit-button__icon" />
+			<Icon icon={ edit } size={ iconSize } className="post-edit-button__icon" />
 			<span className="post-edit-button__label">{ translate( 'Edit' ) }</span>
 		</a>
 	);

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -11,7 +11,7 @@
 	&:focus,
 	&:active {
 
-		.gridicon {
+		svg {
 			fill: var(--color-accent);
 		}
 
@@ -20,7 +20,7 @@
 		}
 	}
 
-	.gridicon {
+	svg {
 		fill: var(--color-neutral-light);
 	}
 

--- a/client/blocks/reader-freshly-pressed-button/index.tsx
+++ b/client/blocks/reader-freshly-pressed-button/index.tsx
@@ -59,7 +59,7 @@ export const ReaderFreshlyPressedButton = ( { blogId, postId }: Props ) => {
 			case 'eligible':
 			case 'not-eligible':
 				return {
-					label: isMobile ? translate( 'Suggest' ) : translate( 'Suggest for Freshly Pressed' ),
+					label: isMobile ? translate( 'Suggest' ) : translate( 'Suggest: Freshly Pressed' ),
 					tooltip: eligibility?.details?.reason,
 				};
 			default:
@@ -123,7 +123,7 @@ export const ReaderFreshlyPressedButton = ( { blogId, postId }: Props ) => {
 					'freshly-pressed__button--has-tooltip': config?.tooltip,
 				} ) }
 			>
-				{ statusIcon && <Icon size={ 20 } icon={ statusIcon } /> }
+				{ statusIcon && <Icon size={ 24 } icon={ statusIcon } /> }
 				{ isLoading && <Spinner className="freshly-pressed__spinner" /> }
 				{ config?.label }
 			</button>

--- a/client/blocks/reader-freshly-pressed-button/index.tsx
+++ b/client/blocks/reader-freshly-pressed-button/index.tsx
@@ -112,11 +112,11 @@ export const ReaderFreshlyPressedButton = ( { blogId, postId }: Props ) => {
 				'freshly-pressed',
 				`freshly-pressed--is-status-${ eligibility?.status ?? 'loading' }`
 			) }
-			aria-label={ config?.label }
 			aria-busy={ isLoading }
 		>
 			<button
 				{ ...( config?.tooltip && { 'data-tooltip': config.tooltip } ) }
+				aria-label={ config?.label }
 				onClick={ handleClick }
 				disabled={ ! isEligible || isLoading || isSuggestionSuccess }
 				className={ clsx( 'freshly-pressed__button', {

--- a/client/blocks/reader-freshly-pressed-button/index.tsx
+++ b/client/blocks/reader-freshly-pressed-button/index.tsx
@@ -125,7 +125,7 @@ export const ReaderFreshlyPressedButton = ( { blogId, postId }: Props ) => {
 			>
 				{ statusIcon && <Icon size={ 24 } icon={ statusIcon } /> }
 				{ isLoading && <Spinner className="freshly-pressed__spinner" /> }
-				{ config?.label }
+				<span className="freshly-pressed__button-label">{ config?.label }</span>
 			</button>
 		</div>
 	);

--- a/client/blocks/reader-freshly-pressed-button/style.scss
+++ b/client/blocks/reader-freshly-pressed-button/style.scss
@@ -28,7 +28,6 @@
 		justify-content: center;
 		align-items: center;
 		cursor: pointer;
-		font-size: 13px;
 
 
 		&--has-tooltip {

--- a/client/blocks/reader-freshly-pressed-button/test/index.test.tsx
+++ b/client/blocks/reader-freshly-pressed-button/test/index.test.tsx
@@ -83,9 +83,7 @@ describe( 'ReaderFreshlyPressedButton', () => {
 		it( 'disables the button', () => {
 			render( <ReaderFreshlyPressedButton blogId={ 1 } postId={ 1 } />, { wrapper: Wrapper } );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Suggest for Freshly Pressed' } )
-			).toBeDisabled();
+			expect( screen.getByRole( 'button', { name: 'Suggest: Freshly Pressed' } ) ).toBeDisabled();
 		} );
 
 		it( 'shows the reason why the post is not eligible', () => {
@@ -116,7 +114,7 @@ describe( 'ReaderFreshlyPressedButton', () => {
 		it( 'enables the button', () => {
 			render( <ReaderFreshlyPressedButton blogId={ 1 } postId={ 1 } />, { wrapper: Wrapper } );
 
-			expect( screen.getByRole( 'button', { name: 'Suggest for Freshly Pressed' } ) ).toBeEnabled();
+			expect( screen.getByRole( 'button', { name: 'Suggest: Freshly Pressed' } ) ).toBeEnabled();
 		} );
 
 		it( 'sends a suggestion', async () => {
@@ -132,9 +130,7 @@ describe( 'ReaderFreshlyPressedButton', () => {
 				wrapper: Wrapper,
 			} );
 
-			await userEvent.click(
-				screen.getByRole( 'button', { name: 'Suggest for Freshly Pressed' } )
-			);
+			await userEvent.click( screen.getByRole( 'button', { name: 'Suggest: Freshly Pressed' } ) );
 
 			expect( mutate ).toHaveBeenCalled();
 		} );
@@ -155,9 +151,7 @@ describe( 'ReaderFreshlyPressedButton', () => {
 		it( 'disables the button', () => {
 			render( <ReaderFreshlyPressedButton blogId={ 1 } postId={ 1 } />, { wrapper: Wrapper } );
 
-			expect(
-				screen.getByRole( 'button', { name: 'Suggest for Freshly Pressed' } )
-			).toBeDisabled();
+			expect( screen.getByRole( 'button', { name: 'Suggest: Freshly Pressed' } ) ).toBeDisabled();
 		} );
 
 		it( 'shows a short version on mobile', () => {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -21,6 +21,10 @@
 	font-family: $sans;
 	padding-top: 16px;
 	line-height: 1.7;
+
+	p {
+		margin-bottom: 16px;
+	}
 }
 
 // Longreads-Specific Full Post View Styles

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -48,7 +48,7 @@ const ReaderFullPostActionBar = ( {
 
 			<div className="reader-full-post__action-bar-right">
 				{ canEdit && (
-					<PostEditButton post={ post } site={ site } iconSize={ 20 } onClick={ onEditClick } />
+					<PostEditButton post={ post } site={ site } iconSize={ 24 } onClick={ onEditClick } />
 				) }
 			</div>
 		</div>

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import CommentButton from 'calypso/blocks/comment-button';
+import PostEditButton from 'calypso/blocks/post-edit-button';
+import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
+import LikeButton from 'calypso/reader/like-button';
+import { shouldShowLikes } from 'calypso/reader/like-helper';
+import { userCan } from 'calypso/state/posts/utils';
+
+const ReaderFullPostActionBar = ( {
+	post,
+	site,
+	commentCount,
+	onCommentClick,
+	onEditClick,
+	commentsApiDisabled,
+	showComments,
+	renderMarkAsSeenButton,
+} ) => {
+	const canEdit = userCan( 'edit_post', post );
+	const showLikes = shouldShowLikes( post );
+
+	return (
+		<div className="reader-full-post__action-bar">
+			<div className="reader-full-post__action-bar-left">
+				{ showComments && ! commentsApiDisabled && (
+					<CommentButton
+						key="comment-button"
+						commentCount={ commentCount }
+						onClick={ onCommentClick }
+						tagName="div"
+						icon={ ReaderCommentIcon( { iconSize: 20 } ) }
+					/>
+				) }
+
+				{ showLikes && (
+					<LikeButton
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
+						fullPost
+						tagName="div"
+						likeSource="reader"
+					/>
+				) }
+
+				{ renderMarkAsSeenButton && renderMarkAsSeenButton() }
+			</div>
+
+			<div className="reader-full-post__action-bar-right">
+				{ canEdit && (
+					<PostEditButton post={ post } site={ site } iconSize={ 20 } onClick={ onEditClick } />
+				) }
+			</div>
+		</div>
+	);
+};
+
+ReaderFullPostActionBar.propTypes = {
+	post: PropTypes.object.isRequired,
+	site: PropTypes.object,
+	commentCount: PropTypes.number,
+	onCommentClick: PropTypes.func,
+	onEditClick: PropTypes.func,
+	commentsApiDisabled: PropTypes.bool,
+	showComments: PropTypes.bool,
+	renderMarkAsSeenButton: PropTypes.func,
+};
+
+export default ReaderFullPostActionBar;

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import CommentButton from 'calypso/blocks/comment-button';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
+import ReaderFollowButton from 'calypso/reader/follow-button';
 import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import { userCan } from 'calypso/state/posts/utils';
@@ -15,9 +16,13 @@ const ReaderFullPostActionBar = ( {
 	commentsApiDisabled,
 	showComments,
 	renderMarkAsSeenButton,
+	feedUrl,
+	siteUrl,
+	onFollowToggle,
 } ) => {
 	const canEdit = site && userCan( 'edit_post', post );
 	const showLikes = shouldShowLikes( post );
+	const followUrl = feedUrl || siteUrl;
 
 	return (
 		<div className="reader-full-post__action-bar">
@@ -51,6 +56,13 @@ const ReaderFullPostActionBar = ( {
 				{ canEdit && (
 					<PostEditButton post={ post } site={ site } iconSize={ 24 } onClick={ onEditClick } />
 				) }
+				{ followUrl && (
+					<ReaderFollowButton
+						siteUrl={ followUrl }
+						onFollowToggle={ onFollowToggle }
+						railcar={ post?.railcar }
+					/>
+				) }
 			</div>
 		</div>
 	);
@@ -65,6 +77,9 @@ ReaderFullPostActionBar.propTypes = {
 	commentsApiDisabled: PropTypes.bool,
 	showComments: PropTypes.bool,
 	renderMarkAsSeenButton: PropTypes.func,
+	feedUrl: PropTypes.string,
+	siteUrl: PropTypes.string,
+	onFollowToggle: PropTypes.func,
 };
 
 export default ReaderFullPostActionBar;

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -29,6 +29,7 @@ const ReaderFullPostActionBar = ( {
 						onClick={ onCommentClick }
 						tagName="div"
 						icon={ ReaderCommentIcon( { iconSize: 24 } ) }
+						alwaysShowTooltip
 					/>
 				) }
 

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -28,7 +28,7 @@ const ReaderFullPostActionBar = ( {
 						commentCount={ commentCount }
 						onClick={ onCommentClick }
 						tagName="div"
-						icon={ ReaderCommentIcon( { iconSize: 20 } ) }
+						icon={ ReaderCommentIcon( { iconSize: 24 } ) }
 					/>
 				) }
 
@@ -39,6 +39,7 @@ const ReaderFullPostActionBar = ( {
 						fullPost
 						tagName="div"
 						likeSource="reader"
+						iconSize={ 24 }
 					/>
 				) }
 

--- a/client/blocks/reader-full-post/action-bar.jsx
+++ b/client/blocks/reader-full-post/action-bar.jsx
@@ -16,7 +16,7 @@ const ReaderFullPostActionBar = ( {
 	showComments,
 	renderMarkAsSeenButton,
 } ) => {
-	const canEdit = userCan( 'edit_post', post );
+	const canEdit = site && userCan( 'edit_post', post );
 	const showLikes = shouldShowLikes( post );
 
 	return (

--- a/client/blocks/reader-full-post/header-meta.jsx
+++ b/client/blocks/reader-full-post/header-meta.jsx
@@ -1,0 +1,116 @@
+import { TimeSince } from '@automattic/components';
+import PropTypes from 'prop-types';
+import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
+import ReaderAvatar from 'calypso/blocks/reader-avatar';
+import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
+import ReaderFollowButton from 'calypso/reader/follow-button';
+import { getStreamUrl } from 'calypso/reader/route';
+import { recordPermalinkClick } from 'calypso/reader/stats';
+
+const ReaderFullPostHeaderMeta = ( {
+	post,
+	author,
+	siteIcon,
+	feedIcon,
+	siteName,
+	siteUrl,
+	feedUrl,
+	feedId,
+	siteId,
+	onFollowToggle,
+} ) => {
+	const recordDateClick = () => {
+		recordPermalinkClick( 'timestamp_full_post', post );
+	};
+
+	const streamUrl = getStreamUrl( feedId, siteId );
+	const followUrl = feedUrl || siteUrl;
+
+	const hasAuthorName = author?.name;
+	const hasMatchingAuthorAndSiteNames =
+		hasAuthorName &&
+		areEqualIgnoringWhitespaceAndCase( String( siteName ), String( author?.name ) );
+	const showAuthorLink = hasAuthorName && ! hasMatchingAuthorAndSiteNames;
+
+	return (
+		<div className="reader-full-post__header-meta-wrapper">
+			<ReaderAvatar
+				author={ author }
+				siteIcon={ siteIcon }
+				feedIcon={ feedIcon }
+				siteUrl={ streamUrl }
+				iconSize={ 36 }
+				className="reader-full-post__header-meta-avatars"
+			/>
+			<div className="reader-full-post__header-meta-info">
+				<div className="reader-full-post__header-meta-line-1">
+					{ showAuthorLink && (
+						<>
+							<ReaderAuthorLink
+								className="reader-full-post__header-meta-author"
+								author={ author }
+								siteUrl={ streamUrl }
+								post={ post }
+							>
+								{ author.name }
+							</ReaderAuthorLink>
+							<span className="reader-full-post__header-meta-separator"> • </span>
+						</>
+					) }
+					{ siteName && (
+						<ReaderSiteStreamLink
+							className="reader-full-post__header-meta-site-link"
+							feedId={ feedId }
+							siteId={ siteId }
+							post={ post }
+						>
+							{ siteName }
+						</ReaderSiteStreamLink>
+					) }
+				</div>
+				<div className="reader-full-post__header-meta-line-2">
+					{ post.date && (
+						<>
+							<span className="reader-full-post__header-meta-date">
+								<a
+									className="reader-full-post__header-meta-date-link"
+									onClick={ recordDateClick }
+									href={ post.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<TimeSince date={ post.date } />
+								</a>
+							</span>
+							<span className="reader-full-post__header-meta-separator"> • </span>
+						</>
+					) }
+					{ followUrl && (
+						<ReaderFollowButton
+							siteUrl={ followUrl }
+							onFollowToggle={ onFollowToggle }
+							railcar={ post?.railcar }
+							className="reader-full-post__header-meta-follow"
+						/>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+ReaderFullPostHeaderMeta.propTypes = {
+	post: PropTypes.object.isRequired,
+	author: PropTypes.object,
+	siteIcon: PropTypes.string,
+	feedIcon: PropTypes.string,
+	siteName: PropTypes.string,
+	siteUrl: PropTypes.string,
+	feedUrl: PropTypes.string,
+	feedId: PropTypes.number,
+	siteId: PropTypes.number,
+	onFollowToggle: PropTypes.func,
+};
+
+export default ReaderFullPostHeaderMeta;

--- a/client/blocks/reader-full-post/header-meta.jsx
+++ b/client/blocks/reader-full-post/header-meta.jsx
@@ -4,26 +4,15 @@ import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
-import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordPermalinkClick } from 'calypso/reader/stats';
 
-const ReaderFullPostHeaderMeta = ( {
-	post,
-	author,
-	siteName,
-	siteUrl,
-	feedUrl,
-	feedId,
-	siteId,
-	onFollowToggle,
-} ) => {
+const ReaderFullPostHeaderMeta = ( { post, author, siteName, feedId, siteId } ) => {
 	const recordDateClick = () => {
 		recordPermalinkClick( 'timestamp_full_post', post );
 	};
 
 	const streamUrl = getStreamUrl( feedId, siteId );
-	const followUrl = feedUrl || siteUrl;
 
 	const hasAuthorName = author?.name;
 	const hasMatchingAuthorAndSiteNames =
@@ -82,14 +71,6 @@ const ReaderFullPostHeaderMeta = ( {
 							</span>
 						</>
 					) }
-					{ followUrl && (
-						<ReaderFollowButton
-							siteUrl={ followUrl }
-							onFollowToggle={ onFollowToggle }
-							railcar={ post?.railcar }
-							className="reader-full-post__header-meta-follow"
-						/>
-					) }
 				</div>
 			</div>
 		</div>
@@ -100,11 +81,8 @@ ReaderFullPostHeaderMeta.propTypes = {
 	post: PropTypes.object.isRequired,
 	author: PropTypes.object,
 	siteName: PropTypes.string,
-	siteUrl: PropTypes.string,
-	feedUrl: PropTypes.string,
 	feedId: PropTypes.number,
 	siteId: PropTypes.number,
-	onFollowToggle: PropTypes.func,
 };
 
 export default ReaderFullPostHeaderMeta;

--- a/client/blocks/reader-full-post/header-meta.jsx
+++ b/client/blocks/reader-full-post/header-meta.jsx
@@ -11,8 +11,6 @@ import { recordPermalinkClick } from 'calypso/reader/stats';
 const ReaderFullPostHeaderMeta = ( {
 	post,
 	author,
-	siteIcon,
-	feedIcon,
 	siteName,
 	siteUrl,
 	feedUrl,
@@ -37,10 +35,9 @@ const ReaderFullPostHeaderMeta = ( {
 		<div className="reader-full-post__header-meta-wrapper">
 			<ReaderAvatar
 				author={ author }
-				siteIcon={ siteIcon }
-				feedIcon={ feedIcon }
 				siteUrl={ streamUrl }
-				iconSize={ 36 }
+				iconSize={ 40 }
+				preferGravatar
 				className="reader-full-post__header-meta-avatars"
 			/>
 			<div className="reader-full-post__header-meta-info">
@@ -83,7 +80,6 @@ const ReaderFullPostHeaderMeta = ( {
 									<TimeSince date={ post.date } />
 								</a>
 							</span>
-							<span className="reader-full-post__header-meta-separator"> • </span>
 						</>
 					) }
 					{ followUrl && (
@@ -103,8 +99,6 @@ const ReaderFullPostHeaderMeta = ( {
 ReaderFullPostHeaderMeta.propTypes = {
 	post: PropTypes.object.isRequired,
 	author: PropTypes.object,
-	siteIcon: PropTypes.string,
-	feedIcon: PropTypes.string,
 	siteName: PropTypes.string,
 	siteUrl: PropTypes.string,
 	feedUrl: PropTypes.string,

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -20,7 +20,6 @@ const ReaderFullPostHeader = ( {
 	feedUrl,
 	feedId,
 	siteId,
-	onFollowToggle,
 } ) => {
 	const handlePermalinkClick = () => {
 		recordPermalinkClick( 'full_post_title', post );
@@ -99,7 +98,6 @@ const ReaderFullPostHeader = ( {
 					feedUrl={ feedUrl }
 					feedId={ feedId }
 					siteId={ siteId }
-					onFollowToggle={ onFollowToggle }
 				/>
 			) }
 			{ layout === 'recent' && (
@@ -157,7 +155,6 @@ ReaderFullPostHeader.propTypes = {
 	feedUrl: PropTypes.string,
 	feedId: PropTypes.number,
 	siteId: PropTypes.number,
-	onFollowToggle: PropTypes.func,
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -7,9 +7,23 @@ import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import AutoDirection from 'calypso/components/auto-direction';
 import { getPostIcon } from 'calypso/reader/get-helpers';
 import { recordPermalinkClick } from 'calypso/reader/stats';
+import ReaderFullPostHeaderMeta from './header-meta';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
-const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => {
+const ReaderFullPostHeader = ( {
+	post,
+	authorProfile,
+	layout = 'default',
+	author,
+	siteIcon,
+	feedIcon,
+	siteName,
+	siteUrl,
+	feedUrl,
+	feedId,
+	siteId,
+	onFollowToggle,
+} ) => {
 	const handlePermalinkClick = () => {
 		recordPermalinkClick( 'full_post_title', post );
 	};
@@ -31,10 +45,11 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 	}
 
 	// Rather than pass in additional props for the `recent` layout, we extract the props we need from authorProfile.
-	const { props: { siteName, followCount } = {} } = authorProfile || {};
+	const { props: { siteName: recentSiteName, followCount } = {} } = authorProfile || {};
 
 	const isDefaultLayout = layout === 'default';
 	const iconSrc = getPostIcon( post );
+	const displaySiteName = layout === 'recent' ? recentSiteName : siteName;
 
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
@@ -48,7 +63,11 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 						post={ post }
 					>
 						{ iconSrc ? (
-							<img src={ iconSrc } alt={ siteName } className="reader-full-post__site-icon" />
+							<img
+								src={ iconSrc }
+								alt={ displaySiteName }
+								className="reader-full-post__site-icon"
+							/>
 						) : (
 							<Gridicon
 								icon="globe"
@@ -73,11 +92,24 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 					</h1>
 				</AutoDirection>
 			) : null }
-			{ isDefaultLayout && <div className="reader-full-post__author-block">{ authorProfile }</div> }
+			{ isDefaultLayout && (
+				<ReaderFullPostHeaderMeta
+					post={ post }
+					author={ author }
+					siteIcon={ siteIcon }
+					feedIcon={ feedIcon }
+					siteName={ siteName }
+					siteUrl={ siteUrl }
+					feedUrl={ feedUrl }
+					feedId={ feedId }
+					siteId={ siteId }
+					onFollowToggle={ onFollowToggle }
+				/>
+			) }
 			<div className="reader-full-post__header-meta">
 				{ layout === 'recent' && (
 					<>
-						{ siteName && (
+						{ displaySiteName && (
 							<span className="reader-full-post__header-site-name">
 								<ReaderSiteStreamLink
 									className="reader-full-post__header-site-name-link"
@@ -85,7 +117,7 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 									siteId={ post.blog_ID }
 									post={ post }
 								>
-									{ siteName }
+									{ displaySiteName }
 								</ReaderSiteStreamLink>
 							</span>
 						) }
@@ -124,6 +156,16 @@ ReaderFullPostHeader.propTypes = {
 	post: PropTypes.object.isRequired,
 	children: PropTypes.node,
 	layout: PropTypes.oneOf( [ 'default', 'recent' ] ),
+	authorProfile: PropTypes.node,
+	author: PropTypes.object,
+	siteIcon: PropTypes.string,
+	feedIcon: PropTypes.string,
+	siteName: PropTypes.string,
+	siteUrl: PropTypes.string,
+	feedUrl: PropTypes.string,
+	feedId: PropTypes.number,
+	siteId: PropTypes.number,
+	onFollowToggle: PropTypes.func,
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -3,7 +3,6 @@ import { formatNumberCompact } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import AutoDirection from 'calypso/components/auto-direction';
 import { getPostIcon } from 'calypso/reader/get-helpers';
@@ -116,7 +115,6 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 					</span>
 				) : null }
 			</div>
-			{ isDefaultLayout && <TagsList post={ post } tagsToShow={ 5 } /> }
 		</div>
 	);
 	/* eslint-enable react/jsx-no-target-blank */

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -12,10 +12,10 @@ import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
 const ReaderFullPostHeader = ( {
 	post,
-	authorProfile,
 	layout = 'default',
 	author,
 	siteName,
+	followCount,
 	feedId,
 	siteId,
 	tags,
@@ -40,12 +40,9 @@ const ReaderFullPostHeader = ( {
 		return <ReaderFullPostHeaderPlaceholder />;
 	}
 
-	// Rather than pass in additional props for the `recent` layout, we extract the props we need from authorProfile.
-	const { props: { siteName: recentSiteName, followCount } = {} } = authorProfile || {};
-
 	const isDefaultLayout = layout === 'default';
 	const iconSrc = getPostIcon( post );
-	const displaySiteName = layout === 'recent' ? recentSiteName : siteName;
+	const displaySiteName = siteName;
 
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
@@ -148,9 +145,9 @@ ReaderFullPostHeader.propTypes = {
 	post: PropTypes.object.isRequired,
 	children: PropTypes.node,
 	layout: PropTypes.oneOf( [ 'default', 'recent' ] ),
-	authorProfile: PropTypes.node,
 	author: PropTypes.object,
 	siteName: PropTypes.string,
+	followCount: PropTypes.number,
 	feedId: PropTypes.number,
 	siteId: PropTypes.number,
 	tags: PropTypes.node,

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -106,47 +106,45 @@ const ReaderFullPostHeader = ( {
 					onFollowToggle={ onFollowToggle }
 				/>
 			) }
-			<div className="reader-full-post__header-meta">
-				{ layout === 'recent' && (
-					<>
-						{ displaySiteName && (
-							<span className="reader-full-post__header-site-name">
-								<ReaderSiteStreamLink
-									className="reader-full-post__header-site-name-link"
-									feedId={ post.feed_ID }
-									siteId={ post.blog_ID }
-									post={ post }
-								>
-									{ displaySiteName }
-								</ReaderSiteStreamLink>
-							</span>
-						) }
-						{ followCount && (
-							<span className="reader-full-post__header-follow-count">
-								{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
-									count: followCount,
-									args: {
-										followCount: formatNumberCompact( followCount ),
-									},
-								} ) }
-							</span>
-						) }
-					</>
-				) }
-				{ post.date ? (
-					<span className="reader-full-post__header-date">
-						<a
-							className="reader-full-post__header-date-link"
-							onClick={ recordDateClick }
-							href={ post.URL }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							<TimeSince date={ post.date } />
-						</a>
-					</span>
-				) : null }
-			</div>
+			{ layout === 'recent' && (
+				<div className="reader-full-post__header-meta">
+					{ displaySiteName && (
+						<span className="reader-full-post__header-site-name">
+							<ReaderSiteStreamLink
+								className="reader-full-post__header-site-name-link"
+								feedId={ post.feed_ID }
+								siteId={ post.blog_ID }
+								post={ post }
+							>
+								{ displaySiteName }
+							</ReaderSiteStreamLink>
+						</span>
+					) }
+					{ followCount && (
+						<span className="reader-full-post__header-follow-count">
+							{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
+								count: followCount,
+								args: {
+									followCount: formatNumberCompact( followCount ),
+								},
+							} ) }
+						</span>
+					) }
+					{ post.date && (
+						<span className="reader-full-post__header-date">
+							<a
+								className="reader-full-post__header-date-link"
+								onClick={ recordDateClick }
+								href={ post.URL }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<TimeSince date={ post.date } />
+							</a>
+						</span>
+					) }
+				</div>
+			) }
 		</div>
 	);
 	/* eslint-enable react/jsx-no-target-blank */

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -20,6 +20,7 @@ const ReaderFullPostHeader = ( {
 	feedUrl,
 	feedId,
 	siteId,
+	tags,
 } ) => {
 	const handlePermalinkClick = () => {
 		recordPermalinkClick( 'full_post_title', post );
@@ -90,15 +91,18 @@ const ReaderFullPostHeader = ( {
 				</AutoDirection>
 			) : null }
 			{ isDefaultLayout && (
-				<ReaderFullPostHeaderMeta
-					post={ post }
-					author={ author }
-					siteName={ siteName }
-					siteUrl={ siteUrl }
-					feedUrl={ feedUrl }
-					feedId={ feedId }
-					siteId={ siteId }
-				/>
+				<div className="reader-full-post__header-meta-and-tags">
+					<ReaderFullPostHeaderMeta
+						post={ post }
+						author={ author }
+						siteName={ siteName }
+						siteUrl={ siteUrl }
+						feedUrl={ feedUrl }
+						feedId={ feedId }
+						siteId={ siteId }
+					/>
+					{ tags && <div className="reader-full-post__header-tags">{ tags }</div> }
+				</div>
 			) }
 			{ layout === 'recent' && (
 				<div className="reader-full-post__header-meta">
@@ -155,6 +159,7 @@ ReaderFullPostHeader.propTypes = {
 	feedUrl: PropTypes.string,
 	feedId: PropTypes.number,
 	siteId: PropTypes.number,
+	tags: PropTypes.node,
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -15,8 +15,6 @@ const ReaderFullPostHeader = ( {
 	authorProfile,
 	layout = 'default',
 	author,
-	siteIcon,
-	feedIcon,
 	siteName,
 	siteUrl,
 	feedUrl,
@@ -96,8 +94,6 @@ const ReaderFullPostHeader = ( {
 				<ReaderFullPostHeaderMeta
 					post={ post }
 					author={ author }
-					siteIcon={ siteIcon }
-					feedIcon={ feedIcon }
 					siteName={ siteName }
 					siteUrl={ siteUrl }
 					feedUrl={ feedUrl }
@@ -156,8 +152,6 @@ ReaderFullPostHeader.propTypes = {
 	layout: PropTypes.oneOf( [ 'default', 'recent' ] ),
 	authorProfile: PropTypes.node,
 	author: PropTypes.object,
-	siteIcon: PropTypes.string,
-	feedIcon: PropTypes.string,
 	siteName: PropTypes.string,
 	siteUrl: PropTypes.string,
 	feedUrl: PropTypes.string,

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -16,8 +16,6 @@ const ReaderFullPostHeader = ( {
 	layout = 'default',
 	author,
 	siteName,
-	siteUrl,
-	feedUrl,
 	feedId,
 	siteId,
 	tags,
@@ -96,8 +94,6 @@ const ReaderFullPostHeader = ( {
 						post={ post }
 						author={ author }
 						siteName={ siteName }
-						siteUrl={ siteUrl }
-						feedUrl={ feedUrl }
 						feedId={ feedId }
 						siteId={ siteId }
 					/>
@@ -155,8 +151,6 @@ ReaderFullPostHeader.propTypes = {
 	authorProfile: PropTypes.node,
 	author: PropTypes.object,
 	siteName: PropTypes.string,
-	siteUrl: PropTypes.string,
-	feedUrl: PropTypes.string,
 	feedId: PropTypes.number,
 	siteId: PropTypes.number,
 	tags: PropTypes.node,

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,7 +7,6 @@ import { get, startsWith, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
-import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
 import Comments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
@@ -674,10 +673,6 @@ export class FullPostView extends Component {
 		const commentCount = get( post, 'discussion.comment_count' );
 		const postKey = { blogId, feedId, postId };
 		const contentWidth = readerContentWidth();
-		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
-
-		// Extract common props to avoid duplication
-		const siteIcon = get( site, 'icon.img' );
 		const feedUrl = get( post, 'feed_URL' );
 		const shouldShowMarkAsSeen =
 			isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) && canBeMarkedAsSeen( { post } );
@@ -715,23 +710,9 @@ export class FullPostView extends Component {
 								post={ post }
 								referralPost={ referralPost }
 								layout={ this.props.layout }
-								authorProfile={
-									<AuthorCompactProfile
-										author={ post.author }
-										siteIcon={ siteIcon }
-										feedIcon={ feedIcon }
-										siteName={ siteName }
-										siteUrl={ post.site_URL }
-										feedUrl={ feedUrl }
-										followCount={ site && site.subscribers_count }
-										onFollowToggle={ this.openSuggestedFollowsModal }
-										feedId={ +post.feed_ID }
-										siteId={ +post.site_ID }
-										post={ post }
-									/>
-								}
 								author={ post.author }
 								siteName={ siteName }
+								followCount={ site && site.subscribers_count }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
 								tags={ isDefaultLayout ? <TagsList post={ post } tagsToShow={ 5 } /> : null }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Gridicon, EmbedContainer, ExternalLink } from '@automattic/components';
+import { Gridicon, EmbedContainer } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { get, startsWith, pickBy } from 'lodash';
@@ -8,11 +8,9 @@ import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import AuthorCompactProfile from 'calypso/blocks/author-compact-profile';
-import CommentButton from 'calypso/blocks/comment-button';
 import Comments from 'calypso/blocks/comments';
 import { COMMENTS_FILTER_ALL } from 'calypso/blocks/comments/comments-filters';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
-import PostEditButton from 'calypso/blocks/post-edit-button';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import { scrollToComments } from 'calypso/blocks/reader-full-post/scroll-to-comments';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
@@ -32,12 +30,9 @@ import {
 } from 'calypso/components/related-posts';
 import { isFeaturedImageInContent } from 'calypso/lib/post-normalizer/utils';
 import ReaderBackButton from 'calypso/reader/components/back-button';
-import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { canBeMarkedAsSeen, getSiteName, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import readerContentWidth from 'calypso/reader/lib/content-width';
-import LikeButton from 'calypso/reader/like-button';
-import { shouldShowLikes } from 'calypso/reader/like-helper';
 import PostExcerptLink from 'calypso/reader/post-excerpt-link';
 import { keyForPost } from 'calypso/reader/post-key';
 import { ReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
@@ -53,7 +48,6 @@ import { requestPostComments } from 'calypso/state/comments/actions';
 import { isCommentsApiDisabled } from 'calypso/state/comments/selectors/get-comments-api-disabled';
 import { like as likePost, unlike as unlikePost } from 'calypso/state/posts/likes/actions';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
-import { userCan } from 'calypso/state/posts/utils';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import {
 	getReaderFollowForFeed,
@@ -80,6 +74,7 @@ import isFeedWPForTeams from 'calypso/state/selectors/is-feed-wpforteams';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { disableAppBanner, enableAppBanner } from 'calypso/state/ui/actions';
+import ReaderFullPostActionBar from './action-bar';
 import ContentProcessor from './content-processor';
 import ReaderFullPostHeader from './header';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
@@ -681,6 +676,12 @@ export class FullPostView extends Component {
 		const contentWidth = readerContentWidth();
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 
+		// Extract common props to avoid duplication
+		const siteIcon = get( site, 'icon.img' );
+		const feedUrl = get( post, 'feed_URL' );
+		const shouldShowMarkAsSeen =
+			isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) && canBeMarkedAsSeen( { post } );
+
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
@@ -708,73 +709,7 @@ export class FullPostView extends Component {
 						forceShow={ this.props.layout === 'recent' }
 						aria-label={ translate( 'Return to the list of posts.' ) }
 					/>
-					<div className="reader-full-post__visit-site-container">
-						<ExternalLink
-							icon
-							href={ post.URL }
-							onClick={ this.handleVisitSiteClick }
-							target="_blank"
-						>
-							<span className="reader-full-post__visit-site-label">
-								{ translate( 'Visit Site' ) }
-							</span>
-						</ExternalLink>
-					</div>
 					<div className="reader-full-post__content">
-						{ isDefaultLayout && (
-							<div className="reader-full-post__sidebar">
-								{ isLoading && <AuthorCompactProfile author={ null } /> }
-								{ ! isLoading && (
-									<AuthorCompactProfile
-										author={ post.author }
-										siteIcon={ get( site, 'icon.img' ) }
-										feedIcon={ feedIcon }
-										siteName={ siteName }
-										siteUrl={ post.site_URL }
-										feedUrl={ get( post, 'feed_URL' ) }
-										followCount={ site && site.subscribers_count }
-										onFollowToggle={ this.openSuggestedFollowsModal }
-										feedId={ +post.feed_ID }
-										siteId={ +post.site_ID }
-										post={ post }
-									/>
-								) }
-								<div className="reader-full-post__sidebar-comment-like">
-									{ userCan( 'edit_post', post ) && (
-										<PostEditButton
-											post={ post }
-											site={ site }
-											iconSize={ 20 }
-											onClick={ this.onEditClick }
-										/>
-									) }
-
-									{ shouldShowComments( post ) && ! commentsApiDisabled && (
-										<CommentButton
-											key="comment-button"
-											commentCount={ commentCount }
-											onClick={ this.handleCommentClick }
-											tagName="div"
-											icon={ ReaderCommentIcon( { iconSize: 20 } ) }
-										/>
-									) }
-
-									{ shouldShowLikes( post ) && (
-										<LikeButton
-											siteId={ +post.site_ID }
-											postId={ +post.ID }
-											fullPost
-											tagName="div"
-											likeSource="reader"
-										/>
-									) }
-
-									{ isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) &&
-										canBeMarkedAsSeen( { post } ) &&
-										this.renderMarkAsSenButton() }
-								</div>
-							</div>
-						) }
 						<article className="reader-full-post__story">
 							<ReaderFullPostHeader
 								post={ post }
@@ -783,11 +718,11 @@ export class FullPostView extends Component {
 								authorProfile={
 									<AuthorCompactProfile
 										author={ post.author }
-										siteIcon={ get( site, 'icon.img' ) }
+										siteIcon={ siteIcon }
 										feedIcon={ feedIcon }
 										siteName={ siteName }
 										siteUrl={ post.site_URL }
-										feedUrl={ get( post, 'feed_URL' ) }
+										feedUrl={ feedUrl }
 										followCount={ site && site.subscribers_count }
 										onFollowToggle={ this.openSuggestedFollowsModal }
 										feedId={ +post.feed_ID }
@@ -795,7 +730,31 @@ export class FullPostView extends Component {
 										post={ post }
 									/>
 								}
+								author={ post.author }
+								siteIcon={ siteIcon }
+								feedIcon={ feedIcon }
+								siteName={ siteName }
+								siteUrl={ post.site_URL }
+								feedUrl={ feedUrl }
+								feedId={ +post.feed_ID }
+								siteId={ +post.site_ID }
+								onFollowToggle={ this.openSuggestedFollowsModal }
 							/>
+
+							{ isDefaultLayout && (
+								<ReaderFullPostActionBar
+									post={ post }
+									site={ site }
+									commentCount={ commentCount }
+									onCommentClick={ this.handleCommentClick }
+									onEditClick={ this.onEditClick }
+									commentsApiDisabled={ commentsApiDisabled }
+									showComments={ shouldShowComments( post ) }
+									renderMarkAsSeenButton={
+										shouldShowMarkAsSeen ? this.renderMarkAsSenButton : null
+									}
+								/>
+							) }
 
 							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
 								<ReaderFeaturedImage

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -736,7 +736,6 @@ export class FullPostView extends Component {
 								feedUrl={ feedUrl }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
-								onFollowToggle={ this.openSuggestedFollowsModal }
 							/>
 
 							{ isDefaultLayout && (
@@ -751,6 +750,9 @@ export class FullPostView extends Component {
 									renderMarkAsSeenButton={
 										shouldShowMarkAsSeen ? this.renderMarkAsSenButton : null
 									}
+									feedUrl={ feedUrl }
+									siteUrl={ post.site_URL }
+									onFollowToggle={ this.openSuggestedFollowsModal }
 								/>
 							) }
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -17,6 +17,7 @@ import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import { scrollToComments } from 'calypso/blocks/reader-full-post/scroll-to-comments';
 import WPiFrameResize from 'calypso/blocks/reader-full-post/wp-iframe-resize';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
+import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import AutoDirection from 'calypso/components/auto-direction';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -822,6 +823,8 @@ export class FullPostView extends Component {
 							) }
 
 							{ post.use_excerpt && <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
+
+							{ isDefaultLayout && <TagsList post={ post } tagsToShow={ 5 } /> }
 
 							<ReaderPostActions
 								post={ post }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -731,8 +731,6 @@ export class FullPostView extends Component {
 									/>
 								}
 								author={ post.author }
-								siteIcon={ siteIcon }
-								feedIcon={ feedIcon }
 								siteName={ siteName }
 								siteUrl={ post.site_URL }
 								feedUrl={ feedUrl }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -732,8 +732,6 @@ export class FullPostView extends Component {
 								}
 								author={ post.author }
 								siteName={ siteName }
-								siteUrl={ post.site_URL }
-								feedUrl={ feedUrl }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
 								tags={ isDefaultLayout ? <TagsList post={ post } tagsToShow={ 5 } /> : null }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -736,6 +736,7 @@ export class FullPostView extends Component {
 								feedUrl={ feedUrl }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
+								tags={ isDefaultLayout ? <TagsList post={ post } tagsToShow={ 5 } /> : null }
 							/>
 
 							{ isDefaultLayout && (
@@ -782,8 +783,6 @@ export class FullPostView extends Component {
 							) }
 
 							{ post.use_excerpt && <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
-
-							{ isDefaultLayout && <TagsList post={ post } tagsToShow={ 5 } /> }
 
 							<ReaderPostActions
 								post={ post }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -53,7 +53,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 .reader-full-post__seen-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: #646970;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
@@ -285,7 +284,9 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.comment-button__label,
 	.like-button__label,
 	.post-edit-button__label,
-	.follow-button__label {
+	.follow-button__label,
+	.reader-full-post__seen-button,
+	.freshly-pressed__button {
 		font-size: $font-body-small;
 		color: var( --color-text-subtle );
 	}
@@ -296,8 +297,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 	.comment-button:hover .comment-button__label,
 	.like-button:hover .like-button__label,
-	.post-edit-button:hover .post-edit-button__label {
-		color: var( --color-text-subtle );
+	.post-edit-button:hover .post-edit-button__label,
+	.reader-full-post__seen-button:hover,
+	.freshly-pressed__button:hover {
+		color: var( --color-link );
 	}
 
 	.comment-button svg,
@@ -560,11 +563,106 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	clear: both;
 	margin-bottom: 20px;
 
-	.post-edit-button__label,
-	.reader-share__button-label,
+	.comment-button svg,
+	.like-button svg,
+	.reader-share svg {
+		width: 24px;
+		height: 24px;
+	}
+
+	// Reset SVG icon that has like-button class to not be affected by container styles
+	svg.like-button {
+		padding: 0;
+		margin: 0;
+		background: none;
+		border: none;
+		border-radius: 0;
+		min-height: auto;
+		height: auto;
+		width: 24px;
+		flex-shrink: 0;
+		display: block;
+		cursor: inherit;
+		transition: none;
+	}
+
 	.comment-button__label,
+	.like-button__label,
+	.reader-share__button-label {
+		font-size: $font-body-small;
+		color: var( --color-text-subtle );
+	}
+
+	// Hide label when there's no count (0 likes)
+	.like-button__label:has(.like-button__label-count:empty),
+	.like-button__label-count:empty {
+		display: none;
+	}
+
+	// Tooltip styles
+	.comment-button.tooltip,
+	.like-button.tooltip {
+		@include tooltip-base;
+		@include tooltip-top;
+	}
+
 	.like-button__label {
-		font-size: rem( 17px );
+		cursor: pointer;
+	}
+
+	// Active/hover states for interactive buttons
+	.comment-button.is-active,
+	.comment-button:hover,
+	.like-button:hover,
+	.like-button.is-active,
+	.like-button.is-liked,
+	.reader-share:hover {
+		border-color: var( --color-primary-10 );
+
+		svg {
+			opacity: 1;
+		}
+	}
+
+	.comment-button.is-active,
+	.comment-button:hover {
+		svg.reader-comment path {
+			stroke: var( --color-link );
+		}
+
+		.comment-button__label {
+			color: var( --color-link );
+		}
+	}
+
+	.like-button:hover,
+	.like-button.is-active,
+	.like-button.is-liked {
+		svg.reader-star path {
+			stroke: var( --color-link );
+		}
+
+		.like-button__label {
+			color: var( --color-link );
+		}
+	}
+
+	.like-button.is-liked {
+		svg.reader-star path {
+			fill: var( --color-link );
+		}
+	}
+
+	.reader-share:hover {
+		svg.reader-share path,
+		svg.reader-external path {
+			stroke: var( --color-link );
+			fill: var( --color-link );
+		}
+
+		.reader-share__button-label {
+			color: var( --color-link );
+		}
 	}
 }
 
@@ -853,29 +951,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-.reader-post-actions__item {
-	&:hover,
-	button.is-active,
-	.like-button.is-liked {
-		svg.reader-external path {
-			fill: var( --color-link );
-		}
-
-		svg.reader-comment path,
-		svg.reader-share path {
-			stroke: var( --color-link );
-		}
-		svg.reader-star path {
-			stroke: var( --color-link );
-		}
-	}
-
-	.like-button.is-liked {
-		svg.reader-star path {
-			fill: var( --color-link );
-		}
-	}
-}
 
 .wp-block-latest-posts__post-date::before {
 	content: ' - ';
@@ -1115,4 +1190,9 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 .coblocks-gallery--item {
 	list-style: none;
+}
+
+.reader-full-post__comments-wrapper .comments__comment-list {
+	border-top: none;
+	margin: 0 0 36px;
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -158,11 +158,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-.reader-full-post__header-meta-follow {
-	.follow-button__label {
-		font-size: $font-body-small;
-	}
-}
 
 // Action Bar Component Styles
 .reader-full-post__action-bar {
@@ -218,49 +213,33 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.follow-button {
 		background: transparent;
 
-		.gridicon {
-			width: 24px;
-			height: 24px;
-		}
-
+		svg,
+		.gridicon,
 		.reader-following-feed,
 		.reader-follow-feed {
 			width: 24px;
 			height: 24px;
-			fill: var( --color-text-subtle ) !important;
 		}
 
+		// Override default green color from follow button component
+		.reader-following-feed,
 		.reader-following-feed path,
+		.reader-follow-feed,
 		.reader-follow-feed path {
 			fill: var( --color-text-subtle ) !important;
 		}
 
-		&.is-following {
-			background: transparent;
-
-			.follow-button__label {
-				color: var( --color-text-subtle ) !important;
-			}
-
-			&:hover {
-				background: var( --color-primary-0 );
-
-				.reader-following-feed,
-				.reader-following-feed path {
-					fill: var( --color-link ) !important;
-					opacity: 1;
-				}
-
-				.follow-button__label {
-					color: var( --color-link ) !important;
-				}
-			}
+		// Override green text color when following
+		&.is-following .follow-button__label {
+			color: var( --color-text-subtle ) !important;
 		}
 
-		&:hover:not(.is-following) {
+		// Hover state
+		&:hover {
 			background: var( --color-primary-0 );
 
-			.gridicon,
+			.reader-following-feed,
+			.reader-following-feed path,
 			.reader-follow-feed,
 			.reader-follow-feed path {
 				fill: var( --color-link ) !important;
@@ -268,7 +247,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			}
 
 			.follow-button__label {
-				color: var( --color-link );
+				color: var( --color-link ) !important;
 			}
 		}
 	}
@@ -282,6 +261,12 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 	.like-button__label {
 		cursor: pointer;
+	}
+
+	// Hide label when there's no count (0 likes)
+	.like-button__label:has(.like-button__label-count:empty),
+	.like-button__label-count:empty {
+		display: none;
 	}
 
 	// Reset SVG icon that has like-button class to not be affected by container styles
@@ -324,15 +309,23 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		height: 24px;
 	}
 
+	// Active/hover states for interactive buttons
 	.comment-button.is-active,
-	.comment-button:hover {
+	.comment-button:hover,
+	.like-button:hover,
+	.like-button.is-active,
+	.like-button.is-liked,
+	.post-edit-button:hover {
 		background: var( --color-primary-0 );
 		border-color: var( --color-primary-10 );
 
 		svg {
 			opacity: 1;
 		}
+	}
 
+	.comment-button.is-active,
+	.comment-button:hover {
 		svg.reader-comment path {
 			stroke: var( --color-link );
 		}
@@ -345,13 +338,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.like-button:hover,
 	.like-button.is-active,
 	.like-button.is-liked {
-		background: var( --color-primary-0 );
-		border-color: var( --color-primary-10 );
-
-		svg {
-			opacity: 1;
-		}
-
 		svg.reader-star path {
 			stroke: var( --color-link );
 		}
@@ -367,24 +353,13 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 	}
 
-	.post-edit-button {
+	.post-edit-button:hover {
 		svg {
-			opacity: 0.6;
+			fill: var( --color-link );
 		}
 
-		&:hover {
-			background: var( --color-primary-0 );
-			border-color: var( --color-primary-10 );
+		.post-edit-button__label {
 			color: var( --color-link );
-
-			svg {
-				fill: var( --color-link );
-				opacity: 1;
-			}
-
-			.post-edit-button__label {
-				color: var( --color-link );
-			}
 		}
 	}
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -249,7 +249,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 
 	.comment-button.tooltip,
-	.like-button.tooltip,
 	.follow-button.tooltip {
 		@include tooltip-base;
 		@include tooltip-top;
@@ -600,8 +599,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 
 	// Tooltip styles
-	.comment-button.tooltip,
-	.like-button.tooltip {
+	.comment-button.tooltip {
 		@include tooltip-base;
 		@include tooltip-top;
 	}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -160,14 +160,20 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	justify-content: space-between;
 	padding: 16px 0;
 	margin-bottom: 24px;
-	border-top: 1px solid var( --color-border-subtle );
-	border-bottom: 1px solid var( --color-border-subtle );
+	border-top: 1px solid var( --color-neutral-5 );
+	border-bottom: 1px solid var( --color-neutral-5 );
 
 	.comment-button,
 	.like-button,
 	.post-edit-button,
 	.reader-full-post__seen-button {
 		margin: 0;
+	}
+
+	.comment-button svg,
+	.like-button svg {
+		width: 24px;
+		height: 24px;
 	}
 
 	.comment-button.is-active,

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -90,12 +90,12 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	align-items: flex-start;
 	justify-content: flex-end;
 	flex: 0 1 auto;
-	max-width: 400px;
+	min-width: 0;
 
-	@include breakpoint-deprecated( '<960px' ) {
+	// When tags wrap to their own row, make them full-width
+	@media ( max-width: 1200px ) {
 		flex: 1 0 100%;
 		justify-content: flex-start;
-		max-width: none;
 	}
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -560,7 +560,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 // Action buttons in full-post
 .reader-full-post .reader-post-actions {
 	clear: both;
-	margin-bottom: 20px;
+	margin: 20px 0;
 
 	.comment-button svg,
 	.like-button svg,

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -200,10 +200,14 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.post-edit-button {
 		color: var( --color-text-subtle );
 
+		svg {
+			fill: var( --color-text-subtle );
+		}
+
 		&:hover {
 			color: var( --color-link );
 
-			.gridicon {
+			svg {
 				fill: var( --color-link );
 			}
 		}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -153,6 +153,82 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.post-edit-button,
 	.reader-full-post__seen-button {
 		margin: 0;
+		padding: 8px 16px;
+		background: var( --color-surface );
+		border: 1px solid var( --color-neutral-10 );
+		border-radius: 24px;
+		transition: all 0.2s ease;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		height: auto;
+		min-height: 40px;
+		color: var( --color-neutral-20 );
+
+		&:hover {
+			background: var( --color-neutral-0 );
+			border-color: var( --color-neutral-20 );
+		}
+
+		svg {
+			flex-shrink: 0;
+			display: block;
+			opacity: 0.6;
+		}
+
+		&:hover svg {
+			opacity: 1;
+		}
+
+		.like-button__like-icons {
+			display: flex;
+			align-items: center;
+			line-height: 1;
+		}
+	}
+
+	.comment-button.tooltip,
+	.like-button.tooltip {
+		@include tooltip-base;
+		@include tooltip-top;
+	}
+
+	.like-button__label {
+		cursor: pointer;
+	}
+
+	// Reset SVG icon that has like-button class to not be affected by container styles
+	svg.like-button {
+		padding: 0;
+		margin: 0;
+		background: none;
+		border: none;
+		border-radius: 0;
+		min-height: auto;
+		height: auto;
+		width: 24px;
+		flex-shrink: 0;
+		display: block;
+		cursor: inherit;
+		transition: none;
+	}
+
+	.comment-button__label,
+	.like-button__label,
+	.post-edit-button__label {
+		font-size: $font-body-small;
+		color: var( --color-neutral-20 );
+	}
+
+	.post-edit-button__label {
+		margin-inline-start: 0;
+	}
+
+	.comment-button:hover .comment-button__label,
+	.like-button:hover .like-button__label,
+	.post-edit-button:hover .post-edit-button__label {
+		color: var( --color-text-subtle );
 	}
 
 	.comment-button svg,
@@ -163,16 +239,38 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 	.comment-button.is-active,
 	.comment-button:hover {
+		background: var( --color-primary-0 );
+		border-color: var( --color-primary-10 );
+
+		svg {
+			opacity: 1;
+		}
+
 		svg.reader-comment path {
 			stroke: var( --color-link );
+		}
+
+		.comment-button__label {
+			color: var( --color-link );
 		}
 	}
 
 	.like-button:hover,
 	.like-button.is-active,
 	.like-button.is-liked {
+		background: var( --color-primary-0 );
+		border-color: var( --color-primary-10 );
+
+		svg {
+			opacity: 1;
+		}
+
 		svg.reader-star path {
 			stroke: var( --color-link );
+		}
+
+		.like-button__label {
+			color: var( --color-link );
 		}
 	}
 
@@ -183,17 +281,22 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 
 	.post-edit-button {
-		color: var( --color-text-subtle );
-
 		svg {
-			fill: var( --color-text-subtle );
+			opacity: 0.6;
 		}
 
 		&:hover {
+			background: var( --color-primary-0 );
+			border-color: var( --color-primary-10 );
 			color: var( --color-link );
 
 			svg {
 				fill: var( --color-link );
+				opacity: 1;
+			}
+
+			.post-edit-button__label {
+				color: var( --color-link );
 			}
 		}
 	}
@@ -203,7 +306,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 .reader-full-post__action-bar-right {
 	display: flex;
 	align-items: center;
-	gap: 20px;
+	gap: 12px;
 }
 
 .reader-full-post__story {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -866,3 +866,14 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 	}
 }
+
+// Add one-off block styles
+.coblocks-gallery {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	margin-left: 0;
+}
+.coblocks-gallery--item {
+	list-style: none;
+}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -453,6 +453,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	font-size: $font-title-medium;
 	font-weight: 700;
 	line-height: 34px;
+	margin-bottom: 20px;
 	max-width: 750px;
 
 	@include breakpoint-deprecated( '>960px' ) {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -808,6 +808,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.reader-full-post__header-title-link:hover {
 		color: var( --color-neutral-70 );
 	}
+
+	.recent-feed__post-column & {
+		margin-bottom: 0;
+	}
 }
 
 .reader-full-post__header-meta {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -34,11 +34,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__content {
-	@media ( min-width: $reader-full-post-desktop-min ) {
-		display: flex;
-		justify-content: space-around;
-		flex-wrap: wrap;
-	}
 	max-width: 1200px;
 	margin: 0 auto;
 
@@ -48,66 +43,11 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post__visit-site-container {
-	align-items: center;
-	background: rgba( 255, 255, 255, 0.8 );
-	display: flex;
-	font-size: $font-body-extra-small;
-	font-weight: 600;
-	height: 46px;
-	justify-content: center;
-	margin: 0;
-	position: fixed;
-	right: 0;
-	top: 0;
-	text-transform: uppercase;
-	width: 46px;
-	z-index: z-index(
-		'.reader-full-post__sidebar-comment-like',
-		'.reader-full-post__visit-site-container'
-	);
-
-	@include breakpoint-deprecated( '>660px' ) {
-		display: none;
-	}
-
-	.external-link .gridicons-external {
-		fill: var( --color-neutral-40 );
-		top: 0;
-	}
-
-	.external-link {
-		color: var( --color-neutral-40 );
-		display: block;
-		height: 18px;
-		margin-left: -3px;
-		position: relative;
-		top: -1px;
-
-		&:hover {
-			color: var( --color-accent );
-
-			.gridicons-external {
-				fill: var( --color-accent );
-			}
-		}
-	}
-
-	.reader-full-post__visit-site-label {
-		@include breakpoint-deprecated( '<660px' ) {
-			display: none;
-		}
-	}
+	display: none;
 }
 
 .reader-full-post__sidebar {
-	width: var( --reader-full-post-sidebar-width );
-	text-align: center;
-	margin-top: 55px;
-
-	// hide the sidebar when it cannot fit to the side of the content.
-	@media ( max-width: $reader-full-post-desktop-min ) {
-		display: none;
-	}
+	display: none;
 }
 
 .reader-full-post__seen-button {
@@ -117,7 +57,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
-	margin-left: -4px;
 	user-select: none;
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -125,14 +64,157 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-.reader-full-post__story {
+// Header Meta Component Styles
+.reader-full-post__header-meta-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-top: 16px;
+	margin-bottom: 24px;
+}
+
+.reader-full-post__header-meta-avatars {
+	flex-shrink: 0;
+
+	.site-icon,
+	.gravatar {
+		border-radius: 50%;
+	}
+
+	&.has-site-and-author-icon {
+		.site-icon {
+			height: 36px;
+			width: 36px;
+		}
+
+		.gravatar {
+			height: 28px;
+			width: 28px;
+			border: 2px solid var( --color-surface );
+			position: relative;
+			left: 6px;
+			top: -28px;
+			margin-bottom: -28px;
+			background-color: var( --color-surface );
+		}
+	}
+
+	.gridicons-globe {
+		fill: var( --color-neutral-70 );
+	}
+}
+
+.reader-full-post__header-meta-info {
 	flex: 1;
+	min-width: 0;
+	font-size: $font-body-small;
+	line-height: 1.5;
+}
+
+.reader-full-post__header-meta-line-1,
+.reader-full-post__header-meta-line-2 {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.reader-full-post__header-meta-author,
+.reader-full-post__header-meta-site-link {
+	color: var( --color-text );
+	font-weight: 600;
+	text-decoration: none;
+
+	&:hover {
+		color: var( --color-link );
+	}
+}
+
+.reader-full-post__header-meta-separator {
+	color: var( --color-text-subtle );
+}
+
+.reader-full-post__header-meta-date {
+	color: var( --color-text-subtle );
+}
+
+.reader-full-post__header-meta-date-link {
+	color: inherit;
+	text-decoration: none;
+
+	&:hover {
+		color: var( --color-link );
+	}
+}
+
+.reader-full-post__header-meta-follow {
+	.follow-button__label {
+		font-size: $font-body-small;
+	}
+}
+
+// Action Bar Component Styles
+.reader-full-post__action-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px 0;
+	margin-bottom: 24px;
+	border-top: 1px solid var( --color-border-subtle );
+	border-bottom: 1px solid var( --color-border-subtle );
+
+	.comment-button,
+	.like-button,
+	.post-edit-button,
+	.reader-full-post__seen-button {
+		margin: 0;
+	}
+
+	.comment-button.is-active,
+	.comment-button:hover {
+		svg.reader-comment path {
+			stroke: var( --color-link );
+		}
+	}
+
+	.like-button:hover,
+	.like-button.is-active,
+	.like-button.is-liked {
+		svg.reader-star path {
+			stroke: var( --color-link );
+		}
+	}
+
+	.like-button.is-liked {
+		svg.reader-star path {
+			fill: var( --color-link );
+		}
+	}
+
+	.post-edit-button {
+		color: var( --color-text-subtle );
+
+		&:hover {
+			color: var( --color-link );
+
+			.gridicon {
+				fill: var( --color-link );
+			}
+		}
+	}
+}
+
+.reader-full-post__action-bar-left,
+.reader-full-post__action-bar-right {
+	display: flex;
+	align-items: center;
+	gap: 20px;
+}
+
+.reader-full-post__story {
 	max-width: var( --reader-full-post-story-max-width );
 	padding: 32px var( --reader-full-post-story-padding );
 	margin: 0 auto;
-	@media ( min-width: $reader-full-post-desktop-min ) {
-		margin: 0;
-	}
 
 	@include breakpoint-deprecated( '<480px' ) {
 		font-size: $font-body;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -76,27 +76,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 .reader-full-post__header-meta-avatars {
 	flex-shrink: 0;
 
-	.site-icon,
 	.gravatar {
 		border-radius: 50%;
-	}
-
-	&.has-site-and-author-icon {
-		.site-icon {
-			height: 36px;
-			width: 36px;
-		}
-
-		.gravatar {
-			height: 28px;
-			width: 28px;
-			border: 2px solid var( --color-surface );
-			position: relative;
-			left: 6px;
-			top: -28px;
-			margin-bottom: -28px;
-			background-color: var( --color-surface );
-		}
+		width: 40px;
+		height: 40px;
 	}
 
 	.gridicons-globe {
@@ -109,6 +92,8 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	min-width: 0;
 	font-size: $font-body-small;
 	line-height: 1.5;
+	position: relative;
+	top: -2px;
 }
 
 .reader-full-post__header-meta-line-1,
@@ -122,7 +107,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 .reader-full-post__header-meta-author,
 .reader-full-post__header-meta-site-link {
 	color: var( --color-text );
-	font-weight: 600;
+	font-weight: 500;
 	text-decoration: none;
 
 	&:hover {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -178,7 +178,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		padding: 8px 16px;
 		background: var( --color-surface );
 		border: 1px solid var( --color-neutral-10 );
-		border-radius: 24px;
+		border-radius: 4px;
 		transition: all 0.2s ease;
 		cursor: pointer;
 		display: flex;
@@ -189,7 +189,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		color: var( --color-neutral-20 );
 
 		&:hover {
-			background: var( --color-neutral-0 );
 			border-color: var( --color-neutral-20 );
 		}
 
@@ -236,8 +235,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 		// Hover state
 		&:hover {
-			background: var( --color-primary-0 );
-
 			.reader-following-feed,
 			.reader-following-feed path,
 			.reader-follow-feed,
@@ -316,7 +313,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.like-button.is-active,
 	.like-button.is-liked,
 	.post-edit-button:hover {
-		background: var( --color-primary-0 );
 		border-color: var( --color-primary-10 );
 
 		svg {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -65,12 +65,38 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 // Header Meta Component Styles
+.reader-full-post__header-meta-and-tags {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-top: 16px;
+	margin-bottom: 24px;
+	flex-wrap: wrap;
+}
+
 .reader-full-post__header-meta-wrapper {
 	display: flex;
 	align-items: center;
 	gap: 12px;
-	margin-top: 16px;
-	margin-bottom: 24px;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.reader-full-post__header-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: flex-start;
+	justify-content: flex-end;
+	flex: 0 1 auto;
+	max-width: 400px;
+
+	@include breakpoint-deprecated( '<960px' ) {
+		flex: 1 0 100%;
+		justify-content: flex-start;
+		max-width: none;
+	}
 }
 
 .reader-full-post__header-meta-avatars {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -151,7 +151,8 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.comment-button,
 	.like-button,
 	.post-edit-button,
-	.reader-full-post__seen-button {
+	.reader-full-post__seen-button,
+	.follow-button {
 		margin: 0;
 		padding: 8px 16px;
 		background: var( --color-surface );
@@ -188,8 +189,67 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		}
 	}
 
+	.follow-button {
+		background: transparent;
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+		}
+
+		.reader-following-feed,
+		.reader-follow-feed {
+			width: 24px;
+			height: 24px;
+			fill: var( --color-text-subtle ) !important;
+		}
+
+		.reader-following-feed path,
+		.reader-follow-feed path {
+			fill: var( --color-text-subtle ) !important;
+		}
+
+		&.is-following {
+			background: transparent;
+
+			.follow-button__label {
+				color: var( --color-text-subtle ) !important;
+			}
+
+			&:hover {
+				background: var( --color-primary-0 );
+
+				.reader-following-feed,
+				.reader-following-feed path {
+					fill: var( --color-link ) !important;
+					opacity: 1;
+				}
+
+				.follow-button__label {
+					color: var( --color-link ) !important;
+				}
+			}
+		}
+
+		&:hover:not(.is-following) {
+			background: var( --color-primary-0 );
+
+			.gridicon,
+			.reader-follow-feed,
+			.reader-follow-feed path {
+				fill: var( --color-link ) !important;
+				opacity: 1;
+			}
+
+			.follow-button__label {
+				color: var( --color-link );
+			}
+		}
+	}
+
 	.comment-button.tooltip,
-	.like-button.tooltip {
+	.like-button.tooltip,
+	.follow-button.tooltip {
 		@include tooltip-base;
 		@include tooltip-top;
 	}
@@ -216,9 +276,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 	.comment-button__label,
 	.like-button__label,
-	.post-edit-button__label {
+	.post-edit-button__label,
+	.follow-button__label {
 		font-size: $font-body-small;
-		color: var( --color-neutral-20 );
+		color: var( --color-text-subtle );
 	}
 
 	.post-edit-button__label {

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -86,7 +86,6 @@ const ReaderPostActions = ( {
 						showZeroCount={ false }
 						likeSource="reader"
 						defaultLabel={ translate( 'Like' ) }
-						showTooltip
 					/>
 				</li>
 			) }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -19,7 +19,7 @@ const ReaderPostActions = ( {
 	post,
 	site,
 	onCommentClick,
-	iconSize = 20,
+	iconSize = 24,
 	className,
 	fullPost,
 	commentsApiDisabled = false,
@@ -39,13 +39,7 @@ const ReaderPostActions = ( {
 		<ul className={ listClassnames }>
 			{ showShare && (
 				<li className="reader-post-actions__item">
-					<ShareButton
-						post={ post }
-						position="bottom"
-						tagName="div"
-						iconSize={ iconSize }
-						showLabel
-					/>
+					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
 				</li>
 			) }
 
@@ -57,7 +51,6 @@ const ReaderPostActions = ( {
 						tagName="div"
 						iconSize={ iconSize }
 						isReblogSelection
-						showLabel
 					/>
 				</li>
 			) }
@@ -74,6 +67,7 @@ const ReaderPostActions = ( {
 							viewBox: '0 -1 20 20',
 						} ) }
 						defaultLabel={ translate( 'Comment' ) }
+						alwaysShowTooltip
 					/>
 				</li>
 			) }
@@ -92,6 +86,7 @@ const ReaderPostActions = ( {
 						showZeroCount={ false }
 						likeSource="reader"
 						defaultLabel={ translate( 'Like' ) }
+						showTooltip
 					/>
 				</li>
 			) }

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -54,6 +54,15 @@
 			}
 		}
 
+		// Hide label on smaller screens
+		.freshly-pressed__button-label {
+			display: none;
+
+			@include break-medium {
+				display: inline;
+			}
+		}
+
 		// Hover states
 		.freshly-pressed:hover {
 			color: var( --color-link );

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -2,33 +2,72 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	gap: 4px;
+	gap: 12px;
 	list-style: none;
 	margin: 0;
-	padding-top: 20px;
-	justify-content: space-between;
-
-	@include break-medium {
-		justify-content: flex-start;
-		gap: 24px;
-	}
+	padding: 16px 0;
+	border-top: 1px solid var( --color-neutral-5 );
+	border-bottom: 1px solid var( --color-neutral-5 );
 
 	.reader-post-actions__item {
 		display: flex;
 		align-items: center;
-		justify-content: flex-start;
-		gap: 10px;
-		flex-direction: column;
 
 		button {
+			margin: 0;
+			padding: 8px 16px;
+			background: var( --color-surface );
+			border: 1px solid var( --color-neutral-10 );
+			border-radius: 4px;
+			transition: all 0.2s ease;
+			cursor: pointer;
 			display: flex;
-			flex-direction: column;
+			flex-direction: row;
+			align-items: center;
+			gap: 8px;
 			height: auto;
-			min-width: 60px;
-			@include break-medium {
-				min-width: unset;
-				flex-direction: row;
+			min-height: 40px;
+			color: var( --color-text-subtle );
+
+			&:hover {
+				border-color: var( --color-neutral-20 );
+			}
+
+			svg {
+				flex-shrink: 0;
+				display: block;
+				opacity: 0.6;
+			}
+
+			&:hover svg {
+				opacity: 1;
 			}
 		}
+
+		// Override freshly-pressed button CSS custom property for consistent styling
+		.freshly-pressed {
+			--color-foreground: var( --color-text-subtle );
+
+			svg {
+				fill: var( --color-text-subtle );
+				opacity: 0.6;
+			}
+		}
+
+		// Hover states
+		.freshly-pressed:hover {
+			color: var( --color-link );
+			--color-foreground: var( --color-link );
+
+			svg {
+				fill: var( --color-link );
+				opacity: 1;
+			}
+		}
+	}
+
+	// Float freshly-pressed button to the right
+	.reader-post-actions__item:has(.freshly-pressed) {
+		margin-inline-start: auto;
 	}
 }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -111,7 +111,7 @@ class ReaderShare extends Component {
 			'reader-share__button': true,
 			'ignore-click': true,
 			'is-active': this.state.showingMenu,
-			tooltip: this.props.isReblogSelection,
+			tooltip: true,
 		} );
 
 		const popoverProps = {
@@ -122,39 +122,35 @@ class ReaderShare extends Component {
 			className: 'popover reader-share__popover',
 		};
 
-		// The event.preventDefault() on the wrapping div is needed to prevent the
+		// The event.preventDefault() is needed to prevent the
 		// full post opening when a share method is selected in the popover
 		return (
-			// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-			<div className="reader-share" onClick={ ( event ) => event.preventDefault() }>
+			<>
 				<Button
 					borderless
 					className={ buttonClasses }
 					compact={ this.props.iconSize === 18 }
 					key="button"
-					onClick={ this.toggle }
+					onClick={ ( event ) => {
+						event.preventDefault();
+						this.toggle();
+					} }
 					ref={ this.shareButton }
 					data-tooltip={
-						this.props.isReblogSelection ? translate( 'Repost with your thoughts' ) : undefined
+						this.props.isReblogSelection
+							? translate( 'Repost with your thoughts' )
+							: translate( 'Share' )
 					}
 				>
-					{ ! this.props.isReblogSelection ? (
-						<>
-							{ ReaderShareIcon( {
+					{ ! this.props.isReblogSelection
+						? ReaderShareIcon( {
 								iconSize: this.props.iconSize,
-								viewBox: '0 -2 24 24',
-							} ) }
-							<span className="reader-share__label">{ translate( 'Share' ) }</span>
-						</>
-					) : (
-						<>
-							{ ReaderRepostIcon( {
+								viewBox: '-1 -1 24 24',
+						  } )
+						: ReaderRepostIcon( {
 								iconSize: this.props.iconSize,
-								viewBox: '0 -1 20 20',
-							} ) }
-							<span className="repost__label">{ translate( 'Repost' ) }</span>
-						</>
-					) }
+								viewBox: '0 0 20 20',
+						  } ) }
 				</Button>
 				{ this.state.showingMenu &&
 					( ! this.props.isReblogSelection ? (
@@ -171,7 +167,7 @@ class ReaderShare extends Component {
 							closeMenu={ this.closeMenu }
 						/>
 					) ) }
-			</div>
+			</>
 		);
 	}
 }

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -136,6 +136,11 @@ class ReaderShare extends Component {
 						this.toggle();
 					} }
 					ref={ this.shareButton }
+					aria-label={
+						this.props.isReblogSelection
+							? translate( 'Repost with your thoughts' )
+							: translate( 'Share' )
+					}
 					data-tooltip={
 						this.props.isReblogSelection
 							? translate( 'Repost with your thoughts' )

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -1,52 +1,53 @@
-.reader-share {
-	.reader-share__button.button {
-		color: var(--color-text-subtle);
+.reader-share__button.button {
+	display: flex;
+	align-items: center;
+	padding: 0;
+	font-size: $font-body-small;
+	font-weight: 400;
+	gap: 4px;
+	line-height: normal;
+
+	svg {
 		fill: var(--color-text-subtle);
-		display: flex;
-		align-items: center;
-		padding: 0;
-		font-size: $font-body-small;
-		font-weight: 400;
-		gap: 4px;
-		line-height: normal;
+		opacity: 0.6;
+	}
 
-		&:hover,
-		&:active {
-			color: var(--color-primary);
-			fill: var(--color-primary);
-		}
+	&:hover svg,
+	&:active svg {
+		fill: var(--color-link);
+		opacity: 1;
+	}
 
-		&:focus {
-			outline: thin dotted;
-		}
+	&:focus {
+		outline: thin dotted;
+	}
 
-		&.is-borderless {
-			.gridicon {
-				margin-right: 0;
-				margin-top: 0;
-			}
+	&.is-borderless {
+		.gridicon {
+			margin-right: 0;
+			margin-top: 0;
 		}
+	}
+
+	.gridicon {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	.gridicons-reblog {
+		top: 0;
+	}
+
+	&.is-active {
+		color: var(--color-primary);
 
 		.gridicon {
-			transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+			fill: var(--color-primary);
 		}
+	}
 
-		.gridicons-reblog {
-			top: 0;
-		}
-
-		&.is-active {
-			color: var(--color-primary);
-
-			.gridicon {
-				fill: var(--color-primary);
-			}
-		}
-
-		&.tooltip {
-			@include tooltip-base;
-			@include tooltip-top;
-		}
+	&.tooltip {
+		@include tooltip-base;
+		@include tooltip-top;
 	}
 }
 

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -106,6 +106,7 @@ class ReaderLikeButton extends Component {
 					icon={ likeIcon }
 					onMouseEnter={ this.showLikesPopover }
 					onMouseLeave={ this.hideLikesPopover }
+					showTooltip={ likeCount === 0 }
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -101,11 +101,12 @@ class ReaderLikeButton extends Component {
 				<LikeButtonContainer
 					{ ...this.props }
 					ref={ this.likeButtonRef }
-					onMouseEnter={ this.showLikesPopover }
-					onMouseLeave={ this.hideLikesPopover }
 					onLikeToggle={ this.onLikeToggle }
 					likeSource="reader"
 					icon={ likeIcon }
+					showTooltip
+					onLabelMouseEnter={ hasEnoughLikes ? this.showLikesPopover : undefined }
+					onLabelMouseLeave={ hasEnoughLikes ? this.hideLikesPopover : undefined }
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -104,8 +104,8 @@ class ReaderLikeButton extends Component {
 					onLikeToggle={ this.onLikeToggle }
 					likeSource="reader"
 					icon={ likeIcon }
-					onMouseEnter={ hasEnoughLikes ? this.showLikesPopover : undefined }
-					onMouseLeave={ hasEnoughLikes ? this.hideLikesPopover : undefined }
+					onMouseEnter={ this.showLikesPopover }
+					onMouseLeave={ this.hideLikesPopover }
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -104,9 +104,8 @@ class ReaderLikeButton extends Component {
 					onLikeToggle={ this.onLikeToggle }
 					likeSource="reader"
 					icon={ likeIcon }
-					showTooltip
-					onLabelMouseEnter={ hasEnoughLikes ? this.showLikesPopover : undefined }
-					onLabelMouseLeave={ hasEnoughLikes ? this.hideLikesPopover : undefined }
+					onMouseEnter={ hasEnoughLikes ? this.showLikesPopover : undefined }
+					onMouseLeave={ hasEnoughLikes ? this.hideLikesPopover : undefined }
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -226,7 +226,7 @@ body.is-reader-full-post {
 			}
 
 			.reader-post-actions {
-				padding-top: 0;
+				padding: 8px 0;
 				margin: 0;
 				justify-content: space-evenly;
 


### PR DESCRIPTION
## Description

I decided to take a pass at cleaning up the full-post view within the reader. 

## Before

Here’s what the view looks like today:

<img width="2940" height="1538" alt="image" src="https://github.com/user-attachments/assets/ada1a865-ef45-4378-aff7-c94dc09fc595" />

## After

<img width="2940" height="1652" alt="CleanShot 2025-11-18 at 07 20 17@2x" src="https://github.com/user-attachments/assets/a82fdd00-4b99-47b8-9660-d966a1d30547" />

## Testing

- Apply this PR locally or use Calypso live
- Test out a bunch of posts
- Test responsive styles