### PR TITLE
change locators due to forms dashboard refactor

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -33,7 +33,7 @@ export class FeedbackInboxPage {
 	 */
 	async clickResponseRowByText( text: string ): Promise< void > {
 		const responseRowLocator = this.page
-			.locator( '.jp-forms__inbox__dataviews .dataviews-view-table__row' )
+			.locator( '.dataviews-view-table__row' )
 			.filter( { hasText: text } )
 			.first();
 		await responseRowLocator.waitFor();
@@ -47,7 +47,7 @@ export class FeedbackInboxPage {
 				await responseRowLocator.click();
 			}
 			await this.page
-				.locator( '.jp-forms__inbox__dataviews .dataviews-view-table__row.is-selected' )
+				.locator( '.dataviews-view-table__row.is-selected' )
 				.filter( { hasText: text } )
 				.waitFor();
 		} else {
@@ -308,7 +308,7 @@ export class FeedbackInboxPage {
 	 */
 	async verifyActionExistsInMenu( text: string, actionName: string ): Promise< void > {
 		const responseRowLocator = this.page
-			.locator( '.jp-forms__inbox__dataviews .dataviews-view-table__row' )
+			.locator( '.dataviews-view-table__row' )
 			.filter( { hasText: text } )
 			.first();
 


### PR DESCRIPTION


## Proposed Changes
This PR addresses locator changes needed after forms dashboard refactor: https://github.com/Automattic/jetpack/pull/45952

## Why are these changes being made?
Because tests were failing do to markup change

## Testing Instructions
Run:

```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"

yarn workspace wp-e2e-tests build && VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/published-content/forms__submissions.ts"
```

See that the tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
