### PR TITLE
I18N: Fix the lib/wp was called before locale data was ready

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -331,7 +331,7 @@ const boot = async ( currentUser, registerRoutes ) => {
 		disablePersistHostingDashboardQueryClient();
 		clearHostingDashboardQueryClient();
 	} );
-	setupLocale( currentUser, reduxStore );
+	await setupLocale( currentUser, reduxStore );
 	setupCountryCode();
 	configureReduxStore( currentUser, reduxStore );
 	setupMiddlewares( currentUser, reduxStore, queryClient );

--- a/client/controller/test/shared.js
+++ b/client/controller/test/shared.js
@@ -1,6 +1,10 @@
 import { setLocale } from '../../state/ui/language/actions';
 import { setLocaleMiddleware } from '../shared';
 
+jest.mock( '../../state/ui/language/actions', () => ( {
+	setLocale: jest.fn( () => jest.fn() ),
+} ) );
+
 describe( 'setLocaleMiddleware', () => {
 	const next = jest.fn();
 	const dispatch = jest.fn();
@@ -10,6 +14,7 @@ describe( 'setLocaleMiddleware', () => {
 	beforeEach( () => {
 		next.mockClear();
 		dispatch.mockClear();
+		setLocale.mockClear();
 		context = { query: {}, params: {}, store: { dispatch } };
 		middleware = setLocaleMiddleware();
 	} );
@@ -25,7 +30,8 @@ describe( 'setLocaleMiddleware', () => {
 		middleware( context, next );
 		expect( next ).toHaveBeenCalledTimes( 1 );
 		expect( context.store.dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( context.store.dispatch ).toHaveBeenCalledWith( setLocale( 'fr' ) );
+		expect( setLocale ).toHaveBeenCalledWith( 'fr' );
+		// expect( context.store.dispatch ).toHaveBeenCalledWith( setLocale( 'fr' ) );
 		expect( context.lang ).toEqual( 'fr' );
 	} );
 
@@ -34,7 +40,8 @@ describe( 'setLocaleMiddleware', () => {
 		middleware( context, next );
 		expect( next ).toHaveBeenCalledTimes( 1 );
 		expect( context.store.dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( context.store.dispatch ).toHaveBeenCalledWith( setLocale( 'fr' ) );
+		expect( setLocale ).toHaveBeenCalledWith( 'fr' );
+		// expect( context.store.dispatch ).toHaveBeenCalledWith( setLocale( 'fr' ) );
 		expect( context.lang ).toEqual( 'fr' );
 	} );
 } );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -425,29 +425,27 @@ export default async function switchLocale( localeSlug ) {
 			debug( error );
 		}
 	} else {
-		await getLanguageFile( localeSlug ).then(
-			// Success.
-			( body ) => {
-				if ( body ) {
-					// Handle race condition when we're requested to switch to a different
-					// locale while we're in the middle of request, we should abandon result
-					if ( localeSlug !== lastRequestedLocale ) {
-						return;
-					}
-
-					i18n.setLocale( body );
-					defaultI18n.setLocaleData( i18n.getLocale() );
-					setLocaleInDOM();
-					loadUserUndeployedTranslations( localeSlug );
-				}
-			},
-			// Failure.
-			() => {
-				debug(
-					`Encountered an error loading locale file for ${ localeSlug }. Falling back to English.`
-				);
+		try {
+			const body = await getLanguageFile( localeSlug );
+			if ( ! body ) {
+				return;
 			}
-		);
+
+			// Handle race condition when we're requested to switch to a different
+			// locale while we're in the middle of request, we should abandon result
+			if ( localeSlug !== lastRequestedLocale ) {
+				return;
+			}
+
+			i18n.setLocale( body );
+			defaultI18n.setLocaleData( i18n.getLocale() );
+			setLocaleInDOM();
+			loadUserUndeployedTranslations( localeSlug );
+		} catch ( error ) {
+			debug(
+				`Encountered an error ${ error } loading locale file for ${ localeSlug }. Falling back to English.`
+			);
+		}
 	}
 }
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,6 +3,7 @@ import { captureException } from '@automattic/calypso-sentry';
 import { getUrlFromParts, getUrlParts } from '@automattic/calypso-url';
 import { isDefaultLocale, getLanguage } from '@automattic/i18n-utils';
 import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
+import { defaultI18n } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
@@ -370,6 +371,7 @@ export default async function switchLocale( localeSlug ) {
 			}
 
 			i18n.setLocale( locale );
+			defaultI18n.setLocaleData( i18n.getLocale() );
 			setLocaleInDOM();
 			removeRequireChunkTranslationsHandler();
 			addRequireChunkTranslationsHandler( localeSlug, { translatedChunks } );
@@ -423,7 +425,7 @@ export default async function switchLocale( localeSlug ) {
 			debug( error );
 		}
 	} else {
-		getLanguageFile( localeSlug ).then(
+		await getLanguageFile( localeSlug ).then(
 			// Success.
 			( body ) => {
 				if ( body ) {
@@ -434,6 +436,7 @@ export default async function switchLocale( localeSlug ) {
 					}
 
 					i18n.setLocale( body );
+					defaultI18n.setLocaleData( i18n.getLocale() );
 					setLocaleInDOM();
 					loadUserUndeployedTranslations( localeSlug );
 				}

--- a/client/state/ui/language/actions.ts
+++ b/client/state/ui/language/actions.ts
@@ -1,5 +1,6 @@
 import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 import 'calypso/state/ui/init';
 
@@ -11,13 +12,13 @@ export const setLocale = (
 	localeVariant: string | null | undefined = null
 ) => {
 	const newLocale = localeVariant || localeSlug;
+	return async ( dispatch: CalypsoDispatch ) => {
+		dispatch( {
+			type: LOCALE_SET,
+			localeSlug,
+			localeVariant,
+		} );
 
-	// Side effect: change the current translation locale.
-	switchLocale( newLocale );
-
-	return {
-		type: LOCALE_SET,
-		localeSlug,
-		localeVariant,
+		await switchLocale( newLocale );
 	};
 };

--- a/client/state/ui/language/actions.ts
+++ b/client/state/ui/language/actions.ts
@@ -13,12 +13,11 @@ export const setLocale = (
 ) => {
 	const newLocale = localeVariant || localeSlug;
 	return async ( dispatch: CalypsoDispatch ) => {
+		await switchLocale( newLocale );
 		dispatch( {
 			type: LOCALE_SET,
 			localeSlug,
 			localeVariant,
 		} );
-
-		await switchLocale( newLocale );
 	};
 };

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -1,18 +1,28 @@
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'setLocale', () => {
-		test( 'returns an appropriate action', () => {
-			expect( setLocale( 'he' ) ).toEqual( {
+		const middlewares = [ thunk ];
+		const mockStore = configureStore( middlewares );
+		test( 'dispatches an appropriate action', () => {
+			const store = mockStore();
+			store.dispatch( setLocale( 'he' ) );
+			const actions = store.getActions();
+			expect( actions[ 0 ] ).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: null,
 			} );
 		} );
 
-		test( 'returns an action with localeVariant set', () => {
-			expect( setLocale( 'he', 'he_formal' ) ).toEqual( {
+		test( 'dispatches an action with localeVariant set', () => {
+			const store = mockStore();
+			store.dispatch( setLocale( 'he', 'he_formal' ) );
+			const actions = store.getActions();
+			expect( actions[ 0 ] ).toEqual( {
 				type: LOCALE_SET,
 				localeSlug: 'he',
 				localeVariant: 'he_formal',

--- a/client/state/ui/language/test/actions.js
+++ b/client/state/ui/language/test/actions.js
@@ -7,9 +7,9 @@ describe( 'actions', () => {
 	describe( 'setLocale', () => {
 		const middlewares = [ thunk ];
 		const mockStore = configureStore( middlewares );
-		test( 'dispatches an appropriate action', () => {
+		test( 'dispatches an appropriate action', async () => {
 			const store = mockStore();
-			store.dispatch( setLocale( 'he' ) );
+			await store.dispatch( setLocale( 'he' ) );
 			const actions = store.getActions();
 			expect( actions[ 0 ] ).toEqual( {
 				type: LOCALE_SET,
@@ -18,9 +18,9 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		test( 'dispatches an action with localeVariant set', () => {
+		test( 'dispatches an action with localeVariant set', async () => {
 			const store = mockStore();
-			store.dispatch( setLocale( 'he', 'he_formal' ) );
+			await store.dispatch( setLocale( 'he', 'he_formal' ) );
 			const actions = store.getActions();
 			expect( actions[ 0 ] ).toEqual( {
 				type: LOCALE_SET,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-217

## Proposed Changes

* Referring to [lib/wp: use Core i18n to read current locale](https://github.com/Automattic/wp-calypso/pull/102628), there was an issue where the locale data was not ready before calling the endpoint, preventing the `_locale` parameter from being injected correctly.
* This PR proposes waiting for the locale data before rendering, so that `lib/wp` receives the correct locale.
* An alternative approach would be to fallback to `_locale: 'user'`; however, it is unclear whether this might cause issues for logged-out users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should display correct language to our users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your account to non-en language
* Go to `/sites/:site`
* Refresh the page
* Before this change, you may see the `Plan` is rendered as English
* After this change, you should see the `Plan` is renders as your current language

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
