### PR TITLE
SSH Migration: Add Port customization

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-generate-ssh-key.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-generate-ssh-key.ts
@@ -6,6 +6,7 @@ interface GenerateSSHKeyParams {
 	siteId: number;
 	remoteUser: string;
 	remoteHost: string;
+	remotePort: number;
 	remoteDomain: string;
 }
 
@@ -31,6 +32,7 @@ const generateSSHKey = async (
 		const body = {
 			remote_user: params.remoteUser,
 			remote_host: params.remoteHost,
+			remote_port: String( params.remotePort ),
 			remote_domain: remoteDomain,
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-start-ssh-migration.ts
@@ -5,6 +5,7 @@ import wpcom from 'calypso/lib/wp';
 interface StartSSHMigrationParams {
 	siteId: number;
 	remoteHost: string;
+	remotePort: number;
 	remoteUser: string;
 	remoteDomain: string;
 	remotePass?: string;
@@ -43,6 +44,7 @@ const startSSHMigration = async (
 
 		const body = {
 			remote_host: params.remoteHost,
+			remote_port: String( params.remotePort ),
 			remote_user: params.remoteUser,
 			remote_domain: remoteDomain,
 			...optionalFields,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -186,6 +186,7 @@ const SiteMigrationSshShareAccess: StepType< {
 			{
 				siteId,
 				remoteHost: formState.serverAddress,
+				remotePort: formState.port,
 				remoteUser: formState.username,
 				remoteDomain: fromUrl,
 				remotePass: formState.authMethod === 'key' ? '' : formState.password,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -283,6 +283,7 @@ export const useSteps = ( {
 				siteId,
 				remoteUser: formState.username,
 				remoteHost: formState.serverAddress,
+				remotePort: formState.port,
 				remoteDomain: fromUrl,
 			},
 			{
@@ -291,7 +292,14 @@ export const useSteps = ( {
 				},
 			}
 		);
-	}, [ generateSSHKey, siteId, formState.username, formState.serverAddress, fromUrl ] );
+	}, [
+		generateSSHKey,
+		siteId,
+		formState.username,
+		formState.serverAddress,
+		formState.port,
+		fromUrl,
+	] );
 
 	const handleGenerateSSHKey = () => {
 		if ( isTransferring ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15230

## Proposed Changes


Include remote port in SSH migration start request
- Added `remotePort` parameter to `StartSSHMigrationParams` interface
- Modified `startSSHMigration` to send `remote_port` in the request body
- Updated `triggerSSHMigration` to pass `formState.port` when starting migration
- Generating the SSH Key should also send the `remote_port` to the `/ssh-migration/configure` endpoint.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The SSH Migration flow collects the remote port, but we were not sending it to the back-end because the Atomic API didn't support it yet.
* Now that we have the support, we should send the port to the back-end so we can allow the users to customize the remote port.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR to your local environment
- Update the `ENABLED_SSH_HOSTS` constant on the `client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/utils/hosting-provider-validation.ts` file:
```diff
- const ENABLED_SSH_HOSTS: string[] = [ 'ionos', 'ovh-sas', 'bluehost', 'digitalocean', 'hostgator' ];
+ const ENABLED_SSH_HOSTS: string[] = [ 'ionos', 'ovh-sas', 'bluehost', 'digitalocean', 'hostgator', 'hostinger-international-limited' ];
```
- Use the instructions on 196300-ghe-Automattic/wpcom to set up your sandbox
- Navigate to `/setup/site-migration` and input a Hostinger site
- Go through the flow until you reach the `Securely share your access` step
- Now use a site that has the SSH port set to an unusual number
- Ensure that the migration works for both using the SSH Key, and using Username and password.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?