### PR TITLE
Fix mobile reader links in dark mode

### DIFF
--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -2,12 +2,18 @@
 // Adding styles here will only affect the apps.
 //
 @import "shared/utils";
-
+@import '@automattic/calypso-color-schemes';
 @import "client/blocks/reader-full-post/content";
 
 @media (prefers-color-scheme: dark) {
 	.reader-full-post__story-content .jetpack-blogging-prompt .jetpack-blogging-prompt__label::before {
 		// stylelint-disable-next-line function-url-quotes
 		background-image: url("data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m12.3438 17.3438h-4.68755c-.08594 0-.15625.0703-.15625.1562v.625c0 .3457.2793.625.625.625h3.75c.3457 0 .625-.2793.625-.625v-.625c0-.0859-.0703-.1562-.1562-.1562zm-2.3438-16.0938c-3.53711 0-6.40625 2.86914-6.40625 6.40625 0 2.37105 1.28906 4.44145 3.20313 5.54885v2.2637c0 .3457.27929.625.625.625h5.15622c.3457 0 .625-.2793.625-.625v-2.2637c1.9141-1.1074 3.2032-3.1778 3.2032-5.54885 0-3.53711-2.8692-6.40625-6.4063-6.40625zm2.498 10.7383-.7011.4062v2.293h-3.59377v-2.293l-.70118-.4062c-1.53711-.8887-2.50195-2.52541-2.50195-4.33205 0-2.76172 2.23828-5 5-5 2.7617 0 5 2.23828 5 5 0 1.80664-.9648 3.44335-2.502 4.33205z' fill='%23fff'/%3E%3C/svg%3E");
+	}
+
+	.reader-full-post.reader-full-post__story-content {
+		a {
+			color: var(--studio-jetpack-green-50);
+		}
 	}
 }

--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -13,7 +13,7 @@
 
 	.reader-full-post.reader-full-post__story-content {
 		a {
-			color: var(--studio-jetpack-green-50);
+			color: var(--studio-jetpack-green-20);
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Makes the mobile reader links stand out more in dark mode.

<table>
<tr>
<th>Before</th>
<th>After</th>
<tr>
<td>
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-14 at 11 46 56" src="https://github.com/user-attachments/assets/2de8db66-42b8-4346-aa0e-e95f49abebbd" />
</td>

<td>
<img width="300" alt="simulator_screenshot_C29CC015-BF31-4D13-9E6C-0B4E2864F04A" src="https://github.com/user-attachments/assets/e10be227-94f1-4ace-bfef-0defd36b07d2" />
</td>
</tr>
</table>

## Why are these changes being made?
Improves visibility


## Testing Instructions
You can modify the apps to pull from a calypso dev build, but this is a low-risk change so there's probably no testing strictly required.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
