### PR TITLE
Try/experimental ai setting wpcom api

### DIFF
--- a/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
+++ b/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
@@ -1,6 +1,5 @@
 import { bigSkyPluginMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import type { BigSkyPluginUpdateRequest } from '@automattic/api-core';
 import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -15,8 +14,7 @@ import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import Notice from '../../components/notice';
-import type { Site, SiteSettings } from '@automattic/api-core';
-
+import type { BigSkyPluginUpdateRequest, Site, SiteSettings } from '@automattic/api-core';
 interface AIAssistantFormData {
 	bigSkyEnabled: boolean;
 }

--- a/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
+++ b/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
@@ -1,5 +1,6 @@
-import { siteSettingsMutation } from '@automattic/api-queries';
+import { bigSkyPluginMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
+import type { BigSkyPluginUpdateRequest } from '@automattic/api-core';
 import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -91,7 +92,7 @@ export function AIAssistantForm( { site, settings }: { site: Site; settings: Sit
 	const mediaLibraryUrl = site?.URL + '/wp-admin/upload.php';
 
 	const mutation = useMutation( {
-		...siteSettingsMutation( site.ID ),
+		...bigSkyPluginMutation( site.ID ),
 		meta: {
 			snackbar: {
 				success: __( 'AI Site Assistant settings saved.' ),
@@ -106,9 +107,9 @@ export function AIAssistantForm( { site, settings }: { site: Site; settings: Sit
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
 
-		const settingsUpdate = toSiteSettings( { bigSkyEnabled: true }, selectedUseCases );
+		const pluginUpdate = toBigSkyPluginUpdate( { bigSkyEnabled: true }, selectedUseCases );
 
-		mutation.mutate( settingsUpdate, {
+		mutation.mutate( pluginUpdate, {
 			onSuccess: () => {
 				// Update initialData to reflect that Big Sky is now enabled
 				setInitialData( { bigSkyEnabled: true } );
@@ -133,9 +134,9 @@ export function AIAssistantForm( { site, settings }: { site: Site; settings: Sit
 	};
 
 	const handleDisable = () => {
-		const settingsUpdate = toSiteSettings( { bigSkyEnabled: false }, new Set() );
+		const pluginUpdate = toBigSkyPluginUpdate( { bigSkyEnabled: false }, new Set() );
 
-		mutation.mutate( settingsUpdate, {
+		mutation.mutate( pluginUpdate, {
 			onSuccess: () => {
 				setInitialData( { bigSkyEnabled: false } );
 				setFormData( { bigSkyEnabled: false } );
@@ -242,25 +243,25 @@ function fromSiteSettings( settings: SiteSettings ): AIAssistantFormData {
 	};
 }
 
-function toSiteSettings(
+function toBigSkyPluginUpdate(
 	formData: AIAssistantFormData,
 	selectedUseCases: Set< UseCaseOption >
-): Partial< SiteSettings > {
-	const settings: Partial< SiteSettings > = {
-		big_sky_enable: formData.bigSkyEnabled,
+): BigSkyPluginUpdateRequest {
+	const update: BigSkyPluginUpdateRequest = {
+		enable: formData.bigSkyEnabled,
 	};
 
 	if ( ! formData.bigSkyEnabled ) {
 		// Set isOnboarded to false when Big Sky is disabled
-		settings.big_sky_site_metadata = {
+		update.metadata = {
 			isOnboarded: false,
 		};
 	} else if ( ! selectedUseCases.has( 'redesign' ) ) {
 		// If "Redesign my site" is NOT selected, set isOnboarded to true
-		settings.big_sky_site_metadata = {
+		update.metadata = {
 			isOnboarded: true,
 		};
 	}
 
-	return settings;
+	return update;
 }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"search:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/search run storybook:start` instead'",
 		"site-admin:storybook:start": "yarn workspace @automattic/site-admin run storybook:start",
-		"start": "NODE_OPTIONS='--max-old-space-size=8192' npx check-node-version --package && NODE_OPTIONS='--max-old-space-size=8192' node bin/welcome.js && NODE_OPTIONS='--max-old-space-size=8192' yarn run build && yarn run start-build",
+		"start": "npx check-node-version --package && node bin/welcome.js && yarn run build && yarn run start-build",
 		"start:debug": "NODE_OPTIONS='--max-old-space-size=6144' SOURCEMAP='eval-source-map' yarn start",
 		"start-mock-wordpress-com": "MOCK_WORDPRESSDOTCOM=1 yarn run start",
 		"start-build": "BROWSERSLIST_ENV=evergreen node build/server.js | bunyan -o short",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"search:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/search run storybook:start` instead'",
 		"site-admin:storybook:start": "yarn workspace @automattic/site-admin run storybook:start",
-		"start": "npx check-node-version --package && node bin/welcome.js && yarn run build && yarn run start-build",
+		"start": "NODE_OPTIONS='--max-old-space-size=8192' npx check-node-version --package && NODE_OPTIONS='--max-old-space-size=8192' node bin/welcome.js && NODE_OPTIONS='--max-old-space-size=8192' yarn run build && yarn run start-build",
 		"start:debug": "NODE_OPTIONS='--max-old-space-size=6144' SOURCEMAP='eval-source-map' yarn start",
 		"start-mock-wordpress-com": "MOCK_WORDPRESSDOTCOM=1 yarn run start",
 		"start-build": "BROWSERSLIST_ENV=evergreen node build/server.js | bunyan -o short",

--- a/packages/api-core/src/big-sky-plugin/fetchers.ts
+++ b/packages/api-core/src/big-sky-plugin/fetchers.ts
@@ -1,0 +1,9 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { BigSkyPluginResponse } from './types';
+
+export async function fetchBigSkyPlugin( siteId: number ): Promise< BigSkyPluginResponse > {
+	return await wpcom.req.get( {
+		path: `/sites/${ siteId }/big-sky-plugin`,
+		apiVersion: '1.1',
+	} );
+}

--- a/packages/api-core/src/big-sky-plugin/index.ts
+++ b/packages/api-core/src/big-sky-plugin/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/big-sky-plugin/index.ts
+++ b/packages/api-core/src/big-sky-plugin/index.ts
@@ -1,2 +1,3 @@
+export * from './fetchers';
 export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/big-sky-plugin/mutators.ts
+++ b/packages/api-core/src/big-sky-plugin/mutators.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { BigSkyPluginUpdateRequest, BigSkyPluginResponse } from './types';
+
+export async function updateBigSkyPlugin(
+	siteId: number,
+	data: BigSkyPluginUpdateRequest
+): Promise< BigSkyPluginResponse > {
+	return await wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/big-sky-plugin`,
+			apiVersion: '1.1',
+		},
+		data
+	);
+}

--- a/packages/api-core/src/big-sky-plugin/types.ts
+++ b/packages/api-core/src/big-sky-plugin/types.ts
@@ -12,9 +12,6 @@ export interface BigSkyPluginUpdateRequest {
 
 export interface BigSkyPluginResponse {
 	blog_id: number;
-	plugin: string;
-	status: string;
-	active: boolean;
-	name: string;
-	version: string;
+	enabled: boolean;
+	metadata?: BigSkyPluginMetadata;
 }

--- a/packages/api-core/src/big-sky-plugin/types.ts
+++ b/packages/api-core/src/big-sky-plugin/types.ts
@@ -1,0 +1,20 @@
+export interface BigSkyPluginMetadata {
+	isOnboarded?: boolean;
+	siteDescription?: string;
+	topic?: string;
+	siteTitle?: string;
+}
+
+export interface BigSkyPluginUpdateRequest {
+	enable: boolean;
+	metadata?: BigSkyPluginMetadata;
+}
+
+export interface BigSkyPluginResponse {
+	blog_id: number;
+	plugin: string;
+	status: string;
+	active: boolean;
+	name: string;
+	version: string;
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './error';
 
 export * from './agency';
+export * from './big-sky-plugin';
 export * from './cancellation-offers';
 export * from './dashboard-site-list';
 export * from './domain';

--- a/packages/api-queries/src/big-sky-plugin.ts
+++ b/packages/api-queries/src/big-sky-plugin.ts
@@ -1,0 +1,15 @@
+import { updateBigSkyPlugin } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import { siteQueryFilter } from './site';
+import { siteSettingsQuery } from './site-settings';
+import type { BigSkyPluginUpdateRequest } from '@automattic/api-core';
+
+export const bigSkyPluginMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: BigSkyPluginUpdateRequest ) => updateBigSkyPlugin( siteId, data ),
+		onSuccess: () => {
+			// Invalidate site and site settings queries to refresh the UI
+			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
+		},
+	} );

--- a/packages/api-queries/src/big-sky-plugin.ts
+++ b/packages/api-queries/src/big-sky-plugin.ts
@@ -1,9 +1,14 @@
-import { updateBigSkyPlugin } from '@automattic/api-core';
-import { mutationOptions } from '@tanstack/react-query';
+import { fetchBigSkyPlugin, updateBigSkyPlugin } from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import { siteSettingsQuery } from './site-settings';
 import type { BigSkyPluginUpdateRequest } from '@automattic/api-core';
+
+export const bigSkyPluginQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'big-sky-plugin' ],
+		queryFn: () => fetchBigSkyPlugin( siteId ),
+	} );
 
 export const bigSkyPluginMutation = ( siteId: number ) =>
 	mutationOptions( {

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -1,5 +1,6 @@
 export * from './query-client';
 
+export * from './big-sky-plugin';
 export * from './cancellation-offers';
 export * from './dashboard-site-list';
 export * from './domain-availability';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTCOM-15184](https://linear.app/a8c/issue/DOTCOM-15184)
Also see https://github.com/Automattic/wp-calypso/pull/107112
Needs Needs wpcom PR 196308


## Proposed Changes

* 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
