### PR TITLE
MSD: Update "use for all subscriptions" checkbox to mirror calypso

### DIFF
--- a/client/dashboard/me/billing-purchases/add-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/add-payment-method.tsx
@@ -29,6 +29,7 @@ function AddPaymentMethod() {
 		isStripeLoading,
 		stripeLoadingError,
 		allowUseForAllSubscriptions: true,
+		defaultToUseForAllSubscriptions: true,
 	} );
 
 	if ( stripeLoadingError || ( ! isStripeLoading && ! creditCardMethod ) ) {

--- a/client/dashboard/me/billing-purchases/payment-method-selector/use-create-assignable-payment-methods.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/use-create-assignable-payment-methods.tsx
@@ -51,6 +51,7 @@ export function useCreateAssignablePaymentMethods( purchase?: Purchase ): Paymen
 		stripeLoadingError,
 		hasExistingCardMethods,
 		allowUseForAllSubscriptions: true,
+		defaultToUseForAllSubscriptions: false,
 	} );
 
 	const currentPaymentMethodId = purchase ? getPaymentMethodIdFromPayment( purchase ) : null;

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -6,8 +6,10 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Fragment, useState } from 'react';
+import InlineSupportLink from '../../../components/inline-support-link';
 import { TaxLocationForm, defaultTaxLocation } from '../../../components/tax-location-form';
 import { PaymentMethodImage } from '../payment-method-image';
 import { CreditCardFields } from './credit-card-fields';
@@ -155,7 +157,14 @@ function CreditCardFieldsWrapper( {
 						checked={ formData.useForAllSubscriptions }
 						onChange={ ( e ) => handleFieldChange( { useForAllSubscriptions: e.target.checked } ) }
 					/>
-					{ __( 'Use this card for all my subscriptions' ) }
+					{ createInterpolateElement(
+						__(
+							'Use this payment method for all subscriptions on my account. <link>Learn more.</link>'
+						),
+						{
+							link: <InlineSupportLink supportContext="payment_method_all_subscriptions" />,
+						}
+					) }
 				</label>
 			) }
 		</VStack>

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -23,22 +23,34 @@ export interface CreditCardFormData {
 	useForAllSubscriptions: boolean;
 }
 
