### PR TITLE
Remove DataViews action in notifications

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,9 +1,7 @@
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	chartBar,
-	chevronRight,
-	chevronLeft,
 	caution,
 	check,
 	comment,
@@ -19,7 +17,7 @@ import clsx from 'clsx';
 import { html } from '../../panel/indices-to-html';
 import NoteIcon from '../note-icon';
 import type { Note } from '../types';
-import type { Action, Field } from '@wordpress/dataviews';
+import type { Field } from '@wordpress/dataviews';
 import type { JSX } from 'react';
 import './dataviews-overrides.scss';
 
@@ -115,24 +113,6 @@ export function getFields(): Field< Note >[] {
 						<span>{ item.title }</span>
 					</HStack>
 				);
-			},
-		},
-	];
-}
-
-export function getActions( {
-	onSelect,
-}: {
-	onSelect: ( selection: string[] ) => void;
-} ): Action< Note >[] {
-	return [
-		{
-			id: 'view',
-			isPrimary: true,
-			icon: <Icon icon={ isRTL() ? chevronLeft : chevronRight } />,
-			label: __( 'View' ),
-			callback: ( items: Note[] ) => {
-				onSelect( items.map( ( item ) => item.id.toString() ) );
 			},
 		},
 	];

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -12,7 +12,7 @@ import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
-import { getFields, getActions } from './dataviews';
+import { getFields } from './dataviews';
 import {
 	useNoteListFocusToLastSelectedNote,
 	useNoteListNavigationKeyboardShortcuts,
@@ -57,8 +57,6 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 
 	const fields = getFields();
 
-	const actions = getActions( { onSelect: onChangeSelection } );
-
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate(
 		visibleNotes,
 		view,
@@ -87,7 +85,6 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 			<DataViews< Note >
 				data={ filteredData }
 				fields={ fields }
-				actions={ actions }
 				view={ view }
 				isLoading={ isLoading }
 				defaultLayouts={ DEFAULT_LAYOUTS }


### PR DESCRIPTION
## Proposed Changes

As discussed in p1762998141014389-slack-C08JZTRS6NA, with the latest changes in DataViews it's no longer to show the primary action as icon. Displaying the text "View" is slightly off, so this PR removes the action altogether as the entire row is clickable.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Open notifications
* Ensure the "View" action is no longer there, and that the notification is still clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?