### PR TITLE
MSD: add view persistence to billing history DataViews

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -19,21 +19,20 @@ import type { Fields, Operator, SortDirection, View } from '@wordpress/dataviews
 
 import './styles.scss';
 
-export const billingHistoryWideFields = [ 'date', 'service', 'type', 'amount' ];
-export const billingHistoryDesktopFields = [ 'date', 'service' ];
-export const billingHistoryMobileFields: string[] = [ 'service' ];
+export const WIDE_FIELDS = [ 'date', 'service', 'type', 'amount' ];
+export const DESKTOP_FIELDS = [ 'date', 'service' ];
+export const MOBILE_FIELDS: string[] = [ 'service' ];
 
-export const defaultBillingHistoryView: View = {
+export const DEFAULT_VIEW: View = {
 	type: 'table',
-	page: 1,
-	search: '',
 	perPage: 10,
-	fields: billingHistoryWideFields,
+	fields: WIDE_FIELDS,
 	sort: {
 		field: 'date',
 		direction: 'desc' as SortDirection,
 	},
 	layout: {
+		density: 'balanced',
 		styles: {
 			date: {
 				width: '14%',
@@ -51,7 +50,7 @@ export const defaultBillingHistoryView: View = {
 	},
 };
 
-export function useBillingHistoryActions() {
+export function useActions() {
 	const navigate = useNavigate();
 	const sendEmailMutation = useMutation( {
 		...sendReceiptEmailMutation(),
@@ -93,7 +92,7 @@ export function useBillingHistoryActions() {
 	);
 }
 
-export function getFieldDefinitions( receipts: Receipt[] ): Fields< Receipt > {
+export function getFields( receipts: Receipt[] ): Fields< Receipt > {
 	return [
 		{
 			id: 'date',


### PR DESCRIPTION
Fixes CHE-258

## Proposed Changes

Add persistence support in billing history DataViews.

Also renamed some variables / functions to align better with existing pattern in the dashboard code.

## Testing Instructions

1. Go to /v2/me/billing/billing-history.
2. Try to update appearance options (density, page size, etc.)
3. Refresh the page.
4. Verify the config is retained.

## Important

If the view is modified, then the automatic field adjustment based on screen width no longer takes effect. It seems, we need to address this more holistically upstream. See this discussion: p1761735187809839/1760623861.876189-slack-C05QAFZSFTL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?