### PR TITLE
Fix issue when site.plan.features.available is undefined

### DIFF
--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,13 +1,12 @@
-import { HostingFeatures, type Site } from '@automattic/api-core';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
-import { isPlanFeatureAvailable } from '../../utils/site-features';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { AppConfig, SiteFeatureSupports } from '../../app/context';
+import type { Site } from '@automattic/api-core';
 
 const hasAppSupport = ( supports: AppConfig[ 'supports' ], feature: keyof SiteFeatureSupports ) => {
 	return supports.sites && supports.sites[ feature ];
@@ -22,6 +21,22 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+			</ResponsiveMenu>
+		);
+	}
+
+	if ( isCommerceGarden( site ) ) {
+		return (
+			<ResponsiveMenu label={ __( 'Site Menu' ) } prefix={ <MenuDivider /> }>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
+					{ __( 'Overview' ) }
+				</ResponsiveMenu.Item>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
+					{ __( 'Domains' ) }
+				</ResponsiveMenu.Item>
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
+					{ __( 'Settings' ) }
 				</ResponsiveMenu.Item>
 			</ResponsiveMenu>
 		);
@@ -62,42 +77,36 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
 				{ __( 'Overview' ) }
 			</ResponsiveMenu.Item>
-			{ hasAppSupport( supports, 'deployments' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.DEPLOYMENT ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
-						{ __( 'Deployments' ) }
-					</ResponsiveMenu.Item>
-				) }
-			{ hasAppSupport( supports, 'performance' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.PERFORMANCE ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
-						{ __( 'Performance' ) }
-					</ResponsiveMenu.Item>
-				) }
-			{ hasAppSupport( supports, 'monitoring' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.MONITOR ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
-						{ __( 'Monitoring' ) }
-					</ResponsiveMenu.Item>
-				) }
-			{ hasAppSupport( supports, 'logs' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.LOGS ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
-						{ __( 'Logs' ) }
-					</ResponsiveMenu.Item>
-				) }
-			{ hasAppSupport( supports, 'scan' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.SCAN ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
-						{ __( 'Scan' ) }
-					</ResponsiveMenu.Item>
-				) }
-			{ hasAppSupport( supports, 'backups' ) &&
-				isPlanFeatureAvailable( site, HostingFeatures.BACKUPS ) && (
-					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
-						{ __( 'Backups' ) }
-					</ResponsiveMenu.Item>
-				) }
+			{ hasAppSupport( supports, 'deployments' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
+					{ __( 'Deployments' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'performance' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
+					{ __( 'Performance' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'monitoring' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
+					{ __( 'Monitoring' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'logs' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/logs` }>
+					{ __( 'Logs' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'scan' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/scan` }>
+					{ __( 'Scan' ) }
+				</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'backups' ) && (
+				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/backups` }>
+					{ __( 'Backups' ) }
+				</ResponsiveMenu.Item>
+			) }
 			{ hasAppSupport( supports, 'domains' ) && (
 				<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/domains` }>
 					{ __( 'Domains' ) }

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -24,7 +24,7 @@ export function isPlanFeatureAvailable( site: Site, feature: HostingFeatureSlug 
 		return false;
 	}
 
-	return !! site.plan.features.available[ feature ];
+	return !! site.plan.features.available?.[ feature ];
 }
 
 // Returns whether the plan supports a specific "hosting feature",

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -9,7 +9,7 @@ export interface SitePlan {
 	billing_period: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
-		available: Record< string, string[] >;
+		available?: Record< string, string[] >;
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

Follow-up of #107149. Turn out `site.plan.features.available` is not always defined, so this PR updates the type definition to optional. This is a small PR to quickly fix the undefined error, but there's another issue that needs to be addressed: There will be a delayed rendering of the site-level tabs menu if `site.plan.features.available` is not available on component render. This is more noticeable as a by product of #107149.

This can be reproducible by clicking either Domains or Settings from the Site List DataViews action.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
