### PR TITLE
MSD: add view persistence to deployments DataViews

### DIFF
--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -19,11 +19,13 @@ import type { DeploymentRunWithDeploymentInfo } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
 interface FilterOptions {
+	repositoryFilter?: string;
 	repositoryOptions: { value: string; label: string }[];
 	userNameOptions: { value: string; label: string }[];
 }
 
-export function useDeploymentFields( {
+export function useFields( {
+	repositoryFilter,
 	repositoryOptions = [],
 	userNameOptions = [],
 }: FilterOptions ): Field< DeploymentRunWithDeploymentInfo >[] {
@@ -32,13 +34,14 @@ export function useDeploymentFields( {
 	return useMemo(
 		() => [
 			{
-				id: 'repository_name',
+				id: 'repository',
 				label: __( 'Repository' ),
 				enableHiding: false,
 				enableGlobalSearch: true,
 				elements: repositoryOptions,
 				filterBy: {
 					operators: [ 'isAny' ],
+					...( repositoryFilter && { isPrimary: true } ),
 				},
 				getValue: ( { item } ) => item.repository_name,
 				render: ( { item } ) => {

--- a/client/dashboard/sites/deployments-list/dataviews/index.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/index.tsx
@@ -1,0 +1,2 @@
+export * from './fields';
+export * from './views';

--- a/client/dashboard/sites/deployments-list/dataviews/views.ts
+++ b/client/dashboard/sites/deployments-list/dataviews/views.ts
@@ -1,21 +1,20 @@
-import type { SortDirection, View } from '@wordpress/dataviews';
+import type { SortDirection, SupportedLayouts, View } from '@wordpress/dataviews';
 
 export const DEFAULT_VIEW: View = {
 	type: 'table',
-	perPage: 25,
-	page: 1,
+	perPage: 20,
 	sort: {
 		field: 'created_on',
 		direction: 'desc' as SortDirection,
 	},
-	search: '',
-	filters: [],
-	fields: [ 'repository_name', 'commit', 'status', 'created_on' ],
-	layout: {},
+	fields: [ 'repository', 'commit', 'status', 'created_on' ],
+	layout: {
+		density: 'balanced',
+	},
 };
 
-export const DEFAULT_LAYOUTS = {
+export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	table: {
-		titleField: 'repository_name',
+		titleField: 'repository',
 	},
 };


### PR DESCRIPTION
Part of CHE-257

Fixes DOTMSD-890

## Proposed Changes

This PR adds persistence to GitHub Deployments' DataViews.

It utilizes the transient filter feature from https://github.com/Automattic/wp-calypso/pull/107066.

I updated the field name from `repository_name` to `repository` because it needs to match with the query param key.

## Testing Instructions

From Deployments:

1. Go to `/v2/sites/:siteSlug/deployments`.
2. Try to change page, search term, and appearance options.
3. Refresh the page.
4. Verify the view persists.
5. Click "Reset view".
6. Verify the view is reset.

From Settings -> repositories:

1. Go to `/v2/sites/:siteSlug/settings/repositories`.
2. Select a row -> click 3-dot action icon -> click "See deployment runs".
3. Verify you see the DataViews with the primary filter set to the selected repository.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
