### PR TITLE
Help Center: Handle bad URLs in hooks

### DIFF
--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -140,6 +140,9 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 				action: ( element: HTMLAnchorElement ) => {
 					const href = element.getAttribute( 'href' ) as string;
 
+					if ( ! canParse( href ) ) {
+						return;
+					}
 					// Skip support articles
 					if ( href && isThisASupportArticleLink( href ) ) {
 						return;
@@ -147,7 +150,7 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 
 					// Support sites add `target="_blank"` to Calypso links.
 					// We should remove that in the context of Calypso.
-					if ( ensureProtocolAndParse( href ) && isSameOrigin( href ) ) {
+					if ( isSameOrigin( href ) ) {
 						element.removeAttribute( 'target' );
 						// On mobile, clicking a local link in the Help Center means the user wants to
 						// interact with that linked page, the Help Center should tuck itself away

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -147,7 +147,7 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 
 					// Support sites add `target="_blank"` to Calypso links.
 					// We should remove that in the context of Calypso.
-					if ( isSameOrigin( href ) ) {
+					if ( ensureProtocolAndParse( href ) && isSameOrigin( href ) ) {
 						element.removeAttribute( 'target' );
 						// On mobile, clicking a local link in the Help Center means the user wants to
 						// interact with that linked page, the Help Center should tuck itself away


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-338/white-screen-when-clicking-on-instrucciones-completas-on-the-traffic

## Testing steps

1. Go to: https://wordpress.com/marketing/traffic/limametropolitana.com
2. Scroll to “Servicios de verificación de webs”.
3. Click “Instrucciones completas”.
4. The Help Center should show correctly, no white screen