### PR TITLE
Hide the plan upsell for the 100-year domain

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -20,6 +20,7 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 	hasPlan,
+	has100YearDomain,
 	planItem,
 } from 'calypso/lib/cart-values/cart-items';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
@@ -163,6 +164,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );
 	const hasPaidPlan = siteHasPaidPlan( selectedSite );
 	const hasPlanInCart = hasPlan( responseCart );
+	const hasHundredYearDomainInCart = has100YearDomain( responseCart );
 	const dispatch = useDispatch();
 	const upsellProductSlug = PLAN_PERSONAL;
 	const upsellPlan = getPlan( upsellProductSlug );
@@ -183,6 +185,9 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 		return null;
 	}
 	if ( hasPaidPlan || hasPlanInCart ) {
+		return null;
+	}
+	if ( hasHundredYearDomainInCart ) {
 		return null;
 	}
 	if ( ! isRegisteringOrTransferringDomain || ! firstDomainInCart ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOMENG-243

## Proposed Changes

* Hide the Domain + Free plan upsell to Personal for 100-year domains because the domain won't be bundled

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Per product request, the domain won't bundle up, so the discount won't apply

## Testing Instructions

* On a free site
* Get a domain and proceed to checkout
* Select Hundred years from the term dropdown
* The plan upsell "Upgrade and save" should disappear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
