### PR TITLE
Plugins redesign: Fix Server Side Rendering for the Dot Pager

### DIFF
--- a/packages/components/src/swipeable/index.js
+++ b/packages/components/src/swipeable/index.js
@@ -265,6 +265,9 @@ export const Swipeable = ( {
 	);
 
 	const getTouchEvents = useCallback( () => {
+		if ( typeof document === 'undefined' ) {
+			return null;
+		}
 		if ( 'onpointerup' in document ) {
 			return {
 				onPointerDown: handleDragStart,

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -39,7 +39,8 @@
 		"debug": "^4.4.1",
 		"hash.js": "^1.1.7",
 		"lru": "^3.1.0",
-		"tannin": "^1.2.0"
+		"tannin": "^1.2.0",
+		"use-subscription": "1.11.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -39,8 +39,7 @@
 		"debug": "^4.4.1",
 		"hash.js": "^1.1.7",
 		"lru": "^3.1.0",
-		"tannin": "^1.2.0",
-		"use-subscription": "1.11.0"
+		"tannin": "^1.2.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/i18n-calypso/src/rtl.js
+++ b/packages/i18n-calypso/src/rtl.js
@@ -1,24 +1,14 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { forwardRef, useContext, useMemo } from 'react';
-import { useSubscription } from 'use-subscription';
+import { forwardRef, useCallback, useContext, useSyncExternalStore } from 'react';
 import I18NContext from './context';
 
 export function useRtl() {
 	const i18n = useContext( I18NContext );
-	// Subscription object (adapter) for the `useSubscription` hook
-	const RtlSubscription = useMemo(
-		() => ( {
-			getCurrentValue() {
-				return i18n.isRtl();
-			},
-			subscribe( callback ) {
-				return i18n.subscribe( callback );
-			},
-		} ),
-		[ i18n ]
-	);
 
-	return useSubscription( RtlSubscription );
+	const getSnapshot = useCallback( () => i18n.isRtl(), [ i18n ] );
+	const subscribe = useCallback( ( callback ) => i18n.subscribe( callback ), [ i18n ] );
+
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
 }
 
 export const withRtl = createHigherOrderComponent(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-258](https://linear.app/a8c/issue/DOTDEV-258/implement-carousel-for-the-discovery-plugins-lists)

## Proposed Changes

* adds a missing check for the `document` element
* replaces the `use-subscription` module, which doesn't work server-side, with the native React equivalent that does

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed to implement the Plugins redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Log out
* Run the calypso build using the `markerplace-redesign` feature flag: `ENABLE_FEATURES=marketplace-redesign yarn start`
* Disable JS
* Go to `http://calypso.localhost:3000/plugins` and `http://calypso.localhost:3000/ar/plugins`
* The pages should be rendered and the carousel arrows show point in the correct directions

| LTR | RTL |
|--------|--------|
| <img width="1417" height="1223" alt="Screenshot 2025-11-14 at 16 00 18" src="https://github.com/user-attachments/assets/98e44d86-295a-4631-a860-c4a88ecd691d" /> | <img width="1412" height="1221" alt="Screenshot 2025-11-14 at 15 59 47" src="https://github.com/user-attachments/assets/e54c7071-6cbe-4834-9be5-d0d6b0b4dc04" /> | 





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
