### PR TITLE
Enable domain-connection-redesign feature flag in wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,7 +30,7 @@
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign": false,
+		"domain-connection-redesign": true,
 		"domain-transfer-redesign": false,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,7 +45,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
-		"domain-connection-redesign": false,
+		"domain-connection-redesign": true,
 		"domain-transfer-redesign": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,


### PR DESCRIPTION
Closes [DOMAINS-1840](https://linear.app/a8c/issue/DOMAINS-1840/enable-domain-connection-redesign-feature-flag-in-wpcalypso-and)

## Proposed Changes
Quick diff to enable domain-connection-redesign feature flag in wpcalypso and horizon environments

## Why are these changes being made?
We need to enable those environments for testing purpose

## Testing Instructions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
