### PR TITLE
Reader: Remove react warning "React does not recognize prop message from infinite list: 

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -3,6 +3,7 @@
 
 import page from '@automattic/calypso-router';
 import debugFactory from 'debug';
+import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import ReactDom from 'react-dom';
@@ -433,7 +434,7 @@ export default class InfiniteList extends Component {
 		}
 
 		return (
-			<div { ...propsToTransfer }>
+			<div { ...omit( propsToTransfer, 'selectedItem' ) }>
 				<div
 					ref={ this.topPlaceholderRef }
 					className={ spacerClassName }


### PR DESCRIPTION




## Proposed Changes
* Fix the React warning by not allowing the infinite list component to add an invalid HTML attribute in a div. 

### WHY
Nowadays, React triggers a warning (only in dev mode) related to the use of a non-HTML attribute in an HTML element.
This PR aims to fix it, preventing the infinite list component from adding a `selectedItem` attribute during the render.
Removing warning is essential to ensure we can further upgrade to React 18. 

<img width="2808" height="860" alt="CleanShot 2025-11-14 at 19 41 55@2x" src="https://github.com/user-attachments/assets/61b29fdd-a792-40ba-b1a0-f8d75fc36125" />



## Testing Instructions
* Run the trunk branch in your local environment
* Go to `http://calypso.localhost:3000/discover/recommended` 
* Check that there is a Warning above
* Go to this branch and reload the page
* Check that the related warning is not triggered anymore. 

<img width="2808" height="860" alt="CleanShot 2025-11-14 at 19 41 55@2x" src="https://github.com/user-attachments/assets/ac7a7171-4742-4ab6-a202-d7aeb36ff55f" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
