### PR TITLE
Add query for the `inbound-transfer-start` endpoint

### DIFF
--- a/packages/api-queries/src/domain-transfer.ts
+++ b/packages/api-queries/src/domain-transfer.ts
@@ -9,6 +9,7 @@ import {
 	domainTransferToUser,
 	transferDomainToSite,
 	fetchDomainInboundTransferStatus,
+	startDomainInboundTransfer,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
@@ -94,4 +95,14 @@ export const domainInboundTransferStatusQuery = ( domainName: string ) =>
 	queryOptions( {
 		queryKey: [ 'domains', domainName, 'inbound-transfer-status' ],
 		queryFn: () => fetchDomainInboundTransferStatus( domainName ),
+	} );
+
+export const startDomainInboundTransferMutation = ( domain: string, siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( authCode: string ) => startDomainInboundTransfer( siteId, domain, authCode ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( domainQuery( domain ) );
+			queryClient.invalidateQueries( domainInboundTransferStatusQuery( domain ) );
+			queryClient.invalidateQueries( domainsQuery() );
+		},
 	} );


### PR DESCRIPTION

Part of [DOMAINS-1841](https://linear.app/a8c/issue/DOMAINS-1841)

## Proposed Changes

This PR adds the `startDomainInboundTransferMutation` query to `@automattic/api-queries`. That query will hit the `GET /domains/%s/inbound-transfer-start/%d` endpoint.

## Why are these changes being made?

We need that query for the [Domain Transfer Redesign](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a/overview) project.

## Testing Instructions

- Code inspection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
