### PR TITLE
Show the right domain when buying a 100-year plan

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -1,4 +1,9 @@
-import { PLAN_100_YEARS, getPlan, domainProductSlugs } from '@automattic/calypso-products';
+import {
+	PLAN_100_YEARS,
+	getPlan,
+	domainProductSlugs,
+	is100Year,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, WordPressLogo } from '@automattic/components';
 import { FLOWS_ZENDESK_FLOWNAME } from '@automattic/help-center/src/constants';
@@ -157,8 +162,15 @@ export default function HundredYearThankYou( {
 	const isReceiptLoading = ! receipt.hasLoadedFromServer || receipt.isRequesting;
 
 	// Infer whether this is a 100-year domain registration/transfer or the 100-year plan
+	// If both are purchased, prioritize showing the plan variant
 	const resolvedProductSlug = useMemo( () => {
 		const purchases = receipt?.data?.purchases || [];
+		// First check if there's a 100-year plan purchase - this takes precedence
+		const hundredYearPlanPurchase = purchases.find( ( p ) => is100Year( p ) );
+		if ( hundredYearPlanPurchase ) {
+			return PLAN_100_YEARS;
+		}
+		// Otherwise, check for 100-year domain purchase
 		const hundredYearDomainPurchase = purchases.find( ( p ) => p.isHundredYearDomain );
 		if ( hundredYearDomainPurchase ) {
 			return hundredYearDomainPurchase.isDomainRegistration

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -178,14 +178,25 @@ export default function HundredYearThankYou( {
 			? isRequestingSite( state, siteId ) || isRequestingSiteDomains( state, siteId )
 			: false
 	);
+
 	let targetDomain: ResponseDomain | null = null;
 	switch ( resolvedProductSlug ) {
-		case domainProductSlugs.TRANSFER_IN:
-			targetDomain = getTransferredInDomains( siteDomains )[ 0 ] ?? null;
+		case domainProductSlugs.TRANSFER_IN: {
+			const transferredDomains = getTransferredInDomains( siteDomains );
+			targetDomain =
+				transferredDomains.find( ( domain ) => domain.isHundredYearDomain ) ??
+				transferredDomains[ 0 ] ??
+				null;
 			break;
-		case domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION:
-			targetDomain = getRegisteredDomains( siteDomains )[ 0 ] ?? null;
+		}
+		case domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION: {
+			const registeredDomains = getRegisteredDomains( siteDomains );
+			targetDomain =
+				registeredDomains.find( ( domain ) => domain.isHundredYearDomain ) ??
+				registeredDomains[ 0 ] ??
+				null;
 			break;
+		}
 		default:
 			targetDomain = null;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -12,14 +12,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HundredYearLoaderView from 'calypso/components/hundred-year-loader-view';
-import { getRegisteredDomains, getTransferredInDomains } from 'calypso/lib/domains';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
-import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
-import { getSiteId, getSiteOptions, isRequestingSite } from 'calypso/state/sites/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSiteId, getSiteOptions } from 'calypso/state/sites/selectors';
 import { hideMasterbar } from 'calypso/state/ui/actions';
-import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const VideoContainer = styled.div< { isMobile: boolean } >`
 	overflow: hidden;
@@ -173,33 +171,12 @@ export default function HundredYearThankYou( {
 	const siteDomains = useSelector( ( state ) =>
 		siteId ? getDomainsBySiteId( state, siteId ) : []
 	);
-	const isLoadingDomains = useSelector( ( state ) =>
-		siteId && resolvedProductSlug !== PLAN_100_YEARS
-			? isRequestingSite( state, siteId ) || isRequestingSiteDomains( state, siteId )
-			: false
-	);
 
-	let targetDomain: ResponseDomain | null = null;
-	switch ( resolvedProductSlug ) {
-		case domainProductSlugs.TRANSFER_IN: {
-			const transferredDomains = getTransferredInDomains( siteDomains );
-			targetDomain =
-				transferredDomains.find( ( domain ) => domain.isHundredYearDomain ) ??
-				transferredDomains[ 0 ] ??
-				null;
-			break;
-		}
-		case domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION: {
-			const registeredDomains = getRegisteredDomains( siteDomains );
-			targetDomain =
-				registeredDomains.find( ( domain ) => domain.isHundredYearDomain ) ??
-				registeredDomains[ 0 ] ??
-				null;
-			break;
-		}
-		default:
-			targetDomain = null;
-	}
+	const purchasedDomainName = useMemo( () => {
+		const purchases = receipt?.data?.purchases || [];
+		const hundredYearDomainPurchase = purchases.find( ( p ) => p.isHundredYearDomain );
+		return hundredYearDomainPurchase?.meta || null;
+	}, [ receipt ] );
 
 	const { mutateAsync: submitUserFields } = useUpdateZendeskUserFields();
 
@@ -236,11 +213,7 @@ export default function HundredYearThankYou( {
 	}
 
 	const isMobile = useMobileBreakpoint();
-	const isDomainDataLoaded = ! isLoadingDomains && targetDomain !== null;
-	const isPageLoading =
-		isReceiptLoading ||
-		isLoadingDomains ||
-		( resolvedProductSlug !== PLAN_100_YEARS && ! isDomainDataLoaded );
+	const isPageLoading = isReceiptLoading;
 	const hundredYearPlanCta = (
 		<StyledLightButton onClick={ () => page( ` /home/${ siteSlug }` ) }>
 			{ translate( 'Manage your site' ) }
@@ -252,16 +225,21 @@ export default function HundredYearThankYou( {
 		</StyledLightButton>
 	);
 	const cta = resolvedProductSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
+	const primaryDomainFromState = siteDomains.find( ( domain ) => domain.isPrimary )?.domain;
+	const displayDomain =
+		resolvedProductSlug === PLAN_100_YEARS
+			? primaryDomainFromState || siteSlug
+			: purchasedDomainName || siteSlug;
 	const domainSpecificDescription =
 		resolvedProductSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
 			? translate( 'Your 100-Year Domain %(domain)s has been registered.', {
 					args: {
-						domain: targetDomain?.domain || siteSlug, // though targetDomain?.domain should be defined here, right?
+						domain: displayDomain,
 					},
 			  } )
 			: translate( 'Your 100-Year Domain %(domain)s is being transferred.', {
 					args: {
-						domain: targetDomain?.domain || siteSlug,
+						domain: displayDomain,
 					},
 			  } );
 	const hundredYearPlanDescription = translate( 'Your %(planTitle)s is now active.', {


### PR DESCRIPTION

Part of DOMENG-244

## Proposed Changes

* Show the recently purchased 100-year domain on a site with multiple
* Show the plan thank-you when purchased together with a 100-year domain

## Why are these changes being made?

* Fixes a regression from the latest changes and an edge case

## Testing Instructions

1. Enable the store sandbox
2. Quick way to buy a 100-year plan is to visit /checkout/SITE/wp_com_hundred_year_bundle_centennially

You need to
1. Get a 100-year plan without a domain and see the plan thank-you
2. Get a 100-year plan with a 100-year domain and see the plan thank-you
3. Get a 100-year domain and see the domain thank-you
4. Get another 100-year domain and see the domain thank-you with the recently purchased domain

<img width="1046" height="664" alt="Screenshot 2025-11-18 at 16 57 35" src="https://github.com/user-attachments/assets/bf97e218-766d-47b5-81cc-209b728e5d15" />
<img width="1046" height="664" alt="Screenshot 2025-11-18 at 16 57 30" src="https://github.com/user-attachments/assets/b87a9e17-0976-44d1-8947-fe08f805267e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
