### PR TITLE
A4A: Use countryOptions so the form sends country codes instead of labels

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
@@ -1,7 +1,7 @@
 import { SearchableDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormSection from 'calypso/a8c-for-agencies/components/form/section';
@@ -123,10 +123,6 @@ export default function ReferHostingForm( {
 
 	const { countryOptions } = useCountriesAndStates();
 
-	const countries = useMemo( () => {
-		return countryOptions.map( ( country ) => country.label );
-	}, [ countryOptions ] );
-
 	const {
 		formData,
 		updateFormData,
@@ -237,7 +233,7 @@ export default function ReferHostingForm( {
 					value={ formData.country }
 					onChange={ ( value: string ) => handleInputChange( 'country', value ) }
 					placeholder={ translate( 'Select country' ) }
-					options={ countries.map( ( country ) => ( { value: country, label: country } ) ) }
+					options={ countryOptions }
 				/>
 
 				<TextField


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1829/add-country-code-country-code-iso2-field-to-hubspot-forms

## Proposed Changes

* Replace the custom label-only list with countryOptions so the form submits country codes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To start submitting the actual country codes, which is what we want to store in the HubSpot form. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your sandbox: 196289-ghe-Automattic/wpcom
* Open the live link
* Go to https://agencies.automattic.com/marketplace/hosting/refer-enterprise-hosting
* Submit the form.
* Check HubSpot Forms → Qualifying Leads submissions and confirm the Country Code (ISO2) field is populated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?