### PR TITLE
MSD Billing: Fix text substitution issue with translation

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -293,7 +293,7 @@ export default function UpsellStep( {
 				>
 					<>
 						{ sprintf(
-							/* Translators: %(plan)s is WordPress.com Personal or another plan */
+							/* translators: %(plan)s is WordPress.com Personal or another plan */
 							__(
 								'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50%% of the cost of your current plan.'
 							),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -292,23 +292,13 @@ export default function UpsellStep( {
 					image={ imgSwitchPlan }
 				>
 					<>
-						{ hasEnTranslation(
-							'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50% of the cost of your current plan.'
-						)
-							? sprintf(
-									/* Translators: %(plan)s is WordPress.com Personal or another plan */
-									__(
-										'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50% of the cost of your current plan.'
-									),
-									{ plan: personalPlanName }
-							  )
-							: sprintf(
-									/* Translators: %(plan)s is WordPress.com Personal or another plan */
-									__(
-										'%(plan)s still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.'
-									),
-									{ plan: personalPlanName }
-							  ) }{ ' ' }
+						{ sprintf(
+							/* Translators: %(plan)s is WordPress.com Personal or another plan */
+							__(
+								'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50%% of the cost of your current plan.'
+							),
+							{ plan: personalPlanName }
+						) }{ ' ' }
 						{ refundAmount &&
 							sprintf(
 								/* translators: %(amount)s is a monetary amount in the form of a refund */


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [SHILL-1305](https://linear.app/a8c/issue/SHILL-1305/hosting-dashboard-cancellation-flow-fix-string-substitution-and-logic)

## Proposed Changes

* Fix a typo.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The string was not being parsed correctly which prevented `sprintf` from replacing the placeholder `%(plan)s`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the dashboard's active purchases page at `/v2/me/billing/purchases` and select "Manage Purchase" for a Premium Plan.
* Append `/cancel` to the end of the url and start cancelling. When asked, choose "too expensive" and "the plan is too expensive.."
* Confirm that you don't see `%(plan)s still gives you access to fast support` but instead see `WordPress.com Premium still gives you access to fast support`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
