### PR TITLE
Update magic login footer text to prevent wrapping

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -63,7 +63,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the email? Check spam, or {{button}}resend the email{{/button}}",
+						"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}.",
 						{
 							components: {
 								button: (
@@ -78,7 +78,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 					) }
 				</p>
 				<p>
-					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}', {
+					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}.', {
 						components: {
 							link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
 						},

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -63,7 +63,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the code? Check your spam folder or {{button}}resend the email{{/button}}",
+						"Didn't get the email? Check spam, or {{button}}resend the email{{/button}}",
 						{
 							components: {
 								button: (

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -63,7 +63,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}.",
+						"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
 						{
 							components: {
 								button: (
@@ -73,16 +73,10 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 										onClick={ onResendEmail }
 									/>
 								),
+								link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
 							},
 						}
 					) }
-				</p>
-				<p>
-					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}.', {
-						components: {
-							link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
-						},
-					} ) }
 				</p>
 			</div>
 		</div>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -113,10 +113,6 @@
 	.magic-login__log-in-link {
 		color: var( --studio-jetpack-green-60, #007117 );
 	}
-
-	> p {
-		margin-bottom: 4px;
-	}
 }
 
 .layout.is-wpcom-magic-login {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -115,7 +115,6 @@
 	}
 
 	> p {
-		text-wrap: balance;
 		margin-bottom: 4px;
 	}
 }

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -115,6 +115,7 @@
 	}
 
 	> p {
+		text-wrap: balance;
 		margin-bottom: 4px;
 	}
 }

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -251,7 +251,7 @@ const VerifyLoginCode = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the code? Check your spam folder or {{button}}resend the email{{/button}}",
+						"Didn't get the code? Check spam, or {{button}}resend the email{{/button}}",
 						{
 							components: {
 								button: (

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -251,7 +251,7 @@ const VerifyLoginCode = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the code? Check spam, or {{button}}resend the email{{/button}}",
+						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}.",
 						{
 							components: {
 								button: (
@@ -267,7 +267,7 @@ const VerifyLoginCode = ( {
 					) }
 				</p>
 				<p>
-					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}', {
+					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}.', {
 						components: {
 							link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
 						},

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -251,7 +251,7 @@ const VerifyLoginCode = ( {
 			<div className="magic-login__successfully-jetpack-actions">
 				<p>
 					{ translate(
-						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}.",
+						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
 						{
 							components: {
 								button: (
@@ -262,16 +262,10 @@ const VerifyLoginCode = ( {
 										disabled={ isRedirecting }
 									/>
 								),
+								link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
 							},
 						}
 					) }
-				</p>
-				<p>
-					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}.', {
-						components: {
-							link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
-						},
-					} ) }
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DSGCOM-153/login-magic-code-on-confirm-page-update-footer-to-a-tertiary-resend

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-153/login-magic-code-on-confirm-page-update-footer-to-a-tertiary-resend

## Proposed Changes

* Updated footer text on magic login confirmation pages to match Figma designs. A single line isntead of two separate lines.
* Updated magic code verification page to use "Didn't get the code?" (semantically correct for users entering the code)
* Updated magic link confirmation page to use "Didn't get the email?" (semantically correct for users waiting for the email)
* Added comma before "or" in both footer texts for better readability

| Before | After |
|--------|--------|
| <img width="600" alt="Screenshot 2025-11-14 at 2 00 41 PM" src="https://github.com/user-attachments/assets/fbdd7339-d739-4b46-82ea-1bd8cddaaf07" /> | <img width="600" alt="Screenshot 2025-11-17 at 5 59 00 PM" src="https://github.com/user-attachments/assets/bc5fd6db-843c-432c-b1c9-7a4f54554525" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The footer text on magic login confirmation pages needed to be updated to match the Figma designs
* The original text "Check your spam folder" was too long and wrapped across 3 lines on desktop, creating a poor visual experience
* We reworked the text to be more concise ("Check spam") so it fits on 2 lines without requiring the form to be wider
* This improves the visual layout and ensures consistent messaging across both magic link and magic code flows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/log-in/link` and submit the form with an email address (e.g., `foo@bar.com`)
2. Verify the confirmation page shows: "Didn't get the email? You might want to double check if the email address is associated with your account, or reset your password."
3. Navigate to `/log-in/jetpack/link` and submit the form with an email address
4. Verify the code verification page shows: "Didn't get the code? Check spam, or resend the email" (should fit on 2 lines)
5. Verify the second line shows: "Wrong email or account? Use a different account"
6. Check that the footer text doesn't wrap to 3 lines on desktop viewport sizes
7. Test on mobile to ensure text remains readable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
