### PR TITLE
MSD: Fix isValid in NextAdventureStep cancel question

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/next-adventure-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/next-adventure-step.tsx
@@ -89,7 +89,7 @@ export default function NextAdventureStep( props: Props ) {
 						options={ options }
 						onChange={ ( value: string ) => {
 							// For plans, require a selection from the adventure dropdown (not the placeholder)
-							const isValid = nextAdventure !== '';
+							const isValid = value !== '';
 							onValidationChange?.( isValid );
 							onDetailsChange( '' );
 							setNextAdventure( value );


### PR DESCRIPTION
Fixes SHILL-1337

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR fixes a small bug in the `NextAdventureStep` of the Multi Site Dashboard cancel flow. There's a validation check to make sure that the answer to the "Where is your next adventure taking you?" question (for plans only) which needs to reference the variable being set rather than the previous value.

I'm not 100% sure but I think the validation actually sort-of worked anyway but this way it actually works. 

<img width="735" height="556" alt="Screenshot 2025-11-14 at 6 11 52 PM" src="https://github.com/user-attachments/assets/f8c9093d-c727-4f34-824c-6138de5cdc0d" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Honestly, I think the main thing is just to read the logic, but here's how you can get the form to display.

- Visit http://calypso.localhost:3000/v2/me/billing/purchases
- Click a plan purchase.
- Because it's not wired yet to the buttons, append `/cancel` to the URL.
- Click through the first cancel question (check the two boxes).
- Click through the second cancel question (select "Too expensive" and then any of the second answers).
- On the "Where is your next adventure taking you?" page, verify that you see the multiple choice question.
- Select an answer and verify you can submit the form.
