### PR TITLE
Sync: Update Studio URL scheme to open sync after hosted site flow

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -52,6 +52,7 @@ import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from '../celebrate-launch-modal';
 import { FullScreenLaunchpad } from '../full-screen-launchpad';
+import openSyncUrlInStudio from './studio-deeplink';
 
 import './style.scss';
 
@@ -137,9 +138,8 @@ const HomeContent = ( {
 		if ( ! studioSiteId ) {
 			return;
 		}
-		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
 		trackStudioSyncConnectSite( false );
-		window.location.href = studioSiteUrl;
+		openSyncUrlInStudio( studioSiteId, siteId );
 	}, [ siteId, trackStudioSyncConnectSite ] );
 
 	const isFirstSecondaryCardInPrimaryLocation =
@@ -292,7 +292,6 @@ const HomeContent = ( {
 		if ( ! studioSiteId ) {
 			return null;
 		}
-		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
 
 		return (
 			<Notice
@@ -305,7 +304,7 @@ const HomeContent = ( {
 				<NoticeAction
 					onClick={ () => {
 						trackStudioSyncConnectSite( true );
-						window.location.href = studioSiteUrl;
+						openSyncUrlInStudio( studioSiteId, siteId );
 					} }
 					external
 				>

--- a/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
+++ b/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
@@ -1,12 +1,13 @@
 // Studio URL scheme - changed from wpcom-local-dev to wp-studio
-// For backward compatibility, we try both schemes to support both old and new Electron app versions
+// For backward compatibility, we try both schemes to support both old and new Studio app versions
 const STUDIO_URL_SCHEME = 'wp-studio';
 const STUDIO_URL_SCHEME_LEGACY = 'wpcom-local-dev';
 
 /**
  * Opens Studio sync URL with backward compatibility support.
  * Tries both the new and old schemes to ensure compatibility with
- * both old and new Electron app versions.
+ * both old and new Studio app versions. We need to remove or update this once we have
+ * large number of users on the new version.
  * @param {string} studioSiteId - The Studio site ID
  * @param {number} siteId - The remote site ID
  */
@@ -15,11 +16,11 @@ const openSyncUrlInStudio = ( studioSiteId: string, siteId: number ) => {
 	const newSchemeUrl = `${ STUDIO_URL_SCHEME }://${ path }`;
 	const legacySchemeUrl = `${ STUDIO_URL_SCHEME_LEGACY }://${ path }`;
 
-	// Try new scheme first (for new Electron app versions)
+	// Try new scheme first (for new Studio app versions)
 	// Use main window location for primary attempt
 	window.location.href = newSchemeUrl;
 
-	// Also try legacy scheme in a hidden iframe as fallback for old Electron app versions
+	// Also try legacy scheme in a hidden iframe as fallback for old Studio app versions
 	// This ensures backward compatibility
 	const iframe = document.createElement( 'iframe' );
 	iframe.style.display = 'none';

--- a/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
+++ b/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
@@ -10,19 +10,14 @@ const openSyncUrlInStudio = ( studioSiteId: string, siteId: number ) => {
 	const legacySchemeUrl = `${ STUDIO_URL_SCHEME_LEGACY }://${ path }`;
 
 	// Use new scheme for new Studio app versions.
-	window.location.href = newSchemeUrl;
+	try {
+		window.location.href = newSchemeUrl;
+	} catch ( error ) {}
 
-	// Also try legacy scheme in a hidden iframe as fallback for old Studio app versions.
-	const iframe = document.createElement( 'iframe' );
-	iframe.style.display = 'none';
-	iframe.src = legacySchemeUrl;
-	document.body.appendChild( iframe );
-
-	// Clean up the iframe after a short delay
+	// Fallback to legacy scheme for old Studio app versions. It will be blocked by the browser
+	// if scheme is not registered.
 	setTimeout( () => {
-		if ( iframe.parentNode ) {
-			iframe.parentNode.removeChild( iframe );
-		}
+		window.location.href = legacySchemeUrl;
 	}, 1000 );
 };
 

--- a/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
+++ b/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
@@ -10,14 +10,14 @@ const openSyncUrlInStudio = ( studioSiteId: string, siteId: number ) => {
 	const legacySchemeUrl = `${ STUDIO_URL_SCHEME_LEGACY }://${ path }`;
 
 	// Use new scheme for new Studio app versions.
-	try {
-		window.location.href = newSchemeUrl;
-	} catch ( error ) {}
+	window.location.href = newSchemeUrl;
 
 	// Fallback to legacy scheme for old Studio app versions. It will be blocked by the browser
 	// if scheme is not registered.
 	setTimeout( () => {
-		window.location.href = legacySchemeUrl;
+		if ( document.hasFocus() ) {
+			window.location.href = legacySchemeUrl;
+		}
 	}, 1000 );
 };
 

--- a/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
+++ b/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
@@ -1,0 +1,37 @@
+// Studio URL scheme - changed from wpcom-local-dev to wp-studio
+// For backward compatibility, we try both schemes to support both old and new Electron app versions
+const STUDIO_URL_SCHEME = 'wp-studio';
+const STUDIO_URL_SCHEME_LEGACY = 'wpcom-local-dev';
+
+/**
+ * Opens Studio sync URL with backward compatibility support.
+ * Tries both the new and old schemes to ensure compatibility with
+ * both old and new Electron app versions.
+ * @param {string} studioSiteId - The Studio site ID
+ * @param {number} siteId - The remote site ID
+ */
+const openSyncUrlInStudio = ( studioSiteId: string, siteId: number ) => {
+	const path = `sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
+	const newSchemeUrl = `${ STUDIO_URL_SCHEME }://${ path }`;
+	const legacySchemeUrl = `${ STUDIO_URL_SCHEME_LEGACY }://${ path }`;
+
+	// Try new scheme first (for new Electron app versions)
+	// Use main window location for primary attempt
+	window.location.href = newSchemeUrl;
+
+	// Also try legacy scheme in a hidden iframe as fallback for old Electron app versions
+	// This ensures backward compatibility
+	const iframe = document.createElement( 'iframe' );
+	iframe.style.display = 'none';
+	iframe.src = legacySchemeUrl;
+	document.body.appendChild( iframe );
+
+	// Clean up the iframe after a short delay
+	setTimeout( () => {
+		if ( iframe.parentNode ) {
+			iframe.parentNode.removeChild( iframe );
+		}
+	}, 1000 );
+};
+
+export default openSyncUrlInStudio;

--- a/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
+++ b/client/my-sites/customer-home/components/home-content/studio-deeplink.ts
@@ -3,25 +3,16 @@
 const STUDIO_URL_SCHEME = 'wp-studio';
 const STUDIO_URL_SCHEME_LEGACY = 'wpcom-local-dev';
 
-/**
- * Opens Studio sync URL with backward compatibility support.
- * Tries both the new and old schemes to ensure compatibility with
- * both old and new Studio app versions. We need to remove or update this once we have
- * large number of users on the new version.
- * @param {string} studioSiteId - The Studio site ID
- * @param {number} siteId - The remote site ID
- */
+// Opens Studio sync URL with backward compatibility support.
 const openSyncUrlInStudio = ( studioSiteId: string, siteId: number ) => {
 	const path = `sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
 	const newSchemeUrl = `${ STUDIO_URL_SCHEME }://${ path }`;
 	const legacySchemeUrl = `${ STUDIO_URL_SCHEME_LEGACY }://${ path }`;
 
-	// Try new scheme first (for new Studio app versions)
-	// Use main window location for primary attempt
+	// Use new scheme for new Studio app versions.
 	window.location.href = newSchemeUrl;
 
-	// Also try legacy scheme in a hidden iframe as fallback for old Studio app versions
-	// This ensures backward compatibility
+	// Also try legacy scheme in a hidden iframe as fallback for old Studio app versions.
 	const iframe = document.createElement( 'iframe' );
 	iframe.style.display = 'none';
 	iframe.src = legacySchemeUrl;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STU-936

## Proposed Changes

* Update Studio deeplink URL scheme from `wpcom-local-dev://` to `wp-studio://` while maintaining backward compatibility for older versions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have decided to update the URL scheme to be more inclusive. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apologies for the long test instructions. 

  * Check out this PR or use the Calypso live link. Copy and keep the link for now.
  * Open the Studio app on the `trunk` branch.
  * Go to the **Sync** tab and click **Connect Site**.
  * Click **Create a new WordPress.com site**.
  * Follow the domain flow and complete the checkout process.
  * You should land on a URL similar to:
    `/home/250259110?studioSiteId=d67f9e58-97da-41d9-b99d-561d9f0b841d`
    It must contain the `studioSiteId` query parameter.
  * At this point, the web will attempt to open the Studio app.
  * Copy the URL fragment from the link similar to above.
  * Open the same link in local Calypso or in the Calypso live link.
  * The page should open the Studio app.
  * Close the Studio app.
  * Check out the branch from [https://github.com/Automattic/studio/pull/2029](https://github.com/Automattic/studio/pull/2029).
  * Run the Studio app again.
  * Refresh the page on local Calypso or the Calypso live link. Ensure the URL still contains the `studioSiteId` parameter.
  * It should still attempt to open the Studio app.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
