### PR TITLE
/support: Fix Help Center footer styling

### DIFF
--- a/packages/help-center/src/components/help-center-footer.scss
+++ b/packages/help-center/src/components/help-center-footer.scss
@@ -13,9 +13,15 @@
 
 	.button.help-center-contact-page__button {
 		margin: 16px;
-		width: calc(100% - 32px);
+		border: 1px solid var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		border-radius: 8px;
-		border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		box-shadow: none;
+		display: inline-block;
+		text-align: center;
+		width: calc(100% - 32px);
+
+		&:hover {
+			box-shadow: none;
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-361/support-need-help-missing-styles

| Before | After |
|--------|--------|
| <img width="470" height="243" alt="image" src="https://github.com/user-attachments/assets/b06ca2e9-3486-4636-9442-57ccbbd3207e" /> | <img width="445" height="220" alt="image" src="https://github.com/user-attachments/assets/b6bd4ccb-a0b3-4e87-9a51-42d7cc8c2f73" /> | 

## Testings steps

1. `yarn dev --sync` from `apps/help-center`
2. Sandbox widgets and go to wordpress.com/support
3. Open the Help Center