### PR TITLE
MSD: Fetch most recent info within domain contact editing form

### DIFF
--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { Card, CardBody } from '../../components/card';
@@ -23,8 +24,28 @@ export default function DomainContactInfo() {
 
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: whoisData } = useQuery( domainWhoisQuery( domainName ) );
+	const { data: whoisData } = useQuery( { ...domainWhoisQuery( domainName ), staleTime: 0 } );
 	const registrantWhoisData = findRegistrantWhois( whoisData );
+
+	const { initialData, key } = useMemo( () => {
+		const initialData = {
+			firstName: registrantWhoisData?.fname ?? '',
+			lastName: registrantWhoisData?.lname ?? '',
+			organization: registrantWhoisData?.org ?? '',
+			email: registrantWhoisData?.email ?? '',
+			phone: registrantWhoisData?.phone ?? '',
+			address1: registrantWhoisData?.sa1 ?? '',
+			address2: registrantWhoisData?.sa2 ?? '',
+			city: registrantWhoisData?.city ?? '',
+			state: registrantWhoisData?.state ?? '',
+			countryCode: registrantWhoisData?.country_code ?? '',
+			postalCode: registrantWhoisData?.pc ?? '',
+			fax: registrantWhoisData?.fax ?? '',
+			optOutTransferLock: false,
+		};
+
+		return { initialData, key: JSON.stringify( initialData ) };
+	}, [ registrantWhoisData ] );
 
 	const validateMutation = useMutation( domainWhoisValidateMutation( [ domainName ] ) );
 	const updateMutation = useMutation( domainWhoisMutation( domainName ) );
@@ -79,22 +100,8 @@ export default function DomainContactInfo() {
 						</Card>
 					)
 				}
-				initialData={
-					{
-						firstName: registrantWhoisData?.fname ?? '',
-						lastName: registrantWhoisData?.lname ?? '',
-						organization: registrantWhoisData?.org ?? '',
-						email: registrantWhoisData?.email ?? '',
-						phone: registrantWhoisData?.phone ?? '',
-						address1: registrantWhoisData?.sa1 ?? '',
-						address2: registrantWhoisData?.sa2 ?? '',
-						city: registrantWhoisData?.city ?? '',
-						state: registrantWhoisData?.state ?? '',
-						countryCode: registrantWhoisData?.country_code ?? '',
-						postalCode: registrantWhoisData?.pc ?? '',
-						fax: registrantWhoisData?.fax ?? '',
-					} as DomainContactDetails
-				}
+				key={ key }
+				initialData={ initialData }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -71,14 +71,18 @@ export default function DomainsContactInfo() {
 		whoisData: WhoisDataEntry[][];
 	};
 
-	const initialData = useMemo( () => {
+	const { initialData, key } = useMemo( () => {
 		if ( ! whoisData?.length ) {
-			return { optOutTransferLock: false };
+			const initialData = { optOutTransferLock: false };
+
+			return { initialData, key: JSON.stringify( initialData ) };
 		}
 
-		return aggregateWhoisDataWithMostCommonValues(
+		const initialData = aggregateWhoisDataWithMostCommonValues(
 			whoisData.flat().filter( ( whois ) => whois.type === WhoisType.REGISTRANT )
 		);
+
+		return { initialData, key: JSON.stringify( initialData ) };
 	}, [ whoisData ] );
 
 	const domainsWithUnmodifiableContactInfo = useMemo( () => {
@@ -188,6 +192,7 @@ export default function DomainsContactInfo() {
 				</div>
 			) }
 			<ContactForm
+				key={ key }
 				initialData={ initialData }
 				isSubmitting={ isValidatePending || isUpdatePending }
 				onSubmit={ handleSubmit }


### PR DESCRIPTION
Follows up on https://github.com/Automattic/wp-calypso/pull/107079.

## Proposed Changes

In the original PR, we were struggling to find a solution for cache invalidation (only 10 things hard in Computer Science!) because, in the front-end, we won't know for certain when the async bulk job that updates the contact information finishes.

We still don't know exactly when it will, but we want to display the freshest data possible to the user. That's why this PR changes the behavior of data fetching when rendering the contact info editing form for single domains: every time the user enters the page, it will fetch the new data, even if it's cached.

## Testing Instructions

1. Enter `/v2/domains/contact-info?selected=%s` where `%s` is a domain you own.
2. Update the information. Don't leave the page.
3. Enter the DARC for the updated domain and make sure the data changes came into effect.
4. Do not refresh the page. Click the domains submenu, enter the domain through the data view and click on the "Contact details & privacy" link.
5. Verify the updated data shows up instead of showing stale information (trunk behavior.)