### PR TITLE
Plugins redesign: Move browse all link to carousel

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,14 +1,17 @@
 import { Card, DotPager } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Spotlight from 'calypso/components/spotlight';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import PluginsResultsHeader from 'calypso/my-sites/plugins/plugins-results-header';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserListVariant } from './types';
 import './style.scss';
 
@@ -48,10 +51,34 @@ const PluginsBrowserList = ( {
 	useCarousel = false,
 	carouselPageSize = DEFAULT_CAROUSEL_PAGE_SIZE,
 } ) => {
+	const { __ } = useI18n();
 	const extendedVariant = extended
 		? PluginsBrowserElementVariant.Extended
 		: PluginsBrowserElementVariant.Compact;
 	const shouldUseCarousel = useCarousel;
+	const selectedSite = useSelector( getSelectedSite );
+
+	const handleBrowseAllClick = () => {
+		if ( ! browseAllLink ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_plugin_browser_all_click', {
+			site: selectedSite?.domain,
+			list_name: listName,
+			blog_id: selectedSite?.ID,
+		} );
+	};
+
+	const browseAllAction = browseAllLink ? (
+		<a
+			className="plugins-results-header__action"
+			href={ browseAllLink }
+			onClick={ handleBrowseAllClick }
+		>
+			{ __( 'Browse all' ) }
+		</a>
+	) : null;
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -126,7 +153,13 @@ const PluginsBrowserList = ( {
 
 			return (
 				<div className="plugins-browser-list__carousel">
-					<DotPager className="plugins-browser-list__carousel-pager" hasDynamicHeight>
+					<DotPager
+						className="plugins-browser-list__carousel-pager"
+						hasDynamicHeight
+						showDots={ false }
+						controlsAction={ browseAllAction }
+						navigationVariant="button"
+					>
 						{ slides.map( ( slideItems, index ) => (
 							<Card
 								tagName="ul"
@@ -170,7 +203,7 @@ const PluginsBrowserList = ( {
 					title={ title }
 					subtitle={ subtitle }
 					resultCount={ resultCount }
-					browseAllLink={ browseAllLink }
+					browseAllLink={ ! useCarousel ? browseAllLink : undefined }
 					listName={ listName }
 					isRootPage={ listType !== 'browse' }
 				/>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,18 +1,18 @@
 import { Card, DotPager } from '@automattic/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Spotlight from 'calypso/components/spotlight';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import PluginBrowserItem from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
-import PluginsResultsHeader from 'calypso/my-sites/plugins/plugins-results-header';
+import PluginsResultsHeader, {
+	BrowseAllAction,
+} from 'calypso/my-sites/plugins/plugins-results-header';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PluginsBrowserListVariant } from './types';
+
 import './style.scss';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
@@ -51,34 +51,11 @@ const PluginsBrowserList = ( {
 	useCarousel = false,
 	carouselPageSize = DEFAULT_CAROUSEL_PAGE_SIZE,
 } ) => {
-	const { __ } = useI18n();
 	const extendedVariant = extended
 		? PluginsBrowserElementVariant.Extended
 		: PluginsBrowserElementVariant.Compact;
 	const shouldUseCarousel = useCarousel;
-	const selectedSite = useSelector( getSelectedSite );
-
-	const handleBrowseAllClick = () => {
-		if ( ! browseAllLink ) {
-			return;
-		}
-
-		recordTracksEvent( 'calypso_plugin_browser_all_click', {
-			site: selectedSite?.domain,
-			list_name: listName,
-			blog_id: selectedSite?.ID,
-		} );
-	};
-
-	const browseAllAction = browseAllLink ? (
-		<a
-			className="plugins-results-header__action"
-			href={ browseAllLink }
-			onClick={ handleBrowseAllClick }
-		>
-			{ __( 'Browse all' ) }
-		</a>
-	) : null;
+	const browseAllAction = <BrowseAllAction browseAllLink={ browseAllLink } listName={ listName } />;
 
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {

--- a/client/my-sites/plugins/plugins-results-header/browse-all-action.tsx
+++ b/client/my-sites/plugins/plugins-results-header/browse-all-action.tsx
@@ -1,0 +1,43 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+type BrowseAllActionProps = {
+	browseAllLink?: string;
+	className?: string;
+	listName?: string;
+};
+
+const DEFAULT_ACTION_CLASS = 'plugins-results-header__action';
+
+export default function BrowseAllAction( {
+	browseAllLink,
+	className,
+	listName,
+}: BrowseAllActionProps ) {
+	const { __ } = useI18n();
+	const selectedSite = useSelector( getSelectedSite );
+
+	if ( ! browseAllLink ) {
+		return null;
+	}
+
+	const handleBrowseAllClick = () => {
+		recordTracksEvent( 'calypso_plugin_browser_all_click', {
+			site: selectedSite?.domain,
+			list_name: listName,
+			blog_id: selectedSite?.ID,
+		} );
+	};
+
+	const actionClassName = className
+		? `${ DEFAULT_ACTION_CLASS } ${ className }`
+		: DEFAULT_ACTION_CLASS;
+
+	return (
+		<a className={ actionClassName } href={ browseAllLink } onClick={ handleBrowseAllClick }>
+			{ __( 'Browse all' ) }
+		</a>
+	);
+}

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -1,8 +1,5 @@
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import BrowseAllAction from './browse-all-action';
 import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
@@ -24,8 +21,6 @@ export default function PluginsResultsHeader( {
 	listName?: string;
 	isRootPage?: boolean;
 } ) {
-	const { __ } = useI18n();
-	const selectedSite = useSelector( getSelectedSite );
 	const TitleTag = isRootPage ? 'h2' : 'h1';
 
 	return (
@@ -39,19 +34,7 @@ export default function PluginsResultsHeader( {
 			{ ( browseAllLink || resultCount ) && (
 				<div className="plugins-results-header__actions">
 					{ browseAllLink && (
-						<a
-							className="plugins-results-header__action"
-							href={ browseAllLink }
-							onClick={ () => {
-								recordTracksEvent( 'calypso_plugin_browser_all_click', {
-									site: selectedSite?.domain,
-									list_name: listName,
-									blog_id: selectedSite?.ID,
-								} );
-							} }
-						>
-							{ __( 'Browse all' ) }
-						</a>
+						<BrowseAllAction browseAllLink={ browseAllLink } listName={ listName } />
 					) }
 					{ resultCount && <span className="plugins-results-header__action">{ resultCount }</span> }
 				</div>
@@ -59,3 +42,5 @@ export default function PluginsResultsHeader( {
 		</div>
 	);
 }
+
+export { default as BrowseAllAction } from './browse-all-action';

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -38,9 +38,13 @@
 			justify-content: flex-end;
 			align-items: center;
 			flex-grow: 4;
+			text-decoration: underline;
 			svg {
 				margin-left: 2px;
 			}
 		}
 	}
+}
+.plugins-results-header__action {
+	text-decoration: none;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-258](https://linear.app/a8c/issue/DOTDEV-258/implement-carousel-for-the-discovery-plugins-lists)


## Proposed Changes

* move browse all links into the carousel

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* needed to implement the Plugins redesign

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins?flags=marketplace-redesign`
* The `Browse all` links should render next to the carousel arrows
* Go to `/plugins`
* The `Browse all` links should render as before

| Before (without flag) | After (with flag) |
|--------|--------|
|<img width="1126" height="970" alt="Screenshot 2025-11-18 at 13 48 51" src="https://github.com/user-attachments/assets/c34909e0-5a8e-47aa-87f3-7c9bfd9ff219" />| <img width="1099" height="879" alt="Screenshot 2025-11-18 at 13 48 59" src="https://github.com/user-attachments/assets/eefb5222-fc98-4f39-ab0b-e3e5ac8d3008" />| 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
