### PR TITLE
Reader: Remove layout shift for tabs that do not have a scrollbar

### DIFF
--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -70,6 +70,9 @@
 
 	&.is-group-reader .layout__content .layout__primary > div {
 		overflow-y: auto;
+		&:has( > .main) {
+			scrollbar-gutter: stable;
+		}
 	}
 
 	.tags__main {


### PR DESCRIPTION

Closes CML-1048

## Proposed Changes

* Remove lateral layout shift when the tab do not have a scroll bar

## Why are these changes being made?
 Layout shifts are harmful to the user experience because they break visual stability, cause users to lose their reading position, and can lead to mis-clicks. 

### Before

https://github.com/user-attachments/assets/890ebde7-d507-47ac-8e7b-454db0924c66

### After 

https://github.com/user-attachments/assets/0568cafe-3cf2-4a1e-b3dc-e30b6572ca30



## Testing Instructions
* Starting at URL: /discover
* Click the Recommended tab
* Then click on the Reddit tab and check that there is a slight lateral layout shift.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
