### PR TITLE
SSH Migration: Fix loading state for the `I don't have SSH` button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -59,17 +59,15 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 				<Button variant="primary" onClick={ handleFoundDetails } disabled={ isInputDisabled }>
 					{ translate( 'I found my SSH details' ) }
 				</Button>
-				<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
-					<Button
-						variant="link"
-						onClick={ handleNoSSH }
-						className="migration-site-ssh__no-ssh-link"
-						disabled={ isInputDisabled }
-					>
-						{ translate( "I don't have SSH" ) }
-						{ isProcessingNoSSH && <Spinner /> }
-					</Button>
-				</div>
+				<Button
+					variant="link"
+					onClick={ handleNoSSH }
+					className="migration-site-ssh__no-ssh-link"
+					disabled={ isInputDisabled }
+				>
+					{ translate( "I don't have SSH" ) }
+					{ isProcessingNoSSH && <Spinner /> }
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-find-ssh-details.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -9,6 +9,7 @@ interface StepFindSSHDetailsProps {
 	hostDisplayName?: string;
 	helpLink: ReactNode;
 	isInputDisabled: boolean;
+	isProcessingNoSSH?: boolean;
 }
 
 export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
@@ -17,6 +18,7 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 	hostDisplayName,
 	helpLink,
 	isInputDisabled,
+	isProcessingNoSSH = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -54,17 +56,20 @@ export const StepFindSSHDetails: FC< StepFindSSHDetailsProps > = ( {
 			<p>{ instructionText }</p>
 			{ helpLink }
 			<div className="migration-site-ssh__find-ssh-details-buttons">
-				<Button variant="primary" onClick={ handleFoundDetails }>
+				<Button variant="primary" onClick={ handleFoundDetails } disabled={ isInputDisabled }>
 					{ translate( 'I found my SSH details' ) }
 				</Button>
-				<Button
-					variant="link"
-					onClick={ handleNoSSH }
-					className="migration-site-ssh__no-ssh-link"
-					disabled={ isInputDisabled }
-				>
-					{ translate( "I don't have SSH" ) }
-				</Button>
+				<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+					<Button
+						variant="link"
+						onClick={ handleNoSSH }
+						className="migration-site-ssh__no-ssh-link"
+						disabled={ isInputDisabled }
+					>
+						{ translate( "I don't have SSH" ) }
+						{ isProcessingNoSSH && <Spinner /> }
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -43,6 +43,7 @@ interface StepsDataOptions {
 	isTransferring: boolean;
 	shouldGenerateKey: boolean;
 	isInputDisabled: boolean;
+	isProcessingNoSSH: boolean;
 }
 
 interface StepData {
@@ -80,6 +81,7 @@ interface UseStepsOptions {
 	migrationStatus?: 'queued' | 'in-progress' | 'migrating' | 'completed' | 'failed';
 	isTransferring: boolean;
 	isInputDisabled: boolean;
+	isProcessingNoSSH?: boolean;
 }
 
 interface SSHFormState {
@@ -116,6 +118,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 						/>
 					}
 					isInputDisabled={ options.isInputDisabled }
+					isProcessingNoSSH={ options.isProcessingNoSSH }
 				/>
 			),
 		},
@@ -188,6 +191,7 @@ export const useSteps = ( {
 	migrationStatus,
 	isTransferring,
 	isInputDisabled,
+	isProcessingNoSSH = false,
 }: UseStepsOptions ): StepsObject => {
 	const [ currentStep, setCurrentStep ] = useState( -1 );
 	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
@@ -342,6 +346,7 @@ export const useSteps = ( {
 		isTransferring,
 		shouldGenerateKey,
 		isInputDisabled,
+		isProcessingNoSSH,
 	} );
 
 	const isComplete = ( stepKey: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/styles.scss
@@ -123,6 +123,9 @@
 
 .migration-site-ssh__no-ssh-link {
 	text-decoration: none !important;
+	.components-spinner {
+		margin-top: 0;
+	}
 }
 
 .migration-site-ssh__help-link {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* This complements: https://github.com/Automattic/wp-calypso/pull/107054

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I forgot to push one commit to https://github.com/Automattic/wp-calypso/pull/107054, which would add a loading state to the `I don't have SSH` button.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
