### PR TITLE
MSD: fix purchase list and purchase management site links

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -21,6 +21,12 @@ export function PurchaseProduct( {
 
 	if ( site ) {
 		if ( productType && site.name && site.slug ) {
+			const linkTitle =
+				site.name === site.slug
+					? __( 'View site' )
+					: // translators: the siteName is the name of the site
+					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
+			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
 				<div>
 					{ createInterpolateElement(
@@ -47,17 +53,8 @@ export function PurchaseProduct( {
 								</Button>
 							),
 							siteDomain: (
-								<ExternalLink
-									href={ 'https://' + site.slug }
-									rel="noreferrer"
-									title={
-										// translators: the siteName is the name of the site
-										sprintf( __( 'View %(siteName)s' ), {
-											siteName: site.name,
-										} )
-									}
-								>
-									{ site.slug }
+								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+									{ linkText }
 								</ExternalLink>
 							),
 						}
@@ -70,8 +67,8 @@ export function PurchaseProduct( {
 			return (
 				<div>
 					{ createInterpolateElement(
-						// translators: The string contains the product name, and the URL of the site e.g. Premium plan for blockstore.com
-						sprintf( __( '%(purchaseType)s for <siteDomain />' ), {
+						// translators: The string contains the product name, the URL of the site, and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
+						sprintf( __( '%(purchaseType)s for <siteDomain /> (<viewSite />)' ), {
 							purchaseType: productType,
 						} ),
 						{
@@ -89,6 +86,15 @@ export function PurchaseProduct( {
 									{ site.slug }
 								</Button>
 							),
+							viewSite: (
+								<ExternalLink
+									href={ 'https://' + site.slug }
+									rel="noreferrer"
+									title={ __( 'View site' ) }
+								>
+									{ __( 'View site' ) }
+								</ExternalLink>
+							),
 						}
 					) }
 				</div>
@@ -96,11 +102,17 @@ export function PurchaseProduct( {
 		}
 
 		if ( site.name && site.slug ) {
+			const linkTitle =
+				site.name === site.slug
+					? __( 'View site' )
+					: // translators: the siteName is the name of the site
+					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
+			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
 				<div>
 					{ createInterpolateElement(
 						// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
-						__( 'for <siteName /> (<siteDomain />)' ),
+						__( 'for <siteName /> (<viewSite />)' ),
 						{
 							siteName: (
 								<Button
@@ -116,18 +128,9 @@ export function PurchaseProduct( {
 									{ site.name }
 								</Button>
 							),
-							siteDomain: (
-								<ExternalLink
-									href={ 'https://' + site.slug }
-									rel="noreferrer"
-									title={
-										// translators: the siteName is the name of the site
-										sprintf( __( 'View %(siteName)s' ), {
-											siteName: site.name,
-										} )
-									}
-								>
-									{ site.slug }
+							viewSite: (
+								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+									{ linkText }
 								</ExternalLink>
 							),
 						}
@@ -140,12 +143,25 @@ export function PurchaseProduct( {
 	if ( ! site && productType ) {
 		return (
 			<div>
-				{ sprintf(
-					// translators: The string contains the product name, and the URL of the site e.g. Premium plan for blockstore.com
-					__( '%(purchaseType)s for %(site)s' ),
+				{ createInterpolateElement(
+					sprintf(
+						// translators: The string contains the product name, the URL of the site, and a link to view the site (e.g. "Premium plan for blockstore.com (view site)")
+						__( '%(purchaseType)s for %(site)s (<viewSite />)' ),
+						{
+							purchaseType: productType,
+							site: purchase.domain,
+						}
+					),
 					{
-						purchaseType: productType,
-						site: purchase.domain,
+						viewSite: (
+							<ExternalLink
+								href={ 'https://' + purchase.domain }
+								rel="noreferrer"
+								title={ __( 'View site' ) }
+							>
+								{ __( 'View site' ) }
+							</ExternalLink>
+						),
 					}
 				) }
 			</div>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1154,7 +1154,7 @@ export default function PurchaseSettings() {
 							title={ __( 'Site' ) }
 							heading={ site.name }
 							description={ purchase.site_slug }
-							link={ `/v2/sites/${ purchase.site_slug }` }
+							link={ `/sites/${ purchase.site_slug }` }
 						/>
 					) }
 					<OverviewCard


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1329/

## Proposed Changes

This fixes a bug with the site overview card on the purchase management page, where the dashboard root was hardcoded. It also makes a change to the purchases list to try to consistently offer an external link to the site and also not show both the site name and domain if the two match (e.g. "Personal plan for michaeldcain.com (michaeldcain.com)").

## Why are these changes being made?

For the purchase management site overview card link, different dashboards can have different roots (e.g. `ciab` and `v2`), and even the `v2` root of the primary dashbaord is in flux. I was testing purchase management in the CIAB dashboard, and noticed that the site link 404'd because it linked to `/ciab/v2/sites/{siteSlug}` vs `/ciab/sites/{siteSlug}`.

For the purchase list links, I was finding it hard to tell when a link in the description would link to a filtered view of all of the site's purchases vs. link to the site itself. Sometimes the latter would be missing entirely, and sometimes the site title and slug can match (either intentionally or automatically when a site is provisioned) adding to the confusion.

| Before      | After |
| ----------- | ----------- |
| <img width="599" height="264" alt="Screenshot 2025-11-13 at 16 32 41" src="https://github.com/user-attachments/assets/8ff02034-5a51-4a09-a061-14181b4a58ac" /> | <img width="567" height="252" alt="Screenshot 2025-11-13 at 16 32 03" src="https://github.com/user-attachments/assets/c735c9d2-aa78-4653-bf83-7d9fc53a4d3a" /> |

## Testing Instructions

- `ENTRY_LIMIT=entry-dashboard-dotcom,entry-dashboard-ciab yarn start` (note the CIAB dashboard)
- visit `/ciab/me/billing/purchases/`
- click on a purchase, and then again on the site overview card
- verify that the card links to the site overview (still with the Woo branded dashboard)
- visit `/v2/me/billing/purchases/`
- verify that your list of purchases look correct and that there are both links to a filtered purchase view and external links to the purchase's site
- click on a purchase, and then again on the site overview card
- verify that the card links to the site overview (still with the WP branded dashboard)
