### PR TITLE
Align magic login confirmation layout

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -74,7 +74,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 										className="one-login__footer-link"
 									/>
 								),
-								link: <a href="/log-in/jetpack" />,
+								link: <a className="one-login__footer-link" href="/log-in/jetpack" />,
 							},
 						}
 					) }

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -61,21 +61,25 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 				/>
 			) }
 			<p>{ preventWidows( translate( "Only one step left—we'll connect your site next." ) ) }</p>
-			<OneLoginFooter
-				loginLink={
-					<p>
-						{ translate(
-							"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
-							{
-								components: {
-									button: <Button variant="link" onClick={ onResendEmail } />,
-									link: <a href="/log-in/jetpack" />,
-								},
-							}
-						) }
-					</p>
-				}
-			/>
+			<OneLoginFooter>
+				<p className="one-login__footer-text">
+					{ translate(
+						"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
+						{
+							components: {
+								button: (
+									<Button
+										variant="link"
+										onClick={ onResendEmail }
+										className="one-login__footer-link"
+									/>
+								),
+								link: <a href="/log-in/jetpack" />,
+							},
+						}
+					) }
+				</p>
+			</OneLoginFooter>
 		</div>
 	);
 };

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -30,7 +30,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 	useEffect( () => {
 		const enhancedRecordPageView = withEnhancers( recordPageView, [ enhanceWithSiteType ] );
 		dispatch( enhancedRecordPageView( '/log-in/jetpack/link', 'Login > Link > Emailed' ) );
-	}, [] );
+	}, [ dispatch ] );
 
 	useEffect( () => {
 		setHeaders( {

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -63,7 +63,7 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 			<p>{ preventWidows( translate( "Only one step left—we'll connect your site next." ) ) }</p>
 			<OneLoginFooter
 				loginLink={
-					<p className="magic-login__footer-text">
+					<p>
 						{ translate(
 							"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
 							{

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { FC, useEffect } from 'react';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import { useDispatch } from 'calypso/state';
 import {
 	recordPageViewWithClientId as recordPageView,
@@ -60,25 +61,21 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 				/>
 			) }
 			<p>{ preventWidows( translate( "Only one step left—we'll connect your site next." ) ) }</p>
-			<div className="magic-login__successfully-jetpack-actions">
-				<p>
-					{ translate(
-						"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
-						{
-							components: {
-								button: (
-									<Button
-										className="magic-login__resend-button"
-										variant="link"
-										onClick={ onResendEmail }
-									/>
-								),
-								link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
-							},
-						}
-					) }
-				</p>
-			</div>
+			<OneLoginFooter
+				loginLink={
+					<p className="magic-login__footer-text">
+						{ translate(
+							"Didn't get the email? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
+							{
+								components: {
+									button: <Button variant="link" onClick={ onResendEmail } />,
+									link: <a href="/log-in/jetpack" />,
+								},
+							}
+						) }
+					</p>
+				}
+			/>
 		</div>
 	);
 };

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -61,7 +61,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 		const { translate, emailAddress } = this.props;
 
 		return (
-			<div className="magic-login__form">
+			<>
 				<RedirectWhenLoggedIn
 					redirectTo="/help"
 					replaceCurrentLocation
@@ -92,7 +92,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 						) }
 					</p>
 				</OneLoginFooter>
-			</div>
+			</>
 		);
 	}
 }

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -8,6 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { login } from 'calypso/lib/paths';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
@@ -72,18 +73,25 @@ class EmailedLoginLinkSuccessfully extends Component {
 						<MagicLoginEmailWrapper emailAddress={ emailAddress } />
 					</div>
 				</Card>
-				<div className="magic-login__footer">
-					<p>
+				<OneLoginFooter>
+					<p className="one-login__footer-text">
 						{ translate(
 							"Didn't get the email? You might want to double check if the email address is associated with your account,{{a}}or reset your password.{{/a}}",
 							{
 								components: {
-									a: <a href="/" onClick={ this.onLostPasswordClick } rel="noopener noreferrer" />,
+									a: (
+										<a
+											className="one-login__footer-link"
+											href="/"
+											onClick={ this.onLostPasswordClick }
+											rel="noopener noreferrer"
+										/>
+									),
 								},
 							}
 						) }
 					</p>
-				</div>
+				</OneLoginFooter>
 			</div>
 		);
 	}

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -249,15 +249,6 @@
 			padding-left: 4px;
 		}
 	}
