### PR TITLE
[Billing] Show domain options when cancelling

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -251,7 +251,7 @@ const CancelPurchaseDomainOptions = ( {
 	}
 
 	return (
-		<div className="cancel-purchase__domain-options">
+		<>
 			<p>
 				{ createInterpolateElement(
 					sprintf(
@@ -268,60 +268,62 @@ const CancelPurchaseDomainOptions = ( {
 					}
 				) }
 			</p>
-			<RadioControl
-				name="keep_bundled_domain_false"
-				id="keep_bundled_domain_false_control"
-				options={ [
-					{
-						label: sprintf(
-							/* translators: %(domain)s is a domain name */
-							__( 'Cancel the plan, but keep "%(domain)s"' ),
-							{
-								domain: includedDomainPurchase.meta,
-							}
-						),
-						value: 'keep',
-						description: sprintf(
-							/* translators: %(refundAmount)s and %(domainCost)s are both monetary amounts. %(productName)s is the name of the product */
-							__(
-								"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
-									'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
-									"registration, and you're free to use it on WordPress.com or transfer it elsewhere."
+			<p>
+				<RadioControl
+					name="keep_bundled_domain_false"
+					id="keep_bundled_domain_false_control"
+					options={ [
+						{
+							label: sprintf(
+								/* translators: %(domain)s is a domain name */
+								__( 'Cancel the plan, but keep "%(domain)s"' ),
+								{
+									domain: includedDomainPurchase.meta,
+								}
 							),
-							{
-								productName: purchase.product_name,
-								domainCost: includedDomainPurchase.cost_to_unbundle_display,
-								refundAmount: purchase.refund_text,
-							}
-						),
-					},
-					{
-						label: sprintf(
-							/* translators: %(domain)s is the domain name */
-							__( 'Cancel the plan and the domain "%(domain)s"' ),
-							{
-								domain: includedDomainPurchase.meta,
-							}
-						),
-						value: 'cancel',
-						description: sprintf(
-							/* translators: %(planCost)s is the monetary amount that the customer will receive in the form of a refund */
-							__(
-								"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
-									"you'll lose it permanently."
+							value: 'keep',
+							description: sprintf(
+								/* translators: %(refundAmount)s and %(domainCost)s are both monetary amounts. %(productName)s is the name of the product */
+								__(
+									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
+										'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
+										"registration, and you're free to use it on WordPress.com or transfer it elsewhere."
+								),
+								{
+									productName: purchase.product_name,
+									domainCost: includedDomainPurchase.cost_to_unbundle_display,
+									refundAmount: purchase.refund_text,
+								}
 							),
-							{
-								planCost: purchase.total_refund_text,
-							}
-						),
-					},
-				] }
-				selected={ cancelBundledDomain ? 'cancel' : 'keep' }
-				onChange={ onCancelBundledDomainChange }
-				disabled={ isLoading }
-			/>
+						},
+						{
+							label: sprintf(
+								/* translators: %(domain)s is the domain name */
+								__( 'Cancel the plan and the domain "%(domain)s"' ),
+								{
+									domain: includedDomainPurchase.meta,
+								}
+							),
+							value: 'cancel',
+							description: sprintf(
+								/* translators: %(planCost)s is the monetary amount that the customer will receive in the form of a refund */
+								__(
+									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
+										"you'll lose it permanently."
+								),
+								{
+									planCost: purchase.total_refund_text,
+								}
+							),
+						},
+					] }
+					selected={ cancelBundledDomain ? 'cancel' : 'keep' }
+					onChange={ onCancelBundledDomainChange }
+					disabled={ isLoading }
+				/>
+			</p>
 			{ cancelBundledDomain && (
-				<span className="cancel-purchase__domain-warning">
+				<p>
 					{ createInterpolateElement(
 						__(
 							"When you cancel a domain, it becomes unavailable for a while. Anyone may register it once it's " +
@@ -357,9 +359,9 @@ const CancelPurchaseDomainOptions = ( {
 							) }
 						</span>
 					</label>
-				</span>
+				</p>
 			) }
-		</div>
+		</>
 	);
 };
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -193,7 +193,8 @@ const CancelPurchaseDomainOptions = ( {
 
 	if (
 		! includedDomainPurchase ||
-		( 'one-time-purchase' !== purchase.expiry_status && ! purchase.is_domain_registration )
+		'one-time-purchase' === purchase.expiry_status ||
+		purchase.is_domain_registration
 	) {
 		return null;
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1183,16 +1183,15 @@ export default function CancelPurchase() {
 			}
 		} )();
 
-		const onClickFn =
-			propOverrides?.onClick ??
-			( shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart );
-
 		return (
 			<Button
 				className="cancel-purchase__button"
 				disabled={ isDisabled }
 				isBusy={ propOverrides?.isBusy ?? state.isLoading ?? false }
-				onClick={ onClickFn }
+				onClick={
+					propOverrides?.onClick ??
+					( shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart )
+				}
 				variant="primary"
 			>
 				{ cancelButtonText }
@@ -1269,7 +1268,7 @@ export default function CancelPurchase() {
 
 				{ ! state.surveyShown && renderConfirmCheckbox() }
 
-				<ButtonStack>
+				<ButtonStack justify="flex-end">
 					{ renderCancelButton() }
 					{ renderKeepSubscriptionButton() }
 				</ButtonStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -667,25 +667,12 @@ export default function CancelPurchase() {
 		} );
 	};
 
-	const handleCancelPurchaseClick = async () => {
-		// For all purchases, including domain registrations, show the survey first
-		// The API call will happen at the end of the survey flow
-
-		// For other purchases, determine if we need domain options step
-		// If onCancellationStart is null, we're already in the domain options step
-		if ( ! onCancellationStart ) {
-			// We're in the domain options step, show survey directly
-			onCancellationComplete();
-		} else {
-			onCancellationStart();
-		}
-	};
 	const handleMarketplaceDialogContinue = () => {
 		// Close the marketplace dialog
 		closeMarketplaceSubscriptionsDialog();
 
 		// Show the appropriate survey based on purchase type
-		handleCancelPurchaseClick();
+		onCancellationStart();
 	};
 
 	const onTextOneChange = (
@@ -1196,16 +1183,16 @@ export default function CancelPurchase() {
 			}
 		} )();
 
+		const onClickFn =
+			propOverrides?.onClick ??
+			( shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart );
+
 		return (
 			<Button
 				className="cancel-purchase__button"
 				disabled={ isDisabled }
 				isBusy={ propOverrides?.isBusy ?? state.isLoading ?? false }
-				onClick={
-					propOverrides?.onClick ?? shouldHandleMarketplaceSubscriptions()
-						? showMarketplaceDialog
-						: handleCancelPurchaseClick
-				}
+				onClick={ onClickFn }
 				variant="primary"
 			>
 				{ cancelButtonText }
@@ -1275,27 +1262,12 @@ export default function CancelPurchase() {
 		);
 	};
 
-	const renderProductRevertContent = () => {
+	const renderPlanProductRevertContent = () => {
 		return (
 			<>
 				{ ! includedDomainPurchase && <p>{ renderFullText() }</p> }
 
 				{ ! state.surveyShown && renderConfirmCheckbox() }
-
-				<ButtonStack>
-					{ renderCancelButton() }
-					{ renderKeepSubscriptionButton() }
-				</ButtonStack>
-			</>
-		);
-	};
-
-	const renderPlanRevertContent = () => {
-		return (
-			<>
-				{ ! includedDomainPurchase && <p>{ renderFullText() }</p> }
-
-				{ renderConfirmCheckbox() }
 
 				<ButtonStack>
 					{ renderCancelButton() }
@@ -1444,7 +1416,7 @@ export default function CancelPurchase() {
 					selectedDomain={ selectedDomain }
 				/>
 
-				{ ! cancellationFeatures.length ? renderProductRevertContent() : renderPlanRevertContent() }
+				{ renderPlanProductRevertContent() }
 			</>
 		);
 	};
@@ -1480,7 +1452,12 @@ export default function CancelPurchase() {
 					isLoading={ false }
 				/>
 				<div className="cancel-purchase__confirm-buttons">
-					{ renderCancelButton( { disabled: ! canContinue(), onClick: onSurveyComplete } ) }
+					{ renderCancelButton( {
+						disabled: ! canContinue(),
+						onClick: () => {
+							onCancellationComplete();
+						},
+					} ) }
 					{ renderKeepSubscriptionButton() }
 				</div>
 			</>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1268,7 +1268,7 @@ export default function CancelPurchase() {
 
 				{ ! state.surveyShown && renderConfirmCheckbox() }
 
-				<ButtonStack justify="flex-end">
+				<ButtonStack>
 					{ renderCancelButton() }
 					{ renderKeepSubscriptionButton() }
 				</ButtonStack>
@@ -1450,7 +1450,7 @@ export default function CancelPurchase() {
 					onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 					isLoading={ false }
 				/>
-				<div className="cancel-purchase__confirm-buttons">
+				<ButtonStack>
 					{ renderCancelButton( {
 						disabled: ! canContinue(),
 						onClick: () => {
@@ -1458,7 +1458,7 @@ export default function CancelPurchase() {
 						},
 					} ) }
 					{ renderKeepSubscriptionButton() }
-				</div>
+				</ButtonStack>
 			</>
 		);
 	};

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -536,17 +536,14 @@ export const getIncludedDomainPurchase = (
 	sitePurchases: Purchase[],
 	subscriptionPurchase: Purchase | undefined
 ): Purchase | undefined => {
-	if (
-		! subscriptionPurchase ||
-		! isNonDomainSubscription( subscriptionPurchase ) ||
-		subscriptionPurchase.included_domain_purchase_amount
-	) {
+	if ( ! subscriptionPurchase || ! isNonDomainSubscription( subscriptionPurchase ) ) {
 		return;
 	}
 
 	const { included_domain: includedDomain } = subscriptionPurchase;
 	const found = sitePurchases.find(
-		( purchase ) => purchase.is_domain && includedDomain === purchase.meta
+		( purchase ) =>
+			purchase.is_domain && includedDomain === purchase.meta && purchase.cost_to_unbundle_display
 	);
 	return found;
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [SHILL-1311](https://linear.app/a8c/issue/SHILL-1311/hosting-dashboard-cancellation-flow-unexpected-behavior-when)

## Proposed Changes

* Fix issues preventing cancellation of a plan and a domain.
* Tidy the interface to include expected margins and button placement.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the bug preventing cancellation of a plan and domain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a plan with a domain and make sure the domain is set to be registered for more than 1 year.
* Visit the active purchases page on the hosting dashboard (`/v2/me/billing/purchases`) and click "Manage purchase" from the "Actions" column for that purchase.
* Append `/cancel` to the end of that URL to see the cancel flow (clicking the cancel button will take you to the old flow).
* Cancel the plan and domain, or just the plan.
* The plan and domain / or just the plan should be cancelled depending on what you chose.
* You should have been refunded the correct amount.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
