### PR TITLE
MSD: align overview card icon with the title

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -11,6 +11,7 @@ import {
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
 import { isRelativeUrl } from '../../utils/url';
@@ -104,6 +105,47 @@ export default function OverviewCard( {
 		externalLink = link;
 	}
 
+	// Align the icon's leftmost edge with the title.
+	// The visible part of the icon might not start at the leftmost edge of the viewBox,
+	// so we add a negative margin to the icon.
+	const iconRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		if ( ! iconRef.current ) {
+			return;
+		}
+
+		const svg = iconRef.current.querySelector( 'svg' );
+		if ( ! svg ) {
+			return;
+		}
+
+		// Get the viewBox coordinate
+		const viewBox = svg.getAttribute( 'viewBox' );
+		let viewBoxMinX = 0;
+		if ( viewBox ) {
+			const viewBoxValues = viewBox.split( /\s+|,/ );
+			viewBoxMinX = parseFloat( viewBoxValues[ 0 ] ) || 0;
+		}
+
+		// Find the leftmost path edge coordinate
+		const paths = svg.querySelectorAll( 'path' );
+		let minX = Infinity;
+		paths.forEach( ( path ) => {
+			// getBBox is not available in test environments (jsdom)
+			if ( typeof path.getBBox !== 'function' ) {
+				return;
+			}
+			const bbox = path.getBBox();
+			minX = Math.min( minX, bbox.x );
+		} );
+
+		// Move the icon to the left by the offset
+		if ( minX !== Infinity ) {
+			const offset = minX - viewBoxMinX;
+			iconRef.current.style.marginLeft = `-${ offset - 1 }px`;
+		}
+	}, [ icon, isLoading ] );
+
 	const topContent = (
 		<HStack
 			className="dashboard-overview-card__content"
@@ -112,7 +154,7 @@ export default function OverviewCard( {
 		>
 			<VStack spacing={ 4 } style={ { flexGrow: 1 } }>
 				<HStack justify="space-between">
-					<HStack spacing={ 2 } alignment="center" expanded={ false }>
+					<HStack ref={ iconRef } spacing={ 2 } alignment="center" expanded={ false }>
 						{ icon && <Icon className="dashboard-overview-card__icon" icon={ icon } /> }
 						<Text
 							className="dashboard-overview-card__title"

--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -61,13 +61,11 @@
 	}
 
 	.dashboard-overview-card--error & {
-		background-color: color-mix(in srgb, var(--dashboard__background-color-error) 8%, transparent);
 		color: var(--dashboard__background-color-error );
 		fill: var(--dashboard__background-color-error );
 	}
 
 	.dashboard-overview-card--warning & {
-		background-color: color-mix(in srgb, var(--dashboard__background-color-warning) 8%, transparent);
 		color: var(--dashboard__background-color-warning);
 		fill: var(--dashboard__background-color-warning);
 	}


### PR DESCRIPTION
Fixes DOTMSD-801

## Proposed Changes

This PR makes sure that the icon and the title of cards in the Site Overview are left-aligned.

It does that by manually adding a negative margin to the icon. The value is taken by iterating all `<path>`s of the icon's SVG and then taking the leftmost one.

The caveat is that we can no longer show the background color on warning and error intents:

|Before|After|
|-|-|
|<img width="325" height="148" alt="image" src="https://github.com/user-attachments/assets/1afd7f3f-ee18-484b-8d47-284f927f3641" />|<img width="325" height="148" alt="image" src="https://github.com/user-attachments/assets/c05b7b45-17f0-45ae-a1ee-fe5b9c9a18c2" />|
|<img width="325" height="171" alt="image" src="https://github.com/user-attachments/assets/8a8468d3-fde9-43a9-9207-b659a0985211" />|<img width="325" height="170" alt="image" src="https://github.com/user-attachments/assets/794c2f03-976b-4b56-b4d3-8db9423408c8" />|

## Why are these changes being made?

Make the icon and title visually left-aligned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check `/v2/sites/:site` of various sites and verify that the icon and title are now left-aligned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
