### PR TITLE
MSD: Hide callout image on mobile.

### DIFF
--- a/client/dashboard/components/callout/index.tsx
+++ b/client/dashboard/components/callout/index.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalText as Text,
 	Icon,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { forwardRef } from 'react';
 import { Card } from '../card';
 import type { CalloutProps } from './types';
@@ -23,6 +24,7 @@ function UnforwardedCallout(
 	}: CalloutProps,
 	ref: React.ForwardedRef< HTMLElement >
 ) {
+	const isMobileViewport = useViewportMatch( 'mobile', '<' );
 	return (
 		<Card ref={ ref } className={ `dashboard-callout is-${ variant } is-image-${ imageVariant }` }>
 			<HStack
@@ -43,7 +45,7 @@ function UnforwardedCallout(
 					{ description }
 					{ actions }
 				</VStack>
-				{ image && (
+				{ image && ! isMobileViewport && (
 					<VStack justify="stretch" alignment="stretch" className="dashboard-callout__image">
 						{ typeof image === 'string' ? <img src={ image } alt={ imageAlt } /> : image }
 					</VStack>


### PR DESCRIPTION
Related to: #107119
Part of DOTMSD-849, DES-52

## Proposed Changes

This PR hides the callout images when on [mobile devices](https://github.com/WordPress/gutenberg/blob/34d7cc927b762cad4bd849d3417db68178168d38/packages/base-styles/_breakpoints.scss#L13). 

@p-jackson [Led some discussion](https://github.com/Automattic/wp-calypso/pull/103414#issuecomment-2897255682) in #103414 to agree on a mobile approach but no resolution was made. He did suggest hiding the images but noted that its underwhelming.

Since these modals are in production, I think it's wise for us to hide them. The experience is not great in the V1 dashboard as it is. Hiding the image, while underwhelming make the callout more useable while giving us time to align on best approach.

## Screenshot
| Before | After |
|--------|--------|
| <img width="750" height="1334" alt="wpcalypso wordpress com_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview(iPhone SE) (1)" src="https://github.com/user-attachments/assets/069f9dab-b4ff-4c20-b97d-42185d89d436" /> | <img width="800" height="1750" alt="calypso localhost_3000_v2_sites_testoverviewcardstatus1234 wordpress com_backups_back_to=overview (5)" src="https://github.com/user-attachments/assets/9e6030e7-fb32-454c-9559-a21f4218d973" /> |
| <img width="750" height="1334" alt="wpcalypso wordpress com_sites(iPhone SE)" src="https://github.com/user-attachments/assets/3126b6c4-52c3-4205-a591-63414d21cfc6" /> | <img width="750" height="1334" alt="calypso localhost_3000_sites_(iPhone SE)" src="https://github.com/user-attachments/assets/04171e76-053c-41bf-9868-875fea13bfa8" /> |

### Responsive

![Screen Recording on 2025-11-14 at 12-54-13](https://github.com/user-attachments/assets/00e1fceb-438e-4944-a58b-004adef48fe9)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
