### PR TITLE
Reader: Add missing subtext to Latest and Tags tabs

### DIFF
--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -12,6 +12,8 @@ import {
 	REDDIT_TAB,
 	RECOMMENDED_TAB,
 	FRESHLY_PRESSED_TAB,
+	TAGS_TAB,
+	LATEST_TAB,
 } from '../../helper';
 
 export interface DiscoverHeaderAndNavigationProps {
@@ -39,6 +41,13 @@ export default function DiscoverHeaderAndNavigation(
 				'Fresh voices, fresh views. Explore first-time posts from new bloggers.'
 			);
 			break;
+		case TAGS_TAB:
+			subHeaderText = fixMe( {
+				text: 'Browse posts by popular tags',
+				newCopy: translate( 'Browse posts by popular tags' ),
+				oldCopy: '', // No previous translation available.
+			} );
+			break;
 		case ADD_NEW_TAB:
 			subHeaderText = translate( 'Subscribe to new blogs, newsletters, and RSS feeds.' );
 			break;
@@ -46,15 +55,16 @@ export default function DiscoverHeaderAndNavigation(
 			subHeaderText = translate( 'Follow your favorite subreddits inside the Reader.' );
 			break;
 		case RECOMMENDED_TAB:
+			subHeaderText = translate( 'Explore popular blogs that inspire, educate, and entertain.' );
+			break;
+		case LATEST_TAB:
 			subHeaderText = fixMe( {
-				text: 'Explore popular blogs that inspire, educate, and entertain.',
-				newCopy: translate( 'Explore popular blogs that inspire, educate, and entertain.' ),
-				oldCopy: translate( 'Explore %s blogs that inspire, educate, and entertain.', {
-					args: [ 'popular' ],
-					comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
-				} ),
+				text: 'Explore recent posts related to the tags you follow.',
+				newCopy: translate( 'Explore recent posts related to the tags you follow.' ),
+				oldCopy: '', // No previous translation available.
 			} );
 			break;
+
 		case FRESHLY_PRESSED_TAB:
 			subHeaderText = translate( "Our team's favorite blog posts." );
 			break;

--- a/client/reader/discover/helper/index.ts
+++ b/client/reader/discover/helper/index.ts
@@ -7,6 +7,7 @@ export const LATEST_TAB = 'latest';
 export const FIRST_POSTS_TAB = 'firstposts';
 export const ADD_NEW_TAB = 'add-new';
 export const REDDIT_TAB = 'reddit';
+export const TAGS_TAB = 'tags';
 
 /**
  * Filters tags data and returns the tags intended to be loaded by the discover pages recommended


### PR DESCRIPTION
closes CML-1045

## Proposed Changes
- Add a subheader text to the `Tags` tab
- Add a subheader text to the `Latest` tab


## Why are these changes being made?
Explain better the tabs' content.

## Testing Instructions
- Go to the `/discover/tags?selectedTag=dailyprompt` and check if you can see the subheader
- Go to `/discover/latest` and check if you can see the subheader



<img width="2166" height="1870" alt="CleanShot 2025-11-14 at 18 20 44@2x" src="https://github.com/user-attachments/assets/c93f215a-bab7-4859-bed1-f709ea5ce993" />
<img width="2164" height="1870" alt="CleanShot 2025-11-14 at 18 20 40@2x" src="https://github.com/user-attachments/assets/9f998f62-961d-4843-a23f-59ddfc21fe3e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
