### PR TITLE
MSD: Add PageHeader.ActionMenu to provide mobile styles.

### DIFF
--- a/client/dashboard/components/page-header/index.stories.tsx
+++ b/client/dashboard/components/page-header/index.stories.tsx
@@ -72,24 +72,26 @@ export const FullExample: Story = {
 				<Button variant="secondary" __next40pxDefaultSize>
 					Preview
 				</Button>
-				<DropdownMenu
-					icon={ moreVertical }
-					label="More actions"
-					toggleProps={ { __next40pxDefaultSize: true } }
-				>
-					{ () => (
-						<>
-							<MenuGroup>
-								<MenuItem>Import</MenuItem>
-								<MenuItem>Export</MenuItem>
-								<MenuItem>Settings</MenuItem>
-							</MenuGroup>
-							<MenuGroup>
-								<MenuItem>Help</MenuItem>
-							</MenuGroup>
-						</>
-					) }
-				</DropdownMenu>
+				<PageHeader.ActionMenu>
+					<DropdownMenu
+						icon={ moreVertical }
+						label="More actions"
+						toggleProps={ { __next40pxDefaultSize: true } }
+					>
+						{ () => (
+							<>
+								<MenuGroup>
+									<MenuItem>Import</MenuItem>
+									<MenuItem>Export</MenuItem>
+									<MenuItem>Settings</MenuItem>
+								</MenuGroup>
+								<MenuGroup>
+									<MenuItem>Help</MenuItem>
+								</MenuGroup>
+							</>
+						) }
+					</DropdownMenu>
+				</PageHeader.ActionMenu>
 			</>
 		),
 	},

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -2,7 +2,6 @@ import { useMatches } from '@tanstack/react-router';
 import { isValidElement } from 'react';
 import { SectionHeader } from '../section-header';
 import type { PageHeaderProps } from './types';
