### PR TITLE
MSD: Fix purchase settings page for removed subscriptions

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1059,8 +1059,13 @@ export default function PurchaseSettings() {
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const upgradeUrl = getUpgradeUrl( purchase );
-	const willRenew = Boolean( purchase.renew_date && ! isExpiring( purchase ) );
+	const willRenew = Boolean(
+		! isExpired( purchase ) && purchase.renew_date && ! isExpiring( purchase )
+	);
 	const expiryDateTitle = ( () => {
+		if ( isExpired( purchase ) ) {
+			return __( 'Expired' );
+		}
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
 			return __( 'Paid until' );
 		}
@@ -1124,6 +1129,9 @@ export default function PurchaseSettings() {
 							}
 							if ( willRenew ) {
 								return formattedRenewal;
+							}
+							if ( purchase.subscription_status !== 'active' ) {
+								return __( 'Inactive' );
 							}
 							return formattedExpiry;
 						} )() }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1178,11 +1178,15 @@ export default function PurchaseSettings() {
 						}
 					/>
 				</Grid>
-				{ site && <WPComResourceMeters purchase={ purchase } site={ site } /> }
+				{ site && purchase.subscription_status === 'active' && (
+					<WPComResourceMeters purchase={ purchase } site={ site } />
+				) }
 				{ isWpcomFlexSubscription( purchase ) && (
 					<BillingFlexUsageCard purchaseId={ purchase.ID } />
 				) }
-				<ManageSubscriptionCard purchase={ purchase } />
+				{ purchase.subscription_status === 'active' && (
+					<ManageSubscriptionCard purchase={ purchase } />
+				) }
 				<PurchaseSettingsActions purchase={ purchase } />
 			</VStack>
 		</PageLayout>

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -32,6 +32,9 @@ export function shouldShowOtherRenewablePurchasesNotice(
 	if ( ! purchase.site_slug ) {
 		return false;
 	}
+	if ( isExpired( purchase ) ) {
+		return false;
+	}
 
 	// For purchases included with a plan, use the plan purchase instead
 	const purchaseIsIncludedInPlan = Boolean(

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -10,6 +10,14 @@ import type { Purchase } from '@automattic/api-core';
  * Used to determine if we should render RenewNoticeAction.
  */
 export function shouldShowRenewNoticeAction( purchase: Purchase ): boolean {
+	// If the purchase is fully removed, do not show any actions. Such a
+	// subscription cannot be renewed; it would have to be purchased again.
+	// However, a purchase can be expired without being removed, and those
+	// purchases can be renewed so we want to allow that case.
+	if ( purchase.subscription_status !== 'active' ) {
+		return false;
+	}
+
 	const shouldAddPaymentSourceInsteadOfRenewingNow =
 		isCloseToExpiration( purchase ) ||
 		purchase.bill_period_days === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -116,8 +116,25 @@ export interface Purchase {
 	can_disable_auto_renew: boolean;
 	can_reenable_auto_renewal: boolean;
 	async_pending_payment_block_is_set: boolean;
+
+	/**
+	 * Similar to `is_renewable` except that this determines if the user is
+	 * allowed to manually renew this subscription right now, whereas
+	 * `is_renewable` only determines if the subscription is the kind of
+	 * subscription that can be manually renewed.
+	 */
 	can_explicit_renew: boolean;
+
+	/**
+	 * If this upgrade is a plan and its domain credit was used to purchase a
+	 * domain registration, and the plan is within its refund period, then
+	 * `cost_to_unbundle_display` will be the formatted amount of the amount that
+	 * would be withheld to keep the domain if the plan is cancelled.
+	 *
+	 * If there is nothing that would be withheld, this will be null.
+	 */
 	cost_to_unbundle_display: undefined | string;
+
 	price_text: string;
 	price_tier_list: Array< PriceTierEntry >;
 	currency_code: string;
@@ -189,7 +206,16 @@ export interface Purchase {
 	is_locked: boolean;
 	is_plan: boolean;
 	is_rechargable: boolean;
+
+	/**
+	 * Determine if this is a kind of subscription that can currently be manually
+	 * renewed by the user, even if it cannot be renewed by the user right now.
+	 *
+	 * `can_explicit_renew` instead checks if the subscription can be manually
+	 * renewed right now.
+	 */
 	is_renewable: boolean;
+
 	is_renewal: boolean;
 	is_titan_mail_product: boolean;
 	is_woo_express_trial: boolean;
@@ -276,7 +302,26 @@ export interface Purchase {
 	blog_id: number;
 
 	blogname: string;
+
+	/**
+	 * The domain of the purchase's site. Sites can have multiple domains but
+	 * this one will usually be the "cannonical" one as far as the user-facing
+	 * domain, with a few caveats.
+	 *
+	 * If the site has a domain mapping or a custom domain registration, the
+	 * primary one will be shown here.
+	 *
+	 * Note that if the domain name includes a path (eg: 'example.com/blog'), it
+	 * will be included in this value!!
+	 *
+	 * If the site has a site redirect active, this will be the *.wordpress.com
+	 * subdomain.
+	 *
+	 * If there is an active Jetpack site using a domain that is mapped to the
+	 * given site, this will be the *.wordpress.com subdomain.
+	 */
 	site_slug: string;
+
 	subscribed_date: string;
 	subscription_status: 'active' | 'inactive';
 	renewal_price_tier_usage_quantity: number | undefined | null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1334/msd-purchase-settings-page-for-removed-purchases-sometimes-does-not

## Proposed Changes

This PR modifies the purchase settings page in the Multi Site Dashboard to fix the display for removed subscriptions.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1503" height="903" alt="Screenshot 2025-11-13 at 6 26 56 PM" src="https://github.com/user-attachments/assets/de3d6687-38db-4953-a278-ff66e2c3d27a" /> | <img width="1505" height="900" alt="Screenshot 2025-11-14 at 12 04 27 PM" src="https://github.com/user-attachments/assets/eb8846a4-01a3-4d58-a894-8b2e984faa83" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The purchase settings page in the Multi Site Dashboard is designed to be shown even for removed subscriptions – something that the calypso purchase settings page, from which this was copied, was never designed to do. This is because it fetches subscriptions by ID rather than finding them in the list of active subscriptions. So if you visit the purchase settings page for a subscription that's been removed, you'll see a notice to that effect and some options rather than being silently redirected to the purchase list page.

Although the purchase list page still does not include removed subscriptions so a direct link is the main way to end up here, when you cancel a subscription you are redirected to this page so it should display accurate information.

Currently, it displays confusing information for removed subscriptions. Even though there is some affordance for _expired_ subscriptions, a subscription can be expired without being removed. Expired subscriptions can usually still be renewed, for example, and their features are often still active. Removed subscriptions are totally disabled, their features removed, and they cannot be renewed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the subscription list at http://calypso.localhost:3000/v2/me/billing/purchases
- Click to select a subscription that you are going to remove.
- Since the removal flow is not yet hooked up to the buttons, append `/cancel` to the URL.
- Complete the cancellation flow.
- Verify you are returned to the purchase page and that it is clear the purchase has been removed.
