### PR TITLE
Fix E2E tests: Update domain search component selectors for domain-connection-redesign

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -92,7 +92,7 @@ export class DomainSearchComponent {
 	 */
 	async fillUseDomainIOwnInput( domainName: string ): Promise< void > {
 		const searchAndPressEnter = async () => {
-			const input = await this.page.getByText( 'Enter the domain you would like to use:' );
+			const input = this.page.locator( '.use-my-domain__domain-input input' );
 			await input.fill( domainName );
 			await input.press( 'Enter' );
 		};
@@ -114,7 +114,9 @@ export class DomainSearchComponent {
 	 * Click on the "Transfer your domain" option in the "Transfer or Connect" page
 	 */
 	async selectTransferYourDomain(): Promise< void > {
-		const button = await this.getContainer().getByRole( 'button', { name: 'Select' } ).nth( 0 );
+		const button = this.getContainer()
+			.locator( '.domain-transfer-or-connect__content button' )
+			.nth( 0 );
 		await button.waitFor();
 		await button.click();
 	}

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -3,8 +3,8 @@ import { Page } from 'playwright';
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
 	continueButton: 'button:text("Continue")',
-	connectDomainButton: '.option-content:has-text("Connect your domain") button:text("Select")',
-	transferDomainButton: '.option-content:has-text("Transfer your domain") button:text("Select")',
+	connectDomainButton: '.domain-transfer-or-connect__content button:nth-child(2)',
+	transferDomainButton: '.domain-transfer-or-connect__content button:nth-child(1)',
 };
 
 /**


### PR DESCRIPTION
## Proposed Changes
Fixes E2E tests broken after enabling the domain-connection-redesign feature flag in the wpcalypso environment. The new UI uses different DOM structure and classes, so the selectors were updated to match.

## Why are these changes being made?
These updates ensure the E2E tests work with the redesigned domain connection flow enabled by the feature flag.

## Testing Instructions
Run this e2e tests against `wpcalypso`

```
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- test/e2e/specs/flows/setup-domain__transfer-domain.ts
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- test/e2e/specs/flows/setup-onboarding__use-a-domain-i-own-transfer-domain.ts
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