-
-	.components-button.is-link {
-		color: var( --studio-wordpress-blue, #3858e9 );
-		font-size: inherit;
-		font-weight: 600;
-		height: auto;
-		padding: 0;
-		text-decoration: underline;
-	}
 }
 
 .magic-login__check-email-image {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -109,12 +109,6 @@
 		}
 	}
 
-	.logged-out-form {
-		.form-label {
-			font-weight: 400;
-		}
-	}
-
 	.magic-login__form-action {
 		margin-top: 16px;
 	}
@@ -267,12 +261,6 @@
 
 		@include break-mobile {
 			@include onboarding-heading-text;
-		}
-	}
-
-	.logged-out-form {
-		.form-label {
-			color: var( --studio-gray-60 );
 		}
 	}
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -66,6 +66,10 @@
 
 		.magic-login__successfully-jetpack {
 			padding: 0 24px 0 24px;
+			// Matches .form-fieldset default margin overwritten in Jetpack view
+			margin-bottom: rem( 20px );
+			// Matches .card.logged-out-form padding-bottom overridden by Jetpack styles
+			padding-bottom: rem( 16px );
 		}
 
 		&__loading-spinner--jetpack {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -137,25 +137,6 @@
 	}
 }
 
-.magic-login__footer-text {
-	font-size: $font-body-small;
-	color: var( --studio-gray-50, #646970 );
-	text-align: center;
-	margin: 24px auto 0;
-	max-width: 400px;
-	line-height: 20px;
-
-	a,
-	.components-button.is-link {
-		color: var( --studio-wordpress-blue, #3858e9 );
-		font-size: inherit;
-		font-weight: 600;
-		height: auto;
-		padding: 0;
-		text-decoration: underline;
-	}
-}
-
 .layout:not( .is-grav-powered-client ) .magic-login__handle-link,
 .layout:not( .is-grav-powered-client ) .magic-login__link-expired {
 	.empty-content__title {
@@ -263,6 +244,15 @@
 			line-height: 20px;
 			padding-left: 4px;
 		}
+	}
+
+	.components-button.is-link {
+		color: var( --studio-wordpress-blue, #3858e9 );
+		font-size: inherit;
+		font-weight: 600;
+		height: auto;
+		padding: 0;
+		text-decoration: underline;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -89,32 +89,6 @@
 		border-color: var( --studio-jetpack-green-60 );
 	}
 }
-.magic-login__successfully-jetpack-actions {
-	color: var( --studio-jetpack-grey-50, #646970 );
-	font-size: 14px;
-	font-weight: 400;
-	line-height: 20px;
-	word-wrap: break-word;
-
-	text-align: center;
-
-	margin-top: 45px;
-	margin-bottom: 45px;
-
-	.magic-login__resend-button {
-		font-size: 100%;
-		color: var( --studio-jetpack-green-60, #007117 );
-
-		&:hover {
-			color: var( --studio-jetpack-green-60, #007117 );
-		}
-	}
-
-	.magic-login__log-in-link {
-		color: var( --studio-jetpack-green-60, #007117 );
-	}
-}
-
 .layout.is-wpcom-magic-login {
 	.magic-login__form-header-icon {
 		text-align: center;
@@ -160,6 +134,25 @@
 		font-weight: 500;
 		line-height: 20px;
 		padding: 0.75rem 1.5rem;
+	}
+}
+
+.magic-login__footer-text {
+	font-size: $font-body-small;
+	color: var( --studio-gray-50, #646970 );
+	text-align: center;
+	margin: 24px auto 0;
+	max-width: 400px;
+	line-height: 20px;
+
+	a,
+	.components-button.is-link {
+		color: var( --studio-wordpress-blue, #3858e9 );
+		font-size: inherit;
+		font-weight: 600;
+		height: auto;
+		padding: 0;
+		text-decoration: underline;
 	}
 }
 

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
@@ -199,76 +200,81 @@ const VerifyLoginCode = ( {
 	const submitEnabled = getVerificationCode().length === CODE_LENGTH && ! isDisabled && ! showError;
 
 	return (
-		<div className="magic-login__successfully-jetpack">
-			<LoggedOutForm
-				className={ clsx( 'magic-login__verify-code-form', {
-					'magic-login__verify-code-form--error': showError,
-				} ) }
-				onSubmit={ onSubmit }
-			>
-				<div className="magic-login__verify-code-field-container">
-					{ Array.from( { length: CODE_LENGTH } ).map( ( _, index ) => (
-						<FormTextInput
-							key={ index }
-							ref={ inputRefs.current[ index ] }
-							autoCapitalize="off"
-							className="magic-login__verify-code-character-field"
-							disabled={ isDisabled }
-							maxLength={ 1 }
-							value={ codeCharacters[ index ] }
-							onChange={ ( event ) => onCodeCharacterChange( index, event.target.value ) }
-							onKeyDown={ ( event ) => onKeyDown( index, event ) }
-							onPaste={ ( event ) => onPaste( index, event ) }
-							aria-label={ translate( 'Verification code character %(position)s of %(total)s', {
-								args: {
-									position: index + 1,
-									total: CODE_LENGTH,
-								},
-							} ) }
-						/>
-					) ) }
-				</div>
-
-				{ showError && (
-					<div className="magic-login__verify-code-error-message">
-						{ translate( "Oops, that's the wrong code. Please verify or resend the email." ) }
-					</div>
-				) }
-
-				<div className="magic-login__form-action">
-					<Button
-						variant="primary"
-						disabled={ ! submitEnabled && ! isDisabled }
-						isBusy={ isDisabled }
-						type="submit"
-						__next40pxDefaultSize
+		<>
+			<div className="magic-login__successfully-jetpack">
+				<div className="magic-login__form">
+					<LoggedOutForm
+						className={ clsx( 'magic-login__verify-code-form', {
+							'magic-login__verify-code-form--error': showError,
+						} ) }
+						onSubmit={ onSubmit }
 					>
-						{ isDisabled ? translate( 'Verifying code…' ) : translate( 'Verify code' ) }
-					</Button>
-				</div>
-			</LoggedOutForm>
+						<div className="magic-login__verify-code-field-container">
+							{ Array.from( { length: CODE_LENGTH } ).map( ( _, index ) => (
+								<FormTextInput
+									key={ index }
+									ref={ inputRefs.current[ index ] }
+									autoCapitalize="off"
+									className="magic-login__verify-code-character-field"
+									disabled={ isDisabled }
+									maxLength={ 1 }
+									value={ codeCharacters[ index ] }
+									onChange={ ( event ) => onCodeCharacterChange( index, event.target.value ) }
+									onKeyDown={ ( event ) => onKeyDown( index, event ) }
+									onPaste={ ( event ) => onPaste( index, event ) }
+									aria-label={ translate( 'Verification code character %(position)s of %(total)s', {
+										args: {
+											position: index + 1,
+											total: CODE_LENGTH,
+										},
+									} ) }
+								/>
+							) ) }
+						</div>
 
-			<div className="magic-login__successfully-jetpack-actions">
-				<p>
-					{ translate(
-						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
-						{
-							components: {
-								button: (
-									<Button
-										className="magic-login__resend-button"
-										variant="link"
-										onClick={ handleResendEmail }
-										disabled={ isRedirecting }
-									/>
-								),
-								link: <a className="magic-login__log-in-link" href="/log-in/jetpack" />,
-							},
-						}
-					) }
-				</p>
+						{ showError && (
+							<div className="magic-login__verify-code-error-message">
+								{ translate( "Oops, that's the wrong code. Please verify or resend the email." ) }
+							</div>
+						) }
+
+						<div className="magic-login__form-action">
+							<Button
+								variant="primary"
+								disabled={ ! submitEnabled && ! isDisabled }
+								isBusy={ isDisabled }
+								type="submit"
+								__next40pxDefaultSize
+							>
+								{ isDisabled ? translate( 'Verifying code…' ) : translate( 'Verify code' ) }
+							</Button>
+						</div>
+					</LoggedOutForm>
+				</div>
 			</div>
-		</div>
+
+			<OneLoginFooter
+				loginLink={
+					<p className="magic-login__footer-text">
+						{ translate(
+							"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
+							{
+								components: {
+									button: (
+										<Button
+											variant="link"
+											onClick={ handleResendEmail }
+											disabled={ isRedirecting }
+										/>
+									),
+									link: <a href="/log-in/jetpack" />,
+								},
+							}
+						) }
+					</p>
+				}
+			/>
+		</>
 	);
 };
 

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -260,9 +260,14 @@ const VerifyLoginCode = ( {
 						{
 							components: {
 								button: (
-									<Button variant="link" onClick={ handleResendEmail } disabled={ isRedirecting } />
+									<Button
+										className="one-login__footer-link"
+										variant="link"
+										onClick={ handleResendEmail }
+										disabled={ isRedirecting }
+									/>
 								),
-								link: <a href="/log-in/jetpack" />,
+								link: <a className="one-login__footer-link" href="/log-in/jetpack" />,
 							},
 						}
 					) }

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
+import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
@@ -252,8 +253,8 @@ const VerifyLoginCode = ( {
 				</div>
 			</div>
 
-			<div className="magic-login__footer">
-				<p>
+			<OneLoginFooter>
+				<p className="one-login__footer-text">
 					{ translate(
 						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
 						{
@@ -266,7 +267,7 @@ const VerifyLoginCode = ( {
 						}
 					) }
 				</p>
-			</div>
+			</OneLoginFooter>
 		</>
 	);
 };

--- a/client/login/magic-login/verify-login-code.jsx
+++ b/client/login/magic-login/verify-login-code.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import { navigate } from 'calypso/lib/navigate';
-import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
@@ -253,27 +252,21 @@ const VerifyLoginCode = ( {
 				</div>
 			</div>
 
-			<OneLoginFooter
-				loginLink={
-					<p className="magic-login__footer-text">
-						{ translate(
-							"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
-							{
-								components: {
-									button: (
-										<Button
-											variant="link"
-											onClick={ handleResendEmail }
-											disabled={ isRedirecting }
-										/>
-									),
-									link: <a href="/log-in/jetpack" />,
-								},
-							}
-						) }
-					</p>
-				}
-			/>
+			<div className="magic-login__footer">
+				<p>
+					{ translate(
+						"Didn't get the code? Check your spam folder, or {{button}}resend the email{{/button}}. Wrong email or account? {{link}}Use a different account{{/link}}.",
+						{
+							components: {
+								button: (
+									<Button variant="link" onClick={ handleResendEmail } disabled={ isRedirecting } />
+								),
+								link: <a href="/log-in/jetpack" />,
+							},
+						}
+					) }
+				</p>
+			</div>
 		</>
 	);
 };

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -7,35 +7,34 @@
 	font-size: $font-body-small;
 	color: var( --studio-jetpack-grey-50, #646970 );
 
-	a,
-	.components-button.is-link {
-		color: var( --studio-gray-90, #1d2327 );
-		font-weight: 500;
-		text-decoration: underline;
-		padding: 0;
-		height: auto;
-	}
+    .one-login__footer-link {
+        text-decoration: underline;
+        padding: 0;
+        height: auto;
+    }
 
 	.one-login__footer-links-wrapper {
 		display: flex;
 		align-self: center;
 		gap: 1em;
-	}
 
-	.one-login__footer-link {
-		display: inline-flex;
-		align-items: center;
-		align-self: center;
-		gap: 0.1em;
+        .one-login__footer-link {
+            color: var( --studio-gray-90, #1d2327 );
+            font-weight: 500;
+            display: inline-flex;
+            align-items: center;
+            align-self: center;
+            gap: 0.1em;
+        }
 	}
 
 	.one-login__footer-text {
 		color: inherit;
 
-		a,
-		.components-button.is-link {
-			color: inherit;
-			font-weight: 600;
-		}
+        .one-login__footer-link {
+            color: inherit;
+            font-weight: inherit;
+            font-size: inherit;
+        }
 	}
 }

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -7,34 +7,34 @@
 	font-size: $font-body-small;
 	color: var( --studio-gray-50, #646970 );
 
-    .one-login__footer-link {
-        text-decoration: underline;
-        padding: 0;
-        height: auto;
-    }
+	.one-login__footer-link {
+		text-decoration: underline;
+		padding: 0;
+		height: auto;
+	}
 
 	.one-login__footer-links-wrapper {
 		display: flex;
 		align-self: center;
 		gap: 1em;
 
-        .one-login__footer-link {
-            color: var( --studio-gray-90, #1d2327 );
-            font-weight: 500;
-            display: inline-flex;
-            align-items: center;
-            align-self: center;
-            gap: 0.1em;
-        }
+		.one-login__footer-link {
+			color: var( --studio-gray-90, #1d2327 );
+			font-weight: 500;
+			display: inline-flex;
+			align-items: center;
+			align-self: center;
+			gap: 0.1em;
+		}
 	}
 
 	.one-login__footer-text {
 		color: inherit;
 
-        .one-login__footer-link {
-            color: inherit;
-            font-weight: inherit;
-            font-size: inherit;
-        }
+		.one-login__footer-link {
+			color: inherit;
+			font-weight: inherit;
+			font-size: inherit;
+		}
 	}
 }

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -1,22 +1,41 @@
 .one-login__footer {
-    display: flex;
-    align-self: center;
-    gap: 1em;
-    flex-direction: column;
+	display: flex;
+	align-self: center;
+	flex-direction: column;
+	gap: 1em;
+	text-align: center;
+	font-size: $font-body-small;
+	color: var( --studio-jetpack-grey-50, #646970 );
 
-    .one-login__footer-links-wrapper {
-        display: flex;
-        align-self: center;
-        gap: 1em;
-    }
+	a,
+	.components-button.is-link {
+		color: var( --studio-gray-90, #1d2327 );
+		font-weight: 500;
+		text-decoration: underline;
+		padding: 0;
+		height: auto;
+	}
 
-    .one-login__footer-link {
-        color: var(--studio-gray-90, #1d2327);
-        font-weight: 500;
-        font-size: $font-body-small;
-        display: inline-flex;
-        align-items: center;
-        align-self: center;
-        gap: 0.1em;
-    }
+	.one-login__footer-links-wrapper {
+		display: flex;
+		align-self: center;
+		gap: 1em;
+	}
+
+	.one-login__footer-link {
+		display: inline-flex;
+		align-items: center;
+		align-self: center;
+		gap: 0.1em;
+	}
+
+	.one-login__footer-text {
+		color: inherit;
+
+		a,
+		.components-button.is-link {
+			color: inherit;
+			font-weight: 600;
+		}
+	}
 }

--- a/client/login/wp-login/components/one-login-footer.scss
+++ b/client/login/wp-login/components/one-login-footer.scss
@@ -5,7 +5,7 @@
 	gap: 1em;
 	text-align: center;
 	font-size: $font-body-small;
-	color: var( --studio-jetpack-grey-50, #646970 );
+	color: var( --studio-gray-50, #646970 );
 
     .one-login__footer-link {
         text-decoration: underline;

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -13,6 +13,7 @@ interface OneLoginFooterProps {
 	 * when `isLoginView` is false, this is the "back to login" link
 	 */
 	loginLink?: JSX.Element;
+	children?: React.ReactNode;
 	/**
 	 * when `isLoginView` is false, this is the "support" link
 	 */
@@ -32,6 +33,7 @@ const OneLoginFooter = ( {
 	loginLink,
 	isLoginView,
 	supportLink,
+	children,
 }: OneLoginFooterProps ) => {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 
@@ -58,10 +60,14 @@ const OneLoginFooter = ( {
 
 	return (
 		<div className="one-login__footer">
-			<div className="one-login__footer-links-wrapper">
-				{ loginLink }
-				{ supportLink }
-			</div>
+			{ children ? (
+				children
+			) : (
+				<div className="one-login__footer-links-wrapper">
+					{ loginLink }
+					{ supportLink }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/login/wp-login/components/one-login-footer.tsx
+++ b/client/login/wp-login/components/one-login-footer.tsx
@@ -6,20 +6,23 @@ import './one-login-footer.scss';
 
 interface OneLoginFooterProps {
 	/**
-	 * when `isLoginView` is true, this is the "lost password" link
+	 * When `isLoginView` is true, this is the "lost password" link.
 	 */
 	lostPasswordLink?: JSX.Element;
 	/**
-	 * when `isLoginView` is false, this is the "back to login" link
+	 * When `isLoginView` is false, this is the "back to login" link.
 	 */
 	loginLink?: JSX.Element;
+	/**
+	 * The content of the footer. If provided, it will be rendered instead of the default links.
+	 */
 	children?: React.ReactNode;
 	/**
-	 * when `isLoginView` is false, this is the "support" link
+	 * When `isLoginView` is false, this is the "support" link.
 	 */
 	supportLink?: JSX.Element;
 	/**
-	 * when true, this is the footer for the main login screen
+	 * When true, this is the footer for the main login screen.
 	 */
 	isLoginView?: boolean;
 }

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -27,8 +27,10 @@
 }
 
 .wp-login__one-login-layout-tos {
+	color: var( --studio-gray-50, #646970 );
+
 	a {
-		color: var( --color-text );
+		color: inherit;
 		text-decoration: underline;
 	}
 }


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DSGCOM-153/login-magic-code-on-confirm-page-update-footer-to-a-tertiary-resend

## Proposed Changes

* Extend `OneLoginFooter` to accept optional children and adjust its styles so inline paragraphs can share the same typography and link treatments as the other login views.
* Swap the custom Jetpack confirmation footers for `OneLoginFooter`, remove bespoke classes, and wrap the forms so the padding/margins match the request page.
* Restore the missing spacing on `.magic-login__successfully-jetpack` so the confirmation cards keep the same bottom margin and padding as `.form-fieldset` / `.card.logged-out-form`.

| Before | After | Code/main screen |
|--------|--------|--------|
| <img width="582" height="556" alt="Screenshot 2025-11-18 at 4 19 15 PM" src="https://github.com/user-attachments/assets/1d3651c3-bae3-4a9f-a33d-61d6ed8b7589" /> | <img width="576" height="566" alt="Screenshot 2025-11-18 at 4 19 45 PM" src="https://github.com/user-attachments/assets/7390abb7-f549-497e-8d8e-1b6871f81382" /> | <img width="535" height="464" alt="Screenshot 2025-11-18 at 4 21 25 PM" src="https://github.com/user-attachments/assets/db9cd699-1e46-40db-8d31-0cc7e8666ddc" /> |



## Why are these changes being made?

* The confirmation pages had drifted from the primary login layout, resulting in misaligned typography, colors, and spacing. Syncing them with `OneLoginFooter` keeps every login step visually consistent and avoids one-off Jetpack-only styles.

## Testing Instructions

* Visit `/log-in/link` and `/log-in/jetpack/link`, trigger the confirmation flow, and confirm the footers render as a single paragraph with consistent fonts/colors and default link hover behavior.
* Verify the code confirmation and Jetpack connect success pages now share the same margins/padding as the request page (no footer touching the form, links centered, matching font sizes).
* Verify that footer links in the main Login pages, like "forgot password" or "use a password instead", have not been affected by the changes

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this PR changes what data or activity we track or use (p4TIVU-aUh-p2)?