-import './style.scss';
 
 const PageTitle = () => {
 	const title = useMatches( {
@@ -18,12 +17,12 @@ const PageTitle = () => {
 /**
  * ActionMenu is a specialized wrapper around DropdownMenu for use in PageHeader actions.
  */
-const ActionMenu = ( { children }: { children: React.ReactNode } ) => {
+const ActionMenu = ( { children }: { children: React.ReactElement | null } ) => {
 	if ( ! isValidElement( children ) ) {
 		return null;
 	}
 
-	return <div className="dashboard-page-header__action-menu">{ children }</div>;
+	return <div style={ { marginInlineStart: 'auto' } }>{ children }</div>;
 };
 
 /**

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -17,7 +17,7 @@ const PageTitle = () => {
 
 /**
  * ActionMenu is a specialized wrapper around DropdownMenu for use in PageHeader actions.
- * It applies special styling when it's the last action in the actions list.
+ * It applies special styling when it's the last action in the actions list on small screens.
  */
 const ActionMenu = ( { children }: { children: React.ReactNode } ) => {
 	if ( ! isValidElement( children ) ) {

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -17,7 +17,6 @@ const PageTitle = () => {
 
 /**
  * ActionMenu is a specialized wrapper around DropdownMenu for use in PageHeader actions.
- * It applies special styling when it's the last action in the actions list on small screens.
  */
 const ActionMenu = ( { children }: { children: React.ReactNode } ) => {
 	if ( ! isValidElement( children ) ) {

--- a/client/dashboard/components/page-header/index.tsx
+++ b/client/dashboard/components/page-header/index.tsx
@@ -1,6 +1,8 @@
 import { useMatches } from '@tanstack/react-router';
+import { isValidElement } from 'react';
 import { SectionHeader } from '../section-header';
 import type { PageHeaderProps } from './types';
+import './style.scss';
 
 const PageTitle = () => {
 	const title = useMatches( {
@@ -11,6 +13,18 @@ const PageTitle = () => {
 	} );
 
 	return title;
+};
+
+/**
+ * ActionMenu is a specialized wrapper around DropdownMenu for use in PageHeader actions.
+ * It applies special styling when it's the last action in the actions list.
+ */
+const ActionMenu = ( { children }: { children: React.ReactNode } ) => {
+	if ( ! isValidElement( children ) ) {
+		return null;
+	}
+
+	return <div className="dashboard-page-header__action-menu">{ children }</div>;
 };
 
 /**
@@ -35,3 +49,5 @@ export const PageHeader = ( props: PageHeaderProps ) => {
 		/>
 	);
 };
+
+PageHeader.ActionMenu = ActionMenu;

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -1,0 +1,5 @@
+.dashboard-page-header__action-menu{
+	margin-inline-start: auto;
+	min-width: fit-content;
+}
+

--- a/client/dashboard/components/page-header/style.scss
+++ b/client/dashboard/components/page-header/style.scss
@@ -1,5 +1,0 @@
-.dashboard-page-header__action-menu{
-	margin-inline-start: auto;
-	min-width: fit-content;
-}
-

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -310,18 +310,20 @@ export default function DomainDns() {
 								>
 									{ __( 'Add record' ) }
 								</Button>
-								<DnsActionsMenu
-									hasDefaultARecords={ hasDefaultARecordsValue }
-									hasDefaultCnameRecord={ hasDefaultCnameRecordValue }
-									hasDefaultEmailRecords={ hasDefaultEmailRecordsValue }
-									onRestoreDefaultARecords={ () => setIsRestoreDefaultARecordsDialogOpen( true ) }
-									onRestoreDefaultCnameRecord={ () =>
-										setIsRestoreDefaultCnameRecordDialogOpen( true )
-									}
-									onRestoreDefaultEmailRecords={ () =>
-										setIsRestoreDefaultEmailRecordsDialogOpen( true )
-									}
-								/>
+								<PageHeader.ActionMenu>
+									<DnsActionsMenu
+										hasDefaultARecords={ hasDefaultARecordsValue }
+										hasDefaultCnameRecord={ hasDefaultCnameRecordValue }
+										hasDefaultEmailRecords={ hasDefaultEmailRecordsValue }
+										onRestoreDefaultARecords={ () => setIsRestoreDefaultARecordsDialogOpen( true ) }
+										onRestoreDefaultCnameRecord={ () =>
+											setIsRestoreDefaultCnameRecordDialogOpen( true )
+										}
+										onRestoreDefaultEmailRecords={ () =>
+											setIsRestoreDefaultEmailRecordsDialogOpen( true )
+										}
+									/>
+								</PageHeader.ActionMenu>
 							</HStack>
 						}
 						description={ <DnsDescription /> }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1090,7 +1090,9 @@ export default function PurchaseSettings() {
 											{ __( 'Upgrade' ) }
 										</Button>
 									) }
-									<PurchaseActionMenu purchase={ purchase } />
+									<PageHeader.ActionMenu>
+										<PurchaseActionMenu purchase={ purchase } />
+									</PageHeader.ActionMenu>
 								</HStack>
 							)
 						}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -197,21 +197,21 @@ function SiteOverview( {
 		}
 
 		return (
-			<HStack justify="space-between">
-				<HStack justify={ isSmallViewport ? 'flex-start' : 'flex-end' } style={ { width: 'auto' } }>
-					<StagingSiteSyncDropdown siteSlug={ siteSlug } />
-					<Button
-						ref={ wpAdminButtonRef }
-						__next40pxDefaultSize
-						variant="primary"
-						href={ site.options.admin_url }
-						icon={ wordpress }
-					>
-						{ __( 'WP Admin' ) }
-					</Button>
-				</HStack>
-				<SiteActionMenu site={ site } />
-			</HStack>
+			<>
+				<StagingSiteSyncDropdown siteSlug={ siteSlug } />
+				<Button
+					ref={ wpAdminButtonRef }
+					__next40pxDefaultSize
+					variant="primary"
+					href={ site.options.admin_url }
+					icon={ wordpress }
+				>
+					{ __( 'WP Admin' ) }
+				</Button>
+				<PageHeader.ActionMenu>
+					<SiteActionMenu site={ site } />
+				</PageHeader.ActionMenu>
+			</>
 		);
 	};
 


### PR DESCRIPTION
Alternative to #107085.
Related: #107003

## Proposed Changes

Adds a `PageHeader.ActionMenu` wrapper component to specifically handle `DropdownMenu` on small screens.


## Testing Instructions

Visit the following pages on mobile/desktop, expect the dropdown menu to be right-aligned on mobile and right beside the buttons to the right on desktop.

- `/v2/sites/:site`
- `/v2/domains/:domain/dns`
- `/v2/me/billing/purchases/:purchaseId`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
