### PR TITLE
Adding site plan data to the site list endpoint

### DIFF
--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -7,9 +7,40 @@ import type { Site } from '@automattic/api-core';
 
 import './style.scss';
 
-export default function SiteIcon( { site, size = 48 }: { site: Site; size?: number } ) {
+export default function SiteIcon( { site, size }: { site: Site; size?: number } ) {
+	const status = getSiteStatus( site );
+	const isMigration = status === 'migration_pending' || status === 'migration_started';
+	const fallbackInitial = getSiteDisplayName( site ).charAt( 0 );
+	return (
+		<SiteIconRenderer
+			alt={ site.name }
+			fallbackInitial={ fallbackInitial }
+			icon={ site.icon }
+			isMigration={ isMigration }
+			size={ size }
+		/>
+	);
+}
+
+/**
+ * The SiteIconInner component allows you to render a site icon when you
+ * don't happen to have a `Site` object on hand.
+ */
+export function SiteIconRenderer( {
+	alt,
+	fallbackInitial,
+	icon,
+	isMigration,
+	size = 48,
+}: {
+	alt: string;
+	fallbackInitial: string;
+	icon?: { img: string; ico: string };
+	isMigration: boolean;
+	size?: number;
+} ) {
 	const dims = { width: size, height: size };
-	const ico = site.icon?.img || site.icon?.ico;
+	const ico = icon?.img || icon?.ico;
 	const src = useMemo( () => {
 		if ( ! ico ) {
 			return;
@@ -31,7 +62,7 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 			<img
 				className={ clsx( 'site-icon', className ) }
 				src={ src }
-				alt={ site.name }
+				alt={ alt }
 				{ ...dims }
 				loading="lazy"
 				style={ { width: size, height: size, minWidth: size } }
@@ -39,14 +70,13 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 		);
 	}
 
-	const status = getSiteStatus( site );
-	if ( status === 'migration_pending' || status === 'migration_started' ) {
+	if ( isMigration ) {
 		return <SiteMigrationIcon className={ clsx( 'site-icon', className ) } size={ size } />;
 	}
 
 	return (
 		<div className={ clsx( 'site-letter', className ) } style={ { ...dims, fontSize: size * 0.5 } }>
-			<span>{ getSiteDisplayName( site ).charAt( 0 ) }</span>
+			<span>{ fallbackInitial }</span>
 		</div>
 	);
 }

--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -23,7 +23,7 @@ export default function SiteIcon( { site, size }: { site: Site; size?: number } 
 }
 
 /**
- * The SiteIconInner component allows you to render a site icon when you
+ * The SiteIconRenderer component allows you to render a site icon when you
  * don't happen to have a `Site` object on hand.
  */
 export function SiteIconRenderer( {

--- a/client/dashboard/components/time-mismatch-notice/test/index.tsx
+++ b/client/dashboard/components/time-mismatch-notice/test/index.tsx
@@ -7,14 +7,6 @@ import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
 import TimeMismatchNotice from '../index';
 
-const mockRecordTracksEvent = jest.fn();
-
-jest.mock( '../../../app/analytics', () => ( {
-	useAnalytics: jest.fn( () => ( {
-		recordTracksEvent: mockRecordTracksEvent,
-	} ) ),
-} ) );
-
 jest.mock( '@automattic/api-queries', () => ( {
 	userPreferenceQuery: jest.fn( ( key: string ) => ( { queryKey: [ 'pref', key ] } ) ),
 	userPreferenceMutation: jest.fn( ( key: string ) => ( { mutationKey: [ 'pref', key ] } ) ),
@@ -113,7 +105,7 @@ describe( 'TimeMismatchNotice', () => {
 		useSuspenseQuery.mockReturnValue( { data: null } );
 
 		const offsetHours = getOffsetHours();
-		render(
+		const { recordTracksEvent } = render(
 			<TimeMismatchNotice
 				siteId={ 987 }
 				siteTime={ offsetHours + 1 }
@@ -123,7 +115,7 @@ describe( 'TimeMismatchNotice', () => {
 
 		await user.click( await screen.findByRole( 'link', { name: /update it if needed/i } ) );
 
-		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_dashboard_time_mismatch_banner_settings_link_click',
 			expect.objectContaining( { site_id: 987 } )
 		);
@@ -134,7 +126,7 @@ describe( 'TimeMismatchNotice', () => {
 		useSuspenseQuery.mockReturnValue( { data: null } );
 
 		const offsetHours = getOffsetHours();
-		render(
+		const { recordTracksEvent } = render(
 			<TimeMismatchNotice
 				siteId={ 321 }
 				siteTime={ offsetHours + 1 }
@@ -151,7 +143,7 @@ describe( 'TimeMismatchNotice', () => {
 		// Avoid -0 vs 0 strict-equality issue
 		expect( parsed.offsetHours ).toBeCloseTo( offsetHours, 10 );
 
-		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_dashboard_time_mismatch_banner_close',
 			expect.objectContaining( {
 				site_id: 321,

--- a/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { DomainGlueRecord } from '@automattic/api-core';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
@@ -75,10 +75,7 @@ test( 'calls delete mutation and onClose when Delete button is clicked and the r
 
 	await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
 
-	// Wait for the mutation to complete
-	await screen.findByText( 'Are you sure you want to delete this glue record?' );
-
-	expect( mockOnClose ).toHaveBeenCalled();
+	await waitFor( () => expect( mockOnClose ).toHaveBeenCalled() );
 } );
 
 test( 'calls delete mutation and onClose when Delete button is clicked and the request fails', async () => {
@@ -91,8 +88,5 @@ test( 'calls delete mutation and onClose when Delete button is clicked and the r
 
 	await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
 
-	// Wait for the mutation to complete
-	await screen.findByText( 'Are you sure you want to delete this glue record?' );
-
-	expect( mockOnClose ).toHaveBeenCalled();
+	await waitFor( () => expect( mockOnClose ).toHaveBeenCalled() );
 } );

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -9,12 +9,6 @@ import { render as dashboardRender } from '../../../test-utils';
 import NotificationsExtras from '../index';
 import type { UserNotificationSettings, WpcomNotificationSettings } from '@automattic/api-core';
 
-jest.mock( '../../../app/analytics', () => ( {
-	useAnalytics: jest.fn().mockReturnValue( {
-		recordTracksEvent: jest.fn(),
-	} ),
-} ) );
-
 const defaultWpcomSettings: WpcomNotificationSettings = {
 	marketing: false,
 	research: false,

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -131,7 +131,9 @@ export default function CIABSites() {
 					view={ view }
 					sites={ sites ?? [] }
 					totalItems={ totalItems ?? 0 }
+					sites__ES={ [] }
 					fields={ fields }
+					fields__ES={ [] }
 					actions={ actions }
 					isLoading={ isLoadingSites || ( isPlaceholderData && sites?.length === 0 ) }
 					empty={

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -3,6 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
+import { type View, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import deepmerge from 'deepmerge';
@@ -15,18 +16,19 @@ import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import { useSiteListQuery } from '../sites';
+import { filterSortAndPaginate__ES, useSiteListQuery } from '../sites';
 import {
 	SitesDataViews,
 	useActions,
 	useFields,
 	getDefaultView,
 	recordViewChanges,
+	useFields__ES,
 } from '../sites/dataviews';
 import noSitesIllustration from '../sites/no-sites-illustration.svg';
 import { SitesNotices } from '../sites/notices';
-import type { Site } from '@automattic/api-core';
-import type { View } from '@wordpress/dataviews';
+import { SiteLink, SiteLink__ES } from '../sites/site-fields';
+import type { DashboardSiteListSite, Site } from '@automattic/api-core';
 
 export default function CIABSites() {
 	const { recordTracksEvent } = useAnalytics();
@@ -51,12 +53,11 @@ export default function CIABSites() {
 		queryParams: currentSearchParams,
 	} );
 
-	const { sites, isLoadingSites, isPlaceholderData, totalItems } = useSiteListQuery(
-		view,
-		isRestoringAccount
-	);
+	const { sites, sites__ES, isLoadingSites, isPlaceholderData, hasNoData, totalItems } =
+		useSiteListQuery( view, isRestoringAccount );
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );
+	const fields__ES = useFields__ES( { isAutomattician, viewType: view.type } );
 	const actions = useActions();
 
 	const handleAddNewStore = () => {
@@ -108,6 +109,52 @@ export default function CIABSites() {
 		ref: 'new-site-popover',
 	} );
 
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
+
+	const { data: filteredData__ES, paginationInfo: paginationInfo__ES } = filterSortAndPaginate__ES(
+		sites__ES ?? [],
+		view,
+		totalItems ?? 0
+	);
+
+	const emptyState = (
+		<DataViewsEmptyState
+			title={ emptyTitle }
+			description={ emptyDescription }
+			illustration={ <img src={ noSitesIllustration } alt="" width={ 408 } height={ 280 } /> }
+			actions={
+				<>
+					{ view.search && (
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => {
+								navigate( {
+									search: {
+										...currentSearchParams,
+										view: Object.fromEntries(
+											Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
+										),
+									},
+								} );
+							} }
+						>
+							{ __( 'Clear search' ) }
+						</Button>
+					) }
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						href={ addNewStoreUrl }
+						onClick={ handleAddNewStore }
+					>
+						{ __( 'Add new store' ) }
+					</Button>
+				</>
+			}
+		/>
+	);
+
 	return (
 		<>
 			<PageLayout
@@ -127,57 +174,35 @@ export default function CIABSites() {
 				}
 				notices={ <SitesNotices /> }
 			>
-				<SitesDataViews
-					view={ view }
-					sites={ sites ?? [] }
-					totalItems={ totalItems ?? 0 }
-					sites__ES={ [] }
-					fields={ fields }
-					fields__ES={ [] }
-					actions={ actions }
-					isLoading={ isLoadingSites || ( isPlaceholderData && sites?.length === 0 ) }
-					empty={
-						<DataViewsEmptyState
-							title={ emptyTitle }
-							description={ emptyDescription }
-							illustration={
-								<img src={ noSitesIllustration } alt="" width={ 408 } height={ 280 } />
-							}
-							actions={
-								<>
-									{ view.search && (
-										<Button
-											__next40pxDefaultSize
-											variant="secondary"
-											onClick={ () => {
-												navigate( {
-													search: {
-														...currentSearchParams,
-														view: Object.fromEntries(
-															Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
-														),
-													},
-												} );
-											} }
-										>
-											{ __( 'Clear search' ) }
-										</Button>
-									) }
-									<Button
-										__next40pxDefaultSize
-										variant="primary"
-										href={ addNewStoreUrl }
-										onClick={ handleAddNewStore }
-									>
-										{ __( 'Add new store' ) }
-									</Button>
-								</>
-							}
-						/>
-					}
-					onChangeView={ handleViewChange }
-					onResetView={ resetView }
-				/>
+				{ isEnabled( 'dashboard/v2/es-site-list' ) ? (
+					<SitesDataViews< DashboardSiteListSite >
+						getItemId={ ( item ) => '' + item.blog_id?.toString() + item.url?.value }
+						view={ view }
+						sites={ filteredData__ES }
+						fields={ fields__ES }
+						// TODO: actions={ actions }
+						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
+						paginationInfo={ paginationInfo__ES }
+						renderItemLink={ ( { item, ...props } ) => <SiteLink__ES { ...props } site={ item } /> }
+						empty={ emptyState }
+						onChangeView={ handleViewChange }
+						onResetView={ resetView }
+					/>
+				) : (
+					<SitesDataViews< Site >
+						getItemId={ ( item ) => item.ID.toString() }
+						view={ view }
+						sites={ filteredData }
+						fields={ fields }
+						actions={ actions }
+						isLoading={ isLoadingSites || ( isPlaceholderData && sites?.length === 0 ) }
+						paginationInfo={ paginationInfo }
+						renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
+						empty={ emptyState }
+						onChangeView={ handleViewChange }
+						onResetView={ resetView }
+					/>
+				) }
 			</PageLayout>
 		</>
 	);

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -10,22 +10,23 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { getSiteStatus, getStatusLabels } from '../../utils/site-status';
-import { isP2, isSelfHostedJetpackConnected } from '../../utils/site-types';
-import { getSiteDisplayUrl, getSiteFormattedUrl } from '../../utils/site-url';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
-import { isSitePlanTrial } from '../plans';
 import {
 	AsyncEngagementStat,
 	EngagementStat,
 	LastBackup,
 	MediaStorage,
 	Name,
+	NameRenderer,
 	PHPVersion,
 	Plan,
 	Preview,
 	Status,
 	URL,
 	Uptime,
+	URLRenderer,
 } from '../site-fields';
 import type { AppConfig } from '../../app/context';
 import type { Site, DashboardSiteListSite } from '@automattic/api-core';
@@ -40,28 +41,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			enableHiding: false,
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayName( item ),
-			render: ( { field, item } ) => {
-				const getBadgeType = () => {
-					if ( item.is_wpcom_staging_site ) {
-						return 'staging';
-					}
-					if ( isSitePlanTrial( item ) ) {
-						return 'trial';
-					}
-					if ( isP2( item ) ) {
-						return 'p2';
-					}
-					return null;
-				};
-
-				return (
-					<Name
-						badge={ getBadgeType() }
-						deleted={ item.is_deleted }
-						value={ field.getValue( { item } ) }
-					/>
-				);
-			},
+			render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
 			enableSorting: ! isEnabled( 'dashboard/v2/es-site-list' ),
 		},
 		{
@@ -69,12 +49,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			label: __( 'URL' ),
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayUrl( item ),
-			render: ( { field, item } ) => {
-				const href = getSiteFormattedUrl( item );
-				return (
-					<URL deleted={ item.is_deleted } href={ href } value={ field.getValue( { item } ) } />
-				);
-			},
+			render: ( { field, item } ) => <URL site={ item } value={ field.getValue( { item } ) } />,
 		},
 		{
 			id: 'icon.ico',
@@ -227,9 +202,9 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			enableGlobalSearch: false, // TODO
 			getValue: ( { item } ) => item.name ?? '',
 			render: ( { field, item } ) => (
-				<Name
+				<NameRenderer
 					badge={ item.badge ?? null }
-					deleted={ item.deleted ?? false }
+					muted={ item.deleted ?? false }
 					value={ field.getValue( { item } ) }
 				/>
 			),
@@ -241,8 +216,8 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => item.url?.value ?? '',
 			render: ( { field, item } ) => (
-				<URL
-					deleted={ item.deleted ?? false }
+				<URLRenderer
+					disabled={ item.deleted ?? false }
 					href={ item.url?.with_scheme ?? '' }
 					value={ field.getValue( { item } ) }
 				/>
@@ -301,8 +276,8 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				operators: [ 'isAny' ],
 			},
 			sort: ( a, b, direction ) => {
-				const planA = getSitePlanDisplayName( a ) ?? '';
-				const planB = getSitePlanDisplayName( b ) ?? '';
+				const planA = a.plan?.product_name_short ?? '';
+				const planB = b.plan?.product_name_short ?? '';
 
 				return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
 			},

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,17 +1,21 @@
-import { queryClient } from '@automattic/api-queries';
+import { queryClient, siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useAppContext } from '../../app/context';
-import SiteIcon from '../../components/site-icon';
+import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { getSiteStatus, getStatusLabels } from '../../utils/site-status';
-import { getSiteDisplayUrl } from '../../utils/site-url';
+import { isP2, isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { getSiteDisplayUrl, getSiteFormattedUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
+import { isSitePlanTrial } from '../plans';
 import {
+	AsyncEngagementStat,
 	EngagementStat,
 	LastBackup,
 	MediaStorage,
@@ -24,7 +28,7 @@ import {
 	Uptime,
 } from '../site-fields';
 import type { AppConfig } from '../../app/context';
-import type { Site } from '@automattic/api-core';
+import type { Site, DashboardSiteListSite } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
 function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
@@ -36,7 +40,28 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			enableHiding: false,
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayName( item ),
-			render: ( { field, item } ) => <Name site={ item } value={ field.getValue( { item } ) } />,
+			render: ( { field, item } ) => {
+				const getBadgeType = () => {
+					if ( item.is_wpcom_staging_site ) {
+						return 'staging';
+					}
+					if ( isSitePlanTrial( item ) ) {
+						return 'trial';
+					}
+					if ( isP2( item ) ) {
+						return 'p2';
+					}
+					return null;
+				};
+
+				return (
+					<Name
+						badge={ getBadgeType() }
+						deleted={ item.is_deleted }
+						value={ field.getValue( { item } ) }
+					/>
+				);
+			},
 			enableSorting: ! isEnabled( 'dashboard/v2/es-site-list' ),
 		},
 		{
@@ -44,7 +69,12 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			label: __( 'URL' ),
 			enableGlobalSearch: true,
 			getValue: ( { item } ) => getSiteDisplayUrl( item ),
-			render: ( { field, item } ) => <URL site={ item } value={ field.getValue( { item } ) } />,
+			render: ( { field, item } ) => {
+				const href = getSiteFormattedUrl( item );
+				return (
+					<URL deleted={ item.is_deleted } href={ href } value={ field.getValue( { item } ) } />
+				);
+			},
 		},
 		{
 			id: 'icon.ico',
@@ -66,7 +96,14 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			id: 'plan',
 			label: __( 'Plan' ),
 			getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
-			render: ( { item } ) => <Plan site={ item } />,
+			render: ( { field, item } ) => (
+				<Plan
+					nag={ item.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
+					isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
+					isJetpack={ item.jetpack }
+					value={ field.getValue( { item } ) }
+				/>
+			),
 			getElements: async () => {
 				const { plan = [] } = await queryClient.fetchQuery( {
 					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
@@ -143,19 +180,19 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'visitors',
 			label: __( '7-day visitors' ),
-			render: ( { item } ) => <EngagementStat site={ item } type="visitors" />,
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="visitors" />,
 			enableSorting: false,
 		},
 		{
 			id: 'views',
 			label: __( '7-day views' ),
-			render: ( { item } ) => <EngagementStat site={ item } type="views" />,
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="views" />,
 			enableSorting: false,
 		},
 		{
 			id: 'likes',
 			label: __( '7-day likes' ),
-			render: ( { item } ) => <EngagementStat site={ item } type="likes" />,
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="likes" />,
 			enableSorting: false,
 		},
 		{
@@ -181,6 +218,104 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 	];
 }
 
+function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< DashboardSiteListSite >[] {
+	return [
+		{
+			id: 'name',
+			label: __( 'Site' ),
+			enableHiding: false,
+			enableGlobalSearch: false, // TODO
+			getValue: ( { item } ) => item.name ?? '',
+			render: ( { field, item } ) => (
+				<Name
+					badge={ item.badge ?? null }
+					deleted={ item.deleted ?? false }
+					value={ field.getValue( { item } ) }
+				/>
+			),
+			enableSorting: false, // TODO
+		},
+		{
+			id: 'URL',
+			label: __( 'URL' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => item.url?.value ?? '',
+			render: ( { field, item } ) => (
+				<URL
+					deleted={ item.deleted ?? false }
+					href={ item.url?.with_scheme ?? '' }
+					value={ field.getValue( { item } ) }
+				/>
+			),
+		},
+		{
+			id: 'icon.ico',
+			label: __( 'Site icon' ),
+			render: ( { item } ) => (
+				<SiteIconRenderer
+					alt={ item.name ?? '' }
+					fallbackInitial={ item.name?.charAt( 0 ) ?? '' }
+					icon={ item.icon ?? undefined }
+					isMigration={ false }
+				/>
+			),
+			enableSorting: false,
+		},
+		{
+			id: 'subscribers_count',
+			getValue: ( { item } ) => item.total_wpcom_subscribers,
+			label: __( 'Subscribers' ),
+		},
+		{
+			id: 'plan',
+			label: __( 'Plan' ),
+			getValue: ( { item } ) => item.plan?.product_name_short ?? '',
+			render: function Plan__ES( { item, field } ) {
+				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+				return (
+					<Plan
+						nag={ site?.plan?.expired ? { isExpired: true, site } : { isExpired: false } }
+						isSelfHostedJetpackConnected={
+							( site && isSelfHostedJetpackConnected( site ) ) ?? false
+						}
+						isJetpack={ site?.jetpack ?? false }
+						value={ field.getValue( { item } ) }
+					/>
+				);
+			},
+			getElements: async () => {
+				const { plan = [] } = await queryClient.fetchQuery( {
+					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
+					staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
+				} );
+
+				// A plan may have different product_slugs due to the period.
+				// However, a filter can only represent one value.
+				// As a result, it seems better to use the name as value for filters.
+				return Array.from( new Set( plan.map( ( plan ) => plan.name ) ) ).map( ( name ) => ( {
+					label: name,
+					value: name,
+				} ) );
+			},
+			filterBy: {
+				operators: [ 'isAny' ],
+			},
+			sort: ( a, b, direction ) => {
+				const planA = getSitePlanDisplayName( a ) ?? '';
+				const planB = getSitePlanDisplayName( b ) ?? '';
+
+				return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
+			},
+		},
+		{
+			id: 'visitors',
+			label: __( '7-day visitors' ),
+			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
+			enableSorting: false,
+		},
+	];
+}
+
 export function useFields( {
 	isAutomattician,
 	viewType,
@@ -192,6 +327,35 @@ export function useFields( {
 
 	return useMemo( () => {
 		const defaultFields = getDefaultFields( queries );
+		return defaultFields.filter( ( field ) => {
+			if ( field.id === 'is_a8c' && ! isAutomattician ) {
+				return false;
+			}
+
+			if ( field.id === 'icon.ico' && viewType === 'grid' ) {
+				return false;
+			}
+
+			if ( field.id === 'preview' && viewType === 'table' ) {
+				return false;
+			}
+
+			return true;
+		} );
+	}, [ isAutomattician, viewType, queries ] );
+}
+
+export function useFields__ES( {
+	isAutomattician,
+	viewType,
+}: {
+	isAutomattician?: boolean;
+	viewType?: string;
+} ) {
+	const { queries } = useAppContext();
+
+	return useMemo( () => {
+		const defaultFields = getDefaultFields__ES( queries );
 		return defaultFields.filter( ( field ) => {
 			if ( field.id === 'is_a8c' && ! isAutomattician ) {
 				return false;

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,103 +1,56 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { DataViews } from '../../app/dataviews';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
-import { SiteLink, SiteLink__ES } from '../site-fields';
 import { DEFAULT_LAYOUTS, DEFAULT_CONFIG } from './views';
-import type { DashboardSiteListSite, Site } from '@automattic/api-core';
 import type { Action, Field, View } from '@wordpress/dataviews';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
-/**
- * Meant to stand in for the dataview's filterSortAndPaginate function when
- * the filtering has already been done on the backend by elasticsearch.
- */
-function filterSortAndPaginate__ES(
-	sites: DashboardSiteListSite[],
-	view: View,
-	totalItems: number
-) {
-	return {
-		data: sites,
-		paginationInfo: {
-			totalItems,
-			totalPages: view.perPage ? Math.ceil( totalItems / view.perPage ) : 1,
-		},
-	};
-}
-
-export const SitesDataViews = ( {
+export function SitesDataViews< SiteType >( {
 	view,
 	sites,
-	sites__ES,
-	totalItems,
 	fields,
-	fields__ES,
 	actions,
 	isLoading,
 	empty,
+	paginationInfo,
+	renderItemLink,
+	getItemId,
 	onChangeView,
 	onResetView,
 }: {
 	view: View;
-	sites: Site[];
-	sites__ES: DashboardSiteListSite[];
-	totalItems: number;
-	fields: Field< Site >[];
-	fields__ES: Field< DashboardSiteListSite >[];
-	actions: Action< Site >[];
+	sites: SiteType[];
+	fields: Field< SiteType >[];
+	actions?: Action< SiteType >[];
 	isLoading: boolean;
 	empty: ReactNode;
+	paginationInfo: ComponentProps< typeof DataViews< SiteType > >[ 'paginationInfo' ];
+	renderItemLink: ComponentProps< typeof DataViews< SiteType > >[ 'renderItemLink' ];
+	getItemId: ComponentProps< typeof DataViews< SiteType > >[ 'getItemId' ];
 	onChangeView: ( view: View ) => void;
 	onResetView?: () => void;
-} ) => {
-	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
-
-	const { data: filteredData__ES, paginationInfo: paginationInfoES } = filterSortAndPaginate__ES(
-		sites__ES,
-		view,
-		totalItems
-	);
-
-	const dv = isEnabled( 'dashboard/v2/es-site-list' ) ? (
-		<DataViews< DashboardSiteListSite >
-			getItemId={ ( item ) => '' + item.blog_id?.toString() + item.url?.value }
-			data={ filteredData__ES }
-			fields={ fields__ES }
-			// TODO: actions={ actions }
-			view={ view }
-			isLoading={ isLoading }
-			onChangeView={ onChangeView }
-			onResetView={ onResetView }
-			defaultLayouts={ DEFAULT_LAYOUTS }
-			paginationInfo={ paginationInfoES }
-			config={ DEFAULT_CONFIG }
-			empty={ empty }
-			renderItemLink={ ( { item, ...props } ) => <SiteLink__ES { ...props } site={ item } /> }
-		/>
-	) : (
-		<DataViews< Site >
-			getItemId={ ( item ) => item.ID.toString() }
-			data={ filteredData }
-			fields={ fields }
-			actions={ actions }
-			view={ view }
-			isLoading={ isLoading }
-			onChangeView={ onChangeView }
-			onResetView={ onResetView }
-			defaultLayouts={ DEFAULT_LAYOUTS }
-			paginationInfo={ paginationInfo }
-			config={ DEFAULT_CONFIG }
-			empty={ empty }
-			renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
-		/>
-	);
-
+} ) {
 	return (
 		<>
-			<DataViewsCard>{ dv }</DataViewsCard>
+			<DataViewsCard>
+				{ /* @ts-ignore - TS doesn't seem able to resolve which branch of the DataViewsProps type to go down, either the branch were the row type has an `id`, or the branch where it does not. */ }
+				<DataViews< SiteType >
+					getItemId={ getItemId }
+					data={ sites }
+					fields={ fields }
+					actions={ actions }
+					view={ view }
+					isLoading={ isLoading }
+					onChangeView={ onChangeView }
+					onResetView={ onResetView }
+					defaultLayouts={ DEFAULT_LAYOUTS }
+					paginationInfo={ paginationInfo }
+					config={ DEFAULT_CONFIG }
+					empty={ empty }
+					renderItemLink={ renderItemLink }
+				/>
+			</DataViewsCard>
 			<GuidedTourContextProvider
 				tourId="hosting-dashboard-tours-sites"
 				isSkippable
@@ -136,4 +89,4 @@ export const SitesDataViews = ( {
 			</GuidedTourContextProvider>
 		</>
 	);
-};
+}

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -4,9 +4,9 @@ import { __ } from '@wordpress/i18n';
 import { DataViews } from '../../app/dataviews';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
-import { SiteLink } from '../site-fields';
+import { SiteLink, SiteLink__ES } from '../site-fields';
 import { DEFAULT_LAYOUTS, DEFAULT_CONFIG } from './views';
-import type { Site } from '@automattic/api-core';
+import type { DashboardSiteListSite, Site } from '@automattic/api-core';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
@@ -14,7 +14,11 @@ import type { ReactNode } from 'react';
  * Meant to stand in for the dataview's filterSortAndPaginate function when
  * the filtering has already been done on the backend by elasticsearch.
  */
-function esFilterSortAndPaginate( sites: Site[], view: View, totalItems: number ) {
+function filterSortAndPaginate__ES(
+	sites: DashboardSiteListSite[],
+	view: View,
+	totalItems: number
+) {
 	return {
 		data: sites,
 		paginationInfo: {
@@ -27,8 +31,10 @@ function esFilterSortAndPaginate( sites: Site[], view: View, totalItems: number 
 export const SitesDataViews = ( {
 	view,
 	sites,
+	sites__ES,
 	totalItems,
 	fields,
+	fields__ES,
 	actions,
 	isLoading,
 	empty,
@@ -37,37 +43,61 @@ export const SitesDataViews = ( {
 }: {
 	view: View;
 	sites: Site[];
+	sites__ES: DashboardSiteListSite[];
 	totalItems: number;
 	fields: Field< Site >[];
+	fields__ES: Field< DashboardSiteListSite >[];
 	actions: Action< Site >[];
 	isLoading: boolean;
 	empty: ReactNode;
 	onChangeView: ( view: View ) => void;
 	onResetView?: () => void;
 } ) => {
-	const { data: filteredData, paginationInfo } = isEnabled( 'dashboard/v2/es-site-list' )
-		? esFilterSortAndPaginate( sites, view, totalItems )
-		: filterSortAndPaginate( sites, view, fields );
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
+
+	const { data: filteredData__ES, paginationInfo: paginationInfoES } = filterSortAndPaginate__ES(
+		sites__ES,
+		view,
+		totalItems
+	);
+
+	const dv = isEnabled( 'dashboard/v2/es-site-list' ) ? (
+		<DataViews< DashboardSiteListSite >
+			getItemId={ ( item ) => '' + item.blog_id?.toString() + item.url?.value }
+			data={ filteredData__ES }
+			fields={ fields__ES }
+			// TODO: actions={ actions }
+			view={ view }
+			isLoading={ isLoading }
+			onChangeView={ onChangeView }
+			onResetView={ onResetView }
+			defaultLayouts={ DEFAULT_LAYOUTS }
+			paginationInfo={ paginationInfoES }
+			config={ DEFAULT_CONFIG }
+			empty={ empty }
+			renderItemLink={ ( { item, ...props } ) => <SiteLink__ES { ...props } site={ item } /> }
+		/>
+	) : (
+		<DataViews< Site >
+			getItemId={ ( item ) => item.ID.toString() }
+			data={ filteredData }
+			fields={ fields }
+			actions={ actions }
+			view={ view }
+			isLoading={ isLoading }
+			onChangeView={ onChangeView }
+			onResetView={ onResetView }
+			defaultLayouts={ DEFAULT_LAYOUTS }
+			paginationInfo={ paginationInfo }
+			config={ DEFAULT_CONFIG }
+			empty={ empty }
+			renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
+		/>
+	);
 
 	return (
 		<>
-			<DataViewsCard>
-				<DataViews< Site >
-					getItemId={ ( item ) => item.ID.toString() + item.URL }
-					data={ filteredData }
-					fields={ fields }
-					actions={ actions }
-					view={ view }
-					isLoading={ isLoading }
-					onChangeView={ onChangeView }
-					onResetView={ onResetView }
-					defaultLayouts={ DEFAULT_LAYOUTS }
-					paginationInfo={ paginationInfo }
-					config={ DEFAULT_CONFIG }
-					empty={ empty }
-					renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
-				/>
-			</DataViewsCard>
+			<DataViewsCard>{ dv }</DataViewsCard>
 			<GuidedTourContextProvider
 				tourId="hosting-dashboard-tours-sites"
 				isSkippable

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import type { AnalyticsClient } from '../../app/analytics';
 import type { User } from '@automattic/api-core';
 import type { Operator, SortDirection, SupportedLayouts, View } from '@wordpress/dataviews';
@@ -9,6 +10,8 @@ export const DEFAULT_LAYOUTS: SupportedLayouts = {
 		},
 		showLevels: false,
 		showMedia: true,
+		showTitle: true,
+		showDescription: true,
 		mediaField: 'icon.ico',
 		titleField: 'name',
 		descriptionField: 'URL',
@@ -19,6 +22,8 @@ export const DEFAULT_LAYOUTS: SupportedLayouts = {
 		},
 		showLevels: false,
 		showMedia: true,
+		showTitle: true,
+		showDescription: true,
 		mediaField: 'preview',
 		titleField: 'name',
 		descriptionField: 'URL',
@@ -33,8 +38,13 @@ export const DEFAULT_PER_PAGE = 12;
 
 const DEFAULT_VIEW: Partial< View > = {
 	perPage: DEFAULT_PER_PAGE,
-	fields: [ 'status', 'visitors', 'subscribers_count', 'plan' ],
-	sort: { field: 'name', direction: 'asc' as SortDirection },
+	fields: isEnabled( 'dashboard/v2/es-site-list' )
+		? [ 'visitors', 'subscribers_count', 'plan' ]
+		: [ 'status', 'visitors', 'subscribers_count', 'plan' ],
+	sort: {
+		field: isEnabled( 'dashboard/v2/es-site-list' ) ? 'URL' : 'name',
+		direction: 'asc' as SortDirection,
+	},
 };
 
 export function getDefaultView( {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -166,7 +166,7 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
  * Meant to stand in for the dataview's filterSortAndPaginate function when
  * the filtering has already been done on the backend by elasticsearch.
  */
-function filterSortAndPaginate__ES(
+export function filterSortAndPaginate__ES(
 	sites: DashboardSiteListSite[],
 	view: View,
 	totalItems: number

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { getISOWeek, getISOWeekYear } from 'date-fns';
 import deepmerge from 'deepmerge';
@@ -32,6 +33,7 @@ import {
 } from './dataviews';
 import noSitesIllustration from './no-sites-illustration.svg';
 import { SitesNotices } from './notices';
+import { SiteLink, SiteLink__ES } from './site-fields';
 import type {
 	FetchSitesOptions,
 	Site,
@@ -160,6 +162,24 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 	};
 }
 
+/**
+ * Meant to stand in for the dataview's filterSortAndPaginate function when
+ * the filtering has already been done on the backend by elasticsearch.
+ */
+function filterSortAndPaginate__ES(
+	sites: DashboardSiteListSite[],
+	view: View,
+	totalItems: number
+) {
+	return {
+		data: sites,
+		paginationInfo: {
+			totalItems,
+			totalPages: view.perPage ? Math.ceil( totalItems / view.perPage ) : 1,
+		},
+	};
+}
+
 export default function Sites() {
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate( { from: sitesRoute.fullPath } );
@@ -228,6 +248,47 @@ export default function Sites() {
 		}
 	}, [ sites, queryClient ] );
 
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites ?? [], view, fields );
+
+	const { data: filteredData__ES, paginationInfo: paginationInfo__ES } = filterSortAndPaginate__ES(
+		sites__ES ?? [],
+		view,
+		totalItems ?? 0
+	);
+
+	const emptyState = (
+		<DataViewsEmptyState
+			title={ emptyTitle }
+			description={ emptyDescription }
+			illustration={ <img src={ noSitesIllustration } alt="" width={ 408 } height={ 280 } /> }
+			actions={
+				<>
+					{ view.search && (
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => {
+								navigate( {
+									search: {
+										...currentSearchParams,
+										view: Object.fromEntries(
+											Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
+										),
+									},
+								} );
+							} }
+						>
+							{ __( 'Clear search' ) }
+						</Button>
+					) }
+					<Button __next40pxDefaultSize variant="primary" onClick={ () => setIsModalOpen( true ) }>
+						{ __( 'Add new site' ) }
+					</Button>
+				</>
+			}
+		/>
+	);
+
 	return (
 		<>
 			{ isModalOpen && (
@@ -252,56 +313,35 @@ export default function Sites() {
 				}
 				notices={ <SitesNotices /> }
 			>
-				<SitesDataViews
-					view={ view }
-					sites={ sites ?? [] }
-					sites__ES={ sites__ES ?? [] }
-					totalItems={ totalItems ?? 0 }
-					fields={ fields }
-					fields__ES={ fields__ES }
-					actions={ actions }
-					isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
-					empty={
-						<DataViewsEmptyState
-							title={ emptyTitle }
-							description={ emptyDescription }
-							illustration={
-								<img src={ noSitesIllustration } alt="" width={ 408 } height={ 280 } />
-							}
-							actions={
-								<>
-									{ view.search && (
-										<Button
-											__next40pxDefaultSize
-											variant="secondary"
-											onClick={ () => {
-												navigate( {
-													search: {
-														...currentSearchParams,
-														view: Object.fromEntries(
-															Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
-														),
-													},
-												} );
-											} }
-										>
-											{ __( 'Clear search' ) }
-										</Button>
-									) }
-									<Button
-										__next40pxDefaultSize
-										variant="primary"
-										onClick={ () => setIsModalOpen( true ) }
-									>
-										{ __( 'Add new site' ) }
-									</Button>
-								</>
-							}
-						/>
-					}
-					onChangeView={ handleViewChange }
-					onResetView={ resetView }
-				/>
+				{ isEnabled( 'dashboard/v2/es-site-list' ) ? (
+					<SitesDataViews< DashboardSiteListSite >
+						getItemId={ ( item ) => '' + item.blog_id?.toString() + item.url?.value }
+						view={ view }
+						sites={ filteredData__ES }
+						fields={ fields__ES }
+						// TODO: actions={ actions }
+						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
+						empty={ emptyState }
+						paginationInfo={ paginationInfo__ES }
+						renderItemLink={ ( { item, ...props } ) => <SiteLink__ES { ...props } site={ item } /> }
+						onChangeView={ handleViewChange }
+						onResetView={ resetView }
+					/>
+				) : (
+					<SitesDataViews< Site >
+						getItemId={ ( item ) => item.ID.toString() }
+						view={ view }
+						sites={ filteredData }
+						fields={ fields }
+						actions={ actions }
+						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
+						empty={ emptyState }
+						paginationInfo={ paginationInfo }
+						onChangeView={ handleViewChange }
+						onResetView={ resetView }
+						renderItemLink={ ( { item, ...props } ) => <SiteLink { ...props } site={ item } /> }
+					/>
+				) }
 			</PageLayout>
 			{ /* ExPlat's Evergreen A/A Test Experiment:
 			 *

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -21,12 +21,12 @@ import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews-empty-state';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
-import { urlToSlug } from '../utils/url';
 import AddNewSite from './add-new-site';
 import {
 	SitesDataViews,
 	useActions,
 	useFields,
+	useFields__ES,
 	getDefaultView,
 	recordViewChanges,
 } from './dataviews';
@@ -36,7 +36,7 @@ import type {
 	FetchSitesOptions,
 	Site,
 	FetchDashboardSiteListParams,
-	SiteProfileSite,
+	DashboardSiteListSite,
 } from '@automattic/api-core';
 import type { View, Filter } from '@wordpress/dataviews';
 
@@ -64,29 +64,30 @@ function getFetchSiteListParams(
 	view: View
 	// isRestoringAccount: boolean TODO: Add site visibility filtering
 ): FetchDashboardSiteListParams {
-	const dataviewFieldToSiteProfileField: Record< string, keyof SiteProfileSite > = {
-		name: 'blogname',
+	const dataviewFieldToSiteProfileField: Record< string, keyof DashboardSiteListSite > = {
+		name: 'name',
 		URL: 'url',
-		'icon.ico': 'site_icon',
+		'icon.ico': 'icon',
 		backup: 'has_backup',
-		views: 'stats_visitors',
-		// plan
+		// views: 'stats_views',
+		plan: 'plan',
 		// wp_version
 		// is_a8c
 		// preview
 		// last_published
 		// uptime
-		// visitors
-		// subscribers_count
+		visitors: 'visitors',
+		subscribers_count: 'total_wpcom_subscribers',
 		// links
 		// php_version
 		// storage
 		// host
 	};
 
-	const fields = new Set< keyof SiteProfileSite >( [ 'blog_id', 'url' ] ); // Always include ID and URL (to calculate site slug).
+	const fields = new Set< keyof DashboardSiteListSite >( [ 'blog_id', 'slug', 'deleted' ] ); // Always include ID and slug (for navigation), and deleted (for styling)
 	if ( view.showTitle && view.titleField ) {
 		fields.add( dataviewFieldToSiteProfileField[ view.titleField ] );
+		fields.add( 'badge' );
 	}
 	if ( view.showMedia && view.mediaField ) {
 		fields.add( dataviewFieldToSiteProfileField[ view.mediaField ] );
@@ -117,44 +118,6 @@ function getFetchSiteListParams(
 	};
 }
 
-function siteProfileSiteToSite( site: SiteProfileSite ): Site {
-	return {
-		ID: site.blog_id ?? 0,
-		slug: urlToSlug( site.url ?? '' ),
-		name: site.blogname ?? '',
-		URL: site.url ?? '',
-		icon: site.site_icon ?? undefined,
-		is_deleted: Boolean( site.deleted ),
-		is_coming_soon: Boolean( site.wpcom_status?.is_coming_soon ),
-		is_private: Boolean( site.private ),
-		is_wpcom_staging_site: Boolean( site.wpcom_status?.is_staging ),
-		capabilities: {
-			manage_options: false, // TODO
-			update_plugins: false, // TODO
-		},
-		garden_is_provisioned: null, // TODO
-		garden_name: null, // TODO
-		garden_partner: null, // TODO
-		is_a4a_dev_site: false, // TODO
-		is_a8c: false, // TODO
-		is_garden: false, // TODO
-		is_wpcom_atomic: false, // TODO
-		is_wpcom_flex: false, // TODO
-		is_vip: false, // TODO
-		lang: 'en', // TODO
-		launch_status: false, // TODO
-		site_migration: { in_progress: false, is_complete: false }, // TODO
-		site_owner: 0, // TODO
-		jetpack: false, // TODO
-		jetpack_connection: false, // TODO
-		jetpack_modules: null, // TODO
-		was_ecommerce_trial: false, // TODO
-		was_migration_trial: false, // TODO
-		was_hosting_trial: false, // TODO
-		was_upgraded_from_trial: false, // TODO
-	};
-}
-
 /**
  * Enables the correct site query based on the dataviews/v2/es-site-list feature flag.
  */
@@ -178,7 +141,9 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 
 	if ( isEnabled( 'dashboard/v2/es-site-list' ) ) {
 		return {
-			sites: siteProfilesQueryResult.data?.sites.map( siteProfileSiteToSite ),
+			sites: [],
+			sites__ES: siteProfilesQueryResult.data?.sites,
+			hasNoData: Boolean( siteProfilesQueryResult.data?.sites.length === 0 ),
 			isLoadingSites: siteProfilesQueryResult.isLoading,
 			isPlaceholderData: siteProfilesQueryResult.isPlaceholderData,
 			totalItems: siteProfilesQueryResult.data?.total,
@@ -187,6 +152,8 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 
 	return {
 		sites: sitesQueryResult.data,
+		sites__ES: [],
+		hasNoData: Boolean( sitesQueryResult.data?.length === 0 ),
 		isLoadingSites: sitesQueryResult.isLoading,
 		isPlaceholderData: sitesQueryResult.isPlaceholderData,
 		totalItems: sitesQueryResult.data?.length,
@@ -215,12 +182,11 @@ export default function Sites() {
 		queryParams: currentSearchParams,
 	} );
 
-	const { sites, isLoadingSites, isPlaceholderData, totalItems } = useSiteListQuery(
-		view,
-		isRestoringAccount
-	);
+	const { sites, sites__ES, isLoadingSites, isPlaceholderData, hasNoData, totalItems } =
+		useSiteListQuery( view, isRestoringAccount );
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );
+	const fields__ES = useFields__ES( { isAutomattician, viewType: view.type } );
 	const actions = useActions();
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -289,10 +255,12 @@ export default function Sites() {
 				<SitesDataViews
 					view={ view }
 					sites={ sites ?? [] }
+					sites__ES={ sites__ES ?? [] }
 					totalItems={ totalItems ?? 0 }
 					fields={ fields }
+					fields__ES={ fields__ES }
 					actions={ actions }
-					isLoading={ isLoadingSites || ( isPlaceholderData && sites?.length === 0 ) }
+					isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 					empty={
 						<DataViewsEmptyState
 							title={ emptyTitle }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -145,7 +145,7 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 		return {
 			sites: [],
 			sites__ES: siteProfilesQueryResult.data?.sites,
-			hasNoData: Boolean( siteProfilesQueryResult.data?.sites.length === 0 ),
+			hasNoData: siteProfilesQueryResult.data?.sites.length === 0,
 			isLoadingSites: siteProfilesQueryResult.isLoading,
 			isPlaceholderData: siteProfilesQueryResult.isPlaceholderData,
 			totalItems: siteProfilesQueryResult.data?.total,
@@ -155,7 +155,7 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 	return {
 		sites: sitesQueryResult.data,
 		sites__ES: [],
-		hasNoData: Boolean( sitesQueryResult.data?.length === 0 ),
+		hasNoData: sitesQueryResult.data?.length === 0,
 		isLoadingSites: sitesQueryResult.isLoading,
 		isPlaceholderData: sitesQueryResult.isPlaceholderData,
 		totalItems: sitesQueryResult.data?.length,

--- a/client/dashboard/sites/logs/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs/dataviews/test/index.test.tsx
@@ -18,14 +18,6 @@ jest.mock( '../../../../app/auth', () => ( {
 	useAuth: () => ( { user: { id: 'test-user' } } ),
 } ) );
 
-const mockRecordTracksEvent = jest.fn();
-
-jest.mock( '../../../../app/analytics', () => ( {
-	useAnalytics: jest.fn( () => ( {
-		recordTracksEvent: mockRecordTracksEvent,
-	} ) ),
-} ) );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: jest.fn(),
@@ -186,7 +178,7 @@ describe( 'SiteLogsDataViews', () => {
 		const user = userEvent.setup();
 		const autoRefresh = jest.fn();
 
-		render(
+		const { recordTracksEvent } = render(
 			<SiteLogsDataViews
 				gmtOffset={ -8 }
 				timezoneString="America/Los_Angeles"
@@ -202,7 +194,7 @@ describe( 'SiteLogsDataViews', () => {
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 		const toggle = screen.getByRole( 'checkbox', { name: 'Auto-refresh' } );
 		await user.click( toggle );
-		expect( mockRecordTracksEvent ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
 		expect( autoRefresh ).not.toHaveBeenCalled();
 	} );
 

--- a/client/dashboard/sites/logs/test/downloader.test.tsx
+++ b/client/dashboard/sites/logs/test/downloader.test.tsx
@@ -45,14 +45,6 @@ jest.mock( '@wordpress/components', () => ( {
 
 jest.mock( '@wordpress/icons', () => ( { download: 'download' } ) );
 
-const mockRecordTracksEvent = jest.fn();
-
-jest.mock( '../../../app/analytics', () => ( {
-	useAnalytics: jest.fn( () => ( {
-		recordTracksEvent: mockRecordTracksEvent,
-	} ) ),
-} ) );
-
 jest.mock( '@automattic/api-core', () => {
 	const actual = jest.requireActual( '@automattic/api-core' );
 	const fetchSiteLogsBatchMock = jest.fn();
@@ -127,7 +119,7 @@ test( 'downloads logs and records analytics', async () => {
 
 	const onSuccess = jest.fn();
 
-	render(
+	const { recordTracksEvent } = render(
 		<LogsDownloader
 			siteId={ 123 }
 			siteSlug="test-site"
@@ -148,13 +140,13 @@ test( 'downloads logs and records analytics', async () => {
 	// Caller notified
 	expect( onSuccess ).toHaveBeenCalledWith( 'Logs downloaded.' );
 
-	expect( mockRecordTracksEvent ).toHaveBeenNthCalledWith(
+	expect( recordTracksEvent ).toHaveBeenNthCalledWith(
 		2,
 		'calypso_dashboard_site_logs_download_started',
 		expect.objectContaining( { site_id: 123 } )
 	);
 
-	expect( mockRecordTracksEvent ).toHaveBeenNthCalledWith(
+	expect( recordTracksEvent ).toHaveBeenNthCalledWith(
 		1,
 		'calypso_dashboard_site_logs_download_completed',
 		expect.objectContaining( { download_filename: 'test-site-server-logs-1-2.csv' } )

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -30,6 +30,8 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
+import { isP2 } from '../../utils/site-types';
+import { getSiteFormattedUrl } from '../../utils/site-url';
 import { canManageSite } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
@@ -90,13 +92,30 @@ export function SiteLink__ES( {
 	);
 }
 
-export function Name( {
+export function Name( { site, value }: { site: Site; value: string } ) {
+	const getBadgeType = () => {
+		if ( site.is_wpcom_staging_site ) {
+			return 'staging';
+		}
+		if ( isSitePlanTrial( site ) ) {
+			return 'trial';
+		}
+		if ( isP2( site ) ) {
+			return 'p2';
+		}
+		return null;
+	};
+
+	return <NameRenderer badge={ getBadgeType() } muted={ site.is_deleted } value={ value } />;
+}
+
+export function NameRenderer( {
 	badge,
-	deleted,
+	muted,
 	value,
 }: {
 	badge: null | 'staging' | 'trial' | 'p2';
-	deleted: boolean;
+	muted: boolean;
 	value: string;
 } ) {
 	const renderBadge = () => {
@@ -116,7 +135,7 @@ export function Name( {
 
 	return (
 		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
-			{ deleted ? (
+			{ muted ? (
 				<Text variant="muted">{ value }</Text>
 			) : (
 				<span style={ titleFieldTextOverflowStyles }>{ value }</span>
@@ -126,8 +145,26 @@ export function Name( {
 	);
 }
 
-export function URL( { deleted, href, value }: { deleted: boolean; href: string; value: string } ) {
-	return deleted ? (
+export function URL( { site, value }: { site: Site; value: string } ) {
+	return (
+		<URLRenderer
+			disabled={ site.is_deleted }
+			href={ getSiteFormattedUrl( site ) }
+			value={ value }
+		/>
+	);
+}
+
+export function URLRenderer( {
+	disabled,
+	href,
+	value,
+}: {
+	disabled: boolean;
+	href: string;
+	value: string;
+} ) {
+	return disabled ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
 		<ExternalLink

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -29,15 +29,12 @@ import { addTransientViewPropertiesToQueryParams } from '../../utils/dashboard-v
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
-import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
-import { isSelfHostedJetpackConnected, isP2 } from '../../utils/site-types';
-import { getSiteFormattedUrl } from '../../utils/site-url';
 import { canManageSite } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
-import type { AtomicTransferStatus, Site } from '@automattic/api-core';
+import type { AtomicTransferStatus, Site, DashboardSiteListSite } from '@automattic/api-core';
 import type { ComponentProps } from 'react';
 
 function IneligibleIndicator() {
@@ -78,45 +75,65 @@ export function SiteLink( { site, ...props }: ComponentProps< typeof Link > & { 
 	);
 }
 
-export function Name( { site, value }: { site: Site; value: string } ) {
+export function SiteLink__ES( {
+	site,
+	...props
+}: ComponentProps< typeof Link > & { site: DashboardSiteListSite } ) {
+	// TODO: Get the correct site management url based on permissions and backport.
+	return (
+		<Link
+			{ ...props }
+			to={ `/sites/${ site.slug }` }
+			disabled={ site.deleted }
+			style={ { width: 'auto', minWidth: 'unset', textDecoration: 'none', ...props.style } }
+		/>
+	);
+}
+
+export function Name( {
+	badge,
+	deleted,
+	value,
+}: {
+	badge: null | 'staging' | 'trial' | 'p2';
+	deleted: boolean;
+	value: string;
+} ) {
 	const renderBadge = () => {
-		if ( site.is_wpcom_staging_site ) {
-			return <Badge>{ __( 'Staging' ) }</Badge>;
+		switch ( badge ) {
+			case 'staging':
+				return <Badge>{ __( 'Staging' ) }</Badge>;
+			case 'trial':
+				return <Badge>{ __( 'Trial' ) }</Badge>;
+			case 'p2':
+				return <Badge>{ __( 'P2' ) }</Badge>;
+			default:
+				break;
 		}
-
-		if ( isSitePlanTrial( site ) ) {
-			return <Badge>{ __( 'Trial' ) }</Badge>;
-		}
-
-		if ( isP2( site ) ) {
-			return <Badge>{ __( 'P2' ) }</Badge>;
-		}
-
-		return null;
 	};
 
-	const badge = renderBadge();
+	const badgeElement = renderBadge();
 
 	return (
 		<HStack justify="flex-start" alignment="center" spacing={ 1 }>
-			{ site.is_deleted ? (
+			{ deleted ? (
 				<Text variant="muted">{ value }</Text>
 			) : (
 				<span style={ titleFieldTextOverflowStyles }>{ value }</span>
 			) }
-			{ badge && <span style={ { flexShrink: 0 } }>{ badge }</span> }
+			{ badgeElement && <span style={ { flexShrink: 0 } }>{ badgeElement }</span> }
 		</HStack>
 	);
 }
 
-export function URL( { site, value }: { site: Site; value: string } ) {
-	return site.is_deleted ? (
+export function URL( { deleted, href, value }: { deleted: boolean; href: string; value: string } ) {
+	return deleted ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
 		<ExternalLink
 			className="dataviews-url-field"
 			style={ titleFieldTextOverflowStyles }
-			href={ getSiteFormattedUrl( site ) }
+			href={ href }
 		>
 			{ value }
 		</ExternalLink>
@@ -170,7 +187,7 @@ export function Preview( { site }: { site: Site } ) {
 	);
 }
 
-export function EngagementStat( {
+export function AsyncEngagementStat( {
 	site,
 	type,
 }: {
@@ -199,6 +216,10 @@ export function EngagementStat( {
 	};
 
 	return <span ref={ ref }>{ renderContent() }</span>;
+}
+
+export function EngagementStat( { value }: { value: number | null } ) {
+	return typeof value !== 'number' ? <IneligibleIndicator /> : value;
 }
 
 export function LastBackup( { site }: { site: Site } ) {
@@ -430,35 +451,43 @@ export function Status( { site }: { site: Site } ) {
 	return renderBasicStatus();
 }
 
-export function Plan( { site }: { site: Site } ) {
-	const planName = getSitePlanDisplayName( site );
-
-	if ( isSelfHostedJetpackConnected( site ) ) {
-		if ( ! site.jetpack ) {
+export function Plan( {
+	nag,
+	isSelfHostedJetpackConnected,
+	isJetpack,
+	value,
+}: {
+	nag: { isExpired: false } | { isExpired: true; site: Site };
+	isSelfHostedJetpackConnected: boolean;
+	isJetpack: boolean;
+	value: string;
+} ) {
+	if ( isSelfHostedJetpackConnected ) {
+		if ( ! isJetpack ) {
 			return <IneligibleIndicator />;
 		}
 		return (
 			<HStack spacing={ 1 } expanded={ false } justify="flex-start">
 				<JetpackLogo size={ 16 } />
-				<span>{ planName }</span>
+				<span>{ value }</span>
 			</HStack>
 		);
 	}
 
-	if ( site.plan?.expired ) {
+	if ( nag.isExpired ) {
 		return (
 			<VStack spacing={ 1 }>
 				<Text intent="error">
 					{ sprintf(
 						/* translators: %s: plan name */
 						__( '%s-expired' ),
-						planName
+						value
 					) }
 				</Text>
-				<PlanRenewNag site={ site } source="plan" />
+				<PlanRenewNag site={ nag.site } source="plan" />
 			</VStack>
 		);
 	}
 
-	return planName;
+	return value;
 }

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -1,15 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import { render as testingLibraryRender } from '@testing-library/react';
 import { AuthContext } from '../../../app/auth';
+import { render as testUtilsRender } from '../../../test-utils';
 import { Plan } from '../index';
 import type { User, Site } from '@automattic/api-core';
 
 const userId = 1;
 
 function render( ui: React.ReactElement ) {
-	return testingLibraryRender(
+	return testUtilsRender(
 		<AuthContext.Provider
 			value={ { user: { ID: userId } as User, logout: () => Promise.resolve() } }
 		>
@@ -19,64 +19,47 @@ function render( ui: React.ReactElement ) {
 }
 
 describe( '<Plan>', () => {
-	test( 'for staging sites, it renders "Staging Site"', () => {
-		const site = {
-			is_wpcom_staging_site: true,
-		} as Site;
-		const { container } = render( <Plan site={ site } /> );
-		expect( container.textContent ).toBe( 'Staging Site' );
-	} );
-
 	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', () => {
-		const site = {
-			is_wpcom_atomic: false,
-			jetpack_connection: true,
-			jetpack: true,
-			plan: {
-				product_name_short: 'Free',
-			},
-		} as Site;
-		const { container } = render( <Plan site={ site } /> );
+		const { container } = render(
+			<Plan isJetpack isSelfHostedJetpackConnected value="Free" nag={ { isExpired: false } } />
+		);
 		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
 		expect( container.textContent ).toBe( 'Free' );
 	} );
 
 	test( 'for self-hosted, Jetpack-connected sites, inactive Jetpack plugin, it renders dash', () => {
-		const site = {
-			is_wpcom_atomic: false,
-			jetpack_connection: true,
-			jetpack: false,
-			plan: {
-				product_name_short: 'Free',
-			},
-		} as Site;
-		const { container } = render( <Plan site={ site } /> );
+		const { container } = render(
+			<Plan
+				isJetpack={ false }
+				isSelfHostedJetpackConnected
+				value="Free"
+				nag={ { isExpired: false } }
+			/>
+		);
 		expect( container.textContent ).toBe( '-' );
 	} );
 
-	test( 'for WordPress.com Simple sites, it renders the plan name', () => {
-		const site = {
-			is_wpcom_atomic: false,
-			jetpack_connection: false,
-			jetpack: false,
-			plan: {
-				product_name_short: 'Premium',
-			},
-		} as Site;
-		const { container } = render( <Plan site={ site } /> );
+	test( 'for WordPress.com Simple sites, it renders the value prop', () => {
+		const { container } = render(
+			<Plan
+				isJetpack={ false }
+				isSelfHostedJetpackConnected={ false }
+				value="Premium"
+				nag={ { isExpired: false } }
+			/>
+		);
 		expect( container.textContent ).toBe( 'Premium' );
 	} );
 
 	test( 'for WordPress.com Atomic sites, it renders the plan name', () => {
-		const site = {
-			is_wpcom_atomic: true,
-			jetpack_connection: true,
-			jetpack: true,
-			plan: {
-				product_name_short: 'Business',
-			},
-		} as Site;
-		const { container } = render( <Plan site={ site } /> );
+		const { container } = render(
+			<Plan
+				isJetpack
+				isSelfHostedJetpackConnected={ false }
+				value="Business"
+				nag={ { isExpired: false } }
+			/>
+		);
 		expect( container.textContent ).toBe( 'Business' );
 	} );
 
@@ -87,7 +70,14 @@ describe( '<Plan>', () => {
 				expired: true,
 			},
 		} as Site;
-		const { container } = render( <Plan site={ site } /> );
+		const { container } = render(
+			<Plan
+				isJetpack={ false }
+				isSelfHostedJetpackConnected={ false }
+				value="Business"
+				nag={ { isExpired: true, site } }
+			/>
+		);
 		expect( container.textContent ).toBe( 'Business-expired' );
 	} );
 
@@ -101,7 +91,14 @@ describe( '<Plan>', () => {
 				expired: true,
 			},
 		} as Site;
-		const { getByText, getByRole } = render( <Plan site={ site } /> );
+		const { getByText, getByRole } = render(
+			<Plan
+				isJetpack={ false }
+				isSelfHostedJetpackConnected={ false }
+				value="Business"
+				nag={ { isExpired: true, site } }
+			/>
+		);
 		expect( getByText( 'Business-expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
 			'href',
@@ -119,7 +116,14 @@ describe( '<Plan>', () => {
 				expired: true,
 			},
 		} as Site;
-		const { getByText, getByRole } = render( <Plan site={ site } /> );
+		const { getByText, getByRole } = render(
+			<Plan
+				isJetpack={ false }
+				isSelfHostedJetpackConnected={ false }
+				value="Trial"
+				nag={ { isExpired: true, site } }
+			/>
+		);
 		expect( getByText( 'Trial-expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Upgrade/ } ) ).toHaveAttribute(
 			'href',

--- a/client/dashboard/sites/site/test/environment-switcher.test.tsx
+++ b/client/dashboard/sites/site/test/environment-switcher.test.tsx
@@ -15,10 +15,6 @@ const mockCreateErrorNotice = jest.fn();
 const mockMutate = jest.fn();
 const mockInvalidateQueries = jest.fn();
 
-jest.mock( '@automattic/calypso-analytics', () => ( {
-	recordTracksEvent: jest.fn(),
-} ) );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: mockCreateSuccessNotice,

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -12,7 +12,6 @@ const mockMutate = jest.fn();
 const mockCreateErrorNotice = jest.fn();
 const mockCreateSuccessNotice = jest.fn();
 const mockNavigate = jest.fn();
-const mockRecordTracksEvent = jest.fn();
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
@@ -48,12 +47,6 @@ jest.mock( '@tanstack/react-query', () => ( {
 		mutate: mockMutate,
 		isPending: false,
 		error: null,
-	} ) ),
-} ) );
-
-jest.mock( '../../../app/analytics', () => ( {
-	useAnalytics: jest.fn( () => ( {
-		recordTracksEvent: mockRecordTracksEvent,
 	} ) ),
 } ) );
 
@@ -172,7 +165,7 @@ describe( 'StagingSiteDeleteModal', () => {
 				error: null,
 			} );
 
-			renderModal( mockStagingSite );
+			const { recordTracksEvent } = renderModal( mockStagingSite );
 
 			await user.click( getButton( 'Delete staging site' ) );
 
@@ -180,7 +173,7 @@ describe( 'StagingSiteDeleteModal', () => {
 				type: 'snackbar',
 			} );
 
-			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_hosting_configuration_staging_site_delete_failure'
 			);
 		} );
@@ -241,7 +234,7 @@ describe( 'StagingSiteDeleteModal', () => {
 			} );
 
 			const mockOnClose = jest.fn();
-			renderModal( mockStagingSite, mockOnClose );
+			const { recordTracksEvent } = renderModal( mockStagingSite, mockOnClose );
 
 			await user.click( getButton( 'Delete staging site' ) );
 
@@ -257,7 +250,7 @@ describe( 'StagingSiteDeleteModal', () => {
 				params: { siteSlug: 'production-site' },
 			} );
 
-			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_hosting_configuration_staging_site_delete_success'
 			);
 		} );

--- a/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
@@ -52,12 +52,6 @@ jest.mock( '../../../../data/activity-log/use-rewindable-activity-log-query', ()
 	} ) )
 );
 
-jest.mock( '../../../app/analytics', () => ( {
-	useAnalytics: () => ( {
-		recordTracksEvent: jest.fn(),
-	} ),
-} ) );
-
 jest.mock( '../../../app/locale', () => ( {
 	useLocale: () => 'en',
 } ) );

--- a/client/dashboard/utils/test/site-plan.ts
+++ b/client/dashboard/utils/test/site-plan.ts
@@ -1,0 +1,23 @@
+import { getSitePlanDisplayName } from '../site-plan';
+import type { Site } from '@automattic/api-core';
+
+describe( 'getSitePlanDisplayName', () => {
+	test( 'for staging sites, it renders "Staging Site"', () => {
+		const site = {
+			is_wpcom_staging_site: true,
+		} as Site;
+		expect( getSitePlanDisplayName( site ) ).toBe( 'Staging Site' );
+	} );
+
+	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the plan name', () => {
+		const site = {
+			is_wpcom_atomic: false,
+			jetpack_connection: true,
+			jetpack: true,
+			plan: {
+				product_name_short: 'Free',
+			},
+		} as Site;
+		expect( getSitePlanDisplayName( site ) ).toBe( 'Free' );
+	} );
+} );

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -7,15 +7,28 @@ import type {
 	DashboardFilters,
 } from './types';
 
+/**
+ * Fetches the site list in a format appropriate for the multi-site dashboard.
+ * Regardless of the fields requested in `params`, `blog_id` and `slug` will
+ * always be included in the response. TypeScript logic is easier to deal with
+ * when we know that they will be present.
+ * @param site_types - Types of sites to fetch.
+ * @param params - Parameters for fetching the site list.
+ * @returns A promise that resolves to the dashboard site list response.
+ */
 export async function fetchDashboardSiteList(
 	site_types: FetchSiteTypes,
-	{ fields, ...params }: FetchDashboardSiteListParams = {}
+	params: FetchDashboardSiteListParams = {}
 ): Promise< DashboardSiteListResponse > {
+	const fields = new Set( params.fields ?? [] );
+	fields.add( 'blog_id' );
+	fields.add( 'slug' );
+
 	return wpcom.req.get(
 		{ path: '/dashboard/site-list', apiNamespace: 'wpcom/v2' },
 		{
 			...params,
-			fields: fields?.join( ',' ),
+			fields: [ ...fields ].join( ',' ),
 			filters: {
 				site_types: site_types !== 'all' ? site_types : undefined,
 			},

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -1,35 +1,38 @@
-export interface SiteProfileSite {
-	blog_id?: number;
-	url?: string;
-	blogname?: string;
-	stats_visitors?: {
-		day: number;
-		week: number;
-		month: number;
-	};
+export interface DashboardSiteListSite {
+	badge?: null | 'staging' | 'trial' | 'p2';
+	blog_id: number; // Site ID is always fetched
+	deleted?: boolean;
 	has_backup?: boolean;
-	site_icon?: null | {
+	name?: string;
+	plan?: {
+		product_id: number;
+		product_name_short: string;
+	};
+	private?: boolean;
+	icon?: null | {
 		ico: string;
 		img: string;
 	};
+	slug: string; // Slug is always fetched
+	visitors?: null | number;
+	total_wpcom_subscribers?: number;
+	url?: { value: string; with_scheme: string };
 	wpcom_status?: {
 		is_staging: boolean;
 		is_coming_soon: boolean;
 		is_redirect: boolean;
 	};
-	private?: boolean;
-	deleted?: boolean;
 }
 
 export interface DashboardSiteListResponse {
-	sites: SiteProfileSite[];
+	sites: DashboardSiteListSite[];
 	total: number;
 }
 
 export interface FetchDashboardSiteListParams {
-	fields?: ( keyof SiteProfileSite )[];
+	fields?: ( keyof DashboardSiteListSite )[];
 	s?: string;
-	sort_by?: keyof SiteProfileSite;
+	sort_by?: keyof DashboardSiteListSite;
 	sort_direction?: 'asc' | 'desc';
 	page?: number;
 	per_page?: number;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-869
Related backend change 196124-ghe-Automattic/wpcom

## Proposed Changes

This PR changes the approach dramatically. Because this is behind a feature flag, we need a way to ship both data fetching methods. The previous approach was to massage the site profile data into a fake `Site` object and then to reuse the exact same dataview component.

This is no longer going to work because there is a lot of logic going on inside each dataview cell. Logic that is not compatible with how we will fetch data from elastic search. E.g. rather than using client-side logic within a cell to calculate a site's display URL, that logic is now on the backend and the dataview can render it directly.

Unfortunately this means duplicating a lot of code 😢 There are two field list definitions, two dataview elements, and two versions of many field components. I have appended `ES` to the end of the elastic-search variants. It is unfortunate.

All this data comes straight from Elastic Search 😮 

<img width="1230" alt="CleanShot 2025-11-19 at 21 41 54@2x" src="https://github.com/user-attachments/assets/14e008a7-c4c6-4e55-a694-671002d6938d" />

The 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It is part of the effort to bring ES to the site list DOTMSD-869. In particular the reasoning behind this particular PR is to implement enough features that we can render a default site list, before the user makes any customisations to the dataview settings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Can be tested by applying this patch to your sandbox 196124-ghe-Automattic/wpcom

Add the `?flags=dashboard/v2/es-site-list` flag to your URL.

It is only working with the default view config at the moment. You should wipe out any persisted dataview preferences before testing.

After loading the page try paging through the site list. We all have a lot of sites, and this is a good way to test some of the fallback logic.

### Known issues

- sorting or searching by site name is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?