### PR TITLE
Help Center Menu Panel: Default experiment value to false

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -35,7 +35,7 @@ function HelpCenterContent() {
 
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
-			is_help_center_visible: isShown,
+			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',
 			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
 		} );

--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -37,7 +37,7 @@ function HelpCenterContent() {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown,
 			section: helpCenterData.sectionName || 'wp-admin',
-			is_menu_panel_enabled: isMenuPanelExperimentEnabled,
+			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
 		} );
 	}, [ isShown, isMenuPanelExperimentEnabled ] );
 

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -85,7 +85,7 @@ function AdminHelpCenterContent() {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown,
 			section: helpCenterData.sectionName || 'wp-admin',
-			is_menu_panel_enabled: isMenuPanelExperimentEnabled,
+			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
 		} );
 	}, [ isShown, isMenuPanelExperimentEnabled ] );
 

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -83,7 +83,7 @@ function AdminHelpCenterContent() {
 
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
-			is_help_center_visible: isShown,
+			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',
 			is_menu_panel_enabled: isMenuPanelExperimentEnabled ?? false,
 		} );

--- a/apps/help-center/hooks/use-menu-panel-experiment.js
+++ b/apps/help-center/hooks/use-menu-panel-experiment.js
@@ -45,9 +45,9 @@ const useMenuPanelExperiment = ( experimentName, treatmentVariation ) => {
 		initialData: () => {
 			try {
 				const cached = window.localStorage.getItem( cacheKey );
-				return cached ? JSON.parse( cached ) : undefined;
+				return cached ? JSON.parse( cached ) : false;
 			} catch ( e ) {
-				return undefined;
+				return false;
 			}
 		},
 	} );


### PR DESCRIPTION
Fix https://linear.app/a8c/issue/DOTCOM-15253/fix-event-props-omitted

Adds a default value for `is_menu_panel_enabled` event prop of `wpcom_help_center_icon_interaction`