### PR TITLE
MSD: land to mailbox registration flow from domain overview card when no emails

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -5,7 +5,7 @@ import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
-import { emailsRoute } from '../../app/router/emails';
+import { emailsRoute, chooseEmailSolutionRoute } from '../../app/router/emails';
 import OverviewCard from '../../components/overview-card';
 import { Truncate } from '../../components/truncate';
 import type { EmailProvider, Mailbox } from '@automattic/api-core';
@@ -70,10 +70,15 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 				</Truncate>
 			}
 			link={
-				router.buildLocation( {
-					to: emailsRoute.fullPath,
-					search: { domainName: domain.domain },
-				} ).href
+				mailboxes.length > 0
+					? router.buildLocation( {
+							to: emailsRoute.fullPath,
+							search: { domainName: domain.domain },
+					  } ).href
+					: router.buildLocation( {
+							to: chooseEmailSolutionRoute.fullPath,
+							params: { domain: domain.domain },
+					  } ).href
 			}
 			icon={ <Icon icon={ envelope } /> }
 			description={ getDescription( mailboxes ) }


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/pull/107032#discussion_r2513579849


## Proposed Changes

Fixes this card in domain overview when that domain has no emails yet:

<img width="618" height="383" alt="image" src="https://github.com/user-attachments/assets/b8643d5b-3b03-433f-b781-cedfcc064b23" />

### BEFORE

Click on that card.

Land on Emails page with empty list and broken filter:

<img width="1107" height="420" alt="image" src="https://github.com/user-attachments/assets/51186c67-28ec-45d4-aedf-01fa4de41cda" />

Click on the `Add mailbox` button at the top right.

Land in email registration flow:

<img width="1031" height="517" alt="image" src="https://github.com/user-attachments/assets/bd743aa7-3003-41c6-9886-e8d9f6876b39" />

Choose EXACTLY THE SAME DOMAIN as you started with.

... finally you can add mailbox:

<img width="704" height="502" alt="image" src="https://github.com/user-attachments/assets/8f87a370-5ec5-4bda-8cbc-ab0a33ab8bc8" />

### AFTER

You land directly on the last screen.

### OUT OF SCOPE

The `<- Emails` back button still points to `/v2/emails` 🥹 seems we need a better solution for handling this scenario. I'm marking this as out of scope of this PR, unless anyone feels strongly. I don't know a good solution for this.

## Why are these changes being made?

The existing flow is confusing.

## Testing Instructions

Test the scenario as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
