### PR TITLE
Woo JPC: Do not use code token type when trying to magic login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -656,7 +656,10 @@ export default connect(
 				redirectTo: stateProps.redirectTo,
 				loginFormFlow: true,
 				showGlobalNotices: false,
-				...( shouldUseMagicCode( { isJetpack: ownProps.isJetpack } ) && { tokenType: 'code' } ),
+				...( shouldUseMagicCode( {
+					isWooJPC: stateProps.isWooJPC,
+					isJetpack: ownProps.isJetpack,
+				} ) && { tokenType: 'code' } ),
 				source: stateProps.isWooJPC ? 'woo-passwordless-jpc' + '-' + get( stateProps, 'from' ) : '',
 				flow:
 					( ownProps.isJetpack && 'jetpack' ) ||

--- a/client/blocks/login/utils/should-use-magic-code.ts
+++ b/client/blocks/login/utils/should-use-magic-code.ts
@@ -5,6 +5,10 @@ type ShouldUseMagicCodeProps = {
 	 * Whether the login is for a Jetpack site.
 	 */
 	isJetpack?: boolean;
+	/**
+	 * Whether the login is for a Woo Jetpack Connection.
+	 */
+	isWooJPC?: boolean;
 };
 
 /**
@@ -12,7 +16,11 @@ type ShouldUseMagicCodeProps = {
  * @param {ShouldUseMagicCodeProps} options
  * @returns {boolean}
  */
-export function shouldUseMagicCode( { isJetpack }: ShouldUseMagicCodeProps ): boolean {
+export function shouldUseMagicCode( { isJetpack, isWooJPC }: ShouldUseMagicCodeProps ): boolean {
+	if ( isWooJPC ) {
+		return false;
+	}
+
 	const isMagicCodeEnabled = config.isEnabled( 'login/use-magic-code' );
 
 	if ( isJetpack && isMagicCodeEnabled ) {


### PR DESCRIPTION
Closes DOTOBRD-347.

## Proposed Changes

The Jetpack connection flow for Woo should always use the magic login through an email link, not a code.

The front-end was forcing the authentication through a magic code (which is not supported on the back-end, hence the empty link reported in the video) using the magic link template because it was not considering Woo JPC (treating every Jetpack connection equally).

This PR changes the token type to `link` instead of `code` when dispatching the front-end request.

On a different note, it's weird to me that we need to declare the magic login type on the front end instead of using a back-end condition.

## Testing Instructions

1. Create a Jurassic Ninja site with Woo preinstalled.
2. Install the Blaze plugin.
3. Click "Connect now" and verify you're in the `https://wordpress.com/jetpack/connect/authorize` page.
4. Copy that address and open it in incognito mode.
5. Try creating an account with an email that's already registered. It should fail. Type the email again in the login page so it sends a magic link. Verify the issue is happening - you get an email with a blank "connect" link just like in the video report.
6. In the login page (`https://wordpress.com/start/account/user-social?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize`), replace the hostname with the Calypso live link from this PR or `calypso.localhost:3000` given you're running it locally.
7. Use the same email so it dispatches the login link to it. This time, verify that you get the correct email with the link. Click it and verify the connection succeeds.