### PR TITLE
MSD Account: Security: Password async validation

### DIFF
--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -1,18 +1,13 @@
+import { validatePassword } from '@automattic/api-core';
 import { userSettingsMutation } from '@automattic/api-queries';
 import { generatePassword } from '@automattic/generate-password';
 import { useMutation } from '@tanstack/react-query';
-import {
-	__experimentalInputControl as InputControl,
-	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
-	__experimentalVStack as VStack,
-	Button,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataForm } from '@wordpress/dataviews';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { seen, unseen } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
@@ -20,12 +15,35 @@ import { Card, CardBody } from '../../components/card';
 import FlashMessage, { reloadWithFlashMessage } from '../../components/flash-message';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import type { Field } from '@wordpress/dataviews';
+import type { Field, Form } from '@wordpress/dataviews';
 
 import './style.scss';
 
 type SecurityPasswordFormData = {
 	password: string;
+};
+
+const fields: Field< SecurityPasswordFormData >[] = [
+	{
+		id: 'password',
+		label: __( 'New password' ),
+		type: 'password' as const,
+		isValid: {
+			custom: async ( data: SecurityPasswordFormData ) => {
+				const validation = await validatePassword( data.password );
+				if ( ! validation.passed ) {
+					return validation.test_results.failed[ 0 ].explanation;
+				}
+
+				return null;
+			},
+		},
+	},
+];
+
+const form: Form = {
+	layout: { type: 'regular' as const, labelPosition: 'top' as const },
+	fields: [ 'password' ],
 };
 
 export default function SecurityPassword() {
@@ -35,13 +53,19 @@ export default function SecurityPassword() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const [ isReloading, setIsReloading ] = useState( false );
 
-	const [ isPasswordVisible, setIsPasswordVisible ] = useState( false );
 	const [ formData, setFormData ] = useState< SecurityPasswordFormData >( {
 		password: '',
 	} );
 
+	const { validity, isValid } = useFormValidity( formData, fields, form );
+	const isLoading = mutation.isPending || isReloading;
+
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
+		if ( ! isValid ) {
+			return;
+		}
+
 		recordTracksEvent( 'calypso_dashboard_security_password_save_password_click' );
 		mutation.mutate(
 			{ password: formData.password },
@@ -67,52 +91,6 @@ export default function SecurityPassword() {
 		} ) );
 	};
 
-	const isLoading = mutation.isPending || isReloading;
-
-	const fields: Field< SecurityPasswordFormData >[] = useMemo(
-		() => [
-			{
-				id: 'password',
-				label: __( 'New password' ),
-				description: __(
-					'If you can’t think of a good password, use the button below to generate one.'
-				),
-				type: 'text' as const,
-				Edit: ( { field, data, onChange } ) => {
-					const { id, getValue } = field;
-					return (
-						<InputControl
-							__next40pxDefaultSize
-							type={ isPasswordVisible ? 'text' : 'password' }
-							label={ field.label }
-							placeholder={ field.placeholder }
-							value={ getValue( { item: data } ) }
-							onChange={ ( value ) => {
-								return onChange( { [ id ]: value ?? '' } );
-							} }
-							disabled={ isLoading }
-							suffix={
-								<InputControlSuffixWrapper>
-									<Button
-										icon={ isPasswordVisible ? unseen : seen }
-										onClick={ () => {
-											setIsPasswordVisible( ! isPasswordVisible );
-										} }
-									/>
-								</InputControlSuffixWrapper>
-							}
-							// Hint to LastPass not to attempt autofill
-							data-lpignore="true"
-						/>
-					);
-				},
-				// TODO: Add validation via isValid.custom.
-				// There is currently a bug that prevents it from working.
-			},
-		],
-		[ isPasswordVisible, isLoading ]
-	);
-
 	return (
 		<PageLayout
 			size="small"
@@ -121,7 +99,7 @@ export default function SecurityPassword() {
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Password' ) }
 					description={ __(
-						'Strong passwords have at least six characters, and use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).'
+						'Strong passwords have at least six characters, and use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ). If you can’t think of a good password, use the button below to generate one.'
 					) }
 				/>
 			}
@@ -134,13 +112,19 @@ export default function SecurityPassword() {
 							<DataForm< SecurityPasswordFormData >
 								data={ formData }
 								fields={ fields }
-								form={ { layout: { type: 'regular' as const }, fields } }
+								form={ form }
+								validity={ validity }
 								onChange={ ( edits: Partial< SecurityPasswordFormData > ) => {
 									setFormData( ( data ) => ( { ...data, ...edits } ) );
 								} }
 							/>
 							<ButtonStack justify="flex-start">
-								<Button variant="primary" type="submit" isBusy={ isLoading } disabled={ isLoading }>
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isLoading }
+									disabled={ isLoading || ! isValid }
+								>
 									{ __( 'Save' ) }
 								</Button>
 								<Button variant="secondary" onClick={ handleGeneratePassword }>

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { UserSettings } from './types';
+import type { PasswordValidationResponse, UserSettings } from './types';
 
 export async function updateUserSettings(
 	data: Partial< UserSettings >
@@ -38,4 +38,8 @@ export async function updateUserSettings(
 		saveableKeys.filter( ( key ) => key in data ).map( ( key ) => [ key, data[ key ] ] )
 	);
 	return await wpcom.req.post( '/me/settings', payload );
+}
+
+export async function validatePassword( password: string ): Promise< PasswordValidationResponse > {
+	return await wpcom.req.post( '/me/settings/password/validate', { password } );
 }

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -62,3 +62,12 @@ export interface UserSettings {
 	user_email_change_pending?: boolean;
 	new_user_email?: string;
 }
+
+export interface PasswordValidationResponse {
+	passed: boolean;
+	test_results: {
+		failed: {
+			explanation: string;
+		}[];
+	};
+}


### PR DESCRIPTION
Fixes DOTMSD-804

## Proposed Changes

This PR uses the native DataForm field type 'password' and introduces async validation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2/me/security/password
* Ensure that password validation works as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
