### PR TITLE
Domains: Extract DomainRegistrarBanner component from DomainConnectionSetup

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-setup.tsx
@@ -20,6 +20,7 @@ import { Card, CardBody } from '../../components/card';
 import ConnectionModeCard from './connection-mode-card';
 import DNSRecordsDataView from './dns-records-dataview';
 import DomainConnectCard from './domain-connect-card';
+import DomainRegistrarBanner from './domain-registrar-banner';
 
 interface DomainConnectionSetupProps {
 	domainName: string;
@@ -165,32 +166,6 @@ export default function DomainConnectionSetup( {
 		} );
 	};
 
-	const renderDomainBanner = () => {
-		return (
-			<Card>
-				<CardBody>
-					<HStack spacing={ 2 } justify="space-between">
-						<Text size="medium" style={ { whiteSpace: 'nowrap' } }>
-							{ domainName }
-						</Text>
-						{ registrar && (
-							<HStack spacing={ 1 } justify="flex-end">
-								<Text variant="muted" size="small">
-									{ __( 'Registered by' ) }
-								</Text>
-								{ ! isReseller && registrar_url ? (
-									<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>
-								) : (
-									<Text size="small">{ registrar }</Text>
-								) }
-							</HStack>
-						) }
-					</HStack>
-				</CardBody>
-			</Card>
-		);
-	};
-
 	if (
 		connectionMode === DomainConnectionSetupMode.DC &&
 		domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null
@@ -198,7 +173,12 @@ export default function DomainConnectionSetup( {
 		return (
 			<div className="domain-connection-setup">
 				<VStack spacing={ 6 }>
-					{ renderDomainBanner() }
+					<DomainRegistrarBanner
+						domainName={ domainName }
+						registrar={ registrar }
+						registrar_url={ registrar_url }
+						isReseller={ isReseller }
+					/>
 					<DomainConnectCard
 						onChangeSetupMode={ () => setConnectionMode( recommendedMode ) }
 						onVerifyConnection={ () => onVerifyConnection( DomainConnectionSetupMode.DC ) }
@@ -216,7 +196,12 @@ export default function DomainConnectionSetup( {
 	return (
 		<div className="domain-connection-setup">
 			<VStack spacing={ 6 }>
-				{ renderDomainBanner() }
+				<DomainRegistrarBanner
+					domainName={ domainName }
+					registrar={ registrar }
+					registrar_url={ registrar_url }
+					isReseller={ isReseller }
+				/>
 				<VStack spacing={ 4 }>
 					{ domainConnectionSetupInfo.domain_connect_apply_wpcom_hosting !== null && (
 						<Card>

--- a/client/dashboard/domains/domain-connection-setup/domain-registrar-banner.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-registrar-banner.tsx
@@ -1,0 +1,45 @@
+import {
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	ExternalLink,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '../../components/card';
+
+interface DomainRegistrarBannerProps {
+	domainName: string;
+	registrar?: string | null;
+	registrar_url?: string | null;
+	isReseller?: boolean;
+}
+
+export default function DomainRegistrarBanner( {
+	domainName,
+	registrar,
+	registrar_url,
+	isReseller = false,
+}: DomainRegistrarBannerProps ) {
+	return (
+		<Card>
+			<CardBody>
+				<HStack spacing={ 2 } justify="space-between">
+					<Text size="medium" style={ { whiteSpace: 'nowrap' } }>
+						{ domainName }
+					</Text>
+					{ registrar && (
+						<HStack spacing={ 1 } justify="flex-end">
+							<Text variant="muted" size="small">
+								{ __( 'Registered by' ) }
+							</Text>
+							{ ! isReseller && registrar_url ? (
+								<ExternalLink href={ registrar_url }>{ registrar }</ExternalLink>
+							) : (
+								<Text size="small">{ registrar }</Text>
+							) }
+						</HStack>
+					) }
+				</HStack>
+			</CardBody>
+		</Card>
+	);
+}


### PR DESCRIPTION
Part of #

## Proposed Changes

This PR extracts the `DomainRegistrarBanner` component from `DomainConnectionSetup`.

## Why are these changes being made?

Improve the code by better modularization.

## Testing Instructions

- Code inspection
- Open the domain connection setup for a connected domain (at `/v2/domains/<domain_name>/domain-connection-setup`) and ensure the domain banner at the top is rendered correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
