### PR TITLE
MSD: Adjust callout spacing on small devices.

### DIFF
--- a/client/dashboard/components/callout-overlay/style.scss
+++ b/client/dashboard/components/callout-overlay/style.scss
@@ -6,8 +6,7 @@
 	width: calc( 100% - 2 * $grid-unit-20 );
 	top: 0;
 	inset-inline-start: 0;
-	padding-top:max(7vh, 40px);
-	padding-top: max(7dvh, 40px);
+	padding-top: 72px;
 	padding-inline: $grid-unit-20;
 	background: linear-gradient(180deg, rgba(252, 252, 252, 0.65) 0%, #FCFCFC 100%);
 	backdrop-filter: blur(3px);

--- a/client/dashboard/components/callout-overlay/style.scss
+++ b/client/dashboard/components/callout-overlay/style.scss
@@ -6,8 +6,8 @@
 	width: calc( 100% - 2 * $grid-unit-20 );
 	top: 0;
 	inset-inline-start: 0;
-	padding-top:max(5vh, 40px);
-	padding-top: max(5dvh, 40px);
+	padding-top:max(7vh, 40px);
+	padding-top: max(7dvh, 40px);
 	padding-inline: $grid-unit-20;
 	background: linear-gradient(180deg, rgba(252, 252, 252, 0.65) 0%, #FCFCFC 100%);
 	backdrop-filter: blur(3px);

--- a/client/dashboard/components/callout-overlay/style.scss
+++ b/client/dashboard/components/callout-overlay/style.scss
@@ -6,10 +6,16 @@
 	width: calc( 100% - 2 * $grid-unit-20 );
 	top: 0;
 	inset-inline-start: 0;
-	padding: 161px $grid-unit-20;
+	padding-top:max(5vh, 40px);
+	padding-top: max(5dvh, 40px);
+	padding-inline: $grid-unit-20;
 	background: linear-gradient(180deg, rgba(252, 252, 252, 0.65) 0%, #FCFCFC 100%);
 	backdrop-filter: blur(3px);
 	z-index: 2;
+
+	@include break-medium {
+		padding-top: 161px;
+	}
 
 	.dashboard-callout {
 		max-width: 600px;


### PR DESCRIPTION
Part of DOTMSD-849

## Proposed Changes

This PR updates the top padding of the callout to make sure it's not so far down the page on small devices.

| Before | After |
|--------|--------|
| <img width="750" height="1334" alt="wpcalypso wordpress com_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview(iPhone SE)" src="https://github.com/user-attachments/assets/a0694828-543a-413f-92c4-f541a7aeff21" /> | <img width="800" height="1750" alt="calypso localhost_3000_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview (3)" src="https://github.com/user-attachments/assets/951b42df-ba20-406c-b12a-0d60d09474ec" /> |
| <img width="1400" height="1750" alt="wpcalypso wordpress com_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview" src="https://github.com/user-attachments/assets/9bd81adc-c6fa-4879-b1a2-0c2bd7a1ab6d" /> | <img width="1400" height="1750" alt="calypso localhost_3000_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview (4)" src="https://github.com/user-attachments/assets/c8f80b05-5e2c-4b92-80ad-9a5af7297eb7" /> |
| <img width="2400" height="2965" alt="wpcalypso wordpress com_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview (1)" src="https://github.com/user-attachments/assets/f5af500d-dfd7-457b-bb6f-0bc2ba284396" /> | <img width="2400" height="2034" alt="calypso localhost_3000_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview (1)" src="https://github.com/user-attachments/assets/ee935b81-da5b-4a5b-acdb-b69701a76835" /> | 
















## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
