### PR TITLE
A4A > BD: Hide the dev site sections if BD checkout is enabled

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { arrowRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo, useState } from 'react';
@@ -141,31 +142,33 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 					/>
 				</HostingPlanSection.Details>
 
-				<HostingPlanSection.Aside
-					heading={ translate( 'Start building for free' ) }
-					cta={ {
-						label: translate( 'Create a development site' ),
-						variant: 'secondary',
-						icon: arrowRight,
-						disabled: ! availableDevSites,
-						onClick: onClickCreateWPCOMDevSite,
-					} }
-				>
-					<p>
-						{ translate(
-							'Included in your membership to Automattic for Agencies. Develop up to 5 WordPress.com sites with free development licenses. Only pay when you launch.'
-						) }
-					</p>
+				{ ! isEnabled( 'a4a-bd-checkout' ) && (
+					<HostingPlanSection.Aside
+						heading={ translate( 'Start building for free' ) }
+						cta={ {
+							label: translate( 'Create a development site' ),
+							variant: 'secondary',
+							icon: arrowRight,
+							disabled: ! availableDevSites,
+							onClick: onClickCreateWPCOMDevSite,
+						} }
+					>
+						<p>
+							{ translate(
+								'Included in your membership to Automattic for Agencies. Develop up to 5 WordPress.com sites with free development licenses. Only pay when you launch.'
+							) }
+						</p>
 
-					<i>
-						{ translate( '%(pendingSites)d of 5 free licenses available', {
-							args: {
-								pendingSites: availableDevSites,
-							},
-							comment: '%(pendingSites)s is the number of free licenses available.',
-						} ) }
-					</i>
-				</HostingPlanSection.Aside>
+						<i>
+							{ translate( '%(pendingSites)d of 5 free licenses available', {
+								args: {
+									pendingSites: availableDevSites,
+								},
+								comment: '%(pendingSites)s is the number of free licenses available.',
+							} ) }
+						</i>
+					</HostingPlanSection.Aside>
+				) }
 			</HostingPlanSection>
 
 			{ showWPCOMDevSiteConfigurationsModal && (

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -41,7 +42,7 @@ export default function MigrationsOverviewV2() {
 					<MigrationsBanner />
 					<MigrationsHostingFeatures />
 					<MigrationsTestimonials />
-					<MigrationsHostingOptions />
+					{ ! isEnabled( 'a4a-bd-checkout' ) && <MigrationsHostingOptions /> }
 					<MigrationsProcess />
 					<MigrationsClientRelationship />
 					<MigrationsCTA />

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -47,7 +47,9 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const availableDevSites = devLicenses?.available;
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+	// Show dev sites section if dev sites are enabled and BD checkout is not enabled
+	const devSitesEnabled =
+		config.isEnabled( 'a4a-dev-sites' ) && ! config.isEnabled( 'a4a-bd-checkout' );
 
 	const handleOnClick = useCallback(
 		( modalType: string ) => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1827/hide-dev-site-creation-temporarily-for-bd-agencies

## Proposed Changes

This PR hides the dev site sections if BD checkout is enabled

## Why are these changes being made?

* We are temporarily hiding the dev site sections when the agency BD checkout is enabled, as we don't yet have a dev site purchase flow for BD.

## Testing Instructions

* Open the A4A live link
* Append the URL with ?flags=a4a-bd-checkout
* Click the `Add Sites` button > Verify the dev site section is hidden

<img width="781" height="452" alt="Screenshot 2025-11-19 at 4 17 16 PM" src="https://github.com/user-attachments/assets/0aa4ee81-12a0-44e8-b9f7-fe28b6e9538e" />

* Go to Migrations > Overview > Verify the dev site + pressable section is hidden
* Go to Marketplace > Hosting > Standard Agency Hosting > Verify the dev site section is hidden

<img width="1512" height="627" alt="Screenshot 2025-11-19 at 4 03 40 PM" src="https://github.com/user-attachments/assets/117fa07c-eb6b-4245-bed2-3233e9e48820" />


* Refresh the page (without the feature flag) > Verify these sections are visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
