### PR TITLE
MSD Billing: Fix cancel skip link and skip survey if already sent

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -418,14 +418,21 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 		const variant = surveyStep !== UPSELL_STEP ? 'primary' : 'secondary';
 
 		return (
-			<Button
-				disabled={ ! canGoNext() }
-				isBusy={ isCancelling }
-				onClick={ onSubmit }
-				variant={ variant }
-			>
-				{ __( 'Submit' ) }
-			</Button>
+			<ButtonStack justify="flex-start">
+				<Button
+					disabled={ ! canGoNext() }
+					isBusy={ isCancelling }
+					onClick={ onSubmit }
+					variant={ variant }
+				>
+					{ __( 'Submit' ) }
+				</Button>
+				{ ! canGoNext() && ! isCancelling && (
+					<Button variant="link" onClick={ onSubmit }>
+						{ __( 'Skip' ) }
+					</Button>
+				) }
+			</ButtonStack>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1308](https://linear.app/a8c/issue/SHILL-1308/hosting-dashboard-cancellation-flow-skip-link-not-present-unless)

## Proposed Changes

* Ensure the "skip" link shows when it is relevant, for all products.
* Restore "Remove plan step" functionality if the customer has already submitted a survey (prevents the survey from being shown and instead just asks if they want to remove the plan or keep it.
* Replace the first page that would normally show cancellation features with the remove plan page if the survey has been completed already.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The "skip" link was not appearing when expected due to the first step being the last step when only one step is present.
* The cancel and remove flow requires going through the marketing survey twice when it was already submitted the first time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test "skip" functionality.
* Visit `/v2/me/billing/purchases` and click "manage purchase" for an active purchase that is outside of the refund window. (Refunds will cancel and remove - we'd like to test those flows separately to make sure the preference is set and received correctly).
* Append `/cancel` to the end of URL and view the resulting page.
* After clicking the checkbox and advancing to the next page, click "skip" and make sure the purchase is cancelled and you are returned to the manage purchase page.
* Click back into the same purchase and append `/cancel` to the URL as before.
* After clicking the checkbox and advancing to the next page, ensure you are given the survey. Complete the survey and you should be returned to the manage purchase page, your purchase now removed.

#### Test skipping survey on remove if submitted on cancel
* Visit `/v2/me/billing/purchases` and click "manage purchase" for an active WPCom plan purchase that is outside of the refund window. (Refunds will cancel and remove - we'd like to test those flows separately to make sure the preference is set and received correctly).
* Append `/cancel` to the end of URL and view the resulting page.
* After clicking the checkbox and advancing to the next page, complete the survey and confirm the purchase has been cancelled.
* Click back into the same purchase and append `/cancel` to the URL as before.
* After clicking, the remove product plan should contain only a couple sentences with two buttons asking if the user wants to "Submit" or "Keep plan". Clicking "Submit" should remove the plan without asking the user to complete a survey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
