### PR TITLE
MSD dataviews: use isAny operator for transient filters

### DIFF
--- a/client/dashboard/app/dataviews/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/dataviews/test/use-persistent-view.test.tsx
@@ -137,7 +137,7 @@ describe( 'usePersistentView', () => {
 				type: 'grid',
 				layout: { previewSize: 120 },
 				sort: { field: 'status', direction: 'asc' },
-				filters: [ { field: 'status', operator: 'isAny', value: 'active' } ],
+				filters: [ { field: 'status', operator: 'isAny', value: [ 'active' ] } ],
 			};
 			mockGetCalypsoPreferences( {
 				'hosting-dashboard-dataviews-view-sites': persistedView,
@@ -169,8 +169,8 @@ describe( 'usePersistentView', () => {
 				expect( result.current.view ).toEqual( {
 					...persistedView,
 					filters: [
-						{ field: 'status', operator: 'isAny', value: 'active' },
-						{ field: 'domainName', operator: 'is', value: 'example.com' },
+						{ field: 'status', operator: 'isAny', value: [ 'active' ] },
+						{ field: 'domainName', operator: 'isAny', value: [ 'example.com' ] },
 					],
 					page: 2,
 					search: 'test',
@@ -274,7 +274,7 @@ describe( 'usePersistentView', () => {
 			act( () => {
 				result.current.updateView( {
 					...defaultView,
-					filters: [ { field: 'status', operator: 'isAny', value: 'active' } ],
+					filters: [ { field: 'status', operator: 'isAny', value: [ 'active' ] } ],
 				} );
 			} );
 

--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -73,8 +73,8 @@ export function usePersistentView( {
 				( field ) =>
 					( {
 						field,
-						operator: 'is',
-						value: queryParams[ field ],
+						operator: 'isAny',
+						value: [ queryParams[ field ] ],
 					} ) as Filter
 			)
 		);
@@ -124,7 +124,8 @@ export function usePersistentView( {
 			const newTransientFilterFields = transientFilterFields.filter(
 				( field ) =>
 					newView.filters?.some(
-						( filter ) => filter.field === field && filter.value === queryParams[ field ]
+						( filter ) =>
+							filter.field === field && fastDeepEqual( filter.value, [ queryParams[ field ] ] )
 					)
 			);
 

--- a/client/dashboard/emails/dataviews/fields/domain-name.ts
+++ b/client/dashboard/emails/dataviews/fields/domain-name.ts
@@ -11,5 +11,8 @@ export const getDomainNameField = (
 	label: __( 'Domain' ),
 	getValue: ( { item }: { item: Email } ) => item.domainName,
 	elements: domains.map( ( { domain } ) => ( { value: domain, label: domain } ) ),
-	...( domainNameFilter && { filterBy: { isPrimary: true } } ),
+	filterBy: {
+		operators: [ 'isAny' ],
+		...( domainNameFilter && { isPrimary: true } ),
+	},
 } );


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/pull/107066#issuecomment-3524270868

## Proposed Changes

It makes more sense for the filter that's part of transient filter to be using `isAny` so that we can select more than one item. The transient filter will be only synced to the query param if it contains exactly one value which is the query param value.

## Testing Instructions

Follow the testing instructions at https://github.com/Automattic/wp-calypso/pull/107066.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
