### PR TITLE
A4A: Allow multiple wpcom plans in the cart

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -68,19 +68,26 @@ function BillingDragonCheckoutContent( {
 
 		debug( '[A4A Checkout] Cart items inside useEffect: ', cartItems );
 
-		const productsToAdd = cartItems.map( ( product ) => {
-			const product_cart = {
-				// When using the wpcom checkout we use alternative a4a-specific billing product ids for wpcom and jetpack products.
-				product_id: product.alternative_product_id || product.product_id,
-				product_slug: product.slug,
-				volume: product.quantity > 0 ? product.quantity : 1,
-				extra: {
-					isA4ASitelessCheckout: true,
-					agency_id: agency.id,
-				},
-			};
-			debug( '[A4A Checkout] Processing product to add: ', product_cart );
-			return createRequestCartProduct( product_cart );
+		const productsToAdd = cartItems.flatMap( ( product ) => {
+			const productQuantity = product.quantity > 0 ? product.quantity : 1;
+
+			let cartItemIndex = 0;
+			// Add each product separately instead of using volume
+			// This ensures each site gets the correct tier pricing
+			return Array.from( { length: productQuantity }, () => {
+				const product_cart = {
+					// When using the wpcom checkout we use alternative a4a-specific billing product ids for wpcom and jetpack products.
+					product_id: product.alternative_product_id || product.product_id,
+					product_slug: product.slug,
+					extra: {
+						isA4ASitelessCheckout: true,
+						agency_id: agency.id,
+						cart_item_index: cartItemIndex++,
+					},
+				};
+				debug( '[A4A Checkout] Processing product to add: ', product_cart );
+				return createRequestCartProduct( product_cart );
+			} );
 		} );
 
 		debug( '[A4A Checkout] Products to add', productsToAdd );

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -73,6 +73,7 @@ function BillingDragonCheckoutContent( {
 				// When using the wpcom checkout we use alternative a4a-specific billing product ids for wpcom and jetpack products.
 				product_id: product.alternative_product_id || product.product_id,
 				product_slug: product.slug,
+				volume: product.quantity > 0 ? product.quantity : 1,
 				extra: {
 					isA4ASitelessCheckout: true,
 					agency_id: agency.id,

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -41,9 +41,8 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
-	// If the item is an A4A client checkout (has referral_id), it cannot be removed from the cart
-	// Agency checkouts (without referral_id) can remove items
-	if ( item.extra?.isA4ASitelessCheckout && item.extra?.referral_id ) {
+	// If the item is an A4A siteless checkout, it cannot be removed from the cart
+	if ( item.extra?.isA4ASitelessCheckout ) {
 		return false;
 	}
 

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -41,8 +41,9 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
-	// If the item is an A4A siteless checkout, it cannot be removed from the cart
-	if ( item.extra?.isA4ASitelessCheckout ) {
+	// If the item is an A4A client checkout (has referral_id), it cannot be removed from the cart
+	// Agency checkouts (without referral_id) can remove items
+	if ( item.extra?.isA4ASitelessCheckout && item.extra?.referral_id ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1614/allow-multiple-plans-in-the-cart
Backend PR: 196303-ghe-Automattic/wpcom

## Proposed Changes

* Allow multiple wpcom plans in the cart

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support buying multiple wpcom plans at a time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See 196303-ghe-Automattic/wpcom for testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
