### PR TITLE
MSD Billing: Remove purchases via removePurchase mutation

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -17,6 +17,7 @@ import {
 	hasPurchaseBeenExtendedQuery,
 	siteLatestAtomicTransferQuery,
 	siteFeaturesQuery,
+	removePurchaseMutation,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -54,6 +55,7 @@ import {
 	hasMarketplaceProduct,
 	isAgencyPartnerType,
 	isAkismetProduct,
+	isAkismetTemporarySitePurchase,
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackTemporarySitePurchase,
@@ -153,6 +155,7 @@ export default function CancelPurchase() {
 	const cancelAndRefundPurchaseMutate = useMutation( cancelAndRefundPurchaseMutation() );
 	const setPurchaseAutoRenewMutation = useMutation( userPurchaseSetAutoRenewQuery() );
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
+	const removePurchaseMutator = useMutation( removePurchaseMutation() );
 	const extendWithFreeMonthMutation = useMutation( extendPurchaseWithFreeMonthMutation() );
 	const userPreferences = useMutation( userPreferencesMutation() );
 	const {
@@ -896,10 +899,76 @@ export default function CancelPurchase() {
 		);
 	};
 
+	const submitRemovePurchase = ( purchase: Purchase ) => {
+		if ( CANCEL_FLOW_TYPE.REMOVE !== flowType ) {
+			return;
+		}
+
+		removePurchaseMutator.mutate( purchase.ID, {
+			onSuccess: () => {
+				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+				/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") and %(siteName)s is a domain name */
+				let successMessage = sprintf( __( '%(productName)s was removed from %(siteName)s.' ), {
+					productName: purchaseName,
+					siteName: purchase.domain,
+				} );
+				if (
+					isAkismetTemporarySitePurchase( purchase ) ||
+					isJetpackTemporarySitePurchase( purchase )
+				) {
+					/* translators: %(productName)s is the name of a product (e.g., "WordPress.com Premium") */
+					successMessage = sprintf( __( '%(productName)s was removed from your account.' ), {
+						productName: purchaseName,
+					} );
+				}
+				if ( purchase.is_domain_registration ) {
+					// if ( isDomainOnlySite ) {
+					// 	this.props.receiveDeletedSite( purchase.siteId );
+					// 	this.props.setAllSitesSelected();
+					// }
+					successMessage = sprintf(
+						/* translators: %(domain)s is a domain name */
+						__( 'The domain %(domain)s was removed from your account.' ),
+						{
+							domain: purchaseName,
+						}
+					);
+				}
+				createSuccessNotice( successMessage, { type: 'snackbar' } );
+				navigate( {
+					to: purchaseSettingsRoute.fullPath,
+					params: { purchaseId: purchase.ID },
+				} );
+			},
+			onError: () => {
+				const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+				createErrorNotice(
+					sprintf(
+						/* translators: %(purchaseName)s is the name of the product that was purchased. */
+						__(
+							'There was a problem removing %(purchaseName)s. Please try again later or contact support.'
+						),
+						{ purchaseName }
+					),
+					{ type: 'snackbar' }
+				);
+				setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
+			},
+		} );
+	};
+
 	const onSurveyComplete = () => {
 		// Set loading state to show busy button
 		setState( ( state ) => ( { ...state, isLoading: true } ) );
-		submitCancelAndRefundPurchase( purchase );
+		switch ( flowType ) {
+			case CANCEL_FLOW_TYPE.REMOVE:
+				submitRemovePurchase( purchase );
+				break;
+			case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW:
+			case CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND:
+				submitCancelAndRefundPurchase( purchase );
+				break;
+		}
 	};
 
 	const onSubmit = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -922,10 +922,6 @@ export default function CancelPurchase() {
 					} );
 				}
 				if ( purchase.is_domain_registration ) {
-					// if ( isDomainOnlySite ) {
-					// 	this.props.receiveDeletedSite( purchase.siteId );
-					// 	this.props.setAllSitesSelected();
-					// }
 					successMessage = sprintf(
 						/* translators: %(domain)s is a domain name */
 						__( 'The domain %(domain)s was removed from your account.' ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1309](https://linear.app/a8c/issue/SHILL-1309/hosting-dashboard-cancellation-flow-removed-products-appear-in-active)

## Proposed Changes

* Add remove purchase capability and choose that option when in the removal flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because currently the flow only supports cancelling (with or without a refund) and not removal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the `/v2/me/billing/purchases` page and select a purchase you would like to remove. Make sure button says "Remove" and not "Cancel". Click the remove button.
* Append `/cancel` to the end of the domain and go through the survey, finally clicking submit.
* Your purchase should be removed and you should be redirected back to the active purchases page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