-const defaultFormData: CreditCardFormData = {
-	cardholderName: '',
-	taxLocation: defaultTaxLocation,
-	useForAllSubscriptions: true,
-};
+function getDefaultFormData( {
+	defaultToUseForAllSubscriptions,
+}: {
+	defaultToUseForAllSubscriptions?: boolean;
+} ): CreditCardFormData {
+	const defaultFormData: Omit< CreditCardFormData, 'useForAllSubscriptions' > = {
+		cardholderName: '',
+		taxLocation: defaultTaxLocation,
+	};
+
+	return {
+		...defaultFormData,
+		useForAllSubscriptions: defaultToUseForAllSubscriptions ?? false,
+	};
+}
 
 export function createCreditCardMethod( {
 	currency,
 	hasExistingCardMethods,
 	allowUseForAllSubscriptions,
+	defaultToUseForAllSubscriptions,
 }: {
 	currency?: string | null | undefined;
 	hasExistingCardMethods?: boolean;
 	allowUseForAllSubscriptions?: boolean;
+	defaultToUseForAllSubscriptions?: boolean;
 } ): PaymentMethod {
-	let sharedFormData = defaultFormData;
+	let sharedFormData = getDefaultFormData( { defaultToUseForAllSubscriptions } );
 	let sharedCardNumberElement: StripeCardNumberElement | undefined;
 
 	const CreditCardFieldsWithData = () => (
@@ -46,6 +58,7 @@ export function createCreditCardMethod( {
 			allowUseForAllSubscriptions={ allowUseForAllSubscriptions }
 			onDataChange={ ( data ) => ( sharedFormData = data ) }
 			onCardElementReady={ ( element ) => ( sharedCardNumberElement = element ) }
+			defaultToUseForAllSubscriptions={ defaultToUseForAllSubscriptions }
 		/>
 	);
 
@@ -118,12 +131,16 @@ function CreditCardFieldsWrapper( {
 	allowUseForAllSubscriptions,
 	onDataChange,
 	onCardElementReady,
+	defaultToUseForAllSubscriptions,
 }: {
 	allowUseForAllSubscriptions?: boolean;
 	onDataChange: ( data: CreditCardFormData ) => void;
 	onCardElementReady: ( element: StripeCardNumberElement | undefined ) => void;
+	defaultToUseForAllSubscriptions?: boolean;
 } ) {
-	const [ formData, setFormData ] = useState< CreditCardFormData >( defaultFormData );
+	const [ formData, setFormData ] = useState< CreditCardFormData >(
+		getDefaultFormData( { defaultToUseForAllSubscriptions } )
+	);
 	const elements = useElements();
 
 	// Notify parent of card element when available

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -26,7 +26,7 @@ export interface CreditCardFormData {
 const defaultFormData: CreditCardFormData = {
 	cardholderName: '',
 	taxLocation: defaultTaxLocation,
-	useForAllSubscriptions: false,
+	useForAllSubscriptions: true,
 };
 
 export function createCreditCardMethod( {

--- a/client/dashboard/me/billing-purchases/payment-methods/use-create-credit-card.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/use-create-credit-card.tsx
@@ -8,12 +8,14 @@ export function useCreateCreditCard( {
 	stripeLoadingError,
 	hasExistingCardMethods,
 	allowUseForAllSubscriptions,
+	defaultToUseForAllSubscriptions,
 }: {
 	currency?: string | null | undefined;
 	isStripeLoading: boolean;
 	stripeLoadingError: Error | null | undefined;
 	hasExistingCardMethods?: boolean;
 	allowUseForAllSubscriptions?: boolean;
+	defaultToUseForAllSubscriptions?: boolean;
 } ): PaymentMethod | null {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 
@@ -24,9 +26,16 @@ export function useCreateCreditCard( {
 						currency,
 						hasExistingCardMethods,
 						allowUseForAllSubscriptions,
+						defaultToUseForAllSubscriptions,
 				  } )
 				: null,
-		[ currency, shouldLoadStripeMethod, hasExistingCardMethods, allowUseForAllSubscriptions ]
+		[
+			currency,
+			shouldLoadStripeMethod,
+			hasExistingCardMethods,
+			allowUseForAllSubscriptions,
+			defaultToUseForAllSubscriptions,
+		]
 	);
 
 	return stripeMethod;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-287/multi-site-dashboard-use-for-all-subscriptions-checkbox-works

## Proposed Changes

This PR modifies the "use for all subscriptions" checkbox in the Multi Site Dashboard "Add Payment Method" form to mirror the implementation used in calypso payment method management.

Specifically it changes the following things:

- Re-word the checkbox label to "Use this payment method of all subscriptions on my account."
- Add a "Learn more" inline support link.
- Checks the box by default for the "add payment method" form (but not for the "change payment method" form).

Before             |  After
:-------------------------:|:-------------------------:
<img width="691" height="810" alt="Screenshot 2025-11-18 at 1 14 03 PM" src="https://github.com/user-attachments/assets/c252d70d-d8da-4239-b6e4-b799904d7f92" /> | <img width="716" height="801" alt="Screenshot 2025-11-18 at 1 13 44 PM" src="https://github.com/user-attachments/assets/2aaf094e-672d-4dc6-907a-ddd5395bbc7b" />
<img width="679" height="845" alt="Screenshot 2025-11-18 at 2 10 36 PM" src="https://github.com/user-attachments/assets/e0547720-28e5-48bc-9ab9-ad668771b272" /> | <img width="693" height="853" alt="Screenshot 2025-11-18 at 2 10 03 PM" src="https://github.com/user-attachments/assets/ffdaa5f1-9198-4e95-aa19-159857322216" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The "use for all subscriptions" checkbox in the payment method management for the Multi Site Dashboard should look and work the same as it does in calypso. Its design and functionality have been heavily tested there already.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Add payment method

- Visit http://calypso.localhost:3000/v2/me/billing/payment-methods/add
- Verify that you see the "use for all subscriptions" text.
- Click the "Learn more" link and verify that it opens an inline support document about the checkbox.
- Verify that the checkbox **is checked** by default.

### Change payment method

- Visit http://calypso.localhost:3000/v2/me/billing/purchases
- Select an existing purchase.
- In the `Manage subscription` card, click the "Update" button next to the payment method or the "Add payment method" link if it is shown instead.
- On the payment method selector page (it should be something like http://calypso.localhost:3000/v2/me/billing/purchases/000000000/payment-method/change), click on the "New credit or debit card" option.
- Verify that you see the "use for all subscriptions" text.
- Click the "Learn more" link and verify that it opens an inline support document about the checkbox.
- Verify that the checkbox **is not checked** by default.
