### PR TITLE
Freshly Pressed: Enable feature flag

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,6 +96,7 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/quick-post": true,
+		"reader/discover/freshly-pressed": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,6 +126,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/quick-post": true,
+		"reader/discover/freshly-pressed": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -124,6 +124,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/quick-post": true,
+		"reader/discover/freshly-pressed": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,6 +131,7 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/quick-post": true,
+		"reader/discover/freshly-pressed": true,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
Closes CML-1053

## Proposed Changes
* Enable feature flag



## Testing Instructions


- Run `yarn run feature-search  "reader/discover/freshly-pressed" `
- Check that the flags are in the state shown in the image below. 
<img width="1028" height="548" alt="CleanShot 2025-11-17 at 15 22 41@2x" src="https://github.com/user-attachments/assets/3d197b16-09d2-475a-9d43-53e7efbb7196" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
