### PR TITLE
MSD: Navigate back to purchase after cancel

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -180,9 +180,8 @@ export default function CancelPurchase() {
 			return;
 		}
 
-		createErrorNotice( 'test', { type: 'snackbar' } );
 		navigate( { to: purchasesRoute.to } );
-	}, [ purchase, navigate, createErrorNotice ] );
+	}, [ purchase, navigate ] );
 
 	const track = useCallback( () => {
 		if ( productSlug ) {
@@ -851,6 +850,10 @@ export default function CancelPurchase() {
 								type: 'snackbar',
 							}
 						);
+						navigate( {
+							to: purchaseSettingsRoute.fullPath,
+							params: { purchaseId: purchase.ID },
+						} );
 					},
 					onError: ( error: Error ) => {
 						createErrorNotice( ( error as Error ).message, { type: 'snackbar' } );
@@ -883,7 +886,10 @@ export default function CancelPurchase() {
 						),
 						{ type: 'snackbar' }
 					);
-					setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
+					navigate( {
+						to: purchaseSettingsRoute.fullPath,
+						params: { purchaseId: purchase.ID },
+					} );
 				},
 				onError: () => {
 					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1306/hosting-dashboard-cancellation-flow-cancelling-plan-does-not-return

## Proposed Changes

This PR modifies the cancel flow in the Multi Site Dashboard so that after a cancellation is complete, it redirects the user back to the purchase settings page for that purchase (with a snackbar notification that the cancellation has completed). Previously, the user received a notification but remained on the first step of the cancel page.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1029" height="651" alt="Screenshot 2025-11-13 at 3 51 16 PM" src="https://github.com/user-attachments/assets/b0866958-9255-4b29-8577-a4d59b1e2350" /> | <img width="1034" height="656" alt="Screenshot 2025-11-13 at 3 50 51 PM" src="https://github.com/user-attachments/assets/f7fd3067-cd08-4bc3-96b4-404716806613" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit https://wpcalypso.wordpress.com/v2/me/billing/purchases
- Select a purchase.
- Modify the URL to add `/cancel` (clicking the Cancel button is not yet wired up to this flow).
- Confirm the cancellation (you may need to click "Skip" because there's some bugs with the survey questions).
- Verify that you are returned to the purchase page with a notification that the purchase was cancelled.
