### PR TITLE
Site-level tabs restrictions for garden sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -48,7 +48,7 @@ import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site } from '@automattic/api-core';
@@ -183,6 +183,12 @@ export const siteDeploymentsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'deployments',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 } ).lazy( () =>
 	import( '../../sites/deployments' ).then( ( d ) =>
 		createLazyRoute( 'site-deployments' )( {
@@ -216,6 +222,12 @@ export const siteMonitoringRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'monitoring',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 } ).lazy( () =>
 	import( '../../sites/monitoring' ).then( ( d ) =>
 		createLazyRoute( 'site-monitoring' )( {
@@ -234,6 +246,12 @@ export const siteLogsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'logs',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 } );
 
 export const siteLogsIndexRoute = createRoute( {
@@ -320,6 +338,12 @@ export const siteScanRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'scan',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 } );
 
 export const siteScanIndexRoute = createRoute( {
@@ -388,6 +412,12 @@ export const siteBackupsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'backups',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		// Preload activity log backup-related entries.
@@ -507,6 +537,12 @@ export const sitePerformanceRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'performance',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( isCommerceGarden( site ) ) {
+			throw redirect( { to: `/sites/${ siteSlug }` } );
+		}
+	},
 } ).lazy( () =>
 	import( '../../sites/performance' ).then( ( d ) =>
 		createLazyRoute( 'site-performance' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -44,11 +44,15 @@ import {
 	canViewSiteVisibilitySettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
-import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import {
+	hasHostingFeature,
+	hasPlanFeature,
+	isPlanFeatureAvailable,
+} from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site } from '@automattic/api-core';
@@ -185,7 +189,7 @@ export const siteDeploymentsRoute = createRoute( {
 	path: 'deployments',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.DEPLOYMENT ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -224,7 +228,7 @@ export const siteMonitoringRoute = createRoute( {
 	path: 'monitoring',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.MONITOR ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -248,7 +252,7 @@ export const siteLogsRoute = createRoute( {
 	path: 'logs',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.LOGS ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -340,7 +344,7 @@ export const siteScanRoute = createRoute( {
 	path: 'scan',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.SCAN ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -414,7 +418,7 @@ export const siteBackupsRoute = createRoute( {
 	path: 'backups',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.BACKUPS ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -539,7 +543,7 @@ export const sitePerformanceRoute = createRoute( {
 	path: 'performance',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( isCommerceGarden( site ) ) {
+		if ( ! isPlanFeatureAvailable( site, HostingFeatures.PERFORMANCE ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,12 +1,13 @@
+import { HostingFeatures, type Site } from '@automattic/api-core';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
+import { isPlanFeatureAvailable } from '../../utils/site-features';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { AppConfig, SiteFeatureSupports } from '../../app/context';
-import type { Site } from '@automattic/api-core';
 
 const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof SiteFeatureSupports ) => {
 	return supports.sites && supports.sites[ feature ];
@@ -22,26 +23,6 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
 				</ResponsiveMenu.Item>
-			</ResponsiveMenu>
-		);
-	}
-
-	if ( isCommerceGarden( site ) ) {
-		return (
-			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` }>
-					{ __( 'Overview' ) }
-				</ResponsiveMenu.Item>
-				{ hasAppSupport( supports, 'domains' ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
-						{ __( 'Domains' ) }
-					</ResponsiveMenu.Item>
-				) }
-				{ site.capabilities.manage_options && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
-						{ __( 'Settings' ) }
-					</ResponsiveMenu.Item>
-				) }
 			</ResponsiveMenu>
 		);
 	}
@@ -81,36 +62,42 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>
-			{ hasAppSupport( supports, 'deployments' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
-					{ __( 'Deployments' ) }
-				</ResponsiveMenu.Item>
-			) }
-			{ hasAppSupport( supports, 'performance' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
-					{ __( 'Performance' ) }
-				</ResponsiveMenu.Item>
-			) }
-			{ hasAppSupport( supports, 'monitoring' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
-					{ __( 'Monitoring' ) }
-				</ResponsiveMenu.Item>
-			) }
-			{ hasAppSupport( supports, 'logs' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
-					{ __( 'Logs' ) }
-				</ResponsiveMenu.Item>
-			) }
-			{ hasAppSupport( supports, 'scan' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
-					{ __( 'Scan' ) }
-				</ResponsiveMenu.Item>
-			) }
-			{ hasAppSupport( supports, 'backups' ) && (
-				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
-					{ __( 'Backups' ) }
-				</ResponsiveMenu.Item>
-			) }
+			{ hasAppSupport( supports, 'deployments' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.DEPLOYMENT ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
+						{ __( 'Deployments' ) }
+					</ResponsiveMenu.Item>
+				) }
+			{ hasAppSupport( supports, 'performance' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.PERFORMANCE ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
+						{ __( 'Performance' ) }
+					</ResponsiveMenu.Item>
+				) }
+			{ hasAppSupport( supports, 'monitoring' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.MONITOR ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
+						{ __( 'Monitoring' ) }
+					</ResponsiveMenu.Item>
+				) }
+			{ hasAppSupport( supports, 'logs' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.LOGS ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
+						{ __( 'Logs' ) }
+					</ResponsiveMenu.Item>
+				) }
+			{ hasAppSupport( supports, 'scan' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.SCAN ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
+						{ __( 'Scan' ) }
+					</ResponsiveMenu.Item>
+				) }
+			{ hasAppSupport( supports, 'backups' ) &&
+				isPlanFeatureAvailable( site, HostingFeatures.BACKUPS ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
+						{ __( 'Backups' ) }
+					</ResponsiveMenu.Item>
+				) }
 			{ hasAppSupport( supports, 'domains' ) && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 					{ __( 'Domains' ) }

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from '../../app/context';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { AppConfig, SiteFeatureSupports } from '../../app/context';
 import type { Site } from '@automattic/api-core';
 
@@ -22,6 +22,26 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
 				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
+		);
+	}
+
+	if ( isCommerceGarden( site ) ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` }>
+					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+				{ hasAppSupport( supports, 'domains' ) && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
+						{ __( 'Domains' ) }
+					</ResponsiveMenu.Item>
+				) }
+				{ site.capabilities.manage_options && (
+					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
+						{ __( 'Settings' ) }
+					</ResponsiveMenu.Item>
+				) }
 			</ResponsiveMenu>
 		);
 	}

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -19,6 +19,14 @@ export function hasPlanFeature(
 	return site.plan.features.active.includes( feature );
 }
 
+export function isPlanFeatureAvailable( site: Site, feature: HostingFeatureSlug ) {
+	if ( ! site.plan ) {
+		return false;
+	}
+
+	return !! site.plan.features.available[ feature ];
+}
+
 // Returns whether the plan supports a specific "hosting feature",
 // which is a feature that requires Atomic or self-hosted infrastructure.
 export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -9,6 +9,7 @@ export interface SitePlan {
 	billing_period: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
+		available: Record< string, string[] >;
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

As discussed in pgz0xU-nU-p2, Garden sites only have site-level tabs Overview, Domains, and Settings across all dashboards.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Select a Garden site
* Ensure that only the site-level tabs Overview, Domains, and Settings are available
* Also check for WPCOM and Jetpack-connected sites for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?