### PR TITLE
MSD: Fix domain "one thing better" form in cancel flow

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -317,7 +317,7 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 			}
 
 			// For plan cancellations, require a valid selection from the adventure dropdown
-			if ( ! isNextAdventureValid ) {
+			if ( purchase.is_plan && ! isNextAdventureValid ) {
 				return false;
 			}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1328/msd-the-one-thing-we-could-have-done-better-form-in-the-cancel-flow

## Proposed Changes

This PR disables one of the submission guard on the "Next Adventure Step" of the Multi Site Dashboard cancellation flow if the thing being canceled is not a plan. The guard would disable the submit button if the "Where is your next adventure taking you?" question was not completed, but that question is only displayed when the thing being canceled is a plan, so we need to skip the validation when the question does not exist.

Before             |  After
:-------------------------:|:-------------------------:
<img width="725" height="387" alt="Screenshot 2025-11-14 at 4 58 05 PM" src="https://github.com/user-attachments/assets/332164c5-57c3-4b03-8600-3d9c5e3add50" /> | <img width="707" height="387" alt="Screenshot 2025-11-14 at 4 57 08 PM" src="https://github.com/user-attachments/assets/6feccbc3-e347-43d4-a91a-b5d0232687f9" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://calypso.localhost:3000/v2/me/billing/purchases
- Click a domain registration purchase.
- Because it's not wired yet to the buttons, append `/cancel` to the URL.
- Click through the first cancel question (check the two boxes).
- Click through the second cancel question (select any option).
- Verify that you can see the Submit button in the "Where is your next adventure taking you?" page.