### PR TITLE
Allow utf8 characters in the checkout contact form too

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -7,7 +7,7 @@ import {
 import { Notice } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize, LocalizeProps } from 'i18n-calypso';
-import { camelCase, deburr } from 'lodash';
+import { camelCase } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainCountries from 'calypso/components/data/query-countries/domains';
@@ -224,7 +224,7 @@ export class ManagedContactDetailsFormFields extends Component<
 		// Strip leading and trailing whitespace
 		const updatedValue =
 			this.props.contactDetails[ camelCase( name ) as keyof DomainContactDetailsData ];
-		const sanitizedValue = deburr( typeof updatedValue === 'string' ? updatedValue.trim() : '' );
+		const sanitizedValue = typeof updatedValue === 'string' ? updatedValue.trim() : '';
 		this.handleFieldChange( name, sanitizedValue );
 	};
 


### PR DESCRIPTION
Turns out that we removed the `deburr` call for the contact form in 183562-ghe-Automattic/wpcom but we didn't do that in the checkout. So let's remove it here too

Part of [DOMENG-199: .de domains and UTF-8 characters](https://linear.app/a8c/issue/DOMENG-199/de-domains-and-utf-8-characters)

## Proposed Changes

* Remove the `deburr` function call that sanitizes all the field in the contact form for the checkout

## Why are these changes being made?

* We want to allow customers to enter utf8 characters in the contact form for domains

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a .de domain in the checkout and make sure that you can enter `ß` or `ä` in the contact fields

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?