### PR TITLE
MSD: Only show if we have records.

### DIFF
--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -191,10 +191,11 @@ function SiteActivityLogsDataViews( {
 		setView( ( next ) => ( { ...next, page: 1 } ) );
 	}, [ dateRangeVersion, setView ] );
 
+	const logData = activityLogData?.activityLogs || [];
 	return (
 		<>
 			<DataViews< Activity >
-				data={ activityLogData?.activityLogs || [] }
+				data={ logData }
 				isLoading={ isFetching }
 				paginationInfo={ paginationInfo }
 				fields={ fields as Field< Activity >[] }
@@ -212,7 +213,7 @@ function SiteActivityLogsDataViews( {
 				children={ hasActivityLogsAccess ? undefined : <DataViews.Layout /> } // showing only the layout when on the free plan.
 			/>
 
-			{ ! hasActivityLogsAccess && ! isFetching && (
+			{ ! hasActivityLogsAccess && ! isFetching && logData.length > 0 && (
 				<HStack alignment="center" className="site-logs-card--activity-callout">
 					<div className="site-logs-card--activity-callout-content">
 						<ActivityLogsCallout siteSlug={ site.slug } />


### PR DESCRIPTION
See context: p1763342512081109-slack-C08JZTRS6NA.

## Proposed Changes

On a new site with no logs we show an upsell banner that suggest users upgrade to remove the "20 free" activity logs restriction. It feels a bit premature to upsell on a feature that user's partially have but haven't seen yet. 

In my opinion, it make sense to only show the upsell banner after a log(s) exists. While we want users to upgrade we want to reduce the number of "gates" we show the user.


### Screenshot
| Before | After |
|--------|--------|
| <img width="1866" height="1924" alt="calypso localhost_3000_v2_sites_abstracting blog_logs_activity (2)" src="https://github.com/user-attachments/assets/68f6b005-e3ed-408f-893e-33e508bd7c8f" /> | <img width="1798" height="1924" alt="calypso localhost_3000_v2_sites_testnewsiteforrecordshow wordpress com_logs_activity (1)" src="https://github.com/user-attachments/assets/63e12d29-d946-4599-b1a0-beccf5a3743c" /> |

Once records exist they'll get:

<img width="1798" height="1924" alt="calypso localhost_3000_v2_sites_testnewsiteforrecordshow wordpress com_logs_activity (2)" src="https://github.com/user-attachments/assets/2255fdd3-a127-47ea-b990-6c755d35b49e" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- On a new free site, check your activity logs, expect to not see a banner.
- Make a site updates (change the name)
- Return to the activity log section, expect to see the banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?